### PR TITLE
Fix javascript debug terminal source maps

### DIFF
--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -33,7 +33,7 @@
     "debug.javascript.terminalOptions": {
       "sourceMapPathOverrides": {
         "webpack:///./~/*": "${workspaceFolder:root}/node_modules/*",
-        "webpack://?:*/*": "${workspaceFolder:root}/*",
+        "webpack://?:*/*": "${workspaceFolder}/*",
         "webpack://@bitwarden/cli/*": "${workspaceFolder}/*"
       }
   },

--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -32,10 +32,9 @@
   "settings": {
     "debug.javascript.terminalOptions": {
       "sourceMapPathOverrides": {
-        "meteor://💻app/*": "${workspaceFolder}/*",
-        "webpack:///./~/*": "${workspaceFolder}/node_modules/*",
-        "webpack://?:*/*": "${workspaceFolder}/*",
-        "webpack://@bitwarden/cli/*": "${workspaceFolder}/apps/cli/*"
+        "webpack:///./~/*": "${workspaceFolder:root}/node_modules/*",
+        "webpack://?:*/*": "${workspaceFolder:root}/*",
+        "webpack://@bitwarden/cli/*": "${workspaceFolder}/*"
       }
   },
   "jest.disabledWorkspaceFolders": [


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The multi-root workspace config broke the Javascript Debug Terminal for cli, i.e. breakpoints are no longer being hit. This PR fixes the source maps in the workspace config.

I've verified that this fixes debugging in cli (including libs).

Credit to @MGibson1 for debugging this with me.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This basically aims to replicate the old [CLI settings.json](https://github.com/bitwarden/cli/blob/master/.vscode/settings.json):

* remove the meteor sourcemap override, we don't use meteor. I assume this was copy/pasted from an online recipe
* `"webpack:///./~/*": "${workspaceFolder:root}/node_modules/*"`   - resolves node_modules to the repo root
*  `"webpack://@bitwarden/cli/*": "${workspaceFolder}/*"`  - if you open the debug terminal in the cli workspace, then workspaceFolder will resolve to `apps/cli`, so there's no need to append the additional path like I had previously

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
