### PR TITLE
Clearing the search bar when switching accounts

### DIFF
--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -105,8 +105,8 @@ export class AccountSwitcherComponent implements OnInit {
   }
 
   async switch(userId: string) {
+    this.messagingService.send("clearSearchBarText");
     this.close();
-
     this.messagingService.send("switchAccount", { userId: userId });
   }
 

--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -106,6 +106,7 @@ export class AccountSwitcherComponent implements OnInit {
 
   async switch(userId: string) {
     this.close();
+    
     this.messagingService.send("switchAccount", { userId: userId });
   }
 

--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -105,7 +105,6 @@ export class AccountSwitcherComponent implements OnInit {
   }
 
   async switch(userId: string) {
-    this.messagingService.send("clearSearchBarText");
     this.close();
     this.messagingService.send("switchAccount", { userId: userId });
   }

--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -106,7 +106,7 @@ export class AccountSwitcherComponent implements OnInit {
 
   async switch(userId: string) {
     this.close();
-    
+
     this.messagingService.send("switchAccount", { userId: userId });
   }
 

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -33,7 +33,7 @@ export class SearchComponent {
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
       this.ngZone.run(async () => {
         switch (message.command) {
-          case "clearSearchBarText":
+          case "switchAccount":
             this.searchBarService.setSearchText("");
             this.searchText.patchValue("");
             break;

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { FormControl } from "@angular/forms";
 
 import { StateService } from "jslib-common/abstractions/state.service";
@@ -9,7 +9,7 @@ import { SearchBarService, SearchBarState } from "./search-bar.service";
   selector: "app-search",
   templateUrl: "search.component.html",
 })
-export class SearchComponent {
+export class SearchComponent implements OnInit, OnDestroy {
   state: SearchBarState;
   searchText: FormControl = new FormControl(null);
 

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -1,7 +1,11 @@
-import { Component } from "@angular/core";
+import { Component, NgZone } from "@angular/core";
 import { FormControl } from "@angular/forms";
 
+import { BroadcasterService } from "jslib-common/abstractions/broadcaster.service";
+
 import { SearchBarService, SearchBarState } from "./search-bar.service";
+
+const BroadcasterSubscriptionId = "SearchComponent";
 
 @Component({
   selector: "app-search",
@@ -10,8 +14,10 @@ import { SearchBarService, SearchBarState } from "./search-bar.service";
 export class SearchComponent {
   state: SearchBarState;
   searchText: FormControl = new FormControl(null);
+  
+  constructor(private searchBarService: SearchBarService,  private broadcasterService: BroadcasterService, private ngZone: NgZone)
+  {
 
-  constructor(private searchBarService: SearchBarService) {
     this.searchBarService.state.subscribe((state) => {
       this.state = state;
     });
@@ -19,5 +25,22 @@ export class SearchComponent {
     this.searchText.valueChanges.subscribe((value) => {
       this.searchBarService.setSearchText(value);
     });
+  } 
+
+  ngOnInit() {
+    this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
+      this.ngZone.run(async () => {
+        switch (message.command) {
+          case "clearSearchBarText":            
+            this.searchBarService.setSearchText('');
+            this.searchText.patchValue('');
+            break;
+        }
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }
 }

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -1,11 +1,9 @@
-import { Component, NgZone } from "@angular/core";
+import { Component } from "@angular/core";
 import { FormControl } from "@angular/forms";
 
-import { BroadcasterService } from "jslib-common/abstractions/broadcaster.service";
+import { StateService } from "jslib-common/abstractions/state.service";
 
 import { SearchBarService, SearchBarState } from "./search-bar.service";
-
-const BroadcasterSubscriptionId = "SearchComponent";
 
 @Component({
   selector: "app-search",
@@ -15,11 +13,7 @@ export class SearchComponent {
   state: SearchBarState;
   searchText: FormControl = new FormControl(null);
 
-  constructor(
-    private searchBarService: SearchBarService,
-    private broadcasterService: BroadcasterService,
-    private ngZone: NgZone
-  ) {
+  constructor(private searchBarService: SearchBarService, private stateService: StateService) {
     this.searchBarService.state.subscribe((state) => {
       this.state = state;
     });
@@ -30,19 +24,13 @@ export class SearchComponent {
   }
 
   ngOnInit() {
-    this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
-      this.ngZone.run(async () => {
-        switch (message.command) {
-          case "switchAccount":
-            this.searchBarService.setSearchText("");
-            this.searchText.patchValue("");
-            break;
-        }
-      });
+    this.stateService.activeAccount.subscribe((value) => {
+      this.searchBarService.setSearchText("");
+      this.searchText.patchValue("");
     });
   }
 
   ngOnDestroy() {
-    this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+    this.stateService.activeAccount.unsubscribe();
   }
 }

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -14,10 +14,12 @@ const BroadcasterSubscriptionId = "SearchComponent";
 export class SearchComponent {
   state: SearchBarState;
   searchText: FormControl = new FormControl(null);
-  
-  constructor(private searchBarService: SearchBarService,  private broadcasterService: BroadcasterService, private ngZone: NgZone)
-  {
 
+  constructor(
+    private searchBarService: SearchBarService,
+    private broadcasterService: BroadcasterService,
+    private ngZone: NgZone
+  ) {
     this.searchBarService.state.subscribe((state) => {
       this.state = state;
     });
@@ -25,15 +27,15 @@ export class SearchComponent {
     this.searchText.valueChanges.subscribe((value) => {
       this.searchBarService.setSearchText(value);
     });
-  } 
+  }
 
   ngOnInit() {
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
       this.ngZone.run(async () => {
         switch (message.command) {
-          case "clearSearchBarText":            
-            this.searchBarService.setSearchText('');
-            this.searchText.patchValue('');
+          case "clearSearchBarText":
+            this.searchBarService.setSearchText("");
+            this.searchText.patchValue("");
             break;
         }
       });


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

The search bar was not clearing in the header when users were switching between accounts.

## Code changes
apps/desktop/src/app/layout/search/search.component.ts
- Added broadcaster service and NgZone , search component now listens for the "clearSearchBarText" message, and then sets the search bar values to empty.

apps/desktop/src/app/layout/account-switcher.component.ts 
- sends a message now to search component to reset the search values to empty string.


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
