### PR TITLE
[PS-1152] CLI serve forbid browser requests

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,7 +35,8 @@
     "publish:npm": "npm run build:prod && npm publish --access public",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:watch:all": "jest --watchAll"
+    "test:watch:all": "jest --watchAll",
+    "nothing": "echo 'Nothing to do'"
   },
   "bin": {
     "bw": "build/bw.js"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,8 +35,7 @@
     "publish:npm": "npm run build:prod && npm publish --access public",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:watch:all": "jest --watchAll",
-    "nothing": "echo 'Nothing to do'"
+    "test:watch:all": "jest --watchAll"
   },
   "bin": {
     "bw": "build/bw.js"

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -476,6 +476,10 @@ export class Program extends BaseProgram {
         .description("Start a RESTful API webserver.")
         .option("--hostname <hostname>", "The hostname to bind your API webserver to.")
         .option("--port <port>", "The port to run your API webserver on.")
+        .option(
+          "--disable-origin-protection",
+          "If set, allows requests with origin header. Not recommended!"
+        )
         .on("--help", () => {
           writeLn("\n  Notes:");
           writeLn("");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Blocks requests that are coming from browser by blocking any request with an `Origin`. Optionally allow users to allow requests with an `origin` header.

Note, a list of allowed origins is not acceptable here since origin can be changed in extensions.

## Code changes

- **serve.command.ts**: Insert koa middleware which responds with 403 if origin protection is enabled.
- **program.ts**: Add option to disable origin protection.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
