### PR TITLE
Fix url in choco install script after monorepo migration

### DIFF
--- a/apps/desktop/stores/chocolatey/tools/chocolateyinstall.ps1
+++ b/apps/desktop/stores/chocolatey/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-$url = 'https://github.com/bitwarden/desktop/releases/download/v__version__/Bitwarden-Installer-__version__.exe'
+$url = 'https://github.com/bitwarden/clients/releases/download/desktop-v__version__/Bitwarden-Installer-__version__.exe'
 $checksum = '__checksum__'
 
 $packageArgs = @{


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix URL pointing to the desktop release in the chocolatey install script.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/stores/chocolatey/tools/chocolateyinstall.ps1:** Change repo and tag name in the url

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
