### PR TITLE
Ps 971/rate limiting error gives html

### DIFF
--- a/libs/common/src/models/response/errorResponse.ts
+++ b/libs/common/src/models/response/errorResponse.ts
@@ -21,14 +21,14 @@ export class ErrorResponse extends BaseResponse {
       }
     }
 
-    if (errorModel) {
-      this.message = this.getResponseProperty("Message", errorModel);
-      this.validationErrors = this.getResponseProperty("ValidationErrors", errorModel);
-      this.captchaSiteKey = this.validationErrors?.HCaptcha_SiteKey?.[0];
-      this.captchaRequired = !Utils.isNullOrWhitespace(this.captchaSiteKey);
+    if (status === 429) {
+      this.message = "Rate limit exceeded. Try again later.";
     } else {
-      if (status === 429) {
-        this.message = "Rate limit exceeded. Try again later.";
+      if (errorModel) {
+        this.message = this.getResponseProperty("Message", errorModel);
+        this.validationErrors = this.getResponseProperty("ValidationErrors", errorModel);
+        this.captchaSiteKey = this.validationErrors?.HCaptcha_SiteKey?.[0];
+        this.captchaRequired = !Utils.isNullOrWhitespace(this.captchaSiteKey);
       }
     }
     this.statusCode = status;

--- a/libs/common/src/models/response/errorResponse.ts
+++ b/libs/common/src/models/response/errorResponse.ts
@@ -23,13 +23,11 @@ export class ErrorResponse extends BaseResponse {
 
     if (status === 429) {
       this.message = "Rate limit exceeded. Try again later.";
-    } else {
-      if (errorModel) {
-        this.message = this.getResponseProperty("Message", errorModel);
-        this.validationErrors = this.getResponseProperty("ValidationErrors", errorModel);
-        this.captchaSiteKey = this.validationErrors?.HCaptcha_SiteKey?.[0];
-        this.captchaRequired = !Utils.isNullOrWhitespace(this.captchaSiteKey);
-      }
+    } else if (errorModel) {
+      this.message = this.getResponseProperty("Message", errorModel);
+      this.validationErrors = this.getResponseProperty("ValidationErrors", errorModel);
+      this.captchaSiteKey = this.validationErrors?.HCaptcha_SiteKey?.[0];
+      this.captchaRequired = !Utils.isNullOrWhitespace(this.captchaSiteKey);
     }
     this.statusCode = status;
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This is to fix the bad HTML UI error that is been displayed when a user exceeds the rate limit on Bitwarden Send 
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/models/response/errorResponse.ts:** Change the if statement to check for the status 429  first and display a toast message for the rate limit error before checking the error object.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
