### PR TITLE
Adding web to the crowdin pull action

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -19,6 +19,8 @@ jobs:
             crowdin_project_id: "268134"
           - app_name: desktop
             crowdin_project_id: "299360"
+          - app_name: web
+            crowdin_project_id: "308189"
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

After migrating web into the mono-repo this also adds it to the crowdin-pull action

The previous action in web was actually failing for quite a while: https://github.com/bitwarden/web/actions/workflows/crowdin-pull.yml so we should execute the action after review & merge.


## Code changes

- **.github/workflows/crowdin-pull.yml:** Add name and crowdin_project_id crowdin-pull action

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
