### PR TITLE
[EC-339] Add eventType and UI strings for Restore/Revoke OrgUser

### DIFF
--- a/apps/web/src/app/services/event.service.ts
+++ b/apps/web/src/app/services/event.service.ts
@@ -280,6 +280,20 @@ export class EventService {
           this.getShortId(ev.organizationUserId)
         );
         break;
+      case EventType.OrganizationUser_Deactivated:
+        msg = this.i18nService.t("revokedUserId", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "revokedUserId",
+          this.getShortId(ev.organizationUserId)
+        );
+        break;
+      case EventType.OrganizationUser_Activated:
+        msg = this.i18nService.t("restoredUserId", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "restoredUserId",
+          this.getShortId(ev.organizationUserId)
+        );
+        break;
       // Org
       case EventType.Organization_Updated:
         msg = humanReadableMsg = this.i18nService.t("editedOrgSettings");

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -644,6 +644,9 @@
   "newAccountCreated": {
     "message": "Your new account has been created! You may now log in."
   },
+  "trialAccountCreated": {
+    "message": "Account created successfully."
+  },
   "masterPassSent": {
     "message": "We've sent you an email with your master password hint."
   },
@@ -1669,6 +1672,12 @@
   "billing": {
     "message": "Billing"
   },
+  "billingPlanLabel": {
+    "message": "Billing Plan"
+  },
+  "paymentType": {
+    "message": "Payment Type"
+  },
   "accountCredit": {
     "message": "Account Credit",
     "description": "Financial term. In the case of Bitwarden, a positive balance means that you owe money, while a negative balance means that you have a credit (Bitwarden owes you money)."
@@ -1785,6 +1794,9 @@
   "year": {
     "message": "year"
   },
+  "yr": {
+    "message": "yr"
+  },
   "month": {
     "message": "month"
   },
@@ -1812,6 +1824,9 @@
   },
   "billingInformation": {
     "message": "Billing Information"
+  },
+  "billingTrialSubLabel": {
+    "message": "Your payment method will not be charged during the 7 day free trial."
   },
   "creditCard": {
     "message": "Credit Card"
@@ -2175,6 +2190,9 @@
   "annually": {
     "message": "Annually"
   },
+  "annual": {
+    "message": "Annual"
+  },
   "basePrice": {
     "message": "Base Price"
   },
@@ -2241,7 +2259,7 @@
   "removeUserConfirmation": {
     "message": "Are you sure you want to remove this user?"
   },
-  "removeUserDesc": {
+  "removeOrgUserConfirmation": {
     "message": "When a member is removed, they no longer have access to organization data and this action is irreversible. To add the member back to the organization, they must be invited and onboarded again."
   },
   "revokeUserConfirmation": {
@@ -4288,7 +4306,7 @@
   "removeUsersWarning": {
     "message": "Are you sure you want to remove the following users? The process may take a few seconds to complete and cannot be interrupted or canceled."
   },
-  "removeUsersDesc": {
+  "removeOrgUsersConfirmation": {
     "message": "When member(s) are removed, they no longer have access to organization data and this action is irreversible. To add the member back to the organization, they must be invited and onboarded again. The process may take a few seconds to complete and cannot be interrupted or canceled."
   },
   "revokeUsersWarning": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5264,5 +5264,8 @@
   },
   "on": {
     "message": "On"
+  },
+  "cardBrandMir": {
+    "message": "Mir"
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1247,8 +1247,8 @@
   "enabled": {
     "message": "Enabled"
   },
-  "activate": {
-    "message": "Activate"
+  "restoreAccess": {
+    "message": "Restore Access"
   },
   "premium": {
     "message": "Premium",
@@ -1275,8 +1275,8 @@
   "disable": {
     "message": "Disable"
   },
-  "deactivate": {
-    "message": "Deactivate"
+  "revokeAccess": {
+    "message": "Revoke Access"
   },
   "twoStepLoginProviderEnabled": {
     "message": "This two-step login provider is enabled on your account."
@@ -2241,11 +2241,11 @@
   "removeUserConfirmation": {
     "message": "Are you sure you want to remove this user?"
   },
-  "deactivateUserConfirmation": {
-    "message": "The member will no longer have access to the organization, but will still have access to their individual vault."
+  "removeUserDesc": {
+    "message": "When a member is removed, they no longer have access to organization data and this action is irreversible. To add the member back to the organization, they must be invited and onboarded again."
   },
-  "activateUserConfirmation": {
-    "message": "Are you sure you want to activate this user, granting them access to the organization?"
+  "revokeUserConfirmation": {
+    "message": "When a member is revoked, they no longer have access to organization data. To quickly restore member access, go to the Revoked tab."
   },
   "removeUserConfirmationKeyConnector": {
     "message": "Warning! This user requires Key Connector to manage their encryption. Removing this user from your organization will permanently disable their account. This action cannot be undone. Do you want to proceed?"
@@ -2592,8 +2592,8 @@
       }
     }
   },
-  "deactivatedUserId": {
-    "message": "Deactivated user $ID$.",
+  "removeUserIdAccess": {
+    "message": "Remove $ID$ access",
     "placeholders": {
       "id": {
         "content": "$1",
@@ -2601,8 +2601,8 @@
       }
     }
   },
-  "activatedUserId": {
-    "message": "Activated user $ID$.",
+  "revokedUserId": {
+    "message": "Revoked organization access for $ID$.",
     "placeholders": {
       "id": {
         "content": "$1",
@@ -2610,8 +2610,8 @@
       }
     }
   },
-  "deactivateUserId": {
-    "message": "Deactivate user $ID$?",
+  "restoredUserId": {
+    "message": "Restored organization access for $ID$.",
     "placeholders": {
       "id": {
         "content": "$1",
@@ -2619,8 +2619,8 @@
       }
     }
   },
-  "activateUserId": {
-    "message": "Activate user $ID$?",
+  "revokeUserId": {
+    "message": "Revoke $ID$ access",
     "placeholders": {
       "id": {
         "content": "$1",
@@ -3684,8 +3684,8 @@
   "disabled": {
     "message": "Disabled"
   },
-  "deactivated": {
-    "message": "Deactivated"
+  "revoked": {
+    "message": "Revoked"
   },
   "sendLink": {
     "message": "Send link",
@@ -4288,11 +4288,11 @@
   "removeUsersWarning": {
     "message": "Are you sure you want to remove the following users? The process may take a few seconds to complete and cannot be interrupted or canceled."
   },
-  "deactivateUsersWarning": {
-    "message": "Are you sure you want to deactivate the following members? They will no longer have access to the organization, but will still have access to their individual vaults. The process may take a few seconds to complete and cannot be interrupted or canceled."
+  "removeUsersDesc": {
+    "message": "When member(s) are removed, they no longer have access to organization data and this action is irreversible. To add the member back to the organization, they must be invited and onboarded again. The process may take a few seconds to complete and cannot be interrupted or canceled."
   },
-  "activateUsersWarning": {
-    "message": "Are you sure you want to activate the following members, granting them access to the organization? The process may take a few seconds to complete and cannot be interrupted or canceled."
+  "revokeUsersWarning": {
+    "message": "When member(s) are revoked, they no longer have access to organization data. To quickly restore member access, go to the Revoked tab. The process may take a few seconds to complete and cannot be interrupted or canceled."
   },
   "theme": {
     "message": "Theme"
@@ -4324,11 +4324,11 @@
   "bulkRemovedMessage": {
     "message": "Removed successfully"
   },
-  "bulkDeactivatedMessage": {
-    "message": "Deactivated successfully"
+  "bulkRevokedMessage": {
+    "message": "Revoked organization access successfully"
   },
-  "bulkActivatedMessage": {
-    "message": "Activated successfully"
+  "bulkRestoredMessage": {
+    "message": "Restored organization access successfully"
   },
   "bulkFilteredMessage": {
     "message": "Excluded, not applicable for this action."
@@ -4339,11 +4339,11 @@
   "removeUsers": {
     "message": "Remove Users"
   },
-  "deactivateUsers": {
-    "message": "Deactivate Users"
+  "revokeUsers": {
+    "message": "Revoke Users"
   },
-  "activateUsers": {
-    "message": "Activate Users"
+  "restoreUsers": {
+    "message": "Restore Users"
   },
   "error": {
     "message": "Error"
@@ -4754,9 +4754,6 @@
   },
   "sponsorshipCreated": {
     "message": "Sponsorship Created"
-  },
-  "revoke": {
-    "message": "Revoke"
   },
   "emailSent": {
     "message": "Email Sent"
@@ -5267,8 +5264,5 @@
   },
   "on": {
     "message": "On"
-  },
-  "cardBrandMir": {
-    "message": "Mir"
   }
 }

--- a/libs/common/src/enums/eventType.ts
+++ b/libs/common/src/enums/eventType.ts
@@ -48,6 +48,8 @@ export enum EventType {
   OrganizationUser_AdminResetPassword = 1508,
   OrganizationUser_ResetSsoLink = 1509,
   OrganizationUser_FirstSsoLogin = 1510,
+  OrganizationUser_Deactivated = 1511,
+  OrganizationUser_Activated = 1512,
 
   Organization_Updated = 1600,
   Organization_PurgedVault = 1601,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We're missing the `EventType`s for restore/revoke events, so the description comes up empty. Fix this by adding the new event types to clients.

**This will be cherry-picked to rc**

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- update `EventType`s to match event types on the server
- add i18n strings in `EventService`
- copy `messages.json` from https://github.com/bitwarden/clients/pull/3135 to get the new wording (no additional changes to this file). We should merge that PR first.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![Screen Shot 2022-07-20 at 10 51 19 am](https://user-images.githubusercontent.com/31796059/179873386-68095819-9611-404e-8240-9e05357f19a4.png)

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
