### PR TITLE
Fully responsive notificationBar

### DIFF
--- a/src/notification/bar.js
+++ b/src/notification/bar.js
@@ -3,7 +3,7 @@ require('./bar.scss');
 document.addEventListener('DOMContentLoaded', () => {
     var i18n = {};
     var lang = window.navigator.language;
-    
+
     i18n.appName = chrome.i18n.getMessage('appName');
     i18n.close = chrome.i18n.getMessage('close');
     i18n.yes = chrome.i18n.getMessage('yes');
@@ -100,12 +100,8 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
-        sendPlatformMessage({
-            command: 'bgAdjustNotificationBar',
-            data: {
-                height: body.scrollHeight
-            }
-        });
+        window.addEventListener("resize", adjustHeight);
+        adjustHeight();
     }
 
     function getQueryVariable(variable) {
@@ -143,6 +139,15 @@ document.addEventListener('DOMContentLoaded', () => {
         folders.forEach((folder) => {
             //Select "No Folder" (id=null) folder by default
             select.appendChild(new Option(folder.name, folder.id || '', false));
+        });
+    }
+
+    function adjustHeight() {
+        sendPlatformMessage({
+            command: 'bgAdjustNotificationBar',
+            data: {
+                height: document.querySelector('body').scrollHeight
+            }
         });
     }
 });

--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -13,29 +13,19 @@
     padding: 0 10px;
     border-bottom: 2px solid #175ddc;
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    column-gap: 10px;
+    grid-template-columns: 24px auto 55px;
     grid-column-gap: 10px;
     box-sizing: border-box;
-    height: 42px;
-}
-
-.outer-wrapper > * {
-    align-self: center;
+    min-height: 42px;
 }
 
 .inner-wrapper {
     display: grid;
-    grid-template-columns: 2fr 1fr;
-    column-gap: 10px;
-    grid-column-gap: 10px;
+    grid-template-columns: auto max-content;
 }
 
-#content .change-buttons {
-    justify-self: end;
-}
 
-.wrapper > *, .inner-wrapper > * {
+.outer-wrapper > *, .inner-wrapper > * {
     align-self: center;
 }
 
@@ -84,17 +74,6 @@ button.neutral {
         cursor: pointer;
         background: none;
         text-decoration: underline;
-    }
-}
-
-body[class*='lang-en'] .add-buttons {
-    width: 175px;
-    text-align: right;
-}
-
-@media (min-width: 768px) {
-    body[class*='lang-en'] .add-buttons {
-        width: 420px;
     }
 }
 


### PR DESCRIPTION
## Objective
The notificationBar behaved weirdly when the window was resized. Text would disappear, scrollbars appear and buttons become stacked instead of aligning in a row.

This PR makes the notificationBar fully responsive and resizes the window accordingly.

Closes #926
Closes #2092 
Asana tickets: https://app.asana.com/0/1169444489336079/1200912318004726 and https://app.asana.com/0/1169444489336079/1201095101752213

## Code Changes
- **bar.js**:  Added listener for window resizing and trigger bgAdjustNotificationBar
- **bar.scss**: 
     - Set `min-height` instead of `height` on `outer-wrapper`
     - Modified `grid-template-columns` of `inner-wrapper` to properly handle the notification text and the buttons (incl. select-folder)
     - Set `align-self: center` for outer- and inner-wrappers children
     - Removed `justify-self: end` for .`change-buttons`
     - Removed `width` and `text-align` modifications for `add-buttons`, as they'd only apply with the browsers language set to en
