### PR TITLE
[fix] Unsubscribe from activeAccount in AppComponent

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -10,6 +10,7 @@ import {
 import { DomSanitizer } from "@angular/platform-browser";
 import { Router } from "@angular/router";
 import { IndividualConfig, ToastrService } from "ngx-toastr";
+import { Subject, takeUntil } from "rxjs";
 
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
@@ -96,6 +97,8 @@ export class AppComponent implements OnInit {
   private isIdle = false;
   private activeUserId: string = null;
 
+  private destroy$: Subject<void> = new Subject<void>();
+
   constructor(
     private broadcasterService: BroadcasterService,
     private tokenService: TokenService,
@@ -127,9 +130,10 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.stateService.activeAccount.subscribe((userId) => {
+    this.stateService.activeAccount.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
       this.activeUserId = userId;
     });
+
     this.ngZone.runOutsideAngular(() => {
       setTimeout(async () => {
         await this.updateAppMenu();
@@ -360,6 +364,8 @@ export class AppComponent implements OnInit {
   }
 
   ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-379
Related to https://github.com/bitwarden/clients/issues/2249

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We have some subscriptions to `activeAccount` in the browser and desktop `AppComponent`s that are not unsubscribed from. There is concern that this is contributing to a memory leak in the browser extension, and so we should unsubscribe from those subscriptions on destory.

## Code changes
[[fix] Unsubscribe from activeAccount in AppComponent](https://github.com/bitwarden/clients/commit/24690c614627661d9ee0d86a457630f81d75b991)
Unsubscribe from `stateService.activeAccount` in the `browser` and `desktop` `AppComponents` when `ngOnDestory` is run.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
