### PR TITLE
Fix Browser Source Code Artifact

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -144,19 +144,23 @@ jobs:
       - name: Build sources for reviewers
         shell: cmd
         run: |
-          mkdir dist\Source
-          mkdir clients
-          call git clone %GITHUB_SERVER_URL%/%GITHUB_REPOSITORY% clients
-          cd clients
-          call git checkout %GITHUB_SHA%
-          call git submodule update --init --recursive
-          cd ..\
-          rmdir /S /Q "clients\.git"
-          copy clients\* dist\Source
-          mkdir dist\Source\apps\browser
-          xcopy clients\apps\browser\* dist\Source\apps\browser /E
-          cd dist
-          call 7z a browser-source.zip "Source\*"
+          REM Remove ".git" directory
+          rmdir /S /Q ".git"
+
+          REM Copy root level files to source directory
+          mkdir browser-source
+          copy * browser-source
+
+          REM Copy apps\browser to Browser source directory
+          mkdir browser-source\apps\browser
+          xcopy apps\browser\* browser-source\apps\browser /E
+          
+          REM Copy libs to Browser source directory
+          mkdir browser-source\libs
+          xcopy libs\* browser-source\libs /E
+
+          call 7z a browser-source.zip "browser-source\*"
+        working-directory: ./
 
       - name: Upload Opera artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
@@ -190,7 +194,7 @@ jobs:
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
         with:
           name: browser-source-${{ env._BUILD_NUMBER }}.zip
-          path: apps/browser/dist/browser-source.zip
+          path: browser-source.zip
           if-no-files-found: error
 
       - name: Upload coverage artifact

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846  # v3.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a  # v3.0.0
+        uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd  # v3.3.0
         with:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
@@ -213,7 +213,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846  # v3.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a  # v3.0.0
+        uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd  # v3.3.0
         with:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -151,11 +151,12 @@ jobs:
           call git checkout %GITHUB_SHA%
           call git submodule update --init --recursive
           cd ..\
-          del /S/Q "clients\.git\objects\pack\*"
+          rmdir /S /Q "clients\.git"
           copy clients\* dist\Source
           mkdir dist\Source\apps\browser
           xcopy clients\apps\browser\* dist\Source\apps\browser /E
-          call 7z a browser-source.zip "dist\Source\*"
+          cd dist
+          call 7z a browser-source.zip "Source\*"
 
       - name: Upload Opera artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -144,18 +144,18 @@ jobs:
       - name: Build sources for reviewers
         shell: cmd
         run: |
-          mkdir Source
+          mkdir dist\Source
           mkdir clients
           call git clone %GITHUB_SERVER_URL%/%GITHUB_REPOSITORY% clients
           cd clients
           call git checkout %GITHUB_SHA%
           call git submodule update --init --recursive
-          cd ../
+          cd ..\
           del /S/Q "clients\.git\objects\pack\*"
-          copy clients\* Source
-          mkdir Source\apps\browser
-          xcopy clients\apps\browser\* Source\apps\browser /E
-          call 7z a browser-source.zip "Source\*"
+          copy clients\* dist\Source
+          mkdir dist\Source\apps\browser
+          xcopy clients\apps\browser\* dist\Source\apps\browser /E
+          call 7z a browser-source.zip "dist\Source\*"
 
       - name: Upload Opera artifact
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -152,7 +152,9 @@ jobs:
           call git submodule update --init --recursive
           cd ../
           del /S/Q "clients\.git\objects\pack\*"
-          xcopy clients\* Source /E
+          copy clients\* Source
+          mkdir Source\apps\browser
+          xcopy clients\apps\browser\* Source\apps\browser /E
           call 7z a browser-source.zip "Source\*"
 
       - name: Upload Opera artifact

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -144,13 +144,15 @@ jobs:
       - name: Build sources for reviewers
         shell: cmd
         run: |
-          mkdir dist\Source
-          call git clone %GITHUB_SERVER_URL%/%GITHUB_REPOSITORY% dist\Source
-          cd dist\Source
+          mkdir Source
+          mkdir clients
+          call git clone %GITHUB_SERVER_URL%/%GITHUB_REPOSITORY% clients
+          cd clients
           call git checkout %GITHUB_SHA%
           call git submodule update --init --recursive
           cd ../
-          del /S/Q "Source\.git\objects\pack\*"
+          del /S/Q "clients\.git\objects\pack\*"
+          xcopy clients\* Source /E
           call 7z a browser-source.zip "Source\*"
 
       - name: Upload Opera artifact


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the Browser Source Code artifact to only contain the source code for the `browser` client.  Currently it contained `browser` and `desktop`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build-browser.yml:** Added logic to copy only the `browser` source to the `browser-source.zip` artifact.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
```
