### PR TITLE
[SG-342] Fix 'Add Send' button being outside section

### DIFF
--- a/apps/desktop/src/app/send/send.component.html
+++ b/apps/desktop/src/app/send/send.component.html
@@ -53,7 +53,7 @@
   </div>
   <div id="items" class="items">
     <div class="content">
-      <div class="list" *ngIf="filteredSends.length">
+      <div class="list full-height" *ngIf="filteredSends.length">
         <button
           *ngFor="let s of filteredSends"
           appStopClick
@@ -129,11 +129,11 @@
           <p>{{ "noItemsInList" | i18n }}</p>
         </ng-container>
       </div>
-    </div>
-    <div class="footer">
-      <button (click)="addSend()" class="block primary" appA11yTitle="{{ 'addItem' | i18n }}">
-        <i class="bwi bwi-plus bwi-lg" aria-hidden="true"></i>
-      </button>
+      <div class="footer">
+        <button (click)="addSend()" class="block primary" appA11yTitle="{{ 'addItem' | i18n }}">
+          <i class="bwi bwi-plus bwi-lg" aria-hidden="true"></i>
+        </button>
+      </div>
     </div>
   </div>
   <app-send-add-edit

--- a/apps/desktop/src/scss/list.scss
+++ b/apps/desktop/src/scss/list.scss
@@ -147,3 +147,8 @@
     }
   }
 }
+
+.list.full-height {
+  height: 100%;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix Add Send button being hidden.

## Code changes

- **apps/desktop/src/app/send/send.component.html:** Move footer with 'Add Send' button into content section
- **apps/desktop/src/scss/list.scss:** Add css class to make send list full height, and scroll on overflow

## Screensho
![Screen Shot 2022-05-19 at 4 18 59 PM](https://user-images.githubusercontent.com/8926729/169397849-a3ed3a71-d25a-4d79-a1b0-64b0159db691.png)
ts

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
