### PR TITLE
[SG-300] Adding an Item defaults owner to selected vault

### DIFF
--- a/apps/browser/src/popup/vault/add-edit.component.ts
+++ b/apps/browser/src/popup/vault/add-edit.component.ts
@@ -95,6 +95,9 @@ export class AddEditComponent extends BaseAddEditComponent {
       if (params.cloneMode != null) {
         this.cloneMode = params.cloneMode === "true";
       }
+      if (params.selectedVault) {
+        this.organizationId = params.selectedVault;
+      }
       await this.load();
 
       if (!this.editMode || this.cloneMode) {

--- a/apps/browser/src/popup/vault/ciphers.component.ts
+++ b/apps/browser/src/popup/vault/ciphers.component.ts
@@ -234,6 +234,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         folderId: this.folderId,
         type: this.type,
         collectionId: this.collectionId,
+        selectedVault: this.vaultFilter.selectedOrganizationId,
       },
     });
   }

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -118,7 +118,13 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
   }
 
   addCipher() {
-    this.router.navigate(["/add-cipher"], { queryParams: { name: this.hostname, uri: this.url } });
+    this.router.navigate(["/add-cipher"], {
+      queryParams: {
+        name: this.hostname,
+        uri: this.url,
+        selectedVault: this.vaultFilterService.getVaultFilter().selectedOrganizationId,
+      },
+    });
   }
 
   viewCipher(cipher: CipherView) {

--- a/apps/browser/src/popup/vault/vault-filter.component.html
+++ b/apps/browser/src/popup/vault/vault-filter.component.html
@@ -22,7 +22,7 @@
     </button>
   </div>
 </header>
-<main tabindex="-1">
+<main tabindex="-1" cdk-scrollable>
   <app-vault-select (onVaultSelectionChanged)="vaultFilterChanged()"></app-vault-select>
   <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
     <i class="bwi bwi-spinner bwi-spin bwi-3x" *ngIf="!loaded"></i>

--- a/apps/browser/src/popup/vault/vault-filter.component.ts
+++ b/apps/browser/src/popup/vault/vault-filter.component.ts
@@ -266,7 +266,9 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   }
 
   async addCipher() {
-    this.router.navigate(["/add-cipher"]);
+    this.router.navigate(["/add-cipher"], {
+      queryParams: { selectedVault: this.vaultFilter.selectedOrganizationId },
+    });
   }
 
   async vaultFilterChanged() {

--- a/apps/browser/src/popup/vault/vault-select.component.ts
+++ b/apps/browser/src/popup/vault/vault-select.component.ts
@@ -145,6 +145,7 @@ export class VaultSelectComponent implements OnInit {
       positionStrategy,
       maxHeight: viewPortHeight - 160,
       backdropClass: "cdk-overlay-transparent-backdrop",
+      scrollStrategy: this.overlay.scrollStrategies.close(),
     });
 
     const templatePortal = new TemplatePortal(this.templateRef, this.viewContainerRef);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

- Adding an Item defaults owner to selected vault
- Close vault filter if view behind it is scrolled

## Code changes

- **apps/browser/src/popup/vault/add-edit.component.ts:** Use selectedVault param to set owner dropdown
- **apps/browser/src/popup/vault/ciphers.component.ts:** Pass selectedVault as a param
- **apps/browser/src/popup/vault/current-tab.component.ts:** Pass selectedVault as a param
- **apps/browser/src/popup/vault/vault-filter.component.ts:** Pass selectedVault as a param
- **apps/browser/src/popup/vault/vault-filter.component.html:** Add `cd-scrollable` directive to allow scrollStrategy to be used for vault filter
- **apps/browser/src/popup/vault/vault-select.component.ts:** Close the vault filter overlay if the user scrolls on the component behind it.

## Screenshots

https://user-images.githubusercontent.com/8926729/168900451-b61bd39e-c897-4b1f-83d0-9daa62172c5b.mov


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
