### PR TITLE
Add publish options to release workflows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -14,21 +14,21 @@ on:
           - Redeploy
           - Dry Run
       snap_publish:
-        description: 'Deploy to snap store'
+        description: 'Publish to snap store'
         required: true
         default: true
         type: boolean
       choco_publish:
-        description: 'Deploy to chocolatey store'
+        description: 'Publish to chocolatey store'
         required: true
         default: true
         type: boolean
       npm_publish:
-        description: 'Deploy to npm registry'
+        description: 'Publish to npm registry'
         required: true
         default: true
         type: boolean
-      
+
 
 defaults:
   run:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -109,7 +109,7 @@ jobs:
     name: Deploy Snap
     runs-on: ubuntu-20.04
     needs: setup
-    if: inputs.snap_publish == true
+    if: inputs.snap_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -153,7 +153,7 @@ jobs:
     name: Deploy Choco
     runs-on: windows-2019
     needs: setup
-    if: inputs.choco_publish == true
+    if: inputs.choco_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -202,7 +202,7 @@ jobs:
     name: Publish NPM
     runs-on: ubuntu-20.04
     needs: setup
-    if: inputs.npm_publish == true
+    if: inputs.npm_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -13,6 +13,22 @@ on:
           - Initial Release
           - Redeploy
           - Dry Run
+      snap_publish:
+        description: 'Deploy to snap store'
+        required: true
+        default: true
+        type: boolean
+      choco_publish:
+        description: 'Deploy to chocolatey store'
+        required: true
+        default: true
+        type: boolean
+      npm_publish:
+        description: 'Deploy to npm registry'
+        required: true
+        default: true
+        type: boolean
+      
 
 defaults:
   run:
@@ -93,6 +109,7 @@ jobs:
     name: Deploy Snap
     runs-on: ubuntu-20.04
     needs: setup
+    if: inputs.snap_publish == true
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -136,6 +153,7 @@ jobs:
     name: Deploy Choco
     runs-on: windows-2019
     needs: setup
+    if: inputs.choco_publish == true
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -184,6 +202,7 @@ jobs:
     name: Publish NPM
     runs-on: ubuntu-20.04
     needs: setup
+    if: inputs.npm_publish == true
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -169,7 +169,7 @@ jobs:
     name: Deploy Snap
     runs-on: ubuntu-20.04
     needs: setup
-    if: inputs.snap_publish == 'true'
+    if: inputs.snap_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -217,7 +217,7 @@ jobs:
     name: Deploy Choco
     runs-on: windows-2019
     needs: setup
-    if: inputs.choco_publish == 'true'
+    if: inputs.choco_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -13,6 +13,17 @@ on:
           - Initial Release
           - Redeploy
           - Dry Run
+      snap_publish:
+        description: 'Publish to snap store'
+        required: true
+        default: true
+        type: boolean
+      choco_publish:
+        description: 'Publish to chocolatey store'
+        required: true
+        default: true
+        type: boolean
+
 defaults:
   run:
     shell: bash
@@ -158,6 +169,7 @@ jobs:
     name: Deploy Snap
     runs-on: ubuntu-20.04
     needs: setup
+    if: inputs.snap_publish == 'true'
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
@@ -205,6 +217,7 @@ jobs:
     name: Deploy Choco
     runs-on: windows-2019
     needs: setup
+    if: inputs.choco_publish == 'true'
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
At times, we find that we need to re-run a workflow to publish to an app store. We need the ability to have more selection over the specific stores. This adds a boolean input for each publish option, which defaults to `true`. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/release-cli.yml:** Added publish options
- **.github/workflows/release-desktop.yml:** Added publish options

## Screenshots
Desktop:
![image](https://user-images.githubusercontent.com/77340197/179071627-b88d0134-9178-4523-90c1-ab97b8279266.png)

CLI:
![image](https://user-images.githubusercontent.com/77340197/179071692-65e20e77-a6af-491e-b1ff-84ccc7f81e70.png)


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
```
