### PR TITLE
[EC-553] Make autofill doc-scanner traverse into shadowroots

### DIFF
--- a/src/content/autofill.js
+++ b/src/content/autofill.js
@@ -39,6 +39,7 @@
   6. Rename com.agilebits.* stuff to com.bitwarden.*
   7. Remove "some useful globals" on window
   8. Add ability to autofill span[data-bwautofill] elements
+  9. Understand ShadowRoots
   */
 
   function collect(document, undefined) {
@@ -224,9 +225,12 @@
           // query the document helper
           function queryDoc(doc, query) {
               var els = [];
+              // START MODIFICATION
               try {
-                  els = doc.querySelectorAll(query);
+                  els.push(... doc.querySelectorAll(query));
               } catch (e) { }
+              doc.querySelectorAll('*').forEach(function (srhost) { if (srhost.shadowRoot) { els.push(... queryDoc(srhost.shadowRoot, query)); } });
+              // END MODIFICATION
               return els;
           }
 


### PR DESCRIPTION
Shadow-roots are a recent invention that makes a web page an environment that can support independently-operating components. They give separate namespaces that the well-known element-query functions work upon, and for which separate searches and answers are given. It's becoming normal for a web page to create UI structures that are maintained by separate code, so (eg) a search form can not interfere with a log-in form.

Since searches do not pass from one (document or shadow) root to other (doc or sh) root, the form username-and-password search functions need to intentionally descend into each new root as it finds it.

Closes: #713

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Autofill finds username and password fields within shadow-roots.

## Code changes

- **src/content/autofill.js:** Make `collect(root, querystring)` recursive so shadowroots found in root are each used in recursive calls as `root`.

## Testing requirements

* Normal log-ins still auto-fill.
* Pages with shadow roots now auto-fill.  E.g.  https://login.clear.com.br/

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
