### PR TITLE
Devops 818 trigger desktop on browser build

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -327,6 +327,19 @@ jobs:
       - build
       - build-safari
     steps:
+
+      - name: Login to Azure
+        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
+        with:
+          keyvault: "bitwarden-prod-kv"
+          secrets: "github-pat-trigger-desktop-build-bitwarden-devops-bot"
+
       - name: Extract branch name
         id: extract_branch
         shell: bash
@@ -334,7 +347,7 @@ jobs:
 
       - name: Call GitHub API to trigger desktop build workflow
         env:
-          TOKEN: ${{ secrets.TOKEN }} # replace this value with actual token secret name
+          TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-trigger-desktop-build-bitwarden-devops-bot }}
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
           curl \

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -350,12 +350,16 @@ jobs:
           TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-trigger-desktop-build-bitwarden-devops-bot }}
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
+          JSON_STRING=$( jq -n \
+                  --arg bn "$BRANCH_NAME" \
+                  '{ref: $bn}' )
+
           curl \
             -X POST \
             -i -u bitwarden-devops-bot:$TOKEN \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/bitwarden/clients/actions/workflows/build-desktop.yml/dispatches \
-            -d '{"ref":"$BRANCH_NAME"}'
+            -d $JSON_STRING
 
   check-failures:
     name: Check for failures

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -321,7 +321,7 @@ jobs:
 
   trigger-desktop-build:
     name: Trigger desktop build
-    if: ${{ (github.ref == 'refs/heads/DEVOPS-818_trigger_desktop_on_browser_build' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
+    if: ${{ ( contains(github.ref, 'DEVOPS-818' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
     runs-on: ubuntu-20.04
     needs:
       - build

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -338,7 +338,7 @@ jobs:
         uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
         with:
           keyvault: "bitwarden-prod-kv"
-          secrets: "github-pat-trigger-desktop-build-bitwarden-devops-bot"
+          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
 
       - name: Extract branch name
         id: extract_branch
@@ -347,7 +347,7 @@ jobs:
 
       - name: Call GitHub API to trigger desktop build workflow
         env:
-          TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-trigger-desktop-build-bitwarden-devops-bot }}
+          TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
 

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -321,7 +321,7 @@ jobs:
 
   trigger-desktop-build:
     name: Trigger desktop build
-    if: ${{ ( contains(github.ref, 'DEVOPS-818' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
+    if: ${{ (github.ref == 'refs/heads/DEVOPS-818_trigger_desktop_on_browser_build' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
     runs-on: ubuntu-20.04
     needs:
       - build

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -350,9 +350,13 @@ jobs:
           TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-trigger-desktop-build-bitwarden-devops-bot }}
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
+          echo $BRANCH_NAME
+
           JSON_STRING=$( jq -n \
                   --arg bn "$BRANCH_NAME" \
                   '{ref: $bn}' )
+
+          echo $JSON_STRING
 
           curl \
             -X POST \

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -320,8 +320,8 @@ jobs:
           upload_translations: false
 
   trigger-desktop-build:
-    name: Crowdin Push
-    if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
+    name: Trigger desktop build
+    if: ${{ (github.ref == 'refs/heads/DEVOPS-818_trigger_desktop_on_browser_build' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
     runs-on: ubuntu-20.04
     needs:
       - build
@@ -334,7 +334,7 @@ jobs:
 
       - name: Call GitHub API to trigger desktop build workflow
         env:
-          TOKEN: ${{ secrets.TOKEN }} # replace this yalue with actual token secret name
+          TOKEN: ${{ secrets.TOKEN }} # replace this value with actual token secret name
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
           curl \

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -319,6 +319,30 @@ jobs:
           upload_sources: true
           upload_translations: false
 
+  trigger-desktop-build:
+    name: Crowdin Push
+    if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
+    runs-on: ubuntu-20.04
+    needs:
+      - build
+      - build-safari
+    steps:
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
+      - name: Call GitHub API to trigger desktop build workflow
+        env:
+          TOKEN: ${{ secrets.TOKEN }} # replace this yalue with actual token secret name
+          BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+        run: |
+          curl \
+            -X POST \
+            -i -u bitwarden-devops-bot:$TOKEN \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/bitwarden/clients/actions/workflows/build-desktop.yml/dispatches \
+            -d '{"ref":"$BRANCH_NAME"}'
 
   check-failures:
     name: Check for failures
@@ -331,6 +355,7 @@ jobs:
       - build
       - build-safari
       - crowdin-push
+      - trigger-desktop-build
     steps:
       - name: Check if any job failed
         if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') }}
@@ -341,6 +366,7 @@ jobs:
           BUILD_STATUS: ${{ needs.build.result }}
           SAFARI_BUILD_STATUS: ${{ needs.build-safari.result }}
           CROWDIN_PUSH_STATUS: ${{ needs.crowdin-push.result }}
+          TRIGGER_DESKTOP_BUILD_STATUS:  ${{ needs.trigger-desktop-build.result }}
         run: |
           if [ "$CLOC_STATUS" = "failure" ]; then
               exit 1
@@ -353,6 +379,8 @@ jobs:
           elif [ "$SAFARI_BUILD_STATUS" = "failure" ]; then
               exit 1
           elif [ "$CROWDIN_PUSH_STATUS" = "failure" ]; then
+              exit 1
+          elif [ "$TRIGGER_DESKTOP_BUILD_STATUS" = "failure" ]; then
               exit 1
           fi
 

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -350,13 +350,8 @@ jobs:
           TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-trigger-desktop-build-bitwarden-devops-bot }}
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
         run: |
-          echo $BRANCH_NAME
 
-          JSON_STRING=$( jq -n \
-                  --arg bn "$BRANCH_NAME" \
-                  '{ref: $bn}' )
-
-          echo $JSON_STRING
+          JSON_STRING=$(printf '{"ref":"%s"}' "$BRANCH_NAME")
 
           curl \
             -X POST \

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -321,7 +321,7 @@ jobs:
 
   trigger-desktop-build:
     name: Trigger desktop build
-    if: ${{ (github.ref == 'refs/heads/DEVOPS-818_trigger_desktop_on_browser_build' || github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
+    if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || contains(github.ref, 'hotfix-rc') }}
     runs-on: ubuntu-20.04
     needs:
       - build

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -619,8 +619,32 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
+      - name: Download artifact from workflow_run event
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          run_id: ${{ github.event.workflow_run.id }}
+          path: ${{ github.workspace }}/browser-build-artifacts
+
+      - name: Extract branch name
+        if: ${{ contains(github.ref, "hotfix-rc") && github.event_name != 'workflow_run' }}
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
+      - name: Download artifact from hotfix-rc
+        if: ${{ contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: ${{ steps.extract_branch.outputs.branch }}
+          path: ${{ github.workspace }}/browser-build-artifacts
+
       - name: Download artifact from rc
-        if: github.ref == 'refs/heads/rc'
+        if: ${{ github.ref == 'refs/heads/rc'  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -629,7 +653,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: github.ref != 'refs/heads/rc'
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -809,8 +833,32 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
+      - name: Download artifact from workflow_run event
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          run_id: ${{ github.event.workflow_run.id }}
+          path: ${{ github.workspace }}/browser-build-artifacts
+
+      - name: Extract branch name
+        if: ${{ contains(github.ref, "hotfix-rc") && github.event_name != 'workflow_run' }}
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
+      - name: Download artifact from hotfix-rc
+        if: ${{ contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
+        with:
+          workflow: build-browser.yml
+          workflow_conclusion: success
+          branch: ${{ steps.extract_branch.outputs.branch }}
+          path: ${{ github.workspace }}/browser-build-artifacts
+
       - name: Download artifact from rc
-        if: github.ref == 'refs/heads/rc'
+        if: ${{ github.ref == 'refs/heads/rc'  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -819,7 +867,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: github.ref != 'refs/heads/rc'
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -629,13 +629,13 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Extract branch name
-        if: ${{ contains(github.ref, "hotfix-rc") && github.event_name != 'workflow_run' }}
+        if: ${{ contains(github.ref, 'hotfix-rc') && github.event_name != 'workflow_run' }}
         id: extract_branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Download artifact from hotfix-rc
-        if: ${{ contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        if: ${{ contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -653,7 +653,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -843,13 +843,13 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Extract branch name
-        if: ${{ contains(github.ref, "hotfix-rc") && github.event_name != 'workflow_run' }}
+        if: ${{ contains(github.ref, 'hotfix-rc') && github.event_name != 'workflow_run' }}
         id: extract_branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Download artifact from hotfix-rc
-        if: ${{ contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        if: ${{ contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -867,7 +867,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, "hotfix-rc")  && github.event_name != 'workflow_run' }}
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -19,6 +19,14 @@ on:
       - '.github/workflows/build-desktop.yml'
   workflow_dispatch:
     inputs: {}
+  workflow_run:
+    workflows: [Build Browser]
+    types:
+      - completed
+    branches:
+      - 'master'
+      - 'rc'
+      - 'hotfix-rc/**'
 
 defaults:
   run:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -19,14 +19,6 @@ on:
       - '.github/workflows/build-desktop.yml'
   workflow_dispatch:
     inputs: {}
-  workflow_run:
-    workflows: [Build Browser]
-    types:
-      - completed
-    branches:
-      - 'master'
-      - 'rc'
-      - 'hotfix-rc/**'
 
 defaults:
   run:
@@ -619,23 +611,14 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Download artifact from workflow_run event
-        if: ${{ github.event_name == 'workflow_run' }}
-        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
-        with:
-          workflow: build-browser.yml
-          workflow_conclusion: success
-          run_id: ${{ github.event.workflow_run.id }}
-          path: ${{ github.workspace }}/browser-build-artifacts
-
       - name: Extract branch name
-        if: ${{ contains(github.ref, 'hotfix-rc') && github.event_name != 'workflow_run' }}
+        if: contains(github.ref, 'hotfix-rc')
         id: extract_branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Download artifact from hotfix-rc
-        if: ${{ contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
+        if: contains(github.ref, 'hotfix-rc')
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -644,7 +627,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from rc
-        if: ${{ github.ref == 'refs/heads/rc'  && github.event_name != 'workflow_run' }}
+        if: github.ref == 'refs/heads/rc'
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -653,7 +636,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc') }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -833,23 +816,14 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Download artifact from workflow_run event
-        if: ${{ github.event_name == 'workflow_run' }}
-        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
-        with:
-          workflow: build-browser.yml
-          workflow_conclusion: success
-          run_id: ${{ github.event.workflow_run.id }}
-          path: ${{ github.workspace }}/browser-build-artifacts
-
       - name: Extract branch name
-        if: ${{ contains(github.ref, 'hotfix-rc') && github.event_name != 'workflow_run' }}
+        if: contains(github.ref, 'hotfix-rc')
         id: extract_branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
       - name: Download artifact from hotfix-rc
-        if: ${{ contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
+        if: contains(github.ref, 'hotfix-rc')
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -858,7 +832,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from rc
-        if: ${{ github.ref == 'refs/heads/rc'  && github.event_name != 'workflow_run' }}
+        if: github.ref == 'refs/heads/rc'
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -867,7 +841,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc')  && github.event_name != 'workflow_run' }}
+        if: ${{ github.ref != 'refs/heads/rc' && !contains(github.ref, 'hotfix-rc') }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

New Desktop Builds should be automatically triggered on a new Safari Extension build completed from master, rc, or hotfix-rc branches.

## Code changes

I've added trigger for desktop build workflow to watch for the browser builds from branches master, rc and hotfix-rc. Also changed the conditions on the artifacts download steps in the desktop build.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
