### PR TITLE
[fix] Pass deleted param to CiphersComponent.reload()

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -540,7 +540,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       this.i18nService.t(this.calculateSearchBarLocalizationString(vaultFilter))
     );
     this.activeFilter = vaultFilter;
-    await this.ciphersComponent.reload(this.buildFilter());
+    await this.ciphersComponent.reload(this.buildFilter(), vaultFilter.status === "trash");
     this.go();
   }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-338
This will be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The trash filter is not working

## Code changes
We aren't passing in the `deleted` param that `CiphersComponent.reload()` expects to facilitate this. This commit passes it from the filter.

## Screenshots
https://user-images.githubusercontent.com/15897251/169148012-51c69dc6-0492-4471-b50e-1d6b307121ab.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
