### PR TITLE
Get full cipher details when update cipher notification is received

### DIFF
--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -259,6 +259,7 @@ export abstract class ApiService {
   renewSendFileUploadUrl: (sendId: string, fileId: string) => Promise<SendFileUploadDataResponse>;
 
   getCipher: (id: string) => Promise<CipherResponse>;
+  getFullCipherDetails: (id: string) => Promise<CipherResponse>;
   getCipherAdmin: (id: string) => Promise<CipherResponse>;
   getAttachmentData: (
     cipherId: string,

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -612,6 +612,11 @@ export class ApiService implements ApiServiceAbstraction {
     return new CipherResponse(r);
   }
 
+  async getFullCipherDetails(id: string): Promise<CipherResponse> {
+    const r = await this.send("GET", "/ciphers/" + id + "/details", null, true, true);
+    return new CipherResponse(r);
+  }
+
   async getCipherAdmin(id: string): Promise<CipherResponse> {
     const r = await this.send("GET", "/ciphers/" + id + "/admin", null, true, true);
     return new CipherResponse(r);

--- a/libs/common/src/services/sync.service.ts
+++ b/libs/common/src/services/sync.service.ts
@@ -196,7 +196,7 @@ export class SyncService implements SyncServiceAbstraction {
         }
 
         if (shouldUpdate) {
-          const remoteCipher = await this.apiService.getCipher(notification.id);
+          const remoteCipher = await this.apiService.getFullCipherDetails(notification.id);
           if (remoteCipher != null) {
             await this.cipherService.upsert(new CipherData(remoteCipher));
             this.messagingService.send("syncedUpsertedCipher", { cipherId: notification.id });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix Organizational vault items disappearing from the Collection filter when they are edited, and return only when the client is synced. After further investigation, I found the issue to be that when an update cipher notification is received the call to get the cipher did not get the collectionIds with it. Changing the call to the `details` route for a cipher returns the same cipher response, but includes collectionIds.


## Code changes

- **libs/common/src/abstractions/api.service.ts** Add method to api service to call cipher details route
- **libs/common/src/services/api.service.ts:** Implement cipher details route
- **libs/common/src/services/sync.service.ts:** Change call in sync service from getCipher to new details route

## Screenshots

Demo:

https://user-images.githubusercontent.com/8926729/177805500-eeefa960-a572-481b-96a0-d4dbe5c2bbdd.mov


## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
