### PR TITLE
[EC-317] Desktop client delete user account

### DIFF
--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -15,7 +15,11 @@
         <div class="box last">
           <div class="box-header">{{ "deleteAccount" | i18n }}</div>
           <div class="box-content">
-            <app-user-verification ngDefaultControl formControlName="secret" name="secret">
+            <app-user-verification
+              ngDefaultControl
+              formControlName="verification"
+              name="verification"
+            >
             </app-user-verification>
           </div>
         </div>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -1,6 +1,12 @@
 <div class="modal fade" role="dialog" aria-modal="true" attr.aria-label="{{ 'settings' | i18n }}">
   <div class="modal-dialog" role="document">
-    <form class="modal-content" #form (ngSubmit)="submit()" [formGroup]="deleteForm">
+    <form
+      class="modal-content"
+      #form
+      [appApiAction]="formPromise"
+      (ngSubmit)="submit()"
+      [formGroup]="deleteForm"
+    >
       <div class="modal-body">
         <p class="modal-text">{{ "deleteAccountDesc" | i18n }}</p>
         <app-callout type="warning" title="{{ 'warning' | i18n }}">
@@ -15,8 +21,13 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="submit" class="danger">{{ "deleteAccount" | i18n }}</button>
-        <button type="button" data-dismiss="modal">{{ "cancel" | i18n }}</button>
+        <button type="submit" class="danger" [disabled]="form.loading">
+          <i class="bwi bwi-spinner bwi-spin" [hidden]="!form.loading" aria-hidden="true"></i>
+          <span [hidden]="form.loading">{{ "deleteAccount" | i18n }}</span>
+        </button>
+        <button type="button" data-dismiss="modal" [disabled]="form.loading">
+          {{ "cancel" | i18n }}
+        </button>
       </div>
     </form>
   </div>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -1,0 +1,13 @@
+<div class="modal fade" role="dialog" aria-modal="true" attr.aria-label="{{ 'settings' | i18n }}">
+  <div class="modal-dialog" role="document">
+    <form class="modal-content" (ngSubmit)="submit()">
+      <div class="modal-body">body</div>
+      <div class="modal-footer">
+        <button type="submit" class="primary" appA11yTitle="{{ 'save' | i18n }}">
+          <i class="bwi bwi-save-changes bwi-lg bwi-fw" aria-hidden="true"></i>
+        </button>
+        <button type="button" data-dismiss="modal">{{ "cancel" | i18n }}</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -1,7 +1,47 @@
 <div class="modal fade" role="dialog" aria-modal="true" attr.aria-label="{{ 'settings' | i18n }}">
   <div class="modal-dialog" role="document">
     <form class="modal-content" (ngSubmit)="submit()">
-      <div class="modal-body">body</div>
+      <div class="modal-body">
+        <div class="modal-title">{{ "deleteAccount" | i18n }}</div>
+        <div class="modal-text">Proceed below to delete your account and all vault data.</div>
+        <app-callout type="warning" title="{{ 'warning' | i18n }}">
+          Deleting your account is permanent. It cannot be undone.
+        </app-callout>
+        <div class="box last">
+          <div class="box-content">
+            <div class="box-content-row box-content-row-flex" appBoxRow>
+              <div class="row-main">
+                <label for="masterPassword">{{ "masterPass" | i18n }}</label>
+                <input
+                  id="masterPassword"
+                  type="{{ showPassword ? 'text' : 'password' }}"
+                  name="MasterPassword"
+                  class="monospaced"
+                  [(ngModel)]="masterPassword"
+                  required
+                  appInputVerbatim
+                />
+              </div>
+              <div class="action-buttons">
+                <button
+                  type="button"
+                  class="row-btn"
+                  appStopClick
+                  appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showPassword"
+                  (click)="togglePassword()"
+                >
+                  <i
+                    class="bwi bwi-lg"
+                    aria-hidden="true"
+                    [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
+                  ></i>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="modal-footer">
         <button type="submit" class="primary" appA11yTitle="{{ 'save' | i18n }}">
           <i class="bwi bwi-save-changes bwi-lg bwi-fw" aria-hidden="true"></i>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -2,9 +2,9 @@
   <div class="modal-dialog" role="document">
     <form class="modal-content" #form (ngSubmit)="submit()" [formGroup]="deleteForm">
       <div class="modal-body">
-        <p class="modal-text">Proceed below to delete your account and all vault data.</p>
+        <p class="modal-text">{{ "deleteAccountDesc" | i18n }}</p>
         <app-callout type="warning" title="{{ 'warning' | i18n }}">
-          Deleting your account is permanent. It cannot be undone.
+          {{ "deleteAccountWarning" | i18n }}
         </app-callout>
         <div class="box last">
           <div class="box-header">{{ "deleteAccount" | i18n }}</div>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -1,6 +1,6 @@
 <div class="modal fade" role="dialog" aria-modal="true" attr.aria-label="{{ 'settings' | i18n }}">
   <div class="modal-dialog" role="document">
-    <form class="modal-content" (ngSubmit)="submit()">
+    <form class="modal-content" #form (ngSubmit)="submit()" [formGroup]="deleteForm">
       <div class="modal-body">
         <div class="modal-title">{{ "deleteAccount" | i18n }}</div>
         <div class="modal-text">Proceed below to delete your account and all vault data.</div>
@@ -9,10 +9,10 @@
         </app-callout>
         <div class="box last">
           <div class="box-content">
-            <div class="box-content-row box-content-row-flex" appBoxRow>
-              <div class="row-main">
-                <label for="masterPassword">{{ "masterPass" | i18n }}</label>
-                <input
+            <!-- <div class="box-content-row box-content-row-flex" appBoxRow> -->
+            <!-- <div class="row-main"> -->
+            <!-- <label for="masterPassword">{{ "masterPass" | i18n }}</label> -->
+            <!-- <input
                   id="masterPassword"
                   type="{{ showPassword ? 'text' : 'password' }}"
                   name="MasterPassword"
@@ -20,32 +20,32 @@
                   [(ngModel)]="masterPassword"
                   required
                   appInputVerbatim
-                />
-              </div>
-              <div class="action-buttons">
-                <button
-                  type="button"
-                  class="row-btn"
-                  appStopClick
-                  appA11yTitle="{{ 'toggleVisibility' | i18n }}"
-                  [attr.aria-pressed]="showPassword"
-                  (click)="togglePassword()"
-                >
-                  <i
-                    class="bwi bwi-lg"
-                    aria-hidden="true"
-                    [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
-                  ></i>
-                </button>
-              </div>
-            </div>
+                /> -->
+            <app-user-verification ngDefaultControl formControlName="secret" name="secret">
+            </app-user-verification>
           </div>
+          <!-- <div class="action-buttons">
+            <button
+              type="button"
+              class="row-btn"
+              appStopClick
+              appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              [attr.aria-pressed]="showPassword"
+              (click)="togglePassword()"
+            >
+              <i
+                class="bwi bwi-lg"
+                aria-hidden="true"
+                [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
+              ></i>
+            </button>
+          </div> -->
         </div>
       </div>
+      <!-- </div> -->
+      <!-- </div> -->
       <div class="modal-footer">
-        <button type="submit" class="primary" appA11yTitle="{{ 'save' | i18n }}">
-          <i class="bwi bwi-save-changes bwi-lg bwi-fw" aria-hidden="true"></i>
-        </button>
+        <button type="submit" class="primary" appA11yTitle="{{ 'save' | i18n }}">Delete</button>
         <button type="button" data-dismiss="modal">{{ "cancel" | i18n }}</button>
       </div>
     </form>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -25,7 +25,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="submit" class="danger" [disabled]="form.loading">
+        <button type="submit" class="danger" [disabled]="form.loading || !secret">
           <i class="bwi bwi-spinner bwi-spin" [hidden]="!form.loading" aria-hidden="true"></i>
           <span [hidden]="form.loading">{{ "deleteAccount" | i18n }}</span>
         </button>

--- a/apps/desktop/src/app/accounts/delete-account.component.html
+++ b/apps/desktop/src/app/accounts/delete-account.component.html
@@ -2,50 +2,20 @@
   <div class="modal-dialog" role="document">
     <form class="modal-content" #form (ngSubmit)="submit()" [formGroup]="deleteForm">
       <div class="modal-body">
-        <div class="modal-title">{{ "deleteAccount" | i18n }}</div>
-        <div class="modal-text">Proceed below to delete your account and all vault data.</div>
+        <p class="modal-text">Proceed below to delete your account and all vault data.</p>
         <app-callout type="warning" title="{{ 'warning' | i18n }}">
           Deleting your account is permanent. It cannot be undone.
         </app-callout>
         <div class="box last">
+          <div class="box-header">{{ "deleteAccount" | i18n }}</div>
           <div class="box-content">
-            <!-- <div class="box-content-row box-content-row-flex" appBoxRow> -->
-            <!-- <div class="row-main"> -->
-            <!-- <label for="masterPassword">{{ "masterPass" | i18n }}</label> -->
-            <!-- <input
-                  id="masterPassword"
-                  type="{{ showPassword ? 'text' : 'password' }}"
-                  name="MasterPassword"
-                  class="monospaced"
-                  [(ngModel)]="masterPassword"
-                  required
-                  appInputVerbatim
-                /> -->
             <app-user-verification ngDefaultControl formControlName="secret" name="secret">
             </app-user-verification>
           </div>
-          <!-- <div class="action-buttons">
-            <button
-              type="button"
-              class="row-btn"
-              appStopClick
-              appA11yTitle="{{ 'toggleVisibility' | i18n }}"
-              [attr.aria-pressed]="showPassword"
-              (click)="togglePassword()"
-            >
-              <i
-                class="bwi bwi-lg"
-                aria-hidden="true"
-                [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
-              ></i>
-            </button>
-          </div> -->
         </div>
       </div>
-      <!-- </div> -->
-      <!-- </div> -->
       <div class="modal-footer">
-        <button type="submit" class="primary" appA11yTitle="{{ 'save' | i18n }}">Delete</button>
+        <button type="submit" class="danger">{{ "deleteAccount" | i18n }}</button>
         <button type="button" data-dismiss="modal">{{ "cancel" | i18n }}</button>
       </div>
     </form>

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -13,6 +13,8 @@ import { UserVerificationService } from "@bitwarden/common/abstractions/userVeri
   templateUrl: "delete-account.component.html",
 })
 export class DeleteAccountComponent {
+  formPromise: Promise<void>;
+
   deleteForm = this.formBuilder.group({
     secret: [""],
   });
@@ -27,19 +29,26 @@ export class DeleteAccountComponent {
     private formBuilder: FormBuilder
   ) {}
 
-  async submit() {
-    try {
-      const secret = this.deleteForm.get("secret").value;
-      const verificationRequest = await this.userVerificationService.buildRequest(secret);
-      await this.apiService.deleteAccount(verificationRequest);
-      this.platformUtilsService.showToast(
-        "success",
-        this.i18nService.t("accountDeleted"),
-        this.i18nService.t("accountDeletedDesc")
-      );
-      this.messagingService.send("logout");
-    } catch (e) {
-      this.logService.error(e);
-    }
+  submit() {
+    this.formPromise = (async () => {
+      try {
+        const secret = this.deleteForm.get("secret").value;
+        const verificationRequest = await this.userVerificationService.buildRequest(secret);
+        await this.apiService.deleteAccount(verificationRequest);
+        this.platformUtilsService.showToast(
+          "success",
+          this.i18nService.t("accountDeleted"),
+          this.i18nService.t("accountDeletedDesc")
+        );
+        this.messagingService.send("logout");
+      } catch (e) {
+        this.platformUtilsService.showToast(
+          "error",
+          this.i18nService.t("errorOccurred"),
+          e.message
+        );
+        this.logService.error(e);
+      }
+    })();
   }
 }

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -7,16 +7,12 @@ import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
-// import { Verification } from "@bitwarden/common/src/types/verification";
 
 @Component({
   selector: "app-delete-account",
   templateUrl: "delete-account.component.html",
 })
 export class DeleteAccountComponent {
-  // showPassword: boolean;
-  // masterPassword: Verification;
-
   deleteForm = this.formBuilder.group({
     secret: [""],
   });
@@ -31,22 +27,17 @@ export class DeleteAccountComponent {
     private formBuilder: FormBuilder
   ) {}
 
-  // togglePassword() {
-  //   this.showPassword = !this.showPassword;
-  // }
-
   async submit() {
     try {
       const secret = this.deleteForm.get("secret").value;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const verificationRequest = await this.userVerificationService.buildRequest(secret);
-      // await this.apiService.deleteAccount(verificationRequest);
+      await this.apiService.deleteAccount(verificationRequest);
       this.platformUtilsService.showToast(
         "success",
         this.i18nService.t("accountDeleted"),
         this.i18nService.t("accountDeletedDesc")
       );
-      // this.messagingService.send("logout");
+      this.messagingService.send("logout");
     } catch (e) {
       this.logService.error(e);
     }

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder } from "@angular/forms";
 
 import { AccountService } from "@bitwarden/common/abstractions/account/account.service.abstraction";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 
 import { Verification } from "../../../../../libs/common/src/types/verification";
@@ -22,7 +23,8 @@ export class DeleteAccountComponent {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private formBuilder: FormBuilder,
-    private accountService: AccountService
+    private accountService: AccountService,
+    private logService: LogService
   ) {}
 
   get secret() {
@@ -39,8 +41,8 @@ export class DeleteAccountComponent {
         this.i18nService.t("accountDeleted"),
         this.i18nService.t("accountDeletedDesc")
       );
-    } catch {
-      // Error handling is done by [appApiAction]
+    } catch (e) {
+      this.logService.error(e);
     }
   }
 }

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -1,0 +1,12 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-delete-account",
+  templateUrl: "delete-account.component.html",
+})
+export class DeleteAccountComponent {
+  submit() {
+    // eslint-disable-next-line no-console
+    console.log("submit");
+  }
+}

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -1,19 +1,54 @@
 import { Component } from "@angular/core";
+import { FormBuilder } from "@angular/forms";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
+import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
+// import { Verification } from "@bitwarden/common/src/types/verification";
 
 @Component({
   selector: "app-delete-account",
   templateUrl: "delete-account.component.html",
 })
 export class DeleteAccountComponent {
-  showPassword: boolean;
-  masterPassword: string;
+  // showPassword: boolean;
+  // masterPassword: Verification;
 
-  submit() {
-    // eslint-disable-next-line no-console
-    console.log("submit");
-  }
+  deleteForm = this.formBuilder.group({
+    secret: [""],
+  });
 
-  togglePassword() {
-    this.showPassword = !this.showPassword;
+  constructor(
+    private apiService: ApiService,
+    private i18nService: I18nService,
+    private platformUtilsService: PlatformUtilsService,
+    private userVerificationService: UserVerificationService,
+    private messagingService: MessagingService,
+    private logService: LogService,
+    private formBuilder: FormBuilder
+  ) {}
+
+  // togglePassword() {
+  //   this.showPassword = !this.showPassword;
+  // }
+
+  async submit() {
+    try {
+      const secret = this.deleteForm.get("secret").value;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const verificationRequest = await this.userVerificationService.buildRequest(secret);
+      // await this.apiService.deleteAccount(verificationRequest);
+      this.platformUtilsService.showToast(
+        "success",
+        this.i18nService.t("accountDeleted"),
+        this.i18nService.t("accountDeletedDesc")
+      );
+      // this.messagingService.send("logout");
+    } catch (e) {
+      this.logService.error(e);
+    }
   }
 }

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -5,8 +5,15 @@ import { Component } from "@angular/core";
   templateUrl: "delete-account.component.html",
 })
 export class DeleteAccountComponent {
+  showPassword: boolean;
+  masterPassword: string;
+
   submit() {
     // eslint-disable-next-line no-console
     console.log("submit");
+  }
+
+  togglePassword() {
+    this.showPassword = !this.showPassword;
   }
 }

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -8,6 +8,8 @@ import { MessagingService } from "@bitwarden/common/abstractions/messaging.servi
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
 
+import { Verification } from "../../../../../libs/common/src/types/verification";
+
 @Component({
   selector: "app-delete-account",
   templateUrl: "delete-account.component.html",
@@ -16,7 +18,7 @@ export class DeleteAccountComponent {
   formPromise: Promise<void>;
 
   deleteForm = this.formBuilder.group({
-    secret: [""],
+    secret: undefined as Verification | undefined,
   });
 
   constructor(

--- a/apps/desktop/src/app/accounts/delete-account.component.ts
+++ b/apps/desktop/src/app/accounts/delete-account.component.ts
@@ -25,6 +25,10 @@ export class DeleteAccountComponent {
     private accountService: AccountService
   ) {}
 
+  get secret() {
+    return this.deleteForm.get("verification")?.value?.secret;
+  }
+
   async submit() {
     try {
       const verification = this.deleteForm.get("verification").value;

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -108,6 +108,14 @@
                   </label>
                 </div>
               </div>
+
+              <div class="form-group">
+                <label>{{ "deleteAccount" | i18n }}</label>
+                <small class="help-block">
+                  {{ "deleteAccountDesc" | i18n }}
+                  <a href="#">{{ "deleteAccount" | i18n }}</a>
+                </small>
+              </div>
             </ng-container>
           </div>
         </div>

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -113,7 +113,7 @@
                 <label>{{ "deleteAccount" | i18n }}</label>
                 <small class="help-block">
                   {{ "deleteAccountDesc" | i18n }}
-                  <a href="#">{{ "deleteAccount" | i18n }}</a>
+                  <a (click)="openDeleteAccount()">{{ "deleteAccount" | i18n }}</a>
                 </small>
               </div>
             </ng-container>

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -18,6 +18,8 @@ import { isWindowsStore } from "@bitwarden/electron/utils";
 
 import { SetPinComponent } from "../components/set-pin.component";
 
+import { DeleteAccountComponent } from "./delete-account.component";
+
 @Component({
   selector: "app-settings",
   templateUrl: "settings.component.html",
@@ -436,5 +438,9 @@ export class SettingsComponent implements OnInit {
     await this.stateService.setEnableBrowserIntegrationFingerprint(
       this.enableBrowserIntegrationFingerprint
     );
+  }
+
+  async openDeleteAccount() {
+    this.modalService.open(DeleteAccountComponent, { allowMultipleModals: true });
   }
 }

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -441,6 +441,6 @@ export class SettingsComponent implements OnInit {
   }
 
   async openDeleteAccount() {
-    this.modalService.open(DeleteAccountComponent, { allowMultipleModals: true });
+    this.modalService.open(DeleteAccountComponent, { replaceTopModal: true });
   }
 }

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -153,9 +153,7 @@ export class AppComponent implements OnInit {
             this.systemService.cancelProcessReload();
             break;
           case "loggedOut":
-            if (this.modal != null) {
-              this.modal.close();
-            }
+            this.modalService.closeAll();
             this.notificationsService.updateConnection();
             this.updateAppMenu();
             await this.systemService.clearPendingClipboard();
@@ -180,9 +178,7 @@ export class AppComponent implements OnInit {
             }
             break;
           case "locked":
-            if (this.modal != null) {
-              this.modal.close();
-            }
+            this.modalService.closeAll();
             if (
               message.userId == null ||
               message.userId === (await this.stateService.getUserId())
@@ -368,9 +364,7 @@ export class AppComponent implements OnInit {
   }
 
   async openExportVault() {
-    if (this.modal != null) {
-      this.modal.close();
-    }
+    this.modalService.closeAll();
 
     const [modal, childComponent] = await this.modalService.openViewRef(
       ExportComponent,
@@ -388,9 +382,7 @@ export class AppComponent implements OnInit {
   }
 
   async addFolder() {
-    if (this.modal != null) {
-      this.modal.close();
-    }
+    this.modalService.closeAll();
 
     const [modal, childComponent] = await this.modalService.openViewRef(
       FolderAddEditComponent,
@@ -410,9 +402,7 @@ export class AppComponent implements OnInit {
   }
 
   async openGenerator() {
-    if (this.modal != null) {
-      this.modal.close();
-    }
+    this.modalService.closeAll();
 
     [this.modal] = await this.modalService.openViewRef(
       GeneratorComponent,
@@ -542,9 +532,7 @@ export class AppComponent implements OnInit {
   }
 
   private async openModal<T>(type: Type<T>, ref: ViewContainerRef) {
-    if (this.modal != null) {
-      this.modal.close();
-    }
+    this.modalService.closeAll();
 
     [this.modal] = await this.modalService.openViewRef(type, ref);
 

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -40,6 +40,7 @@ import { CipherType } from "@bitwarden/common/enums/cipherType";
 
 import { MenuUpdateRequest } from "../main/menu/menu.updater";
 
+import { DeleteAccountComponent } from "./accounts/delete-account.component";
 import { PremiumComponent } from "./accounts/premium.component";
 import { SettingsComponent } from "./accounts/settings.component";
 import { ExportComponent } from "./vault/export.component";
@@ -219,6 +220,9 @@ export class AppComponent implements OnInit {
             }
             break;
           }
+          case "deleteAccount":
+            this.modalService.open(DeleteAccountComponent, { replaceTopModal: true });
+            break;
           case "openPasswordHistory":
             await this.openModal<PasswordGeneratorHistoryComponent>(
               PasswordGeneratorHistoryComponent,

--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -57,6 +57,7 @@ import localeZhTw from "@angular/common/locales/zh-Hant";
 import { NgModule } from "@angular/core";
 
 import { AccessibilityCookieComponent } from "./accounts/accessibility-cookie.component";
+import { DeleteAccountComponent } from "./accounts/delete-account.component";
 import { EnvironmentComponent } from "./accounts/environment.component";
 import { HintComponent } from "./accounts/hint.component";
 import { LockComponent } from "./accounts/lock.component";
@@ -165,6 +166,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     AttachmentsComponent,
     CiphersComponent,
     CollectionsComponent,
+    DeleteAccountComponent,
     EnvironmentComponent,
     ExportComponent,
     FolderAddEditComponent,

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1406,7 +1406,7 @@
     "message": "Account deleted"
   },
   "accountDeletedDesc": {
-    "message": "You account has been closed and all associated data has been deleted."
+    "message": "Your account has been closed and all associated data has been deleted."
   },
   "preferences": {
     "message": "Preferences"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1406,7 +1406,7 @@
     "message": "Account deleted"
   },
   "accountDeletedDesc": {
-    "message": "Your Bitwarden account and vault data were permanently deleted."
+    "message": "You account has been closed and all associated data has been deleted."
   },
   "preferences": {
     "message": "Preferences"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1393,6 +1393,12 @@
   "lockWithMasterPassOnRestart": {
     "message": "Lock with master password on restart"
   },
+  "deleteAccount": {
+    "message": "Delete account"
+  },
+  "deleteAccountDesc": {
+    "message": "Deleting your account is permanent. It cannot be undone."
+  },
   "preferences": {
     "message": "Preferences"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1397,7 +1397,16 @@
     "message": "Delete account"
   },
   "deleteAccountDesc": {
+    "message": "Proceed below to delete your account and all vault data."
+  },
+  "deleteAccountWarning": {
     "message": "Deleting your account is permanent. It cannot be undone."
+  },
+  "accountDeleted": {
+    "message": "Account deleted"
+  },
+  "accountDeletedDesc": {
+    "message": "Your Bitwarden account and vault data were permanently deleted."
   },
   "preferences": {
     "message": "Preferences"
@@ -1981,5 +1990,5 @@
   },
   "cardBrandMir": {
     "message": "Mir"
-  }  
+  }
 }

--- a/apps/desktop/src/main/menu/menu.account.ts
+++ b/apps/desktop/src/main/menu/menu.account.ts
@@ -19,6 +19,8 @@ export class AccountMenu implements IMenubarMenu {
       this.changeMasterPassword,
       this.twoStepLogin,
       this.fingerprintPhrase,
+      this.separator,
+      this.deleteAccount,
     ];
   }
 
@@ -103,6 +105,19 @@ export class AccountMenu implements IMenubarMenu {
       click: () => this.sendMessage("showFingerprintPhrase"),
       enabled: !this._isLocked,
     };
+  }
+
+  private get deleteAccount(): MenuItemConstructorOptions {
+    return {
+      label: this.localize("deleteAccount"),
+      id: "deleteAccount",
+      click: () => this.sendMessage("deleteAccount"),
+      enabled: !this._isLocked,
+    };
+  }
+
+  private get separator(): MenuItemConstructorOptions {
+    return { type: "separator" };
   }
 
   private localize(s: string) {

--- a/apps/desktop/src/scss/box.scss
+++ b/apps/desktop/src/scss/box.scss
@@ -102,6 +102,10 @@
       color: themed("mutedColor");
     }
   }
+
+  &.last {
+    margin-bottom: 15px;
+  }
 }
 
 .box-content-row {

--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -336,6 +336,25 @@ form,
     @include themify($themes) {
       color: themed("mutedColor");
     }
+
+    a {
+      @extend .btn;
+      @extend .link;
+
+      padding: 0;
+      font-size: inherit;
+      font-weight: bold;
+
+      @include themify($themes) {
+        color: themed("mutedColor");
+      }
+
+      &:hover {
+        @include themify($themes) {
+          color: darken(themed("mutedColor"), 6%);
+        }
+      }
+    }
   }
 }
 

--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -184,10 +184,6 @@ p.lead {
   }
 }
 
-.modal-text {
-  margin: 15px 10px 5px 10px;
-}
-
 .generated-block {
   font-size: $font-size-large;
   font-family: $font-family-monospace;

--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -184,6 +184,10 @@ p.lead {
   }
 }
 
+.modal-text {
+  margin: 15px 10px 5px 10px;
+}
+
 .generated-block {
   font-size: $font-size-large;
   font-family: $font-family-monospace;

--- a/apps/desktop/src/scss/pages.scss
+++ b/apps/desktop/src/scss/pages.scss
@@ -71,10 +71,6 @@
 
     .box {
       margin-bottom: 20px;
-
-      &.last {
-        margin-bottom: 15px;
-      }
     }
 
     .buttons {

--- a/apps/web/src/app/settings/delete-account.component.html
+++ b/apps/web/src/app/settings/delete-account.component.html
@@ -6,6 +6,7 @@
       (ngSubmit)="submit()"
       [appApiAction]="formPromise"
       ngNativeValidate
+      [formGroup]="deleteForm"
     >
       <div class="modal-header">
         <h2 class="modal-title" id="deleteAccountTitle">{{ "deleteAccount" | i18n }}</h2>
@@ -21,7 +22,7 @@
       <div class="modal-body">
         <p>{{ "deleteAccountDesc" | i18n }}</p>
         <app-callout type="warning">{{ "deleteAccountWarning" | i18n }}</app-callout>
-        <app-user-verification [(ngModel)]="masterPassword" ngDefaultControl name="secret">
+        <app-user-verification ngDefaultControl formControlName="verification" name="verification">
         </app-user-verification>
       </div>
       <div class="modal-footer">

--- a/apps/web/src/app/settings/delete-account.component.ts
+++ b/apps/web/src/app/settings/delete-account.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder } from "@angular/forms";
 
 import { AccountService } from "@bitwarden/common/abstractions/account/account.service.abstraction";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { Verification } from "@bitwarden/common/types/verification";
 
@@ -21,7 +22,8 @@ export class DeleteAccountComponent {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private formBuilder: FormBuilder,
-    private accountService: AccountService
+    private accountService: AccountService,
+    private logService: LogService
   ) {}
 
   async submit() {
@@ -34,8 +36,8 @@ export class DeleteAccountComponent {
         this.i18nService.t("accountDeleted"),
         this.i18nService.t("accountDeletedDesc")
       );
-    } catch {
-      // Error handling is done by [appApiAction]
+    } catch (e) {
+      this.logService.error(e);
     }
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1088,7 +1088,7 @@
     "message": "Account Deleted"
   },
   "accountDeletedDesc": {
-    "message": "You account has been closed and all associated data has been deleted."
+    "message": "Your account has been closed and all associated data has been deleted."
   },
   "myAccount": {
     "message": "My Account"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1088,7 +1088,7 @@
     "message": "Account Deleted"
   },
   "accountDeletedDesc": {
-    "message": "Your Bitwarden account and vault data were permanently deleted."
+    "message": "You account has been closed and all associated data has been deleted."
   },
   "myAccount": {
     "message": "My Account"

--- a/libs/angular/src/components/user-verification.component.ts
+++ b/libs/angular/src/components/user-verification.component.ts
@@ -5,6 +5,7 @@ import { ControlValueAccessor, UntypedFormControl, NG_VALUE_ACCESSOR } from "@an
 import { KeyConnectorService } from "@bitwarden/common/abstractions/keyConnector.service";
 import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
 import { VerificationType } from "@bitwarden/common/enums/verificationType";
+import { Utils } from "@bitwarden/common/misc/utils";
 import { Verification } from "@bitwarden/common/types/verification";
 
 /**
@@ -90,7 +91,7 @@ export class UserVerificationComponent implements ControlValueAccessor, OnInit {
 
     this.onChange({
       type: this.usesKeyConnector ? VerificationType.OTP : VerificationType.MasterPassword,
-      secret: secret,
+      secret: Utils.isNullOrWhitespace(secret) ? null : secret,
     });
   }
 }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -3,6 +3,7 @@ import { InjectionToken, Injector, LOCALE_ID, NgModule } from "@angular/core";
 import { ThemingService } from "@bitwarden/angular/services/theming/theming.service";
 import { AbstractThemingService } from "@bitwarden/angular/services/theming/theming.service.abstraction";
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";
+import { AccountService as AccountServiceAbstraction } from "@bitwarden/common/abstractions/account/account.service.abstraction";
 import { ApiService as ApiServiceAbstraction } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService as AppIdServiceAbstraction } from "@bitwarden/common/abstractions/appId.service";
 import { AuditService as AuditServiceAbstraction } from "@bitwarden/common/abstractions/audit.service";
@@ -49,6 +50,7 @@ import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "@bitwarde
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
 import { Account } from "@bitwarden/common/models/domain/account";
 import { GlobalState } from "@bitwarden/common/models/domain/globalState";
+import { AccountService } from "@bitwarden/common/services/account/account.service";
 import { ApiService } from "@bitwarden/common/services/api.service";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
 import { AuditService } from "@bitwarden/common/services/audit.service";
@@ -233,6 +235,16 @@ export const LOG_MAC_FAILURES = new InjectionToken<string>("LOG_MAC_FAILURES");
       provide: FolderApiServiceAbstraction,
       useClass: FolderApiService,
       deps: [FolderServiceAbstraction, ApiServiceAbstraction],
+    },
+    {
+      provide: AccountServiceAbstraction,
+      useClass: AccountService,
+      deps: [
+        ApiServiceAbstraction,
+        UserVerificationServiceAbstraction,
+        MessagingServiceAbstraction,
+        LogService,
+      ],
     },
     { provide: LogService, useFactory: () => new ConsoleLogService(false) },
     {

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -3,6 +3,7 @@ import { InjectionToken, Injector, LOCALE_ID, NgModule } from "@angular/core";
 import { ThemingService } from "@bitwarden/angular/services/theming/theming.service";
 import { AbstractThemingService } from "@bitwarden/angular/services/theming/theming.service.abstraction";
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";
+import { AccountApiService as AccountApiServiceAbstraction } from "@bitwarden/common/abstractions/account/account-api.service.abstraction";
 import { AccountService as AccountServiceAbstraction } from "@bitwarden/common/abstractions/account/account.service.abstraction";
 import { ApiService as ApiServiceAbstraction } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService as AppIdServiceAbstraction } from "@bitwarden/common/abstractions/appId.service";
@@ -50,6 +51,7 @@ import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "@bitwarde
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
 import { Account } from "@bitwarden/common/models/domain/account";
 import { GlobalState } from "@bitwarden/common/models/domain/globalState";
+import { AccountApiService } from "@bitwarden/common/services/account/account-api.service";
 import { AccountService } from "@bitwarden/common/services/account/account.service";
 import { ApiService } from "@bitwarden/common/services/api.service";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
@@ -237,10 +239,15 @@ export const LOG_MAC_FAILURES = new InjectionToken<string>("LOG_MAC_FAILURES");
       deps: [FolderServiceAbstraction, ApiServiceAbstraction],
     },
     {
+      provide: AccountApiServiceAbstraction,
+      useClass: AccountApiService,
+      deps: [ApiServiceAbstraction],
+    },
+    {
       provide: AccountServiceAbstraction,
       useClass: AccountService,
       deps: [
-        ApiServiceAbstraction,
+        AccountApiServiceAbstraction,
         UserVerificationServiceAbstraction,
         MessagingServiceAbstraction,
         LogService,

--- a/libs/angular/src/services/modal.service.ts
+++ b/libs/angular/src/services/modal.service.ts
@@ -65,9 +65,9 @@ export class ModalService {
   }
 
   open(componentType: Type<any>, config: ModalConfig = {}) {
-    const { replaceTopModal: replaceCurrent = false, allowMultipleModals = false } = config;
+    const { replaceTopModal = false, allowMultipleModals = false } = config;
 
-    if (this.modalCount > 0 && replaceCurrent) {
+    if (this.modalCount > 0 && replaceTopModal) {
       this.topModal.instance.close();
     }
 
@@ -93,6 +93,10 @@ export class ModalService {
     }
 
     return this.componentFactoryResolver.resolveComponentFactory(componentType);
+  }
+
+  closeAll(): void {
+    this.modalList.forEach((modal) => modal.instance.close());
   }
 
   protected openInternal(

--- a/libs/angular/src/services/modal.service.ts
+++ b/libs/angular/src/services/modal.service.ts
@@ -17,7 +17,8 @@ import { ModalRef } from "../components/modal/modal.ref";
 
 export class ModalConfig<D = any> {
   data?: D;
-  allowMultipleModals = false;
+  allowMultipleModals?: boolean;
+  replaceTopModal?: boolean;
 }
 
 @Injectable()
@@ -63,8 +64,14 @@ export class ModalService {
     return [modalRef, modalComponentRef.instance.componentRef.instance];
   }
 
-  open(componentType: Type<any>, config?: ModalConfig) {
-    if (!(config?.allowMultipleModals ?? false) && this.modalCount > 0) {
+  open(componentType: Type<any>, config: ModalConfig = {}) {
+    const { replaceTopModal: replaceCurrent = false, allowMultipleModals = false } = config;
+
+    if (this.modalCount > 0 && replaceCurrent) {
+      this.topModal.instance.close();
+    }
+
+    if (this.modalCount > 0 && !allowMultipleModals) {
       return;
     }
 

--- a/libs/angular/src/services/modal.service.ts
+++ b/libs/angular/src/services/modal.service.ts
@@ -75,8 +75,7 @@ export class ModalService {
       return;
     }
 
-    // eslint-disable-next-line
-    const [modalRef, _] = this.openInternal(componentType, config, true);
+    const [modalRef] = this.openInternal(componentType, config, true);
 
     return modalRef;
   }

--- a/libs/common/src/abstractions/account/account-api.service.abstraction.ts
+++ b/libs/common/src/abstractions/account/account-api.service.abstraction.ts
@@ -1,0 +1,5 @@
+import { SecretVerificationRequest } from "@bitwarden/common/models/request/secretVerificationRequest";
+
+export abstract class AccountApiService {
+  abstract deleteAccount(request: SecretVerificationRequest): Promise<void>;
+}

--- a/libs/common/src/abstractions/account/account.service.abstraction.ts
+++ b/libs/common/src/abstractions/account/account.service.abstraction.ts
@@ -1,0 +1,5 @@
+import { Verification } from "../../types/verification";
+
+export abstract class AccountService {
+  abstract delete(verification: Verification): Promise<any>;
+}

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -209,7 +209,6 @@ export abstract class ApiService {
   setPassword: (request: SetPasswordRequest) => Promise<any>;
   postSetKeyConnectorKey: (request: SetKeyConnectorKeyRequest) => Promise<any>;
   postSecurityStamp: (request: SecretVerificationRequest) => Promise<any>;
-  deleteAccount: (request: SecretVerificationRequest) => Promise<any>;
   getAccountRevisionDate: () => Promise<number>;
   postPasswordHint: (request: PasswordHintRequest) => Promise<any>;
   postRegister: (request: RegisterRequest) => Promise<any>;

--- a/libs/common/src/services/account/account-api.service.ts
+++ b/libs/common/src/services/account/account-api.service.ts
@@ -1,0 +1,11 @@
+import { AccountApiService as AccountApiServiceAbstraction } from "@bitwarden/common/abstractions/account/account-api.service.abstraction";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { SecretVerificationRequest } from "@bitwarden/common/models/request/secretVerificationRequest";
+
+export class AccountApiService implements AccountApiServiceAbstraction {
+  constructor(private apiService: ApiService) {}
+
+  deleteAccount(request: SecretVerificationRequest): Promise<void> {
+    return this.apiService.send("DELETE", "/accounts", request, true, false);
+  }
+}

--- a/libs/common/src/services/account/account.service.ts
+++ b/libs/common/src/services/account/account.service.ts
@@ -6,15 +6,13 @@ import { UserVerificationService } from "@bitwarden/common/abstractions/userVeri
 import { AccountService as AccountServiceAbstraction } from "../../abstractions/account/account.service.abstraction";
 import { Verification } from "../../types/verification";
 
-export class AccountService extends AccountServiceAbstraction {
+export class AccountService implements AccountServiceAbstraction {
   constructor(
     private apiService: ApiService,
     private userVerificationService: UserVerificationService,
     private messagingService: MessagingService,
     private logService: LogService
-  ) {
-    super();
-  }
+  ) {}
 
   async delete(verification: Verification): Promise<any> {
     try {

--- a/libs/common/src/services/account/account.service.ts
+++ b/libs/common/src/services/account/account.service.ts
@@ -1,0 +1,29 @@
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
+import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
+
+import { AccountService as AccountServiceAbstraction } from "../../abstractions/account/account.service.abstraction";
+import { Verification } from "../../types/verification";
+
+export class AccountService extends AccountServiceAbstraction {
+  constructor(
+    private apiService: ApiService,
+    private userVerificationService: UserVerificationService,
+    private messagingService: MessagingService,
+    private logService: LogService
+  ) {
+    super();
+  }
+
+  async delete(verification: Verification): Promise<any> {
+    try {
+      const verificationRequest = await this.userVerificationService.buildRequest(verification);
+      await this.apiService.deleteAccount(verificationRequest);
+      this.messagingService.send("logout");
+    } catch (e) {
+      this.logService.error(e);
+      throw e;
+    }
+  }
+}

--- a/libs/common/src/services/account/account.service.ts
+++ b/libs/common/src/services/account/account.service.ts
@@ -1,4 +1,4 @@
-import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { AccountApiService } from "@bitwarden/common/abstractions/account/account-api.service.abstraction";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { UserVerificationService } from "@bitwarden/common/abstractions/userVerification.service";
@@ -8,7 +8,7 @@ import { Verification } from "../../types/verification";
 
 export class AccountService implements AccountServiceAbstraction {
   constructor(
-    private apiService: ApiService,
+    private apiService: AccountApiService,
     private userVerificationService: UserVerificationService,
     private messagingService: MessagingService,
     private logService: LogService

--- a/libs/common/src/services/account/account.service.ts
+++ b/libs/common/src/services/account/account.service.ts
@@ -8,7 +8,7 @@ import { Verification } from "../../types/verification";
 
 export class AccountService implements AccountServiceAbstraction {
   constructor(
-    private apiService: AccountApiService,
+    private accountApiService: AccountApiService,
     private userVerificationService: UserVerificationService,
     private messagingService: MessagingService,
     private logService: LogService
@@ -17,7 +17,7 @@ export class AccountService implements AccountServiceAbstraction {
   async delete(verification: Verification): Promise<any> {
     try {
       const verificationRequest = await this.userVerificationService.buildRequest(verification);
-      await this.apiService.deleteAccount(verificationRequest);
+      await this.accountApiService.deleteAccount(verificationRequest);
       this.messagingService.send("logout");
     } catch (e) {
       this.logService.error(e);

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -350,10 +350,6 @@ export class ApiService implements ApiServiceAbstraction {
     return this.send("POST", "/accounts/security-stamp", request, true, false);
   }
 
-  deleteAccount(request: SecretVerificationRequest): Promise<any> {
-    return this.send("DELETE", "/accounts", request, true, false);
-  }
-
   async getAccountRevisionDate(): Promise<number> {
     const r = await this.send("GET", "/accounts/revision-date", null, true, true);
     return r as number;


### PR DESCRIPTION
Placeholder

## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
MAS (Mac App Store) has rejected our release due to some new changes to the app store review guidelines effective June 30 which were not communicated due to our Desktop client missing an ability for a user to delete their user account.

## Code changes
- **apps/desktop/src/app/accounts/delete-account.component.html:** New desktop modal
- **apps/desktop/src/app/accounts/delete-account.component.ts:** New desktop modal
- **apps/desktop/src/app/accounts/settings.component.html:** New option linking to desktop modal
- **apps/desktop/src/app/accounts/settings.component.ts:** New option linking to desktop modal
- **apps/desktop/src/app/app.component.ts:** Use new function in modal service to close all modals
- **apps/desktop/src/app/app.module.ts:** New desktop modal component
- **apps/desktop/src/locales/en/messages.json:** Modal translations
- **apps/desktop/src/main/menu/menu.account.ts:** Add modal to menu bar
- **apps/desktop/src/scss/box.scss:** Add generic css `.last` class with bottom margin
- **apps/desktop/src/scss/misc.scss:** Styling for link in settings page
- **apps/desktop/src/scss/pages.scss:** Remove specific css `.last` class with bottom margin
- **libs/angular/src/services/modal.service.ts:**
     - Add ability to replace top-most modal (see comment further down)
     - Add ability to close all modals
- **apps/web/src/app/settings/delete-account.component:**  Update web vault modal to use reactive forms and new `AccountService`
- **apps/web/src/locales/en/messages.json:** Update translations in web vault
- **libs/angular/src/components/user-verification.component.ts:** Fix `secret` not returning `null` when field is empty during master password verification
- **libs/angular/src/services/jslib-services.module.ts:** Add new services
- **libs/common/src/abstractions/account/account-api.service.abstraction.ts:** see below
- **libs/common/src/abstractions/account/account.service.abstraction.ts:** see below
- **libs/common/src/abstractions/api.service.ts:** see below
- **libs/common/src/services/account/account-api.service.ts:** Create new service with `deleteAccount` method
- **libs/common/src/services/account/account.service.ts:** Create new service with ability to delete account. This performs all the necessary calls for deleting an account, ending with logging out.
- **libs/common/src/services/api.service.ts:** Remove `deleteAccount` methods


## Screenshots
#### Menu
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181016265-9a4d0fa6-41c3-4e6d-be40-136be0271b60.png">

### With master password
#### Dialog
Button disabled if empty secret
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475333-69b7fb39-c92b-4597-9961-4e64c4357886.png">

#### Error when entering wrong password
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475503-f5860fa3-d9c4-4c1c-ac33-7e91047dc04d.png">

#### Successful deletion with master password
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475576-da7ec446-5ca7-413d-8afb-025a6057f530.png">

### With key connector
#### Dialog
Button disabled if empty secret
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475717-0aade52e-f1a5-43e1-84d5-ec4a98e3f066.png">

#### Error when entering wrong code
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475835-8e8562fe-074c-4040-b3ac-f43ac387ff3f.png">

#### Successful deletion with key connector
<img alt="image" src="https://user-images.githubusercontent.com/2285588/181475980-3e10368c-a0a0-426b-9360-a2d279e25538.png">

## Before you submir
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
