### PR TITLE
[ENG 71] Add calls to Github Deployments API to allow Jira integration on Deployments

### DIFF
--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -90,6 +90,23 @@ jobs:
       - setup
       - locales-test
     steps:
+
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          environment: 'Browser - Production (${GITHUB_REF##*/})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Download latest Release build artifacts
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
@@ -141,3 +158,21 @@ jobs:
           body: "<insert release notes here>"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
+
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -95,7 +95,9 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Browser - Production ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
+          environment: 'Browser - Production'
+          description: 'Deployment ${{ needs.setup.outputs.release_version }} from branch ${{ github.ref_name }}'
+          task: release
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -95,14 +95,12 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
           environment: 'Browser - Production ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
           state: 'in_progress'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -163,7 +161,6 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
           state: 'success'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -172,6 +169,5 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: 'Browser - Production (${GITHUB_REF##*/})'
+          environment: 'Browser - Production $${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -90,14 +90,13 @@ jobs:
       - setup
       - locales-test
     steps:
-
       - name: Create GitHub deployment
         uses: chrnorm/deployment-action@v2
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: 'Browser - Production $${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
+          environment: 'Browser - Production ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -91,7 +91,7 @@ jobs:
       - locales-test
     steps:
       - name: Create GitHub deployment
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -100,7 +100,7 @@ jobs:
           task: release
       
       - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'in_progress'
@@ -160,7 +160,7 @@ jobs:
 
       - name: Update deployment status to Success
         if: success()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'success'
@@ -168,7 +168,7 @@ jobs:
 
       - name: Update deployment status to Failure
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment: 'Browser - Production'
-          description: 'Deployment ${{ needs.setup.outputs.release_version }} from branch ${{ github.ref_name }}'
+          description: 'Deployment ${{ needs.setup.outputs.release-version }} from branch ${{ github.ref_name }}'
           task: release
       
       - name: Update deployment status to In Progress

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -69,7 +69,9 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'CLI - Production ${{ steps.version.outputs.version }} (${{ github.ref_name }})'
+          environment: 'CLI - Production'
+          description: 'Deployment ${{ steps.version.outputs.version }} from branch ${{ github.ref_name }}'
+          task: release
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -113,6 +113,20 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
+      - name: Create GitHub deployment for Snap
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'CLI Snap - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -159,6 +173,21 @@ jobs:
           snapcraft push bw_${{ env._PKG_VERSION }}_amd64.snap --release stable
           snapcraft logout
 
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
   choco:
     name: Deploy Choco
@@ -168,6 +197,20 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
+      - name: Create GitHub deployment for Choco
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'CLI Choco - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -219,6 +262,21 @@ jobs:
           cd dist
           choco push
 
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
   npm:
     name: Publish NPM
@@ -228,6 +286,20 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
+      - name: Create GitHub deployment for npm
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'CLI npm - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -274,3 +346,19 @@ jobs:
       - name: Publish NPM
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: npm publish --access public
+
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -64,6 +64,20 @@ jobs:
           monorepo: true
           monorepo-project: cli
 
+      - name: Create GitHub deployment for Snap
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'CLI - Production ${{ steps.version.outputs.version }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Download all Release artifacts
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
@@ -104,6 +118,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
 
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
   snap:
     name: Deploy Snap
@@ -113,20 +142,6 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
-      - name: Create GitHub deployment for Snap
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'CLI Snap - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
-      
-      - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -173,22 +188,6 @@ jobs:
           snapcraft push bw_${{ env._PKG_VERSION }}_amd64.snap --release stable
           snapcraft logout
 
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
   choco:
     name: Deploy Choco
     runs-on: windows-2019
@@ -197,20 +196,6 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
-      - name: Create GitHub deployment for Choco
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'CLI Choco - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
-      
-      - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -262,22 +247,6 @@ jobs:
           cd dist
           choco push
 
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
   npm:
     name: Publish NPM
     runs-on: ubuntu-20.04
@@ -286,20 +255,6 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
-      - name: Create GitHub deployment for npm
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'CLI npm - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
-      
-      - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
       - name: Checkout repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -347,18 +302,3 @@ jobs:
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: npm publish --access public
 
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -65,7 +65,7 @@ jobs:
           monorepo-project: cli
 
       - name: Create GitHub deployment for Snap
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -74,7 +74,7 @@ jobs:
           task: release
       
       - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'in_progress'
@@ -122,7 +122,7 @@ jobs:
 
       - name: Update deployment status to Success
         if: success()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'success'
@@ -130,7 +130,7 @@ jobs:
 
       - name: Update deployment status to Failure
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -173,6 +173,20 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
+      - name: Create GitHub deployment for Snap
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'Desktop Snap - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout Repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
@@ -224,6 +238,22 @@ jobs:
           snapcraft logout
         working-directory: apps/desktop/dist
 
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
   choco:
     name: Deploy Choco
     runs-on: windows-2019
@@ -232,6 +262,20 @@ jobs:
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
     steps:
+      - name: Create GitHub deployment for Choco
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'Desktop Choco - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout Repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
@@ -288,3 +332,20 @@ jobs:
         shell: pwsh
         run: choco push
         working-directory: apps/desktop/dist
+
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -77,7 +77,7 @@ jobs:
           esac
 
       - name: Create GitHub deployment
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -86,7 +86,7 @@ jobs:
           task: release
       
       - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'
@@ -182,7 +182,7 @@ jobs:
 
       - name: Update deployment status to Success
         if: success()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'success'
@@ -190,7 +190,7 @@ jobs:
 
       - name: Update deployment status to Failure
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -76,118 +76,117 @@ jobs:
               ;;
           esac
 
-      - name: Create GitHub deployment
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop - Production'
-          description: 'Deployment ${{ steps.version.outputs.version }} to channel ${{ steps.release-channel.outputs.channel }} from branch ${{ github.ref_name }}'
-          task: release
+      # - name: Create GitHub deployment
+      #   uses: chrnorm/deployment-action@v2
+      #   id: deployment
+      #   with:
+      #     token: '${{ secrets.GITHUB_TOKEN }}'
+      #     environment: 'Desktop - Production'
+      #     description: 'Deployment ${{ steps.version.outputs.version }} to channel ${{ steps.release-channel.outputs.channel }} from branch ${{ github.ref_name }}'
+      #     task: release
       
-
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          deployment-id: 610000065
 
-      - name: Login to Azure
-        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
-        with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+      # - name: Login to Azure
+      #   uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
+      #   with:
+      #     creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "aws-electron-access-id, aws-electron-access-key, aws-electron-bucket-name"
+      # - name: Retrieve secrets
+      #   id: retrieve-secrets
+      #   uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
+      #   with:
+      #     keyvault: "bitwarden-prod-kv"
+      #     secrets: "aws-electron-access-id, aws-electron-access-key, aws-electron-bucket-name"
 
-      - name: Download all artifacts
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
-        with:
-          workflow: build-desktop.yml
-          workflow_conclusion: success
-          branch: ${{ github.ref_name }}
-          path: apps/desktop/artifacts
+      # - name: Download all artifacts
+      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+      #   uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
+      #   with:
+      #     workflow: build-desktop.yml
+      #     workflow_conclusion: success
+      #     branch: ${{ github.ref_name }}
+      #     path: apps/desktop/artifacts
 
-      - name: Download all artifacts
-        if: ${{ github.event.inputs.release_type == 'Dry Run' }}
-        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
-        with:
-          workflow: build-desktop.yml
-          workflow_conclusion: success
-          branch: master
-          path: apps/desktop/artifacts
+      # - name: Download all artifacts
+      #   if: ${{ github.event.inputs.release_type == 'Dry Run' }}
+      #   uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
+      #   with:
+      #     workflow: build-desktop.yml
+      #     workflow_conclusion: success
+      #     branch: master
+      #     path: apps/desktop/artifacts
 
-      - name: Rename .pkg to .pkg.archive
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.version }}
-        working-directory: apps/desktop/artifacts
-        run: mv Bitwarden-${{ env.PKG_VERSION }}-universal.pkg Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive
+      # - name: Rename .pkg to .pkg.archive
+      #   env:
+      #     PKG_VERSION: ${{ steps.version.outputs.version }}
+      #   working-directory: apps/desktop/artifacts
+      #   run: mv Bitwarden-${{ env.PKG_VERSION }}-universal.pkg Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive
 
-      - name: Publish artifacts to S3
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-electron-access-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-electron-access-key }}
-          AWS_DEFAULT_REGION: 'us-west-2'
-          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.aws-electron-bucket-name }}
-        working-directory: apps/desktop/artifacts
-        run: |
-          aws s3 cp ./ $AWS_S3_BUCKET_NAME/desktop/ \
-          --acl "public-read" \
-          --recursive \
-          --quiet
+      # - name: Publish artifacts to S3
+      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-electron-access-id }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-electron-access-key }}
+      #     AWS_DEFAULT_REGION: 'us-west-2'
+      #     AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.aws-electron-bucket-name }}
+      #   working-directory: apps/desktop/artifacts
+      #   run: |
+      #     aws s3 cp ./ $AWS_S3_BUCKET_NAME/desktop/ \
+      #     --acl "public-read" \
+      #     --recursive \
+      #     --quiet
 
-      - name: Create release
-        uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09  # v2.8.5
-        if: ${{ steps.release-channel.outputs.channel == 'latest' && github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
-        with:
-          artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
-            apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
-            apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
-            apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32.appx,
-            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-ia32.nsis.7z,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64-store.appx,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.appx,
-            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-x64.nsis.7z,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64-store.appx,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.appx,
-            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-arm64.nsis.7z,
-            apps/desktop/artifacts/bitwarden.${{ env.PKG_VERSION }}.nupkg,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal-mac.zip,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg.blockmap,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive,
-            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}.yml,
-            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-linux.yml,
-            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-mac.yml"
-          commit: ${{ github.sha }}
-          tag: desktop-v${{ env.PKG_VERSION }}
-          name: Desktop v${{ env.PKG_VERSION }}
-          body: "<insert release notes here>"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+      # - name: Create release
+      #   uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09  # v2.8.5
+      #   if: ${{ steps.release-channel.outputs.channel == 'latest' && github.event.inputs.release_type != 'Dry Run' }}
+      #   env:
+      #     PKG_VERSION: ${{ steps.version.outputs.version }}
+      #     RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
+      #   with:
+      #     artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
+      #       apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
+      #       apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
+      #       apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32.appx,
+      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-ia32.nsis.7z,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64-store.appx,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.appx,
+      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-x64.nsis.7z,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64-store.appx,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.appx,
+      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-arm64.nsis.7z,
+      #       apps/desktop/artifacts/bitwarden.${{ env.PKG_VERSION }}.nupkg,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal-mac.zip,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg.blockmap,
+      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive,
+      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}.yml,
+      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-linux.yml,
+      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-mac.yml"
+      #     commit: ${{ github.sha }}
+      #     tag: desktop-v${{ env.PKG_VERSION }}
+      #     name: Desktop v${{ env.PKG_VERSION }}
+      #     body: "<insert release notes here>"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     draft: true
 
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+      # - name: Update deployment status to Success
+      #   if: success()
+      #   uses: chrnorm/deployment-status@v2
+      #   with:
+      #     token: '${{ secrets.GITHUB_TOKEN }}'
+      #     state: 'success'
+      #     deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Update deployment status to Failure
         if: failure()
@@ -195,7 +194,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          deployment-id: 610000065
 
   snap:
     name: Deploy Snap

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -81,8 +81,11 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop - Production ${{ steps.version.outputs.version }}:${{ steps.release-channel.outputs.channel }} (${{ github.ref_name }})'
+          environment: 'Desktop - Production'
+          description: 'Deployment ${{ steps.version.outputs.version }} to channel ${{ steps.release-channel.outputs.channel }} from branch ${{ github.ref_name }}'
+          task: release
       
+
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -89,7 +89,7 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
+          state: 'failure'
           deployment-id: 610000065
 
       # - name: Login to Azure
@@ -188,13 +188,13 @@ jobs:
       #     state: 'success'
       #     deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: 610000065
+      # - name: Update deployment status to Failure
+      #   if: failure()
+      #   uses: chrnorm/deployment-status@v2
+      #   with:
+      #     token: '${{ secrets.GITHUB_TOKEN }}'
+      #     state: 'failure'
+      #     deployment-id: 610000065
 
   snap:
     name: Deploy Snap

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -76,125 +76,125 @@ jobs:
               ;;
           esac
 
-      # - name: Create GitHub deployment
-      #   uses: chrnorm/deployment-action@v2
-      #   id: deployment
-      #   with:
-      #     token: '${{ secrets.GITHUB_TOKEN }}'
-      #     environment: 'Desktop - Production'
-      #     description: 'Deployment ${{ steps.version.outputs.version }} to channel ${{ steps.release-channel.outputs.channel }} from branch ${{ github.ref_name }}'
-      #     task: release
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'Desktop - Production'
+          description: 'Deployment ${{ steps.version.outputs.version }} to channel ${{ steps.release-channel.outputs.channel }} from branch ${{ github.ref_name }}'
+          task: release
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'
-          deployment-id: 610000065
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
-      # - name: Login to Azure
-      #   uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
-      #   with:
-      #     creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+      - name: Login to Azure
+        uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
-      # - name: Retrieve secrets
-      #   id: retrieve-secrets
-      #   uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
-      #   with:
-      #     keyvault: "bitwarden-prod-kv"
-      #     secrets: "aws-electron-access-id, aws-electron-access-key, aws-electron-bucket-name"
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
+        with:
+          keyvault: "bitwarden-prod-kv"
+          secrets: "aws-electron-access-id, aws-electron-access-key, aws-electron-bucket-name"
 
-      # - name: Download all artifacts
-      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-      #   uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
-      #   with:
-      #     workflow: build-desktop.yml
-      #     workflow_conclusion: success
-      #     branch: ${{ github.ref_name }}
-      #     path: apps/desktop/artifacts
+      - name: Download all artifacts
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
+        with:
+          workflow: build-desktop.yml
+          workflow_conclusion: success
+          branch: ${{ github.ref_name }}
+          path: apps/desktop/artifacts
 
-      # - name: Download all artifacts
-      #   if: ${{ github.event.inputs.release_type == 'Dry Run' }}
-      #   uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
-      #   with:
-      #     workflow: build-desktop.yml
-      #     workflow_conclusion: success
-      #     branch: master
-      #     path: apps/desktop/artifacts
+      - name: Download all artifacts
+        if: ${{ github.event.inputs.release_type == 'Dry Run' }}
+        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
+        with:
+          workflow: build-desktop.yml
+          workflow_conclusion: success
+          branch: master
+          path: apps/desktop/artifacts
 
-      # - name: Rename .pkg to .pkg.archive
-      #   env:
-      #     PKG_VERSION: ${{ steps.version.outputs.version }}
-      #   working-directory: apps/desktop/artifacts
-      #   run: mv Bitwarden-${{ env.PKG_VERSION }}-universal.pkg Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive
+      - name: Rename .pkg to .pkg.archive
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        working-directory: apps/desktop/artifacts
+        run: mv Bitwarden-${{ env.PKG_VERSION }}-universal.pkg Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive
 
-      # - name: Publish artifacts to S3
-      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-electron-access-id }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-electron-access-key }}
-      #     AWS_DEFAULT_REGION: 'us-west-2'
-      #     AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.aws-electron-bucket-name }}
-      #   working-directory: apps/desktop/artifacts
-      #   run: |
-      #     aws s3 cp ./ $AWS_S3_BUCKET_NAME/desktop/ \
-      #     --acl "public-read" \
-      #     --recursive \
-      #     --quiet
+      - name: Publish artifacts to S3
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-electron-access-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-electron-access-key }}
+          AWS_DEFAULT_REGION: 'us-west-2'
+          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.aws-electron-bucket-name }}
+        working-directory: apps/desktop/artifacts
+        run: |
+          aws s3 cp ./ $AWS_S3_BUCKET_NAME/desktop/ \
+          --acl "public-read" \
+          --recursive \
+          --quiet
 
-      # - name: Create release
-      #   uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09  # v2.8.5
-      #   if: ${{ steps.release-channel.outputs.channel == 'latest' && github.event.inputs.release_type != 'Dry Run' }}
-      #   env:
-      #     PKG_VERSION: ${{ steps.version.outputs.version }}
-      #     RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
-      #   with:
-      #     artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
-      #       apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
-      #       apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
-      #       apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32.appx,
-      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-ia32.nsis.7z,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64-store.appx,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.appx,
-      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-x64.nsis.7z,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64-store.appx,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.appx,
-      #       apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-arm64.nsis.7z,
-      #       apps/desktop/artifacts/bitwarden.${{ env.PKG_VERSION }}.nupkg,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal-mac.zip,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg.blockmap,
-      #       apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive,
-      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}.yml,
-      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-linux.yml,
-      #       apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-mac.yml"
-      #     commit: ${{ github.sha }}
-      #     tag: desktop-v${{ env.PKG_VERSION }}
-      #     name: Desktop v${{ env.PKG_VERSION }}
-      #     body: "<insert release notes here>"
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     draft: true
+      - name: Create release
+        uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09  # v2.8.5
+        if: ${{ steps.release-channel.outputs.channel == 'latest' && github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
+        with:
+          artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
+            apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
+            apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
+            apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32.appx,
+            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-ia32.nsis.7z,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64-store.appx,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.appx,
+            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-x64.nsis.7z,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64-store.appx,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.appx,
+            apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-arm64.nsis.7z,
+            apps/desktop/artifacts/bitwarden.${{ env.PKG_VERSION }}.nupkg,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal-mac.zip,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.dmg.blockmap,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-universal.pkg.archive,
+            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}.yml,
+            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-linux.yml,
+            apps/desktop/artifacts/${{ env.RELEASE_CHANNEL }}-mac.yml"
+          commit: ${{ github.sha }}
+          tag: desktop-v${{ env.PKG_VERSION }}
+          name: Desktop v${{ env.PKG_VERSION }}
+          body: "<insert release notes here>"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
 
-      # - name: Update deployment status to Success
-      #   if: success()
-      #   uses: chrnorm/deployment-status@v2
-      #   with:
-      #     token: '${{ secrets.GITHUB_TOKEN }}'
-      #     state: 'success'
-      #     deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
-      # - name: Update deployment status to Failure
-      #   if: failure()
-      #   uses: chrnorm/deployment-status@v2
-      #   with:
-      #     token: '${{ secrets.GITHUB_TOKEN }}'
-      #     state: 'failure'
-      #     deployment-id: 610000065
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
   snap:
     name: Deploy Snap

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -76,6 +76,20 @@ jobs:
               ;;
           esac
 
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment: 'Desktop - Production ${{ steps.version.outputs.version }}:${{ steps.release-channel.outputs.channel }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Login to Azure
         uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
         with:
@@ -164,6 +178,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
 
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
   snap:
     name: Deploy Snap
@@ -172,22 +201,7 @@ jobs:
     if: inputs.snap_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
-      _RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
     steps:
-      - name: Create GitHub deployment for Snap
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop Snap - Production ${{ env._PKG_VERSION }}:${{ env._RELEASE_CHANNEL }} (${{ github.ref_name }})'
-      
-      - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
       - name: Checkout Repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
@@ -239,22 +253,6 @@ jobs:
           snapcraft logout
         working-directory: apps/desktop/dist
 
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
   choco:
     name: Deploy Choco
     runs-on: windows-2019
@@ -262,22 +260,7 @@ jobs:
     if: inputs.choco_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
-      _RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
     steps:
-      - name: Create GitHub deployment for Choco
-        uses: chrnorm/deployment-action@v2
-        id: deployment
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop Choco - Production ${{ env._PKG_VERSION }}:${{ env._RELEASE_CHANNEL }} (${{ github.ref_name }})'
-      
-      - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
       - name: Checkout Repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
@@ -334,21 +317,3 @@ jobs:
         shell: pwsh
         run: choco push
         working-directory: apps/desktop/dist
-
-      - name: Update deployment status to Success
-        if: success()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Update deployment status to Failure
-        if: failure()
-        uses: chrnorm/deployment-status@v2
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-          

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -172,13 +172,14 @@ jobs:
     if: inputs.snap_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
+      _RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
     steps:
       - name: Create GitHub deployment for Snap
         uses: chrnorm/deployment-action@v2
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop Snap - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+          environment: 'Desktop Snap - Production ${{ env._PKG_VERSION }}:${{ env._RELEASE_CHANNEL }} (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
@@ -261,13 +262,14 @@ jobs:
     if: inputs.choco_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release-version }}
+      _RELEASE_CHANNEL: ${{ steps.release-channel.outputs.channel }}
     steps:
       - name: Create GitHub deployment for Choco
         uses: chrnorm/deployment-action@v2
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment: 'Desktop Choco - Production ${{ env._PKG_VERSION }} (${{ github.ref_name }})'
+          environment: 'Desktop Choco - Production ${{ env._PKG_VERSION }}:${{ env._RELEASE_CHANNEL }} (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -350,4 +350,5 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
           

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -72,6 +72,22 @@ jobs:
     name: Deploy Web Vault to QA CloudFlare Pages branch
     runs-on: ubuntu-20.04
     steps:
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          environment: 'Web Vault - QA ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Checkout Repo
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
@@ -118,3 +134,22 @@ jobs:
             echo "No changes to commit!";
           fi
         working-directory: deployment
+
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Create GitHub deployment
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -82,7 +82,7 @@ jobs:
           description: 'Deployment from branch ${{ github.ref_name }}'
       
       - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.qa.bitwarden.pw
@@ -138,7 +138,7 @@ jobs:
 
       - name: Update deployment status to Success
         if: success()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.qa.bitwarden.pw
@@ -147,7 +147,7 @@ jobs:
 
       - name: Update deployment status to Failure
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.qa.bitwarden.pw

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -152,4 +152,3 @@ jobs:
           environment-url: http://vault.qa.bitwarden.pw
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-          

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -78,7 +78,8 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.qa.bitwarden.pw
-          environment: 'Web Vault - QA (${{ github.ref_name }})'
+          environment: 'Web Vault - QA'
+          description: 'Deployment from branch ${{ github.ref_name }}'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-qa-web.yml
+++ b/.github/workflows/release-qa-web.yml
@@ -77,14 +77,14 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
-          environment: 'Web Vault - QA ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})'
+          environment-url: http://vault.qa.bitwarden.pw
+          environment: 'Web Vault - QA (${{ github.ref_name }})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
+          environment-url: http://vault.qa.bitwarden.pw
           state: 'in_progress'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -140,7 +140,7 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
+          environment-url: http://vault.qa.bitwarden.pw
           state: 'success'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -149,7 +149,7 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          environment-url: http://vault.bitwarden.com
+          environment-url: http://vault.qa.bitwarden.pw
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
           

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -283,7 +283,7 @@ jobs:
             apps/web/artifacts/web-${{ needs.setup.outputs.release_version }}-selfhosted-open-source.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
-          
+
       - name: Update deployment status to Success
         if: success()
         uses: chrnorm/deployment-status@v2
@@ -301,3 +301,4 @@ jobs:
           environment-url: http://vault.bitwarden.com
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -228,7 +228,7 @@ jobs:
       - cfpages-deploy
     steps:
       - name: Create GitHub deployment
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@1b599fe41a0ef1f95191e7f2eec4743f2d7dfc48
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -238,7 +238,7 @@ jobs:
           task: release
       
       - name: Update deployment status to In Progress
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
@@ -288,7 +288,7 @@ jobs:
 
       - name: Update deployment status to Success
         if: success()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
@@ -297,7 +297,7 @@ jobs:
 
       - name: Update deployment status to Failure
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,9 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: "Web Vault - Production ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})"
+          environment: 'Web Vault - Production'
+          description: 'Deployment ${{ needs.setup.outputs.release_version }} from branch ${{ github.ref_name }}'
+          task: release
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: production
+          environment: 'Web Vault - Production (${GITHUB_REF##*/})'
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2
@@ -301,4 +301,3 @@ jobs:
           environment-url: http://vault.bitwarden.com
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-          

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -227,6 +227,22 @@ jobs:
       - self-host
       - cfpages-deploy
     steps:
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          environment: production
+      
+      - name: Update deployment status to In Progress
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'in_progress'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
       - name: Download latest build artifacts
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
@@ -267,3 +283,21 @@ jobs:
             apps/web/artifacts/web-${{ needs.setup.outputs.release_version }}-selfhosted-open-source.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
+          
+      - name: Update deployment status to Success
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status to Failure
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          environment-url: http://vault.bitwarden.com
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: "Web Vault - Production (${{ github.ref_name##*/ }})"
+          environment: "Web Vault - Production (${{ github.ref_name }})"
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: 'Web Vault - Production (${GITHUB_REF##*/})'
+          environment: "Web Vault - Production (${{ github.ref_name##*/ }})"
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: "Web Vault - Production $${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})"
+          environment: "Web Vault - Production ${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})"
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           environment-url: http://vault.bitwarden.com
-          environment: "Web Vault - Production (${{ github.ref_name }})"
+          environment: "Web Vault - Production $${{ needs.setup.outputs.release_version }} (${{ github.ref_name }})"
       
       - name: Update deployment status to In Progress
         uses: chrnorm/deployment-status@v2


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In order for Jira to track Deployments, our release/deploy YAML jobs needed to call the Deployment and Deployment Status APIs in GitHub.  See [here](https://github.com/atlassian/github-for-jira/blob/main/docs/deployments.md) for documentation.

## Code changes

.github/workflows/release-browser.yml
.github/workflows/release-cli.yml
.github/workflows/release-desktop.yml
.github/workflows/release-qa-web.yml
.github/workflows/release-web.yml

- For all of these files, the changes were to add job steps that will create a Github deployment, then update the deployment status to success or failure.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
```
