### PR TITLE
[PS-524] show error when trying to enable browser integration on desktop

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -367,7 +367,7 @@ export class SettingsComponent implements OnInit {
     if (process.platform === "darwin" && !this.platformUtilsService.isMacAppStore()) {
       await this.platformUtilsService.showDialog(
         this.i18nService.t("browserIntegrationMasOnlyDesc"),
-        this.i18nService.t("browserIntegrationMasOnlyTitle"),
+        this.i18nService.t("browserIntegrationUnsupportedTitle"),
         this.i18nService.t("ok"),
         null,
         "warning"
@@ -378,7 +378,18 @@ export class SettingsComponent implements OnInit {
     } else if (isWindowsStore()) {
       await this.platformUtilsService.showDialog(
         this.i18nService.t("browserIntegrationWindowsStoreDesc"),
-        this.i18nService.t("browserIntegrationWindowsStoreTitle"),
+        this.i18nService.t("browserIntegrationUnsupportedTitle"),
+        this.i18nService.t("ok"),
+        null,
+        "warning"
+      );
+
+      this.enableBrowserIntegration = false;
+      return;
+    } else if (process.platform == "linux") {
+      await this.platformUtilsService.showDialog(
+        this.i18nService.t("browserIntegrationLinuxDesc"),
+        this.i18nService.t("browserIntegrationUnsupportedTitle"),
         this.i18nService.t("ok"),
         null,
         "warning"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1518,17 +1518,17 @@
   "enableBrowserIntegrationDesc": {
     "message": "Browser integration is used for biometrics in browser."
   },
-  "browserIntegrationMasOnlyTitle": {
+  "browserIntegrationUnsupportedTitle": {
     "message": "Browser integration not supported"
   },
   "browserIntegrationMasOnlyDesc": {
     "message": "Unfortunately browser integration is only supported in the Mac App Store version for now."
   },
-  "browserIntegrationWindowsStoreTitle": {
-    "message": "Browser integration not supported"
-  },
   "browserIntegrationWindowsStoreDesc": {
     "message": "Unfortunately browser integration is currently not supported in the Windows Store version."
+  },
+  "browserIntegrationLinuxDesc": {
+    "message": "Unfortunately browser integration is currently not supported in the linux version."
   },
   "enableBrowserIntegrationFingerprint": {
     "message": "Require verification for browser integration"


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Desktop browser integration is currently unavailable on the linux platform. This fix shows an error when the user tries to enable it in settings.

closes #2556

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/24985544/170771886-8c164680-9f65-4cd1-be0a-ffbabceef793.png">


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
