### PR TITLE
[fix] Always use the Window directly in ThemingService

### DIFF
--- a/libs/angular/src/services/theming/theming.service.ts
+++ b/libs/angular/src/services/theming/theming.service.ts
@@ -1,10 +1,11 @@
-import { MediaMatcher } from "@angular/cdk/layout";
 import { DOCUMENT } from "@angular/common";
 import { Inject, Injectable } from "@angular/core";
 import { BehaviorSubject, filter, fromEvent, Observable } from "rxjs";
 
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { ThemeType } from "@bitwarden/common/enums/themeType";
+
+import { WINDOW } from "../jslib-services.module";
 
 import { Theme } from "./theme";
 import { ThemeBuilder } from "./themeBuilder";
@@ -17,7 +18,7 @@ export class ThemingService implements AbstractThemingService {
 
   constructor(
     private stateService: StateService,
-    private mediaMatcher: MediaMatcher | Window,
+    @Inject(WINDOW) private window: Window,
     @Inject(DOCUMENT) private document: Document
   ) {
     this.monitorThemeChanges();
@@ -55,14 +56,14 @@ export class ThemingService implements AbstractThemingService {
   // We use a media match query for monitoring the system theme on web and browser, but this doesn't work for electron apps on Linux.
   // In desktop we override these methods to track systemTheme with the electron renderer instead, which works for all OSs.
   protected async getSystemTheme(): Promise<ThemeType> {
-    return this.mediaMatcher.matchMedia("(prefers-color-scheme: dark)").matches
+    return this.window.matchMedia("(prefers-color-scheme: dark)").matches
       ? ThemeType.Dark
       : ThemeType.Light;
   }
 
   protected monitorSystemThemeChanges(): void {
     fromEvent<MediaQueryListEvent>(
-      this.mediaMatcher.matchMedia("(prefers-color-scheme: dark)"),
+      this.window.matchMedia("(prefers-color-scheme: dark)"),
       "change"
     ).subscribe((event) => {
       this.updateSystemTheme(event.matches ? ThemeType.Dark : ThemeType.Light);


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-1135

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
DI is busted on the latest desktop build and needs to be patched. Current builds on TestFlight don't load.

## Code changes
This is happening because on https://github.com/bitwarden/clients/pull/3107 I used a union typed constructor argument that Angular (understandably) does not know how to inject on clients that don't use a factory to build it.

To resolve the issue I've removed the reference to Angular's `MediaMatcher`  in `ThemingService` and instead universally leaned on a `Window` for `ThemingService`'s media matching needs.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
