### PR TITLE
Remove popout button when shown in Firefox sidebar and when window is a popout

### DIFF
--- a/src/popup/components/pop-out.component.html
+++ b/src/popup/components/pop-out.component.html
@@ -1,4 +1,4 @@
-<ng-container>
+<ng-container *ngIf="this.show">
     <button (click)="expand()" appA11yTitle="{{'popOutNewWindow' | i18n}}">
         <i class="fa fa-external-link fa-rotate-270 fa-lg fa-fw" aria-hidden="true"></i>
     </button>

--- a/src/popup/components/pop-out.component.ts
+++ b/src/popup/components/pop-out.component.ts
@@ -22,7 +22,7 @@ export class PopOutComponent implements OnInit {
 
     ngOnInit() {
         if (this.show) {
-            if (this.popupUtilsService.inSidebar(window) && this.platformUtilsService.isFirefox()) {
+            if (this.popupUtilsService.inPopout(window) || (this.popupUtilsService.inSidebar(window) && this.platformUtilsService.isFirefox())) {
                 this.show = false;
             }
         }


### PR DESCRIPTION
Fixes #1690 

As requested by @eliykat I opened this PR with my suggested changes.

Fixed the popout button been shown in Firefox Sidebar and also when opened in a regular popout.

Marked this as draft as there is still a styling issue (missing left margin) when the button is removed. 

![removed button screenshot](https://user-images.githubusercontent.com/2670567/112210224-b8a82e00-8c1a-11eb-8bff-3d6a8968489a.png)