### PR TITLE
[PS-683] Fix missed defaults and sentence cases

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.html
+++ b/apps/browser/src/popup/settings/settings.component.html
@@ -59,7 +59,11 @@
           [(ngModel)]="biometric"
         />
       </div>
-      <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="supportsBiometric">
+      <div
+        class="box-content-row box-content-row-checkbox"
+        appBoxRow
+        *ngIf="supportsBiometric && biometric"
+      >
         <label for="autoBiometricsPrompt">{{ "enableAutoBiometricsPrompt" | i18n }}</label>
         <input
           id="autoBiometricsPrompt"

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -114,9 +114,7 @@ export class SettingsComponent implements OnInit {
 
     this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
     this.biometric = await this.vaultTimeoutService.isBiometricLockSet();
-    const disableAutoBiometricsPrompt =
-      (await this.stateService.getDisableAutoBiometricsPrompt()) ?? true;
-    this.enableAutoBiometricsPrompt = !disableAutoBiometricsPrompt;
+    this.enableAutoBiometricsPrompt = !(await this.stateService.getDisableAutoBiometricsPrompt());
     this.showChangeMasterPass = !(await this.keyConnectorService.getUsesKeyConnector());
   }
 

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -94,7 +94,7 @@
                   </label>
                 </div>
               </div>
-              <div class="form-group" *ngIf="supportsBiometric">
+              <div class="form-group" *ngIf="supportsBiometric && biometric">
                 <div class="checkbox">
                   <label for="autoPromptBiometrics">
                     <input
@@ -102,7 +102,6 @@
                       type="checkbox"
                       name="autoPromptBiometrics"
                       [(ngModel)]="autoPromptBiometrics"
-                      [disabled]="!biometric"
                       (change)="updateAutoPromptBiometrics()"
                     />
                     {{ autoPromptBiometricsText | i18n }}

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -87,8 +87,8 @@
                       id="biometric"
                       type="checkbox"
                       name="biometric"
-                      [checked]="biometric"
-                      (change)="updateBiometric()"
+                      [ngModel]="biometric"
+                      (ngModelChange)="updateBiometric($event)"
                     />
                     {{ biometricText | i18n }}
                   </label>

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -265,21 +265,33 @@ export class SettingsComponent implements OnInit {
     }
   }
 
-  async updateBiometric() {
-    const current = this.biometric;
-    if (this.biometric) {
+  async updateBiometric(newValue: boolean) {
+    // NOTE: A bug in angular causes [ngModel] to not reflect the backing field value
+    // causing the checkbox to remain checked even if authentication fails.
+    // See: https://github.com/angular/angular/issues/13063
+
+    if (!newValue) {
       this.biometric = false;
-    } else if (this.supportsBiometric) {
-      this.biometric = await this.platformUtilsService.authenticateBiometric();
-    }
-    if (this.biometric === current) {
+      await this.stateService.setBiometricUnlock(null);
+      await this.stateService.setBiometricLocked(false);
+      await this.cryptoService.toggleKey();
       return;
     }
-    if (this.biometric) {
-      await this.stateService.setBiometricUnlock(true);
-    } else {
-      await this.stateService.setBiometricUnlock(null);
+
+    if (!this.supportsBiometric) {
+      this.biometric = false;
+      return;
     }
+
+    const authResult = await this.platformUtilsService.authenticateBiometric();
+
+    if (!authResult) {
+      this.biometric = false;
+      return;
+    }
+
+    this.biometric = true;
+    await this.stateService.setBiometricUnlock(true);
     await this.stateService.setBiometricLocked(false);
     await this.cryptoService.toggleKey();
   }

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -271,16 +271,11 @@ export class SettingsComponent implements OnInit {
     // The bug should resolve itself once the angular issue is resolved.
     // See: https://github.com/angular/angular/issues/13063
 
-    if (!newValue) {
+    if (!newValue || !this.supportsBiometric) {
       this.biometric = false;
       await this.stateService.setBiometricUnlock(null);
       await this.stateService.setBiometricLocked(false);
       await this.cryptoService.toggleKey();
-      return;
-    }
-
-    if (!this.supportsBiometric) {
-      this.biometric = false;
       return;
     }
 

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -268,6 +268,7 @@ export class SettingsComponent implements OnInit {
   async updateBiometric(newValue: boolean) {
     // NOTE: A bug in angular causes [ngModel] to not reflect the backing field value
     // causing the checkbox to remain checked even if authentication fails.
+    // The bug should resolve itself once the angular issue is resolved.
     // See: https://github.com/angular/angular/issues/13063
 
     if (!newValue) {

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -279,18 +279,12 @@ export class SettingsComponent implements OnInit {
       await this.stateService.setBiometricUnlock(true);
     } else {
       await this.stateService.setBiometricUnlock(null);
-      await this.stateService.setNoAutoPromptBiometrics(null);
-      this.autoPromptBiometrics = false;
     }
     await this.stateService.setBiometricLocked(false);
     await this.cryptoService.toggleKey();
   }
 
   async updateAutoPromptBiometrics() {
-    if (!this.biometric) {
-      this.autoPromptBiometrics = false;
-    }
-
     if (this.autoPromptBiometrics) {
       await this.stateService.setNoAutoPromptBiometrics(null);
     } else {

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -934,7 +934,7 @@
     "message": "Always show an icon in the system tray."
   },
   "startToTray": {
-    "message": "Start To tray icon"
+    "message": "Start to tray icon"
   },
   "startToTrayDesc": {
     "message": "When the application is first started, only show an icon in the system tray."
@@ -1553,7 +1553,7 @@
     "message": "Allow browser integration"
   },
   "enableBrowserIntegrationDesc": {
-    "message": "Browser integration is used for biometrics in browser."
+    "message": "Used for biometrics in browser."
   },
   "browserIntegrationUnsupportedTitle": {
     "message": "Browser integration not supported"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

1. I missed some changes and some typos in the initial PR, this fixes those.
2. After discussions with @danielleflinn the "Ask for biometrics on launch" checkbox is now hidden if biometrics are disabled (see: https://bitwarden.atlassian.net/browse/PS-684)
3. I refactored biometric checkbox to use `ngModel`. Also added a note about a bug that's is affecting the checkbox (the bug is not introduced in this PR, it's been there since before). The bug affects `[checked]` as well as `[ngModel]`.

## Code changes

- **apps/browser/src/popup/settings/settings.component.html:** Hide auto prompt checkbox if biometrics disabled.
- **apps/browser/src/popup/settings/settings.component.ts :** Remove superfluous default. State service already contains default values.
- **apps/desktop/src/app/accounts/settings.component.html :** Hide auto prompt checkbox if biometrics disabled. Use `ngModel` for biometric checkbox.
- **apps/desktop/src/app/accounts/settings.component.ts :** Refactor `updateBiometric` to make it easier to read. Remove if-guard in `updateAutoPromptBiometrics` which is no longer needed because we hide the checkbox.
- **apps/desktop/src/locales/en/messages.json :** Fix typo and translation I missed intially.

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/178692431-c49f6629-e82b-4a58-91c1-596ae920ebbd.png)
![image](https://user-images.githubusercontent.com/2285588/178692968-2c7426ef-d8eb-43d2-8e8b-95c94a574920.png)


## Before you submit

<!-- (mark with an `X`) -->

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
