### PR TITLE
Desktop: fix styling for vault ciphers list scroller (double scrollbars, "+" button out of view)

### DIFF
--- a/apps/desktop/src/scss/vault.scss
+++ b/apps/desktop/src/scss/vault.scss
@@ -15,7 +15,7 @@ app-root {
   height: 100%;
   display: flex;
 
-  > .items,
+  > .items > div,
   > .details,
   > .logo {
     display: flex;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

- following recent change in structure, with `<app-vault-ciphers>`, the flex styles were one level too high. as a result, you end up with double vertical scrollbars, as the `<cdk-virtual-scroll-viewport>` wants the entire height of the window ... so the "+" button is off-screen and causes the second scrollbar. This PR fixes this.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/scss/vault.scss**: tweak selector - retarget the selector to apply the necessary flex stuff not to `.vault > .items`, but to `.vault > .items > div`. Now that column uses proper vertical column flex stuff again, no more double scrollbar.

## Screenshots

Before/after video (with items blurred). Current `master` showing the double scrollbar, then after the fix only the virtual scroller has scrollbar and "+" button is in view.

https://user-images.githubusercontent.com/895831/168678416-220c417c-8471-45fc-bc98-7227fb72ee69.mp4

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
