### PR TITLE
[EC-135] Skip decryption of provider-encrypted org keys in CLI

### DIFF
--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -65,7 +65,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     });
 
     // Convert provider encrypted keys to user encrypted.
-    // If a user logs in with CLI using their api key, the key may not be available to complete these operations.
+    // If a user logs in with CLI using their api key, the Master Key may not be available to complete these operations.
     // However, in this case we can skip this step because provider org items are not accessible via the CLI anyway
     if (await this.hasKey()) {
       for (const providerOrg of providerOrgs) {
@@ -73,6 +73,8 @@ export class CryptoService implements CryptoServiceAbstraction {
         const decValue = await this.decryptToBytes(new EncString(providerOrg.key), providerKey);
         orgKeys[providerOrg.id] = (await this.rsaEncrypt(decValue)).encryptedString;
       }
+    } else {
+      this.logService.info("Master key not available, skipping decryption of provider items.");
     }
 
     await this.stateService.setDecryptedOrganizationKeys(null);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix:
> If you log into CLI as a provider user (with at least 1 client org), using --apikey, the initial sync fails silently and you don't get your sync data.
>
>This is because we try to decrypt provider-encrypted organization keys too early (as part of the sync) before the user has entered their MP. Without the MP, we don’t have the user’s key available, and the required decryption operations cannot be completed.
>
>We need to defer decryption of the provider-encrypted org keys until later, when org keys are normally decrypted.

After writing a fix that did just that, I realised that it doesn't matter - because the CLI only syncs regular vault data, i.e. items associated with the user. It doesn't hit the admin endpoints required to get all organization items (those are only used by the admin pages in web).

So, a much simpler solution is just to skip decryption of provider-encrypted org keys altogether if the user's Master Key is not available - which _should_ only occur if the user is logging in with their api key. The risk here is that this could silently skip this step in some other unforeseen case, so I've added logging just in case; but it seemed like a reasonable assumption.

The original solution is available [on this branch](https://github.com/bitwarden/clients/compare/fix/provider-org-decryption). It delays decrypting provider-encrypted org keys until the user actually goes to access them. It's a more robust solution in some ways, because in principle, we shouldn't need a decrypted vault to sync data. But it also seems like overkill, and I'm not sure it's worth the risk of regressions when we can have this very short & simple fix. I'm really not sure - open to feedback here. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/services/crypto.service.ts** - skip decrypting provider-encrypted org keys if the user's master key is not available (indicating an `--apikey` login).

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
