### PR TITLE
[SG-485] and [SG-486] Trial Initiation routing and bug fixes

### DIFF
--- a/apps/web/src/app/modules/trial-initiation/billing.component.ts
+++ b/apps/web/src/app/modules/trial-initiation/billing.component.ts
@@ -11,6 +11,7 @@ import { OrganizationService } from "@bitwarden/common/abstractions/organization
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy.service";
 import { SyncService } from "@bitwarden/common/abstractions/sync.service";
+import { ProductType } from "@bitwarden/common/enums/productType";
 
 import { OrganizationPlansComponent } from "src/app/settings/organization-plans.component";
 
@@ -51,10 +52,11 @@ export class BillingComponent extends OrganizationPlansComponent {
   }
 
   async ngOnInit() {
+    const additionalSeats = this.product == ProductType.Families ? 0 : 1;
     this.formGroup.patchValue({
       name: this.orgInfoForm.get("name")?.value,
       billingEmail: this.orgInfoForm.get("email")?.value,
-      additionalSeats: 1,
+      additionalSeats: additionalSeats,
       plan: this.plan,
       product: this.product,
     });

--- a/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts
@@ -34,6 +34,7 @@ export class TrialInitiationComponent implements OnInit {
   accountCreateOnly = true;
   policies: Policy[];
   enforcedPolicyOptions: MasterPasswordPolicyOptions;
+  validOrgs: string[] = ["teams", "enterprise", "families"];
   @ViewChild("stepper", { static: false }) verticalStepper: VerticalStepperComponent;
 
   orgInfoFormGroup = this.formBuilder.group({
@@ -63,17 +64,22 @@ export class TrialInitiationComponent implements OnInit {
         return;
       }
 
-      this.org = qParams.org;
+      if (this.validOrgs.includes(qParams.org)) {
+        this.org = qParams.org;
+      } else {
+        this.org = "families";
+      }
+
       this.orgLabel = this.titleCasePipe.transform(this.org);
       this.accountCreateOnly = false;
 
-      if (qParams.org === "families") {
+      if (this.org === "families") {
         this.plan = PlanType.FamiliesAnnually;
         this.product = ProductType.Families;
-      } else if (qParams.org === "teams") {
+      } else if (this.org === "teams") {
         this.plan = PlanType.TeamsAnnually;
         this.product = ProductType.Teams;
-      } else if (qParams.org === "enterprise") {
+      } else if (this.org === "enterprise") {
         this.plan = PlanType.EnterpriseAnnually;
         this.product = ProductType.Enterprise;
       }

--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -63,10 +63,16 @@ const routes: Routes = [
       { path: "2fa", component: TwoFactorComponent, canActivate: [UnauthGuard] },
       {
         path: "register",
-        component: flagEnabled("showTrial") ? TrialInitiationComponent : RegisterComponent,
+        component: RegisterComponent,
         canActivate: [UnauthGuard],
         data: { titleId: "createAccount" },
       },
+      buildFlaggedRoute("showTrial", {
+        path: "trial",
+        component: TrialInitiationComponent,
+        canActivate: [UnauthGuard],
+        data: { titleId: "startTrial" },
+      }),
       {
         path: "sso",
         component: SsoComponent,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- Allow routing to both Register component and Trial Component to allow Marketing to do a phased rollout of the new trial flow
- Fix bug where if a valid org param isn't passed, no org type is chosen and going through the stepper errors on billing
- Fix a bug where creating a families org in the the stepper throws an error

## Code changes

- **apps/web/src/app/modules/trial-initiation/billing.component.ts:** Set additional seats to 0 is it is a families plan
- **apps/web/src/app/modules/trial-initiation/trial-initiation.component.ts:** Default org selected to families if the param is not a valid one
- **apps/web/src/app/oss-routing.module.ts:** Allow routing to both Register and Trial (but still have Trial feature flagged)

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
