### PR TITLE
[fix] Truncate text buttons on overflow

### DIFF
--- a/apps/desktop/src/scss/buttons.scss
+++ b/apps/desktop/src/scss/buttons.scss
@@ -176,4 +176,7 @@ button.no-btn {
   @include themify($themes) {
     color: themed("textColor");
   }
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-282
This will be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Long filters do not truncate when they wrap and instead cut off the screen. They should truncate with an ellipsis.

## Code changes
Add the necessary scss to truncate text buttons

## Screenshots
![Screen Shot 2022-05-17 at 2 44 57 PM](https://user-images.githubusercontent.com/15897251/168887775-3c7103ba-0e02-42d9-a32b-df91611a2658.png)

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
