### PR TITLE
[fix] Organization switcher not loading on initial login

### DIFF
--- a/apps/browser/src/popup/vault/vault-select.component.html
+++ b/apps/browser/src/popup/vault/vault-select.component.html
@@ -1,4 +1,4 @@
-<div class="content org-filter-content" *ngIf="loaded && showOrganizations">
+<div class="content org-filter-content" *ngIf="loaded && show">
   <button
     class="org-filter"
     (click)="toggle()"


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-262

This will be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When logging in to the extension the organization switcher added for the End User Vault Refresh initiative does not appear until the page is refreshed in some way.

This is happening because of a sync problem. We are rendering content before a sync completes, so the switcher is checking for organizations before that data has been registered to state. The switcher shows up when refreshing the page because usually the sync has completed by then.

Unfortunately, this is a pattern of behavior that I don't think we can properly fix right now. Collections and folders have the same problem, and there is a bit of a hack in place right now that refreshes that data when a sync completes. This might be the proper way to do it in the end (I think some form of subscription makes more sense though), but the current implementation may result in pop in and is hard to follow in the code.

## Code changes
I have not addressed the underlying pattern here and instead have just applied the same `syncComplete` check to the switcher. This involved extracting the load logic of the switcher out of `ngOnInit`, and calling it again when a sync completes. I also made the `showOrganization` boolean into a getter, but this isn't necessary and just happened during debugging and was left in.

## Screenshots
https://user-images.githubusercontent.com/15897251/168326344-a5f85953-be3f-4c94-8397-6d27941badec.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
