### PR TITLE
Don't allow updateState to set state to null

### DIFF
--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2674,10 +2674,9 @@ export class StateService<
   protected async clearDecryptedDataForActiveUser(): Promise<void> {
     await this.updateState(async (state) => {
       const userId = state?.activeUserId;
-      if (userId == null || state?.accounts[userId]?.data == null) {
-        return;
+      if (userId != null && state?.accounts[userId]?.data != null) {
+        state.accounts[userId].data = new AccountData();
       }
-      state.accounts[userId].data = new AccountData();
 
       return state;
     });
@@ -2756,6 +2755,9 @@ export class StateService<
   ) {
     await this.state().then(async (state) => {
       const updatedState = await stateUpdater(state);
+      if (updatedState == null) {
+        throw new Error("Attempted to update state to null value");
+      }
 
       await this.setState(updatedState);
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When logging in to CLI with a username and password, I receive:

```
webpack-internal:///../../libs/common/src/services/state.service.ts:2000
                userId: state.activeUserId,
                              ^

TypeError: Cannot read properties of null (reading 'activeUserId')
    at StateService.eval (webpack-internal:///../../libs/common/src/services/state.service.ts:2000:31)
    at Generator.next (<anonymous>)
    at fulfilled (webpack-internal:///../../libs/common/src/services/state.service.ts:41:58)
```

This is because a callback (`stateUpdater`) passed to the `updateState` method was returning null, so it was setting the state to null, and this error was thrown the next time we tried to check something on the state.

**This will be picked to rc**

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/services/state.service.ts**
  - Change the problematic `stateUpdater` callback to always return a state
  - add an explicit null check and throw if the state is set to null, otherwise null propagation can make this very difficult to debug. I'm not aware of any situation where we'd want to use `stateUpdater` to null out the state entirely, and it's not a current use case in the code.

Honestly I would've thought the function signature on `updateState` would've prevented this from happening, but the TS type system can be a bit loose sometimes.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
