### PR TITLE
[PS-94] Ensure autofill always uses the same tab

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -16,7 +16,7 @@ import LockedVaultPendingNotificationsItem from "./models/lockedVaultPendingNoti
 export default class RuntimeBackground {
   private autofillTimeout: any;
   private pageDetailsToAutoFill: any[] = [];
-  private tabToAutoFill: any;
+  private tabToAutoFill: chrome.tabs.Tab;
   private onInstalledReason: string = null;
   private lockedVaultPendingNotifications: LockedVaultPendingNotificationsItem[] = [];
 

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -16,6 +16,7 @@ import LockedVaultPendingNotificationsItem from "./models/lockedVaultPendingNoti
 export default class RuntimeBackground {
   private autofillTimeout: any;
   private pageDetailsToAutoFill: any[] = [];
+  private tabToAutoFill: any;
   private onInstalledReason: string = null;
   private lockedVaultPendingNotifications: LockedVaultPendingNotificationsItem[] = [];
 
@@ -143,6 +144,7 @@ export default class RuntimeBackground {
               tab: msg.tab,
               details: msg.details,
             });
+            this.tabToAutoFill = msg.tab;
             this.autofillTimeout = setTimeout(async () => await this.autofillPage(), 300);
             break;
           default:
@@ -207,6 +209,7 @@ export default class RuntimeBackground {
 
   private async autofillPage() {
     const totpCode = await this.autofillService.doAutoFill({
+      tab: this.tabToAutoFill,
       cipher: this.main.loginToAutoFill,
       pageDetails: this.pageDetailsToAutoFill,
       fillNewPassword: true,
@@ -219,6 +222,7 @@ export default class RuntimeBackground {
     // reset
     this.main.loginToAutoFill = null;
     this.pageDetailsToAutoFill = [];
+    this.tabToAutoFill = null;
   }
 
   private async checkOnInstalled() {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -16,7 +16,6 @@ import LockedVaultPendingNotificationsItem from "./models/lockedVaultPendingNoti
 export default class RuntimeBackground {
   private autofillTimeout: any;
   private pageDetailsToAutoFill: any[] = [];
-  private tabToAutoFill: chrome.tabs.Tab;
   private onInstalledReason: string = null;
   private lockedVaultPendingNotifications: LockedVaultPendingNotificationsItem[] = [];
 
@@ -144,8 +143,7 @@ export default class RuntimeBackground {
               tab: msg.tab,
               details: msg.details,
             });
-            this.tabToAutoFill = msg.tab;
-            this.autofillTimeout = setTimeout(async () => await this.autofillPage(), 300);
+            this.autofillTimeout = setTimeout(async () => await this.autofillPage(msg.tab), 300);
             break;
           default:
             break;
@@ -207,9 +205,9 @@ export default class RuntimeBackground {
     }
   }
 
-  private async autofillPage() {
+  private async autofillPage(tabToAutoFill: chrome.tabs.Tab) {
     const totpCode = await this.autofillService.doAutoFill({
-      tab: this.tabToAutoFill,
+      tab: tabToAutoFill,
       cipher: this.main.loginToAutoFill,
       pageDetails: this.pageDetailsToAutoFill,
       fillNewPassword: true,
@@ -222,7 +220,6 @@ export default class RuntimeBackground {
     // reset
     this.main.loginToAutoFill = null;
     this.pageDetailsToAutoFill = [];
-    this.tabToAutoFill = null;
   }
 
   private async checkOnInstalled() {

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -28,7 +28,7 @@ const BroadcasterSubscriptionId = "CurrentTabComponent";
 })
 export class CurrentTabComponent implements OnInit, OnDestroy {
   pageDetails: any[] = [];
-  tab: any;
+  tab: chrome.tabs.Tab;
   cardCiphers: CipherView[];
   identityCiphers: CipherView[];
   loginCiphers: CipherView[];

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -28,6 +28,7 @@ const BroadcasterSubscriptionId = "CurrentTabComponent";
 })
 export class CurrentTabComponent implements OnInit, OnDestroy {
   pageDetails: any[] = [];
+  tab: any;
   cardCiphers: CipherView[];
   identityCiphers: CipherView[];
   loginCiphers: CipherView[];
@@ -151,6 +152,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
 
     try {
       this.totpCode = await this.autofillService.doAutoFill({
+        tab: this.tab,
         cipher: cipher,
         pageDetails: this.pageDetails,
         doc: window.document,
@@ -196,9 +198,9 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
 
   private async load() {
     this.loaded = false;
-    const tab = await BrowserApi.getTabFromCurrentWindow();
-    if (tab != null) {
-      this.url = tab.url;
+    this.tab = await BrowserApi.getTabFromCurrentWindow();
+    if (this.tab != null) {
+      this.url = this.tab.url;
     } else {
       this.loginCiphers = [];
       this.loaded = true;
@@ -207,9 +209,9 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
 
     this.hostname = Utils.getHostname(this.url);
     this.pageDetails = [];
-    BrowserApi.tabSendMessage(tab, {
+    BrowserApi.tabSendMessage(this.tab, {
       command: "collectPageDetails",
-      tab: tab,
+      tab: this.tab,
       sender: BroadcasterSubscriptionId,
     });
 

--- a/apps/browser/src/popup/vault/view.component.ts
+++ b/apps/browser/src/popup/vault/view.component.ts
@@ -276,6 +276,7 @@ export class ViewComponent extends BaseViewComponent {
 
     try {
       this.totpCode = await this.autofillService.doAutoFill({
+        tab: this.tab,
         cipher: this.cipher,
         pageDetails: this.pageDetails,
         doc: window.document,

--- a/apps/browser/src/services/autofill.service.ts
+++ b/apps/browser/src/services/autofill.service.ts
@@ -66,7 +66,7 @@ export default class AutofillService implements AutofillServiceInterface {
 
   async doAutoFill(options: any) {
     let totpPromise: Promise<string> = null;
-    const tab = await this.getActiveTab();
+    const tab = options.tab;
     if (!tab || !options.cipher || !options.pageDetails || !options.pageDetails.length) {
       throw new Error("Nothing to auto-fill.");
     }
@@ -168,6 +168,7 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     const totpCode = await this.doAutoFill({
+      tab: tab,
       cipher: cipher,
       pageDetails: pageDetails,
       skipLastUsed: !fromCommand,


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Require specifying the tab that is to be autofilled in the autofill service.

## Code changes

- **apps/browser/src/services/autofill.service.ts:** Add a `tab` property to `options` to specify the tab to be autofilled.
- **_all others changes_:** Make use of the new `tab` property when calling `doAutoFill()` from the `autofillService`

## Before you submit
```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```