### PR TITLE
[SG-409] Use ngSwitchDefault so that ‘singleOrgPolicy’ affected users see org filters

### DIFF
--- a/apps/desktop/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/apps/desktop/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -45,7 +45,7 @@
         </li>
       </ul>
     </ng-container>
-    <ng-container *ngSwitchCase="'organizationMember'">
+    <ng-container *ngSwitchDefault>
       <div class="filter-heading" [ngClass]="{ active: !hasActiveFilter }">
         <button
           appA11yTitle="{{ 'toggleCollapse' | i18n }}"


### PR DESCRIPTION
…filter

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix issue where Organization Vault Filters where not showing up for users and managers in an org with the SingleOrgPolicy enabled and the PersonalOwnershipPoilicy disabled.

## Code changes

- **apps/desktop/src/app/modules/vault-filter/components/organization-filter.component.html:** ngSwitch can only take one case at a time, so switch the organizationMember case to be the default so that the `singleOrganization` case is supported . The `noOrganizations` and `singleOrganizationAndPersonalOwnershipPolicies` cases are handled by the `show` variable, so this change will not affect them. 


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
