### PR TITLE
[EC-282/EC-286] Update queryParams to use new filter object

### DIFF
--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -57,16 +57,16 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
   @ViewChild("updateKeyTemplate", { read: ViewContainerRef, static: true })
   updateKeyModalRef: ViewContainerRef;
 
-  favorites = false;
+  favorites = false; // Unused
   folderId: string = null;
-  collectionId: string = null;
-  organizationId: string = null;
+  collectionId: string = null; // Unused
+  organizationId: string = null; // Unused
   myVaultOnly = false;
   showVerifyEmail = false;
   showBrowserOutdated = false;
   showUpdateKey = false;
   showPremiumCallout = false;
-  deleted = false;
+  deleted = false; // Unused
   trashCleanupWarning: string = null;
   activeFilter: VaultFilter = new VaultFilter();
 
@@ -402,11 +402,11 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
   private go(queryParams: any = null) {
     if (queryParams == null) {
       queryParams = {
-        favorites: this.favorites ? true : null,
+        favorites: this.activeFilter.status === "favorites" ? true : null,
         type: this.activeFilter.cipherType,
-        folderId: this.folderId,
-        collectionId: this.collectionId,
-        deleted: this.deleted ? true : null,
+        folderId: this.activeFilter.selectedFolderId,
+        collectionId: this.activeFilter.selectedCollectionId,
+        deleted: this.activeFilter.status === "trash" ? true : null,
       };
     }
 

--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -57,16 +57,12 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
   @ViewChild("updateKeyTemplate", { read: ViewContainerRef, static: true })
   updateKeyModalRef: ViewContainerRef;
 
-  favorites = false; // Unused
   folderId: string = null;
-  collectionId: string = null; // Unused
-  organizationId: string = null; // Unused
   myVaultOnly = false;
   showVerifyEmail = false;
   showBrowserOutdated = false;
   showUpdateKey = false;
   showPremiumCallout = false;
-  deleted = false; // Unused
   trashCleanupWarning: string = null;
   activeFilter: VaultFilter = new VaultFilter();
 

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -340,9 +340,9 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
   private go(queryParams: any = null) {
     if (queryParams == null) {
       queryParams = {
-        type: this.type,
-        collectionId: this.collectionId,
-        deleted: this.deleted ? true : null,
+        type: this.activeFilter.cipherType,
+        collectionId: this.activeFilter.selectedCollectionId,
+        deleted: this.activeFilter.status === "trash" ? true : null,
       };
     }
 

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -151,6 +151,10 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
     });
   }
 
+  get deleted(): boolean {
+    return this.activeFilter.status === "trash";
+  }
+
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }
@@ -170,7 +174,7 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
       if (this.activeFilter.status === "favorites" && cipherPassesFilter) {
         cipherPassesFilter = cipher.favorite;
       }
-      if (this.activeFilter.status === "trash" && cipherPassesFilter) {
+      if (this.deleted && cipherPassesFilter) {
         cipherPassesFilter = cipher.isDeleted;
       }
       if (this.activeFilter.cipherType != null && cipherPassesFilter) {
@@ -335,7 +339,7 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
       queryParams = {
         type: this.activeFilter.cipherType,
         collectionId: this.activeFilter.selectedCollectionId,
-        deleted: this.activeFilter.status === "trash" ? true : null,
+        deleted: this.deleted ? true : null,
       };
     }
 

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -54,7 +54,6 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
   organization: Organization;
   collectionId: string = null;
   type: CipherType = null;
-  deleted = false;
   trashCleanupWarning: string = null;
   activeFilter: VaultFilter = new VaultFilter();
 
@@ -329,12 +328,6 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
       comp.showUser = true;
       comp.entity = "cipher";
     });
-  }
-
-  private clearFilters() {
-    this.collectionId = null;
-    this.type = null;
-    this.deleted = false;
   }
 
   private go(queryParams: any = null) {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Replace the query param strings as they were inadvertently removed during the vault filter refresh
> EC-282 
> EC-286

## Code changes
- **individual-vault.component.ts**: Updated `go` method to reference `activeFilter` object instead of class properties. 
- **organization-vault.component.ts**: Updated `go` method to reference `activeFilter` object instead of class properties. Added `deleted` getter and updated all references to `activeFilter.status === "trash"` to use the getter. 

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

