### PR TITLE
Desktop: Custom webkit scrollbar styles for `.vault-filters`

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -96,18 +96,21 @@ textarea {
 }
 
 div:not(.modal)::-webkit-scrollbar,
-.cdk-virtual-scroll-viewport::-webkit-scrollbar {
+.cdk-virtual-scroll-viewport::-webkit-scrollbar,
+.vault-filters::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
 div:not(.modal)::-webkit-scrollbar-track,
-.cdk-virtual-scroll-viewport::-webkit-scrollbar-track {
+.cdk-virtual-scroll-viewport::-webkit-scrollbar-track,
+.vault-filters::-webkit-scrollbar-track {
   background-color: transparent;
 }
 
 div:not(.modal)::-webkit-scrollbar-thumb,
-.cdk-virtual-scroll-viewport::-webkit-scrollbar-thumb {
+.cdk-virtual-scroll-viewport::-webkit-scrollbar-thumb,
+.vault-filters::-webkit-scrollbar-thumb {
   border-radius: 10px;
   margin-right: 1px;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When there's not enough vertical space, the `.vault-filters` container has a vertical scrollbar. Currently in `master`, this is the raw unstyled standard scrollbar, which looks ugly and odd compared to the custom styled scrollbars in the other columns.

This PR applies the same custom `--webkit-scrollbar...` styles to `.vault-filters` as well.

## Code changes

- **apps/desktop/src/scss/base.scss**: expand selectors for the various `--webkit-scrollbar...` pseudos to also include `.vault-filters`

## Screenshots

Before, with the default scrollbar in the vault filters:

![before with ugly scrollbar](https://user-images.githubusercontent.com/895831/168679982-7da9b657-d6a3-4664-a675-9d14495cc28d.png)

After, with the fix (note that here the "+" button in the second column is scrolled out of view, as this PR does not include the fix from https://github.com/bitwarden/clients/pull/2693):

![after, with same styled scrollbars throughout](https://user-images.githubusercontent.com/895831/168680117-8db56469-17b9-46e9-b8c9-ed7457f01957.png)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
