### PR TITLE
Copy Custom field Name: Fix input element lookup from label

### DIFF
--- a/src/content/contextMenuHandler.ts
+++ b/src/content/contextMenuHandler.ts
@@ -12,27 +12,24 @@ function getClickedElementIdentifier() {
         return invalidElement;
     }
 
-    const tagName = clickedEl.nodeName.toLowerCase();
+    const clickedTag = clickedEl.nodeName.toLowerCase();
     let inputEl = null;
 
     // Try to identify the input element (which may not be the clicked element)
-    if (inputTags.includes(tagName)) {
-        inputEl = clickedEl;
-    } else if (labelTags.includes(tagName)) {
-        let inputName = null;
-        if (tagName === 'label') {
-            inputName = clickedEl.getAttribute('for');
+    if (labelTags.includes(clickedTag)) {
+        let inputId = null;
+        if (clickedTag === 'label') {
+            inputId = clickedEl.getAttribute('for');
         } else {
-            inputName = clickedEl.closest('label')?.getAttribute('for');
+            inputId = clickedEl.closest('label')?.getAttribute('for');
         }
 
-        if (inputName != null) {
-            inputEl = document.querySelector('input[name=' + inputName + '], select[name=' + inputName +
-                '], textarea[name=' + inputName + ']');
-        }
+        inputEl = document.getElementById(inputId);
+    } else {
+        inputEl = clickedEl;
     }
 
-    if (inputEl == null) {
+    if (inputEl == null || !inputTags.includes(inputEl.nodeName.toLowerCase())) {
         return invalidElement;
     }
 


### PR DESCRIPTION
## Objective

Follow-up to https://github.com/bitwarden/browser/pull/2091. I was getting the label's `for` attribute and then looking up the input `name` using that value, whereas `for` should actually point to the input's `id`.

## Code changes

* lookup element using `id` instead of `name`
* rearrange existing code to avoid duplication