### PR TITLE
[EC-299] Desktop: Add callout warning when vault timeout is set to "Never"

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -35,6 +35,13 @@
                 [formControl]="vaultTimeout"
                 ngDefaultControl
               ></app-vault-timeout-input>
+              <app-callout
+                type="warning"
+                *ngIf="showVaultTimeoutNeverWarning"
+                icon="bwi bwi-exclamation-triangle"
+              >
+                {{ "neverLockWarning" | i18n }}
+              </app-callout>
               <div class="form-group">
                 <label>{{ "vaultTimeoutAction" | i18n }}</label>
                 <div class="radio radio-mt-2">

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -65,6 +65,7 @@ export class SettingsComponent implements OnInit {
   showSecurity = true;
   showAccountPreferences = true;
   showAppPreferences = true;
+  showVaultTimeoutNeverWarning = false;
 
   currentUserEmail: string;
 
@@ -195,6 +196,9 @@ export class SettingsComponent implements OnInit {
   }
 
   async saveVaultTimeoutOptions() {
+    // Check if the selected value is "Never" and if true then the callout warning appears
+    this.showVaultTimeoutNeverWarning = this.vaultTimeout.value == null;
+
     if (this.vaultTimeoutAction === "logOut") {
       const confirmed = await this.platformUtilsService.showDialog(
         this.i18nService.t("vaultTimeoutLogOutConfirmation"),

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1963,5 +1963,8 @@
   },
   "apiKey": {
     "message": "API Key"
+  },
+  "neverLockWarning": {
+    "message": "Setting your lock options to \"Never\" stores your vault's encryption key on your device. If you use this option you should ensure that you keep your device properly protected."
   }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Add callout warning when the user changes the vault timeout value to "Never".

## Code changes

- **apps/desktop/src/app/accounts/settings.component.html** Added the warning callout control
- **apps/desktop/src/app/accounts/settings.component.ts** Added the logic to determine if the user changed the value to "Never"
- **apps/desktop/src/locales/en/messages.json** Added the warning text message

## Screenshots

![image](https://user-images.githubusercontent.com/108268980/177577409-5a8cbedc-b370-4dc0-91e5-4cf0892fea4e.png)


## Before you submit

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
