### PR TITLE
[fix] File downloads in Safari

### DIFF
--- a/apps/browser/src/services/browserFileDownloadService.ts
+++ b/apps/browser/src/services/browserFileDownloadService.ts
@@ -17,9 +17,7 @@ export class BrowserFileDownloadService implements FileDownloadService {
       if (builder.blobOptions.type === "text/plain" && typeof request.blobData === "string") {
         data = request.blobData;
       } else {
-        builder.blob.arrayBuffer().then((buf) => {
-          data = Utils.fromBufferToB64(buf);
-        });
+        data = Utils.fromBufferToB64(request.blobData as ArrayBuffer);
       }
       SafariApp.sendMessageToApp(
         "downloadFile",


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-441

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
File downloads in Safari are not working. 

## Code changes
This bug was introduced on https://github.com/bitwarden/clients/pull/2907 - I stopped using an `any` type for our blob building needs, but didn't account for all the cases. We usually pass in an `ArrayBuffer`, which is something that can be a `BlobPart`, but a `BlobPart` can also be a string - so we have to explicitly call our data an `ArrayBuffer` to be able to manipulate it as such.

* Cast our `BlobData` to an `ArrayBuffer` when needed for Safari downloads.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
