### PR TITLE
[EC-241] Fix Manage SSO navigation permissions

### DIFF
--- a/apps/web/src/app/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/organizations/layouts/organization-layout.component.ts
@@ -83,6 +83,9 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
       case this.organization.canManagePolicies:
         route = "manage/policies";
         break;
+      case this.organization.canManageSso:
+        route = "manage/sso";
+        break;
       case this.organization.canAccessEventLogs:
         route = "manage/events";
         break;

--- a/apps/web/src/app/organizations/services/navigation-permissions.service.ts
+++ b/apps/web/src/app/organizations/services/navigation-permissions.service.ts
@@ -12,6 +12,7 @@ const permissions = {
     Permissions.ManageGroups,
     Permissions.ManageUsers,
     Permissions.ManagePolicies,
+    Permissions.ManageSso,
   ],
   tools: [Permissions.AccessImportExport, Permissions.AccessReports],
   settings: [Permissions.ManageOrganization],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
A user with the Manage SSO custom permission cannot access the org admin page.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/services/navigation-permissions.service.ts** - add the `ManageSso` permission to the array of permissions that get access to the "Manage" tab (and therefore the Organization admin view)
- **apps/web/src/app/organizations/layouts/organization-layout.component.ts** - add the manage SSO route to the `manageRoute()` getter. This determines which sub-page to navigate the user to when they click the Manage tab.

More work needs to be done to refactor these permissions, but this will be cherry-picked to `rc`, so I don't intend to do it here.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
