### PR TITLE
[PS-968] regression bug fix on custom timeout switch for the browser

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1846,7 +1846,7 @@
       }
     }
   },
-  "vaultTimeoutToLarge": {
+  "vaultTimeoutTooLarge": {
     "message": "Your vault timeout exceeds the restrictions set by your organization."
   },
   "vaultExportDisabled": {

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -135,8 +135,9 @@ export class SettingsComponent implements OnInit {
       }
     }
 
-    //we do not need to display an error from the browser since 0 is equivalent to immediately
-    if (!this.vaultTimeout.valid && this.vaultTimeout.value !== 0) {
+    // The minTimeoutError does not apply to browser because it supports Immediately
+    // So only check for the policyError
+    if (this.vaultTimeout.hasError("policyError")) {
       this.platformUtilsService.showToast(
         "error",
         null,
@@ -176,7 +177,7 @@ export class SettingsComponent implements OnInit {
       }
     }
 
-    if (!this.vaultTimeout.valid) {
+    if (this.vaultTimeout.hasError("policyError")) {
       this.platformUtilsService.showToast(
         "error",
         null,

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -136,8 +136,15 @@ export class SettingsComponent implements OnInit {
     }
 
     if (!this.vaultTimeout.valid) {
-      this.platformUtilsService.showToast("error", null, this.i18nService.t("vaultTimeoutToLarge"));
-      return;
+      //we do not need to display an error fro the browser since 0 is equivalent to immediately
+      if (this.vaultTimeout.value !== 0) {
+        this.platformUtilsService.showToast(
+          "error",
+          null,
+          this.i18nService.t("vaultTimeoutToLarge")
+        );
+        return;
+      }
     }
 
     this.previousVaultTimeout = this.vaultTimeout.value;

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -135,16 +135,10 @@ export class SettingsComponent implements OnInit {
       }
     }
 
-    if (!this.vaultTimeout.valid) {
-      //we do not need to display an error fro the browser since 0 is equivalent to immediately
-      if (this.vaultTimeout.value !== 0) {
-        this.platformUtilsService.showToast(
-          "error",
-          null,
-          this.i18nService.t("vaultTimeoutToLarge")
-        );
-        return;
-      }
+    //we do not need to display an error from the browser since 0 is equivalent to immediately
+    if (!this.vaultTimeout.valid && this.vaultTimeout.value !== 0) {
+      this.platformUtilsService.showToast("error", null, this.i18nService.t("vaultTimeoutToLarge"));
+      return;
     }
 
     this.previousVaultTimeout = this.vaultTimeout.value;

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -137,7 +137,11 @@ export class SettingsComponent implements OnInit {
 
     //we do not need to display an error from the browser since 0 is equivalent to immediately
     if (!this.vaultTimeout.valid && this.vaultTimeout.value !== 0) {
-      this.platformUtilsService.showToast("error", null, this.i18nService.t("vaultTimeoutToLarge"));
+      this.platformUtilsService.showToast(
+        "error",
+        null,
+        this.i18nService.t("vaultTimeoutTooLarge")
+      );
       return;
     }
 
@@ -173,7 +177,11 @@ export class SettingsComponent implements OnInit {
     }
 
     if (!this.vaultTimeout.valid) {
-      this.platformUtilsService.showToast("error", null, this.i18nService.t("vaultTimeoutToLarge"));
+      this.platformUtilsService.showToast(
+        "error",
+        null,
+        this.i18nService.t("vaultTimeoutTooLarge")
+      );
       return;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When switching to a custom time interval of 0 hours 0 minutes, an error toast appears. This happens because of this  https://github.com/bitwarden/clients/pull/2836  change on the web which prevents a user from having 0 hours 0 minutes or less as a custom timeout value on the web.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- **apps/browser/src/popup/settings/settings.component.ts:** Added an extra condition to check if the vault value is 0 on the browser, this prevents execution from getting to the toast error since the `immediately` feature on the browser is `0`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
