### PR TITLE
[ENG-72] Added Git hooks to populate commit message with Jira issue

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,7 +4,7 @@
 file=$1
 commit_message="$(cat $file)"
 
-if [[ "$commit_message" =~ ([A-Z]{2,}-\d+) ]]
+if [[ "$commit_message" =~ [A-Z]{2,}-\d+ ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,19 +1,21 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-message="$(cat $1)"
-requiredPattern="((?<!([A-Za-z]{1,10})-?)[A-Z]+-\d+)"
-if ! [[ $message =~ $requiredPattern ]];
+# Add git branch if relevant
+parse_git_branch() {
+  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+}
+
+# Extact tracker abbreviation and ticket number (e.g. PS-123)
+parse_git_tracker_and_ticket() {
+  parse_git_branch | grep -e '[A-Z]\+-[0-9]\+' -o
+}
+
+MESSAGE="$(cat $1)"
+TICKET=`parse_git_tracker_and_ticket`
+
+if [ -n "$TICKET" ]
 then
-  echo "-"
-  echo "-"
-  echo "-"
-  echo "The commit message must contain a JIRA issue identifier in the format XXX-9999"
-  echo "-"
-  echo "Your commit message was:"
-  echo $message
-  echo "-"
-  echo "For more information, check script in .husky/commit-msg"
-  echo "-"
-  exit 1
+   echo "New commit message: [$TICKET] $MESSAGE"
+   echo "[$TICKET] $MESSAGE" > $1
 fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,19 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+message="$(cat $1)"
+requiredPattern="((?<!([A-Za-z]{1,10})-?)[A-Z]+-\d+)"
+if ! [[ $message =~ $requiredPattern ]];
+then
+  echo "-"
+  echo "-"
+  echo "-"
+  echo "The commit message must contain a JIRA issue identifier in the format XXX-9999"
+  echo "-"
+  echo "Your commit message was:"
+  echo $message
+  echo "-"
+  echo "For more information, check script in .husky/commit-msg"
+  echo "-"
+  exit 1
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,11 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-issue_pattern='([A-Z]{2,}-\d+)'
 file=$1
 commit_message="$(cat $file)"
 
-if [[ "$commit_message" =~ $issue_pattern ]]
+if [[ "$commit_message" =~ ([A-Z]{2,}-\d+) ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -8,7 +8,7 @@ if [[ $commit_message =~ [A-Z]{2,}-\d+ ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else
-  # If the commit message doesn't have the issue, let's check the branch.
+  # If the commit message does not have the issue, let's check the branch.
   # This is the same logic as the prepare-commit-msg hook, but this handles the case where the user discarded the suggestion or accidentally overwrote it.
   echo "Commit message '$commit_message' does not have a Jira issue in it.  Checking the branch..."
  

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -25,6 +25,7 @@ else
     echo >&2 "ERROR: Commit message '$commit_message' is missing Jira identifier and it cannot be inferred from the current branch."
     exit 1
   else
+    echo "Modified commit message to include '$issue_identifier'."
     echo "$issue_identifier $commit_message" > $file
   fi
 fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,32 +1,30 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-issue_pattern="[A-Z]{2,}-\d+"
+issue_pattern='([A-Z]{2,}-\d+)'
+file=$1
+commit_message="$(cat $file)"
 
-# If the commit message doesn't have the issue, let's check the branch
-if [ "" != "$(grep $issue_pattern "$1")" ]
+if [[ "$issue_pattern" =~ "$commit_message" ]]
 then
-  # Get the current git branch if we're in a git repo (see http://kenglish.co/add-jira-issue-number-to-git-commit-message/)
-  parse_git_branch() {
-    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
-  }
-
-  # Parse issue identifier in XXX-9999 format from branch (e.g. PS-123)
-  parse_issue_identifier() {
-    parse_git_branch | grep -e $issue_pattern -o
-  }
-
-  current_message="$(cat $1)"
-  issue_identifier=$(parse_issue_identifier)
-
-  if [ -n "$issue_identifier" ]
-  then
-    echo "New commit message: [$issue_identifier] $current_message"
-    echo "[$issue_identifier] $current_message" > $1
-  else
-    echo >&2 "ERROR: Commit message is missing Jira identifier and it cannot be inferred from the current branch."
-    exit 1
-  fi
+  echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else
-  echo "Commit message contains Jira issue identifier."
+  # If the commit message doesn't have the issue, let's check the branch.
+  # This is the same logic as the prepare-commit-msg hook, but this handles the case where the user discarded the suggestion or accidentally overwrote it.
+  echo "Commit message '$commit_message' does not have a Jira issue in it.  Checking the branch..."
+ 
+  # Use git rev-parse to find the current branch and send the full branch through grep to parse out the Jira identifier
+  issue_identifier=[$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+/)?(\w+[-_])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")]
+
+  echo "Found issue identifier '$issue_identifier' from current branch."
+
+  # If there was no identifier found in the branch, exit with an error.
+  # If there was an identifier found in the branch, add it to the message.
+  if [[ $issue_identifier == "[]" ]];
+  then
+    echo >&2 "ERROR: Commit message '$commit_message' is missing Jira identifier and it cannot be inferred from the current branch."
+    exit 1
+  else
+    echo "$issue_identifier $commit_message" > $file
+  fi
 fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,7 +4,7 @@
 file=$1
 commit_message="$(cat $file)"
 
-if [[ $commit_message =~ [A-Z]{2,}-\d+ ]]
+if [[ $commit_message =~ ([A-Z][A-Z0-9]+-[0-9]+) ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,21 +1,32 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Add git branch if relevant
-parse_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
-}
+issue_pattern="[A-Z]{2,}-\d+"
 
-# Extact tracker abbreviation and ticket number (e.g. PS-123)
-parse_git_tracker_and_ticket() {
-  parse_git_branch | grep -e '[A-Z]\+-[0-9]\+' -o
-}
-
-MESSAGE="$(cat $1)"
-TICKET=`parse_git_tracker_and_ticket`
-
-if [ -n "$TICKET" ]
+# If the commit message doesn't have the issue, let's check the branch
+if [ "" != "$(grep $issue_pattern "$1")" ]
 then
-   echo "New commit message: [$TICKET] $MESSAGE"
-   echo "[$TICKET] $MESSAGE" > $1
+  # Get the current git branch if we're in a git repo (see http://kenglish.co/add-jira-issue-number-to-git-commit-message/)
+  parse_git_branch() {
+    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+  }
+
+  # Parse issue identifier in XXX-9999 format from branch (e.g. PS-123)
+  parse_issue_identifier() {
+    parse_git_branch | grep -e $issue_pattern -o
+  }
+
+  current_message="$(cat $1)"
+  issue_identifier=$(parse_issue_identifier)
+
+  if [ -n "$issue_identifier" ]
+  then
+    echo "New commit message: [$issue_identifier] $current_message"
+    echo "[$issue_identifier] $current_message" > $1
+  else
+    echo >&2 "ERROR: Commit message is missing Jira identifier and it cannot be inferred from the current branch."
+    exit 1
+  fi
+else
+  echo "Commit message contains Jira issue identifier."
 fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,7 +4,7 @@
 file=$1
 commit_message="$(cat $file)"
 
-if [[ "$commit_message" =~ [A-Z]{2,}-\d+ ]]
+if [[ $commit_message =~ [A-Z]{2,}-\d+ ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -20,8 +20,7 @@ else
   # If there was an identifier found in the branch, add it to the message.
   if [[ $issue_identifier == "[]" ]];
   then
-    echo >&2 "ERROR: Commit message '$commit_message' is missing Jira identifier and it cannot be inferred from the current branch."
-    exit 1
+    echo "  WARNING: Commit message '$commit_message' is missing Jira identifier and it cannot be inferred from the current branch."
   else
     echo "Found issue identifier '$issue_identifier' from current branch."
     echo "Modified commit message to include '$issue_identifier'."

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -16,8 +16,6 @@ else
   # Use git rev-parse to find the current branch and send the full branch through grep to parse out the Jira identifier
   issue_identifier=[$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+/)?(\w+[-_])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")]
 
-  echo "Found issue identifier '$issue_identifier' from current branch."
-
   # If there was no identifier found in the branch, exit with an error.
   # If there was an identifier found in the branch, add it to the message.
   if [[ $issue_identifier == "[]" ]];
@@ -25,6 +23,7 @@ else
     echo >&2 "ERROR: Commit message '$commit_message' is missing Jira identifier and it cannot be inferred from the current branch."
     exit 1
   else
+    echo "Found issue identifier '$issue_identifier' from current branch."
     echo "Modified commit message to include '$issue_identifier'."
     echo "$issue_identifier $commit_message" > $file
   fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,7 +5,7 @@ issue_pattern='([A-Z]{2,}-\d+)'
 file=$1
 commit_message="$(cat $file)"
 
-if [[ "$issue_pattern" =~ "$commit_message" ]]
+if [[ "$commit_message" =~ $issue_pattern ]]
 then
   echo "Commit message '$commit_message' has a Jira issue in it. No changes needed."
 else

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,20 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# See https://betterprogramming.pub/how-to-automatically-add-the-ticket-number-in-git-commit-message-bda5426ded05 for implementation details
+
+# The input is a file containing the commit message
+file=$1
+commit_message=$(cat $file)
+
+# Use git rev-parse to find the current branch and send the full branch through grep to parse out the Jira identifier
+issue_identifier=[$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+/)?(\w+[-_])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")]
+
+# If there was no identifier found, or the message already contains it, exit
+if [[ $issue_identifier == "[]" || "$commit_message" == "$issue_identifier"* ]];
+then
+  exit 0;
+fi
+
+# Otherwise, add the ticket to the existing message and send it back to the file
+echo "$issue_identifier $commit_message" > $file

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -16,5 +16,5 @@ then
   exit 0;
 fi
 
-# Otherwise, add the ticket to the existing message and send it back to the file
+# Otherwise, add the ticket to the existing message and send it back to the file.
 echo "$issue_identifier $commit_message" > $file

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -3,7 +3,7 @@
 
 # See https://betterprogramming.pub/how-to-automatically-add-the-ticket-number-in-git-commit-message-bda5426ded05 for implementation details
 
-# The input is a file containing the commit message
+# The input is a file containing the commit message.
 file=$1
 commit_message=$(cat $file)
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

In order to tie Jira issues to code deployments, each commit message must have the Jira identifier in it.  To prevent developers from having to type the issue in each commit, this PR added Git hooks through Husky to try to pre-populate the commit message with the issue identifier if it can be found in the branch name.

## Code changes

- **prepare-commit-msg** Added logic to check for a Jira issue identifier in the message.  If no identifier is there, check for one in the branch name.  If there is one in the branch name, prepend it to the message that is presented to the user when doing the commit.

- **commit-msg** Added logic to check for a Jira issue identifier in the message.  If no identifier is there, do the same logic as the prepare-commit-msg hook, to try to infer it from the branch name.  The check is replicated here in case the user deleted the pre-populated value or is using VS Code, where the prepare-commit-msg hook doesn't fill in the message in the UI.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
