### PR TITLE
[SG-294] Show folders and properly filter collections

### DIFF
--- a/apps/browser/src/popup/vault/ciphers.component.ts
+++ b/apps/browser/src/popup/vault/ciphers.component.ts
@@ -115,7 +115,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         }
         await this.load(this.buildFilter());
       } else if (params.folderId) {
-        this.showVaultFilter = false;
+        this.showVaultFilter = true;
         this.folderId = params.folderId === "none" ? null : params.folderId;
         this.searchPlaceholder = this.i18nService.t("searchFolder");
         if (this.folderId != null) {

--- a/apps/browser/src/popup/vault/vault-filter.component.html
+++ b/apps/browser/src/popup/vault/vault-filter.component.html
@@ -115,7 +115,7 @@
         </button>
       </div>
     </div>
-    <div class="box list" *ngIf="!selectedOrganization && nestedFolders?.length">
+    <div class="box list" *ngIf="nestedFolders?.length">
       <h2 class="box-header">
         {{ "folders" | i18n }}
         <span class="flex-right">{{ folderCount }}</span>

--- a/apps/browser/src/popup/vault/vault-filter.component.ts
+++ b/apps/browser/src/popup/vault/vault-filter.component.ts
@@ -174,7 +174,9 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   }
 
   async loadCollections() {
-    const allCollections = await this.vaultFilterService.buildCollections();
+    const allCollections = await this.vaultFilterService.buildCollections(
+      this.selectedOrganization
+    );
     this.collections = allCollections.fullList;
     this.nestedCollections = allCollections.nestedList;
   }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Show folders and filter collections based on the selected collection

## Code changes

- **apps/browser/src/popup/vault/ciphers.component.ts:** Show vault filter in folders
- **apps/browser/src/popup/vault/vault-filter.component.html** Don't hide folders if an org is selected
- **apps/browser/src/popup/vault/vault-filter.component.ts** Pass org id to buildCollections to filter out collections from other orgs.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
