### PR TITLE
Fix Variable Substitution in Version Bump Workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -107,10 +107,10 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git commit -m "Bumped $CLIENT version to ${{ github.event.inputs.version_number }}" -a
+          git commit -m "Bumped ${CLIENT} version to ${{ github.event.inputs.version_number }}" -a
 
       - name: Push changes
-        run: git push -u origin $CLIENT_version_bump_${{ github.event.inputs.version_number }}
+        run: git push -u origin ${CLIENT}_version_bump_${{ github.event.inputs.version_number }}
 
       - name: Create Bump Version PR
         env:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This fixes the variable substitution for `CLIENT`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/version-bump.yml:** Fixes two spots where `$CLIENT` was not substituted properly.  Changed to `${CLIENT}`.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
