### PR TITLE
Resolve the path being wrong in the cli release pipeline

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -206,7 +206,7 @@ jobs:
         uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
         with:
           workflow: build-cli.yml
-          path: apps/cli
+          path: apps/cli/build
           workflow_conclusion: success
           branch: ${{ github.ref_name }}
           artifacts: bitwarden-cli-${{ env._PKG_VERSION }}-npm-build.zip


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In the old repository we used the path `build` in the workflow for the _Download artifacts_ step [1].  After the move to the mono repository we changed this to `apps/cli`. Since the release artifact from `build-cli.yml` https://github.com/bitwarden/clients/actions/runs/2584460574 looks identical to the artifacts generated from the old repository, I believe this to be the cause of the issue.

[1] https://github.com/bitwarden/cli/blob/master/.github/workflows/release.yml#L191
[2] https://github.com/bitwarden/clients/blob/master/.github/workflows/release-cli.yml#L209

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
