### PR TITLE
Move the QA Web Vault to CloudFlare Pages

### DIFF
--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -59,21 +59,20 @@ jobs:
           cp -R ../apps/web/build/* .
         working-directory: deployment
 
-      - name: Create cf-pages-qa-deploy branch
+      - name: Push new ver to cf-pages-qa
         run: |
-          git switch -c cf-pages-qa-deploy-${{ github.ref_name }}
           git add .
-          git commit -m "Staging deploy ${{ github.ref_name }}"
-          git push -u origin cf-pages-qa-deploy-${{ github.ref_name }}
+          git commit -m "Deploy ${{ github.ref_name }} to QA Cloudflare pages"
+          git push -u origin cf-pages-qa
         working-directory: deployment
 
-      - name: Create CloudFlare Pages Deploy PR
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          PR_BRANCH: cf-pages-qa-deploy-${{ github.ref_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr create --title "Deploy ${{ github.ref_name }} to CloudFlare Pages" \
-            --body "Deploying ${{ github.ref_name }}" \
-            --base cf-pages-qa \
-            --head "$PR_BRANCH"
+      # - name: Create CloudFlare Pages Deploy PR
+      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+      #   env:
+      #     PR_BRANCH: cf-pages-qa-deploy-${{ github.ref_name }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh pr create --title "Deploy ${{ github.ref_name }} to QA CloudFlare Pages" \
+      #       --body "Deploying ${{ github.ref_name }}" \
+      #       --base cf-pages-qa \
+      #       --head "$PR_BRANCH"

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Branch check
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/feature/DEVOPS-843_qa_web_vault_to_cloudflare" ]] && [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
             echo "==================================="
             echo "[!] Can only release from the 'master', 'rc' or 'hotfix-rc/*' branches"
             echo "==================================="

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Branch check
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/DEVOPS-843_qa_web_vault_to_cloudflare" ]] && [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/feature/DEVOPS-843_qa_web_vault_to_cloudflare" ]] && [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
             echo "==================================="
             echo "[!] Can only release from the 'master', 'rc' or 'hotfix-rc/*' branches"
             echo "==================================="

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -3,25 +3,71 @@ name: QA - Web Release
 
 on:
   workflow_dispatch:
+    inputs:
+      image_extension:
+        description: "Image tag extension"
+        required: false
+
+env:
+  _QA_CLUSTER_RESOURCE_GROUP: "bw-env-qa"
+  _QA_CLUSTER_NAME: "bw-aks-qa"
+  _QA_K8S_NAMESPACE: "bw-qa"
+  _QA_K8S_APP_NAME: "bw-web"
 
 jobs:
-  setup:
-    name: Setup
+  deploy:
+    name: Deploy QA Web
     runs-on: ubuntu-20.04
     steps:
-      - name: Branch check
+      - name: Checkout Repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
+
+      - name: Setup
+        run: export PATH=$PATH:~/work/web/web
+
+      - name: Login to Azure
+        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010  # v1.1
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f  # v1
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "qa-aks-kubectl-credentials"
+
+      - name: Login with qa-aks-kubectl-credentials SP
+        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010  # v1.1
+        with:
+          creds: ${{ env.qa-aks-kubectl-credentials }}
+
+      - name: Setup AKS access
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'master', 'rc' or 'hotfix-rc/*' branches"
-            echo "==================================="
-            exit 1
+          echo "---az install---"
+          az aks install-cli --install-location ./kubectl --kubelogin-install-location ./kubelogin
+          echo "---az get-creds---"
+          az aks get-credentials -n $_QA_CLUSTER_NAME -g $_QA_CLUSTER_RESOURCE_GROUP
+      - name: Get image tag
+        id: image_tag
+        run: |
+          IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")
+          TAG_EXTENSION=${{ github.event.inputs.image_extension }}
+          if [[ $TAG_EXTENSION ]]; then
+            IMAGE_TAG=$IMAGE_TAG-$TAG_EXTENSION
           fi
+          echo "::set-output name=value::$IMAGE_TAG"
+      - name: Deploy Web image
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
+        run: |
+          kubectl set image -n $_QA_K8S_NAMESPACE deployment/web web=bitwardenqa.azurecr.io/web:$IMAGE_TAG --record
+          kubectl rollout restart -n $_QA_K8S_NAMESPACE deployment/web
+          kubectl rollout status deployment/web -n $_QA_K8S_NAMESPACE
 
   cfpages-deploy:
     name: Deploy Web Vault to QA CloudFlare Pages branch
     runs-on: ubuntu-20.04
-    needs: setup
     steps:
       - name: Checkout Repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -69,14 +69,3 @@ jobs:
             echo "No changes to commit!";
           fi
         working-directory: deployment
-
-      # - name: Create CloudFlare Pages Deploy PR
-      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-      #   env:
-      #     PR_BRANCH: cf-pages-qa-deploy-${{ github.ref_name }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gh pr create --title "Deploy ${{ github.ref_name }} to QA CloudFlare Pages" \
-      #       --body "Deploying ${{ github.ref_name }}" \
-      #       --base cf-pages-qa \
-      #       --head "$PR_BRANCH"

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -48,15 +48,18 @@ jobs:
           az aks install-cli --install-location ./kubectl --kubelogin-install-location ./kubelogin
           echo "---az get-creds---"
           az aks get-credentials -n $_QA_CLUSTER_NAME -g $_QA_CLUSTER_RESOURCE_GROUP
+
       - name: Get image tag
         id: image_tag
         run: |
           IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")
           TAG_EXTENSION=${{ github.event.inputs.image_extension }}
+
           if [[ $TAG_EXTENSION ]]; then
             IMAGE_TAG=$IMAGE_TAG-$TAG_EXTENSION
           fi
           echo "::set-output name=value::$IMAGE_TAG"
+
       - name: Deploy Web image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Setup git config
         run: |
-          git config --global user.name = "GitHub Action Bot"
-          git config --global user.email = "<>"
+          git config --global user.name "GitHub Action Bot"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           git config --global url."https://".insteadOf ssh://
 

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -3,67 +3,77 @@ name: QA - Web Release
 
 on:
   workflow_dispatch:
-    inputs:
-      image_extension:
-        description: "Image tag extension"
-        required: false
-
-env:
-  _QA_CLUSTER_RESOURCE_GROUP: "bw-env-qa"
-  _QA_CLUSTER_NAME: "bw-aks-qa"
-  _QA_K8S_NAMESPACE: "bw-qa"
-  _QA_K8S_APP_NAME: "bw-web"
 
 jobs:
-  deploy:
-    name: Deploy QA Web
+  setup:
+    name: Setup
     runs-on: ubuntu-20.04
+    steps:
+      - name: Branch check
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/DEVOPS-843_qa_web_vault_to_cloudflare" ]] && [[ "$GITHUB_REF" != "refs/heads/master" ]] && [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc/* ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'master', 'rc' or 'hotfix-rc/*' branches"
+            echo "==================================="
+            exit 1
+          fi
+
+  cfpages-deploy:
+    name: Deploy Web Vault to QA CloudFlare Pages branch
+    runs-on: ubuntu-20.04
+    needs: setup
     steps:
       - name: Checkout Repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
-      - name: Setup
-        run: export PATH=$PATH:~/work/web/web
-
-      - name: Login to Azure
-        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010  # v1.1
+      - name: Download latest cloud asset
+        uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
         with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+          workflow: build-web.yml
+          path: apps/web
+          workflow_conclusion: success
+          branch: ${{ github.ref_name }}
+          artifacts: web-*-cloud-COMMERCIAL.zip
 
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f  # v1
+      # This should result in a build directory in the current working directory
+      - name: Unzip build asset
+        working-directory: apps/web
+        run: unzip web-*-cloud-COMMERCIAL.zip
+
+      - name: Checkout Repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
         with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "qa-aks-kubectl-credentials"
+          ref: cf-pages-qa
+          path: deployment
 
-      - name: Login with qa-aks-kubectl-credentials SP
-        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010  # v1.1
-        with:
-          creds: ${{ env.qa-aks-kubectl-credentials }}
-
-      - name: Setup AKS access
+      - name: Setup git config
         run: |
-          echo "---az install---"
-          az aks install-cli --install-location ./kubectl --kubelogin-install-location ./kubelogin
-          echo "---az get-creds---"
-          az aks get-credentials -n $_QA_CLUSTER_NAME -g $_QA_CLUSTER_RESOURCE_GROUP
+          git config --global user.name = "GitHub Action Bot"
+          git config --global user.email = "<>"
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://".insteadOf ssh://
 
-      - name: Get image tag
-        id: image_tag
+      - name: Deploy CloudFlare Pages
         run: |
-          IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")
-          TAG_EXTENSION=${{ github.event.inputs.image_extension }}
+          rm -rf ./*
+          cp -R ../apps/web/build/* .
+        working-directory: deployment
 
-          if [[ $TAG_EXTENSION ]]; then
-            IMAGE_TAG=$IMAGE_TAG-$TAG_EXTENSION
-          fi
-          echo "::set-output name=value::$IMAGE_TAG"
+      - name: Create cf-pages-qa-deploy branch
+        run: |
+          git switch -c cf-pages-qa-deploy-${{ github.ref_name }}
+          git add .
+          git commit -m "Staging deploy ${{ github.ref_name }}"
+          git push -u origin cf-pages-qa-deploy-${{ github.ref_name }}
+        working-directory: deployment
 
-      - name: Deploy Web image
+      - name: Create CloudFlare Pages Deploy PR
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
-          IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
+          PR_BRANCH: cf-pages-qa-deploy-${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          kubectl set image -n $_QA_K8S_NAMESPACE deployment/web web=bitwardenqa.azurecr.io/web:$IMAGE_TAG --record
-          kubectl rollout restart -n $_QA_K8S_NAMESPACE deployment/web
-          kubectl rollout status deployment/web -n $_QA_K8S_NAMESPACE
+          gh pr create --title "Deploy ${{ github.ref_name }} to CloudFlare Pages" \
+            --body "Deploying ${{ github.ref_name }}" \
+            --base cf-pages-qa \
+            --head "$PR_BRANCH"

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -61,9 +61,13 @@ jobs:
 
       - name: Push new ver to cf-pages-qa
         run: |
-          git add .
-          git commit -m "Deploy ${{ github.ref_name }} to QA Cloudflare pages"
-          git push -u origin cf-pages-qa
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "Deploy ${{ github.ref_name }} to QA Cloudflare pages"
+            git push -u origin cf-pages-qa
+          else
+            echo "No changes to commit!";
+          fi
         working-directory: deployment
 
       # - name: Create CloudFlare Pages Deploy PR


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Publish QA web vault to separate branch (same strategy as on production web vault). To create better parity between Production and QA, we need to move the QA Web Vault to Cloudflare Pages.

## Code changes

- **.github/workflows/release-qa-web.yml:** Download the newest web vault version and commit it to `cf-pages-qa` branch. The branch is tracked by Cloudflare pages and web vault will be published from it.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
