### PR TITLE
[CL-17] Use focus-visible for keyboard selection

### DIFF
--- a/libs/components/src/tabs/tab-item.component.ts
+++ b/libs/components/src/tabs/tab-item.component.ts
@@ -25,10 +25,10 @@ export class TabItemComponent {
       "!tw-text-main",
       "hover:tw-underline",
       "hover:!tw-text-main",
-      "focus:tw-z-10",
-      "focus:tw-outline-none",
-      "focus:tw-ring-2",
-      "focus:tw-ring-primary-700",
+      "focus-visible:tw-z-10",
+      "focus-visible:tw-outline-none",
+      "focus-visible:tw-ring-2",
+      "focus-visible:tw-ring-primary-700",
       "disabled:tw-bg-secondary-100",
       "disabled:!tw-text-muted",
       "disabled:tw-no-underline",
@@ -47,8 +47,8 @@ export class TabItemComponent {
       "!tw-text-primary-500",
       "hover:tw-border-t-primary-700",
       "hover:!tw-text-primary-700",
-      "focus:tw-border-t-primary-700",
-      "focus:!tw-text-primary-700",
+      "focus-visible:tw-border-t-primary-700",
+      "focus-visible:!tw-text-primary-700",
     ].join(" ");
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> Update tabs component to use the `focus-visible` attribute for keyboard selection instead of `focus`. This prevents focus from mouse clicks.
> CL-17

## Code changes
- **tab-item.component.ts**: Replaced `focus` with `focus-visible` for keyboard selection

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

