### PR TITLE
Fix active account and searchBar observables/subscriptions

### DIFF
--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -56,7 +56,7 @@ export class AppComponent implements OnInit, OnDestroy {
     // Clear them aggressively to make sure this doesn't occur
     await this.clearComponentStates();
 
-    this.stateService.activeAccount.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
+    this.stateService.activeAccount$.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
       this.activeUserId = userId;
     });
 

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -84,7 +84,7 @@ export class AppComponent implements OnInit, OnDestroy {
               });
             }
 
-            if (this.stateService.activeAccount.getValue() == null) {
+            if (this.activeUserId === null) {
               this.router.navigate(["home"]);
             }
           });

--- a/apps/desktop/src/app/accounts/lock.component.ts
+++ b/apps/desktop/src/app/accounts/lock.component.ts
@@ -1,4 +1,4 @@
-import { Component, NgZone, OnDestroy } from "@angular/core";
+import { Component, NgZone } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ipcRenderer } from "electron";
 
@@ -22,7 +22,7 @@ const BroadcasterSubscriptionId = "LockComponent";
   selector: "app-lock",
   templateUrl: "lock.component.html",
 })
-export class LockComponent extends BaseLockComponent implements OnDestroy {
+export class LockComponent extends BaseLockComponent {
   private deferFocus: boolean = null;
   authenicatedUrl = "vault";
   unAuthenicatedUrl = "update-temp-password";
@@ -103,6 +103,7 @@ export class LockComponent extends BaseLockComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
+    super.ngOnDestroy();
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }
 

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   NgZone,
+  OnDestroy,
   OnInit,
   SecurityContext,
   Type,
@@ -77,7 +78,7 @@ const systemTimeoutOptions = {
     </div>
   `,
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
   @ViewChild("settings", { read: ViewContainerRef, static: true }) settingsRef: ViewContainerRef;
   @ViewChild("premium", { read: ViewContainerRef, static: true }) premiumRef: ViewContainerRef;
   @ViewChild("passwordHistory", { read: ViewContainerRef, static: true })

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -130,7 +130,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.stateService.activeAccount.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
+    this.stateService.activeAccount$.pipe(takeUntil(this.destroy$)).subscribe((userId) => {
       this.activeUserId = userId;
     });
 

--- a/apps/desktop/src/app/layout/search/search-bar.service.ts
+++ b/apps/desktop/src/app/layout/search/search-bar.service.ts
@@ -8,7 +8,8 @@ export type SearchBarState = {
 
 @Injectable()
 export class SearchBarService {
-  searchText = new BehaviorSubject<string>(null);
+  private searchTextSubject = new BehaviorSubject<string>(null);
+  searchText = this.searchTextSubject.asObservable();
 
   private _state = {
     enabled: false,
@@ -16,7 +17,8 @@ export class SearchBarService {
   };
 
   // tslint:disable-next-line:member-ordering
-  state = new BehaviorSubject<SearchBarState>(this._state);
+  private stateSubject = new BehaviorSubject<SearchBarState>(this._state);
+  state = this.stateSubject.asObservable();
 
   setEnabled(enabled: boolean) {
     this._state.enabled = enabled;
@@ -29,10 +31,10 @@ export class SearchBarService {
   }
 
   setSearchText(value: string) {
-    this.searchText.next(value);
+    this.searchTextSubject.next(value);
   }
 
   private updateState() {
-    this.state.next(this._state);
+    this.stateSubject.next(this._state);
   }
 }

--- a/apps/desktop/src/app/layout/search/search-bar.service.ts
+++ b/apps/desktop/src/app/layout/search/search-bar.service.ts
@@ -9,7 +9,7 @@ export type SearchBarState = {
 @Injectable()
 export class SearchBarService {
   private searchTextSubject = new BehaviorSubject<string>(null);
-  searchText = this.searchTextSubject.asObservable();
+  searchText$ = this.searchTextSubject.asObservable();
 
   private _state = {
     enabled: false,
@@ -18,7 +18,7 @@ export class SearchBarService {
 
   // tslint:disable-next-line:member-ordering
   private stateSubject = new BehaviorSubject<SearchBarState>(this._state);
-  state = this.stateSubject.asObservable();
+  state$ = this.stateSubject.asObservable();
 
   setEnabled(enabled: boolean) {
     this._state.enabled = enabled;

--- a/apps/desktop/src/app/layout/search/search-bar.service.ts
+++ b/apps/desktop/src/app/layout/search/search-bar.service.ts
@@ -16,7 +16,6 @@ export class SearchBarService {
     placeholderText: "",
   };
 
-  // tslint:disable-next-line:member-ordering
   private stateSubject = new BehaviorSubject<SearchBarState>(this._state);
   state$ = this.stateSubject.asObservable();
 

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -17,7 +17,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   private activeAccountSubscription: Subscription;
 
   constructor(private searchBarService: SearchBarService, private stateService: StateService) {
-    this.searchBarService.state.subscribe((state) => {
+    this.searchBarService.state$.subscribe((state) => {
       this.state = state;
     });
 
@@ -27,7 +27,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.activeAccountSubscription = this.stateService.activeAccount.subscribe((value) => {
+    this.activeAccountSubscription = this.stateService.activeAccount$.subscribe((value) => {
       this.searchBarService.setSearchText("");
       this.searchText.patchValue("");
     });

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { UntypedFormControl } from "@angular/forms";
+import { Subscription } from "rxjs";
 
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 
@@ -13,6 +14,8 @@ export class SearchComponent implements OnInit, OnDestroy {
   state: SearchBarState;
   searchText: UntypedFormControl = new UntypedFormControl(null);
 
+  private activeAccountSubscription: Subscription;
+
   constructor(private searchBarService: SearchBarService, private stateService: StateService) {
     this.searchBarService.state.subscribe((state) => {
       this.state = state;
@@ -24,13 +27,13 @@ export class SearchComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.stateService.activeAccount.subscribe((value) => {
+    this.activeAccountSubscription = this.stateService.activeAccount.subscribe((value) => {
       this.searchBarService.setSearchText("");
       this.searchText.patchValue("");
     });
   }
 
   ngOnDestroy() {
-    this.stateService.activeAccount.unsubscribe();
+    this.activeAccountSubscription.unsubscribe();
   }
 }

--- a/apps/desktop/src/app/send/send.component.ts
+++ b/apps/desktop/src/app/send/send.component.ts
@@ -56,7 +56,7 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
       policyService,
       logService
     );
-    this.searchBarService.searchText.subscribe((searchText) => {
+    this.searchBarService.searchText$.subscribe((searchText) => {
       this.searchText = searchText;
       this.searchTextChanged();
     });

--- a/apps/desktop/src/app/vault/ciphers.component.ts
+++ b/apps/desktop/src/app/vault/ciphers.component.ts
@@ -14,7 +14,7 @@ export class CiphersComponent extends BaseCiphersComponent {
   constructor(searchService: SearchService, searchBarService: SearchBarService) {
     super(searchService);
 
-    searchBarService.searchText.subscribe((searchText) => {
+    searchBarService.searchText$.subscribe((searchText) => {
       this.searchText = searchText;
       this.search(200);
     });

--- a/libs/angular/src/components/lock.component.ts
+++ b/libs/angular/src/components/lock.component.ts
@@ -60,7 +60,7 @@ export class LockComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     // Load the first and observe updates
     await this.load();
-    this.activeAccountSubscription = this.stateService.activeAccount.subscribe(async () => {
+    this.activeAccountSubscription = this.stateService.activeAccount$.subscribe(async () => {
       await this.load();
     });
   }

--- a/libs/angular/src/components/lock.component.ts
+++ b/libs/angular/src/components/lock.component.ts
@@ -1,5 +1,6 @@
-import { Directive, NgZone, OnInit } from "@angular/core";
+import { Directive, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
+import { Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -20,7 +21,7 @@ import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetricCry
 import { SecretVerificationRequest } from "@bitwarden/common/models/request/secretVerificationRequest";
 
 @Directive()
-export class LockComponent implements OnInit {
+export class LockComponent implements OnInit, OnDestroy {
   masterPassword = "";
   pin = "";
   showPassword = false;
@@ -38,6 +39,8 @@ export class LockComponent implements OnInit {
 
   private invalidPinAttempts = 0;
   private pinSet: [boolean, boolean];
+
+  private activeAccountSubscription: Subscription;
 
   constructor(
     protected router: Router,
@@ -57,9 +60,13 @@ export class LockComponent implements OnInit {
   async ngOnInit() {
     // Load the first and observe updates
     await this.load();
-    this.stateService.activeAccount.subscribe(async () => {
+    this.activeAccountSubscription = this.stateService.activeAccount.subscribe(async () => {
       await this.load();
     });
+  }
+
+  ngOnDestroy() {
+    this.activeAccountSubscription.unsubscribe();
   }
 
   async submit() {

--- a/libs/common/spec/services/folder.service.spec.ts
+++ b/libs/common/spec/services/folder.service.spec.ts
@@ -32,7 +32,7 @@ describe("Folder Service", () => {
     stateService.getEncryptedFolders().resolves({
       "1": folderData("1", "test"),
     });
-    stateService.activeAccount.returns(activeAccount);
+    stateService.activeAccount$.returns(activeAccount);
     stateService.activeAccountUnlocked.returns(activeAccountUnlocked);
     (window as any).bitwardenContainerService = new ContainerService(cryptoService);
 

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -26,7 +26,7 @@ import { SendView } from "../models/view/sendView";
 
 export abstract class StateService<T extends Account = Account> {
   accounts: BehaviorSubject<{ [userId: string]: T }>;
-  activeAccount: Observable<string>;
+  activeAccount$: Observable<string>;
 
   activeAccountUnlocked: Observable<boolean>;
 

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -26,7 +26,7 @@ import { SendView } from "../models/view/sendView";
 
 export abstract class StateService<T extends Account = Account> {
   accounts: BehaviorSubject<{ [userId: string]: T }>;
-  activeAccount: BehaviorSubject<string>;
+  activeAccount: Observable<string>;
 
   activeAccountUnlocked: Observable<boolean>;
 

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -27,8 +27,7 @@ import { SendView } from "../models/view/sendView";
 export abstract class StateService<T extends Account = Account> {
   accounts: BehaviorSubject<{ [userId: string]: T }>;
   activeAccount$: Observable<string>;
-
-  activeAccountUnlocked: Observable<boolean>;
+  activeAccountUnlocked$: Observable<boolean>;
 
   addAccount: (account: T) => Promise<void>;
   setActiveUser: (userId: string) => Promise<void>;

--- a/libs/common/src/services/environment.service.ts
+++ b/libs/common/src/services/environment.service.ts
@@ -22,7 +22,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
   private scimUrl: string = null;
 
   constructor(private stateService: StateService) {
-    this.stateService.activeAccount.subscribe(async () => {
+    this.stateService.activeAccount$.subscribe(async () => {
       await this.setUrlsFromStorage();
     });
   }

--- a/libs/common/src/services/folder/folder.service.ts
+++ b/libs/common/src/services/folder/folder.service.ts
@@ -25,7 +25,7 @@ export class FolderService implements InternalFolderServiceAbstraction {
     private cipherService: CipherService,
     private stateService: StateService
   ) {
-    this.stateService.activeAccountUnlocked.subscribe(async (unlocked) => {
+    this.stateService.activeAccountUnlocked$.subscribe(async (unlocked) => {
       if ((Utils.global as any).bitwardenContainerService == null) {
         return;
       }

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -56,8 +56,10 @@ export class StateService<
 {
   accounts = new BehaviorSubject<{ [userId: string]: TAccount }>({});
   private activeAccountSubject = new BehaviorSubject<string>(null);
-  activeAccountUnlocked = new BehaviorSubject<boolean>(false);
   activeAccount$ = this.activeAccountSubject.asObservable();
+
+  private activeAccountUnlockedSubject = new BehaviorSubject<boolean>(false);
+  activeAccountUnlocked$ = this.activeAccountUnlockedSubject.asObservable();
 
   private hasBeenInited = false;
   private isRecoveredSession = false;
@@ -75,16 +77,16 @@ export class StateService<
   ) {
     // If the account gets changed, verify the new account is unlocked
     this.activeAccountSubject.subscribe(async (userId) => {
-      if (userId == null && this.activeAccountUnlocked.getValue() == false) {
+      if (userId == null && this.activeAccountUnlockedSubject.getValue() == false) {
         return;
       } else if (userId == null) {
-        this.activeAccountUnlocked.next(false);
+        this.activeAccountUnlockedSubject.next(false);
       }
 
       // FIXME: This should be refactored into AuthService or a similar service,
       //  as checking for the existance of the crypto key is a low level
       //  implementation detail.
-      this.activeAccountUnlocked.next((await this.getCryptoMasterKey()) != null);
+      this.activeAccountUnlockedSubject.next((await this.getCryptoMasterKey()) != null);
     });
   }
 
@@ -502,8 +504,8 @@ export class StateService<
       const nextValue = value != null;
 
       // Avoid emitting if we are already unlocked
-      if (this.activeAccountUnlocked.getValue() != nextValue) {
-        this.activeAccountUnlocked.next(nextValue);
+      if (this.activeAccountUnlockedSubject.getValue() != nextValue) {
+        this.activeAccountUnlockedSubject.next(nextValue);
       }
     }
   }

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -57,7 +57,7 @@ export class StateService<
   accounts = new BehaviorSubject<{ [userId: string]: TAccount }>({});
   private activeAccountSubject = new BehaviorSubject<string>(null);
   activeAccountUnlocked = new BehaviorSubject<boolean>(false);
-  activeAccount = this.activeAccountSubject.asObservable();
+  activeAccount$ = this.activeAccountSubject.asObservable();
 
   private hasBeenInited = false;
   private isRecoveredSession = false;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We should only be subscribing to observables and if we create subscriptions, we should keep a reference and clean them up when not needed anymore (`unsubscribe`). We currently expose the `BehaviourSubject` and subscribe to this and also call unsubscribe. Calling `unsubscribe` on a subject, cancels all subscriptions and not just the one in use.

This is part of https://bitwarden.atlassian.net/browse/TDL-121

## Code changes

- **libs/common/src/abstractions/state.service.ts**: Change type of `activeAccount` to be an `Observable` instead of a `BehaviourSubject`
- **libs/common/src/services/state.service.ts**: 
  - Change type of `activeAccount` to be an `Observable` instead of a `BehaviourSubject`
  - Change `activeAccountSubject` to be used change state (`BehaviourSubject`) internally and not be exposed

- **Create and track the subscription of the activeAccount observable and unsubscribe on `ngOnDestroy`**
  - **libs/angular/src/components/lock.component.ts**: 
  - **apps/desktop/src/app/accounts/lock.component.ts**: 
  - **apps/desktop/src/app/layout/search/search.component.ts**: 

- **apps/desktop/src/app/app.component.ts**: Ensure `OnDestroy` is added which calls `ngOnDestroy`

- **apps/browser/src/popup/app.component.ts**: Fix check for no active accounts to redirect to the login page instead of lock

- **apps/desktop/src/app/layout/search/search-bar.service.ts**: Change subscription handling on SearchBarService 

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```