### PR TITLE
[PS-556] Desktop / Browser: Fix vertical alignment of expandable header chevron

### DIFF
--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -26,6 +26,7 @@
     display: flex;
     width: 100%;
     box-sizing: border-box;
+    align-items: center;
 
     @include themify($themes) {
       color: themed("headingColor");

--- a/apps/desktop/src/scss/box.scss
+++ b/apps/desktop/src/scss/box.scss
@@ -40,6 +40,7 @@
     display: flex;
     width: 100%;
     box-sizing: border-box;
+    align-items: center;
 
     @include themify($themes) {
       color: themed("headingColor");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, both in the browser extension (in Chrome) and the desktop app, the chevron icon for expandable headers buttons is vertically misaligned. The problem is particularly visible in the chrome extension when navigating using the keyboard, as the outline awkwardly goes around the vertical "bump" of the icon. This PR fixes the alignment.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/box.scss** and **apps/desktop/src/scss/box.scss**: add `align-items:center` to fix the vertical alignment of the icon

## Screenshots

Current look of the expand/collapse controls in the chrome extension - note the chevron icon being too far to the top:

![top of the options view in chrome extension, showing the vertical misalignment](https://user-images.githubusercontent.com/895831/167253197-e76e1eaa-a377-4777-af9f-1858fb345744.png)

![options expand/collapse control in add send showing the vertical misalignment and how the keyboard focus outline 'bumps' over the icon](https://user-images.githubusercontent.com/895831/167253239-7def57ce-eaaa-419e-be46-05f81231d177.png)

--- 

Note that in Firefox, this is currently not an issue, strangely enough. 

![top of the options view in firefox, appearing correct even in current extension](https://user-images.githubusercontent.com/895831/167253295-39a743f8-6c84-4a89-98c2-4271fc0ee84b.png)

However, I verified that the change from this PR does not adversely affect Firefox in this case. There is no visual change in the extension there.

---

The same vertical misalignment in the desktop application (top of the settings modal)

![top of the native app's settings dialog showing the vertical misalignment](https://user-images.githubusercontent.com/895831/167253347-c271aaad-4ae5-4c2a-a2fc-d3e0f092c13a.png)

---

After the fix from this PR is applied, the chevron appears centered (and the focus outline in the chrome extension is fixed):

![top of the options view in chrome extension, with the icon's vertical alignment corrected](https://user-images.githubusercontent.com/895831/167253389-e910315f-8b19-411c-aa67-67f077117048.png)

![options expand/collapse control in add send showing correct vertical misalignment and how the keyboard focus outline is now 'smooth'/straight on the top](https://user-images.githubusercontent.com/895831/167253421-5ad5f009-3968-4322-95b8-9d92d024ab8e.png)

![top of the native app's settings dialog showing the correct  vertical alignment](https://user-images.githubusercontent.com/895831/167253454-b85ae9f6-3136-45ea-9e0b-765647e4a40a.png)


## Testing requirements

- visual verification that this change does not affect any other components
- navigate with keyboard through the extension in chrome to verify the outline around the expand/collapse controls now appears uniform and correct

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

Linting is currently broken