### PR TITLE
[EC-195] Mono-repo: Update issues link to our new repos

### DIFF
--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -64,7 +64,7 @@ export class HelpMenu implements IMenubarMenu {
     return {
       id: "fileBugReport",
       label: this.localize("fileBugReport"),
-      click: () => shell.openExternal("https://github.com/bitwarden/desktop/issues"),
+      click: () => shell.openExternal("https://github.com/bitwarden/clients/issues"),
     };
   }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Udpating the link in the desktop help menu to open a github issue.

## Code changes

- **apps/desktop/src/main/menu/menu.help.ts:** Updated help menu link from `https://github.com/bitwarden/desktop/issues` to `https://github.com/bitwarden/clients/issues`

## Testing requirements
When clicking on the menu entry, expect to be directed to the bitwarden/clients issues

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
