### PR TITLE
[fix] Be more precise about what is reloaded in the vault on sync complete

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -128,7 +128,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             await this.openGenerator(false);
             break;
           case "syncCompleted":
-            await this.load();
+            await this.ciphersComponent.reload(this.buildFilter());
             await this.vaultFilterComponent.reloadCollectionsAndFolders(this.activeFilter);
             await this.vaultFilterComponent.reloadOrganizations();
             break;


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-335
This will be cherry-picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When a sync completes we reload the entire vault component. This is a little overkill, because that re-evaluates query params that haven't changed. Right now this is causing the active filter to be changed randomly on sync.

## Code changes
I think we just want to reload ciphers here, along with orgs/collections/folders in filters. I removed the `load()` call and just explicitly reload ciphers instead.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
