### PR TITLE
[PS-766] Fix for CLI check full array of URIs in search

### DIFF
--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -182,7 +182,7 @@ export class SearchService implements SearchServiceAbstraction {
       }
       if (
         c.login &&
-        c.login.uris != null &&
+        c.login.hasUris &&
         c.login.uris.some((loginUri) => loginUri.uri.toLowerCase().indexOf(query) > -1)
       ) {
         return true;

--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -180,15 +180,12 @@ export class SearchService implements SearchServiceAbstraction {
       if (c.subTitle != null && c.subTitle.toLowerCase().indexOf(query) > -1) {
         return true;
       }
-      if (c.login && c.login.uri != null) {
-        if (c.login.uri.toLowerCase().indexOf(query) > -1) {
-          return true;
-        } else if (
-          c.login.uris != null &&
-          c.login.uris.some((loginUri) => loginUri.uri.toLowerCase().indexOf(query) > -1)
-        ) {
-          return true;
-        }
+      if (
+        c.login &&
+        c.login.uris != null &&
+        c.login.uris.some((loginUri) => loginUri.uri.toLowerCase().indexOf(query) > -1)
+      ) {
+        return true;
       }
       return false;
     });

--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -180,8 +180,15 @@ export class SearchService implements SearchServiceAbstraction {
       if (c.subTitle != null && c.subTitle.toLowerCase().indexOf(query) > -1) {
         return true;
       }
-      if (c.login && c.login.uri != null && c.login.uri.toLowerCase().indexOf(query) > -1) {
-        return true;
+      if (c.login && c.login.uri != null) {
+        if (c.login.uri.toLowerCase().indexOf(query) > -1) {
+          return true;
+        } else if (
+          c.login.uris != null &&
+          c.login.uris.some((loginUri) => loginUri.uri.toLowerCase().indexOf(query) > -1)
+        ) {
+          return true;
+        }
       }
       return false;
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to enable the Bitwarden CLI command `bw get <object> <id>` to search for the `<id>` provided in the list of URIs in a specific vault item. 

Currently, the search will only check the first URI on a specific vault item.  
See https://github.com/bitwarden/clients/issues/2762 for more details.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

### libs/common/src/services/search.service.ts

Added code to search through all the values in the URIs array.
Even with just a singular URI on the vault item, c.login.uris will be an array of one. 

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
