### PR TITLE
Bug/badge forecolour fix

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -771,7 +771,7 @@ export default class MainBackground {
     this.actionSetBadgeBackgroundColor(chrome.browserAction);
     this.actionSetBadgeTextColor(chrome.browserAction);
 	
-	this.actionSetBadgeBackgroundColor(this.sidebarAction);
+    this.actionSetBadgeBackgroundColor(this.sidebarAction);
     
 
     this.menuOptionsLoaded = [];

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -769,7 +769,10 @@ export default class MainBackground {
     }
 
     this.actionSetBadgeBackgroundColor(chrome.browserAction);
-    this.actionSetBadgeBackgroundColor(this.sidebarAction);
+    this.actionSetBadgeTextColor(chrome.browserAction);
+	
+	this.actionSetBadgeBackgroundColor(this.sidebarAction);
+    
 
     this.menuOptionsLoaded = [];
     const authStatus = await this.authService.getAuthStatus();
@@ -988,6 +991,12 @@ export default class MainBackground {
   private actionSetBadgeBackgroundColor(action: any) {
     if (action && action.setBadgeBackgroundColor) {
       action.setBadgeBackgroundColor({ color: "#294e5f" });
+    }
+  }
+  
+  private actionSetBadgeTextColor(action: any) {
+    if (action && action.setBadgeTextColor) {
+      action.setBadgeTextColor({ color: "#fff" });
     }
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The plugin currently takes the accent colour of the operating system as the forecolor for the badge text. Thus if you're running under a dark theme / accent, the badge becomes hard to read.

Forcing the text to be always white fixes the problem in both light and dark themes / accents.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/background/main.background.ts:** Added a method to change the badge text colour and call it when we load the UI.

## Screenshots
Old:
![image](https://user-images.githubusercontent.com/21192520/173431169-f93e3539-7f34-4dde-9a6a-a07ef348ff74.png)

New:
![image](https://user-images.githubusercontent.com/21192520/173431565-1b138208-42f6-49fc-b83f-fd2536617e80.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
