### PR TITLE
Desktop / Browser: Accessibility - make TOTP countdown announce for assistive technology users

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -146,6 +146,10 @@ p.lead {
   border: 0 !important;
 }
 
+:not(:focus)>.exists-only-on-parent-focus {
+  display: none;
+}
+
 .password-wrapper {
   overflow-wrap: break-word;
   white-space: pre-wrap;

--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -151,7 +151,7 @@
             >
             <span class="totp-code">{{ totpCodeFormatted }}</span>
           </div>
-          <span class="totp-countdown">
+          <span class="totp-countdown" aria-hidden="true">
             <span class="totp-sec">{{ totpSec }}</span>
             <svg>
               <g>
@@ -175,6 +175,7 @@
               (click)="copy(totpCode, 'verificationCodeTotp', 'TOTP')"
             >
               <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+              <span class="sr-only exists-only-on-parent-focus" aria-live="polite">{{ totpSec }}</span>
             </button>
           </div>
         </div>

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -111,7 +111,7 @@
               >
               <span class="totp-code">{{ totpCodeFormatted }}</span>
             </div>
-            <span class="totp-countdown">
+            <span class="totp-countdown" aria-hidden="true">
               <span class="totp-sec">{{ totpSec }}</span>
               <svg>
                 <g>
@@ -135,6 +135,7 @@
                 (click)="copy(totpCode, 'verificationCodeTotp', 'TOTP')"
               >
                 <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+                <span class="sr-only exists-only-on-parent-focus" aria-live="polite">{{ totpSec }}</span>
               </button>
             </div>
           </div>

--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -112,6 +112,10 @@ p.lead {
   border: 0 !important;
 }
 
+:not(:focus)>.exists-only-on-parent-focus {
+  display: none;
+}
+
 .totp {
   .totp-code {
     font-family: $font-family-monospace;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, the countdown for a TOTP is not announced dynamically for assistive technology users. Further, when navigating through a cipher/item view with a screen reader, the current timer value is announced as if it was part of the TOTP code itself. See the video in https://github.com/bitwarden/clients/issues/2657

This PR fixes both aspects: when reading through the view, the TOTP code itself is now read out/announced correctly (without the appended timer value). When focus is on the copy button, the countdown is now dynamically announced (so a screen reader user knows when it's ok to activate the button to copy, that there's enough time left for that code they're copying to be valid). This uses an `aria-live` region, but the region only announces when the copy button itself is focused - otherwise, the live region would have constantly made announcements as soon as the screen reader user entered the cipher/item view.

Closes https://github.com/bitwarden/clients/issues/2657

## Code changes

- **apps/browser/src/popup/vault/view.component.html** and **apps/desktop/src/app/vault/view.component.html**: make the visible totp countdown timer `aria-hidden` (so it's not announced when navigating to the field as part of the code itself); add a copy of the countdown number itself as part of the copy button, set to `sr-only`, with `aria-live="polite"` to make it continuously announce when its content gets updated.
- **apps/browser/src/popup/scss/misc.scss** and **apps/desktop/src/scss/misc.scss**: add a new utility class, naively titled `.exists-only-on-parent-focus`; this allows to have the an element `display:none` (and thus not exposed at all both visually *and* to assistive technologies) unless its direct parent element is focused. this, in combination with the change to the view component, ensures that the `sr-only` live region only "exists" (and thus only does the live region announcements) when the parent totp copy button has focus (otherwise the live region would lead to continuous announcements all the time while the user is anywhere in the cipher/item view...a continuously announced countdown regardless of which element/control the user was currently on/reading, which would be a horrid user experience)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

- go to a cipher/item with a TOTP field
- test using a screen reader that once focus is on the copy button, there are dynamic announcements for the countdown
- read through the view with reading keys, and verify that the TOTP code itself is read out correctly, without the current countdown value being appended to it

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

Linting is currently broken.