### PR TITLE
Fix non-enterprise users being able to access scim

### DIFF
--- a/libs/common/src/models/domain/organization.ts
+++ b/libs/common/src/models/domain/organization.ts
@@ -176,7 +176,7 @@ export class Organization {
   }
 
   get canManageScim() {
-    return this.isAdmin || this.permissions.manageScim;
+    return (this.isAdmin || this.permissions.manageScim) && this.useScim;
   }
 
   get canManagePolicies() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bug where non-enterprise owners and admins can access the Manage SCIM page.

**This will be picked to `hotfix-rc-scim`**

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/models/domain/organization.ts** - add `useScim` to the `canManageScim` checks, which makes sure that the organization has SCIM enabled. This is not the current pattern for this class, but logically you cannot manage it for your org if the org does not have it enabled. I will create a tech debt ticket to review this and refactor permission handling.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
