### PR TITLE
[PS-1162] Preventing escape from closing popup when vault selector is open

### DIFF
--- a/apps/browser/src/popup/vault/vault-select.component.ts
+++ b/apps/browser/src/popup/vault/vault-select.component.ts
@@ -11,6 +11,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  HostListener,
 } from "@angular/core";
 import { merge } from "rxjs";
 
@@ -86,6 +87,14 @@ export class VaultSelectComponent implements OnInit {
     private viewContainerRef: ViewContainerRef,
     private platformUtilsService: PlatformUtilsService
   ) {}
+
+  @HostListener("document:keydown", ["$event"])
+  handleKeyboardEvent(event: KeyboardEvent) {
+    if (event.key == "Escape" && this.isOpen) {
+      event.preventDefault();
+      this.close();
+    }
+  }
 
   async ngOnInit() {
     await this.load();

--- a/apps/browser/src/popup/vault/vault-select.component.ts
+++ b/apps/browser/src/popup/vault/vault-select.component.ts
@@ -88,9 +88,9 @@ export class VaultSelectComponent implements OnInit {
     private platformUtilsService: PlatformUtilsService
   ) {}
 
-  @HostListener("document:keydown", ["$event"])
+  @HostListener("document:keydown.escape", ["$event"])
   handleKeyboardEvent(event: KeyboardEvent) {
-    if (event.key == "Escape" && this.isOpen) {
+    if (this.isOpen) {
       event.preventDefault();
       this.close();
     }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Currently when the vault selector is open and Escape key is pressed. The whole browser extension popup is closed. It should close the selector on this case.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **vault-select.component.ts:** Added listener to prevent escape from closing the extension popup

## Before you submit

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
