### PR TITLE
Fix Account initialization in Manifest V3

### DIFF
--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -3,7 +3,7 @@
   "minimum_chrome_version": "102.0",
   "name": "__MSG_extName__",
   "short_name": "__MSG_appName__",
-  "version": "2022.05.0",
+  "version": "2022.6.1",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "author": "Bitwarden Inc.",

--- a/apps/browser/src/services/localBackedSessionStorage.service.ts
+++ b/apps/browser/src/services/localBackedSessionStorage.service.ts
@@ -25,11 +25,13 @@ export class LocalBackedSessionStorageService extends AbstractStorageService {
   }
 
   async get<T>(key: string): Promise<T> {
+    const sessionEncKey = await this.getSessionEncKey();
+
     if (this.cache.has(key)) {
       return this.cache.get(key);
     }
 
-    const session = await this.getLocalSession(await this.getSessionEncKey());
+    const session = await this.getLocalSession(sessionEncKey);
     if (session == null || !Object.keys(session).includes(key)) {
       return null;
     }


### PR DESCRIPTION
For unknown reasons this fixes the issues with account initialization. There must be an unawaited promise somewhere that an early cache return was causing issues but delaying with an await fixes them.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
