### PR TITLE
add appApiAction to username generation

### DIFF
--- a/apps/browser/src/popup/generator/generator.component.html
+++ b/apps/browser/src/popup/generator/generator.component.html
@@ -43,7 +43,7 @@
   </div>
   <div class="generated-block" *ngIf="type === 'username'">
     <div class="generated-wrapper" [innerHTML]="username | colorPassword" appSelectCopy></div>
-    <div class="action-buttons">
+    <div class="action-buttons" #form [appApiAction]="usernameGeneratingPromise">
       <button
         type="button"
         class="row-btn"
@@ -59,8 +59,13 @@
         appBlurClick
         appA11yTitle="{{ 'regenerateUsername' | i18n }}"
         (click)="regenerate()"
+        [disabled]="form.loading"
       >
-        <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+        <i
+          class="bwi bwi-lg bwi-generate"
+          [ngClass]="form.loading ? 'bwi-spin' : ''"
+          aria-hidden="true"
+        ></i>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

After adding email forwarding services to username generation, I neglected to implement `appApiAction` to handle the `usernameGeneratingPromise` as done in https://github.com/bitwarden/desktop/commit/75470dc1699eae28d79b39b02f5627f0b8716d67 .

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **generator component html:** Add `appApiAction` and spinning/disabled regenerate button.

## Screenshots

n/a

## Testing requirements

Make sure button spins and disabled while waiting on API calls to third party services to finish.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
