### PR TITLE
Add NSIS custom installer script for UAC fix on Windows

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -91,8 +91,9 @@
     "perMachine": false,
     "allowToChangeInstallationDirectory": false,
     "artifactName": "${productName}-Installer-${version}.${ext}",
-    "uninstallDisplayName": "${productName}",
-    "deleteAppDataOnUninstall": true
+    "uninstallDisplayName": "${productName}", 
+    "deleteAppDataOnUninstall": true,
+    "include": "installer.nsh"
   },
   "portable": { "artifactName": "${productName}-Portable-${version}.${ext}" },
   "appx": {

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -1,10 +1,16 @@
 {
-  "extraMetadata": { "name": "bitwarden" },
+  "extraMetadata": {
+    "name": "bitwarden"
+  },
   "productName": "Bitwarden",
   "appId": "com.bitwarden.desktop",
   "buildDependenciesFromSource": true,
   "copyright": "Copyright © 2015-2022 Bitwarden Inc.",
-  "directories": { "buildResources": "resources", "output": "dist", "app": "build" },
+  "directories": {
+    "buildResources": "resources",
+    "output": "dist",
+    "app": "build"
+  },
   "afterSign": "scripts/after-sign.js",
   "asarUnpack": ["**/*.node"],
   "files": ["**/*", "!**/node_modules/@bitwarden/desktop-native/**/*"],
@@ -62,40 +68,67 @@
     "target": ["portable", "nsis-web", "appx"],
     "sign": "./sign.js",
     "extraResources": [
-      { "from": "node_modules/regedit/vbs", "to": "regedit/vbs", "filter": ["**/*"] },
-      { "from": "resources/native-messaging.bat", "to": "native-messaging.bat" }
+      {
+        "from": "node_modules/regedit/vbs",
+        "to": "regedit/vbs",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "resources/native-messaging.bat",
+        "to": "native-messaging.bat"
+      }
     ]
   },
   "linux": {
     "category": "Utility",
     "synopsis": "A secure and free password manager for all of your devices.",
     "target": ["deb", "freebsd", "rpm", "AppImage", "snap"],
-    "desktop": { "Name": "Bitwarden", "Type": "Application", "GenericName": "Password Manager" }
+    "desktop": {
+      "Name": "Bitwarden",
+      "Type": "Application",
+      "GenericName": "Password Manager"
+    }
   },
   "dmg": {
     "icon": "dmg.icns",
     "contents": [
-      { "x": 150, "y": 185, "type": "file" },
-      { "x": 390, "y": 180, "type": "link", "path": "/Applications" }
+      {
+        "x": 150,
+        "y": 185,
+        "type": "file"
+      },
+      {
+        "x": 390,
+        "y": 180,
+        "type": "link",
+        "path": "/Applications"
+      }
     ],
-    "window": { "width": 540, "height": 380 }
+    "window": {
+      "width": 540,
+      "height": 380
+    }
   },
   "mas": {
     "entitlements": "resources/entitlements.mas.plist",
     "entitlementsInherit": "resources/entitlements.mas.inherit.plist",
     "hardenedRuntime": false,
-    "extendInfo": { "LSMinimumSystemVersion": "10.14.0" }
+    "extendInfo": {
+      "LSMinimumSystemVersion": "10.14.0"
+    }
   },
   "nsisWeb": {
     "oneClick": false,
     "perMachine": false,
     "allowToChangeInstallationDirectory": false,
     "artifactName": "${productName}-Installer-${version}.${ext}",
-    "uninstallDisplayName": "${productName}", 
+    "uninstallDisplayName": "${productName}",
     "deleteAppDataOnUninstall": true,
     "include": "installer.nsh"
   },
-  "portable": { "artifactName": "${productName}-Portable-${version}.${ext}" },
+  "portable": {
+    "artifactName": "${productName}-Portable-${version}.${ext}"
+  },
   "appx": {
     "artifactName": "${productName}-${version}-${arch}.${ext}",
     "backgroundColor": "#175DDC",
@@ -112,13 +145,22 @@
   "appImage": {
     "artifactName": "${productName}-${version}-${arch}.${ext}"
   },
-  "rpm": { "artifactName": "${productName}-${version}-${arch}.${ext}" },
-  "freebsd": { "artifactName": "${productName}-${version}-${arch}.${ext}" },
+  "rpm": {
+    "artifactName": "${productName}-${version}-${arch}.${ext}"
+  },
+  "freebsd": {
+    "artifactName": "${productName}-${version}-${arch}.${ext}"
+  },
   "snap": {
     "autoStart": true,
     "confinement": "strict",
     "plugs": ["default", "password-manager-service"],
     "stagePackages": ["default"]
   },
-  "protocols": [{ "name": "Bitwarden", "schemes": ["bitwarden"] }]
+  "protocols": [
+    {
+      "name": "Bitwarden",
+      "schemes": ["bitwarden"]
+    }
+  ]
 }

--- a/apps/desktop/installer.nsh
+++ b/apps/desktop/installer.nsh
@@ -1,0 +1,9 @@
+!macro customInit
+    ${if} $installMode == "all"
+        ${IfNot} ${UAC_IsAdmin}
+            ShowWindow $HWNDPARENT ${SW_HIDE}
+            !insertmacro UAC_RunElevated
+            Quit
+        ${endif}
+    ${endif}
+!macroend


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes our Windows installer from removing Bitwarden and crashing before installing the new version.

Found the fix here: https://github.com/electron-userland/electron-builder/issues/2363#issuecomment-350693134

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/electron-builder.json:** Adds the `include` key to our `nsis` config to specify the custom installer script
- **apps/desktop/installer.nsh:** Custom installer script that fixes the issue of prompting for UAC when Bitwarden is installed for `All Users`

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
