### PR TITLE
[fix] System theming in the Safari extension

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -153,6 +153,9 @@ export default class MainBackground {
   broadcasterService: BroadcasterService;
   folderApiService: FolderApiServiceAbstraction;
 
+  // Passed to the popup for Safari to workaround issues with theming, downloading, etc.
+  backgroundWindow = window;
+
   onUpdatedRan: boolean;
   onReplacedRan: boolean;
   loginToAutoFill: CipherView = null;

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -7,6 +7,8 @@ import {
   MEMORY_STORAGE,
   SECURE_STORAGE,
 } from "@bitwarden/angular/services/jslib-services.module";
+import { ThemingService } from "@bitwarden/angular/services/theming/theming.service";
+import { AbstractThemingService } from "@bitwarden/angular/services/theming/theming.service.abstraction";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
@@ -292,6 +294,20 @@ function getBgService<T>(service: keyof MainBackground) {
     {
       provide: FileDownloadService,
       useClass: BrowserFileDownloadService,
+    },
+    {
+      provide: AbstractThemingService,
+      useFactory: () => {
+        return new ThemingService(
+          getBgService<StateServiceAbstraction>("stateService")(),
+          // Safari doesn't properly handle the (prefers-color-scheme) media query in the popup window, it always returns light.
+          // In Safari we have to use the background page instead, which comes with limitations like not dynamically changing the extension theme when the system theme is changed.
+          getBgService<PlatformUtilsService>("platformUtilsService")().isSafari()
+            ? getBgService<Window>("backgroundWindow")()
+            : window,
+          document
+        );
+      },
     },
   ],
 })

--- a/libs/angular/src/services/theming/theming.service.ts
+++ b/libs/angular/src/services/theming/theming.service.ts
@@ -17,7 +17,7 @@ export class ThemingService implements AbstractThemingService {
 
   constructor(
     private stateService: StateService,
-    private mediaMatcher: MediaMatcher,
+    private mediaMatcher: MediaMatcher | Window,
     @Inject(DOCUMENT) private document: Document
   ) {
     this.monitorThemeChanges();


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-379

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The Safari extension is not respecting the OS set system theme, and is always in light mode when system theme is selected in the extension.

## Code changes
On https://github.com/bitwarden/clients/pull/2943 we moved theming out of the background page and into the popup exclusively (yay). It turns out, Safari doesn't like this (oh no). The Safari popup does not handle the `(prefers-color-scheme)` media query correctly, and always matches to light mode. I don't have an explanation for why this happens, I never found any resources related to this issue, but using the background  window instead to determine the system theme works correctly.

Using the background window has many downsides, however. 
* The entire background page is being deprecated with Manifest V3, and this is something we will want to keep an eye on when that changes happens.
* We can't subscribe to updates in the background page from the popup because the page is only sent in the state it originally appeared in. This results in Safari needing to be restarted to apply any system theme changes made while it was open. This is not a regression, however, and is the way the extension behaved in the `2022.06` release. 

This PR:
1. Allows `ThemingService` to accept a `Window` instead of the preferred `MediaMatcher` if necessary. 
2. Exposes the background window in a variable in `MainBackground` to be consumed by the popup's `ServicesModule`.
3. Informs ServicesModule to use the background window if the extension is running in Safari, but lets it use the popup window for other browsers since they work correctly and benefit from being able to dynamically adapt to OS system theme setting changes.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
