### PR TITLE
[PS-616] [PS-795] Fix/withdraw master password reset without user verification

### DIFF
--- a/apps/web/src/app/accounts/accept-emergency.component.ts
+++ b/apps/web/src/app/accounts/accept-emergency.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
@@ -31,7 +31,7 @@ export class AcceptEmergencyComponent extends BaseAcceptComponent {
     super(router, platformUtilsService, i18nService, route, stateService);
   }
 
-  async authedHandler(qParams: any): Promise<void> {
+  async authedHandler(qParams: Params): Promise<void> {
     const request = new EmergencyAccessAcceptRequest();
     request.token = qParams.token;
     this.actionPromise = this.apiService.postEmergencyAccessAccept(qParams.id, request);
@@ -45,7 +45,7 @@ export class AcceptEmergencyComponent extends BaseAcceptComponent {
     this.router.navigate(["/vault"]);
   }
 
-  async unauthedHandler(qParams: any): Promise<void> {
+  async unauthedHandler(qParams: Params): Promise<void> {
     this.name = qParams.name;
     if (this.name != null) {
       // Fix URL encoding of space issue with Angular

--- a/apps/web/src/app/accounts/accept-organization.component.ts
+++ b/apps/web/src/app/accounts/accept-organization.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
@@ -37,7 +37,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     super(router, platformUtilsService, i18nService, route, stateService);
   }
 
-  async authedHandler(qParams: any): Promise<void> {
+  async authedHandler(qParams: Params): Promise<void> {
     this.actionPromise = this.prepareAcceptRequest(qParams).then(async (request) => {
       await this.apiService.postOrganizationUserAccept(
         qParams.organizationId,
@@ -58,7 +58,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     this.router.navigate(["/vault"]);
   }
 
-  async unauthedHandler(qParams: any): Promise<void> {
+  async unauthedHandler(qParams: Params): Promise<void> {
     this.orgName = qParams.organizationName;
     if (this.orgName != null) {
       // Fix URL encoding of space issue with Angular
@@ -67,7 +67,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     await this.stateService.setOrganizationInvitation(qParams);
   }
 
-  private async prepareAcceptRequest(qParams: any): Promise<OrganizationUserAcceptRequest> {
+  private async prepareAcceptRequest(qParams: Params): Promise<OrganizationUserAcceptRequest> {
     const request = new OrganizationUserAcceptRequest();
     request.token = qParams.token;
 

--- a/apps/web/src/app/common/base.accept.component.ts
+++ b/apps/web/src/app/common/base.accept.component.ts
@@ -1,5 +1,5 @@
 import { Directive, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 import { first } from "rxjs/operators";
 
 import { I18nService } from "jslib-common/abstractions/i18n.service";
@@ -25,8 +25,8 @@ export abstract class BaseAcceptComponent implements OnInit {
     protected stateService: StateService
   ) {}
 
-  abstract authedHandler(qParams: any): Promise<void>;
-  abstract unauthedHandler(qParams: any): Promise<void>;
+  abstract authedHandler(qParams: Params): Promise<void>;
+  abstract unauthedHandler(qParams: Params): Promise<void>;
 
   ngOnInit() {
     this.route.queryParams.pipe(first()).subscribe(async (qParams) => {

--- a/apps/web/src/app/modules/organizations/users/enroll-master-password-reset.component.html
+++ b/apps/web/src/app/modules/organizations/users/enroll-master-password-reset.component.html
@@ -14,7 +14,7 @@
     >
       <div class="modal-header">
         <h2 class="modal-title" id="enrollMasterPasswordResetTitle">
-          {{ (isEnrolled ? "withdrawPasswordReset" : "enrollPasswordReset") | i18n }}
+          {{ "enrollPasswordReset" | i18n }}
         </h2>
         <button
           type="button"
@@ -26,7 +26,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <app-callout type="warning" *ngIf="!isEnrolled">
+        <app-callout type="warning">
           {{ "resetPasswordEnrollmentWarning" | i18n }}
         </app-callout>
         <app-user-verification [(ngModel)]="verification" name="secret"> </app-user-verification>

--- a/apps/web/src/app/modules/organizations/users/enroll-master-password-reset.component.ts
+++ b/apps/web/src/app/modules/organizations/users/enroll-master-password-reset.component.ts
@@ -47,38 +47,27 @@ export class EnrollMasterPasswordReset {
         // Set variables
         let keyString: string = null;
 
-        // Enrolling
-        if (!this.organization.resetPasswordEnrolled) {
-          // Retrieve Public Key
-          const orgKeys = await this.apiService.getOrganizationKeys(this.organization.id);
-          if (orgKeys == null) {
-            throw new Error(this.i18nService.t("resetPasswordOrgKeysError"));
-          }
-
-          const publicKey = Utils.fromB64ToArray(orgKeys.publicKey);
-
-          // RSA Encrypt user's encKey.key with organization public key
-          const encKey = await this.cryptoService.getEncKey();
-          const encryptedKey = await this.cryptoService.rsaEncrypt(encKey.key, publicKey.buffer);
-          keyString = encryptedKey.encryptedString;
-          toastStringRef = "enrollPasswordResetSuccess";
-
-          // Create request and execute enrollment
-          request.resetPasswordKey = keyString;
-          await this.apiService.putOrganizationUserResetPasswordEnrollment(
-            this.organization.id,
-            this.organization.userId,
-            request
-          );
-        } else {
-          // Withdrawal
-          request.resetPasswordKey = keyString;
-          await this.apiService.putOrganizationUserResetPasswordEnrollment(
-            this.organization.id,
-            this.organization.userId,
-            request
-          );
+        // Retrieve Public Key
+        const orgKeys = await this.apiService.getOrganizationKeys(this.organization.id);
+        if (orgKeys == null) {
+          throw new Error(this.i18nService.t("resetPasswordOrgKeysError"));
         }
+
+        const publicKey = Utils.fromB64ToArray(orgKeys.publicKey);
+
+        // RSA Encrypt user's encKey.key with organization public key
+        const encKey = await this.cryptoService.getEncKey();
+        const encryptedKey = await this.cryptoService.rsaEncrypt(encKey.key, publicKey.buffer);
+        keyString = encryptedKey.encryptedString;
+        toastStringRef = "enrollPasswordResetSuccess";
+
+        // Create request and execute enrollment
+        request.resetPasswordKey = keyString;
+        await this.apiService.putOrganizationUserResetPasswordEnrollment(
+          this.organization.id,
+          this.organization.userId,
+          request
+        );
 
         await this.syncService.fullSync(true);
       });
@@ -89,9 +78,5 @@ export class EnrollMasterPasswordReset {
     } catch (e) {
       this.logService.error(e);
     }
-  }
-
-  get isEnrolled(): boolean {
-    return this.organization.resetPasswordEnrolled;
   }
 }

--- a/apps/web/src/app/modules/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/modules/vault-filter/components/organization-options.component.html
@@ -6,7 +6,11 @@
   ></i>
   <span class="sr-only">{{ "loading" | i18n }}</span>
 </ng-container>
-<div *ngIf="loaded" class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col" [appApiAction]="actionPromise">
+<div
+  *ngIf="loaded"
+  class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col"
+  [appApiAction]="actionPromise"
+>
   <button
     *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
     class="dropdown-item"

--- a/apps/web/src/app/modules/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/modules/vault-filter/components/organization-options.component.html
@@ -6,7 +6,7 @@
   ></i>
   <span class="sr-only">{{ "loading" | i18n }}</span>
 </ng-container>
-<div *ngIf="loaded" class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col">
+<div *ngIf="loaded" class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col" [appApiAction]="actionPromise">
   <button
     *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
     class="dropdown-item"

--- a/apps/web/src/app/organizations/sponsorships/accept-family-sponsorship.component.ts
+++ b/apps/web/src/app/organizations/sponsorships/accept-family-sponsorship.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { Params } from "@angular/router";
 
 import { BaseAcceptComponent } from "src/app/common/base.accept.component";
 
@@ -12,11 +13,11 @@ export class AcceptFamilySponsorshipComponent extends BaseAcceptComponent {
 
   requiredParameters = ["email", "token"];
 
-  async authedHandler(qParams: any) {
+  async authedHandler(qParams: Params) {
     this.router.navigate(["/setup/families-for-enterprise"], { queryParams: qParams });
   }
 
-  async unauthedHandler(qParams: any) {
+  async unauthedHandler(qParams: Params) {
     if (!qParams.register) {
       this.router.navigate(["/login"], { queryParams: { email: qParams.email } });
     } else {

--- a/bitwarden_license/bit-web/src/app/providers/manage/accept-provider.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/accept-provider.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
@@ -31,7 +31,7 @@ export class AcceptProviderComponent extends BaseAcceptComponent {
     super(router, platformUtilService, i18nService, route, stateService);
   }
 
-  async authedHandler(qParams: any) {
+  async authedHandler(qParams: Params) {
     const request = new ProviderUserAcceptRequest();
     request.token = qParams.token;
 
@@ -49,7 +49,7 @@ export class AcceptProviderComponent extends BaseAcceptComponent {
     this.router.navigate(["/vault"]);
   }
 
-  async unauthedHandler(qParams: any) {
+  async unauthedHandler(qParams: Params) {
     this.providerName = qParams.providerName;
   }
 }

--- a/bitwarden_license/bit-web/src/app/providers/setup/setup-provider.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/setup/setup-provider.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { Params } from "@angular/router";
 
 import { BaseAcceptComponent } from "src/app/common/base.accept.component";
 
@@ -12,11 +13,11 @@ export class SetupProviderComponent extends BaseAcceptComponent {
 
   requiredParameters = ["providerId", "email", "token"];
 
-  async authedHandler(qParams: any) {
+  async authedHandler(qParams: Params) {
     this.router.navigate(["/providers/setup"], { queryParams: qParams });
   }
 
-  async unauthedHandler(qParams: any) {
+  async unauthedHandler(qParams: Params) {
     // Empty
   }
 }

--- a/libs/common/src/models/request/organizationUserAcceptRequest.ts
+++ b/libs/common/src/models/request/organizationUserAcceptRequest.ts
@@ -1,3 +1,5 @@
 export class OrganizationUserAcceptRequest {
   token: string;
+  // Used to auto-enroll in master password reset
+  resetPasswordKey: string;
 }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes two feature deficiencies with [PS-616] (bitwarden/web#1698). 

1. Withdraw should not require a user verification request
2. Auto enrollment was broken due to all enrollment requiring user verification. This is not possible with the current acceptance flow. [PS-795]

## Code changes
* **accept-organization**: Update accept request to optionally specify a reset password key. This key is required if (and only used if) auto enroll in master password is enabled for the organization. Side benefit of cleaning up this promise flow a bit.
* **enroll-master-password-reset.component**: This modal component now only handles enrollment in MPR. Withdrawing is handled by the organization-options component.
* **organization-options**:
  * use api-action-directive to properly parse and handle api exceptions -- this is used across organization-actions
  * withdraw from MPR instead of spawning a modal. Note: the user verification is used only during enrollment, but validation of the form still occurs server-side, so it cannot be blank.

## Before you submit

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```

[PS-616]: https://bitwarden.atlassian.net/browse/PS-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-795]: https://bitwarden.atlassian.net/browse/PS-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ