### PR TITLE
[PS-788] - Item links use `cipherId` in query string

### DIFF
--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -7,7 +7,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 import { first } from "rxjs/operators";
 
 import { VaultFilter } from "jslib-angular/modules/vault-filter/models/vault-filter.model";
@@ -23,7 +23,6 @@ import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.se
 import { StateService } from "jslib-common/abstractions/state.service";
 import { SyncService } from "jslib-common/abstractions/sync.service";
 import { TokenService } from "jslib-common/abstractions/token.service";
-import { CipherType } from "jslib-common/enums/cipherType";
 import { CipherView } from "jslib-common/models/view/cipherView";
 
 import { UpdateKeyComponent } from "../../../../settings/update-key.component";
@@ -109,9 +108,11 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       this.filterComponent.reloadOrganizations();
       this.showUpdateKey = !(await this.cryptoService.hasEncKey());
 
-      if (params.cipherId) {
+      const cipherId = getCipherIdFromParams(params);
+
+      if (cipherId) {
         const cipherView = new CipherView();
-        cipherView.id = params.cipherId;
+        cipherView.id = cipherId;
         if (params.action === "clone") {
           await this.cloneCipher(cipherView);
         } else if (params.action === "edit") {
@@ -121,9 +122,10 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       await this.ciphersComponent.reload();
 
       this.route.queryParams.subscribe(async (params) => {
-        if (params.cipherId) {
-          if ((await this.cipherService.get(params.cipherId)) != null) {
-            this.editCipherId(params.cipherId);
+        const cipherId = getCipherIdFromParams(params);
+        if (cipherId) {
+          if ((await this.cipherService.get(cipherId)) != null) {
+            this.editCipherId(cipherId);
           } else {
             this.platformUtilsService.showToast(
               "error",
@@ -131,7 +133,7 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
               this.i18nService.t("unknownCipher")
             );
             this.router.navigate([], {
-              queryParams: { cipherId: null },
+              queryParams: { itemId: null, cipherId: null },
               queryParamsHandling: "merge",
             });
           }
@@ -353,7 +355,7 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
     const cipher = await this.cipherService.get(id);
     if (cipher != null && cipher.reprompt != 0) {
       if (!(await this.passwordRepromptService.showPasswordPrompt())) {
-        this.go({ cipherId: null });
+        this.go({ cipherId: null, itemId: null });
         return;
       }
     }
@@ -379,7 +381,7 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
     );
 
     modal.onClosedPromise().then(() => {
-      this.go({ cipherId: null });
+      this.go({ cipherId: null, itemId: null });
     });
 
     return childComponent;
@@ -412,4 +414,12 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       replaceUrl: true,
     });
   }
+}
+
+/**
+ * Allows backwards compatibility with 
+ * old links that used the original `cipherId` param
+ */
+ const getCipherIdFromParams = (params: Params): string => {
+  return params['itemId'] || params['cipherId'];
 }

--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -417,9 +417,9 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
 }
 
 /**
- * Allows backwards compatibility with 
+ * Allows backwards compatibility with
  * old links that used the original `cipherId` param
  */
- const getCipherIdFromParams = (params: Params): string => {
-  return params['itemId'] || params['cipherId'];
-}
+const getCipherIdFromParams = (params: Params): string => {
+  return params["itemId"] || params["cipherId"];
+};

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -351,9 +351,9 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
 }
 
 /**
- * Allows backwards compatibility with 
+ * Allows backwards compatibility with
  * old links that used the original `cipherId` param
  */
- const getCipherIdFromParams = (params: Params): string => {
-  return params['itemId'] || params['cipherId'];
-}
+const getCipherIdFromParams = (params: Params): string => {
+  return params["itemId"] || params["cipherId"];
+};

--- a/apps/web/src/app/organizations/guards/permissions.guard.ts
+++ b/apps/web/src/app/organizations/guards/permissions.guard.ts
@@ -41,10 +41,11 @@ export class PermissionsGuard implements CanActivate {
     if (permissions != null && !org.hasAnyPermission(permissions)) {
       // Handle linkable ciphers for organizations the user only has view access to
       // https://bitwarden.atlassian.net/browse/EC-203
-      if (state.root.queryParamMap.has("cipherId")) {
+      const cipherId = state.root.queryParamMap.get("itemId") || state.root.queryParamMap.get("cipherId");
+      if (cipherId) {
         return this.router.createUrlTree(["/vault"], {
           queryParams: {
-            cipherId: state.root.queryParamMap.get("cipherId"),
+            itemId: cipherId,
           },
         });
       }

--- a/apps/web/src/app/organizations/guards/permissions.guard.ts
+++ b/apps/web/src/app/organizations/guards/permissions.guard.ts
@@ -41,7 +41,8 @@ export class PermissionsGuard implements CanActivate {
     if (permissions != null && !org.hasAnyPermission(permissions)) {
       // Handle linkable ciphers for organizations the user only has view access to
       // https://bitwarden.atlassian.net/browse/EC-203
-      const cipherId = state.root.queryParamMap.get("itemId") || state.root.queryParamMap.get("cipherId");
+      const cipherId =
+        state.root.queryParamMap.get("itemId") || state.root.queryParamMap.get("cipherId");
       if (cipherId) {
         return this.router.createUrlTree(["/vault"], {
           queryParams: {

--- a/apps/web/src/app/vault/ciphers.component.html
+++ b/apps/web/src/app/vault/ciphers.component.html
@@ -19,7 +19,7 @@
           <a
             appStopProp
             [routerLink]="[]"
-            [queryParams]="{ cipherId: c.id }"
+            [queryParams]="{ itemId: c.id }"
             queryParamsHandling="merge"
             title="{{ 'editItem' | i18n }}"
             >{{ c.name }}</a


### PR DESCRIPTION
## Type of change


- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other


## Objective

Changes the query parameter for linkable ciphers in Web Vault to use `itemId` instead of `cipherId` to avoid using "cipher" terminology in front of end users. Also maintains backwards compatibility for any `cipherId` links that are already in use.

Direct links to ciphers will now look like:  `https://vault.bitwarden.com/#/vault?itemId={GUID}`

## Code changes

- **individual-vault.component.ts:** Add small helper function to retrieve cipherId from either `itemId` or `cipherId` query parameters.
- **organization-vault.component.ts:** Add small helper function to retrieve cipherId from either `itemId` or `cipherId` query parameters.
- **permissions.guard.ts:** Check for both `cipherId` and `itemId` query parameters when direct linking to an organization's cipher.
- **ciphers.component.ts:** Use `itemId` instead of `cipherId` when clicking on ciphers in the vault.

## Before you submit


- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

