### PR TITLE
feat: Introduce a custom TOTP field type

### DIFF
--- a/autofill-playground.html
+++ b/autofill-playground.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>Bitwarden Autofill playground</title>
+</head>
+
+<body>
+  <h1>Bitwarden Autofill playground</h1>
+  <input type="text" name="totp" placeholder="TOTP field" />
+  <input type="text" name="plaintext" placeholder="Plaintext field" />
+</body>
+
+</html>

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -977,6 +977,9 @@
   "cfTypeBoolean": {
     "message": "Boolean"
   },
+  "cfTypeTOTP": {
+    "message": "TOTP"
+  },
   "popup2faCloseMessage": {
     "message": "Clicking outside the popup window to check your email for your verification code will cause this popup to close. Do you want to open this popup in a new window so that it does not close?"
   },

--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -347,6 +347,8 @@
                                 name="Field.Value{{i}}" [(ngModel)]="f.value" class="monospaced" appInputVerbatim
                                 *ngIf="f.type === fieldType.Hidden" placeholder="{{'value' | i18n}}"
                                 [disabled]="!cipher.viewPassword && !f.newField">
+                            <input id="fieldValue{{i}}" type="text" name="Field.Value{{i}}" [(ngModel)]="f.value"
+                                *ngIf="f.type === fieldType.TOTP" placeholder="{{'value' | i18n}}" appInputVerbatim>
                         </div>
                         <input id="fieldValue{{i}}" name="Field.Value{{i}}" type="checkbox" [(ngModel)]="f.value"
                             *ngIf="f.type === fieldType.Boolean" appTrueFalseValue trueValue="true" falseValue="false">


### PR DESCRIPTION
Allow TOTPs to be entered into custom fields. These are populated based
on an additional field type (TOTP) which will enter the TOTP into the
matched field.

This only takes effect if all of the following are true:

 - There is a TOTP defined for the current cipher
 - The user (or their org) has TOTP functionality
 - A TOTP-based custom field has been defined
 - There are matching field(s) found in the page

The TOTP entry can be customized by the end user through the placement
of a `%s` token. For example `0000%s1111` might generate a TOTP entry of
`00009999991111` if the TOTP was `999999` at the time of form fill.

This change also introduces a simple static HTML file, which can be used
as an autofill playground. By defining a new site in the user's vault
for `file://` URLs, the developer can navigate to
`file://<...>/autofill-playground.html` to easily test the autofill
functionality.