### PR TITLE
Fix input group disabled button styling

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -180,6 +180,27 @@ const ButtonGroupTemplate: Story<BitFormFieldComponent> = (args: BitFormFieldCom
 export const ButtonInputGroup = ButtonGroupTemplate.bind({});
 ButtonInputGroup.args = {};
 
+const DisabledButtonInputGroupTemplate: Story<BitFormFieldComponent> = (
+  args: BitFormFieldComponent
+) => ({
+  props: args,
+  template: `
+    <bit-form-field>
+      <bit-label>Label</bit-label>
+      <input bitInput placeholder="Placeholder" disabled />
+      <button bitSuffix bitButton disabled>
+        <i aria-hidden="true" class="bwi bwi-lg bwi-eye"></i>
+      </button>
+      <button bitSuffix bitButton>
+        <i aria-hidden="true" class="bwi bwi-lg bwi-clone"></i>
+      </button>
+    </bit-form-field>
+  `,
+});
+
+export const DisabledButtonInputGroup = DisabledButtonInputGroupTemplate.bind({});
+DisabledButtonInputGroup.args = {};
+
 const SelectTemplate: Story<BitFormFieldComponent> = (args: BitFormFieldComponent) => ({
   props: args,
   template: `

--- a/libs/components/src/form-field/prefix.directive.ts
+++ b/libs/components/src/form-field/prefix.directive.ts
@@ -10,6 +10,8 @@ export const PrefixClasses = [
   "tw-border-secondary-500",
   "tw-text-muted",
   "tw-rounded-none",
+  "disabled:!tw-text-muted",
+  "disabled:tw-border-secondary-500",
 ];
 
 @Directive({


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Resolves the weird styling for disabled input group buttons.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

![image](https://user-images.githubusercontent.com/137855/179557085-70572995-7eaf-427b-ab6e-25fd45ed9997.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
