### PR TITLE
Fix missing settings button

### DIFF
--- a/apps/browser/src/popup/scss/pages.scss
+++ b/apps/browser/src/popup/scss/pages.scss
@@ -56,7 +56,7 @@ app-home {
     margin-top: 10px;
   }
 
-  a.settings-icon {
+  button.settings-icon {
     position: absolute;
     top: 10px;
     left: 10px;

--- a/apps/desktop/src/scss/environment.scss
+++ b/apps/desktop/src/scss/environment.scss
@@ -25,21 +25,6 @@
     }
   }
 
-  #login-page {
-    .content {
-      a.settings-icon {
-        position: absolute;
-        left: unset;
-        right: 20px;
-
-        span {
-          margin-right: 8px;
-          float: left;
-        }
-      }
-    }
-  }
-
   .vault .header-search {
     -webkit-app-region: drag;
 

--- a/apps/desktop/src/scss/pages.scss
+++ b/apps/desktop/src/scss/pages.scss
@@ -111,33 +111,6 @@
         }
       }
     }
-
-    a.settings-icon {
-      position: absolute;
-      top: 10px;
-      left: 10px;
-
-      @include themify($themes) {
-        color: themed("mutedColor");
-      }
-
-      span {
-        visibility: hidden;
-      }
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
-
-        @include themify($themes) {
-          color: themed("primaryColor");
-        }
-
-        span {
-          visibility: visible;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
With the changes made with https://github.com/bitwarden/clients/pull/2662 the settings button for setting the environment urls disappeared. This brings it back.

Additionally I removed the no longer needed css for the settings button for desktop.

## Code changes

- **apps/browser/src/popup/scss/pages.scss:** Change css to be applied to a <button> instead of a link (<a>)
- **apps/desktop/src/scss/environment.scss:** Removed no longer needed `settings-icon` from css, which was replaced with `environment-urls-settings-icon`
- **apps/desktop/src/scss/pages.scss:** Removed no longer needed `settings-icon` from css, which was replaced with `environment-urls-settings-icon`

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
