### PR TITLE
[EC-381] Transition settings service into providing observables

### DIFF
--- a/libs/common/spec/services/settings.service.spec.ts
+++ b/libs/common/spec/services/settings.service.spec.ts
@@ -1,0 +1,55 @@
+import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+
+import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
+import { ContainerService } from "@bitwarden/common/services/container.service";
+import { SettingsService } from "@bitwarden/common/services/settings.service";
+import { StateService } from "@bitwarden/common/services/state.service";
+
+describe("SettingsService", () => {
+  let settingsService: SettingsService;
+
+  let cryptoService: SubstituteOf<CryptoService>;
+  let stateService: SubstituteOf<StateService>;
+  let activeAccount: BehaviorSubject<string>;
+  let activeAccountUnlocked: BehaviorSubject<boolean>;
+
+  beforeEach(() => {
+    cryptoService = Substitute.for();
+    stateService = Substitute.for();
+    activeAccount = new BehaviorSubject("123");
+    activeAccountUnlocked = new BehaviorSubject(true);
+
+    stateService.getSettings().resolves({ equivalentDomains: "test" });
+    stateService.activeAccount.returns(activeAccount);
+    stateService.activeAccountUnlocked.returns(activeAccountUnlocked);
+    (window as any).bitwardenContainerService = new ContainerService(cryptoService);
+
+    settingsService = new SettingsService(stateService);
+  });
+
+  it("getEquivalentDomains", async () => {
+    const result = await settingsService.getEquivalentDomains();
+
+    expect(result).toEqual("test");
+    expect(await firstValueFrom(settingsService.settings$)).toEqual({ equivalentDomains: "test" });
+  });
+
+  it("setEquivalentDomains", async () => {
+    await settingsService.setEquivalentDomains([["test2"]]);
+
+    stateService.received(1).setSettings(Arg.any());
+
+    expect(await firstValueFrom(settingsService.settings$)).toEqual({
+      equivalentDomains: [["test2"]],
+    });
+  });
+
+  it("clear", async () => {
+    await settingsService.clear();
+
+    stateService.received(1).setSettings(Arg.any(), Arg.any());
+
+    expect((await firstValueFrom(settingsService.settings$)).length).toBe(0);
+  });
+});

--- a/libs/common/src/abstractions/settings.service.ts
+++ b/libs/common/src/abstractions/settings.service.ts
@@ -1,4 +1,10 @@
+import { Observable } from "rxjs";
+
+import { AccountSettings } from "../models/domain/account";
+
 export abstract class SettingsService {
+  settings$: Observable<AccountSettings[]>;
+
   getEquivalentDomains: () => Promise<any>;
   setEquivalentDomains: (equivalentDomains: string[][]) => Promise<any>;
   clear: (userId?: string) => Promise<void>;

--- a/libs/common/src/abstractions/settings.service.ts
+++ b/libs/common/src/abstractions/settings.service.ts
@@ -1,5 +1,4 @@
 export abstract class SettingsService {
-  clearCache: () => Promise<void>;
   getEquivalentDomains: () => Promise<any>;
   setEquivalentDomains: (equivalentDomains: string[][]) => Promise<any>;
   clear: (userId?: string) => Promise<void>;

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -291,7 +291,13 @@ export abstract class StateService<T extends Account = Account> {
   setRememberedEmail: (value: string, options?: StorageOptions) => Promise<void>;
   getSecurityStamp: (options?: StorageOptions) => Promise<string>;
   setSecurityStamp: (value: string, options?: StorageOptions) => Promise<void>;
+  /**
+   * @deprecated Do not call this directly, use SettingsService
+   */
   getSettings: (options?: StorageOptions) => Promise<any>;
+  /**
+   * @deprecated Do not call this directly, use SettingsService
+   */
   setSettings: (value: string, options?: StorageOptions) => Promise<void>;
   getSsoCodeVerifier: (options?: StorageOptions) => Promise<string>;
   setSsoCodeVerifier: (value: string, options?: StorageOptions) => Promise<void>;

--- a/libs/common/src/services/settings.service.ts
+++ b/libs/common/src/services/settings.service.ts
@@ -9,10 +9,6 @@ const Keys = {
 export class SettingsService implements SettingsServiceAbstraction {
   constructor(private stateService: StateService) {}
 
-  async clearCache(): Promise<void> {
-    await this.stateService.setSettings(null);
-  }
-
   getEquivalentDomains(): Promise<any> {
     return this.getSettingsKey(Keys.equivalentDomains);
   }

--- a/libs/common/src/services/settings.service.ts
+++ b/libs/common/src/services/settings.service.ts
@@ -48,7 +48,7 @@ export class SettingsService implements SettingsServiceAbstraction {
   // Helpers
 
   private async getSettings(): Promise<any> {
-    const settings = await this._settings.getValue();
+    const settings = this._settings.getValue();
     if (settings == null) {
       // eslint-disable-next-line
       const userId = await this.stateService.getUserId();

--- a/libs/common/src/services/settings.service.ts
+++ b/libs/common/src/services/settings.service.ts
@@ -41,7 +41,10 @@ export class SettingsService implements SettingsServiceAbstraction {
   }
 
   async clear(userId?: string): Promise<void> {
-    this._settings.next([]);
+    if (userId == null || userId == (await this.stateService.getUserId())) {
+      this._settings.next([]);
+    }
+
     await this.stateService.setSettings(null, { userId: userId });
   }
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Update Settings Service to provide observable list to get/set data and add unit tests for all methods.

## Code changes

- **libs/common/spec/services/settings.service.spec.ts:** Added unit tests for all methods in settings service.
- **libs/common/src/abstractions/settings.service.ts:** Added Observable settings and deleted unused "clearCache" method.
- **libs/common/src/abstractions/state.service.ts:** Marked getSettings and setSettings methods as deprecated.
- **libs/common/src/services/settings.service.ts:** Added Observable settings and deleted unused "clearCache" method.

## Before you submit

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
