### PR TITLE
Remove cut-off outline from popout and add buttons

### DIFF
--- a/src/popup/scss/base.scss
+++ b/src/popup/scss/base.scss
@@ -43,7 +43,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
     font-family: $font-family-sans-serif;
-    
+
     @include themify($themes) {
         color: themed('textColor');
     }
@@ -164,6 +164,7 @@ header {
         flex-direction: row;
         justify-content: center;
         align-items: center;
+        outline: none;
 
         @include themify($themes) {
             color: themed('headerColor');


### PR DESCRIPTION
This fix removes the cut-off outline color that shows up when the Popup or Add buttons are focused.
Fixes one of the bugs of Issue #1692.

Before:
![image](https://user-images.githubusercontent.com/1341760/111018685-369d4700-8388-11eb-946b-c53a2fc0ce5b.png)

After:
![image](https://user-images.githubusercontent.com/1341760/111018689-3b61fb00-8388-11eb-998a-e8c3d9a5da83.png)
