### PR TITLE
[SG-445] Fix additional storage binding for annual total

### DIFF
--- a/apps/web/src/app/settings/organization-plans.component.html
+++ b/apps/web/src/app/settings/organization-plans.component.html
@@ -234,7 +234,8 @@
             }}
           </small>
           <small *ngIf="selectablePlan.hasAdditionalStorageOption">
-            {{ "additionalStorageGb" | i18n }}: {{ additionalStorage || 0 }} &times;
+            {{ "additionalStorageGb" | i18n }}:
+            {{ formGroup.controls["additionalStorage"].value || 0 }} &times;
             {{ selectablePlan.additionalStoragePricePerGb / 12 | currency: "$" }} &times; 12
             {{ "monthAbbr" | i18n }} =
             {{ additionalStorageTotal(selectablePlan) | currency: "$" }} /{{ "year" | i18n }}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When switching the template driven form to a reactive form, a field was missed, causing the binding to not display correctly. 
This is just swapping out the old property for the new one.

## Code changes

- **apps/web/src/app/settings/organization-plans.component.html:** Replace `additionalStorage` with `formGroup.controls["additionalStorage"].value`

## Screenshots
Before:
![Screen Shot 2022-07-14 at 2 00 24 PM](https://user-images.githubusercontent.com/8926729/179051596-654e4fff-d728-4db8-9a1b-f7bd8b15a108.png)

After:
![Screen Shot 2022-07-14 at 1 58 02 PM](https://user-images.githubusercontent.com/8926729/179051610-19927125-b037-4c41-bf72-eefa314729f7.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
