### PR TITLE
Fix #2288 - Prevent saving credentials if the password is all periods

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -349,7 +349,8 @@ document.addEventListener("DOMContentLoaded", (event) => {
           login.username != null &&
           login.username !== "" &&
           login.password != null &&
-          login.password !== ""
+          login.password !== "" &&
+          login.password.replace(/\./g, "").length > 0
         ) {
           processedForm(form);
           sendPlatformMessage({
@@ -389,6 +390,10 @@ document.addEventListener("DOMContentLoaded", (event) => {
               newPass = passwords[1];
             }
           }
+        }
+
+        if (newPass && newPass.replace(/\./g, "").length === 0) {
+          return;
         }
 
         if ((newPass != null && curPass != null) || (newPassOnly && newPass != null)) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix for #2288 where literal `................` is being saved as the password for some sites

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/content/notificationBar.ts** 
I found that in this scenario there are two addLogin events being triggered. The first has the actual password, and the second has the password replaced with all periods. This appears to be occurring because  `bitwardenProcessed` flag is set to '1' and then reset to '0' before the second event is triggered. One approach could have been to increase the timeout a bit in the 'processedForm' function, but that still leaves a possible race condition depending on network connectivity, etc. I went with the alternative approach of checking the new password to see if it is all periods. If it is, then we don't trigger the addLogin event.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Regression testing steps are documented in the original issue.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
