### PR TITLE
Fix form input group suffix not working without prefix

### DIFF
--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -7,7 +7,7 @@
     <ng-content select="[bitPrefix]"></ng-content>
   </div>
   <ng-content></ng-content>
-  <div *ngIf="prefixChildren.length" class="tw-flex">
+  <div *ngIf="suffixChildren.length" class="tw-flex">
     <ng-content select="[bitSuffix]"></ng-content>
   </div>
 </div>

--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -167,8 +167,6 @@ const ButtonGroupTemplate: Story<BitFormFieldComponent> = (args: BitFormFieldCom
     <bit-form-field>
       <bit-label>Label</bit-label>
       <input bitInput placeholder="Placeholder" />
-      <button bitPrefix bitButton>Button</button>
-      <button bitPrefix bitButton>Button</button>
       <button bitSuffix bitButton>
         <i aria-hidden="true" class="bwi bwi-lg bwi-eye"></i>
       </button>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves an issue where form suffixes doesn't work if the input group doesn't have the same number of prefixes.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
