### PR TITLE
Fix desktop crowdin pull

### DIFF
--- a/.github/workflows/crowdin-pull-browser.yml
+++ b/.github/workflows/crowdin-pull-browser.yml
@@ -1,5 +1,5 @@
 ---
-name: Crowdin Sync
+name: Crowdin Sync Browser
 
 on:
   workflow_dispatch:

--- a/.github/workflows/crowdin-pull-desktop.yml
+++ b/.github/workflows/crowdin-pull-desktop.yml
@@ -1,0 +1,49 @@
+---
+name: Crowdin Sync Desktop
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  schedule:
+    - cron: "0 0 * * 5"
+
+jobs:
+  crowdin-sync:
+    name: Autosync
+    runs-on: ubuntu-20.04
+    env:
+      _CROWDIN_PROJECT_ID: "299360"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        with:
+          keyvault: "bitwarden-prod-kv"
+          secrets: "crowdin-api-token"
+
+      - name: Download translations
+        uses: crowdin/github-action@e39093fd75daae7859c68eded4b43d42ec78d8ea
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+        with:
+          config: apps/desktop/crowdin.yml
+          crowdin_branch_name: master
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          github_user_name: "github-actions"
+          github_user_email: "<>"
+          commit_message: "Autosync the updated translations"
+          localization_branch_name: crowdin-auto-sync
+          create_pull_request: true
+          pull_request_title: "Autosync Crowdin Translations"
+          pull_request_body: "Autosync the updated translations"

--- a/apps/desktop/crowdin.yml
+++ b/apps/desktop/crowdin.yml
@@ -2,9 +2,9 @@ project_id_env: _CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_API_TOKEN
 preserve_hierarchy: true
 files:
-  - source: /src/locales/en/messages.json
-    dest: /src/locales/en/%original_file_name%
-    translation: /src/locales/%two_letters_code%/%original_file_name%
+  - source: /apps/desktop/src/locales/en/messages.json
+    dest: /apps/desktop/src/locales/en/%original_file_name%
+    translation: /apps/desktop/src/locales/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
     languages_mapping:
       two_letters_code:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the move of desktop to this mono-repo, the workflow for the Crowdin-pull was missed. This re-adds and fixes the paths analog to the PRs (https://github.com/bitwarden/clients/pull/2542 and https://github.com/bitwarden/clients/pull/2641)

To not make any big changes to the pipelines (dev cut off approaching), the crowdin pull jobs are still separate. As they are very similar and have run at the same intervals previously, they could possible be combined and simplified.

## Code changes

- **.github/workflows/crowdin-pull-browser.yml:** Rename existing `Crowdin Sync` to `Crowdin Sync Browser`
- **.github/workflows/crowdin-pull-desktop.yml:** Add crowdin pull from [old desktop repo](https://github.com/bitwarden/desktop/blob/master/.github/workflows/crowndin-pull.yml) and fix paths
- **apps/desktop/crowdin.yml:** Fix paths

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
