### PR TITLE
[PS-1201] Allow bw sync without unlocking

### DIFF
--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -281,7 +281,7 @@ export class Program extends BaseProgram {
         writeLn("", true);
       })
       .action(async (cmd) => {
-        await this.exitIfLocked();
+        await this.exitIfNotAuthed();
         const command = new SyncCommand(this.main.syncService);
         const response = await command.run(cmd);
         this.processResponse(response);


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The CLI command `bw sync` will run even if the vault is locked. You only need to be logged in. This makes it easier to use `bw sync` in automated scripts.

As far as I can tell, `bw sync` doesn't use the master password at any point, so there is no compelling reason to ask for it.

Potentially related or similar issues: #2739, bitwarden/cli#91, bitwarden/cli#423

## Code changes

- **program.ts:** Replace the unlock check.

I think that's it. It seems to me that sync.command.ts and sync.service.ts don't need changing.

(I noticed sync.service.ts calls cryptoService, but apparently not to decrypt anything.)

## Rationale

- As far as I can tell, the Bitwarden browser extensions (apps/browser/src/background/main.background.ts) and desktop app (apps/desktop/src/app/app.component.ts + apps/desktop/src/main/messaging.main.ts) are already able to sync in the background when the vault is locked. If that is correct, then this is nothing new, it just adds the same power to the CLI.
- **Edited to add** from [comment](https://github.com/bitwarden/clients/pull/2916#issuecomment-1179358953): Another reason why bw sync should work without a password is that you can already do it without a password using `bw serve` + `curl -X POST http://localhost:8087/sync`.
    This is because the [/sync handler in serve.command.ts](https://github.com/bitwarden/clients/blob/7c3facec80937ca2865f7f823ae127858bbf1c31/apps/cli/src/commands/serve.command.ts#L222) does not call errorIfLocked. `bw sync` should be made consistent with `bw serve` and also work without unlocking.

## Before you submit

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
