### PR TITLE
Add vscode workspace file

### DIFF
--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -31,7 +31,7 @@
         "meteor://💻app/*": "${workspaceFolder}/*",
         "webpack:///./~/*": "${workspaceFolder}/node_modules/*",
         "webpack://?:*/*": "${workspaceFolder}/*",
-        "webpack://@bitwarden/cli/*": "${workspaceFolder}/*"
+        "webpack://@bitwarden/cli/*": "${workspaceFolder}/apps/cli/*"
       }
     }
   }

--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -1,0 +1,38 @@
+{
+	"folders": [
+		{
+			"name": "root",
+			"path": "."
+		},
+		{
+			"name": "web vault",
+			"path": "apps/web"
+		},
+		{
+			"name": "cli",
+			"path": "apps/cli"
+		},
+		{
+			"name": "desktop",
+			"path": "apps/desktop"
+		},
+		{
+			"name": "browser",
+			"path": "apps/browser"
+		},
+		{
+			"name": "libs",
+			"path": "libs"
+		}
+	],
+  "settings": {
+    "debug.javascript.terminalOptions": {
+      "sourceMapPathOverrides": {
+        "meteor://💻app/*": "${workspaceFolder}/*",
+        "webpack:///./~/*": "${workspaceFolder}/node_modules/*",
+        "webpack://?:*/*": "${workspaceFolder}/*",
+        "webpack://@bitwarden/cli/*": "${workspaceFolder}/*"
+      }
+    }
+  }
+}

--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -9,6 +9,10 @@
 			"path": "apps/web"
 		},
 		{
+			"name": "web vault (bit)",
+			"path": "bitwarden_license/bit-web"
+		},
+		{
 			"name": "cli",
 			"path": "apps/cli"
 		},


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Improve the developer experience by providing a preconfigured vscode workspace file, using the [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) feature. This is much better for the monorepo.

Devs should just open this file as a vscode workspace, rather than opening the folder.

Benefits:
* better UI for navigating and searching (see screenshots below)
* required to pick up vscode settings (including debugging settings) without opening app folders individually

I'll update our contributing docs to note this once merged.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
File tree:
![Screen Shot 2022-06-07 at 12 08 40 pm](https://user-images.githubusercontent.com/31796059/172282008-df5b5aba-86a1-4dd2-9a50-f8e938cd0be0.png)

Searching for a file:
![Screen Shot 2022-06-07 at 12 08 57 pm](https://user-images.githubusercontent.com/31796059/172282063-1d802db6-e32c-4dc0-b926-5b4d53692934.png)

Opening a debugging terminal:
![Screen Shot 2022-06-07 at 12 09 12 pm](https://user-images.githubusercontent.com/31796059/172282082-35b3b1e3-1f6a-45ca-988e-f035294731ca.png)

Searching for text:
![Screen Shot 2022-06-07 at 12 13 24 pm](https://user-images.githubusercontent.com/31796059/172282105-8738f296-218f-4c48-8dc6-fbdecf52ebdd.png)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
