### PR TITLE
Crowdin-Pull: Fix paths in browsers crowdin.yml

### DIFF
--- a/apps/browser/crowdin.yml
+++ b/apps/browser/crowdin.yml
@@ -2,9 +2,9 @@ project_id_env: _CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_API_TOKEN
 preserve_hierarchy: true
 files:
-  - source: /src/_locales/en/messages.json
-    dest: /src/_locales/en/%original_file_name%
-    translation: /src/_locales/%two_letters_code%/%original_file_name%
+  - source: /apps/browser/src/_locales/en/messages.json
+    dest: /apps/browser/src/_locales/en/%original_file_name%
+    translation: /apps/browser/src/_locales/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
     languages_mapping:
       two_letters_code:
@@ -14,9 +14,9 @@ files:
         zh-TW: zh_TW
         en-GB: en_GB
         en-IN: en_IN
-  - source: /store/locales/en/copy.resx
-    dest: /store/locales/en/%original_file_name%
-    translation: /store/locales/%two_letters_code%/%original_file_name%
+  - source: /apps/browser/store/locales/en/copy.resx
+    dest: /apps/browser/store/locales/en/%original_file_name%
+    translation: /apps/browser/store/locales/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
     languages_mapping:
       two_letters_code:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

The Crowdin pull for browser was failing (https://github.com/bitwarden/clients/actions/runs/2278951990). The paths in the crowdin.yml had to be adjusted to the new repo structure.

If these changes fix the pull issue, then here's another [PR](https://github.com/bitwarden/clients/pull/2642) to add desktop crowdin pull and also fix the paths in `apps/desktop/crowdin.yml`.

## Code changes

- **apps/browser/crowdin.yml:** appended `/apps/browser` to all paths inside crowdin.yml for browser

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
