### PR TITLE
Change eslint settings to error instead of warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
   ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off", // TODO: This should be re-enabled
-    "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
+    "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
     "@typescript-eslint/explicit-member-accessibility": [
       "error",
       {
@@ -27,7 +27,7 @@
         "allowedNames": ["self"]
       }
     ],
-    "no-console": "warn",
+    "no-console": "error",
     "import/no-unresolved": "off", // TODO: Look into turning off once each package is an actual package.
     "import/order": [
       "error",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://bitwarden.com",
   "scripts": {
     "prepare": "husky install",
-    "lint": "eslint . && prettier --check .",
+    "lint": "eslint . || prettier --check .",
     "lint:fix": "eslint . --fix",
     "prettier": "prettier --write .",
     "test": "jest",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Ensures the pipeline fails on eslint errors, and changes some warnings to errors as we want those to be blocked.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
