### PR TITLE
[PS-555] Browser: Accessibility - Add `aria-pressed` to URI toggles, remove `appBlurClick`

### DIFF
--- a/apps/browser/src/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/popup/settings/excluded-domains.component.html
@@ -61,9 +61,9 @@
                 *ngIf="currentUris && currentUris.length"
                 class="row-btn"
                 appStopClick
-                appBlurClick
                 appA11yTitle="{{ 'toggleCurrentUris' | i18n }}"
                 (click)="toggleUriInput(domain)"
+                [attr.aria-pressed]="domain.showCurrentUris === true"
               >
                 <i aria-hidden="true" class="bwi bwi-lg bwi-list"></i>
               </button>

--- a/apps/browser/src/popup/vault/add-edit.component.html
+++ b/apps/browser/src/popup/vault/add-edit.component.html
@@ -464,9 +464,9 @@
                 *ngIf="currentUris && currentUris.length"
                 class="row-btn"
                 appStopClick
-                appBlurClick
                 appA11yTitle="{{ 'toggleCurrentUris' | i18n }}"
                 (click)="toggleUriInput(u)"
+                [attr.aria-pressed]="u.showCurrentUris === true"
               >
                 <i aria-hidden="true" class="bwi bwi-lg bwi-list"></i>
               </button>
@@ -474,9 +474,9 @@
                 type="button"
                 class="row-btn"
                 appStopClick
-                appBlurClick
                 appA11yTitle="{{ 'toggleOptions' | i18n }}"
                 (click)="toggleUriOptions(u)"
+                [attr.aria-pressed]="u.showOptions === true"
               >
                 <i class="bwi bwi-lg bwi-cog" aria-hidden="true"></i>
               </button>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, URI toggles ("Toggle current URIs" and "Toggle options" in the "Add item" view, "Toggle current URIs" in the "Settings > Excluded domains" listing) don't expose their toggle state to assistive technologies. This PR adds `aria-pressed` to these toggles. Additionally, it removes `appBlurClick` which leads to unnecessary loss of focus (similar to https://github.com/bitwarden/desktop/pull/1514)

Closes https://github.com/bitwarden/clients/issues/2653

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/popup/vault/add-edit.component.html:** remove `appBlurClick` from the two URI toggles, add `aria-pressed` to reflect their state
- **src/popup/settings/excluded-domains.component.html:**remove `appBlurClick` from the URI toggle, add `aria-pressed` to reflect its state

## Screenshots

Videos using Chrome/NVDA on Windows, demonstrating how the toggles now announce their state, and dynamically announce when they're pressed/not pressed when toggled.

https://user-images.githubusercontent.com/895831/167257398-9d4cd0be-6443-484f-a3a0-0dbe0ba54198.mp4

https://user-images.githubusercontent.com/895831/167257418-29c89bcb-453b-4005-a110-ec975adb8cb0.mp4

Compare to the video in https://github.com/bitwarden/clients/issues/2653 that shows current behaviour.

## Testing requirements

- test using a screen reader to verify the URI toggles are announced correctly and convey their state (pressed/not-pressed)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

Linting is currently broken.