### PR TITLE
Add webpack-bundle-analyzer

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,2 +1,3 @@
 !dev-server.shared.pem
 config/local.json
+stats.json

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build:oss:watch": "webpack serve",
     "build:bit:watch": "webpack serve -c ../../bitwarden_license/bit-web/webpack.config.js",
     "build:bit:dev": "cross-env ENV=development npm run build:bit",
+    "build:bit:dev:analyze": "cross-env LOGGING=false webpack -c ../../bitwarden_license/bit-web/webpack.config.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json build/",
     "build:bit:dev:watch": "cross-env ENV=development npm run build:bit:watch",
     "build:bit:qa": "cross-env NODE_ENV=production ENV=qa npm run build:bit",
     "build:bit:cloud": "cross-env NODE_ENV=production ENV=cloud npm run build:bit",

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -15,9 +15,12 @@ const pjson = require("./package.json");
 
 const ENV = process.env.ENV == null ? "development" : process.env.ENV;
 const NODE_ENV = process.env.NODE_ENV == null ? "development" : process.env.NODE_ENV;
+const LOGGING = process.env.LOGGING != "false";
 
 const envConfig = config.load(ENV);
-config.log(envConfig);
+if (LOGGING) {
+  config.log(envConfig);
+}
 
 const moduleRules = [
   {
@@ -205,8 +208,8 @@ const devServer =
               {
                 key: "Content-Security-Policy",
                 value: `
-                  default-src 'self'; 
-                  script-src 
+                  default-src 'self';
+                  script-src
                     'self'
                     'sha256-ryoU+5+IUZTuUyTElqkrQGBJXr1brEv6r2CA62WUw8w='
                     https://js.stripe.com
@@ -255,7 +258,7 @@ const devServer =
                     https://*.blob.core.windows.net
                     https://app.simplelogin.io/api/alias/random/new
                     https://app.anonaddy.com/api/v1/aliases;
-                  object-src 
+                  object-src
                     'self'
                     blob:;`,
               },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to help us understand the size of our bundles and how webpack splits it up as we start to implement lazy loading (prompted by #2918).

The results are shown like so:

![Screen Shot 2022-06-23 at 11 15 50 am](https://user-images.githubusercontent.com/31796059/175192978-06278e0a-1c79-4f8a-9f99-70bef8d97789.png)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- install `webpack-bundle-analyzer`
- add `npm run build:bit:dev:analyze`. This command runs webpack, outputs build stats to a `stats.json` file, then runs `webpack-bundle-analyzer` pointing at that file.
- add a logging environment variable for `webpack.config.js`, otherwise the `envConfig` logging also gets written to the `stats.json` file
- add `stats.json` to `.gitignore`

I have deliberately chosen the CLI usage, because this ensures that the webpack bundles exist on disk and their size can be accurately measured. The alternative is use the plugin, which runs it alongside the webpack dev server. This is more convenient, but because the dev server runs in memory, you can't get an accurate read on bundle size. (more info in the [README](https://github.com/webpack-contrib/webpack-bundle-analyzer#troubleshooting)) I thought it was more important to get an accurate read, and it's probably not something we'll be using all the time anyway.

A similar config can trivially be added to the other apps, but I haven't done that at this time.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
