### PR TITLE
[SG-387] [Vault Filter] - Clicking the dropdown header while menu is open does not close overlay

### DIFF
--- a/apps/browser/src/popup/vault/vault-select.component.ts
+++ b/apps/browser/src/popup/vault/vault-select.component.ts
@@ -141,7 +141,7 @@ export class VaultSelectComponent implements OnInit {
       .withPositions(this.overlayPostition);
 
     this.overlayRef = this.overlay.create({
-      hasBackdrop: false,
+      hasBackdrop: true,
       positionStrategy,
       maxHeight: viewPortHeight - 160,
       backdropClass: "cdk-overlay-transparent-backdrop",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix bug related to dropdown that would reopen when closed.

## Code changes

Changed the param passed to restrict click throughs, which caused the issue.
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Before you submit

<!-- (mark with an `X`) -->


- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
