### PR TITLE
[fix] Organization filter list expansion on badge click

### DIFF
--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -190,8 +190,8 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       this.activeFilter.myVaultOnly = true;
     } else {
       this.activeFilter.selectedOrganizationId = orgId;
-      await this.vaultFilterService.ensureVaultFiltersAreExpanded();
     }
+    await this.vaultFilterService.ensureVaultFiltersAreExpanded();
     await this.applyVaultFilter(this.activeFilter);
   }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-293?focusedCommentId=13459&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13459

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In the ciphers list we show a badge for organization ownership that can be clicked to filter the vault by the organization in question. This expansion does not work for items labeled "Me". Clicking these badges filters by "My Vault" but doesn't expand the filter list.

This commit corrects this behavior so the "Me" badges expand the organization filters when clicked. It does so by simply moving the line that checks for filter expansion out of a conditional that expects an organization, and instead does it any time an organization filter is changed.

## Code changes
* Move the `VaultFilterService.ensureVaultFiltersAreExpanded()` reference in `IndividualVaultComponent.applyOrganizationFilter()` out of the conditional that requires an `organizationId`
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

## Screenshots
https://user-images.githubusercontent.com/15897251/173424392-f06b9523-c3d9-47cd-b043-3689700aa4c4.mov

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
