### PR TITLE
Display Creation Date in Clients

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1311,6 +1311,10 @@
     "message": "Updated",
     "description": "ex. Date this item was updated"
   },
+  "dateCreated": {
+    "message": "Created",
+    "description": "ex. Date this item was created"
+  },
   "datePasswordUpdated": {
     "message": "Password Updated",
     "description": "ex. Date this password was updated"

--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -501,6 +501,10 @@
         <b class="font-weight-semibold">{{ "dateUpdated" | i18n }}:</b>
         {{ cipher.revisionDate | date: "medium" }}
       </div>
+      <div *ngIf="cipher.creationDate">
+        <b class="font-weight-semibold">{{ "dateCreated" | i18n }}:</b>
+        {{ cipher.creationDate | date: "medium" }}
+      </div>
       <div *ngIf="cipher.passwordRevisionDisplayDate">
         <b class="font-weight-semibold">{{ "datePasswordUpdated" | i18n }}:</b>
         {{ cipher.passwordRevisionDisplayDate | date: "medium" }}

--- a/apps/cli/src/models/response/cipherResponse.ts
+++ b/apps/cli/src/models/response/cipherResponse.ts
@@ -11,6 +11,7 @@ export class CipherResponse extends CipherWithIdExport implements BaseResponse {
   object: string;
   attachments: AttachmentResponse[];
   revisionDate: Date;
+  creationDate: Date;
   deletedDate: Date;
   passwordHistory: PasswordHistoryResponse[];
 
@@ -22,6 +23,9 @@ export class CipherResponse extends CipherWithIdExport implements BaseResponse {
       this.attachments = o.attachments.map((a) => new AttachmentResponse(a));
     }
     this.revisionDate = o.revisionDate;
+    if (o.creationDate != null) {
+      this.creationDate = o.creationDate;
+    }
     this.deletedDate = o.deletedDate;
     if (o.passwordHistory != null) {
       this.passwordHistory = o.passwordHistory.map((h) => new PasswordHistoryResponse(h));

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -355,6 +355,10 @@
           <b class="font-weight-semibold">{{ "dateUpdated" | i18n }}:</b>
           {{ cipher.revisionDate | date: "medium" }}
         </div>
+        <div *ngIf="cipher.creationDate">
+          <b class="font-weight-semibold">{{ "dateCreated" | i18n }}:</b>
+          {{ cipher.creationDate | date: "medium" }}
+        </div>
         <div *ngIf="cipher.passwordRevisionDisplayDate">
           <b class="font-weight-semibold">{{ "datePasswordUpdated" | i18n }}:</b>
           {{ cipher.passwordRevisionDisplayDate | date: "medium" }}

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1266,6 +1266,10 @@
     "message": "Updated",
     "description": "ex. Date this item was updated"
   },
+  "dateCreated": {
+    "message": "Created",
+    "description": "ex. Date this item was created"
+  },
   "datePasswordUpdated": {
     "message": "Password Updated",
     "description": "ex. Date this password was updated"

--- a/apps/web/src/app/vault/add-edit.component.html
+++ b/apps/web/src/app/vault/add-edit.component.html
@@ -753,6 +753,10 @@
               <b class="font-weight-semibold">{{ "dateUpdated" | i18n }}:</b>
               {{ cipher.revisionDate | date: "medium" }}
             </div>
+            <div *ngIf="cipher.creationDate">
+              <b class="font-weight-semibold">{{ "dateCreated" | i18n }}:</b>
+              {{ cipher.creationDate | date: "medium" }}
+            </div>
             <div *ngIf="showRevisionDate">
               <b class="font-weight-semibold">{{ "datePasswordUpdated" | i18n }}:</b>
               {{ cipher.passwordRevisionDisplayDate | date: "medium" }}

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3250,6 +3250,10 @@
     "message": "Updated",
     "description": "ex. Date this item was updated"
   },
+  "dateCreated": {
+    "message": "Created",
+    "description": "ex. Date this item was created"
+  },
   "datePasswordUpdated": {
     "message": "Password Updated",
     "description": "ex. Date this password was updated"

--- a/libs/common/spec/domain/cipher.spec.ts
+++ b/libs/common/spec/domain/cipher.spec.ts
@@ -36,6 +36,7 @@ describe("Cipher DTO", () => {
       revisionDate: null,
       collectionIds: undefined,
       localData: null,
+      creationDate: null,
       deletedDate: null,
       reprompt: undefined,
       attachments: null,
@@ -60,6 +61,7 @@ describe("Cipher DTO", () => {
         type: CipherType.Login,
         name: "EncryptedString",
         notes: "EncryptedString",
+        creationDate: null,
         deletedDate: null,
         reprompt: CipherRepromptType.None,
         login: {
@@ -125,6 +127,7 @@ describe("Cipher DTO", () => {
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
         collectionIds: undefined,
         localData: null,
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         login: {
@@ -194,6 +197,7 @@ describe("Cipher DTO", () => {
       cipher.type = CipherType.Login;
       cipher.name = mockEnc("EncryptedString");
       cipher.notes = mockEnc("EncryptedString");
+      cipher.creationDate = null;
       cipher.deletedDate = null;
       cipher.reprompt = CipherRepromptType.None;
 
@@ -224,6 +228,7 @@ describe("Cipher DTO", () => {
         passwordHistory: null,
         collectionIds: undefined,
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         localData: undefined,
@@ -247,6 +252,7 @@ describe("Cipher DTO", () => {
         type: CipherType.SecureNote,
         name: "EncryptedString",
         notes: "EncryptedString",
+        creationDate: null,
         deletedDate: null,
         reprompt: CipherRepromptType.None,
         secureNote: {
@@ -272,6 +278,7 @@ describe("Cipher DTO", () => {
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
         collectionIds: undefined,
         localData: null,
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         secureNote: { type: SecureNoteType.Generic },
@@ -299,6 +306,7 @@ describe("Cipher DTO", () => {
       cipher.type = CipherType.SecureNote;
       cipher.name = mockEnc("EncryptedString");
       cipher.notes = mockEnc("EncryptedString");
+      cipher.creationDate = null;
       cipher.deletedDate = null;
       cipher.reprompt = CipherRepromptType.None;
       cipher.secureNote = new SecureNote();
@@ -323,6 +331,7 @@ describe("Cipher DTO", () => {
         passwordHistory: null,
         collectionIds: undefined,
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         localData: undefined,
@@ -346,6 +355,7 @@ describe("Cipher DTO", () => {
         type: CipherType.Card,
         name: "EncryptedString",
         notes: "EncryptedString",
+        creationDate: null,
         deletedDate: null,
         reprompt: CipherRepromptType.None,
         card: {
@@ -376,6 +386,7 @@ describe("Cipher DTO", () => {
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
         collectionIds: undefined,
         localData: null,
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         card: {
@@ -410,6 +421,7 @@ describe("Cipher DTO", () => {
       cipher.type = CipherType.Card;
       cipher.name = mockEnc("EncryptedString");
       cipher.notes = mockEnc("EncryptedString");
+      cipher.creationDate = null;
       cipher.deletedDate = null;
       cipher.reprompt = CipherRepromptType.None;
 
@@ -440,6 +452,7 @@ describe("Cipher DTO", () => {
         passwordHistory: null,
         collectionIds: undefined,
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         localData: undefined,
@@ -463,6 +476,7 @@ describe("Cipher DTO", () => {
         type: CipherType.Identity,
         name: "EncryptedString",
         notes: "EncryptedString",
+        creationDate: null,
         deletedDate: null,
         reprompt: CipherRepromptType.None,
         identity: {
@@ -505,6 +519,7 @@ describe("Cipher DTO", () => {
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
         collectionIds: undefined,
         localData: null,
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         identity: {
@@ -551,6 +566,7 @@ describe("Cipher DTO", () => {
       cipher.type = CipherType.Identity;
       cipher.name = mockEnc("EncryptedString");
       cipher.notes = mockEnc("EncryptedString");
+      cipher.creationDate = null;
       cipher.deletedDate = null;
       cipher.reprompt = CipherRepromptType.None;
 
@@ -581,6 +597,7 @@ describe("Cipher DTO", () => {
         passwordHistory: null,
         collectionIds: undefined,
         revisionDate: new Date("2022-01-31T12:00:00.000Z"),
+        creationDate: null,
         deletedDate: null,
         reprompt: 0,
         localData: undefined,

--- a/libs/common/src/models/data/cipherData.ts
+++ b/libs/common/src/models/data/cipherData.ts
@@ -30,6 +30,7 @@ export class CipherData {
   attachments?: AttachmentData[];
   passwordHistory?: PasswordHistoryData[];
   collectionIds?: string[];
+  creationDate: string;
   deletedDate: string;
   reprompt: CipherRepromptType;
 
@@ -50,6 +51,7 @@ export class CipherData {
     this.name = response.name;
     this.notes = response.notes;
     this.collectionIds = collectionIds != null ? collectionIds : response.collectionIds;
+    this.creationDate = response.creationDate;
     this.deletedDate = response.deletedDate;
     this.reprompt = response.reprompt;
 

--- a/libs/common/src/models/domain/cipher.ts
+++ b/libs/common/src/models/domain/cipher.ts
@@ -35,6 +35,7 @@ export class Cipher extends Domain {
   fields: Field[];
   passwordHistory: Password[];
   collectionIds: string[];
+  creationDate: Date;
   deletedDate: Date;
   reprompt: CipherRepromptType;
 
@@ -69,6 +70,7 @@ export class Cipher extends Domain {
     this.revisionDate = obj.revisionDate != null ? new Date(obj.revisionDate) : null;
     this.collectionIds = obj.collectionIds;
     this.localData = localData;
+    this.creationDate = obj.creationDate != null ? new Date(obj.creationDate) : null;
     this.deletedDate = obj.deletedDate != null ? new Date(obj.deletedDate) : null;
     this.reprompt = obj.reprompt;
 
@@ -197,6 +199,7 @@ export class Cipher extends Domain {
     c.revisionDate = this.revisionDate != null ? this.revisionDate.toISOString() : null;
     c.type = this.type;
     c.collectionIds = this.collectionIds;
+    c.creationDate = this.creationDate != null ? this.creationDate.toISOString() : null;
     c.deletedDate = this.deletedDate != null ? this.deletedDate.toISOString() : null;
     c.reprompt = this.reprompt;
 

--- a/libs/common/src/models/response/cipherResponse.ts
+++ b/libs/common/src/models/response/cipherResponse.ts
@@ -29,6 +29,7 @@ export class CipherResponse extends BaseResponse {
   attachments: AttachmentResponse[];
   passwordHistory: PasswordHistoryResponse[];
   collectionIds: string[];
+  creationDate: string;
   deletedDate: string;
   reprompt: CipherRepromptType;
 
@@ -50,6 +51,7 @@ export class CipherResponse extends BaseResponse {
     this.organizationUseTotp = this.getResponseProperty("OrganizationUseTotp");
     this.revisionDate = this.getResponseProperty("RevisionDate");
     this.collectionIds = this.getResponseProperty("CollectionIds");
+    this.creationDate = this.getResponseProperty("CreationDate");
     this.deletedDate = this.getResponseProperty("DeletedDate");
 
     const login = this.getResponseProperty("Login");

--- a/libs/common/src/models/view/cipherView.ts
+++ b/libs/common/src/models/view/cipherView.ts
@@ -33,6 +33,7 @@ export class CipherView implements View {
   passwordHistory: PasswordHistoryView[] = null;
   collectionIds: string[] = null;
   revisionDate: Date = null;
+  creationDate: Date = null;
   deletedDate: Date = null;
   reprompt: CipherRepromptType = CipherRepromptType.None;
 
@@ -52,6 +53,7 @@ export class CipherView implements View {
     this.localData = c.localData;
     this.collectionIds = c.collectionIds;
     this.revisionDate = c.revisionDate;
+    this.creationDate = c.creationDate;
     this.deletedDate = c.deletedDate;
     // Old locally stored ciphers might have reprompt == null. If so set it to None.
     this.reprompt = c.reprompt ?? CipherRepromptType.None;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds item creation date to Browser, CLI, Desktop, and Web. All views of creationDate are wrapped with `if` statements so that null data doesn't show if the server hasn't been updated to send the response yet.

Pairs with https://github.com/bitwarden/server/pull/2142.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

For all files, just adding creationDate field.

## Screenshots

CLI:
<img width="575" alt="CLI Output" src="https://user-images.githubusercontent.com/42774874/180910555-520ecf95-f52e-4634-b987-f6f9d01e6ec2.png">

Desktop:
<img width="615" alt="Desktop Output" src="https://user-images.githubusercontent.com/42774874/180910587-35d3d8fe-0698-4090-8e0a-5d786e1a9398.png">

Web:
<img width="780" alt="Web Output" src="https://user-images.githubusercontent.com/42774874/180910613-f03ea82f-e300-4ea4-ab7c-1bd36fce4481.png">

Browser:
~No screenshots, because a commit broke the settings icon.~ This has now been fixed
<img width="430" alt="Browser Output" src="https://user-images.githubusercontent.com/42774874/180915643-435aed32-6eb4-4770-8033-b77b12a34bd4.png">


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [NA] This change has particular **deployment requirements** (notify the DevOps team)
```
