### PR TITLE
[PS-787] Emergency access page UI issues

### DIFF
--- a/apps/web/src/app/settings/emergency-access-add-edit.component.html
+++ b/apps/web/src/app/settings/emergency-access-add-edit.component.html
@@ -101,18 +101,17 @@
       </div>
       <div class="modal-footer">
         <button
-          #submitBtn
           type="submit"
           class="btn btn-primary"
-          [disabled]="loading || submitBtn.loading || readOnly"
+          [disabled]="loading || form.loading || readOnly"
         >
           <i
             class="bwi bwi-spinner bwi-spin"
             title="{{ 'loading' | i18n }}"
             aria-hidden="true"
-            *ngIf="loading || submitBtn.loading"
+            *ngIf="loading || form.loading"
           ></i>
-          <span *ngIf="!loading && !submitBtn.loading">{{ "save" | i18n }}</span>
+          <span *ngIf="!loading && !form.loading">{{ "save" | i18n }}</span>
         </button>
         <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
           {{ "cancel" | i18n }}

--- a/apps/web/src/app/settings/emergency-access-add-edit.component.html
+++ b/apps/web/src/app/settings/emergency-access-add-edit.component.html
@@ -120,7 +120,7 @@
         <div class="ml-auto">
           <button
             #deleteBtn
-            bitButton 
+            bitButton
             buttonType="danger"
             type="button"
             (click)="delete()"

--- a/apps/web/src/app/settings/emergency-access-add-edit.component.html
+++ b/apps/web/src/app/settings/emergency-access-add-edit.component.html
@@ -101,8 +101,9 @@
       </div>
       <div class="modal-footer">
         <button
+          bitButton
           type="submit"
-          class="btn btn-primary"
+          buttonType="primary"
           [disabled]="loading || form.loading || readOnly"
         >
           <i
@@ -113,15 +114,16 @@
           ></i>
           <span *ngIf="!loading && !form.loading">{{ "save" | i18n }}</span>
         </button>
-        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+        <button bitButton buttonType="secondary" type="button" data-dismiss="modal">
           {{ "cancel" | i18n }}
         </button>
         <div class="ml-auto">
           <button
             #deleteBtn
+            bitButton 
+            buttonType="danger"
             type="button"
             (click)="delete()"
-            class="btn btn-outline-danger"
             appA11yTitle="{{ 'delete' | i18n }}"
             *ngIf="editMode"
             [disabled]="deleteBtn.loading"

--- a/apps/web/src/app/settings/emergency-access.component.html
+++ b/apps/web/src/app/settings/emergency-access.component.html
@@ -140,7 +140,17 @@
   </tbody>
 </table>
 
-<p *ngIf="!trustedContacts || !trustedContacts.length">{{ "noTrustedContacts" | i18n }}</p>
+<ng-container *ngIf="!trustedContacts || !trustedContacts.length">
+  <p *ngIf="loaded">{{ "noTrustedContacts" | i18n }}</p>
+  <ng-container *ngIf="!loaded">
+    <i
+      class="bwi bwi-spinner bwi-spin text-muted"
+      title="{{ 'loading' | i18n }}"
+      aria-hidden="true"
+    ></i>
+    <span class="sr-only">{{ "loading" | i18n }}</span>
+  </ng-container>
+</ng-container>
 
 <div class="page-header spaced-header">
   <h2>{{ "designatedEmergencyContacts" | i18n }}</h2>
@@ -247,7 +257,17 @@
   </tbody>
 </table>
 
-<p *ngIf="!grantedContacts || !grantedContacts.length">{{ "noGrantedAccess" | i18n }}</p>
+<ng-container *ngIf="!grantedContacts || !grantedContacts.length">
+  <p *ngIf="loaded">{{ "noGrantedAccess" | i18n }}</p>
+  <ng-container *ngIf="!loaded">
+    <i
+      class="bwi bwi-spinner bwi-spin text-muted"
+      title="{{ 'loading' | i18n }}"
+      aria-hidden="true"
+    ></i>
+    <span class="sr-only">{{ "loading" | i18n }}</span>
+  </ng-container>
+</ng-container>
 
 <ng-template #addEdit></ng-template>
 <ng-template #takeoverTemplate></ng-template>

--- a/apps/web/src/app/settings/emergency-access.component.html
+++ b/apps/web/src/app/settings/emergency-access.component.html
@@ -74,67 +74,55 @@
         <small class="text-muted d-block" *ngIf="c.name">{{ c.name }}</small>
       </td>
       <td class="table-list-options">
-        <div class="dropdown" appListDropdown>
+        <button
+          [bitMenuTriggerFor]="trustedContactOptions"
+          class="tw-border-none tw-bg-transparent tw-text-main"
+          type="button"
+          appA11yTitle="{{ 'options' | i18n }}"
+        >
+          <i class="bwi bwi-ellipsis-v bwi-lg" aria-hidden="true"></i>
+        </button>
+        <bit-menu #trustedContactOptions>
           <button
-            class="btn btn-outline-secondary dropdown-toggle"
-            type="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-            appA11yTitle="{{ 'options' | i18n }}"
+            bitMenuItem
+            *ngIf="c.status === emergencyAccessStatusType.Invited"
+            (click)="reinvite(c)"
           >
-            <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
+            <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
+            {{ "resendInvitation" | i18n }}
           </button>
-          <div class="dropdown-menu dropdown-menu-right">
-            <a
-              class="dropdown-item"
-              href="#"
-              appStopClick
-              (click)="reinvite(c)"
-              *ngIf="c.status === emergencyAccessStatusType.Invited"
-            >
-              <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
-              {{ "resendInvitation" | i18n }}
-            </a>
-            <a
-              class="dropdown-item text-success"
-              href="#"
-              appStopClick
-              (click)="confirm(c)"
-              *ngIf="c.status === emergencyAccessStatusType.Accepted"
-            >
-              <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
-              {{ "confirm" | i18n }}
-            </a>
-            <a
-              class="dropdown-item text-success"
-              href="#"
-              appStopClick
-              (click)="approve(c)"
-              *ngIf="c.status === emergencyAccessStatusType.RecoveryInitiated"
-            >
-              <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
-              {{ "approve" | i18n }}
-            </a>
-            <a
-              class="dropdown-item text-warning"
-              href="#"
-              appStopClick
-              (click)="reject(c)"
-              *ngIf="
-                c.status === emergencyAccessStatusType.RecoveryInitiated ||
-                c.status === emergencyAccessStatusType.RecoveryApproved
-              "
-            >
-              <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
-              {{ "reject" | i18n }}
-            </a>
-            <a class="dropdown-item text-danger" href="#" appStopClick (click)="remove(c)">
-              <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
-              {{ "remove" | i18n }}
-            </a>
-          </div>
-        </div>
+          <button
+            bitMenuItem
+            *ngIf="c.status === emergencyAccessStatusType.Accepted"
+            (click)="confirm(c)"
+          >
+            <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
+            {{ "confirm" | i18n }}
+          </button>
+          <button
+            bitMenuItem
+            *ngIf="c.status === emergencyAccessStatusType.RecoveryInitiated"
+            (click)="approve(c)"
+          >
+            <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
+            {{ "approve" | i18n }}
+          </button>
+          <button
+            bitMenuItem
+            *ngIf="
+              c.status === emergencyAccessStatusType.RecoveryInitiated ||
+              c.status === emergencyAccessStatusType.RecoveryApproved
+            "
+            (click)="reject(c)"
+          >
+            <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
+            {{ "reject" | i18n }}
+          </button>
+          <button bitMenuItem (click)="remove(c)">
+            <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
+            {{ "remove" | i18n }}
+          </button>
+        </bit-menu>
       </td>
     </tr>
   </tbody>
@@ -200,58 +188,50 @@
         <small class="text-muted d-block" *ngIf="c.name">{{ c.name }}</small>
       </td>
       <td class="table-list-options">
-        <div class="dropdown" appListDropdown>
+        <button
+          [bitMenuTriggerFor]="grantedContactOptions"
+          class="tw-border-none tw-bg-transparent tw-text-main"
+          type="button"
+          appA11yTitle="{{ 'options' | i18n }}"
+        >
+          <i class="bwi bwi-ellipsis-v bwi-lg" aria-hidden="true"></i>
+        </button>
+        <bit-menu #grantedContactOptions>
           <button
-            class="btn btn-outline-secondary dropdown-toggle"
-            type="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-            appA11yTitle="{{ 'options' | i18n }}"
+            bitMenuItem
+            *ngIf="c.status === emergencyAccessStatusType.Confirmed"
+            (click)="requestAccess(c)"
           >
-            <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
+            <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
+            {{ "requestAccess" | i18n }}
           </button>
-          <div class="dropdown-menu dropdown-menu-right">
-            <a
-              class="dropdown-item"
-              href="#"
-              appStopClick
-              (click)="requestAccess(c)"
-              *ngIf="c.status === emergencyAccessStatusType.Confirmed"
-            >
-              <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
-              {{ "requestAccess" | i18n }}
-            </a>
-            <a
-              class="dropdown-item"
-              href="#"
-              appStopClick
-              (click)="takeover(c)"
-              *ngIf="
-                c.status === emergencyAccessStatusType.RecoveryApproved &&
-                c.type === emergencyAccessType.Takeover
-              "
-            >
-              <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
-              {{ "takeover" | i18n }}
-            </a>
-            <a
-              class="dropdown-item"
-              [routerLink]="c.id"
-              *ngIf="
-                c.status === emergencyAccessStatusType.RecoveryApproved &&
-                c.type === emergencyAccessType.View
-              "
-            >
-              <i class="bwi bwi-fw bwi-eye" aria-hidden="true"></i>
-              {{ "view" | i18n }}
-            </a>
-            <a class="dropdown-item text-danger" href="#" appStopClick (click)="remove(c)">
-              <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
-              {{ "remove" | i18n }}
-            </a>
-          </div>
-        </div>
+          <button
+            bitMenuItem
+            *ngIf="
+              c.status === emergencyAccessStatusType.RecoveryApproved &&
+              c.type === emergencyAccessType.Takeover
+            "
+            (click)="takeover(c)"
+          >
+            <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
+            {{ "takeover" | i18n }}
+          </button>
+          <button
+            bitMenuItem
+            *ngIf="
+              c.status === emergencyAccessStatusType.RecoveryApproved &&
+              c.type === emergencyAccessType.View
+            "
+            [routerLink]="c.id"
+          >
+            <i class="bwi bwi-fw bwi-eye" aria-hidden="true"></i>
+            {{ "view" | i18n }}
+          </button>
+          <button bitMenuItem (click)="remove(c)">
+            <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
+            {{ "remove" | i18n }}
+          </button>
+        </bit-menu>
       </td>
     </tr>
   </tbody>

--- a/apps/web/src/app/settings/emergency-access.component.ts
+++ b/apps/web/src/app/settings/emergency-access.component.ts
@@ -34,6 +34,7 @@ export class EmergencyAccessComponent implements OnInit {
   @ViewChild("confirmTemplate", { read: ViewContainerRef, static: true })
   confirmModalRef: ViewContainerRef;
 
+  loaded = false;
   canAccessPremium: boolean;
   trustedContacts: EmergencyAccessGranteeDetailsResponse[];
   grantedContacts: EmergencyAccessGrantorDetailsResponse[];
@@ -65,6 +66,7 @@ export class EmergencyAccessComponent implements OnInit {
   async load() {
     this.trustedContacts = (await this.apiService.getEmergencyAccessTrusted()).data;
     this.grantedContacts = (await this.apiService.getEmergencyAccessGranted()).data;
+    this.loaded = true;
   }
 
   async premiumRequired() {


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The emergency access page was missing some UX candy (spinners/disabled buttons) and was using the old-style options menu for managing contacts.

## Code changes

* **emergency-access-add-edit.component.html:** Fix the modal to reference the `form.loading` flag instead of the submit button so that the save button is properly disabled during network communication.

* **emergency-access.component.html:** Use the new `<bit-menu />` component for the options menu and add spinners for both trusted and granted contacts while they are loading.

* **emergency-access.component.ts:** Add a `loaded` flag for spinners in the template.

## Screenshots

![Trusted Contacts](https://user-images.githubusercontent.com/8764515/172683379-23a10f46-b8c5-4bdd-a933-d798cf7e1852.png)
![D](https://user-images.githubusercontent.com/8764515/172683588-74bc4c64-f702-42a7-a1ad-024e45819508.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
