### PR TITLE
[SG 435 & SG-436] Reusable org Component bug fixes

### DIFF
--- a/apps/web/src/app/settings/organization-plans.component.html
+++ b/apps/web/src/app/settings/organization-plans.component.html
@@ -131,8 +131,6 @@
             type="number"
             name="additionalSeats"
             formControlName="additionalSeats"
-            min="1"
-            max="100000"
             placeholder="{{ 'userSeatsDesc' | i18n }}"
             required
           />
@@ -150,8 +148,6 @@
           type="number"
           name="additionalSeats"
           formControlName="additionalSeats"
-          min="0"
-          max="100000"
           placeholder="{{ 'userSeatsDesc' | i18n }}"
         />
         <small class="text-muted form-text">{{
@@ -169,8 +165,6 @@
           type="number"
           name="additionalStorageGb"
           formControlName="additionalStorage"
-          min="0"
-          max="99"
           step="1"
           placeholder="{{ 'additionalStorageGbDesc' | i18n }}"
         />

--- a/apps/web/src/app/settings/organization-plans.component.html
+++ b/apps/web/src/app/settings/organization-plans.component.html
@@ -323,10 +323,9 @@
     <app-callout [type]="'error'">{{ "singleOrgBlockCreateMessage" | i18n }}</app-callout>
   </div>
   <div class="mt-4">
-    <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
-      <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-      <span>{{ "submit" | i18n }}</span>
-    </button>
+    <bit-submit-button [loading]="form.loading" [disabled]="!formGroup.valid">{{
+      "submit" | i18n
+    }}</bit-submit-button>
     <button type="button" class="btn btn-outline-secondary" (click)="cancel()" *ngIf="showCancel">
       {{ "cancel" | i18n }}
     </button>

--- a/apps/web/src/app/settings/organization-plans.component.ts
+++ b/apps/web/src/app/settings/organization-plans.component.ts
@@ -96,7 +96,7 @@ export class OrganizationPlansComponent implements OnInit {
       this.changedOwnedBusiness();
     }
 
-    if (!this.createOrganization) {
+    if (!this.createOrganization || this.acceptingSponsorship) {
       this.formGroup.controls.product.setValue(ProductType.Families);
       this.changedProduct();
     } else {

--- a/apps/web/src/app/settings/organization-plans.component.ts
+++ b/apps/web/src/app/settings/organization-plans.component.ts
@@ -52,8 +52,8 @@ export class OrganizationPlansComponent implements OnInit {
   discount = 0;
 
   formGroup = this.formBuilder.group({
-    name: ["", [Validators.required]],
-    billingEmail: ["", [Validators.required, Validators.email]],
+    name: [""],
+    billingEmail: ["", [Validators.email]],
     businessOwned: [false],
     premiumAccessAddon: [false],
     additionalStorage: [0, [Validators.min(0), Validators.max(99)]],
@@ -99,6 +99,9 @@ export class OrganizationPlansComponent implements OnInit {
     if (!this.createOrganization) {
       this.formGroup.controls.product.setValue(ProductType.Families);
       this.changedProduct();
+    } else {
+      this.formGroup.controls.name.addValidators(Validators.required);
+      this.formGroup.controls.billingEmail.addValidators(Validators.required);
     }
 
     this.loading = false;
@@ -255,6 +258,7 @@ export class OrganizationPlansComponent implements OnInit {
     }
     this.formGroup.controls.product.setValue(ProductType.Teams);
     this.formGroup.controls.plan.setValue(PlanType.TeamsAnnually);
+    this.changedProduct();
   }
 
   changedCountry() {

--- a/apps/web/src/app/settings/organization-plans.component.ts
+++ b/apps/web/src/app/settings/organization-plans.component.ts
@@ -99,7 +99,9 @@ export class OrganizationPlansComponent implements OnInit {
     if (!this.createOrganization || this.acceptingSponsorship) {
       this.formGroup.controls.product.setValue(ProductType.Families);
       this.changedProduct();
-    } else {
+    }
+
+    if (this.createOrganization) {
       this.formGroup.controls.name.addValidators(Validators.required);
       this.formGroup.controls.billingEmail.addValidators(Validators.required);
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix issue where form would allow submit if email is invalid
Fix issue with F4E org create form not having default product set

## Code changes

- **apps/web/src/app/settings/organization-plans.component.html:** 
    - Use new bit-submit-button component to assist in form validation
    - Remove duplicate form field validators
- **apps/web/src/app/settings/organization-plans.component.ts:** 
    - Make name and billing email required only if a new org is being created. 
    - Set default product if `acceptingSponsorship` is true.

## Screenshots

Submit in new org:
https://user-images.githubusercontent.com/8926729/178771687-c95800ea-fa8d-4f8e-bcba-b0a63e383294.mov

F4E new org screen:
https://user-images.githubusercontent.com/8926729/178776302-eea90787-4002-47d3-91df-911d836405b9.mov



## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
