### PR TITLE
[DEVOPS-832] Update timing on SelfHost "latest" tag

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -88,7 +88,6 @@ jobs:
             docker tag bitwarden/web:latest bitwarden/web:$_RELEASE_VERSION
           else
             docker tag bitwarden/web:$_BRANCH_NAME bitwarden/web:$_RELEASE_VERSION
-            docker tag bitwarden/web:$_BRANCH_NAME bitwarden/web:latest
           fi
 
       - name: Docker Push version and latest image
@@ -98,7 +97,6 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
         run: |
           docker push bitwarden/web:$_RELEASE_VERSION
-          docker push bitwarden/web:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -120,16 +118,12 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker tag bitwarden/web:latest $REGISTRY/web:$_RELEASE_VERSION
-            docker tag bitwarden/web:latest $REGISTRY/web:latest
 
             docker tag bitwarden/web:latest $REGISTRY/web-sh:$_RELEASE_VERSION
-            docker tag bitwarden/web:latest $REGISTRY/web-sh:latest
           else
             docker tag bitwarden/web:$_BRANCH_NAME $REGISTRY/web:$_RELEASE_VERSION
-            docker tag bitwarden/web:$_BRANCH_NAME $REGISTRY/web:latest
 
             docker tag bitwarden/web:$_BRANCH_NAME $REGISTRY/web-sh:$_RELEASE_VERSION
-            docker tag bitwarden/web:$_BRANCH_NAME $REGISTRY/web-sh:latest
           fi
 
       - name: Push version and latest image
@@ -138,10 +132,8 @@ jobs:
           REGISTRY: bitwardenqa.azurecr.io
         run: |
           docker push $REGISTRY/web:$_RELEASE_VERSION
-          docker push $REGISTRY/web:latest
 
           docker push $REGISTRY/web-sh:$_RELEASE_VERSION
-          docker push $REGISTRY/web-sh:latest
 
       - name: Log out of Docker
         run: docker logout


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Move the `latest` tag to be created on update to the self-host script instead of the server/web releases.

Related PRs:
- https://github.com/bitwarden/self-host/pull/33
- https://github.com/bitwarden/server/pull/2098

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/release-web.yml:** Remove tagging Docker images as `lastest, only tag a static version.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
