### PR TITLE
[SG-383] Fix ‘No Folder’ filter showing everything

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -583,7 +583,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         cipherPassesFilter = cipher.type === this.activeFilter.cipherType;
       }
       if (
-        this.activeFilter.selectedFolderId != null &&
+        this.activeFilter.selectedFolder &&
         this.activeFilter.selectedFolderId != "none" &&
         cipherPassesFilter
       ) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes 'No Folder' showing all items in Desktop

## Code changes



- **apps/desktop/src/app/vault/vault.component.ts:** Fix folder condition check that was flagging all as passing the vault filter because the 'No Folder' selection does not have a folder id and we need to rely on the `selectedFolder` property to determine this properly.

## Screenshots
Showing that Desktop and Web show the same items for the No Folder selection 
![Screen Shot 2022-06-10 at 5 03 56 PM](https://user-images.githubusercontent.com/8926729/173151120-5b0d92e8-991a-403c-96aa-6e15d49aaf37.png)

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
