### PR TITLE
[fix] Force send attachment to always download and never open

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -14,6 +14,7 @@ import { CryptoFunctionService } from "jslib-common/abstractions/cryptoFunction.
 import { EnvironmentService } from "jslib-common/abstractions/environment.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { FileUploadService } from "jslib-common/abstractions/fileUpload.service";
 import { FolderService } from "jslib-common/abstractions/folder.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
@@ -47,6 +48,7 @@ import MainBackground from "../../background/main.background";
 import { BrowserApi } from "../../browser/browserApi";
 import { AutofillService } from "../../services/abstractions/autofill.service";
 import { StateService as StateServiceAbstraction } from "../../services/abstractions/state.service";
+import { BrowserFileDownloadService } from "../../services/browserFileDownloadService";
 import BrowserMessagingService from "../../services/browserMessaging.service";
 import BrowserMessagingPrivateModePopupService from "../../services/browserMessagingPrivateModePopup.service";
 import { VaultFilterService } from "../../services/vaultFilter.service";
@@ -263,6 +265,10 @@ function getBgService<T>(service: keyof MainBackground) {
       provide: BaseStateServiceAbstraction,
       useExisting: StateServiceAbstraction,
       deps: [],
+    },
+    {
+      provide: FileDownloadService,
+      useClass: BrowserFileDownloadService,
     },
   ],
 })

--- a/apps/browser/src/popup/settings/export.component.ts
+++ b/apps/browser/src/popup/settings/export.component.ts
@@ -6,6 +6,7 @@ import { ExportComponent as BaseExportComponent } from "jslib-angular/components
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -27,7 +28,8 @@ export class ExportComponent extends BaseExportComponent {
     private router: Router,
     logService: LogService,
     userVerificationService: UserVerificationService,
-    formBuilder: FormBuilder
+    formBuilder: FormBuilder,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cryptoService,
@@ -39,7 +41,8 @@ export class ExportComponent extends BaseExportComponent {
       window,
       logService,
       userVerificationService,
-      formBuilder
+      formBuilder,
+      fileDownloadService
     );
   }
 

--- a/apps/browser/src/popup/vault/attachments.component.ts
+++ b/apps/browser/src/popup/vault/attachments.component.ts
@@ -7,6 +7,7 @@ import { AttachmentsComponent as BaseAttachmentsComponent } from "jslib-angular/
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -28,7 +29,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     private location: Location,
     private route: ActivatedRoute,
     stateService: StateService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -38,7 +40,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
       apiService,
       window,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
 

--- a/apps/browser/src/popup/vault/view.component.ts
+++ b/apps/browser/src/popup/vault/view.component.ts
@@ -10,6 +10,7 @@ import { BroadcasterService } from "jslib-common/abstractions/broadcaster.servic
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
@@ -61,7 +62,8 @@ export class ViewComponent extends BaseViewComponent {
     private popupUtilsService: PopupUtilsService,
     apiService: ApiService,
     passwordRepromptService: PasswordRepromptService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -79,7 +81,8 @@ export class ViewComponent extends BaseViewComponent {
       apiService,
       passwordRepromptService,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
 

--- a/apps/browser/src/services/browserFileDownloadService.ts
+++ b/apps/browser/src/services/browserFileDownloadService.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@angular/core";
+
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
+
+import { BrowserApi } from "../browser/browserApi";
+
+@Injectable()
+export class BrowserFileDownloadService implements FileDownloadService {
+  download(request: FileDownloadRequest): void {
+    BrowserApi.downloadFile(
+      request.window,
+      request.blobData,
+      request.blobOptions,
+      request.fileName
+    );
+  }
+}

--- a/apps/browser/src/services/browserPlatformUtils.service.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.ts
@@ -124,10 +124,6 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     BrowserApi.createNewTab(uri, options && options.extensionPage === true);
   }
 
-  saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {
-    BrowserApi.downloadFile(win, blobData, blobOptions, fileName);
-  }
-
   getApplicationVersion(): Promise<string> {
     return Promise.resolve(BrowserApi.getApplicationVersion());
   }

--- a/apps/desktop/src/app/services/desktopFileDownloadService.ts
+++ b/apps/desktop/src/app/services/desktopFileDownloadService.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
+
+@Injectable()
+export class DesktopFileDownloadService implements FileDownloadService {
+  download(request: FileDownloadRequest): void {
+    const a = request.window.document.createElement("a");
+    a.href = URL.createObjectURL(request.blob);
+    a.download = request.fileName;
+    a.style.position = "fixed";
+    request.window.document.body.appendChild(a);
+    a.click();
+    request.window.document.body.removeChild(a);
+  }
+}

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -12,6 +12,7 @@ import {
 import { BroadcasterService as BroadcasterServiceAbstraction } from "jslib-common/abstractions/broadcaster.service";
 import { CryptoService as CryptoServiceAbstraction } from "jslib-common/abstractions/crypto.service";
 import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from "jslib-common/abstractions/cryptoFunction.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService as I18nServiceAbstraction } from "jslib-common/abstractions/i18n.service";
 import {
   LogService,
@@ -43,6 +44,7 @@ import { StateService } from "../../services/state.service";
 import { LoginGuard } from "../guards/login.guard";
 import { SearchBarService } from "../layout/search/search-bar.service";
 
+import { DesktopFileDownloadService } from "./desktopFileDownloadService";
 import { InitService } from "./init.service";
 
 const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
@@ -128,6 +130,10 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
         STATE_FACTORY,
         STATE_SERVICE_USE_CACHE,
       ],
+    },
+    {
+      provide: FileDownloadService,
+      useClass: DesktopFileDownloadService,
     },
   ],
 })

--- a/apps/desktop/src/app/vault/attachments.component.ts
+++ b/apps/desktop/src/app/vault/attachments.component.ts
@@ -4,6 +4,7 @@ import { AttachmentsComponent as BaseAttachmentsComponent } from "jslib-angular/
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -21,7 +22,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     platformUtilsService: PlatformUtilsService,
     apiService: ApiService,
     logService: LogService,
-    stateService: StateService
+    stateService: StateService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -31,7 +33,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
       apiService,
       window,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
 }

--- a/apps/desktop/src/app/vault/export.component.ts
+++ b/apps/desktop/src/app/vault/export.component.ts
@@ -8,6 +8,7 @@ import { BroadcasterService } from "jslib-common/abstractions/broadcaster.servic
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -31,7 +32,8 @@ export class ExportComponent extends BaseExportComponent implements OnInit {
     userVerificationService: UserVerificationService,
     formBuilder: FormBuilder,
     private broadcasterService: BroadcasterService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cryptoService,
@@ -43,7 +45,8 @@ export class ExportComponent extends BaseExportComponent implements OnInit {
       window,
       logService,
       userVerificationService,
-      formBuilder
+      formBuilder,
+      fileDownloadService
     );
   }
 

--- a/apps/desktop/src/app/vault/view.component.ts
+++ b/apps/desktop/src/app/vault/view.component.ts
@@ -14,6 +14,7 @@ import { BroadcasterService } from "jslib-common/abstractions/broadcaster.servic
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
@@ -49,7 +50,8 @@ export class ViewComponent extends BaseViewComponent implements OnChanges {
     private messagingService: MessagingService,
     passwordRepromptService: PasswordRepromptService,
     logService: LogService,
-    stateService: StateService
+    stateService: StateService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -67,7 +69,8 @@ export class ViewComponent extends BaseViewComponent implements OnChanges {
       apiService,
       passwordRepromptService,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
   ngOnInit() {

--- a/apps/web/src/app/common/base.events.component.ts
+++ b/apps/web/src/app/common/base.events.component.ts
@@ -1,9 +1,11 @@
 import { Directive } from "@angular/core";
 
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 import { EventResponse } from "jslib-common/models/response/eventResponse";
 import { ListResponse } from "jslib-common/models/response/listResponse";
 import { EventView } from "jslib-common/models/view/eventView";
@@ -30,7 +32,8 @@ export abstract class BaseEventsComponent {
     protected i18nService: I18nService,
     protected exportService: ExportService,
     protected platformUtilsService: PlatformUtilsService,
-    protected logService: LogService
+    protected logService: LogService,
+    protected fileDownloadService: FileDownloadService
   ) {
     const defaultDates = this.eventService.getDefaultDateFilters();
     this.start = defaultDates[0];
@@ -173,6 +176,8 @@ export abstract class BaseEventsComponent {
 
     const data = await this.exportService.getEventExport(events);
     const fileName = this.exportService.getFileName(this.exportFileName, "csv");
-    this.platformUtilsService.saveFile(window, data, { type: "text/plain" }, fileName);
+    this.fileDownloadService.download(
+      new FileDownloadRequest(window, fileName, data, { type: "text/plain" })
+    );
   }
 }

--- a/apps/web/src/app/organizations/manage/events.component.ts
+++ b/apps/web/src/app/organizations/manage/events.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { UserNamePipe } from "jslib-angular/pipes/user-name.pipe";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
@@ -37,9 +38,17 @@ export class EventsComponent extends BaseEventsComponent implements OnInit {
     logService: LogService,
     private userNamePipe: UserNamePipe,
     private organizationService: OrganizationService,
-    private providerService: ProviderService
+    private providerService: ProviderService,
+    fileDownloadService: FileDownloadService
   ) {
-    super(eventService, i18nService, exportService, platformUtilsService, logService);
+    super(
+      eventService,
+      i18nService,
+      exportService,
+      platformUtilsService,
+      logService,
+      fileDownloadService
+    );
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/organizations/settings/download-license.component.ts
+++ b/apps/web/src/app/organizations/settings/download-license.component.ts
@@ -1,8 +1,9 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { LogService } from "jslib-common/abstractions/log.service";
-import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 
 @Component({
   selector: "app-download-license",
@@ -18,7 +19,7 @@ export class DownloadLicenseComponent {
 
   constructor(
     private apiService: ApiService,
-    private platformUtilsService: PlatformUtilsService,
+    private fileDownloadService: FileDownloadService,
     private logService: LogService
   ) {}
 
@@ -34,11 +35,8 @@ export class DownloadLicenseComponent {
       );
       const license = await this.formPromise;
       const licenseString = JSON.stringify(license, null, 2);
-      this.platformUtilsService.saveFile(
-        window,
-        licenseString,
-        null,
-        "bitwarden_organization_license.json"
+      this.fileDownloadService.download(
+        new FileDownloadRequest(window, "bitwarden_organization_license.json", licenseString)
       );
       this.onDownloaded.emit();
     } catch (e) {

--- a/apps/web/src/app/organizations/tools/export.component.ts
+++ b/apps/web/src/app/organizations/tools/export.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from "@angular/router";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -28,7 +29,8 @@ export class ExportComponent extends BaseExportComponent {
     policyService: PolicyService,
     logService: LogService,
     userVerificationService: UserVerificationService,
-    formBuilder: FormBuilder
+    formBuilder: FormBuilder,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cryptoService,
@@ -39,7 +41,8 @@ export class ExportComponent extends BaseExportComponent {
       policyService,
       logService,
       userVerificationService,
-      formBuilder
+      formBuilder,
+      fileDownloadService
     );
   }
 

--- a/apps/web/src/app/organizations/vault/attachments.component.ts
+++ b/apps/web/src/app/organizations/vault/attachments.component.ts
@@ -3,6 +3,7 @@ import { Component } from "@angular/core";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -29,7 +30,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     stateService: StateService,
     platformUtilsService: PlatformUtilsService,
     apiService: ApiService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -38,7 +40,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
       stateService,
       platformUtilsService,
       apiService,
-      logService
+      logService,
+      fileDownloadService
     );
   }
 

--- a/apps/web/src/app/send/access.component.ts
+++ b/apps/web/src/app/send/access.component.ts
@@ -113,7 +113,7 @@ export class AccessComponent implements OnInit {
       const buf = await response.arrayBuffer();
       const decBuf = await this.cryptoService.decryptFromBytes(buf, this.decKey);
       this.fileDownloadService.download(
-        new FileDownloadRequest(window, this.send.file.fileName, decBuf)
+        new FileDownloadRequest(window, this.send.file.fileName, decBuf, null, true)
       );
     } catch (e) {
       this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));

--- a/apps/web/src/app/send/access.component.ts
+++ b/apps/web/src/app/send/access.component.ts
@@ -4,11 +4,13 @@ import { ActivatedRoute } from "@angular/router";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { CryptoFunctionService } from "jslib-common/abstractions/cryptoFunction.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { SEND_KDF_ITERATIONS } from "jslib-common/enums/kdfType";
 import { SendType } from "jslib-common/enums/sendType";
 import { Utils } from "jslib-common/misc/utils";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 import { SendAccess } from "jslib-common/models/domain/sendAccess";
 import { SymmetricCryptoKey } from "jslib-common/models/domain/symmetricCryptoKey";
 import { SendAccessRequest } from "jslib-common/models/request/sendAccessRequest";
@@ -44,7 +46,8 @@ export class AccessComponent implements OnInit {
     private apiService: ApiService,
     private platformUtilsService: PlatformUtilsService,
     private route: ActivatedRoute,
-    private cryptoService: CryptoService
+    private cryptoService: CryptoService,
+    private fileDownloadService: FileDownloadService
   ) {}
 
   get sendText() {
@@ -109,7 +112,9 @@ export class AccessComponent implements OnInit {
     try {
       const buf = await response.arrayBuffer();
       const decBuf = await this.cryptoService.decryptFromBytes(buf, this.decKey);
-      this.platformUtilsService.saveFile(window, decBuf, null, this.send.file.fileName);
+      this.fileDownloadService.download(
+        new FileDownloadRequest(window, this.send.file.fileName, decBuf)
+      );
     } catch (e) {
       this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));
     }

--- a/apps/web/src/app/services/services.module.ts
+++ b/apps/web/src/app/services/services.module.ts
@@ -14,6 +14,7 @@ import { ApiService as ApiServiceAbstraction } from "jslib-common/abstractions/a
 import { CipherService as CipherServiceAbstraction } from "jslib-common/abstractions/cipher.service";
 import { CollectionService as CollectionServiceAbstraction } from "jslib-common/abstractions/collection.service";
 import { CryptoService as CryptoServiceAbstraction } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { FolderService as FolderServiceAbstraction } from "jslib-common/abstractions/folder.service";
 import { I18nService as I18nServiceAbstraction } from "jslib-common/abstractions/i18n.service";
 import { ImportService as ImportServiceAbstraction } from "jslib-common/abstractions/import.service";
@@ -43,6 +44,7 @@ import { PermissionsGuard as OrgPermissionsGuard } from "../organizations/guards
 import { NavigationPermissionsService as OrgPermissionsService } from "../organizations/services/navigation-permissions.service";
 
 import { EventService } from "./event.service";
+import { WebFileDownloadService } from "./webFileDownload.service";
 import { InitService } from "./init.service";
 import { ModalService } from "./modal.service";
 import { PolicyListService } from "./policy-list.service";
@@ -127,6 +129,10 @@ import { RouterService } from "./router.service";
     {
       provide: PasswordRepromptServiceAbstraction,
       useClass: PasswordRepromptService,
+    },
+    {
+      provide: FileDownloadService,
+      useClass: WebFileDownloadService,
     },
     HomeGuard,
   ],

--- a/apps/web/src/app/services/webFileDownload.service.ts
+++ b/apps/web/src/app/services/webFileDownload.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@angular/core";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
+
+import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
+
+@Injectable()
+export class WebFileDownloadService implements FileDownloadService {
+  constructor(private platformUtilsService: PlatformUtilsService) {}
+
+  download(request: FileDownloadRequest): void {
+    const a = request.window.document.createElement("a");
+    if (request.downloadMethod === "save") {
+      a.download = request.fileName;
+    } else if (!this.platformUtilsService.isSafari()) {
+      a.target = "_blank";
+    }
+    a.href = URL.createObjectURL(request.blob);
+    a.style.position = "fixed";
+    request.window.document.body.appendChild(a);
+    a.click();
+    request.window.document.body.removeChild(a);
+  }
+}

--- a/apps/web/src/app/settings/emergency-access-attachments.component.ts
+++ b/apps/web/src/app/settings/emergency-access-attachments.component.ts
@@ -4,6 +4,7 @@ import { AttachmentsComponent as BaseAttachmentsComponent } from "jslib-angular/
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -25,7 +26,8 @@ export class EmergencyAccessAttachmentsComponent extends BaseAttachmentsComponen
     stateService: StateService,
     platformUtilsService: PlatformUtilsService,
     apiService: ApiService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -35,7 +37,8 @@ export class EmergencyAccessAttachmentsComponent extends BaseAttachmentsComponen
       apiService,
       window,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
 

--- a/apps/web/src/app/settings/user-subscription.component.ts
+++ b/apps/web/src/app/settings/user-subscription.component.ts
@@ -2,10 +2,12 @@ import { Component, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { TokenService } from "jslib-common/abstractions/token.service";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 import { SubscriptionResponse } from "jslib-common/models/response/subscriptionResponse";
 
 @Component({
@@ -30,7 +32,8 @@ export class UserSubscriptionComponent implements OnInit {
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
     private router: Router,
-    private logService: LogService
+    private logService: LogService,
+    private fileDownloadService: FileDownloadService
   ) {
     this.selfHosted = platformUtilsService.isSelfHost();
   }
@@ -139,11 +142,8 @@ export class UserSubscriptionComponent implements OnInit {
     }
 
     const licenseString = JSON.stringify(this.sub.license, null, 2);
-    this.platformUtilsService.saveFile(
-      window,
-      licenseString,
-      null,
-      "bitwarden_premium_license.json"
+    this.fileDownloadService.download(
+      new FileDownloadRequest(window, "bitwarden_premium_license.json", licenseString)
     );
   }
 

--- a/apps/web/src/app/tools/export.component.ts
+++ b/apps/web/src/app/tools/export.component.ts
@@ -5,6 +5,7 @@ import { ExportComponent as BaseExportComponent } from "jslib-angular/components
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -27,7 +28,8 @@ export class ExportComponent extends BaseExportComponent {
     policyService: PolicyService,
     logService: LogService,
     userVerificationService: UserVerificationService,
-    formBuilder: FormBuilder
+    formBuilder: FormBuilder,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cryptoService,
@@ -39,7 +41,8 @@ export class ExportComponent extends BaseExportComponent {
       window,
       logService,
       userVerificationService,
-      formBuilder
+      formBuilder,
+      fileDownloadService
     );
   }
 

--- a/apps/web/src/app/vault/attachments.component.ts
+++ b/apps/web/src/app/vault/attachments.component.ts
@@ -4,6 +4,7 @@ import { AttachmentsComponent as BaseAttachmentsComponent } from "jslib-angular/
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -24,7 +25,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     stateService: StateService,
     platformUtilsService: PlatformUtilsService,
     apiService: ApiService,
-    logService: LogService
+    logService: LogService,
+    fileDownloadService: FileDownloadService
   ) {
     super(
       cipherService,
@@ -34,7 +36,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
       apiService,
       window,
       logService,
-      stateService
+      stateService,
+      fileDownloadService
     );
   }
 

--- a/apps/web/src/services/webPlatformUtils.service.ts
+++ b/apps/web/src/services/webPlatformUtils.service.ts
@@ -108,54 +108,6 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     document.body.removeChild(a);
   }
 
-  saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {
-    let blob: Blob = null;
-    let type: string = null;
-    const fileNameLower = fileName.toLowerCase();
-    let doDownload = true;
-    if (fileNameLower.endsWith(".pdf")) {
-      type = "application/pdf";
-      doDownload = false;
-    } else if (fileNameLower.endsWith(".xlsx")) {
-      type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-    } else if (fileNameLower.endsWith(".docx")) {
-      type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    } else if (fileNameLower.endsWith(".pptx")) {
-      type = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-    } else if (fileNameLower.endsWith(".csv")) {
-      type = "text/csv";
-    } else if (fileNameLower.endsWith(".png")) {
-      type = "image/png";
-    } else if (fileNameLower.endsWith(".jpg") || fileNameLower.endsWith(".jpeg")) {
-      type = "image/jpeg";
-    } else if (fileNameLower.endsWith(".gif")) {
-      type = "image/gif";
-    }
-    if (type != null) {
-      blobOptions = blobOptions || {};
-      if (blobOptions.type == null) {
-        blobOptions.type = type;
-      }
-    }
-    if (blobOptions != null) {
-      blob = new Blob([blobData], blobOptions);
-    } else {
-      blob = new Blob([blobData]);
-    }
-
-    const a = win.document.createElement("a");
-    if (doDownload) {
-      a.download = fileName;
-    } else if (!this.isSafari()) {
-      a.target = "_blank";
-    }
-    a.href = URL.createObjectURL(blob);
-    a.style.position = "fixed";
-    win.document.body.appendChild(a);
-    a.click();
-    win.document.body.removeChild(a);
-  }
-
   getApplicationVersion(): Promise<string> {
     return Promise.resolve(process.env.APPLICATION_VERSION || "-");
   }
@@ -250,6 +202,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
   copyToClipboard(text: string, options?: any): void | boolean {
     let win = window;
     let doc = window.document;
+    console.log("in copyToClipboard", { text, options, window, doc });
     if (options && (options.window || options.win)) {
       win = options.window || options.win;
       doc = win.document;

--- a/bitwarden_license/bit-web/src/app/providers/manage/events.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/events.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { UserNamePipe } from "jslib-angular/pipes/user-name.pipe";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -34,9 +35,17 @@ export class EventsComponent extends BaseEventsComponent implements OnInit {
     platformUtilsService: PlatformUtilsService,
     private router: Router,
     logService: LogService,
-    private userNamePipe: UserNamePipe
+    private userNamePipe: UserNamePipe,
+    fileDownloadService: FileDownloadService
   ) {
-    super(eventService, i18nService, exportService, platformUtilsService, logService);
+    super(
+      eventService,
+      i18nService,
+      exportService,
+      platformUtilsService,
+      logService,
+      fileDownloadService
+    );
   }
 
   async ngOnInit() {

--- a/libs/angular/src/components/attachments.component.ts
+++ b/libs/angular/src/components/attachments.component.ts
@@ -3,11 +3,13 @@ import { Directive, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { StateService } from "jslib-common/abstractions/state.service";
 import { Cipher } from "jslib-common/models/domain/cipher";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 import { ErrorResponse } from "jslib-common/models/response/errorResponse";
 import { AttachmentView } from "jslib-common/models/view/attachmentView";
 import { CipherView } from "jslib-common/models/view/cipherView";
@@ -36,7 +38,8 @@ export class AttachmentsComponent implements OnInit {
     protected apiService: ApiService,
     protected win: Window,
     protected logService: LogService,
-    protected stateService: StateService
+    protected stateService: StateService,
+    protected fileDownloadService: FileDownloadService
   ) {}
 
   async ngOnInit() {
@@ -171,7 +174,9 @@ export class AttachmentsComponent implements OnInit {
           ? attachment.key
           : await this.cryptoService.getOrgKey(this.cipher.organizationId);
       const decBuf = await this.cryptoService.decryptFromBytes(buf, key);
-      this.platformUtilsService.saveFile(this.win, decBuf, null, attachment.fileName);
+      this.fileDownloadService.download(
+        new FileDownloadRequest(this.win, attachment.fileName, decBuf)
+      );
     } catch (e) {
       this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));
     }

--- a/libs/angular/src/components/export.component.ts
+++ b/libs/angular/src/components/export.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder } from "@angular/forms";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
 import { ExportService } from "jslib-common/abstractions/export.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
@@ -11,6 +12,7 @@ import { PolicyService } from "jslib-common/abstractions/policy.service";
 import { UserVerificationService } from "jslib-common/abstractions/userVerification.service";
 import { EventType } from "jslib-common/enums/eventType";
 import { PolicyType } from "jslib-common/enums/policyType";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 
 @Directive()
 export class ExportComponent implements OnInit {
@@ -40,7 +42,8 @@ export class ExportComponent implements OnInit {
     protected win: Window,
     private logService: LogService,
     private userVerificationService: UserVerificationService,
-    private formBuilder: FormBuilder
+    private formBuilder: FormBuilder,
+    protected fileDownloadService: FileDownloadService
   ) {}
 
   async ngOnInit() {
@@ -150,6 +153,8 @@ export class ExportComponent implements OnInit {
 
   private downloadFile(csv: string): void {
     const fileName = this.getFileName();
-    this.platformUtilsService.saveFile(this.win, csv, { type: "text/plain" }, fileName);
+    this.fileDownloadService.download(
+      new FileDownloadRequest(this.win, fileName, csv, { type: "text/plain" })
+    );
   }
 }

--- a/libs/angular/src/components/view.component.ts
+++ b/libs/angular/src/components/view.component.ts
@@ -15,6 +15,7 @@ import { BroadcasterService } from "jslib-common/abstractions/broadcaster.servic
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { EventService } from "jslib-common/abstractions/event.service";
+import { FileDownloadService } from "jslib-common/abstractions/fileDownload.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { PasswordRepromptService } from "jslib-common/abstractions/passwordReprompt.service";
@@ -26,6 +27,7 @@ import { CipherRepromptType } from "jslib-common/enums/cipherRepromptType";
 import { CipherType } from "jslib-common/enums/cipherType";
 import { EventType } from "jslib-common/enums/eventType";
 import { FieldType } from "jslib-common/enums/fieldType";
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
 import { ErrorResponse } from "jslib-common/models/response/errorResponse";
 import { AttachmentView } from "jslib-common/models/view/attachmentView";
 import { CipherView } from "jslib-common/models/view/cipherView";
@@ -76,7 +78,8 @@ export class ViewComponent implements OnDestroy, OnInit {
     protected apiService: ApiService,
     protected passwordRepromptService: PasswordRepromptService,
     private logService: LogService,
-    protected stateService: StateService
+    protected stateService: StateService,
+    protected fileDownloadService: FileDownloadService
   ) {}
 
   ngOnInit() {
@@ -373,7 +376,9 @@ export class ViewComponent implements OnDestroy, OnInit {
           ? attachment.key
           : await this.cryptoService.getOrgKey(this.cipher.organizationId);
       const decBuf = await this.cryptoService.decryptFromBytes(buf, key);
-      this.platformUtilsService.saveFile(this.win, decBuf, null, attachment.fileName);
+      this.fileDownloadService.download(
+        new FileDownloadRequest(this.win, attachment.fileName, decBuf)
+      );
     } catch (e) {
       this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));
     }

--- a/libs/common/src/abstractions/fileDownload.service.ts
+++ b/libs/common/src/abstractions/fileDownload.service.ts
@@ -1,0 +1,5 @@
+import { FileDownloadRequest } from "jslib-common/models/domain/fileDownloadRequest";
+
+export abstract class FileDownloadService {
+  download: (request: FileDownloadRequest) => void;
+}

--- a/libs/common/src/abstractions/platformUtils.service.ts
+++ b/libs/common/src/abstractions/platformUtils.service.ts
@@ -19,7 +19,6 @@ export abstract class PlatformUtilsService {
   isMacAppStore: () => boolean;
   isViewOpen: () => Promise<boolean>;
   launchUri: (uri: string, options?: any) => void;
-  saveFile: (win: Window, blobData: any, blobOptions: any, fileName: string) => void;
   getApplicationVersion: () => Promise<string>;
   supportsWebAuthn: (win: Window) => boolean;
   supportsDuo: () => boolean;

--- a/libs/common/src/models/domain/fileDownloadRequest.ts
+++ b/libs/common/src/models/domain/fileDownloadRequest.ts
@@ -1,0 +1,64 @@
+export class FileDownloadRequest {
+  window: Window;
+  fileName: string;
+  forceDownload: boolean;
+
+  blobData: any;
+
+  private _blobOptions: any;
+  get blobOptions(): any {
+    const options = this._blobOptions ?? {};
+    if (options.type == null) {
+      options.type = this.fileType;
+    }
+    return options;
+  }
+
+  get blob(): Blob {
+    if (this.blobOptions != null) {
+      return new Blob([this.blobData], this.blobOptions);
+    } else {
+      return new Blob([this.blobData]);
+    }
+  }
+
+  get downloadMethod(): "save" | "open" {
+    return this.forceDownload || this.fileType != "application/pdf" ? "save" : "open";
+  }
+
+  get fileType() {
+    const fileNameLower = this.fileName.toLowerCase();
+    if (fileNameLower.endsWith(".pdf")) {
+      return "application/pdf";
+    } else if (fileNameLower.endsWith(".xlsx")) {
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    } else if (fileNameLower.endsWith(".docx")) {
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    } else if (fileNameLower.endsWith(".pptx")) {
+      return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    } else if (fileNameLower.endsWith(".csv")) {
+      return "text/csv";
+    } else if (fileNameLower.endsWith(".png")) {
+      return "image/png";
+    } else if (fileNameLower.endsWith(".jpg") || fileNameLower.endsWith(".jpeg")) {
+      return "image/jpeg";
+    } else if (fileNameLower.endsWith(".gif")) {
+      return "image/gif";
+    }
+    return null;
+  }
+
+  constructor(
+    window: Window,
+    fileName: string,
+    blobData: any,
+    blobOptions?: any,
+    forceDownload = false
+  ) {
+    this.window = window;
+    this.fileName = fileName;
+    this.blobData = blobData;
+    this._blobOptions = blobOptions;
+    this.forceDownload = forceDownload;
+  }
+}

--- a/libs/electron/src/services/electronPlatformUtils.service.ts
+++ b/libs/electron/src/services/electronPlatformUtils.service.ts
@@ -84,16 +84,6 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
     shell.openExternal(uri);
   }
 
-  saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {
-    const blob = new Blob([blobData], blobOptions);
-    const a = win.document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = fileName;
-    win.document.body.appendChild(a);
-    a.click();
-    win.document.body.removeChild(a);
-  }
-
   getApplicationVersion(): Promise<string> {
     return ipcRenderer.invoke("appVersion");
   }

--- a/libs/node/src/cli/services/cliPlatformUtils.service.ts
+++ b/libs/node/src/cli/services/cliPlatformUtils.service.ts
@@ -85,10 +85,6 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
     }
   }
 
-  saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {
-    throw new Error("Not implemented.");
-  }
-
   getApplicationVersion(): Promise<string> {
     return Promise.resolve(this.packageJson.version);
   }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-348

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The main objective here is to always download the file attached to a file Send when accessed, and to never open them in a new tab. The previous behavior was that PDFs specifically opened in a new tab, and this is causing confusion for users and issues with browser PDF viewers.

**NOTE:** There was some discourse internally about whether or not we should ever allow PDFs to be downloaded, even from Send, but the end decision was that most folks expect files sent with Send to download as a rule.

___

There are some refactoring goals in here as well for how we download files. The `platformUtilsService.saveFile` method has been refactored away in favor of a `FileDownloadService` and `FileDownloadRequest` that handle the logic that was previously in `platformUtilsService.saveFile`. There are a few reasons to do this:

1. `platformUtilsService.saveFile` is rigid. We explicitly forbid downloading PDFs in it, and the only way to fix that and maintain the method as it exists today is with a `forceDownload` parameter added directly to the parameter list of `platformUtilsService.saveFile`. We are still doing this in some capacity on the `FileDownloadRequest` model, so open to feedback there, but generally I think a model is more flexible and less cumbersome to work in. 
2. `platformUtilsService.saveFile` is not universally implemented. We have to `NotImplementedException` it in the CLI, because it uses a different pattern for attachments.
3. `PlatformUtilsService` is too broad of a scope for a service. Refactoring it away is a preexisting goal for the team. 
4. `platformUtilsService.saveFile` does a lot of data manipulation that is better left to a class. The end methods are smaller and more easily understood by generating things like file type in a class instead of directly in the service method.

## Code changes
[[refactor] Introduce a file download service](https://github.com/bitwarden/clients/commit/c05c4cfbcd2a3fe581a74527f618508d4f59527a)
- Create an abstraction for `FileDownloadService`
- Create an implementations of `FileDownloadService` in `web`, `desktop`, and `browser` individually as they all have specific needs. The logic in each is mostly unchanged from `platformUtilsService.saveFile`, with the exception of the logic that was abstracted to the `FileDownloadRequest` model like filetype discovery and preferred download method.   
    - Web can open some files in a new tab
    - Desktop can only download files
    - Browser depends on a BrowserApi class for downloads
- Wire up my `FileDownloadService` implementations in their respective `ServiceModules` for dependency injection 

[[refactor] Point platformUtilsService.saveFile() callers to fileDownl…](https://github.com/bitwarden/clients/commit/95546d88be2176bf833abc9d9804536a00d57402)
- Point all existing calls to `platformUtilsService.saveFile` in clients to `fileDownloadService.download`

[[refactor] Remove platformUtilsService.saveFile()](https://github.com/bitwarden/clients/commit/54730945abf9ebfc92be3b768b6d918a42c8442b)
- Remove `platformUtilsService.saveFile()` from the `PlatformUtilsService` abstraction and its implementations

[[fix] Force send attachements to always download and never open](https://github.com/bitwarden/clients/commit/3e1e2364e63ef1a2b720f43814bf89b1b122c719)
- Fix the bug by passing the `forceDownload` flag to the `FileDownloadRequest` model used in the `AccessComponent`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
