### PR TITLE
[PS-722] Desktop: Add warning when vault timeout is set to never

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1960,5 +1960,8 @@
   },
   "apiKey": {
     "message": "API Key"
+  },
+  "neverLockWarning": {
+    "message": "Are you sure you want to use the \"Never\" option? Setting your lock options to \"Never\" stores your vault's encryption key on your device. If you use this option you should ensure that you keep your device properly protected."
   }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Added a warning when the user selects vault timeout value "Never". Similar to what already happens on the browser client.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/app/accounts/settings.component.ts** Added logic to determine if the selected value equals to the option "Never". If true opens a dialog to confirm the choice.
- **apps/desktop/src/locales/en/messages.json**  Added dialog text message to confirm the choice

## Screenshots

![image](https://user-images.githubusercontent.com/108268980/177363202-9a554538-59fd-4afc-be31-fa4190cd007b.png)

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
