### PR TITLE
[PS-1078] Refactor FolderService to use Observables

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -44,6 +44,7 @@ import { ApiService } from "@bitwarden/common/services/api.service";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
 import { AuditService } from "@bitwarden/common/services/audit.service";
 import { AuthService } from "@bitwarden/common/services/auth.service";
+import { BroadcasterService } from "@bitwarden/common/services/broadcaster.service";
 import { CipherService } from "@bitwarden/common/services/cipher.service";
 import { CollectionService } from "@bitwarden/common/services/collection.service";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
@@ -149,6 +150,7 @@ export default class MainBackground {
   vaultFilterService: VaultFilterService;
   usernameGenerationService: UsernameGenerationServiceAbstraction;
   encryptService: EncryptService;
+  broadcasterService: BroadcasterService;
   folderApiService: FolderApiServiceAbstraction;
 
   onUpdatedRan: boolean;
@@ -267,11 +269,13 @@ export default class MainBackground {
       this.logService,
       this.stateService
     );
+    this.broadcasterService = new BroadcasterService();
     this.folderService = new FolderService(
       this.cryptoService,
       this.i18nService,
       this.cipherService,
-      this.stateService
+      this.stateService,
+      this.broadcasterService
     );
     this.folderApiService = new FolderApiService(this.folderService, this.apiService);
     this.collectionService = new CollectionService(

--- a/apps/browser/src/background/notification.background.ts
+++ b/apps/browser/src/background/notification.background.ts
@@ -1,3 +1,5 @@
+import { firstValueFrom } from "rxjs";
+
 import { AuthService } from "@bitwarden/common/abstractions/auth.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
@@ -385,7 +387,7 @@ export default class NotificationBackground {
     model.login = loginModel;
 
     if (!Utils.isNullOrWhitespace(folderId)) {
-      const folders = await this.folderService.getAllDecrypted();
+      const folders = await firstValueFrom(this.folderService.folderViews$);
       if (folders.some((x) => x.id === folderId)) {
         model.folderId = folderId;
       }
@@ -437,7 +439,7 @@ export default class NotificationBackground {
   private async getDataForTab(tab: chrome.tabs.Tab, responseCommand: string) {
     const responseData: any = {};
     if (responseCommand === "notificationBarGetFoldersList") {
-      responseData.folders = await this.folderService.getAllDecrypted();
+      responseData.folders = await firstValueFrom(this.folderService.folderViews$);
     }
 
     await BrowserApi.tabSendMessageData(tab, responseCommand, responseData);

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -11,6 +11,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/abstractions/auth.service";
+import { BroadcasterService as BroadcasterServiceAbstraction } from "@bitwarden/common/abstractions/broadcaster.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
@@ -110,6 +111,10 @@ function getBgService<T>(service: keyof MainBackground) {
           ? new BrowserMessagingPrivateModePopupService()
           : new BrowserMessagingService();
       },
+    },
+    {
+      provide: BroadcasterServiceAbstraction,
+      useFactory: getBgService<BroadcasterServiceAbstraction>("broadcasterService"),
     },
     {
       provide: TwoFactorService,

--- a/apps/browser/src/popup/settings/folders.component.html
+++ b/apps/browser/src/popup/settings/folders.component.html
@@ -20,20 +20,20 @@
   </div>
 </header>
 <main tabindex="-1">
-  <div class="box list full-list" *ngIf="folders && folders.length">
+  <div class="box list full-list" *ngIf="(folders$ | async)?.length">
     <div class="box-content">
       <button
         type="button"
         appStopClick
         (click)="folderSelected(f)"
         class="box-content-row padded"
-        *ngFor="let f of folders"
+        *ngFor="let f of folders$ | async"
       >
         {{ f.name }}
       </button>
     </div>
   </div>
-  <div class="no-items" *ngIf="!folders || !folders.length">
+  <div class="no-items" *ngIf="!(folders$ | async)?.length">
     <p>{{ "noFolders" | i18n }}</p>
   </div>
 </main>

--- a/apps/browser/src/popup/settings/folders.component.ts
+++ b/apps/browser/src/popup/settings/folders.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { Router } from "@angular/router";
+import { map, Observable } from "rxjs";
 
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
 import { FolderView } from "@bitwarden/common/models/view/folderView";
@@ -8,17 +9,19 @@ import { FolderView } from "@bitwarden/common/models/view/folderView";
   selector: "app-folders",
   templateUrl: "folders.component.html",
 })
-export class FoldersComponent implements OnInit {
-  folders: FolderView[];
+export class FoldersComponent {
+  folders$: Observable<FolderView[]>;
 
-  constructor(private folderService: FolderService, private router: Router) {}
+  constructor(private folderService: FolderService, private router: Router) {
+    this.folders$ = this.folderService.folderViews$.pipe(
+      map((folders) => {
+        if (folders.length > 0) {
+          folders = folders.slice(0, folders.length - 1);
+        }
 
-  async ngOnInit() {
-    this.folders = await this.folderService.getAllDecrypted();
-    // Remove "No Folder"
-    if (this.folders.length > 0) {
-      this.folders = this.folders.slice(0, this.folders.length - 1);
-    }
+        return folders;
+      })
+    );
   }
 
   folderSelected(folder: FolderView) {

--- a/apps/browser/src/popup/vault/add-edit.component.html
+++ b/apps/browser/src/popup/vault/add-edit.component.html
@@ -515,7 +515,7 @@
         <div class="box-content-row" appBoxRow>
           <label for="folder">{{ "folder" | i18n }}</label>
           <select id="folder" name="FolderId" [(ngModel)]="cipher.folderId">
-            <option *ngFor="let f of folders" [ngValue]="f.id">{{ f.name }}</option>
+            <option *ngFor="let f of folders$ | async" [ngValue]="f.id">{{ f.name }}</option>
           </select>
         </div>
         <div class="box-content-row box-content-row-checkbox" appBoxRow>

--- a/apps/browser/src/popup/vault/ciphers.component.ts
+++ b/apps/browser/src/popup/vault/ciphers.component.ts
@@ -120,7 +120,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnInit, On
         this.searchPlaceholder = this.i18nService.t("searchFolder");
         if (this.folderId != null) {
           this.showOrganizations = false;
-          const folderNode = await this.folderService.getNested(this.folderId);
+          const folderNode = await this.vaultFilterService.getFolderNested(this.folderId);
           if (folderNode != null && folderNode.node != null) {
             this.groupingTitle = folderNode.node.name;
             this.nestedFolders =

--- a/apps/browser/src/popup/vault/vault-filter.component.ts
+++ b/apps/browser/src/popup/vault/vault-filter.component.ts
@@ -1,6 +1,7 @@
 import { Location } from "@angular/common";
 import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 import { first } from "rxjs/operators";
 
 import { VaultFilter } from "@bitwarden/angular/modules/vault-filter/models/vault-filter.model";
@@ -182,9 +183,11 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   }
 
   async loadFolders() {
-    const allFolders = await this.vaultFilterService.buildFolders(this.selectedOrganization);
+    const allFolders = await firstValueFrom(
+      this.vaultFilterService.buildFolders(this.selectedOrganization)
+    );
     this.folders = allFolders.fullList;
-    this.nestedFolders = await allFolders.nestedList;
+    this.nestedFolders = allFolders.nestedList;
   }
 
   async search(timeout: number = null) {

--- a/apps/browser/src/popup/vault/vault-filter.component.ts
+++ b/apps/browser/src/popup/vault/vault-filter.component.ts
@@ -184,7 +184,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
 
   async loadFolders() {
     const allFolders = await firstValueFrom(
-      this.vaultFilterService.buildFolders(this.selectedOrganization)
+      this.vaultFilterService.buildNestedFolders(this.selectedOrganization)
     );
     this.folders = allFolders.fullList;
     this.nestedFolders = allFolders.nestedList;

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -14,6 +14,7 @@ import { GlobalState } from "@bitwarden/common/models/domain/globalState";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
 import { AuditService } from "@bitwarden/common/services/audit.service";
 import { AuthService } from "@bitwarden/common/services/auth.service";
+import { BroadcasterService } from "@bitwarden/common/services/broadcaster.service";
 import { CipherService } from "@bitwarden/common/services/cipher.service";
 import { CollectionService } from "@bitwarden/common/services/collection.service";
 import { ContainerService } from "@bitwarden/common/services/container.service";
@@ -103,6 +104,7 @@ export class Main {
   organizationService: OrganizationService;
   providerService: ProviderService;
   twoFactorService: TwoFactorService;
+  broadcasterService: BroadcasterService;
   folderApiService: FolderApiService;
 
   constructor() {
@@ -198,11 +200,14 @@ export class Main {
       this.stateService
     );
 
+    this.broadcasterService = new BroadcasterService();
+
     this.folderService = new FolderService(
       this.cryptoService,
       this.i18nService,
       this.cipherService,
-      this.stateService
+      this.stateService,
+      this.broadcasterService
     );
 
     this.folderApiService = new FolderApiService(this.folderService, this.apiService);

--- a/apps/cli/src/commands/get.command.ts
+++ b/apps/cli/src/commands/get.command.ts
@@ -1,3 +1,5 @@
+import { firstValueFrom } from "rxjs";
+
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
@@ -358,7 +360,7 @@ export class GetCommand extends DownloadCommand {
         decFolder = await folder.decrypt();
       }
     } else if (id.trim() !== "") {
-      let folders = await this.folderService.getAllDecrypted();
+      let folders = await firstValueFrom(this.folderService.folderViews$);
       folders = CliUtils.searchFolders(folders, id);
       if (folders.length > 1) {
         return Response.multipleResults(folders.map((f) => f.id));

--- a/apps/cli/src/commands/list.command.ts
+++ b/apps/cli/src/commands/list.command.ts
@@ -1,3 +1,5 @@
+import { firstValueFrom } from "rxjs";
+
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
@@ -126,7 +128,7 @@ export class ListCommand {
   }
 
   private async listFolders(options: Options) {
-    let folders = await this.folderService.getAllDecrypted();
+    let folders = await firstValueFrom(this.folderService.folderViews$);
 
     if (options.search != null && options.search.trim() !== "") {
       folders = CliUtils.searchFolders(folders, options.search);

--- a/apps/desktop/src/app/modules/vault-filter/vault-filter.component.html
+++ b/apps/desktop/src/app/modules/vault-filter/vault-filter.component.html
@@ -32,7 +32,7 @@
     [hide]="hideFolders"
     [activeFilter]="activeFilter"
     [collapsedFilterNodes]="collapsedFilterNodes"
-    [folderNodes]="folders"
+    [folderNodes]="folders$ | async"
     (onNodeCollapseStateChange)="toggleFilterNodeCollapseState($event)"
     (onFilterChange)="applyFilter($event)"
     (onAddFolder)="addFolder()"

--- a/apps/desktop/src/app/vault/add-edit.component.html
+++ b/apps/desktop/src/app/vault/add-edit.component.html
@@ -455,7 +455,7 @@
           <div class="box-content-row" appBoxRow>
             <label for="folder">{{ "folder" | i18n }}</label>
             <select id="folder" name="FolderId" [(ngModel)]="cipher.folderId">
-              <option *ngFor="let f of folders" [ngValue]="f.id">{{ f.name }}</option>
+              <option *ngFor="let f of folders$ | async" [ngValue]="f.id">{{ f.name }}</option>
             </select>
           </div>
           <div class="box-content-row box-content-row-checkbox" appBoxRow>

--- a/apps/web/src/app/modules/vault-filter/vault-filter.component.html
+++ b/apps/web/src/app/modules/vault-filter/vault-filter.component.html
@@ -57,7 +57,7 @@
           [hide]="hideFolders"
           [activeFilter]="activeFilter"
           [collapsedFilterNodes]="collapsedFilterNodes"
-          [folderNodes]="folders"
+          [folderNodes]="folders$ | async"
           (onNodeCollapseStateChange)="toggleFilterNodeCollapseState($event)"
           (onFilterChange)="applyFilter($event)"
           (onAddFolder)="addFolder()"

--- a/apps/web/src/app/settings/change-password.component.ts
+++ b/apps/web/src/app/settings/change-password.component.ts
@@ -1,5 +1,6 @@
 import { Component } from "@angular/core";
 import { Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 
 import { ChangePasswordComponent as BaseChangePasswordComponent } from "@bitwarden/angular/components/change-password.component";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -192,7 +193,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
     request.key = encKey[1].encryptedString;
     request.masterPasswordHash = masterPasswordHash;
 
-    const folders = await this.folderService.getAllDecrypted();
+    const folders = await firstValueFrom(this.folderService.folderViews$);
     for (let i = 0; i < folders.length; i++) {
       if (folders[i].id == null) {
         continue;

--- a/apps/web/src/app/settings/update-key.component.ts
+++ b/apps/web/src/app/settings/update-key.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
@@ -81,7 +82,7 @@ export class UpdateKeyComponent {
 
     await this.syncService.fullSync(true);
 
-    const folders = await this.folderService.getAllDecrypted();
+    const folders = await firstValueFrom(this.folderService.folderViews$);
     for (let i = 0; i < folders.length; i++) {
       if (folders[i].id == null) {
         continue;

--- a/apps/web/src/app/vault/add-edit.component.html
+++ b/apps/web/src/app/vault/add-edit.component.html
@@ -60,7 +60,7 @@
               class="form-control"
               [disabled]="cipher.isDeleted || viewOnly"
             >
-              <option *ngFor="let f of folders" [ngValue]="f.id">{{ f.name }}</option>
+              <option *ngFor="let f of folders$ | async" [ngValue]="f.id">{{ f.name }}</option>
             </select>
           </div>
         </div>

--- a/apps/web/src/app/vault/bulk-move.component.html
+++ b/apps/web/src/app/vault/bulk-move.component.html
@@ -19,7 +19,7 @@
         <div class="form-group">
           <label for="folder">{{ "folder" | i18n }}</label>
           <select id="folder" name="FolderId" [(ngModel)]="folderId" class="form-control">
-            <option *ngFor="let f of folders" [ngValue]="f.id">{{ f.name }}</option>
+            <option *ngFor="let f of folders$ | async" [ngValue]="f.id">{{ f.name }}</option>
           </select>
         </div>
       </div>

--- a/apps/web/src/app/vault/bulk-move.component.ts
+++ b/apps/web/src/app/vault/bulk-move.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { firstValueFrom, Observable } from "rxjs";
 
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
@@ -15,7 +16,7 @@ export class BulkMoveComponent implements OnInit {
   @Output() onMoved = new EventEmitter();
 
   folderId: string = null;
-  folders: FolderView[] = [];
+  folders$: Observable<FolderView[]>;
   formPromise: Promise<any>;
 
   constructor(
@@ -26,8 +27,8 @@ export class BulkMoveComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
-    this.folders = await this.folderService.getAllDecrypted();
-    this.folderId = this.folders[0].id;
+    this.folders$ = this.folderService.folderViews$;
+    this.folderId = (await firstValueFrom(this.folders$))[0].id;
   }
 
   async submit() {

--- a/libs/angular/src/components/add-edit.component.ts
+++ b/libs/angular/src/components/add-edit.component.ts
@@ -1,4 +1,5 @@
 import { Directive, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { Observable } from "rxjs";
 
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
@@ -51,7 +52,7 @@ export class AddEditComponent implements OnInit {
 
   editMode = false;
   cipher: CipherView;
-  folders: FolderView[];
+  folders$: Observable<FolderView[]>;
   collections: CollectionView[] = [];
   title: string;
   formPromise: Promise<any>;
@@ -243,7 +244,7 @@ export class AddEditComponent implements OnInit {
       }
     }
 
-    this.folders = await this.folderService.getAllDecrypted();
+    this.folders$ = this.folderService.folderViews$;
 
     if (this.editMode && this.previousCipherId !== this.cipherId) {
       this.eventService.collect(EventType.Cipher_ClientViewed, this.cipherId);

--- a/libs/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -1,5 +1,5 @@
 import { Directive, EventEmitter, Input, OnInit, Output } from "@angular/core";
-import { lastValueFrom, Observable } from "rxjs";
+import { firstValueFrom, Observable } from "rxjs";
 
 import { Organization } from "@bitwarden/common/models/domain/organization";
 import { ITreeNodeObject } from "@bitwarden/common/models/domain/treeNode";
@@ -105,7 +105,7 @@ export class VaultFilterComponent implements OnInit {
   protected async pruneInvalidFolderSelection(filter: VaultFilter): Promise<VaultFilter> {
     if (
       filter.selectedFolder &&
-      !(await lastValueFrom(this.folders$))?.hasId(filter.selectedFolderId)
+      !(await firstValueFrom(this.folders$))?.hasId(filter.selectedFolderId)
     ) {
       filter.selectedFolder = false;
       filter.selectedFolderId = null;

--- a/libs/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -46,7 +46,7 @@ export class VaultFilterComponent implements OnInit {
       this.activeSingleOrganizationPolicy =
         await this.vaultFilterService.checkForSingleOrganizationPolicy();
     }
-    this.folders$ = await this.vaultFilterService.buildFolders();
+    this.folders$ = await this.vaultFilterService.buildNestedFolders();
     this.collections = await this.initCollections();
     this.isLoaded = true;
   }
@@ -74,7 +74,7 @@ export class VaultFilterComponent implements OnInit {
   }
 
   async reloadCollectionsAndFolders(filter: VaultFilter) {
-    this.folders$ = await this.vaultFilterService.buildFolders(filter.selectedOrganizationId);
+    this.folders$ = await this.vaultFilterService.buildNestedFolders(filter.selectedOrganizationId);
     this.collections = filter.myVaultOnly
       ? null
       : await this.vaultFilterService.buildCollections(filter.selectedOrganizationId);

--- a/libs/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -1,4 +1,5 @@
 import { Directive, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { lastValueFrom, Observable } from "rxjs";
 
 import { Organization } from "@bitwarden/common/models/domain/organization";
 import { ITreeNodeObject } from "@bitwarden/common/models/domain/treeNode";
@@ -28,7 +29,7 @@ export class VaultFilterComponent implements OnInit {
   activePersonalOwnershipPolicy: boolean;
   activeSingleOrganizationPolicy: boolean;
   collections: DynamicTreeNode<CollectionView>;
-  folders: DynamicTreeNode<FolderView>;
+  folders$: Observable<DynamicTreeNode<FolderView>>;
 
   constructor(protected vaultFilterService: VaultFilterService) {}
 
@@ -45,7 +46,7 @@ export class VaultFilterComponent implements OnInit {
       this.activeSingleOrganizationPolicy =
         await this.vaultFilterService.checkForSingleOrganizationPolicy();
     }
-    this.folders = await this.vaultFilterService.buildFolders();
+    this.folders$ = await this.vaultFilterService.buildFolders();
     this.collections = await this.initCollections();
     this.isLoaded = true;
   }
@@ -67,13 +68,13 @@ export class VaultFilterComponent implements OnInit {
   async applyFilter(filter: VaultFilter) {
     if (filter.refreshCollectionsAndFolders) {
       await this.reloadCollectionsAndFolders(filter);
-      filter = this.pruneInvalidatedFilterSelections(filter);
+      filter = await this.pruneInvalidatedFilterSelections(filter);
     }
     this.onFilterChange.emit(filter);
   }
 
   async reloadCollectionsAndFolders(filter: VaultFilter) {
-    this.folders = await this.vaultFilterService.buildFolders(filter.selectedOrganizationId);
+    this.folders$ = await this.vaultFilterService.buildFolders(filter.selectedOrganizationId);
     this.collections = filter.myVaultOnly
       ? null
       : await this.vaultFilterService.buildCollections(filter.selectedOrganizationId);
@@ -95,14 +96,17 @@ export class VaultFilterComponent implements OnInit {
     this.onEditFolder.emit(folder);
   }
 
-  protected pruneInvalidatedFilterSelections(filter: VaultFilter): VaultFilter {
-    filter = this.pruneInvalidFolderSelection(filter);
+  protected async pruneInvalidatedFilterSelections(filter: VaultFilter): Promise<VaultFilter> {
+    filter = await this.pruneInvalidFolderSelection(filter);
     filter = this.pruneInvalidCollectionSelection(filter);
     return filter;
   }
 
-  protected pruneInvalidFolderSelection(filter: VaultFilter): VaultFilter {
-    if (filter.selectedFolder && !this.folders?.hasId(filter.selectedFolderId)) {
+  protected async pruneInvalidFolderSelection(filter: VaultFilter): Promise<VaultFilter> {
+    if (
+      filter.selectedFolder &&
+      !(await lastValueFrom(this.folders$))?.hasId(filter.selectedFolderId)
+    ) {
       filter.selectedFolder = false;
       filter.selectedFolderId = null;
     }

--- a/libs/angular/src/modules/vault-filter/vault-filter.service.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.service.ts
@@ -7,11 +7,15 @@ import { OrganizationService } from "@bitwarden/common/abstractions/organization
 import { PolicyService } from "@bitwarden/common/abstractions/policy.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { PolicyType } from "@bitwarden/common/enums/policyType";
+import { ServiceUtils } from "@bitwarden/common/misc/serviceUtils";
 import { Organization } from "@bitwarden/common/models/domain/organization";
+import { TreeNode } from "@bitwarden/common/models/domain/treeNode";
 import { CollectionView } from "@bitwarden/common/models/view/collectionView";
 import { FolderView } from "@bitwarden/common/models/view/folderView";
 
 import { DynamicTreeNode } from "./models/dynamic-tree-node.model";
+
+const NestingDelimiter = "/";
 
 @Injectable()
 export class VaultFilterService {
@@ -50,7 +54,7 @@ export class VaultFilterService {
     } else {
       folders = storedFolders;
     }
-    const nestedFolders = await this.folderService.getAllNested(folders);
+    const nestedFolders = await this.getAllFoldersNested(folders);
     return new DynamicTreeNode<FolderView>({
       fullList: folders,
       nestedList: nestedFolders,
@@ -78,5 +82,23 @@ export class VaultFilterService {
 
   async checkForPersonalOwnershipPolicy(): Promise<boolean> {
     return await this.policyService.policyAppliesToUser(PolicyType.PersonalOwnership);
+  }
+
+  protected async getAllFoldersNested(folders?: FolderView[]): Promise<TreeNode<FolderView>[]> {
+    folders = folders ?? (await this.folderService.getAllDecrypted());
+    const nodes: TreeNode<FolderView>[] = [];
+    folders.forEach((f) => {
+      const folderCopy = new FolderView();
+      folderCopy.id = f.id;
+      folderCopy.revisionDate = f.revisionDate;
+      const parts = f.name != null ? f.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];
+      ServiceUtils.nestedTraverse(nodes, 0, parts, folderCopy, null, NestingDelimiter);
+    });
+    return nodes;
+  }
+
+  async getFolderNested(id: string): Promise<TreeNode<FolderView>> {
+    const folders = await this.getAllFoldersNested();
+    return ServiceUtils.getTreeNodeObject(folders, id) as TreeNode<FolderView>;
   }
 }

--- a/libs/angular/src/modules/vault-filter/vault-filter.service.ts
+++ b/libs/angular/src/modules/vault-filter/vault-filter.service.ts
@@ -41,7 +41,7 @@ export class VaultFilterService {
     return await this.organizationService.getAll();
   }
 
-  buildFolders(organizationId?: string): Observable<DynamicTreeNode<FolderView>> {
+  buildNestedFolders(organizationId?: string): Observable<DynamicTreeNode<FolderView>> {
     const transformation = async (storedFolders: FolderView[]) => {
       let folders: FolderView[];
       if (organizationId != null) {

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -223,6 +223,7 @@ export const LOG_MAC_FAILURES = new InjectionToken<string>("LOG_MAC_FAILURES");
         I18nServiceAbstraction,
         CipherServiceAbstraction,
         StateServiceAbstraction,
+        BroadcasterServiceAbstraction,
       ],
     },
     {

--- a/libs/common/spec/services/export.service.spec.ts
+++ b/libs/common/spec/services/export.service.spec.ts
@@ -1,4 +1,5 @@
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { BehaviorSubject } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
@@ -97,8 +98,8 @@ describe("ExportService", () => {
     folderService = Substitute.for<FolderService>();
     cryptoService = Substitute.for<CryptoService>();
 
-    folderService.getAllDecrypted().resolves([]);
-    folderService.getAll().resolves([]);
+    folderService.folderViews$.returns(new BehaviorSubject([]));
+    folderService.folders$.returns(new BehaviorSubject([]));
 
     exportService = new ExportService(
       folderService,

--- a/libs/common/spec/services/folder.service.spec.ts
+++ b/libs/common/spec/services/folder.service.spec.ts
@@ -148,6 +148,43 @@ describe("Folder Service", () => {
     ]);
   });
 
+  it("clearCache", async () => {
+    await folderService.clearCache();
+
+    expect((await firstValueFrom(folderService.folders$)).length).toBe(1);
+    expect((await firstValueFrom(folderService.folderViews$)).length).toBe(0);
+  });
+
+  describe("clear", () => {
+    it("null userId", async () => {
+      await folderService.clear();
+
+      stateService.received(1).setEncryptedFolders(Arg.any(), Arg.any());
+
+      expect((await firstValueFrom(folderService.folders$)).length).toBe(0);
+      expect((await firstValueFrom(folderService.folderViews$)).length).toBe(0);
+    });
+
+    it("matching userId", async () => {
+      stateService.getUserId().resolves("1");
+      await folderService.clear("1");
+
+      stateService.received(1).setEncryptedFolders(Arg.any(), Arg.any());
+
+      expect((await firstValueFrom(folderService.folders$)).length).toBe(0);
+      expect((await firstValueFrom(folderService.folderViews$)).length).toBe(0);
+    });
+
+    it("missmatching userId", async () => {
+      await folderService.clear("12");
+
+      stateService.received(1).setEncryptedFolders(Arg.any(), Arg.any());
+
+      expect((await firstValueFrom(folderService.folders$)).length).toBe(1);
+      expect((await firstValueFrom(folderService.folderViews$)).length).toBe(2);
+    });
+  });
+
   function folderData(id: string, name: string) {
     const data = new FolderData({} as any);
     data.id = id;

--- a/libs/common/spec/services/folder.service.spec.ts
+++ b/libs/common/spec/services/folder.service.spec.ts
@@ -1,0 +1,158 @@
+import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+
+import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.service";
+import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
+import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { FolderData } from "@bitwarden/common/models/data/folderData";
+import { EncString } from "@bitwarden/common/models/domain/encString";
+import { FolderView } from "@bitwarden/common/models/view/folderView";
+import { ContainerService } from "@bitwarden/common/services/container.service";
+import { FolderService } from "@bitwarden/common/services/folder/folder.service";
+import { StateService } from "@bitwarden/common/services/state.service";
+
+describe("Folder Service", () => {
+  let folderService: FolderService;
+
+  let cryptoService: SubstituteOf<CryptoService>;
+  let i18nService: SubstituteOf<I18nService>;
+  let cipherService: SubstituteOf<CipherService>;
+  let stateService: SubstituteOf<StateService>;
+  let broadcasterService: SubstituteOf<BroadcasterService>;
+  let activeAccount: BehaviorSubject<string>;
+
+  beforeEach(() => {
+    cryptoService = Substitute.for();
+    i18nService = Substitute.for();
+    cipherService = Substitute.for();
+    stateService = Substitute.for();
+    broadcasterService = Substitute.for();
+    activeAccount = new BehaviorSubject("123");
+
+    stateService.getEncryptedFolders().resolves({
+      "1": folderData("1", "test"),
+    });
+    stateService.activeAccount.returns(activeAccount);
+    (window as any).bitwardenContainerService = new ContainerService(cryptoService);
+
+    folderService = new FolderService(
+      cryptoService,
+      i18nService,
+      cipherService,
+      stateService,
+      broadcasterService
+    );
+  });
+
+  it("encrypt", async () => {
+    const model = new FolderView();
+    model.id = "2";
+    model.name = "Test Folder";
+
+    cryptoService.encrypt(Arg.any()).resolves(new EncString("ENC"));
+    cryptoService.decryptToUtf8(Arg.any()).resolves("DEC");
+
+    const result = await folderService.encrypt(model);
+
+    expect(result).toEqual({
+      id: "2",
+      name: {
+        encryptedString: "ENC",
+        encryptionType: 0,
+      },
+    });
+  });
+
+  describe("get", () => {
+    it("exists", async () => {
+      const result = await folderService.get("1");
+
+      expect(result).toEqual({
+        id: "1",
+        name: {
+          decryptedValue: [],
+          encryptedString: "test",
+          encryptionType: 0,
+        },
+        revisionDate: null,
+      });
+    });
+
+    it("not exists", async () => {
+      const result = await folderService.get("2");
+
+      expect(result).toBe(undefined);
+    });
+  });
+
+  it("upsert", async () => {
+    await folderService.upsert(folderData("2", "test 2"));
+
+    expect(await firstValueFrom(folderService.folders$)).toEqual([
+      {
+        id: "1",
+        name: {
+          decryptedValue: [],
+          encryptedString: "test",
+          encryptionType: 0,
+        },
+        revisionDate: null,
+      },
+      {
+        id: "2",
+        name: {
+          decryptedValue: [],
+          encryptedString: "test 2",
+          encryptionType: 0,
+        },
+        revisionDate: null,
+      },
+    ]);
+
+    expect(await firstValueFrom(folderService.folderViews$)).toEqual([
+      { id: "1", name: [], revisionDate: null },
+      { id: "2", name: [], revisionDate: null },
+      { id: null, name: [], revisionDate: null },
+    ]);
+  });
+
+  it("replace", async () => {
+    await folderService.replace({ "2": folderData("2", "test 2") });
+
+    expect(await firstValueFrom(folderService.folders$)).toEqual([
+      {
+        id: "2",
+        name: {
+          decryptedValue: [],
+          encryptedString: "test 2",
+          encryptionType: 0,
+        },
+        revisionDate: null,
+      },
+    ]);
+
+    expect(await firstValueFrom(folderService.folderViews$)).toEqual([
+      { id: "2", name: [], revisionDate: null },
+      { id: null, name: [], revisionDate: null },
+    ]);
+  });
+
+  it("delete", async () => {
+    await folderService.delete("1");
+
+    expect((await firstValueFrom(folderService.folders$)).length).toBe(0);
+
+    expect(await firstValueFrom(folderService.folderViews$)).toEqual([
+      { id: null, name: [], revisionDate: null },
+    ]);
+  });
+
+  function folderData(id: string, name: string) {
+    const data = new FolderData({} as any);
+    data.id = id;
+    data.name = name;
+
+    return data;
+  }
+});

--- a/libs/common/src/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/abstractions/folder/folder.service.abstraction.ts
@@ -1,15 +1,17 @@
+import { Observable } from "rxjs";
+
 import { FolderData } from "../../models/data/folderData";
 import { Folder } from "../../models/domain/folder";
 import { SymmetricCryptoKey } from "../../models/domain/symmetricCryptoKey";
-import { TreeNode } from "../../models/domain/treeNode";
 import { FolderView } from "../../models/view/folderView";
 
 export abstract class FolderService {
+  folders$: Observable<Folder[]>;
+  folderViews$: Observable<FolderView[]>;
+
   clearCache: () => Promise<void>;
   encrypt: (model: FolderView, key?: SymmetricCryptoKey) => Promise<Folder>;
   get: (id: string) => Promise<Folder>;
-  getAll: () => Promise<Folder[]>;
-  getAllDecrypted: () => Promise<FolderView[]>;
 }
 
 export abstract class InternalFolderService extends FolderService {

--- a/libs/common/src/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/abstractions/folder/folder.service.abstraction.ts
@@ -15,8 +15,8 @@ export abstract class FolderService {
 }
 
 export abstract class InternalFolderService extends FolderService {
-  upsert: (folder: FolderData | FolderData[]) => Promise<any>;
-  replace: (folders: { [id: string]: FolderData }) => Promise<any>;
+  upsert: (folder: FolderData | FolderData[]) => Promise<void>;
+  replace: (folders: { [id: string]: FolderData }) => Promise<void>;
   clear: (userId: string) => Promise<any>;
   delete: (id: string | string[]) => Promise<any>;
 }

--- a/libs/common/src/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/abstractions/folder/folder.service.abstraction.ts
@@ -5,7 +5,7 @@ import { TreeNode } from "../../models/domain/treeNode";
 import { FolderView } from "../../models/view/folderView";
 
 export abstract class FolderService {
-  clearCache: (userId?: string) => Promise<void>;
+  clearCache: () => Promise<void>;
   encrypt: (model: FolderView, key?: SymmetricCryptoKey) => Promise<Folder>;
   get: (id: string) => Promise<Folder>;
   getAll: () => Promise<Folder[]>;

--- a/libs/common/src/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/abstractions/folder/folder.service.abstraction.ts
@@ -10,8 +10,6 @@ export abstract class FolderService {
   get: (id: string) => Promise<Folder>;
   getAll: () => Promise<Folder[]>;
   getAllDecrypted: () => Promise<FolderView[]>;
-  getAllNested: (folders?: FolderView[]) => Promise<TreeNode<FolderView>[]>;
-  getNested: (id: string) => Promise<TreeNode<FolderView>>;
 }
 
 export abstract class InternalFolderService extends FolderService {

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -180,7 +180,13 @@ export abstract class StateService<T extends Account = Account> {
   ) => Promise<void>;
   getEncryptedCryptoSymmetricKey: (options?: StorageOptions) => Promise<string>;
   setEncryptedCryptoSymmetricKey: (value: string, options?: StorageOptions) => Promise<void>;
+  /**
+   * @deprecated Do not call this directly, use FolderService
+   */
   getEncryptedFolders: (options?: StorageOptions) => Promise<{ [id: string]: FolderData }>;
+  /**
+   * @deprecated Do not call this directly, use FolderService
+   */
   setEncryptedFolders: (
     value: { [id: string]: FolderData },
     options?: StorageOptions

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -88,8 +88,6 @@ export abstract class StateService<T extends Account = Account> {
     value: SymmetricCryptoKey,
     options?: StorageOptions
   ) => Promise<void>;
-  getDecryptedFolders: (options?: StorageOptions) => Promise<FolderView[]>;
-  setDecryptedFolders: (value: FolderView[], options?: StorageOptions) => Promise<void>;
   getDecryptedOrganizationKeys: (
     options?: StorageOptions
   ) => Promise<Map<string, SymmetricCryptoKey>>;

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -21,7 +21,6 @@ import { SymmetricCryptoKey } from "../models/domain/symmetricCryptoKey";
 import { WindowState } from "../models/domain/windowState";
 import { CipherView } from "../models/view/cipherView";
 import { CollectionView } from "../models/view/collectionView";
-import { FolderView } from "../models/view/folderView";
 import { SendView } from "../models/view/sendView";
 
 export abstract class StateService<T extends Account = Account> {

--- a/libs/common/src/models/domain/account.ts
+++ b/libs/common/src/models/domain/account.ts
@@ -11,7 +11,6 @@ import { ProviderData } from "../data/providerData";
 import { SendData } from "../data/sendData";
 import { CipherView } from "../view/cipherView";
 import { CollectionView } from "../view/collectionView";
-import { FolderView } from "../view/folderView";
 import { SendView } from "../view/sendView";
 
 import { EncString } from "./encString";
@@ -31,15 +30,19 @@ export class DataEncryptionPair<TEncrypted, TDecrypted> {
   decrypted?: TDecrypted[];
 }
 
+// This is a temporary structure to handle migrated `DataEncryptionPair` to
+//  avoid needing a data migration at this stage. It should be replaced with
+//  proper data migrations when `DataEncryptionPair` is deprecated.
+export class TemporaryDataEncryption<TEncrypted> {
+  encrypted?: { [id: string]: TEncrypted };
+}
+
 export class AccountData {
   ciphers?: DataEncryptionPair<CipherData, CipherView> = new DataEncryptionPair<
     CipherData,
     CipherView
   >();
-  folders?: DataEncryptionPair<FolderData, FolderView> = new DataEncryptionPair<
-    FolderData,
-    FolderView
-  >();
+  folders? = new TemporaryDataEncryption<FolderData>();
   localData?: any;
   sends?: DataEncryptionPair<SendData, SendView> = new DataEncryptionPair<SendData, SendView>();
   collections?: DataEncryptionPair<CollectionData, CollectionView> = new DataEncryptionPair<

--- a/libs/common/src/services/export.service.ts
+++ b/libs/common/src/services/export.service.ts
@@ -1,4 +1,5 @@
 import * as papa from "papaparse";
+import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "../abstractions/api.service";
 import { CipherService } from "../abstractions/cipher.service";
@@ -115,7 +116,7 @@ export class ExportService implements ExportServiceAbstraction {
     const promises = [];
 
     promises.push(
-      this.folderService.getAllDecrypted().then((folders) => {
+      firstValueFrom(this.folderService.folderViews$).then((folders) => {
         decFolders = folders;
       })
     );
@@ -191,7 +192,7 @@ export class ExportService implements ExportServiceAbstraction {
     const promises = [];
 
     promises.push(
-      this.folderService.getAll().then((f) => {
+      firstValueFrom(this.folderService.folders$).then((f) => {
         folders = f;
       })
     );

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -63,6 +63,7 @@ export class FolderService implements FolderServiceAbstraction {
     this._folderViews.next([]);
   }
 
+  // TODO: This should be moved to EncryptService or something
   async encrypt(model: FolderView, key?: SymmetricCryptoKey): Promise<Folder> {
     const folder = new Folder();
     folder.id = model.id;
@@ -76,7 +77,7 @@ export class FolderService implements FolderServiceAbstraction {
     return folders.find((folder) => folder.id === id);
   }
 
-  async upsert(folder: FolderData | FolderData[]): Promise<any> {
+  async upsert(folder: FolderData | FolderData[]): Promise<void> {
     let folders = await this.stateService.getEncryptedFolders();
     if (folders == null) {
       folders = {};
@@ -95,7 +96,7 @@ export class FolderService implements FolderServiceAbstraction {
     await this.stateService.setEncryptedFolders(folders);
   }
 
-  async replace(folders: { [id: string]: FolderData }): Promise<any> {
+  async replace(folders: { [id: string]: FolderData }): Promise<void> {
     await this.updateObservables(folders);
     await this.stateService.setEncryptedFolders(folders);
   }

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -102,7 +102,7 @@ export class FolderService implements FolderServiceAbstraction {
   }
 
   async clear(userId?: string): Promise<any> {
-    if (userId == (await this.stateService.getUserId())) {
+    if (userId == null || userId == (await this.stateService.getUserId())) {
       this._folders.next([]);
       this._folderViews.next([]);
     }

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -3,16 +3,12 @@ import { CryptoService } from "../../abstractions/crypto.service";
 import { FolderService as FolderServiceAbstraction } from "../../abstractions/folder/folder.service.abstraction";
 import { I18nService } from "../../abstractions/i18n.service";
 import { StateService } from "../../abstractions/state.service";
-import { ServiceUtils } from "../../misc/serviceUtils";
 import { Utils } from "../../misc/utils";
 import { CipherData } from "../../models/data/cipherData";
 import { FolderData } from "../../models/data/folderData";
 import { Folder } from "../../models/domain/folder";
 import { SymmetricCryptoKey } from "../../models/domain/symmetricCryptoKey";
-import { TreeNode } from "../../models/domain/treeNode";
 import { FolderView } from "../../models/view/folderView";
-
-const NestingDelimiter = "/";
 
 export class FolderService implements FolderServiceAbstraction {
   constructor(
@@ -82,24 +78,6 @@ export class FolderService implements FolderServiceAbstraction {
 
     await this.stateService.setDecryptedFolders(decFolders);
     return decFolders;
-  }
-
-  async getAllNested(folders?: FolderView[]): Promise<TreeNode<FolderView>[]> {
-    folders = folders ?? (await this.getAllDecrypted());
-    const nodes: TreeNode<FolderView>[] = [];
-    folders.forEach((f) => {
-      const folderCopy = new FolderView();
-      folderCopy.id = f.id;
-      folderCopy.revisionDate = f.revisionDate;
-      const parts = f.name != null ? f.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];
-      ServiceUtils.nestedTraverse(nodes, 0, parts, folderCopy, null, NestingDelimiter);
-    });
-    return nodes;
-  }
-
-  async getNested(id: string): Promise<TreeNode<FolderView>> {
-    const folders = await this.getAllNested();
-    return ServiceUtils.getTreeNodeObject(folders, id) as TreeNode<FolderView>;
   }
 
   async upsert(folder: FolderData | FolderData[]): Promise<any> {

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -35,7 +35,8 @@ export class FolderService implements FolderServiceAbstraction {
       }
 
       if (activeAccount == null) {
-        return;
+        this._folders.next([]);
+        this._folderViews.next([]);
       }
 
       const data = await this.stateService.getEncryptedFolders();

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -13,7 +13,6 @@ import { Folder } from "../../models/domain/folder";
 import { SymmetricCryptoKey } from "../../models/domain/symmetricCryptoKey";
 import { FolderView } from "../../models/view/folderView";
 
-
 const BroadcasterSubscriptionId = "FolderService";
 
 export class FolderService implements FolderServiceAbstraction {
@@ -74,14 +73,6 @@ export class FolderService implements FolderServiceAbstraction {
     const folders = this._folders.getValue();
 
     return folders.find((folder) => folder.id === id);
-  }
-
-  async getAll(): Promise<Folder[]> {
-    return this._folders.getValue();
-  }
-
-  async getAllDecrypted(): Promise<FolderView[]> {
-    return this._folderViews.getValue();
   }
 
   async upsert(folder: FolderData | FolderData[]): Promise<any> {

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -37,6 +37,7 @@ export class FolderService implements FolderServiceAbstraction {
       if (activeAccount == null) {
         this._folders.next([]);
         this._folderViews.next([]);
+        return;
       }
 
       const data = await this.stateService.getEncryptedFolders();

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -31,7 +31,6 @@ import { SymmetricCryptoKey } from "../models/domain/symmetricCryptoKey";
 import { WindowState } from "../models/domain/windowState";
 import { CipherView } from "../models/view/cipherView";
 import { CollectionView } from "../models/view/collectionView";
-import { FolderView } from "../models/view/folderView";
 import { SendView } from "../models/view/sendView";
 
 const keys = {

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -658,24 +658,6 @@ export class StateService<
     );
   }
 
-  @withPrototypeForArrayMembers(FolderView)
-  async getDecryptedFolders(options?: StorageOptions): Promise<FolderView[]> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultInMemoryOptions()))
-    )?.data?.folders?.decrypted;
-  }
-
-  async setDecryptedFolders(value: FolderView[], options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
-    );
-    account.data.folders.decrypted = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
-    );
-  }
-
   @withPrototypeForMap(SymmetricCryptoKey, SymmetricCryptoKey.initFromJson)
   async getDecryptedOrganizationKeys(
     options?: StorageOptions

--- a/libs/common/src/services/vaultTimeout.service.ts
+++ b/libs/common/src/services/vaultTimeout.service.ts
@@ -80,6 +80,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
 
     if (userId == null || userId === (await this.stateService.getUserId())) {
       this.searchService.clearIndex();
+      await this.folderService.clearCache();
     }
 
     await this.stateService.setEverBeenUnlocked(true, { userId: userId });
@@ -91,7 +92,6 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     await this.cryptoService.clearKeyPair(true, userId);
     await this.cryptoService.clearEncKey(true, userId);
 
-    await this.folderService.clearCache(userId);
     await this.cipherService.clearCache(userId);
     await this.collectionService.clearCache(userId);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Changes the `FolderService` to use Observables for folders and folderViews. Also updates all usages to use Observables primarily using either the `async` pipe inside the templates. Or if we only need the value once using `firstValueFrom` which resolves the first value from the Observable.

I also identified a couple of follow up tasks after this:

* The nesting of folders could be a pipe that we can use and therefore remove from the services. `{{ folders | nested : '/' }}`. This would ensure the folders stay updated in the vault filter component.
* Create a new observable for account status that emits when an account is locked/unlocked, so we don't have to listen to `broadcasterService`.
* Move cleanup to `FolderService` and let it listen to the relevant events itself.

TODO: We should update our documentation for best practices.

- Avoid subscribing to subscriptions in components (and if you need to do so, ensure you clean up the subscription.
	- Better alternatives is to use the `async` pipe. You can use the rxjs pipe to transform a subscription.. The `async` pipe automatically cleans up itself.
	- Sub components can accept the input as regular `@Input`, combine it with `async`.
- Write presentational components to be reactive and not one-off fetches of state.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **folder.service.ts:** Removed `getAll` and `getAllDecrypted` and replaced them with `folders$` and `folderViews$`. Move `getAllNested` to `VaultFilterService`, it's far from the optimal place but it's closer to the usage than the `FolderService`.
- **state.service.ts:** Removed memory related operations for folders as that state is maintained in the `folderService`.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
