### PR TITLE
[PS-565] Browser: Remove underline from focused buttons/controls

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -200,10 +200,6 @@ header {
       }
     }
 
-    &:focus {
-      text-decoration: underline;
-    }
-
     &[disabled] {
       opacity: 0.65;
       cursor: default !important;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

This may come down to a stylistic preference, but: currently, when certain controls/buttons (mostly it seems, the ones in the top toolbar) receive focus, they have a text underline. This looks strangely "webby" for text buttons, but leads to the very strange look of the "+" add button with underline, which just looks like an odd +/- symbol.

As it seems that in most other buttons/links this underline is then re-suppressed/not displayed (see for instance the "Pop out to new window" button which, in the CSS, is also set to underline, but due to the way the icon looks the underline is hidden), I'd love to see the underline removed here, for a cleaner/more consistent look.

Obviously, this will need to be run past design/UI decision makers.

## Code changes

- **/apps/browser/src/popup/scss/base.scss:** Remove the `text-decoration: underline` style

## Screenshots

Current look:

![cancel/save text buttons, with save focused and showing underline under the text](https://user-images.githubusercontent.com/895831/167247587-9417d709-22be-46de-ae4d-53c44fa0e756.png)

![the plus/add button, focused and showing the weird underline under the +](https://user-images.githubusercontent.com/895831/167247604-9b0c28be-0037-4335-9aac-d23e94eb019d.png)

After this PR:

![cancel/save text buttons, with save focused and no underline](https://user-images.githubusercontent.com/895831/167247664-e30b67da-7319-4240-ab7d-99ea6ed99ea2.png)

![the plus/add button, focused and no weird underline](https://user-images.githubusercontent.com/895831/167247681-513db6c2-0c9a-46a2-9ede-8b6b23298a4e.png)

## Testing requirements

- use keyboard navigation to set focus to the various controls

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

`npm run lint` appears broken at the moment
