### PR TITLE
[PS-1051] Fix/add master pass hash to all org reset key requests

### DIFF
--- a/apps/web/src/app/modules/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/modules/vault-filter/components/organization-options.component.ts
@@ -120,6 +120,7 @@ export class OrganizationOptionsComponent {
         },
       });
     } else {
+      // Remove reset password
       const request = new OrganizationUserResetPasswordEnrollmentRequest();
       request.masterPasswordHash = "ignored";
       request.resetPasswordKey = null;

--- a/apps/web/src/app/settings/change-password.component.ts
+++ b/apps/web/src/app/settings/change-password.component.ts
@@ -224,7 +224,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
 
     await this.updateEmergencyAccesses(encKey[0]);
 
-    await this.updateAllResetPasswordKeys(encKey[0]);
+    await this.updateAllResetPasswordKeys(encKey[0], masterPasswordHash);
   }
 
   private async updateEmergencyAccesses(encKey: SymmetricCryptoKey) {
@@ -252,7 +252,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
     }
   }
 
-  private async updateAllResetPasswordKeys(encKey: SymmetricCryptoKey) {
+  private async updateAllResetPasswordKeys(encKey: SymmetricCryptoKey, masterPasswordHash: string) {
     const orgs = await this.organizationService.getAll();
 
     for (const org of orgs) {
@@ -270,6 +270,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
 
       // Create/Execute request
       const request = new OrganizationUserResetPasswordEnrollmentRequest();
+      request.masterPasswordHash = masterPasswordHash;
       request.resetPasswordKey = encryptedKey.encryptedString;
 
       await this.apiService.putOrganizationUserResetPasswordEnrollment(org.id, org.userId, request);

--- a/libs/angular/src/components/set-password.component.ts
+++ b/libs/angular/src/components/set-password.component.ts
@@ -128,6 +128,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
             );
 
             const resetRequest = new OrganizationUserResetPasswordEnrollmentRequest();
+            resetRequest.masterPasswordHash = masterPasswordHash;
             resetRequest.resetPasswordKey = encryptedKey.encryptedString;
 
             return this.apiService.putOrganizationUserResetPasswordEnrollment(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

PS-616 added user verification to master password enrollment requests, but missed a few instances of password setting. This PR includes the new password hash in those requests.

## Code changes

* **change-password.component**: missed updating on master password change
* **set-password.component**: missed updating when we're setting our password after auth. This occurs for SSO-created accounts.


## Before you submit

<!-- (mark with an `X`) -->

```
- [ x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
