### PR TITLE
[fix] Prefill add cipher form from filter data

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -397,7 +397,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.addType = type;
     this.action = "add";
     this.cipherId = null;
-    this.updateCollectionProperties();
+    this.prefillNewCipherFromFilter();
     this.go();
   }
 
@@ -747,19 +747,21 @@ export class VaultComponent implements OnInit, OnDestroy {
     });
   }
 
-  private updateCollectionProperties() {
-    if (this.collectionId != null) {
-      const collection = this.vaultFilterComponent.collections?.fullList?.filter(
-        (c) => c.id === this.collectionId
+  private prefillNewCipherFromFilter() {
+    if (this.activeFilter.selectedCollectionId != null) {
+      const collection = this.vaultFilterComponent.collections.fullList.filter(
+        (c) => c.id === this.activeFilter.selectedCollectionId
       );
-      if (collection != null && collection.length > 0) {
+      if (collection.length > 0) {
         this.addOrganizationId = collection[0].organizationId;
-        this.addCollectionIds = [this.collectionId];
-        return;
+        this.addCollectionIds = [this.activeFilter.selectedCollectionId];
       }
+    } else if (this.activeFilter.selectedOrganizationId) {
+      this.addOrganizationId = this.activeFilter.selectedOrganizationId;
     }
-    this.addOrganizationId = null;
-    this.addCollectionIds = null;
+    if (this.activeFilter.selectedFolderId && this.activeFilter.selectedFolder) {
+      this.folderId = this.activeFilter.selectedFolderId;
+    }
   }
 
   private async canNavigateAway(action: string, cipher?: CipherView) {


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-334
This will be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When the add cipher button is clicked we are supposed to be pre-filling organization, collection, and folder based on what vault filters are active.

QA reported that we aren't doing this for organizations, and I noticed it also wasn't working for folders.

## Code changes
Replace `VaultComponent.updateCollectionProperties()` with `VaultComponent.prefillNewCipherFromFilter()` that also considers the active organization filter and folder filter.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
