### PR TITLE
[SG-439] Turn off trial route in qa for testing

### DIFF
--- a/apps/web/config/qa.json
+++ b/apps/web/config/qa.json
@@ -9,6 +9,6 @@
     "proxyEvents": "https://events.qa.bitwarden.pw"
   },
   "flags": {
-    "showTrial": true
+    "showTrial": false
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Test that turning off the showTrial flag in qa.json turns off the ability to route to `https://vault.qa.bitwarden.pw/#/trial`

## Code changes

Set `showTrial` to false

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
