### PR TITLE
[EC-267] Unassigned collection has disappeared in web vault

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -128,7 +128,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             await this.openGenerator(false);
             break;
           case "syncCompleted":
-            await this.ciphersComponent.reload(this.buildFilter());
+            await this.ciphersComponent.reload(this.activeFilter.buildFilter());
             await this.vaultFilterComponent.reloadCollectionsAndFolders(this.activeFilter);
             await this.vaultFilterComponent.reloadOrganizations();
             break;
@@ -241,7 +241,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         selectedOrganizationId: params.selectedOrganizationId,
         myVaultOnly: params.myVaultOnly ?? false,
       });
-      await this.ciphersComponent.reload(this.buildFilter());
+      await this.ciphersComponent.reload(this.activeFilter.buildFilter());
     });
   }
 
@@ -540,7 +540,10 @@ export class VaultComponent implements OnInit, OnDestroy {
       this.i18nService.t(this.calculateSearchBarLocalizationString(vaultFilter))
     );
     this.activeFilter = vaultFilter;
-    await this.ciphersComponent.reload(this.buildFilter(), vaultFilter.status === "trash");
+    await this.ciphersComponent.reload(
+      this.activeFilter.buildFilter(),
+      vaultFilter.status === "trash"
+    );
     this.go();
   }
 
@@ -568,40 +571,6 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     return "searchVault";
-  }
-
-  private buildFilter(): (cipher: CipherView) => boolean {
-    return (cipher) => {
-      let cipherPassesFilter = true;
-      if (this.activeFilter.status === "favorites" && cipherPassesFilter) {
-        cipherPassesFilter = cipher.favorite;
-      }
-      if (this.activeFilter.status === "trash" && cipherPassesFilter) {
-        cipherPassesFilter = cipher.isDeleted;
-      }
-      if (this.activeFilter.cipherType != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.type === this.activeFilter.cipherType;
-      }
-      if (
-        this.activeFilter.selectedFolder &&
-        this.activeFilter.selectedFolderId != "none" &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter = cipher.folderId === this.activeFilter.selectedFolderId;
-      }
-      if (this.activeFilter.selectedCollectionId != null && cipherPassesFilter) {
-        cipherPassesFilter =
-          cipher.collectionIds != null &&
-          cipher.collectionIds.indexOf(this.activeFilter.selectedCollectionId) > -1;
-      }
-      if (this.activeFilter.selectedOrganizationId != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === this.activeFilter.selectedOrganizationId;
-      }
-      if (this.activeFilter.myVaultOnly && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === null;
-      }
-      return cipherPassesFilter;
-    };
   }
 
   async openGenerator(comingFromAddEdit: boolean, passwordType = true) {

--- a/apps/web/src/app/modules/vault-filter/components/collection-filter.component.html
+++ b/apps/web/src/app/modules/vault-filter/components/collection-filter.component.html
@@ -23,7 +23,7 @@
       <li
         *ngFor="let c of collections"
         [ngClass]="{
-          active: c.node.id === activeFilter.selectedCollectionId
+          active: c.node.id === activeFilter.selectedCollectionId && activeFilter.selectedCollection
         }"
         class="filter-option"
       >

--- a/apps/web/src/app/modules/vault-filter/vault-filter.service.ts
+++ b/apps/web/src/app/modules/vault-filter/vault-filter.service.ts
@@ -7,6 +7,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder.service";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
@@ -27,6 +28,7 @@ export class VaultFilterService extends BaseVaultFilterService {
     cipherService: CipherService,
     collectionService: CollectionService,
     policyService: PolicyService,
+    private i18nService: I18nService,
     protected apiService: ApiService
   ) {
     super(
@@ -68,6 +70,10 @@ export class VaultFilterService extends BaseVaultFilterService {
       );
       result = await this.collectionService.decryptMany(collectionDomains);
     }
+
+    const noneCollection = new CollectionView();
+    noneCollection.name = this.i18nService.t("unassigned");
+    result.push(noneCollection);
 
     const nestedCollections = await this.collectionService.getAllNested(result);
     return new DynamicTreeNode<CollectionView>({

--- a/apps/web/src/app/modules/vault-filter/vault-filter.service.ts
+++ b/apps/web/src/app/modules/vault-filter/vault-filter.service.ts
@@ -73,6 +73,7 @@ export class VaultFilterService extends BaseVaultFilterService {
 
     const noneCollection = new CollectionView();
     noneCollection.name = this.i18nService.t("unassigned");
+    noneCollection.organizationId = organizationId;
     result.push(noneCollection);
 
     const nestedCollections = await this.collectionService.getAllNested(result);

--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -215,6 +215,15 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       ) {
         cipherPassesFilter = cipher.folderId === this.activeFilter.selectedFolderId;
       }
+      if (
+        this.activeFilter.selectedCollection &&
+        this.activeFilter.selectedCollectionId === null &&
+        cipherPassesFilter
+      ) {
+        cipherPassesFilter =
+          cipher.organizationId != null &&
+          (cipher.collectionIds == null || cipher.collectionIds.length === 0);
+      }
       if (this.activeFilter.selectedCollectionId != null && cipherPassesFilter) {
         cipherPassesFilter =
           cipher.collectionIds != null &&

--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -217,14 +217,18 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
       }
       if (
         this.activeFilter.selectedCollection &&
-        this.activeFilter.selectedCollectionId === null &&
+        this.activeFilter.selectedCollectionId == null &&
         cipherPassesFilter
       ) {
         cipherPassesFilter =
           cipher.organizationId != null &&
           (cipher.collectionIds == null || cipher.collectionIds.length === 0);
       }
-      if (this.activeFilter.selectedCollectionId != null && cipherPassesFilter) {
+      if (
+        this.activeFilter.selectedCollection &&
+        this.activeFilter.selectedCollectionId != null &&
+        cipherPassesFilter
+      ) {
         cipherPassesFilter =
           cipher.collectionIds != null &&
           cipher.collectionIds.indexOf(this.activeFilter.selectedCollectionId) > -1;

--- a/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts
@@ -173,7 +173,10 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
   async applyVaultFilter(vaultFilter: VaultFilter) {
     this.ciphersComponent.showAddNew = vaultFilter.status !== "trash";
     this.activeFilter = vaultFilter;
-    await this.ciphersComponent.reload(this.buildFilter(), vaultFilter.status === "trash");
+    await this.ciphersComponent.reload(
+      this.activeFilter.buildFilter(),
+      vaultFilter.status === "trash"
+    );
     this.filterComponent.searchPlaceholder = this.vaultService.calculateSearchBarLocalizationString(
       this.activeFilter
     );
@@ -194,53 +197,6 @@ export class IndividualVaultComponent implements OnInit, OnDestroy {
   filterSearchText(searchText: string) {
     this.ciphersComponent.searchText = searchText;
     this.ciphersComponent.search(200);
-  }
-
-  private buildFilter(): (cipher: CipherView) => boolean {
-    return (cipher) => {
-      let cipherPassesFilter = true;
-      if (this.activeFilter.status === "favorites" && cipherPassesFilter) {
-        cipherPassesFilter = cipher.favorite;
-      }
-      if (this.activeFilter.status === "trash" && cipherPassesFilter) {
-        cipherPassesFilter = cipher.isDeleted;
-      }
-      if (this.activeFilter.cipherType != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.type === this.activeFilter.cipherType;
-      }
-      if (
-        this.activeFilter.selectedFolder &&
-        this.activeFilter.selectedFolderId != "none" &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter = cipher.folderId === this.activeFilter.selectedFolderId;
-      }
-      if (
-        this.activeFilter.selectedCollection &&
-        this.activeFilter.selectedCollectionId == null &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter =
-          cipher.organizationId != null &&
-          (cipher.collectionIds == null || cipher.collectionIds.length === 0);
-      }
-      if (
-        this.activeFilter.selectedCollection &&
-        this.activeFilter.selectedCollectionId != null &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter =
-          cipher.collectionIds != null &&
-          cipher.collectionIds.indexOf(this.activeFilter.selectedCollectionId) > -1;
-      }
-      if (this.activeFilter.selectedOrganizationId != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === this.activeFilter.selectedOrganizationId;
-      }
-      if (this.activeFilter.myVaultOnly && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === null;
-      }
-      return cipherPassesFilter;
-    };
   }
 
   async editCipherAttachments(cipher: CipherView) {

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -187,7 +187,20 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
       ) {
         cipherPassesFilter = cipher.folderId === this.activeFilter.selectedFolderId;
       }
-      if (this.activeFilter.selectedCollectionId != null && cipherPassesFilter) {
+      if (
+        this.activeFilter.selectedCollection &&
+        this.activeFilter.selectedCollectionId == null &&
+        cipherPassesFilter
+      ) {
+        cipherPassesFilter =
+          cipher.organizationId != null &&
+          (cipher.collectionIds == null || cipher.collectionIds.length === 0);
+      }
+      if (
+        this.activeFilter.selectedCollection &&
+        this.activeFilter.selectedCollectionId != null &&
+        cipherPassesFilter
+      ) {
         cipherPassesFilter =
           cipher.collectionIds != null &&
           cipher.collectionIds.indexOf(this.activeFilter.selectedCollectionId) > -1;

--- a/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -162,57 +162,13 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
   async applyVaultFilter(vaultFilter: VaultFilter) {
     this.ciphersComponent.showAddNew = vaultFilter.status !== "trash";
     this.activeFilter = vaultFilter;
-    await this.ciphersComponent.reload(this.buildFilter(), vaultFilter.status === "trash");
+    await this.ciphersComponent.reload(
+      this.activeFilter.buildFilter(),
+      vaultFilter.status === "trash"
+    );
     this.vaultFilterComponent.searchPlaceholder =
       this.vaultService.calculateSearchBarLocalizationString(this.activeFilter);
     this.go();
-  }
-
-  private buildFilter(): (cipher: CipherView) => boolean {
-    return (cipher) => {
-      let cipherPassesFilter = true;
-      if (this.activeFilter.status === "favorites" && cipherPassesFilter) {
-        cipherPassesFilter = cipher.favorite;
-      }
-      if (this.deleted && cipherPassesFilter) {
-        cipherPassesFilter = cipher.isDeleted;
-      }
-      if (this.activeFilter.cipherType != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.type === this.activeFilter.cipherType;
-      }
-      if (
-        this.activeFilter.selectedFolder != null &&
-        this.activeFilter.selectedFolderId != "none" &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter = cipher.folderId === this.activeFilter.selectedFolderId;
-      }
-      if (
-        this.activeFilter.selectedCollection &&
-        this.activeFilter.selectedCollectionId == null &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter =
-          cipher.organizationId != null &&
-          (cipher.collectionIds == null || cipher.collectionIds.length === 0);
-      }
-      if (
-        this.activeFilter.selectedCollection &&
-        this.activeFilter.selectedCollectionId != null &&
-        cipherPassesFilter
-      ) {
-        cipherPassesFilter =
-          cipher.collectionIds != null &&
-          cipher.collectionIds.indexOf(this.activeFilter.selectedCollectionId) > -1;
-      }
-      if (this.activeFilter.selectedOrganizationId != null && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === this.activeFilter.selectedOrganizationId;
-      }
-      if (this.activeFilter.myVaultOnly && cipherPassesFilter) {
-        cipherPassesFilter = cipher.organizationId === null;
-      }
-      return cipherPassesFilter;
-    };
   }
 
   filterSearchText(searchText: string) {

--- a/apps/web/src/app/modules/vault/vault.service.ts
+++ b/apps/web/src/app/modules/vault/vault.service.ts
@@ -14,7 +14,7 @@ export class VaultService {
     if (vaultFilter.selectedFolderId != null && vaultFilter.selectedFolderId != "none") {
       return "searchFolder";
     }
-    if (vaultFilter.selectedCollectionId != null) {
+    if (vaultFilter.selectedCollection) {
       return "searchCollection";
     }
     if (vaultFilter.selectedOrganizationId != null) {

--- a/libs/angular/src/modules/vault-filter/components/collection-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/components/collection-filter.component.ts
@@ -41,6 +41,7 @@ export class CollectionFilterComponent {
 
   applyFilter(collection: CollectionView) {
     this.activeFilter.resetFilter();
+    this.activeFilter.selectedCollection = true;
     this.activeFilter.selectedCollectionId = collection.id;
     this.onFilterChange.emit(this.activeFilter);
   }

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -1,0 +1,205 @@
+import { CipherType } from "@bitwarden/common/enums/cipherType";
+import { CipherView } from "@bitwarden/common/models/view/cipherView";
+
+import { VaultFilter } from "./vault-filter.model";
+
+describe("VaultFilter", () => {
+  describe("filterFunction", () => {
+    it("should return true when filter is set to all statuses", () => {
+      const cipher = createCipher();
+      const filterFunction = createFilterFunction({ status: "all" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when filter is set to favorites and cipher is favorite", () => {
+      const cipher = createCipher({ favorite: true });
+      const filterFunction = createFilterFunction({ status: "favorites" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filter is set to all and cipher is not favorite", () => {
+      const cipher = createCipher({ favorite: false });
+      const filterFunction = createFilterFunction({ status: "favorites" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when filter is set to trash and cipher is deleted", () => {
+      const cipher = createCipher({ deletedDate: new Date() });
+      const filterFunction = createFilterFunction({ status: "trash" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filter is set to trash and cipher is not deleted", () => {
+      const cipher = createCipher({ deletedDate: undefined });
+      const filterFunction = createFilterFunction({ status: "trash" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when filter matches cipher type", () => {
+      const cipher = createCipher({ type: CipherType.Identity });
+      const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filter does not match cipher type", () => {
+      const cipher = createCipher({ type: CipherType.Card });
+      const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when filter matches folder id", () => {
+      const cipher = createCipher({ folderId: "folderId" });
+      const filterFunction = createFilterFunction({
+        selectedFolder: true,
+        selectedFolderId: "folderId",
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when filtering on unassigned folder and cipher does not have folder", () => {
+      const cipher = createCipher({ folderId: undefined });
+      const filterFunction = createFilterFunction({
+        selectedFolder: true,
+        selectedFolderId: null,
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filter does not match folder id", () => {
+      const cipher = createCipher({ folderId: "folderId" });
+      const filterFunction = createFilterFunction({
+        selectedFolder: true,
+        selectedFolderId: "anotherFolderId",
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when filter matches collection id", () => {
+      const cipher = createCipher({ collectionIds: ["collectionId", "anotherId"] });
+      const filterFunction = createFilterFunction({ selectedCollectionId: "collectionId" });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when filtering on unassigned collection and cipher belongs to organization and does not have any collections", () => {
+      const cipher = createCipher({ organizationId: "organizationId", collectionIds: [] });
+      const filterFunction = createFilterFunction({
+        selectedCollection: true,
+        selectedCollectionId: null,
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filtering on unassigned collection but cipher does not have organization", () => {
+      const cipher = createCipher({ organizationId: null, collectionIds: [] });
+      const filterFunction = createFilterFunction({
+        selectedCollection: true,
+        selectedCollectionId: null,
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when filter does not match collection id", () => {
+      const cipher = createCipher({
+        organizationId: "organizationId",
+        collectionIds: ["collectionId", "anotherId"],
+      });
+      const filterFunction = createFilterFunction({
+        selectedCollection: true,
+        selectedCollectionId: "nonMatchingId",
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when filter matches organization id", () => {
+      const cipher = createCipher({ organizationId: "organizationId" });
+      const filterFunction = createFilterFunction({
+        selectedOrganizationId: "organizationId",
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when filtering on my vault only and cipher does not have any organization", () => {
+      const cipher = createCipher({ organizationId: null });
+      const filterFunction = createFilterFunction({
+        myVaultOnly: true,
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when filter does not match organization id", () => {
+      const cipher = createCipher({ organizationId: "organizationId" });
+      const filterFunction = createFilterFunction({
+        selectedOrganizationId: "anotherOrganizationId",
+      });
+
+      const result = filterFunction(cipher);
+
+      expect(result).toBe(false);
+    });
+  });
+});
+
+function createFilterFunction(options: Partial<VaultFilter> = {}) {
+  return new VaultFilter(options).buildFilter();
+}
+
+function createCipher(options: Partial<CipherView> = {}) {
+  const cipher = new CipherView();
+
+  cipher.favorite = options.favorite ?? false;
+  cipher.deletedDate = options.deletedDate;
+  cipher.type = options.type;
+  cipher.folderId = options.folderId;
+  cipher.collectionIds = options.collectionIds;
+  cipher.organizationId = options.organizationId;
+
+  return cipher;
+}

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -16,7 +16,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("favorite cipher", () => {
+    describe("given a favorite cipher", () => {
       const cipher = createCipher({ favorite: true });
 
       it("should return true when filtering for favorites", () => {
@@ -36,7 +36,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("deleted cipher", () => {
+    describe("given a deleted cipher", () => {
       const cipher = createCipher({ deletedDate: new Date() });
 
       it("should return true when filtering for trash", () => {
@@ -56,7 +56,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("cipher with type", () => {
+    describe("given a cipher with type", () => {
       it("should return true when filter matches cipher type", () => {
         const cipher = createCipher({ type: CipherType.Identity });
         const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
@@ -76,7 +76,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("cipher with folder id", () => {
+    describe("given a cipher with folder id", () => {
       it("should return true when filter matches folder id", () => {
         const cipher = createCipher({ folderId: "folderId" });
         const filterFunction = createFilterFunction({
@@ -102,7 +102,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("cipher without folder", () => {
+    describe("given a cipher without folder", () => {
       const cipher = createCipher({ folderId: undefined });
 
       it("should return true when filtering on unassigned folder", () => {
@@ -117,7 +117,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("organizational cipher (with organization and collections)", () => {
+    describe("given an organizational cipher (with organization and collections)", () => {
       const cipher = createCipher({
         organizationId: "organizationId",
         collectionIds: ["collectionId", "anotherId"],
@@ -166,7 +166,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("unassigned organizational cipher (with organization, without collection)", () => {
+    describe("given an unassigned organizational cipher (with organization, without collection)", () => {
       const cipher = createCipher({ organizationId: "organizationId", collectionIds: [] });
 
       it("should return true when filtering for unassigned collection", () => {
@@ -191,7 +191,7 @@ describe("VaultFilter", () => {
       });
     });
 
-    describe("individual cipher (without organization or collection)", () => {
+    describe("given an individual cipher (without organization or collection)", () => {
       const cipher = createCipher({ organizationId: null, collectionIds: [] });
 
       it("should return false when filtering for unassigned collection", () => {

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -151,6 +151,16 @@ describe("VaultFilter", () => {
 
         expect(result).toBe(false);
       });
+
+      it("should return false when filtering for my vault only", () => {
+        const filterFunction = createFilterFunction({
+          myVaultOnly: true,
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
     });
 
     describe("unassigned organizational cipher (with organization, without collection)", () => {

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -103,7 +103,7 @@ describe("VaultFilter", () => {
     });
 
     describe("given a cipher without folder", () => {
-      const cipher = createCipher({ folderId: undefined });
+      const cipher = createCipher({ folderId: null });
 
       it("should return true when filtering on unassigned folder", () => {
         const filterFunction = createFilterFunction({

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -5,184 +5,203 @@ import { VaultFilter } from "./vault-filter.model";
 
 describe("VaultFilter", () => {
   describe("filterFunction", () => {
-    it("should return true when filter is set to all statuses", () => {
-      const cipher = createCipher();
-      const filterFunction = createFilterFunction({ status: "all" });
+    describe("generic cipher", () => {
+      it("should return true when not filtering for anything specific", () => {
+        const cipher = createCipher();
+        const filterFunction = createFilterFunction({ status: "all" });
 
-      const result = filterFunction(cipher);
+        const result = filterFunction(cipher);
 
-      expect(result).toBe(true);
+        expect(result).toBe(true);
+      });
     });
 
-    it("should return true when filter is set to favorites and cipher is favorite", () => {
+    describe("favorite cipher", () => {
       const cipher = createCipher({ favorite: true });
-      const filterFunction = createFilterFunction({ status: "favorites" });
 
-      const result = filterFunction(cipher);
+      it("should return true when filtering for favorites", () => {
+        const filterFunction = createFilterFunction({ status: "favorites" });
 
-      expect(result).toBe(true);
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
+      });
+
+      it("should return false when filtering for trash", () => {
+        const filterFunction = createFilterFunction({ status: "trash" });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
     });
 
-    it("should return false when filter is set to all and cipher is not favorite", () => {
-      const cipher = createCipher({ favorite: false });
-      const filterFunction = createFilterFunction({ status: "favorites" });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return true when filter is set to trash and cipher is deleted", () => {
+    describe("deleted cipher", () => {
       const cipher = createCipher({ deletedDate: new Date() });
-      const filterFunction = createFilterFunction({ status: "trash" });
 
-      const result = filterFunction(cipher);
+      it("should return true when filtering for trash", () => {
+        const filterFunction = createFilterFunction({ status: "trash" });
 
-      expect(result).toBe(true);
-    });
+        const result = filterFunction(cipher);
 
-    it("should return false when filter is set to trash and cipher is not deleted", () => {
-      const cipher = createCipher({ deletedDate: undefined });
-      const filterFunction = createFilterFunction({ status: "trash" });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return true when filter matches cipher type", () => {
-      const cipher = createCipher({ type: CipherType.Identity });
-      const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(true);
-    });
-
-    it("should return false when filter does not match cipher type", () => {
-      const cipher = createCipher({ type: CipherType.Card });
-      const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return true when filter matches folder id", () => {
-      const cipher = createCipher({ folderId: "folderId" });
-      const filterFunction = createFilterFunction({
-        selectedFolder: true,
-        selectedFolderId: "folderId",
+        expect(result).toBe(true);
       });
 
-      const result = filterFunction(cipher);
+      it("should return false when filtering for favorites", () => {
+        const filterFunction = createFilterFunction({ status: "favorites" });
 
-      expect(result).toBe(true);
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
     });
 
-    it("should return true when filtering on unassigned folder and cipher does not have folder", () => {
+    describe("cipher with type", () => {
+      it("should return true when filter matches cipher type", () => {
+        const cipher = createCipher({ type: CipherType.Identity });
+        const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
+      });
+
+      it("should return false when filter does not match cipher type", () => {
+        const cipher = createCipher({ type: CipherType.Card });
+        const filterFunction = createFilterFunction({ cipherType: CipherType.Identity });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("cipher with folder id", () => {
+      it("should return true when filter matches folder id", () => {
+        const cipher = createCipher({ folderId: "folderId" });
+        const filterFunction = createFilterFunction({
+          selectedFolder: true,
+          selectedFolderId: "folderId",
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
+      });
+
+      it("should return false when filter does not match folder id", () => {
+        const cipher = createCipher({ folderId: "folderId" });
+        const filterFunction = createFilterFunction({
+          selectedFolder: true,
+          selectedFolderId: "anotherFolderId",
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("cipher without folder", () => {
       const cipher = createCipher({ folderId: undefined });
-      const filterFunction = createFilterFunction({
-        selectedFolder: true,
-        selectedFolderId: null,
+
+      it("should return true when filtering on unassigned folder", () => {
+        const filterFunction = createFilterFunction({
+          selectedFolder: true,
+          selectedFolderId: null,
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
       });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(true);
     });
 
-    it("should return false when filter does not match folder id", () => {
-      const cipher = createCipher({ folderId: "folderId" });
-      const filterFunction = createFilterFunction({
-        selectedFolder: true,
-        selectedFolderId: "anotherFolderId",
-      });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return true when filter matches collection id", () => {
-      const cipher = createCipher({ collectionIds: ["collectionId", "anotherId"] });
-      const filterFunction = createFilterFunction({ selectedCollectionId: "collectionId" });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(true);
-    });
-
-    it("should return true when filtering on unassigned collection and cipher belongs to organization and does not have any collections", () => {
-      const cipher = createCipher({ organizationId: "organizationId", collectionIds: [] });
-      const filterFunction = createFilterFunction({
-        selectedCollection: true,
-        selectedCollectionId: null,
-      });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(true);
-    });
-
-    it("should return false when filtering on unassigned collection but cipher does not have organization", () => {
-      const cipher = createCipher({ organizationId: null, collectionIds: [] });
-      const filterFunction = createFilterFunction({
-        selectedCollection: true,
-        selectedCollectionId: null,
-      });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when filter does not match collection id", () => {
+    describe("organizational cipher (with organization and collections)", () => {
       const cipher = createCipher({
         organizationId: "organizationId",
         collectionIds: ["collectionId", "anotherId"],
       });
-      const filterFunction = createFilterFunction({
-        selectedCollection: true,
-        selectedCollectionId: "nonMatchingId",
+
+      it("should return true when filter matches collection id", () => {
+        const filterFunction = createFilterFunction({ selectedCollectionId: "collectionId" });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
       });
 
-      const result = filterFunction(cipher);
+      it("should return false when filter does not match collection id", () => {
+        const filterFunction = createFilterFunction({
+          selectedCollection: true,
+          selectedCollectionId: "nonMatchingId",
+        });
 
-      expect(result).toBe(false);
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
+
+      it("should return false when filter does not match organization id", () => {
+        const filterFunction = createFilterFunction({
+          selectedOrganizationId: "anotherOrganizationId",
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
+      });
     });
 
-    it("should return true when filter matches organization id", () => {
-      const cipher = createCipher({ organizationId: "organizationId" });
-      const filterFunction = createFilterFunction({
-        selectedOrganizationId: "organizationId",
+    describe("unassigned organizational cipher (with organization, without collection)", () => {
+      const cipher = createCipher({ organizationId: "organizationId", collectionIds: [] });
+
+      it("should return true when filtering for unassigned collection", () => {
+        const filterFunction = createFilterFunction({
+          selectedCollection: true,
+          selectedCollectionId: null,
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
       });
 
-      const result = filterFunction(cipher);
+      it("should return true when filter matches organization id", () => {
+        const filterFunction = createFilterFunction({
+          selectedOrganizationId: "organizationId",
+        });
 
-      expect(result).toBe(true);
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(true);
+      });
     });
 
-    it("should return true when filtering on my vault only and cipher does not have any organization", () => {
-      const cipher = createCipher({ organizationId: null });
-      const filterFunction = createFilterFunction({
-        myVaultOnly: true,
+    describe("individual cipher (without organization or collection)", () => {
+      const cipher = createCipher({ organizationId: null, collectionIds: [] });
+
+      it("should return false when filtering for unassigned collection", () => {
+        const filterFunction = createFilterFunction({
+          selectedCollection: true,
+          selectedCollectionId: null,
+        });
+
+        const result = filterFunction(cipher);
+
+        expect(result).toBe(false);
       });
 
-      const result = filterFunction(cipher);
+      it("should return true when filtering for my vault only", () => {
+        const cipher = createCipher({ organizationId: null });
+        const filterFunction = createFilterFunction({
+          myVaultOnly: true,
+        });
 
-      expect(result).toBe(true);
-    });
+        const result = filterFunction(cipher);
 
-    it("should return false when filter does not match organization id", () => {
-      const cipher = createCipher({ organizationId: "organizationId" });
-      const filterFunction = createFilterFunction({
-        selectedOrganizationId: "anotherOrganizationId",
+        expect(result).toBe(true);
       });
-
-      const result = filterFunction(cipher);
-
-      expect(result).toBe(false);
     });
   });
 });

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts
@@ -124,7 +124,10 @@ describe("VaultFilter", () => {
       });
 
       it("should return true when filter matches collection id", () => {
-        const filterFunction = createFilterFunction({ selectedCollectionId: "collectionId" });
+        const filterFunction = createFilterFunction({
+          selectedCollection: true,
+          selectedCollectionId: "collectionId",
+        });
 
         const result = filterFunction(cipher);
 

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
@@ -4,6 +4,7 @@ import { CipherStatus } from "./cipher-status.model";
 
 export class VaultFilter {
   cipherType?: CipherType;
+  selectedCollection = false; // This is needed because of how the "Unassigned" collection works. It has a null id.
   selectedCollectionId?: string;
   status?: CipherStatus;
   selectedFolder = false; // This is needed because of how the "No Folder" folder works. It has a null id.
@@ -19,6 +20,7 @@ export class VaultFilter {
   resetFilter() {
     this.cipherType = null;
     this.status = null;
+    this.selectedCollection = false;
     this.selectedCollectionId = null;
     this.selectedFolder = false;
     this.selectedFolderId = null;

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
@@ -47,7 +47,10 @@ export class VaultFilter {
       if (this.cipherType != null && cipherPassesFilter) {
         cipherPassesFilter = cipher.type === this.cipherType;
       }
-      if (this.selectedFolder != null && this.selectedFolderId != "none" && cipherPassesFilter) {
+      if (this.selectedFolder && this.selectedFolderId == null && cipherPassesFilter) {
+        cipherPassesFilter = cipher.folderId == null;
+      }
+      if (this.selectedFolder && this.selectedFolderId != null && cipherPassesFilter) {
         cipherPassesFilter = cipher.folderId === this.selectedFolderId;
       }
       if (this.selectedCollection && this.selectedCollectionId == null && cipherPassesFilter) {
@@ -57,8 +60,7 @@ export class VaultFilter {
       }
       if (this.selectedCollection && this.selectedCollectionId != null && cipherPassesFilter) {
         cipherPassesFilter =
-          cipher.collectionIds != null &&
-          cipher.collectionIds.indexOf(this.selectedCollectionId) > -1;
+          cipher.collectionIds != null && cipher.collectionIds.includes(this.selectedCollectionId);
       }
       if (this.selectedOrganizationId != null && cipherPassesFilter) {
         cipherPassesFilter = cipher.organizationId === this.selectedOrganizationId;

--- a/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
+++ b/libs/angular/src/modules/vault-filter/models/vault-filter.model.ts
@@ -1,6 +1,9 @@
 import { CipherType } from "@bitwarden/common/enums/cipherType";
+import { CipherView } from "@bitwarden/common/models/view/cipherView";
 
 import { CipherStatus } from "./cipher-status.model";
+
+export type VaultFilterFunction = (cipher: CipherView) => boolean;
 
 export class VaultFilter {
   cipherType?: CipherType;
@@ -30,5 +33,40 @@ export class VaultFilter {
     this.myVaultOnly = false;
     this.selectedOrganizationId = null;
     this.resetFilter();
+  }
+
+  buildFilter(): VaultFilterFunction {
+    return (cipher) => {
+      let cipherPassesFilter = true;
+      if (this.status === "favorites" && cipherPassesFilter) {
+        cipherPassesFilter = cipher.favorite;
+      }
+      if (this.status === "trash" && cipherPassesFilter) {
+        cipherPassesFilter = cipher.isDeleted;
+      }
+      if (this.cipherType != null && cipherPassesFilter) {
+        cipherPassesFilter = cipher.type === this.cipherType;
+      }
+      if (this.selectedFolder != null && this.selectedFolderId != "none" && cipherPassesFilter) {
+        cipherPassesFilter = cipher.folderId === this.selectedFolderId;
+      }
+      if (this.selectedCollection && this.selectedCollectionId == null && cipherPassesFilter) {
+        cipherPassesFilter =
+          cipher.organizationId != null &&
+          (cipher.collectionIds == null || cipher.collectionIds.length === 0);
+      }
+      if (this.selectedCollection && this.selectedCollectionId != null && cipherPassesFilter) {
+        cipherPassesFilter =
+          cipher.collectionIds != null &&
+          cipher.collectionIds.indexOf(this.selectedCollectionId) > -1;
+      }
+      if (this.selectedOrganizationId != null && cipherPassesFilter) {
+        cipherPassesFilter = cipher.organizationId === this.selectedOrganizationId;
+      }
+      if (this.myVaultOnly && cipherPassesFilter) {
+        cipherPassesFilter = cipher.organizationId === null;
+      }
+      return cipherPassesFilter;
+    };
   }
 }

--- a/libs/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -111,9 +111,11 @@ export class VaultFilterComponent implements OnInit {
 
   protected pruneInvalidCollectionSelection(filter: VaultFilter): VaultFilter {
     if (
+      filter.selectedCollection &&
       filter.selectedCollectionId != null &&
       !this.collections?.hasId(filter.selectedCollectionId)
     ) {
+      filter.selectedCollection = false;
       filter.selectedCollectionId = null;
     }
     return filter;

--- a/libs/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -111,9 +111,10 @@ export class VaultFilterComponent implements OnInit {
 
   protected pruneInvalidCollectionSelection(filter: VaultFilter): VaultFilter {
     if (
-      filter.selectedCollection &&
-      filter.selectedCollectionId != null &&
-      !this.collections?.hasId(filter.selectedCollectionId)
+      filter.myVaultOnly ||
+      (filter.selectedCollection &&
+        filter.selectedCollectionId != null &&
+        !this.collections?.hasId(filter.selectedCollectionId))
     ) {
       filter.selectedCollection = false;
       filter.selectedCollectionId = null;

--- a/libs/angular/src/modules/vault-filter/vault-filter.service.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.service.ts
@@ -61,7 +61,9 @@ export class VaultFilterService {
     const storedCollections = await this.collectionService.getAllDecrypted();
     let collections: CollectionView[];
     if (organizationId != null) {
-      collections = storedCollections.filter((c) => c.organizationId === organizationId);
+      collections = storedCollections.filter(
+        (c) => c.organizationId === organizationId || c.organizationId === null
+      );
     } else {
       collections = storedCollections;
     }

--- a/libs/angular/src/modules/vault-filter/vault-filter.service.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.service.ts
@@ -61,9 +61,7 @@ export class VaultFilterService {
     const storedCollections = await this.collectionService.getAllDecrypted();
     let collections: CollectionView[];
     if (organizationId != null) {
-      collections = storedCollections.filter(
-        (c) => c.organizationId === organizationId || c.organizationId === null
-      );
+      collections = storedCollections.filter((c) => c.organizationId === organizationId);
     } else {
       collections = storedCollections;
     }

--- a/libs/common/src/services/collection.service.ts
+++ b/libs/common/src/services/collection.service.ts
@@ -86,6 +86,11 @@ export class CollectionService implements CollectionServiceAbstraction {
 
     const collections = await this.getAll();
     decryptedCollections = await this.decryptMany(collections);
+
+    const noneCollection = new CollectionView();
+    noneCollection.name = this.i18nService.t("unassigned");
+    decryptedCollections.push(noneCollection);
+
     await this.stateService.setDecryptedCollections(decryptedCollections);
     return decryptedCollections;
   }

--- a/libs/common/src/services/collection.service.ts
+++ b/libs/common/src/services/collection.service.ts
@@ -87,10 +87,6 @@ export class CollectionService implements CollectionServiceAbstraction {
     const collections = await this.getAll();
     decryptedCollections = await this.decryptMany(collections);
 
-    const noneCollection = new CollectionView();
-    noneCollection.name = this.i18nService.t("unassigned");
-    decryptedCollections.push(noneCollection);
-
     await this.stateService.setDecryptedCollections(decryptedCollections);
     return decryptedCollections;
   }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix regression where filtering on "Unassigned" collections is no longer possible

## Code changes
- **apps/web/src/app/modules/vault-filter/vault-filter.service.ts**
  Always add an `Unassigned` collection when the user is an admin (emulating how `No folder` is implemented.)

- **apps/web/src/app/modules/vault/modules/individual-vault/individual-vault.component.ts**
  Remove `buildFilter` and use the new common one in `vault-filter.model.ts`
  
- **apps/web/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts**
  Remove `buildFilter` and use the new common one in `vault-filter.model.ts`
  
- **libs/angular/src/modules/vault-filter/models/vault-filter.model.spec.ts**
  Added tests for existing and new filter function behavior  

- **libs/angular/src/modules/vault-filter/models/vault-filter.model.ts**
  Expand with the ability to build filter functions (this logic was previously duplicated across all clients).
  
- **libs/angular/src/modules/vault-filter/vault-filter.component.ts**
  Pruning now removes collection selection if the user selects `My vault` or an organization that does not have the currently selected collection.  

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/176439890-a081f4db-b3ca-4838-a6f4-fcedacc8e342.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
