### PR TITLE
Sm 90 addison

### DIFF
--- a/libs/common/src/abstractions/config/ServerConfig.ts
+++ b/libs/common/src/abstractions/config/ServerConfig.ts
@@ -11,4 +11,15 @@ export class ServerConfig {
   constructor() {
     this.environment = new EnvironmentServerConfig();
   }
+
+  isValid() {
+    const twentyFourHours = 24;
+    const currentUtcDate = new Date(new Date().toISOString());
+    return this.getDateDiffInHours(currentUtcDate, this.utcDate) >= twentyFourHours;
+  }
+
+  private getDateDiffInHours(dateA: Date, dateB: Date) {
+    const oneHourInMs = 3600000;
+    return Math.abs(dateA.getTime() - dateB.getTime()) / oneHourInMs;
+  }
 }

--- a/libs/common/src/services/config.service.ts
+++ b/libs/common/src/services/config.service.ts
@@ -19,17 +19,17 @@ export class ConfigService implements ConfigServiceAbstraction {
   private async getStateServiceServerConfig(): Promise<void> {
     const currentUtcDate = new Date(new Date().toISOString());
 
-    const stateServerConfig = await this.stateService.getServerConfig();
-    if (this.isNullOrUndefined(stateServerConfig)) {
+    const storedServerConfig = await this.stateService.getServerConfig();
+    if (this.isNullOrUndefined(storedServerConfig)) {
       await this.getApiServiceServerConfig();
     } else {
       // check if serverConfig is out of date
       if (
-        this.getDateDiffInHours(currentUtcDate, stateServerConfig.utcDate) >= this.TwentyFourHours
+        this.getDateDiffInHours(currentUtcDate, storedServerConfig.utcDate) >= this.TwentyFourHours
       ) {
         this.getApiServiceServerConfig();
       } else {
-        this._serverConfig.next(stateServerConfig);
+        this._serverConfig.next(storedServerConfig);
       }
     }
   }

--- a/libs/common/src/services/config.service.ts
+++ b/libs/common/src/services/config.service.ts
@@ -16,13 +16,13 @@ export class ConfigService implements ConfigServiceAbstraction {
   private async buildServerConfig(): Promise<void> {
     const storedServerConfig = await this.stateService.getServerConfig();
     if (storedServerConfig == null || !storedServerConfig.isValid()) {
-      await this.getApiServiceServerConfig();
+      await this.pollServerConfig();
     } else {
       this._serverConfig.next(storedServerConfig);
     }
   }
 
-  private async getApiServiceServerConfig(): Promise<void> {
+  private async pollServerConfig(): Promise<void> {
     const apiServerConfig = await this.apiService.getServerConfig();
     if (apiServerConfig == null) {
       // begin retry / polling mechanism

--- a/libs/common/src/services/config.service.ts
+++ b/libs/common/src/services/config.service.ts
@@ -15,7 +15,7 @@ export class ConfigService implements ConfigServiceAbstraction {
 
   private async getStateServiceServerConfig(): Promise<void> {
     const storedServerConfig = await this.stateService.getServerConfig();
-    if (this.isNullOrUndefined(storedServerConfig) || !storedServerConfig.isValid()) {
+    if (storedServerConfig == null || !storedServerConfig.isValid()) {
       await this.getApiServiceServerConfig();
     } else {
       this._serverConfig.next(storedServerConfig);
@@ -24,14 +24,10 @@ export class ConfigService implements ConfigServiceAbstraction {
 
   private async getApiServiceServerConfig(): Promise<void> {
     const apiServerConfig = await this.apiService.getServerConfig();
-    if (this.isNullOrUndefined(apiServerConfig)) {
+    if (apiServerConfig == null) {
       // begin retry / polling mechanism
     } else {
       this._serverConfig.next(apiServerConfig);
     }
-  }
-
-  private isNullOrUndefined(value: any) {
-    return value == null || value == undefined;
   }
 }

--- a/libs/common/src/services/config.service.ts
+++ b/libs/common/src/services/config.service.ts
@@ -10,10 +10,10 @@ export class ConfigService implements ConfigServiceAbstraction {
   serverConfig$: Observable<ServerConfig> = this._serverConfig.asObservable();
 
   constructor(private stateService: StateService, private apiService: ApiService) {
-    this.getStateServiceServerConfig();
+    this.buildServerConfig();
   }
 
-  private async getStateServiceServerConfig(): Promise<void> {
+  private async buildServerConfig(): Promise<void> {
     const storedServerConfig = await this.stateService.getServerConfig();
     if (storedServerConfig == null || !storedServerConfig.isValid()) {
       await this.getApiServiceServerConfig();


### PR DESCRIPTION
Most of these commits are not relevant to the issue you were facing, and are just changes I made along the way while debugging. Feel free to merge this PR, cherry pick the stuff you want, or recreate the changes you need by hand.

The final commit, [Build server config in async](https://github.com/bitwarden/clients/commit/599e03583147da1a9659ec6a1c700d9339eac346), fixes your issue with subscriptions. Javascript doesn't support async management in constructors, but some of your observable logic runs asynchronously like fetching configs from state or the server. A good way to circumvent this is to lean on some other observable that doesn't have this dependency, like checking if the active account is unlocked in state. Then you can do all of your async checks in the subscription callback. This has the added benefit of letting us clear out data when the active account is locked or changed. You can also see this pattern used in the `FolderService`