### PR TITLE
[fix] Adjust extraResources in electronBuilder to account for the monorepo move

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -69,7 +69,7 @@
     "sign": "./sign.js",
     "extraResources": [
       {
-        "from": "node_modules/regedit/vbs",
+        "from": "../../node_modules/regedit/vbs",
         "to": "regedit/vbs",
         "filter": ["**/*"]
       },


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-421

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Patch a bug we are seeing from the `2022.06` `desktop` release that renders browser biometrics unusable on Windows machines. 

## Code changes
When we moved the projects to a monorepo we also started using a root level `package.json` file. 

One of the desktop dependencies is `regedit`, and we package a registry list from `regedit` into the distribution files of Windows builds. This is then used to modify registries to enable browser biometrics.

We did not modify the file path for these dist files, so they are still looking for `desktop/node_modules`. They should be looking for `clients/node_modules`.

This commit updates this file path to look upwards to the root `node_modules` folder.


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
