### PR TITLE
[PS-713] Fix locale search bug

### DIFF
--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -80,7 +80,9 @@ export class AppComponent implements OnDestroy, OnInit {
   ) {}
 
   ngOnInit() {
-    this.document.documentElement.lang = this.i18nService.locale;
+    this.i18nService.locale.subscribe({
+      next: (newLocale) => (this.document.documentElement.lang = newLocale),
+    });
 
     this.ngZone.runOutsideAngular(() => {
       window.onmousemove = () => this.recordActivity();

--- a/apps/web/src/app/settings/sponsoring-org-row.component.ts
+++ b/apps/web/src/app/settings/sponsoring-org-row.component.ts
@@ -23,12 +23,18 @@ export class SponsoringOrgRowComponent implements OnInit {
   revokeSponsorshipPromise: Promise<any>;
   resendEmailPromise: Promise<any>;
 
+  private locale = "";
+
   constructor(
     private apiService: ApiService,
     private i18nService: I18nService,
     private logService: LogService,
     private platformUtilsService: PlatformUtilsService
-  ) {}
+  ) {
+    this.i18nService.locale.subscribe({
+      next: (newLocale) => (this.locale = newLocale),
+    });
+  }
 
   ngOnInit(): void {
     this.setStatus(
@@ -98,7 +104,7 @@ export class SponsoringOrgRowComponent implements OnInit {
       // They want to delete but there is a valid until date which means there is an active sponsorship
       this.statusMessage = this.i18nService.t(
         "revokeWhenExpired",
-        formatDate(validUntil, "MM/dd/yyyy", this.i18nService.locale)
+        formatDate(validUntil, "MM/dd/yyyy", this.locale)
       );
       this.statusClass = "text-danger";
     } else if (toDelete) {

--- a/libs/common/src/abstractions/i18n.service.ts
+++ b/libs/common/src/abstractions/i18n.service.ts
@@ -1,5 +1,7 @@
+import { Subject } from "rxjs";
+
 export abstract class I18nService {
-  locale: string;
+  locale: Subject<string>;
   supportedTranslationLocales: string[];
   translationLocale: string;
   collator: Intl.Collator;

--- a/libs/common/src/services/i18n.service.ts
+++ b/libs/common/src/services/i18n.service.ts
@@ -1,7 +1,9 @@
+import { Subject } from "rxjs";
+
 import { I18nService as I18nServiceAbstraction } from "../abstractions/i18n.service";
 
 export class I18nService implements I18nServiceAbstraction {
-  locale: string;
+  locale: Subject<string>;
   // First locale is the default (English)
   supportedTranslationLocales: string[] = ["en"];
   translationLocale: string;
@@ -74,6 +76,7 @@ export class I18nService implements I18nServiceAbstraction {
     protected getLocalesJson: (formattedLocale: string) => Promise<any>
   ) {
     this.systemLanguage = systemLanguage.replace("_", "-");
+    this.locale = new Subject<string>();
   }
 
   async init(locale?: string) {
@@ -85,10 +88,14 @@ export class I18nService implements I18nServiceAbstraction {
     }
 
     this.inited = true;
-    this.locale = this.translationLocale = locale != null ? locale : this.systemLanguage;
+    this.translationLocale = locale != null ? locale : this.systemLanguage;
+    this.locale.next(this.translationLocale);
 
     try {
-      this.collator = new Intl.Collator(this.locale, { numeric: true, sensitivity: "base" });
+      this.collator = new Intl.Collator(this.translationLocale, {
+        numeric: true,
+        sensitivity: "base",
+      });
     } catch {
       this.collator = null;
     }

--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -24,7 +24,7 @@ export class SearchService implements SearchServiceAbstraction {
   ) {
     this.i18nService.locale.subscribe({
       next: (newLocale) => {
-        if (["zh-CN", "zh-TW"].indexOf(newLocale) !== -1) {
+        if (["zh-CN", "zh-TW", "ja", "ko", "vi"].indexOf(newLocale) !== -1) {
           this.searchableMinLength = 1;
         } else {
           this.searchableMinLength = this.defaultSearchableMinLength;

--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -14,16 +14,24 @@ export class SearchService implements SearchServiceAbstraction {
   indexedEntityId?: string = null;
   private indexing = false;
   private index: lunr.Index = null;
-  private searchableMinLength = 2;
+  private readonly defaultSearchableMinLength: number = 2;
+  private searchableMinLength: number = this.defaultSearchableMinLength;
 
   constructor(
     private cipherService: CipherService,
     private logService: LogService,
     private i18nService: I18nService
   ) {
-    if (["zh-CN", "zh-TW"].indexOf(i18nService.locale) !== -1) {
-      this.searchableMinLength = 1;
-    }
+    this.i18nService.locale.subscribe({
+      next: (newLocale) => {
+        if (["zh-CN", "zh-TW"].indexOf(newLocale) !== -1) {
+          this.searchableMinLength = 1;
+        } else {
+          this.searchableMinLength = this.defaultSearchableMinLength;
+        }
+      },
+    });
+
     //register lunr pipeline function
     lunr.Pipeline.registerFunction(this.normalizeAccentsPipelineFunction, "normalizeAccents");
   }

--- a/libs/components/src/utils/i18n-mock.service.ts
+++ b/libs/components/src/utils/i18n-mock.service.ts
@@ -1,7 +1,9 @@
+import { Subject } from "rxjs";
+
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 
 export class I18nMockService implements I18nService {
-  locale: string;
+  locale: Subject<string>;
   supportedTranslationLocales: string[];
   translationLocale: string;
   collator: Intl.Collator;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

If the user is using a language that has characters rather than an "alphabet", we should start searching ciphers after one character has been entered into the search bar, rather than the default of two (like for English). However, this was not happening; for all languages the search started at two characters entered into the search bar.

This PR fixes that bug, setting the `searchableMinLength` in the `SearchService` to `1` properly. New languages have also been added to this locale list (where search starts at one):

- `zh-CN` (pre-existing)
- `zh-TW` (pre-existing)
- `ja` (new)
- `ko` (new)
- `vi` (new)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
