### PR TITLE
Ps 693/fix localhost exclude domain bug 2

### DIFF
--- a/apps/browser/src/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/popup/settings/excluded-domains.component.ts
@@ -9,8 +9,6 @@ import { Utils } from "@bitwarden/common/misc/utils";
 
 import { BrowserApi } from "../../browser/browserApi";
 
-import { Item } from "./../../../../../libs/common/src/importers/onepasswordImporters/types/onepassword1PuxImporterTypes";
-
 interface ExcludedDomain {
   uri: string;
   showCurrentUris: boolean;

--- a/apps/browser/src/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/popup/settings/excluded-domains.component.ts
@@ -9,6 +9,8 @@ import { Utils } from "@bitwarden/common/misc/utils";
 
 import { BrowserApi } from "../../browser/browserApi";
 
+import { Item } from "./../../../../../libs/common/src/importers/onepasswordImporters/types/onepassword1PuxImporterTypes";
+
 interface ExcludedDomain {
   uri: string;
   showCurrentUris: boolean;
@@ -22,6 +24,7 @@ const BroadcasterSubscriptionId = "excludedDomains";
 })
 export class ExcludedDomainsComponent implements OnInit, OnDestroy {
   excludedDomains: ExcludedDomain[] = [];
+  existingExcludedDomains: ExcludedDomain[] = [];
   currentUris: string[];
   loadCurrentUrisTimeout: number;
 
@@ -39,6 +42,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
     if (savedDomains) {
       for (const uri of Object.keys(savedDomains)) {
         this.excludedDomains.push({ uri: uri, showCurrentUris: false });
+        this.existingExcludedDomains.push({ uri: uri, showCurrentUris: false });
       }
     }
 
@@ -78,26 +82,41 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
 
   async submit() {
     const savedDomains: { [name: string]: null } = {};
+    const newExcludedDomains = this.getNewlyAddedDomians(this.excludedDomains);
     for (const domain of this.excludedDomains) {
-      if (domain.uri && domain.uri !== "") {
-        const validDomain = Utils.getHostname(domain.uri);
-        if (!validDomain) {
-          this.platformUtilsService.showToast(
-            "error",
-            null,
-            this.i18nService.t("excludedDomainsInvalidDomain", domain.uri)
-          );
-          return;
+      const resp = newExcludedDomains.filter((e) => e.uri === domain.uri);
+      if (resp.length === 0) {
+        savedDomains[domain.uri] = null;
+      } else {
+        if (domain.uri && domain.uri !== "") {
+          const validDomain = Utils.getHostname(domain.uri);
+          if (!validDomain) {
+            this.platformUtilsService.showToast(
+              "error",
+              null,
+              this.i18nService.t("excludedDomainsInvalidDomain", domain.uri)
+            );
+            return;
+          }
+          savedDomains[validDomain] = null;
         }
-        savedDomains[validDomain] = null;
       }
     }
+
     await this.stateService.setNeverDomains(savedDomains);
     this.router.navigate(["/tabs/settings"]);
   }
 
   trackByFunction(index: number, item: any) {
     return index;
+  }
+
+  getNewlyAddedDomians(domain: ExcludedDomain[]): ExcludedDomain[] {
+    const result = this.excludedDomains.filter(
+      (newDomain) =>
+        !this.existingExcludedDomains.some((oldDomain) => newDomain.uri === oldDomain.uri)
+    );
+    return result;
   }
 
   toggleUriInput(domain: ExcludedDomain) {


### PR DESCRIPTION
## Type of change
This is to fix the error of "localhost is not a valid domain" whenever localhost is added to the excluded domains on the settings menu.

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/settings/excluded-domains.component.ts:** 
    - Added a new method `getNewlyAddedDomians` that extract the new/modified URI that the user added. 
    - Made modifications to the `submit`, so that only the newly/Modified URI will be validated, while the existing ones will be saved without validation because they have been validated already. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
