### PR TITLE
[SG-68] Implement org info step

### DIFF
--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.component.html
@@ -28,20 +28,19 @@
             Start your 7-Day free trial of Bitwarden for {{ org }}
           </h2>
         </div>
-        <app-vertical-stepper #stepper linear>
-          <!-- Content is for demo purposes. Replace with form components for each step-->
+        <app-vertical-stepper #stepper linear (selectionChange)="stepSelectionChange($event)">
           <app-vertical-step label="Create Account" [editable]="false" [subLabel]="email">
             <app-register-form
               [isInTrialFlow]="true"
               (createdAccount)="createdAccount($event)"
             ></app-register-form>
           </app-vertical-step>
-          <app-vertical-step label="Create Organization" [subLabel]="formGroup.get('name').value">
-            <app-org-info [nameOnly]="true" [formGroup]="formGroup"></app-org-info>
+          <app-vertical-step label="Organization Information" [subLabel]="orgInfoSubLabel">
+            <app-org-info [nameOnly]="true" [formGroup]="orgInfoFormGroup"></app-org-info>
             <button
               bitButton
               buttonType="primary"
-              [disabled]="formGroup.get('name').hasError('required')"
+              [disabled]="orgInfoFormGroup.get('name').hasError('required')"
               cdkStepperNext
             >
               Next

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.component.html
@@ -36,10 +36,16 @@
               (createdAccount)="createdAccount($event)"
             ></app-register-form>
           </app-vertical-step>
-          <app-vertical-step label="Create Organization" subLabel="It better be a good org">
-            <!-- Replace with Org creation step -->
-            <p>This is content of "Step 2"</p>
-            <button bitButton buttonType="primary" cdkStepperNext>Complete step</button>
+          <app-vertical-step label="Create Organization" [subLabel]="formGroup.get('name').value">
+            <app-org-info [nameOnly]="true" [formGroup]="formGroup"></app-org-info>
+            <button
+              bitButton
+              buttonType="primary"
+              [disabled]="formGroup.get('name').hasError('required')"
+              cdkStepperNext
+            >
+              Next
+            </button>
           </app-vertical-step>
           <app-vertical-step label="Billing">
             <!-- Replace with Billing step -->

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
+import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { first } from "rxjs";
 
@@ -13,7 +14,16 @@ export class TrialInitiationComponent implements OnInit {
   org = "teams";
   @ViewChild("stepper", { static: true }) verticalStepper: VerticalStepperComponent;
 
-  constructor(private route: ActivatedRoute) {}
+  formGroup = this.formBuilder.group({
+    name: ["", [Validators.required]],
+    additionalStorage: [0, [Validators.min(0), Validators.max(99)]],
+    additionalSeats: [0, [Validators.min(0), Validators.max(100000)]],
+    businessName: [""],
+    plan: [],
+    product: [],
+  });
+
+  constructor(private route: ActivatedRoute, private formBuilder: FormBuilder) {}
 
   ngOnInit(): void {
     this.route.queryParams.pipe(first()).subscribe((qParams) => {

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
@@ -1,3 +1,5 @@
+import { StepperSelectionEvent } from "@angular/cdk/stepper";
+import { TitleCasePipe } from "@angular/common";
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
@@ -12,9 +14,10 @@ import { VerticalStepperComponent } from "../vertical-stepper/vertical-stepper.c
 export class TrialInitiationComponent implements OnInit {
   email = "";
   org = "teams";
+  orgInfoSubLabel = "";
   @ViewChild("stepper", { static: true }) verticalStepper: VerticalStepperComponent;
 
-  formGroup = this.formBuilder.group({
+  orgInfoFormGroup = this.formBuilder.group({
     name: ["", [Validators.required]],
     additionalStorage: [0, [Validators.min(0), Validators.max(99)]],
     additionalSeats: [0, [Validators.min(0), Validators.max(100000)]],
@@ -23,7 +26,11 @@ export class TrialInitiationComponent implements OnInit {
     product: [],
   });
 
-  constructor(private route: ActivatedRoute, private formBuilder: FormBuilder) {}
+  constructor(
+    private route: ActivatedRoute,
+    private formBuilder: FormBuilder,
+    private titleCasePipe: TitleCasePipe
+  ) {}
 
   ngOnInit(): void {
     this.route.queryParams.pipe(first()).subscribe((qParams) => {
@@ -34,6 +41,16 @@ export class TrialInitiationComponent implements OnInit {
         this.org = qParams.org;
       }
     });
+  }
+
+  stepSelectionChange(event: StepperSelectionEvent) {
+    // Set org info sub label
+    if (event.selectedIndex === 1 && this.orgInfoFormGroup.controls.name.value === "") {
+      this.orgInfoSubLabel =
+        "Enter your " + this.titleCasePipe.transform(this.org) + " organization information";
+    } else if (event.previouslySelectedIndex === 1) {
+      this.orgInfoSubLabel = this.orgInfoFormGroup.controls.name.value;
+    }
   }
 
   createdAccount(email: string) {

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.module.ts
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.module.ts
@@ -1,4 +1,5 @@
 import { CdkStepperModule } from "@angular/cdk/stepper";
+import { TitleCasePipe } from "@angular/common";
 import { NgModule } from "@angular/core";
 
 import { FormFieldModule } from "@bitwarden/components";
@@ -29,5 +30,6 @@ import { TrialInitiationComponent } from "./trial-initiation.component";
     TeamsContentComponent,
   ],
   exports: [TrialInitiationComponent],
+  providers: [TitleCasePipe],
 })
 export class TrialInitiationModule {}

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.module.ts
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 
 import { FormFieldModule } from "@bitwarden/components";
 
+import { OrganizationCreateModule } from "../organizations/create/organization-create.module";
 import { RegisterFormModule } from "../register-form/register-form.module";
 import { SharedModule } from "../shared.module";
 import { VerticalStepperModule } from "../vertical-stepper/vertical-stepper.module";
@@ -19,6 +20,7 @@ import { TrialInitiationComponent } from "./trial-initiation.component";
     VerticalStepperModule,
     FormFieldModule,
     RegisterFormModule,
+    OrganizationCreateModule,
   ],
   declarations: [
     TrialInitiationComponent,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add Organization Info component to vertical stepper.

**NOTE** the organization is not yet created at the completion of this step. That is handled with the Billing & Payment step

## Code changes

- **apps/web/src/app/modules/trial-initiation/trial-initiation.component.html:** Replace demo for step 2 with organization info component
- **apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts:** Add orgInfoFormGroup to hold organization info that will be created in the following step

## Screenshots

https://user-images.githubusercontent.com/8926729/178349713-4b7d0fd0-affd-404d-b7cb-8ab69bfabe1a.mov



## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
