### PR TITLE
[PS-927] center hcaptcha in connector and fix formatting on desktop

### DIFF
--- a/apps/desktop/src/app/accounts/login.component.html
+++ b/apps/desktop/src/app/accounts/login.component.html
@@ -68,8 +68,8 @@
       </div>
       <div class="box last" [hidden]="!showCaptcha()">
         <div class="box-content">
+          <iframe id="hcaptcha_iframe" style="margin-top: 20px"></iframe>
           <div class="box-content-row">
-            <iframe id="hcaptcha_iframe" height="80"></iframe>
             <button class="btn block" type="button" routerLink="/accessibility-cookie">
               <i class="bwi bwi-universal-access" aria-hidden="true"></i>
               {{ "loadAccessibilityCookie" | i18n }}

--- a/apps/web/src/connectors/captcha.scss
+++ b/apps/web/src/connectors/captcha.scss
@@ -3,4 +3,6 @@ body {
   padding: 0;
   margin: 0;
   background: transparent;
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Our hcaptcha on desktop had formatting that caused scrollbars and weird formatting. This PR centers our hcaptcha in our connector and fixes the scrollbar issue on desktop.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
### Before
![image (1)](https://user-images.githubusercontent.com/24985544/173885103-fd0b30e1-2dbb-4dc0-9566-452b7a2b4aa4.png)

### After
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/24985544/173854009-e20bc410-a57e-4413-930d-efdc14a2caa8.png">
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/24985544/173854058-7af53a25-9386-4584-8dee-53a3daa66b4b.png">


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
