### PR TITLE
Update the release branch constraint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branches"
+            echo "[!] Can only release from the 'release' branch"
             echo "==================================="
             exit 1
           fi


### PR DESCRIPTION
## Summary

We have iterated on our release branching strategy by adding a `release` branch. This PR updates the release branch constraint and the CI pipeline code constraint to be `release` instead of `rc` (which will continue being used for pre-release testing)