### PR TITLE
[PS-1199] Fixed button text clipping and text breaking in the middle of a word in some locales

### DIFF
--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -367,6 +367,7 @@
       display: block;
       width: initial;
       margin-bottom: 0;
+      word-break: normal;
 
       @include themify($themes) {
         color: themed("textColor");

--- a/apps/browser/src/popup/scss/buttons.scss
+++ b/apps/browser/src/popup/scss/buttons.scss
@@ -98,4 +98,5 @@ button {
   border: none;
   background: transparent;
   color: inherit;
+  white-space: normal;
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

There are text clipping and breaking in Russian locale (and probably in some others). 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/box.scss**: added `word-break: normal` for `label` tag to use correct word breaking.
- **apps/browser/src/popup/scss/buttons.scss**: added `white-space: normal` for `button` to wrap lines if text doesn't fit.
## Screenshots

<details>
  <summary>2-factor authentication</summary>
<img width="777" alt="2022-05-20_20-05-16" src="https://user-images.githubusercontent.com/668493/169638790-23b7e4de-fc60-4ee6-b432-91ccf14c7592.png">
</details>

<details>
  <summary>Create Send</summary>
<img width="778" alt="2022-05-20_20-15-49" src="https://user-images.githubusercontent.com/668493/169638831-6432315b-ecae-43ba-990d-a965773784a9.png">
</details>

<details>
  <summary>Settings</summary>
<img width="777" alt="2022-05-20_20-24-04" src="https://user-images.githubusercontent.com/668493/169638854-97df9141-8968-4f5c-b9a9-59c9c96130a0.png">

</details>

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
