### PR TITLE
[PM-2083] Subdomains exclusion

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -63,7 +63,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
     }
 
     const domains = obj[activeUserId].settings.neverDomains;
-    if (domains != null && domains.hasOwnProperty(window.location.hostname)) {
+    if (domains != null && Object.keys(domains).some((d) => window.location.hostname.endsWith(d))) {
       return;
     }
 


### PR DESCRIPTION

## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Feature request to allow all subdomains exclusion, based on domain suffix

See also: https://community.bitwarden.com/t/excluded-sub-domains/30985

Note: I'm not sure if backward compatibility would be expected for excluded domains, ie by default NOT excluding all subdomains when a specific excluded domain is set. If so, probably there could be a checkbox in the domain exclusion config screen, to explicitly ask for turning this feature on.
I can try to do that if requested, however would appreciate some guidance.


## Code changes

In `notificationBar.ts`, instead of checking for the whole hostname in excluded domains, checks that hostname `endsWidth` any of the excluded domains.

## Screenshots

n/a

## Testing requirements

non-regression on excluded domains / eventually add new test cases for subdomains exclusion.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team) => https://bitwarden.com/help/exclude-domains/
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
