### PR TITLE
[PS-972] Update translation keys to match content

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -567,22 +567,22 @@
     "message": "No Folder",
     "description": "This is the folder for uncategorized items"
   },
-  "enableAddLoginNotification": {
+  "askToAddLogin": {
     "message": "Ask to add login"
   },
-  "addLoginNotificationDesc": {
+  "askToAddLoginDesc": {
     "message": "Ask to add an item if one isn't found in your vault."
   },
-  "showCardsCurrentTab": {
+  "showCardsOnTabPage": {
     "message": "Show cards on Tab page"
   },
-  "showCardsCurrentTabDesc": {
+  "showCardsOnTabPageDesc": {
     "message": "List card items on the Tab page for easy auto-fill."
   },
-  "showIdentitiesCurrentTab": {
+  "showIdentitiesOnTabPage": {
     "message": "Show identities on Tab page"
   },
-  "showIdentitiesCurrentTabDesc": {
+  "showIdentitiesOnTabPageDesc": {
     "message": "List identity items on the Tab page for easy auto-fill."
   },
   "clearClipboard": {
@@ -599,10 +599,10 @@
   "notificationAddSave": {
     "message": "Save"
   },
-  "enableChangedPasswordNotification": {
+  "askToUpdateExistingLogin": {
     "message": "Ask to update existing login"
   },
-  "changedPasswordNotificationDesc": {
+  "askToUpdateExistingLoginDesc": {
     "message": "Ask to update a login's password when a change is detected on a website."
   },
   "notificationChangeDesc": {
@@ -611,10 +611,10 @@
   "notificationChangeSave": {
     "message": "Update"
   },
-  "enableContextMenuItem": {
+  "showContextMenuOptions": {
     "message": "Show context menu options"
   },
-  "contextMenuItemDesc": {
+  "showContextMenuOptionsDesc": {
     "message": "Use a secondary click to access password generation and matching logins for the website. "
   },
   "defaultUriMatchDetection": {
@@ -806,13 +806,13 @@
   "refreshComplete": {
     "message": "Refresh complete"
   },
-  "enableAutoTotpCopy": {
+  "copyTotpAutomatically": {
     "message": "Copy TOTP automatically"
   },
-  "disableAutoTotpCopyDesc": {
+  "copyTotpAutomaticallyDesc": {
     "message": "If a login has an authenticator key, copy the TOTP verification code to your clip-board when you auto-fill the login."
   },
-  "enableAutoBiometricsPrompt": {
+  "askForBiometricsOnLaunch": {
     "message": "Ask for biometrics on launch"
   },
   "premiumRequired": {
@@ -1033,16 +1033,16 @@
   "popupU2fCloseMessage": {
     "message": "This browser cannot process U2F requests in this popup window. Do you want to open this popup in a new window so that you can log in using U2F?"
   },
-  "enableFavicon": {
+  "showWebsiteIcons": {
     "message": "Show website icons"
   },
-  "faviconDesc": {
+  "showWebsiteIconsDesc": {
     "message": "Show a recognizable image next to each login."
   },
-  "enableBadgeCounter": {
+  "showBadgeCounter": {
     "message": "Show badge counter"
   },
-  "badgeCounterDesc": {
+  "showBadgeCounterDesc": {
     "message": "Indicate how many logins you have for the current web page."
   },
   "cardholderName": {

--- a/apps/browser/src/popup/settings/options.component.html
+++ b/apps/browser/src/popup/settings/options.component.html
@@ -63,7 +63,7 @@
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="totp">{{ "enableAutoTotpCopy" | i18n }}</label>
+          <label for="totp">{{ "copyTotpAutomatically" | i18n }}</label>
           <input
             id="totp"
             type="checkbox"
@@ -72,12 +72,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "disableAutoTotpCopyDesc" | i18n }}</div>
+      <div class="box-footer">{{ "copyTotpAutomaticallyDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="addlogin-notification-bar">{{ "enableAddLoginNotification" | i18n }}</label>
+          <label for="addlogin-notification-bar">{{ "askToAddLogin" | i18n }}</label>
           <input
             id="addlogin-notification-bar"
             type="checkbox"
@@ -86,14 +86,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "addLoginNotificationDesc" | i18n }}</div>
+      <div class="box-footer">{{ "askToAddLoginDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="changedpass-notification-bar">{{
-            "enableChangedPasswordNotification" | i18n
-          }}</label>
+          <label for="changedpass-notification-bar">{{ "askToUpdateExistingLogin" | i18n }}</label>
           <input
             id="changedpass-notification-bar"
             type="checkbox"
@@ -102,12 +100,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "changedPasswordNotificationDesc" | i18n }}</div>
+      <div class="box-footer">{{ "askToUpdateExistingLoginDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="context-menu">{{ "enableContextMenuItem" | i18n }}</label>
+          <label for="context-menu">{{ "showContextMenuOptions" | i18n }}</label>
           <input
             id="context-menu"
             type="checkbox"
@@ -116,7 +114,7 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "contextMenuItemDesc" | i18n }}</div>
+      <div class="box-footer">{{ "showContextMenuOptionsDesc" | i18n }}</div>
     </div>
   </ng-container>
   <div class="box box-section-divider">
@@ -137,7 +135,7 @@
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="showCardsCurrentTab">{{ "showCardsCurrentTab" | i18n }}</label>
+          <label for="showCardsCurrentTab">{{ "showCardsOnTabPage" | i18n }}</label>
           <input
             id="showCardsCurrentTab"
             type="checkbox"
@@ -146,12 +144,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "showCardsCurrentTabDesc" | i18n }}</div>
+      <div class="box-footer">{{ "showCardsOnTabPageDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="showIdentitiesCurrentTab">{{ "showIdentitiesCurrentTab" | i18n }}</label>
+          <label for="showIdentitiesCurrentTab">{{ "showIdentitiesOnTabPage" | i18n }}</label>
           <input
             id="showIdentitiesCurrentTab"
             type="checkbox"
@@ -160,12 +158,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "showIdentitiesCurrentTabDesc" | i18n }}</div>
+      <div class="box-footer">{{ "showIdentitiesOnTabPageDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="favicon">{{ "enableFavicon" | i18n }}</label>
+          <label for="favicon">{{ "showWebsiteIcons" | i18n }}</label>
           <input
             id="favicon"
             type="checkbox"
@@ -174,12 +172,12 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "faviconDesc" | i18n }}</div>
+      <div class="box-footer">{{ "showWebsiteIconsDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">
         <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="badge">{{ "enableBadgeCounter" | i18n }}</label>
+          <label for="badge">{{ "showBadgeCounter" | i18n }}</label>
           <input
             id="badge"
             type="checkbox"
@@ -188,7 +186,7 @@
           />
         </div>
       </div>
-      <div class="box-footer">{{ "badgeCounterDesc" | i18n }}</div>
+      <div class="box-footer">{{ "showBadgeCounterDesc" | i18n }}</div>
     </div>
     <div class="box">
       <div class="box-content">

--- a/apps/browser/src/popup/settings/settings.component.html
+++ b/apps/browser/src/popup/settings/settings.component.html
@@ -60,7 +60,7 @@
         />
       </div>
       <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="supportsBiometric">
-        <label for="autoBiometricsPrompt">{{ "enableAutoBiometricsPrompt" | i18n }}</label>
+        <label for="autoBiometricsPrompt">{{ "askForBiometricsOnLaunch" | i18n }}</label>
         <input
           id="autoBiometricsPrompt"
           type="checkbox"

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -174,10 +174,10 @@
                       [(ngModel)]="enableFavicons"
                       (change)="saveFavicons()"
                     />
-                    {{ "enableFavicon" | i18n }}
+                    {{ "showWebsiteIcons" | i18n }}
                   </label>
                 </div>
-                <small class="help-block">{{ "faviconDesc" | i18n }}</small>
+                <small class="help-block">{{ "showWebsiteIconsDesc" | i18n }}</small>
               </div>
             </ng-container>
           </div>
@@ -305,10 +305,10 @@
                       [(ngModel)]="enableBrowserIntegration"
                       (change)="saveBrowserIntegration()"
                     />
-                    {{ "enableBrowserIntegration" | i18n }}
+                    {{ "allowBrowserIntegration" | i18n }}
                   </label>
                 </div>
-                <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
+                <small class="help-block">{{ "allowBrowserIntegrationDesc" | i18n }}</small>
               </div>
               <div class="form-group">
                 <div class="checkbox">
@@ -321,11 +321,11 @@
                       (change)="saveBrowserIntegrationFingerprint()"
                       [disabled]="!enableBrowserIntegration"
                     />
-                    {{ "enableBrowserIntegrationFingerprint" | i18n }}
+                    {{ "requireVerificationForBrowserIntegration" | i18n }}
                   </label>
                 </div>
                 <small class="help-block">{{
-                  "enableBrowserIntegrationFingerprintDesc" | i18n
+                  "requireVerificationForBrowserIntegrationDesc" | i18n
                 }}</small>
               </div>
               <div class="form-group">

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -81,7 +81,7 @@ export class SettingsComponent implements OnInit {
     // Workaround to avoid ghosting trays https://github.com/electron/electron/issues/17622
     this.requireEnableTray = this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
 
-    const trayKey = isMac ? "enableMenuBar" : "enableTray";
+    const trayKey = isMac ? "showMenuBarIcon" : "showTrayIcon";
     this.enableTrayText = this.i18nService.t(trayKey);
     this.enableTrayDescText = this.i18nService.t(trayKey + "Desc");
 

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -894,10 +894,10 @@
     "message": "Automatically clear copied values from your clipboard.",
     "description": "Clipboard is the operating system thing where you copy/paste data to on your device."
   },
-  "enableFavicon": {
+  "showWebsiteIcons": {
     "message": "Show website icons"
   },
-  "faviconDesc": {
+  "showWebsiteIconsDesc": {
     "message": "Show a recognizable image next to each login."
   },
   "enableMinToTray": {
@@ -924,10 +924,10 @@
   "enableCloseToMenuBarDesc": {
     "message": "When closing the window, show an icon in the menu bar instead."
   },
-  "enableTray": {
-    "message": "Enable tray icon"
+  "showTrayIcon": {
+    "message": "Show tray icon"
   },
-  "enableTrayDesc": {
+  "showTrayIconDesc": {
     "message": "Always show an icon in the system tray."
   },
   "startToTray": {
@@ -1381,10 +1381,10 @@
   "touchIdConsentMessage": {
     "message": "unlock your vault"
   },
-  "autoPromptWindowsHello": {
+  "askForWindowsHelloOnLaunch": {
     "message": "Ask for Windows Hello on launch"
   },
-  "autoPromptTouchId": {
+  "askForTouchIdOnLaunch": {
     "message": "Ask for Touch ID on launch"
   },
   "lockWithMasterPassOnRestart": {
@@ -1393,10 +1393,10 @@
   "preferences": {
     "message": "Preferences"
   },
-  "enableMenuBar": {
+  "showMenuBarIcon": {
     "message": "Show menu bar icon"
   },
-  "enableMenuBarDesc": {
+  "showMenuBarIconDesc": {
     "message": "Always show an icon in the menu bar."
   },
   "hideToMenuBar": {
@@ -1546,10 +1546,10 @@
   "acceptPoliciesError": {
     "message": "Terms of Service and Privacy Policy have not been acknowledged."
   },
-  "enableBrowserIntegration": {
+  "allowBrowserIntegration": {
     "message": "Allow browser integration"
   },
-  "enableBrowserIntegrationDesc": {
+  "allowBrowserIntegrationDesc": {
     "message": "Browser integration is used for biometrics in browser."
   },
   "browserIntegrationUnsupportedTitle": {
@@ -1564,10 +1564,10 @@
   "browserIntegrationLinuxDesc": {
     "message": "Unfortunately browser integration is currently not supported in the linux version."
   },
-  "enableBrowserIntegrationFingerprint": {
+  "requireVerificationForBrowserIntegration": {
     "message": "Require verification for browser integration"
   },
-  "enableBrowserIntegrationFingerprintDesc": {
+  "requireVerificationForBrowserIntegrationDesc": {
     "message": "Add an additional layer of security by requiring fingerprint phrase confirmation when establishing a link between your desktop and browser. This requires user action and verification each time a connection is created."
   },
   "approve": {

--- a/apps/desktop/src/main/biometric/biometric.darwin.main.ts
+++ b/apps/desktop/src/main/biometric/biometric.darwin.main.ts
@@ -13,7 +13,7 @@ export default class BiometricDarwinMain implements BiometricMain {
   async init() {
     await this.stateService.setEnableBiometric(await this.supportsBiometric());
     await this.stateService.setBiometricText("unlockWithTouchId");
-    await this.stateService.setNoAutoPromptBiometricsText("autoPromptTouchId");
+    await this.stateService.setNoAutoPromptBiometricsText("askForTouchIdOnLaunch");
 
     // eslint-disable-next-line
     ipcMain.on("biometric", async (event: any, message: any) => {

--- a/apps/desktop/src/main/biometric/biometric.windows.main.ts
+++ b/apps/desktop/src/main/biometric/biometric.windows.main.ts
@@ -31,7 +31,7 @@ export default class BiometricWindowsMain implements BiometricMain {
     }
     await this.stateService.setEnableBiometric(supportsBiometric);
     await this.stateService.setBiometricText("unlockWithWindowsHello");
-    await this.stateService.setNoAutoPromptBiometricsText("autoPromptWindowsHello");
+    await this.stateService.setNoAutoPromptBiometricsText("askForWindowsHelloOnLaunch");
 
     ipcMain.on("biometric", async (event: any, message: any) => {
       event.returnValue = await this.authenticateBiometric();

--- a/apps/web/src/app/settings/preferences.component.html
+++ b/apps/web/src/app/settings/preferences.component.html
@@ -77,7 +77,7 @@
         [(ngModel)]="enableFavicons"
       />
       <label class="form-check-label" for="enableFavicons">
-        {{ "enableFavicon" | i18n }}
+        {{ "showWebsiteIcons" | i18n }}
       </label>
       <a
         href="https://bitwarden.com/help/website-icons/"
@@ -88,7 +88,7 @@
         <i class="bwi bwi-question-circle" aria-hidden="true"></i>
       </a>
     </div>
-    <small class="form-text text-muted">{{ "faviconDesc" | i18n }}</small>
+    <small class="form-text text-muted">{{ "showWebsiteIconsDesc" | i18n }}</small>
   </div>
   <div class="form-group">
     <div class="form-check">
@@ -100,7 +100,7 @@
         [(ngModel)]="enableGravatars"
       />
       <label class="form-check-label" for="enableGravatars">
-        {{ "enableGravatars" | i18n }}
+        {{ "showGravatars" | i18n }}
       </label>
       <a
         href="https://gravatar.com/"
@@ -111,7 +111,7 @@
         <i class="bwi bwi-question-circle" aria-hidden="true"></i>
       </a>
     </div>
-    <small class="form-text text-muted">{{ "enableGravatarsDesc" | i18n }}</small>
+    <small class="form-text text-muted">{{ "showGravatarsDesc" | i18n }}</small>
   </div>
   <div class="form-group">
     <div class="form-check">
@@ -123,10 +123,10 @@
         [(ngModel)]="enableFullWidth"
       />
       <label class="form-check-label" for="enableFullWidth">
-        {{ "enableFullWidth" | i18n }}
+        {{ "displayFullWidthLayout" | i18n }}
       </label>
     </div>
-    <small class="form-text text-muted">{{ "enableFullWidthDesc" | i18n }}</small>
+    <small class="form-text text-muted">{{ "displayFullWidthLayoutDesc" | i18n }}</small>
   </div>
   <div class="row">
     <div class="col-6">

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1151,24 +1151,24 @@
   "languageDesc": {
     "message": "Change the language used by the web vault."
   },
-  "enableFavicon": {
+  "showWebsiteIcons": {
     "message": "Show website icons"
   },
-  "faviconDesc": {
+  "showWebsiteIconsDesc": {
     "message": "Show a recognizable image next to each login."
   },
-  "enableGravatars": {
+  "showGravatars": {
     "message": "Show Gravatars",
     "description": "Use avatar images loaded from gravatar.com."
   },
-  "enableGravatarsDesc": {
+  "showGravatarsDesc": {
     "message": "Use avatar images loaded from gravatar.com."
   },
-  "enableFullWidth": {
+  "displayFullWidthLayout": {
     "message": "Display full width layout",
     "description": "Allows scaling the web vault UI's width"
   },
-  "enableFullWidthDesc": {
+  "displayFullWidthLayoutDesc": {
     "message": "Allow the web vault to expand the full width of the browser window."
   },
   "default": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

This PR is based on a Code Review comment posted by @fedemkr on changes made to Mobile app:

> The key should be the same as the value (except for large values like descriptions) in order to be read easier in code without the need to go to the resx to check which is the value. So in this case, it'd be CopyTOTPAutomatically. Furthermore, if for some reason in the future we need the value "Auto TOTP Copy" the key would be already taken by this one.

https://github.com/bitwarden/mobile/pull/1961#discussion_r902775838

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **messages.json:** Update translation keys
- ***.ts:** Use new translation keys

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
