### PR TITLE
persist browser context on popout, add uri options input & toggle

### DIFF
--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -219,7 +219,7 @@
                             <select *ngIf="uriOptions != null && uriOptions.length"
                                 id="loginUriOptions{{i}}" name="Login.Uris[{{i}}].Options" [(ngModel)]="u.uri"
                                 [hidden]="u.showUriOptionsInput === false || u.showUriOptionsInput == null || uriOptions == null">
-                                <option *ngFor="let o of uriOptions" [ngValue]="o">{{o}}</option>
+                                <option *ngFor="let o of uriOptions" [ngValue]="o.url">{{o.url}}</option>
                             </select>
                             <label for="loginUriMatch{{i}}" class="sr-only">
                                 {{'matchDetection' | i18n}} {{(i + 1)}}

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -27,7 +27,7 @@ import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/componen
     templateUrl: 'add-edit.component.html',
 })
 export class AddEditComponent extends BaseAddEditComponent {
-    uriOptions: string[];
+    uriOptions: any[];
     showAttachments = true;
 
     constructor(cipherService: CipherService, folderService: FolderService,
@@ -84,7 +84,7 @@ export class AddEditComponent extends BaseAddEditComponent {
 
         if (!this.editMode) {
             const tabs = await BrowserApi.tabsQuery({ windowType: 'normal' });
-            this.uriOptions = tabs.map(({url}) => url);
+            this.uriOptions = tabs.filter((tab) => tab.url);
         }
 
         window.setTimeout(() => {


### PR DESCRIPTION
- Added uri input mode toggle button
- Added options input to `add-edit` component when in edit mode
- Populated options input with active tab data using `BrowserApi` (data persists on popout)

**Addresses Issue:**
[Pop-Out Window Loses Current Domain #839](https://github.com/bitwarden/browser/issues/839)
**as well as feature requests:**
[Pop-out to a new window should retain current site match or search results](https://community.bitwarden.com/t/pop-out-to-a-new-window-should-retain-current-site-match-or-search-results/4644)
[Kepp current tab filter when pop out to new window](https://community.bitwarden.com/t/kepp-current-tab-filter-when-pop-out-to-new-window/7856)