### PR TITLE
[SG-329] Disabled Org display

### DIFF
--- a/apps/web/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/apps/web/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -129,6 +129,12 @@
             <button class="filter-button" (click)="applyOrganizationFilter(organization)">
               <i class="bwi bwi-fw bwi-business" aria-hidden="true"></i>
               {{ organization.name }}
+              <i
+                *ngIf="!organization.enabled"
+                class="bwi bwi-fw bwi-exclamation-triangle text-danger"
+                aria-label="{{ 'organizationIsDisabled' | i18n }}"
+                appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
+              ></i>
             </button>
             <ng-container>
               <button [bitMenuTriggerFor]="orgMenu" class="org-options ml-auto">

--- a/apps/web/src/app/modules/vault-filter/components/organization-filter.component.ts
+++ b/apps/web/src/app/modules/vault-filter/components/organization-filter.component.ts
@@ -1,6 +1,9 @@
 import { Component } from "@angular/core";
 
 import { OrganizationFilterComponent as BaseOrganizationFilterComponent } from "@bitwarden/angular/modules/vault-filter/components/organization-filter.component";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
+import { Organization } from "@bitwarden/common/models/domain/organization";
 
 @Component({
   selector: "app-organization-filter",
@@ -8,4 +11,24 @@ import { OrganizationFilterComponent as BaseOrganizationFilterComponent } from "
 })
 export class OrganizationFilterComponent extends BaseOrganizationFilterComponent {
   displayText = "allVaults";
+
+  constructor(
+    private i18nService: I18nService,
+    private platformUtilsService: PlatformUtilsService
+  ) {
+    super();
+  }
+
+  async applyOrganizationFilter(organization: Organization) {
+    if (organization.enabled) {
+      //proceed with default behaviour for enabled organizations
+      super.applyOrganizationFilter(organization);
+    } else {
+      this.platformUtilsService.showToast(
+        "error",
+        null,
+        this.i18nService.t("disabledOrganizationFilterError")
+      );
+    }
+  }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3209,6 +3209,9 @@
   "organizationIsDisabled": {
     "message": "Organization is disabled."
   },
+  "disabledOrganizationFilterError" : {
+    "message" : "Items in disabled Organizations cannot be accessed. Contact your Organization owner for assistance."
+  },
   "licenseIsExpired": {
     "message": "License is expired."
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

With the end user vault refresh we removed the tile for organizations, which was previously where we displayed to users when an organization they belonged to was disabled.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
