### PR TITLE
persist browser context on popout, add uri options input & toggle

### DIFF
--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -214,7 +214,13 @@
                         <div class="row-main">
                             <label for="loginUri{{i}}">{{'uriPosition' | i18n : (i + 1)}}</label>
                             <input id="loginUri{{i}}" type="text" name="Login.Uris[{{i}}].Uri" [(ngModel)]="u.uri"
-                                placeholder="{{'ex' | i18n}} https://google.com" inputmode="url" appInputVerbatim>
+                                [hidden]="u.showUriOptionsInput === true" placeholder="{{'ex' | i18n}} https://google.com"
+                                inputmode="url" appInputVerbatim>
+                            <select *ngIf="uriOptions != null && uriOptions.length"
+                                id="loginUriOptions{{i}}" name="Login.Uris[{{i}}].Options" [(ngModel)]="u.uri"
+                                [hidden]="u.showUriOptionsInput === false || u.showUriOptionsInput == null || uriOptions == null">
+                                <option *ngFor="let o of uriOptions" [ngValue]="o">{{o}}</option>
+                            </select>
                             <label for="loginUriMatch{{i}}" class="sr-only">
                                 {{'matchDetection' | i18n}} {{(i + 1)}}
                             </label>
@@ -225,6 +231,11 @@
                             </select>
                         </div>
                         <div class="action-buttons">
+                            <a *ngIf="uriOptions != null && uriOptions.length" class="row-btn" href="#" appStopClick appBlurClick
+                                appA11yTitle="{{'Toggle Input Mode'}}" (click)="toggleUriInput(u)">
+                                <i aria-hidden="true" class="fa fa-lg"
+                                [ngClass]="u.showUriOptionsInput ? 'fa-edit' : 'fa-list'"></i>
+                            </a>
                             <a class="row-btn" href="#" appStopClick appBlurClick
                                 appA11yTitle="{{'toggleOptions' | i18n}}" (click)="toggleUriOptions(u)">
                                 <i class="fa fa-lg fa-cog" aria-hidden="true"></i>

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -5,6 +5,8 @@ import {
     Router,
 } from '@angular/router';
 
+import { BrowserApi } from '../../browser/browserApi';
+
 import { AuditService } from 'jslib/abstractions/audit.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
 import { CollectionService } from 'jslib/abstractions/collection.service';
@@ -76,6 +78,11 @@ export class AddEditComponent extends BaseAddEditComponent {
                 queryParamsSub.unsubscribe();
             }
         });
+
+        if (!this.editMode) {
+            const tabs = await BrowserApi.tabsQuery({ windowType: 'normal' });
+            this.uriOptions = tabs.map(({url}) => url);
+        }
 
         window.setTimeout(() => {
             if (!this.editMode) {


### PR DESCRIPTION
- Added uri input mode toggle button
- Added options input to `add-edit` component when in edit mode
- Populated options input with active tab data using `BrowserApi` (data persists on popout)

**Addresses Issue:**
[Pop-Out Window Loses Current Domain #839](https://github.com/bitwarden/browser/issues/839)
**as well as feature requests:**
[Pop-out to a new window should retain current site match or search results](https://community.bitwarden.com/t/pop-out-to-a-new-window-should-retain-current-site-match-or-search-results/4644)
[Kepp current tab filter when pop out to new window](https://community.bitwarden.com/t/kepp-current-tab-filter-when-pop-out-to-new-window/7856)
