### PR TITLE
[DEVOPS-810] Move Safari build to browser workflow

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -330,6 +330,7 @@ jobs:
           SETUP_STATUS: ${{ needs.setup.result }}
           LOCALES_TEST_STATUS: ${{ needs.locales-test.result }}
           BUILD_STATUS: ${{ needs.build.result }}
+          SAFARI_BUILD_STATUS: ${{ needs.build-safari.result }}
           CROWDIN_PUSH_STATUS: ${{ needs.crowdin-push.result }}
         run: |
           if [ "$CLOC_STATUS" = "failure" ]; then
@@ -339,6 +340,8 @@ jobs:
           elif [ "$LOCALES_TEST_STATUS" = "failure" ]; then
               exit 1
           elif [ "$BUILD_STATUS" = "failure" ]; then
+              exit 1
+          elif [ "$SAFARI_BUILD_STATUS" = "failure" ]; then
               exit 1
           elif [ "$CROWDIN_PUSH_STATUS" = "failure" ]; then
               exit 1

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -118,6 +118,7 @@ jobs:
           npm ci
           npm run dist
           npm run test
+          npm run dist:safari
 
       - name: Gulp
         run: gulp ci

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Zip Safari build artifact
         run: |
-          cd $GITHUB_WORKSPACE/apps/browser/dist
+          cd apps/browser/dist
           zip dist-safari.zip ./Safari/**/build/Release/safari.appex -r
           pwd
           ls -la
@@ -272,7 +272,7 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-safari-${{ env._BUILD_NUMBER }}.zip
-          path: /Users/runner/work/clients/clients/apps/browser/dist/apps/browser/dist/dist-safari.zip
+          path: apps/browser/dist/dist-safari.zip
           if-no-files-found: error
 
   crowdin-push:

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -270,7 +270,7 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-safari-${{ env._BUILD_NUMBER }}.zip
-          path: $GITHUB_WORKSPACE/apps/browser/dist/Safari/**/build/Release/safari.appex
+          path: $GITHUB_WORKSPACE/apps/browser/dist/dist-safari.zip
           if-no-files-found: error
 
   crowdin-push:

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -118,7 +118,6 @@ jobs:
           npm ci
           npm run dist
           npm run test
-          npm run dist:safari
 
       - name: Gulp
         run: gulp ci
@@ -178,6 +177,35 @@ jobs:
           path: apps/browser/coverage/coverage-${{ env._BUILD_NUMBER }}.zip
           if-no-files-found: error
 
+  build-safari:
+    name: Build Safari
+    runs-on: windows-2019
+    needs:
+      - setup
+      - locales-test
+    env:
+      _BUILD_NUMBER: ${{ needs.setup.outputs.adj_build_number }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846  # v3.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a  # v3.0.0
+        with:
+          cache: 'npm'
+          cache-dependency-path: 'apps/browser/**/package-lock.json'
+          node-version: '16'
+
+      - name: Print environment
+        run: |
+          node --version
+          npm --version
+
+      - name: Build Safari extension
+        run: |
+          npm ci
+          npm run dist:safari
+        working-directory: apps/browser
 
   crowdin-push:
     name: Crowdin Push
@@ -185,6 +213,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - build
+      - build-safari
     steps:
       - name: Checkout repo
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846  # v3.0.0
@@ -223,6 +252,7 @@ jobs:
       - setup
       - locales-test
       - build
+      - build-safari
       - crowdin-push
     steps:
       - name: Check if any job failed

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -261,6 +261,11 @@ jobs:
           npm run dist:safari
         working-directory: apps/browser
 
+      - name: Zip Safari build artifact
+        run: |
+          cd $GITHUB_WORKSPACE/apps/browser/dist
+          zip dist-safari.zip ./Safari/**/build/Release/safari.appex -r
+
       - name: Upload Safari artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -265,6 +265,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/apps/browser/dist
           zip dist-safari.zip ./Safari/**/build/Release/safari.appex -r
+          pwd
+          ls -la
 
       - name: Upload Safari artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -207,6 +207,16 @@ jobs:
           npm run dist:safari
         working-directory: apps/browser
 
+      - name: Zip artifact for deployment
+        run: zip dist-safari.zip $GITHUB_WORKSPACE/apps/browser/dist/Safari -r
+
+      - name: Upload Safari artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
+        with:
+          name: dist-safari-${{ env._BUILD_NUMBER }}.zip
+          path: dist-safari.zip
+          if-no-files-found: error
+
   crowdin-push:
     name: Crowdin Push
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -179,7 +179,7 @@ jobs:
 
   build-safari:
     name: Build Safari
-    runs-on: windows-2019
+    runs-on: macos-11
     needs:
       - setup
       - locales-test

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -201,14 +201,68 @@ jobs:
           node --version
           npm --version
 
+      - name: Decrypt secrets
+        env:
+          DECRYPT_FILE_PASSWORD: ${{ secrets.DECRYPT_FILE_PASSWORD }}
+        run: |
+          mkdir -p $HOME/secrets
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/bitwarden-desktop-key.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/bitwarden-desktop-key.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/appstore-app-cert.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/appstore-app-cert.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/appstore-installer-cert.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/appstore-installer-cert.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/devid-app-cert.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/devid-app-cert.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/devid-installer-cert.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/devid-installer-cert.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/macdev-cert.p12" \
+            "$GITHUB_WORKSPACE/.github/secrets/macdev-cert.p12.gpg"
+          gpg --quiet --batch --yes --decrypt --passphrase="$DECRYPT_FILE_PASSWORD" \
+            --output "$HOME/secrets/bitwarden_desktop_appstore.provisionprofile" \
+            "$GITHUB_WORKSPACE/.github/secrets/bitwarden_desktop_appstore.provisionprofile.gpg"
+
+      - name: Set up keychain
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          DESKTOP_KEY_PASSWORD: ${{ secrets.DESKTOP_KEY_PASSWORD }}
+          DEVID_CERT_PASSWORD: ${{ secrets.DEVID_CERT_PASSWORD }}
+          APPSTORE_CERT_PASSWORD: ${{ secrets.APPSTORE_CERT_PASSWORD }}
+          MACDEV_CERT_PASSWORD: ${{ secrets.MACDEV_CERT_PASSWORD }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        run: |
+          security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security set-keychain-settings -lut 1200 build.keychain
+          security import "$HOME/secrets/bitwarden-desktop-key.p12" -k build.keychain -P $DESKTOP_KEY_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import "$HOME/secrets/devid-app-cert.p12" -k build.keychain -P $DEVID_CERT_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import "$HOME/secrets/devid-installer-cert.p12" -k build.keychain -P $DEVID_CERT_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import "$HOME/secrets/appstore-app-cert.p12" -k build.keychain -P $APPSTORE_CERT_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import "$HOME/secrets/appstore-installer-cert.p12" -k build.keychain -P $APPSTORE_CERT_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import "$HOME/secrets/macdev-cert.p12" -k build.keychain -P $MACDEV_CERT_PASSWORD \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
+
       - name: Build Safari extension
         run: |
           npm ci
           npm run dist:safari
         working-directory: apps/browser
 
-      - name: Zip artifact for deployment
-        run: zip dist-safari.zip $GITHUB_WORKSPACE/apps/browser/dist/Safari -r
+      - name: Zip Safari build artifact
+        run: zip dist-safari.zip $GITHUB_WORKSPACE/apps/browser/dist/Safari/**/build/Release/ -r
 
       - name: Upload Safari artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -261,14 +261,11 @@ jobs:
           npm run dist:safari
         working-directory: apps/browser
 
-      - name: Zip Safari build artifact
-        run: zip dist-safari.zip $GITHUB_WORKSPACE/apps/browser/dist/Safari/**/build/Release/ -r
-
       - name: Upload Safari artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-safari-${{ env._BUILD_NUMBER }}.zip
-          path: dist-safari.zip
+          path: $GITHUB_WORKSPACE/apps/browser/dist/Safari/**/build/Release/safari.appex
           if-no-files-found: error
 
   crowdin-push:

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: dist-safari-${{ env._BUILD_NUMBER }}.zip
-          path: $GITHUB_WORKSPACE/apps/browser/dist/dist-safari.zip
+          path: /Users/runner/work/clients/clients/apps/browser/dist/apps/browser/dist/dist-safari.zip
           if-no-files-found: error
 
   crowdin-push:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -626,7 +626,7 @@ jobs:
         run: |
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
-          print $SAFARI_DIR
+          echo $SAFARI_DIR
           unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
@@ -817,7 +817,7 @@ jobs:
         run: |
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
-          print $SAFARI_DIR
+          echo $SAFARI_DIR
           unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
@@ -1000,7 +1000,7 @@ jobs:
         run: |
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
-          print $SAFARI_DIR
+          echo $SAFARI_DIR
           unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -610,7 +610,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -618,16 +618,17 @@ jobs:
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: DEVOPS-810_safari_build_browser #master
+          branch: DEVOPS-810_safari_build_browser # master
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
           ls -la
-          ls -la ./browser-build-artifacts
+          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
+          ls -la browser-build-artifacts
           mkdir PlugIns
-          cp -r ./browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -798,7 +799,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -806,16 +807,16 @@ jobs:
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: master
+          branch: DEVOPS-810_safari_build_browser # master
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           ls -la
-          ls -la ./browser-build-artifacts
+          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
           mkdir PlugIns
-          cp -r ./browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -978,7 +979,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -986,16 +987,17 @@ jobs:
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: master
+          branch: DEVOPS-810_safari_build_browser # master
           # name: dist-safari-32a0a5c.zip
-          # path: $GITHUB_WORKSPACE/browser-build-artifacts
+          path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           ls -la
-          ls -la ./browser-build-artifacts
+          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
+          ls -la browser-build-artifacts
           mkdir PlugIns
-          cp -r ./browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -609,7 +609,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: rc
-          # name: dist-safari-32a0a5c.zip
+
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
@@ -619,7 +619,7 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser # master
-          # name: dist-safari-32a0a5c.zip
+
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact
@@ -801,7 +801,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: rc
-          # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
@@ -811,7 +810,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser # master
-          # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact
@@ -985,7 +983,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: rc
-          # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
@@ -995,7 +992,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser # master
-          # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -475,12 +475,6 @@ jobs:
       - name: Build application (dev)
         run: npm run build
 
-      - name: Build Safari extension
-        run: |
-          npm install
-          npm run dist:safari
-        working-directory: apps/browser
-
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
@@ -608,17 +602,30 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Build Safari extension
-        if: steps.safari-cache.outputs.cache-hit != 'true'
-        run: |
-          npm install
-          npm run dist:safari
-        working-directory: apps/browser
+      - name: Download artifact from rc
+        if: github.ref == 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: rc
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
+
+      - name: Download artifact from master
+        if: github.ref != 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: master
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/apps/browser/dist/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ~/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -781,17 +788,30 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Build Safari extension
-        if: steps.safari-cache.outputs.cache-hit != 'true'
-        run: |
-          npm install
-          npm run dist:safari
-        working-directory: apps/browser
+      - name: Download artifact from rc
+        if: github.ref == 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: rc
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
+
+      - name: Download artifact from master
+        if: github.ref != 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: master
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/apps/browser/dist/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ~/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -946,17 +966,30 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Build Safari extension
-        if: steps.safari-cache.outputs.cache-hit != 'true'
-        run: |
-          npm install
-          npm run dist:safari
-        working-directory: apps/browser
+      - name: Download artifact from rc
+        if: github.ref == 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: rc
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
+
+      - name: Download artifact from master
+        if: github.ref != 'refs/heads/rc'
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: master
+          # name: dist-safari-32a0a5c.zip
+          path: ~/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/apps/browser/dist/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ~/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -626,7 +626,7 @@ jobs:
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
@@ -818,7 +818,7 @@ jobs:
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
@@ -1002,12 +1002,12 @@ jobs:
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -618,7 +618,7 @@ jobs:
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: master
+          branch: DEVOPS-810_safari_build_browser #master
           # name: dist-safari-32a0a5c.zip
           path: ~/browser-build-artifacts
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -624,9 +624,9 @@ jobs:
 
       - name: Load Safari extension for .dmg
         run: |
-          ls -la
-          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
-          ls -la browser-build-artifacts
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
+          SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
+          print $SAFARI_DIR
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
@@ -813,8 +813,9 @@ jobs:
 
       - name: Load Safari extension for App Store
         run: |
-          ls -la
-          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
+          SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
+          print $SAFARI_DIR
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
@@ -993,11 +994,11 @@ jobs:
 
       - name: Load Safari extension for App Store
         run: |
-          ls -la
-          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
-          ls -la browser-build-artifacts
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
+          SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
+          print $SAFARI_DIR
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -627,7 +627,7 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
@@ -818,7 +818,7 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
@@ -1001,7 +1001,7 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
-          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -624,11 +624,9 @@ jobs:
 
       - name: Load Safari extension for .dmg
         run: |
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
@@ -815,11 +813,9 @@ jobs:
 
       - name: Load Safari extension for App Store
         run: |
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
@@ -998,11 +994,9 @@ jobs:
 
       - name: Load Safari extension for App Store
         run: |
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
-          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -622,11 +622,14 @@ jobs:
           # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
-      - name: Load Safari extension for .dmg
+      - name: Unzip Safari artifact
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+
+      - name: Load Safari extension for .dmg
+        run: |
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
@@ -811,11 +814,14 @@ jobs:
           # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
-      - name: Load Safari extension for App Store
+      - name: Unzip Safari artifact
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+
+      - name: Load Safari extension for App Store
+        run: |
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
@@ -992,11 +998,14 @@ jobs:
           # name: dist-safari-32a0a5c.zip
           path: ${{ github.workspace }}/browser-build-artifacts
 
-      - name: Load Safari extension for App Store
+      - name: Unzip Safari artifact
         run: |
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           echo $SAFARI_DIR
           unzip $SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+
+      - name: Load Safari extension for App Store
+        run: |
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -610,7 +610,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -620,14 +620,14 @@ jobs:
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser #master
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
-          ls -la $GITHUB_WORKSPACE
-          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
+          ls -la
+          ls -la ./browser-build-artifacts
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ./browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -798,7 +798,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -808,12 +808,14 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
+          ls -la
+          ls -la ./browser-build-artifacts
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ./browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -976,7 +978,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -986,12 +988,14 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: $GITHUB_WORKSPACE/browser-build-artifacts
+          # path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
+          ls -la
+          ls -la ./browser-build-artifacts
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r ./browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -610,7 +610,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -620,14 +620,14 @@ jobs:
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser #master
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
-          ls -la
-          ls -la browser-build-artifacts
+          ls -la $GITHUB_WORKSPACE
+          ls -la $GITHUB_WORKSPACE/browser-build-artifacts
           mkdir PlugIns
-          cp -r browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -798,7 +798,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -808,12 +808,12 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -976,7 +976,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -986,12 +986,12 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: browser-build-artifacts
+          path: $GITHUB_WORKSPACE/browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -627,6 +627,8 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           print $SAFARI_DIR
+          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
@@ -816,6 +818,8 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           print $SAFARI_DIR
+          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
           cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
@@ -997,8 +1001,10 @@ jobs:
           ls -laR $GITHUB_WORKSPACE/browser-build-artifacts
           SAFARI_DIR=$(find $GITHUB_WORKSPACE/browser-build-artifacts -name 'dist-safari-*.zip')
           print $SAFARI_DIR
+          unzip $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/dist-safari.zip -d $GITHUB_WORKSPACE/browser-build-artifacts/Safari
+          ls -laR $GITHUB_WORKSPACE/browser-build-artifacts/Safari
           mkdir PlugIns
-          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/$SAFARI_DIR/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r $GITHUB_WORKSPACE/browser-build-artifacts/Safari/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -624,7 +624,8 @@ jobs:
 
       - name: Load Safari extension for .dmg
         run: |
-          ls browser-build-artifacts
+          ls -la
+          ls -la browser-build-artifacts
           mkdir PlugIns
           cp -r browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -604,7 +604,7 @@ jobs:
 
       - name: Download artifact from rc
         if: github.ref == 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
@@ -614,11 +614,11 @@ jobs:
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: DEVOPS-810_safari_build_browser # master
+          branch: master
 
           path: ${{ github.workspace }}/browser-build-artifacts
 
@@ -796,7 +796,7 @@ jobs:
 
       - name: Download artifact from rc
         if: github.ref == 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
@@ -805,11 +805,11 @@ jobs:
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: DEVOPS-810_safari_build_browser # master
+          branch: master
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact
@@ -978,7 +978,7 @@ jobs:
 
       - name: Download artifact from rc
         if: github.ref == 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
@@ -987,11 +987,11 @@ jobs:
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: DEVOPS-810_safari_build_browser # master
+          branch: master
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -610,7 +610,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -620,13 +620,13 @@ jobs:
           workflow_conclusion: success
           branch: DEVOPS-810_safari_build_browser #master
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Load Safari extension for .dmg
         run: |
-          ls ~/browser-build-artifacts
+          ls browser-build-artifacts
           mkdir PlugIns
-          cp -r ~/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -797,7 +797,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -807,12 +807,12 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r ~/browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r browser-build-artifacts/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -975,7 +975,7 @@ jobs:
           workflow_conclusion: success
           branch: rc
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Download artifact from master
         if: github.ref != 'refs/heads/rc'
@@ -985,12 +985,12 @@ jobs:
           workflow_conclusion: success
           branch: master
           # name: dist-safari-32a0a5c.zip
-          path: ~/browser-build-artifacts
+          path: browser-build-artifacts
 
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp -r ~/browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r browser-build-artifacts/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -609,7 +609,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: rc
-
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
@@ -619,7 +618,6 @@ jobs:
           workflow: build-browser.yml
           workflow_conclusion: success
           branch: master
-
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Unzip Safari artifact

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -624,6 +624,7 @@ jobs:
 
       - name: Load Safari extension for .dmg
         run: |
+          ls ~/browser-build-artifacts
           mkdir PlugIns
           cp -r ~/browser-build-artifacts/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Move the Safari extension build task from the desktop build workflow to the browser build.

Use the build Safari extension artifact in the desktop build to prepare mac OS packages

## Code changes


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
