### PR TITLE
Add root config files to trigger build workflows

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'apps/browser/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-browser.yml'
   push:
     branches:
@@ -18,6 +25,13 @@ on:
     paths:
       - 'apps/browser/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-browser.yml'
   workflow_dispatch:
     inputs: {}

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -9,14 +9,9 @@ on:
     paths:
       - 'apps/browser/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
-      - '.github/workflows/build-browser.yml'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
   push:
     branches:
       - 'master'
@@ -25,13 +20,9 @@ on:
     paths:
       - 'apps/browser/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-browser.yml'
   workflow_dispatch:
     inputs: {}

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'apps/cli/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-cli.yml'
   push:
     branches:
@@ -18,6 +25,13 @@ on:
     paths:
       - 'apps/cli/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-cli.yml'
   workflow_dispatch:
     inputs: {}
@@ -84,7 +98,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
           node-version: '16'
-      
+
       - name: Install node-gyp
         run: |
           npm install -g node-gyp

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -9,13 +9,9 @@ on:
     paths:
       - 'apps/cli/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-cli.yml'
   push:
     branches:
@@ -25,13 +21,9 @@ on:
     paths:
       - 'apps/cli/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-cli.yml'
   workflow_dispatch:
     inputs: {}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -8,14 +8,9 @@ on:
       - 'gh-pages'
     paths:
       - 'apps/desktop/**'
-      - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-desktop.yml'
   push:
     branches:
@@ -25,13 +20,9 @@ on:
     paths:
       - 'apps/desktop/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-desktop.yml'
   workflow_dispatch:
     inputs: {}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'apps/desktop/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-desktop.yml'
   push:
     branches:
@@ -18,6 +25,13 @@ on:
     paths:
       - 'apps/desktop/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-desktop.yml'
   workflow_dispatch:
     inputs: {}

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'apps/web/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-web.yml'
   push:
     branches:
@@ -18,6 +25,13 @@ on:
     paths:
       - 'apps/web/**'
       - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintignore'
+      - '.eslintrc.json'
+      - '.nvmrc'
+      - '.prettierignore'
+      - '.prettierrc.json'
       - '.github/workflows/build-web.yml'
   workflow_dispatch:
     inputs: {}
@@ -394,7 +408,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
-          CROWDIN_PROJECT_ID: "308189"          
+          CROWDIN_PROJECT_ID: "308189"
         with:
           config: apps/web/crowdin.yml
           crowdin_branch_name: master

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -9,13 +9,9 @@ on:
     paths:
       - 'apps/web/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-web.yml'
   push:
     branches:
@@ -25,13 +21,9 @@ on:
     paths:
       - 'apps/web/**'
       - 'libs/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.eslintignore'
-      - '.eslintrc.json'
-      - '.nvmrc'
-      - '.prettierignore'
-      - '.prettierrc.json'
+      - '*'
+      - '!*.md'
+      - '!*.txt'
       - '.github/workflows/build-web.yml'
   workflow_dispatch:
     inputs: {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add root config files to trigger builds for all of the clients.

## Code changes

- **.github/workflows/build-browser.yml**: Update both pull_request and push trigger paths to include all files from the root directory except for the`.md` and `.txt` ones.
- **.github/workflows/build-cli.yml**: Update both pull_request and push trigger paths to include all files from the root directory except for the`.md` and `.txt` ones.
- **.github/workflows/build-desktop.yml**: Update both pull_request and push trigger paths to include all files from the root directory except for the`.md` and `.txt` ones.
- **.github/workflows/build-web.yml**: Update both pull_request and push trigger paths to include all files from the root directory except for the`.md` and `.txt` ones.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
```
