### PR TITLE
[PS-998] Add button type to premium badge

### DIFF
--- a/apps/web/src/app/components/premium-badge.component.ts
+++ b/apps/web/src/app/components/premium-badge.component.ts
@@ -5,7 +5,7 @@ import { MessagingService } from "@bitwarden/common/abstractions/messaging.servi
 @Component({
   selector: "app-premium-badge",
   template: `
-    <button *appNotPremium appStopClick bitBadge badgeType="success" (click)="premiumRequired()">
+    <button type="button" *appNotPremium bitBadge badgeType="success" (click)="premiumRequired()">
       {{ "premium" | i18n }}
     </button>
   `,

--- a/apps/web/src/app/components/premium-badge.component.ts
+++ b/apps/web/src/app/components/premium-badge.component.ts
@@ -5,7 +5,7 @@ import { MessagingService } from "@bitwarden/common/abstractions/messaging.servi
 @Component({
   selector: "app-premium-badge",
   template: `
-    <button *appNotPremium bitBadge badgeType="success" (click)="premiumRequired()">
+    <button *appNotPremium appStopClick bitBadge badgeType="success" (click)="premiumRequired()">
       {{ "premium" | i18n }}
     </button>
   `,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Our new premium badge is actually a button that has a popup. The button didn't have a type and we weren't preventing the default behavior when clicking the button. This meant that when adding a new item and pressing `Enter`, the button would be clicked, the form submitted, and the popup would show.

This PR prevents this behavior


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Before (Pressing `Enter` to submit)
https://user-images.githubusercontent.com/24985544/175538562-1c5d56cd-2221-423d-9cff-cdfebefabfb0.mov

After (Pressing `Enter` to submit)
https://user-images.githubusercontent.com/24985544/175548320-ef482062-d27a-490a-958e-7d9d29c601b5.mov



## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
