### PR TITLE
[PS-1265] fix on install hook

### DIFF
--- a/apps/browser/config/development.json
+++ b/apps/browser/config/development.json
@@ -1,6 +1,9 @@
 {
   "devFlags": {
-    "storeSessionDecrypted": false
+    "storeSessionDecrypted": false,
+    "managedEnvironment": {
+      "base": "https://localhost:8080"
+    }
   },
   "flags": {}
 }

--- a/apps/browser/src/background.ts
+++ b/apps/browser/src/background.ts
@@ -1,10 +1,12 @@
 import MainBackground from "./background/main.background";
 import { onCommandListener } from "./listeners/onCommandListener";
+import { onInstallListener } from "./listeners/onInstallListener";
 
 const manifest = chrome.runtime.getManifest();
 
 if (manifest.manifest_version === 3) {
   chrome.commands.onCommand.addListener(onCommandListener);
+  chrome.runtime.onInstalled.addListener(onInstallListener);
 } else {
   const bitwardenMain = ((window as any).bitwardenMain = new MainBackground());
   bitwardenMain.bootstrap().then(() => {

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -200,34 +200,26 @@ export default class MainBackground {
       await this.logout(expired, userId);
 
     const factoryInstances: Record<string, unknown> = {};
+    const factoryOptions = {
+      isDev: false,
+      win: window,
+      stateFactory: new StateFactory(GlobalState, Account),
+      instances: factoryInstances,
+    };
 
     this.messagingService = isPrivateMode
       ? new BrowserMessagingPrivateModeBackgroundService()
       : new BrowserMessagingService();
-    this.logService = logServiceFactory({ isDev: false, instances: factoryInstances });
-    this.cryptoFunctionService = cryptoFunctionServiceFactory({
-      win: window,
-      instances: factoryInstances,
-    });
-    this.storageService = diskStorageServiceFactory({ instances: factoryInstances });
-    this.secureStorageService = secureStorageServiceFactory({ instances: factoryInstances });
+    this.logService = logServiceFactory(factoryOptions);
+    this.cryptoFunctionService = cryptoFunctionServiceFactory(factoryOptions);
+    this.storageService = diskStorageServiceFactory(factoryOptions);
+    this.secureStorageService = secureStorageServiceFactory(factoryOptions);
     this.memoryStorageService = memoryStorageServiceFactory({
-      win: window,
-      isDev: false,
+      ...factoryOptions,
       logMacFailures: false,
-      instances: factoryInstances,
     });
-    this.stateMigrationService = stateMigrationServiceFactory({
-      stateFactory: new StateFactory(GlobalState, Account),
-      instances: factoryInstances,
-    });
-    this.stateService = stateServiceFactory({
-      win: window,
-      isDev: false,
-      logMacFailures: false,
-      stateFactory: new StateFactory(GlobalState, Account),
-      instances: factoryInstances,
-    });
+    this.stateMigrationService = stateMigrationServiceFactory(factoryOptions);
+    this.stateService = stateServiceFactory({ ...factoryOptions, logMacFailures: false });
     this.platformUtilsService = new BrowserPlatformUtilsService(
       this.messagingService,
       this.stateService,
@@ -252,11 +244,9 @@ export default class MainBackground {
     );
     this.i18nService = new I18nService(BrowserApi.getUILanguage(window));
     this.encryptService = encryptServiceFactory({
+      ...factoryOptions,
       logMacFailures: true,
-      win: window,
-      isDev: false,
       alwaysInitializeNewService: true,
-      instances: factoryInstances,
     }); // Update encrypt service with new instances
     this.cryptoService = new BrowserCryptoService(
       this.cryptoFunctionService,
@@ -268,11 +258,8 @@ export default class MainBackground {
     this.tokenService = new TokenService(this.stateService);
     this.appIdService = new AppIdService(this.storageService);
     this.environmentService = environmentServiceFactory({
-      win: window,
-      isDev: false,
+      ...factoryOptions,
       logMacFailures: false,
-      stateFactory: new StateFactory(GlobalState, Account),
-      instances: factoryInstances,
     });
     this.apiService = new ApiService(
       this.tokenService,

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -47,7 +47,6 @@ import { AuditService } from "@bitwarden/common/services/audit.service";
 import { AuthService } from "@bitwarden/common/services/auth.service";
 import { CipherService } from "@bitwarden/common/services/cipher.service";
 import { CollectionService } from "@bitwarden/common/services/collection.service";
-import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
 import { ContainerService } from "@bitwarden/common/services/container.service";
 import { EncryptService } from "@bitwarden/common/services/encrypt.service";
 import { EventService } from "@bitwarden/common/services/event.service";
@@ -55,7 +54,6 @@ import { ExportService } from "@bitwarden/common/services/export.service";
 import { FileUploadService } from "@bitwarden/common/services/fileUpload.service";
 import { FolderApiService } from "@bitwarden/common/services/folder/folder-api.service";
 import { KeyConnectorService } from "@bitwarden/common/services/keyConnector.service";
-import { MemoryStorageService } from "@bitwarden/common/services/memoryStorage.service";
 import { NotificationsService } from "@bitwarden/common/services/notifications.service";
 import { OrganizationService } from "@bitwarden/common/services/organization.service";
 import { PasswordGenerationService } from "@bitwarden/common/services/passwordGeneration.service";
@@ -74,7 +72,6 @@ import { TwoFactorService } from "@bitwarden/common/services/twoFactor.service";
 import { UserVerificationApiService } from "@bitwarden/common/services/userVerification/userVerification-api.service";
 import { UserVerificationService } from "@bitwarden/common/services/userVerification/userVerification.service";
 import { UsernameGenerationService } from "@bitwarden/common/services/usernameGeneration.service";
-import { WebCryptoFunctionService } from "@bitwarden/common/services/webCryptoFunction.service";
 
 import { BrowserApi } from "../browser/browserApi";
 import { SafariApp } from "../browser/safariApp";
@@ -85,15 +82,11 @@ import { StateService as StateServiceAbstraction } from "../services/abstraction
 import AutofillService from "../services/autofill.service";
 import { BrowserEnvironmentService } from "../services/browser-environment.service";
 import { BrowserCryptoService } from "../services/browserCrypto.service";
-import BrowserLocalStorageService from "../services/browserLocalStorage.service";
 import BrowserMessagingService from "../services/browserMessaging.service";
 import BrowserMessagingPrivateModeBackgroundService from "../services/browserMessagingPrivateModeBackground.service";
 import BrowserPlatformUtilsService from "../services/browserPlatformUtils.service";
 import { FolderService } from "../services/folders/folder.service";
 import I18nService from "../services/i18n.service";
-import { KeyGenerationService } from "../services/keyGeneration.service";
-import { LocalBackedSessionStorageService } from "../services/localBackedSessionStorage.service";
-import { StateService } from "../services/state.service";
 import { VaultFilterService } from "../services/vaultFilter.service";
 import VaultTimeoutService from "../services/vaultTimeout.service";
 
@@ -104,6 +97,17 @@ import IconDetails from "./models/iconDetails";
 import { NativeMessagingBackground } from "./nativeMessaging.background";
 import NotificationBackground from "./notification.background";
 import RuntimeBackground from "./runtime.background";
+import { cryptoFunctionServiceFactory } from "./service_factories/crypto-function-service.factory";
+import { encryptServiceFactory } from "./service_factories/encrypt-service.factory";
+import { environmentServiceFactory } from "./service_factories/environment-service.factory";
+import { logServiceFactory } from "./service_factories/log-service.factory";
+import { stateMigrationServiceFactory } from "./service_factories/state-migration-service.factory";
+import { stateServiceFactory } from "./service_factories/state-service.factory";
+import {
+  diskStorageServiceFactory,
+  memoryStorageServiceFactory,
+  secureStorageServiceFactory,
+} from "./service_factories/storage-service.factory";
 import TabsBackground from "./tabs.background";
 import WebRequestBackground from "./webRequest.background";
 
@@ -195,33 +199,35 @@ export default class MainBackground {
     const logoutCallback = async (expired: boolean, userId?: string) =>
       await this.logout(expired, userId);
 
+    const factoryInstances: Record<string, unknown> = {};
+
     this.messagingService = isPrivateMode
       ? new BrowserMessagingPrivateModeBackgroundService()
       : new BrowserMessagingService();
-    this.logService = new ConsoleLogService(false);
-    this.cryptoFunctionService = new WebCryptoFunctionService(window);
-    this.storageService = new BrowserLocalStorageService();
-    this.secureStorageService = new BrowserLocalStorageService();
-    this.memoryStorageService =
-      chrome.runtime.getManifest().manifest_version == 3
-        ? new LocalBackedSessionStorageService(
-            new EncryptService(this.cryptoFunctionService, this.logService, false),
-            new KeyGenerationService(this.cryptoFunctionService)
-          )
-        : new MemoryStorageService();
-    this.stateMigrationService = new StateMigrationService(
-      this.storageService,
-      this.secureStorageService,
-      new StateFactory(GlobalState, Account)
-    );
-    this.stateService = new StateService(
-      this.storageService,
-      this.secureStorageService,
-      this.memoryStorageService,
-      this.logService,
-      this.stateMigrationService,
-      new StateFactory(GlobalState, Account)
-    );
+    this.logService = logServiceFactory({ isDev: false, instances: factoryInstances });
+    this.cryptoFunctionService = cryptoFunctionServiceFactory({
+      win: window,
+      instances: factoryInstances,
+    });
+    this.storageService = diskStorageServiceFactory({ instances: factoryInstances });
+    this.secureStorageService = secureStorageServiceFactory({ instances: factoryInstances });
+    this.memoryStorageService = memoryStorageServiceFactory({
+      win: window,
+      isDev: false,
+      logMacFailures: false,
+      instances: factoryInstances,
+    });
+    this.stateMigrationService = stateMigrationServiceFactory({
+      stateFactory: new StateFactory(GlobalState, Account),
+      instances: factoryInstances,
+    });
+    this.stateService = stateServiceFactory({
+      win: window,
+      isDev: false,
+      logMacFailures: false,
+      stateFactory: new StateFactory(GlobalState, Account),
+      instances: factoryInstances,
+    });
     this.platformUtilsService = new BrowserPlatformUtilsService(
       this.messagingService,
       this.stateService,
@@ -245,7 +251,13 @@ export default class MainBackground {
       }
     );
     this.i18nService = new I18nService(BrowserApi.getUILanguage(window));
-    this.encryptService = new EncryptService(this.cryptoFunctionService, this.logService, true);
+    this.encryptService = encryptServiceFactory({
+      logMacFailures: true,
+      win: window,
+      isDev: false,
+      alwaysInitializeNewService: true,
+      instances: factoryInstances,
+    }); // Update encrypt service with new instances
     this.cryptoService = new BrowserCryptoService(
       this.cryptoFunctionService,
       this.encryptService,
@@ -255,7 +267,13 @@ export default class MainBackground {
     );
     this.tokenService = new TokenService(this.stateService);
     this.appIdService = new AppIdService(this.storageService);
-    this.environmentService = new BrowserEnvironmentService(this.stateService, this.logService);
+    this.environmentService = environmentServiceFactory({
+      win: window,
+      isDev: false,
+      logMacFailures: false,
+      stateFactory: new StateFactory(GlobalState, Account),
+      instances: factoryInstances,
+    });
     this.apiService = new ApiService(
       this.tokenService,
       this.platformUtilsService,

--- a/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
+++ b/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
@@ -1,9 +1,13 @@
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
 import { WebCryptoFunctionService } from "@bitwarden/common/services/webCryptoFunction.service";
 
-type CryptoFunctionServiceFactoryOptions = {
+import { factory, FactoryOptions } from "./factory-options";
+
+type CryptoFunctionServiceFactoryOptions = FactoryOptions & {
   win: Window | typeof global;
-  cryptoFunctionService?: CryptoFunctionService;
+  instances: {
+    cryptoFunctionService?: CryptoFunctionService;
+  };
 };
 
 export type CryptoFunctionServiceInitOptions = CryptoFunctionServiceFactoryOptions;
@@ -11,8 +15,5 @@ export type CryptoFunctionServiceInitOptions = CryptoFunctionServiceFactoryOptio
 export function cryptoFunctionServiceFactory(
   opts: CryptoFunctionServiceFactoryOptions
 ): CryptoFunctionService {
-  if (!opts.cryptoFunctionService) {
-    opts.cryptoFunctionService = new WebCryptoFunctionService(opts.win);
-  }
-  return opts.cryptoFunctionService;
+  return factory(opts, "cryptoFunctionService", () => new WebCryptoFunctionService(opts.win));
 }

--- a/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
+++ b/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
@@ -1,0 +1,18 @@
+import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
+import { WebCryptoFunctionService } from "@bitwarden/common/services/webCryptoFunction.service";
+
+type CryptoFunctionServiceFactoryOptions = {
+  win: Window | typeof global;
+  cryptoFunctionService?: CryptoFunctionService;
+};
+
+export type CryptoFunctionServiceInitOptions = CryptoFunctionServiceFactoryOptions;
+
+export function cryptoFunctionServiceFactory(
+  opts: CryptoFunctionServiceFactoryOptions
+): CryptoFunctionService {
+  if (!opts.cryptoFunctionService) {
+    opts.cryptoFunctionService = new WebCryptoFunctionService(opts.win);
+  }
+  return opts.cryptoFunctionService;
+}

--- a/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
+++ b/apps/browser/src/background/service_factories/crypto-function-service.factory.ts
@@ -1,19 +1,24 @@
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
 import { WebCryptoFunctionService } from "@bitwarden/common/services/webCryptoFunction.service";
 
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 
 type CryptoFunctionServiceFactoryOptions = FactoryOptions & {
-  win: Window | typeof global;
-  instances: {
-    cryptoFunctionService?: CryptoFunctionService;
+  cryptoFunctionServiceOptions: {
+    win: Window | typeof global;
   };
 };
 
 export type CryptoFunctionServiceInitOptions = CryptoFunctionServiceFactoryOptions;
 
 export function cryptoFunctionServiceFactory(
+  cache: { cryptoFunctionService?: CryptoFunctionService } & CachedServices,
   opts: CryptoFunctionServiceFactoryOptions
 ): CryptoFunctionService {
-  return factory(opts, "cryptoFunctionService", () => new WebCryptoFunctionService(opts.win));
+  return factory(
+    cache,
+    "cryptoFunctionService",
+    opts,
+    () => new WebCryptoFunctionService(opts.cryptoFunctionServiceOptions.win)
+  );
 }

--- a/apps/browser/src/background/service_factories/encrypt-service.factory.ts
+++ b/apps/browser/src/background/service_factories/encrypt-service.factory.ts
@@ -4,13 +4,12 @@ import {
   cryptoFunctionServiceFactory,
   CryptoFunctionServiceInitOptions,
 } from "./crypto-function-service.factory";
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
 
 type EncryptServiceFactoryOptions = FactoryOptions & {
-  logMacFailures: boolean;
-  instances: {
-    encryptService?: EncryptService;
+  encryptServiceOptions: {
+    logMacFailures: boolean;
   };
 };
 
@@ -18,15 +17,19 @@ export type EncryptServiceInitOptions = EncryptServiceFactoryOptions &
   CryptoFunctionServiceInitOptions &
   LogServiceInitOptions;
 
-export function encryptServiceFactory(opts: EncryptServiceInitOptions): EncryptService {
+export function encryptServiceFactory(
+  cache: { encryptService?: EncryptService } & CachedServices,
+  opts: EncryptServiceInitOptions
+): EncryptService {
   return factory(
-    opts,
+    cache,
     "encryptService",
+    opts,
     () =>
       new EncryptService(
-        cryptoFunctionServiceFactory(opts),
-        logServiceFactory(opts),
-        opts.logMacFailures
+        cryptoFunctionServiceFactory(cache, opts),
+        logServiceFactory(cache, opts),
+        opts.encryptServiceOptions.logMacFailures
       )
   );
 }

--- a/apps/browser/src/background/service_factories/encrypt-service.factory.ts
+++ b/apps/browser/src/background/service_factories/encrypt-service.factory.ts
@@ -4,11 +4,14 @@ import {
   cryptoFunctionServiceFactory,
   CryptoFunctionServiceInitOptions,
 } from "./crypto-function-service.factory";
+import { factory, FactoryOptions } from "./factory-options";
 import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
 
-type EncryptServiceFactoryOptions = {
+type EncryptServiceFactoryOptions = FactoryOptions & {
   logMacFailures: boolean;
-  encryptService?: EncryptService;
+  instances: {
+    encryptService?: EncryptService;
+  };
 };
 
 export type EncryptServiceInitOptions = EncryptServiceFactoryOptions &
@@ -16,12 +19,14 @@ export type EncryptServiceInitOptions = EncryptServiceFactoryOptions &
   LogServiceInitOptions;
 
 export function encryptServiceFactory(opts: EncryptServiceInitOptions): EncryptService {
-  if (!opts.encryptService) {
-    opts.encryptService = new EncryptService(
-      cryptoFunctionServiceFactory(opts),
-      logServiceFactory(opts),
-      opts.logMacFailures
-    );
-  }
-  return opts.encryptService;
+  return factory(
+    opts,
+    "encryptService",
+    () =>
+      new EncryptService(
+        cryptoFunctionServiceFactory(opts),
+        logServiceFactory(opts),
+        opts.logMacFailures
+      )
+  );
 }

--- a/apps/browser/src/background/service_factories/encrypt-service.factory.ts
+++ b/apps/browser/src/background/service_factories/encrypt-service.factory.ts
@@ -1,0 +1,27 @@
+import { EncryptService } from "@bitwarden/common/services/encrypt.service";
+
+import {
+  cryptoFunctionServiceFactory,
+  CryptoFunctionServiceInitOptions,
+} from "./crypto-function-service.factory";
+import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
+
+type EncryptServiceFactoryOptions = {
+  logMacFailures: boolean;
+  encryptService?: EncryptService;
+};
+
+export type EncryptServiceInitOptions = EncryptServiceFactoryOptions &
+  CryptoFunctionServiceInitOptions &
+  LogServiceInitOptions;
+
+export function encryptServiceFactory(opts: EncryptServiceInitOptions): EncryptService {
+  if (!opts.encryptService) {
+    opts.encryptService = new EncryptService(
+      cryptoFunctionServiceFactory(opts),
+      logServiceFactory(opts),
+      opts.logMacFailures
+    );
+  }
+  return opts.encryptService;
+}

--- a/apps/browser/src/background/service_factories/environment-service.factory.ts
+++ b/apps/browser/src/background/service_factories/environment-service.factory.ts
@@ -1,0 +1,27 @@
+import { BrowserEnvironmentService } from "../../services/browser-environment.service";
+
+import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
+import {
+  stateServiceFactory as stateServiceFactory,
+  StateServiceInitOptions,
+} from "./state-service.factory";
+
+type EnvironmentServiceFactoryOptions = {
+  environmentService?: BrowserEnvironmentService;
+};
+
+export type EnvironmentServiceInitOptions = EnvironmentServiceFactoryOptions &
+  StateServiceInitOptions &
+  LogServiceInitOptions;
+
+export function environmentServiceFactory(
+  opts: EnvironmentServiceInitOptions
+): BrowserEnvironmentService {
+  if (!opts.environmentService) {
+    opts.environmentService = new BrowserEnvironmentService(
+      stateServiceFactory(opts),
+      logServiceFactory(opts)
+    );
+  }
+  return opts.environmentService;
+}

--- a/apps/browser/src/background/service_factories/environment-service.factory.ts
+++ b/apps/browser/src/background/service_factories/environment-service.factory.ts
@@ -1,28 +1,30 @@
 import { BrowserEnvironmentService } from "../../services/browser-environment.service";
 
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
 import {
   stateServiceFactory as stateServiceFactory,
   StateServiceInitOptions,
 } from "./state-service.factory";
 
-type EnvironmentServiceFactoryOptions = FactoryOptions & {
-  instances: {
-    environmentService?: BrowserEnvironmentService;
-  };
-};
+type EnvironmentServiceFactoryOptions = FactoryOptions;
 
 export type EnvironmentServiceInitOptions = EnvironmentServiceFactoryOptions &
   StateServiceInitOptions &
   LogServiceInitOptions;
 
 export function environmentServiceFactory(
+  cache: { environmentService?: BrowserEnvironmentService } & CachedServices,
   opts: EnvironmentServiceInitOptions
 ): BrowserEnvironmentService {
   return factory(
-    opts,
+    cache,
     "environmentService",
-    () => new BrowserEnvironmentService(stateServiceFactory(opts), logServiceFactory(opts))
+    opts,
+    () =>
+      new BrowserEnvironmentService(
+        stateServiceFactory(cache, opts),
+        logServiceFactory(cache, opts)
+      )
   );
 }

--- a/apps/browser/src/background/service_factories/environment-service.factory.ts
+++ b/apps/browser/src/background/service_factories/environment-service.factory.ts
@@ -1,13 +1,16 @@
 import { BrowserEnvironmentService } from "../../services/browser-environment.service";
 
+import { factory, FactoryOptions } from "./factory-options";
 import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
 import {
   stateServiceFactory as stateServiceFactory,
   StateServiceInitOptions,
 } from "./state-service.factory";
 
-type EnvironmentServiceFactoryOptions = {
-  environmentService?: BrowserEnvironmentService;
+type EnvironmentServiceFactoryOptions = FactoryOptions & {
+  instances: {
+    environmentService?: BrowserEnvironmentService;
+  };
 };
 
 export type EnvironmentServiceInitOptions = EnvironmentServiceFactoryOptions &
@@ -17,11 +20,9 @@ export type EnvironmentServiceInitOptions = EnvironmentServiceFactoryOptions &
 export function environmentServiceFactory(
   opts: EnvironmentServiceInitOptions
 ): BrowserEnvironmentService {
-  if (!opts.environmentService) {
-    opts.environmentService = new BrowserEnvironmentService(
-      stateServiceFactory(opts),
-      logServiceFactory(opts)
-    );
-  }
-  return opts.environmentService;
+  return factory(
+    opts,
+    "environmentService",
+    () => new BrowserEnvironmentService(stateServiceFactory(opts), logServiceFactory(opts))
+  );
 }

--- a/apps/browser/src/background/service_factories/factory-options.ts
+++ b/apps/browser/src/background/service_factories/factory-options.ts
@@ -1,22 +1,24 @@
+export type CachedServices = Record<string, any>;
+
 export type FactoryOptions = {
-  instances: Record<string, unknown>;
   alwaysInitializeNewService?: boolean;
   doNotStoreInitializedService?: boolean;
+  [optionsKey: string]: unknown;
 };
 
-export function factory<TOpts extends FactoryOptions, T>(
-  opts: TOpts,
-  name: string,
-  factory: (opts: TOpts) => T
-): T {
-  let instance = opts.instances[name];
+export function factory<
+  TCache extends CachedServices,
+  TName extends keyof TCache,
+  TOpts extends FactoryOptions
+>(cachedServices: TCache, name: TName, opts: TOpts, factory: () => TCache[TName]): TCache[TName] {
+  let instance = cachedServices[name];
   if (opts.alwaysInitializeNewService || !instance) {
-    instance = factory(opts);
+    instance = factory();
   }
 
   if (!opts.doNotStoreInitializedService) {
-    opts.instances[name] = instance;
+    cachedServices[name] = instance;
   }
 
-  return instance as T;
+  return instance as TCache[TName];
 }

--- a/apps/browser/src/background/service_factories/factory-options.ts
+++ b/apps/browser/src/background/service_factories/factory-options.ts
@@ -1,0 +1,22 @@
+export type FactoryOptions = {
+  instances: Record<string, unknown>;
+  alwaysInitializeNewService?: boolean;
+  doNotStoreInitializedService?: boolean;
+};
+
+export function factory<TOpts extends FactoryOptions, T>(
+  opts: TOpts,
+  name: string,
+  factory: (opts: TOpts) => T
+): T {
+  let instance = opts.instances[name];
+  if (opts.alwaysInitializeNewService || !instance) {
+    instance = factory(opts);
+  }
+
+  if (!opts.doNotStoreInitializedService) {
+    opts.instances[name] = instance;
+  }
+
+  return instance as T;
+}

--- a/apps/browser/src/background/service_factories/key-generation-service.factory.ts
+++ b/apps/browser/src/background/service_factories/key-generation-service.factory.ts
@@ -4,9 +4,12 @@ import {
   cryptoFunctionServiceFactory,
   CryptoFunctionServiceInitOptions,
 } from "./crypto-function-service.factory";
+import { factory, FactoryOptions } from "./factory-options";
 
-type KeyGenerationServiceFactoryOptions = {
-  keyGenerationService?: KeyGenerationService;
+type KeyGenerationServiceFactoryOptions = FactoryOptions & {
+  instances: {
+    keyGenerationService?: KeyGenerationService;
+  };
 };
 
 export type KeyGenerationServiceInitOptions = KeyGenerationServiceFactoryOptions &
@@ -15,8 +18,9 @@ export type KeyGenerationServiceInitOptions = KeyGenerationServiceFactoryOptions
 export function keyGenerationServiceFactory(
   opts: KeyGenerationServiceInitOptions
 ): KeyGenerationService {
-  if (!opts.keyGenerationService) {
-    opts.keyGenerationService = new KeyGenerationService(cryptoFunctionServiceFactory(opts));
-  }
-  return opts.keyGenerationService;
+  return factory(
+    opts,
+    "keyGenerationService",
+    () => new KeyGenerationService(cryptoFunctionServiceFactory(opts))
+  );
 }

--- a/apps/browser/src/background/service_factories/key-generation-service.factory.ts
+++ b/apps/browser/src/background/service_factories/key-generation-service.factory.ts
@@ -4,23 +4,21 @@ import {
   cryptoFunctionServiceFactory,
   CryptoFunctionServiceInitOptions,
 } from "./crypto-function-service.factory";
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 
-type KeyGenerationServiceFactoryOptions = FactoryOptions & {
-  instances: {
-    keyGenerationService?: KeyGenerationService;
-  };
-};
+type KeyGenerationServiceFactoryOptions = FactoryOptions;
 
 export type KeyGenerationServiceInitOptions = KeyGenerationServiceFactoryOptions &
   CryptoFunctionServiceInitOptions;
 
 export function keyGenerationServiceFactory(
+  cache: { keyGenerationService?: KeyGenerationService } & CachedServices,
   opts: KeyGenerationServiceInitOptions
 ): KeyGenerationService {
   return factory(
-    opts,
+    cache,
     "keyGenerationService",
-    () => new KeyGenerationService(cryptoFunctionServiceFactory(opts))
+    opts,
+    () => new KeyGenerationService(cryptoFunctionServiceFactory(cache, opts))
   );
 }

--- a/apps/browser/src/background/service_factories/key-generation-service.factory.ts
+++ b/apps/browser/src/background/service_factories/key-generation-service.factory.ts
@@ -1,0 +1,22 @@
+import { KeyGenerationService } from "../../services/keyGeneration.service";
+
+import {
+  cryptoFunctionServiceFactory,
+  CryptoFunctionServiceInitOptions,
+} from "./crypto-function-service.factory";
+
+type KeyGenerationServiceFactoryOptions = {
+  keyGenerationService?: KeyGenerationService;
+};
+
+export type KeyGenerationServiceInitOptions = KeyGenerationServiceFactoryOptions &
+  CryptoFunctionServiceInitOptions;
+
+export function keyGenerationServiceFactory(
+  opts: KeyGenerationServiceInitOptions
+): KeyGenerationService {
+  if (!opts.keyGenerationService) {
+    opts.keyGenerationService = new KeyGenerationService(cryptoFunctionServiceFactory(opts));
+  }
+  return opts.keyGenerationService;
+}

--- a/apps/browser/src/background/service_factories/log-service.factory.ts
+++ b/apps/browser/src/background/service_factories/log-service.factory.ts
@@ -1,0 +1,18 @@
+import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LogLevelType } from "@bitwarden/common/enums/logLevelType";
+import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
+
+type LogServiceFactoryOptions = {
+  isDev: boolean;
+  filter?: (level: LogLevelType) => boolean;
+  logService?: LogService;
+};
+
+export type LogServiceInitOptions = LogServiceFactoryOptions;
+
+export function logServiceFactory(opts: LogServiceInitOptions): LogService {
+  if (!opts.logService) {
+    opts.logService = new ConsoleLogService(opts.isDev, opts.filter);
+  }
+  return opts.logService;
+}

--- a/apps/browser/src/background/service_factories/log-service.factory.ts
+++ b/apps/browser/src/background/service_factories/log-service.factory.ts
@@ -2,18 +2,25 @@ import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { LogLevelType } from "@bitwarden/common/enums/logLevelType";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
 
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 
 type LogServiceFactoryOptions = FactoryOptions & {
-  isDev: boolean;
-  filter?: (level: LogLevelType) => boolean;
-  instances: {
-    logService?: LogService;
+  logServiceOptions: {
+    isDev: boolean;
+    filter?: (level: LogLevelType) => boolean;
   };
 };
 
 export type LogServiceInitOptions = LogServiceFactoryOptions;
 
-export function logServiceFactory(opts: LogServiceInitOptions): LogService {
-  return factory(opts, "logService", () => new ConsoleLogService(opts.isDev, opts.filter));
+export function logServiceFactory(
+  cache: { logService?: LogService } & CachedServices,
+  opts: LogServiceInitOptions
+): LogService {
+  return factory(
+    cache,
+    "logService",
+    opts,
+    () => new ConsoleLogService(opts.logServiceOptions.isDev, opts.logServiceOptions.filter)
+  );
 }

--- a/apps/browser/src/background/service_factories/log-service.factory.ts
+++ b/apps/browser/src/background/service_factories/log-service.factory.ts
@@ -2,17 +2,18 @@ import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { LogLevelType } from "@bitwarden/common/enums/logLevelType";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
 
-type LogServiceFactoryOptions = {
+import { factory, FactoryOptions } from "./factory-options";
+
+type LogServiceFactoryOptions = FactoryOptions & {
   isDev: boolean;
   filter?: (level: LogLevelType) => boolean;
-  logService?: LogService;
+  instances: {
+    logService?: LogService;
+  };
 };
 
 export type LogServiceInitOptions = LogServiceFactoryOptions;
 
 export function logServiceFactory(opts: LogServiceInitOptions): LogService {
-  if (!opts.logService) {
-    opts.logService = new ConsoleLogService(opts.isDev, opts.filter);
-  }
-  return opts.logService;
+  return factory(opts, "logService", () => new ConsoleLogService(opts.isDev, opts.filter));
 }

--- a/apps/browser/src/background/service_factories/state-migration-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-migration-service.factory.ts
@@ -1,0 +1,34 @@
+import { StateFactory } from "@bitwarden/common/factories/stateFactory";
+import { GlobalState } from "@bitwarden/common/models/domain/globalState";
+import { StateMigrationService } from "@bitwarden/common/services/stateMigration.service";
+
+import { Account } from "../../models/account";
+
+import {
+  diskStorageServiceFactory,
+  DiskStorageServiceInitOptions,
+  secureStorageServiceFactory,
+  SecureStorageServiceInitOptions,
+} from "./storage-service.factory";
+
+type StateMigrationServiceFactoryOptions = {
+  stateFactory: StateFactory<GlobalState, Account>;
+  stateMigrationService?: StateMigrationService;
+};
+
+export type StateMigrationServiceInitOptions = StateMigrationServiceFactoryOptions &
+  DiskStorageServiceInitOptions &
+  SecureStorageServiceInitOptions;
+
+export function stateMigrationServiceFactory(
+  opts: StateMigrationServiceInitOptions
+): StateMigrationService {
+  if (!opts.stateMigrationService) {
+    opts.stateMigrationService = new StateMigrationService(
+      diskStorageServiceFactory(opts),
+      secureStorageServiceFactory(opts),
+      opts.stateFactory
+    );
+  }
+  return opts.stateMigrationService;
+}

--- a/apps/browser/src/background/service_factories/state-migration-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-migration-service.factory.ts
@@ -4,6 +4,7 @@ import { StateMigrationService } from "@bitwarden/common/services/stateMigration
 
 import { Account } from "../../models/account";
 
+import { factory, FactoryOptions } from "./factory-options";
 import {
   diskStorageServiceFactory,
   DiskStorageServiceInitOptions,
@@ -11,9 +12,11 @@ import {
   SecureStorageServiceInitOptions,
 } from "./storage-service.factory";
 
-type StateMigrationServiceFactoryOptions = {
+type StateMigrationServiceFactoryOptions = FactoryOptions & {
   stateFactory: StateFactory<GlobalState, Account>;
-  stateMigrationService?: StateMigrationService;
+  instances: {
+    stateMigrationService?: StateMigrationService;
+  };
 };
 
 export type StateMigrationServiceInitOptions = StateMigrationServiceFactoryOptions &
@@ -23,12 +26,14 @@ export type StateMigrationServiceInitOptions = StateMigrationServiceFactoryOptio
 export function stateMigrationServiceFactory(
   opts: StateMigrationServiceInitOptions
 ): StateMigrationService {
-  if (!opts.stateMigrationService) {
-    opts.stateMigrationService = new StateMigrationService(
-      diskStorageServiceFactory(opts),
-      secureStorageServiceFactory(opts),
-      opts.stateFactory
-    );
-  }
-  return opts.stateMigrationService;
+  return factory(
+    opts,
+    "stateMigrationService",
+    () =>
+      new StateMigrationService(
+        diskStorageServiceFactory(opts),
+        secureStorageServiceFactory(opts),
+        opts.stateFactory
+      )
+  );
 }

--- a/apps/browser/src/background/service_factories/state-migration-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-migration-service.factory.ts
@@ -4,7 +4,7 @@ import { StateMigrationService } from "@bitwarden/common/services/stateMigration
 
 import { Account } from "../../models/account";
 
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 import {
   diskStorageServiceFactory,
   DiskStorageServiceInitOptions,
@@ -13,9 +13,8 @@ import {
 } from "./storage-service.factory";
 
 type StateMigrationServiceFactoryOptions = FactoryOptions & {
-  stateFactory: StateFactory<GlobalState, Account>;
-  instances: {
-    stateMigrationService?: StateMigrationService;
+  stateMigrationServiceOptions: {
+    stateFactory: StateFactory<GlobalState, Account>;
   };
 };
 
@@ -24,16 +23,18 @@ export type StateMigrationServiceInitOptions = StateMigrationServiceFactoryOptio
   SecureStorageServiceInitOptions;
 
 export function stateMigrationServiceFactory(
+  cache: { stateMigrationService?: StateMigrationService } & CachedServices,
   opts: StateMigrationServiceInitOptions
 ): StateMigrationService {
   return factory(
-    opts,
+    cache,
     "stateMigrationService",
+    opts,
     () =>
       new StateMigrationService(
-        diskStorageServiceFactory(opts),
-        secureStorageServiceFactory(opts),
-        opts.stateFactory
+        diskStorageServiceFactory(cache, opts),
+        secureStorageServiceFactory(cache, opts),
+        opts.stateMigrationServiceOptions.stateFactory
       )
   );
 }

--- a/apps/browser/src/background/service_factories/state-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-service.factory.ts
@@ -4,6 +4,7 @@ import { GlobalState } from "@bitwarden/common/models/domain/globalState";
 import { Account } from "../../models/account";
 import { StateService } from "../../services/state.service";
 
+import { factory, FactoryOptions } from "./factory-options";
 import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
 import {
   stateMigrationServiceFactory,
@@ -18,10 +19,12 @@ import {
   MemoryStorageServiceInitOptions,
 } from "./storage-service.factory";
 
-type StateServiceFactoryOptions = {
-  stateService?: StateService;
+type StateServiceFactoryOptions = FactoryOptions & {
   useAccountCache?: boolean;
   stateFactory: StateFactory<GlobalState, Account>;
+  instances: {
+    stateService?: StateService;
+  };
 };
 
 export type StateServiceInitOptions = StateServiceFactoryOptions &
@@ -32,16 +35,18 @@ export type StateServiceInitOptions = StateServiceFactoryOptions &
   StateMigrationServiceInitOptions;
 
 export function stateServiceFactory(opts: StateServiceInitOptions): StateService {
-  if (!opts.stateService) {
-    opts.stateService = new StateService(
-      diskStorageServiceFactory(opts),
-      secureStorageServiceFactory(opts),
-      memoryStorageServiceFactory(opts),
-      logServiceFactory(opts),
-      stateMigrationServiceFactory(opts),
-      opts.stateFactory,
-      opts.useAccountCache
-    );
-  }
-  return opts.stateService;
+  return factory(
+    opts,
+    "stateService",
+    () =>
+      new StateService(
+        diskStorageServiceFactory(opts),
+        secureStorageServiceFactory(opts),
+        memoryStorageServiceFactory(opts),
+        logServiceFactory(opts),
+        stateMigrationServiceFactory(opts),
+        opts.stateFactory,
+        opts.useAccountCache
+      )
+  );
 }

--- a/apps/browser/src/background/service_factories/state-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-service.factory.ts
@@ -1,0 +1,47 @@
+import { StateFactory } from "@bitwarden/common/factories/stateFactory";
+import { GlobalState } from "@bitwarden/common/models/domain/globalState";
+
+import { Account } from "../../models/account";
+import { StateService } from "../../services/state.service";
+
+import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
+import {
+  stateMigrationServiceFactory,
+  StateMigrationServiceInitOptions,
+} from "./state-migration-service.factory";
+import {
+  diskStorageServiceFactory,
+  secureStorageServiceFactory,
+  memoryStorageServiceFactory,
+  DiskStorageServiceInitOptions,
+  SecureStorageServiceInitOptions,
+  MemoryStorageServiceInitOptions,
+} from "./storage-service.factory";
+
+type StateServiceFactoryOptions = {
+  stateService?: StateService;
+  useAccountCache?: boolean;
+  stateFactory: StateFactory<GlobalState, Account>;
+};
+
+export type StateServiceInitOptions = StateServiceFactoryOptions &
+  DiskStorageServiceInitOptions &
+  SecureStorageServiceInitOptions &
+  MemoryStorageServiceInitOptions &
+  LogServiceInitOptions &
+  StateMigrationServiceInitOptions;
+
+export function stateServiceFactory(opts: StateServiceInitOptions): StateService {
+  if (!opts.stateService) {
+    opts.stateService = new StateService(
+      diskStorageServiceFactory(opts),
+      secureStorageServiceFactory(opts),
+      memoryStorageServiceFactory(opts),
+      logServiceFactory(opts),
+      stateMigrationServiceFactory(opts),
+      opts.stateFactory,
+      opts.useAccountCache
+    );
+  }
+  return opts.stateService;
+}

--- a/apps/browser/src/background/service_factories/state-service.factory.ts
+++ b/apps/browser/src/background/service_factories/state-service.factory.ts
@@ -4,7 +4,7 @@ import { GlobalState } from "@bitwarden/common/models/domain/globalState";
 import { Account } from "../../models/account";
 import { StateService } from "../../services/state.service";
 
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 import { logServiceFactory, LogServiceInitOptions } from "./log-service.factory";
 import {
   stateMigrationServiceFactory,
@@ -20,10 +20,9 @@ import {
 } from "./storage-service.factory";
 
 type StateServiceFactoryOptions = FactoryOptions & {
-  useAccountCache?: boolean;
-  stateFactory: StateFactory<GlobalState, Account>;
-  instances: {
-    stateService?: StateService;
+  stateServiceOptions: {
+    useAccountCache?: boolean;
+    stateFactory: StateFactory<GlobalState, Account>;
   };
 };
 
@@ -34,19 +33,23 @@ export type StateServiceInitOptions = StateServiceFactoryOptions &
   LogServiceInitOptions &
   StateMigrationServiceInitOptions;
 
-export function stateServiceFactory(opts: StateServiceInitOptions): StateService {
+export function stateServiceFactory(
+  cache: { stateService?: StateService } & CachedServices,
+  opts: StateServiceInitOptions
+): StateService {
   return factory(
-    opts,
+    cache,
     "stateService",
+    opts,
     () =>
       new StateService(
-        diskStorageServiceFactory(opts),
-        secureStorageServiceFactory(opts),
-        memoryStorageServiceFactory(opts),
-        logServiceFactory(opts),
-        stateMigrationServiceFactory(opts),
-        opts.stateFactory,
-        opts.useAccountCache
+        diskStorageServiceFactory(cache, opts),
+        secureStorageServiceFactory(cache, opts),
+        memoryStorageServiceFactory(cache, opts),
+        logServiceFactory(cache, opts),
+        stateMigrationServiceFactory(cache, opts),
+        opts.stateServiceOptions.stateFactory,
+        opts.stateServiceOptions.useAccountCache
       )
   );
 }

--- a/apps/browser/src/background/service_factories/storage-service.factory.ts
+++ b/apps/browser/src/background/service_factories/storage-service.factory.ts
@@ -23,7 +23,7 @@ export type MemoryStorageServiceInitOptions = StorageServiceFactoryOptions &
   KeyGenerationServiceInitOptions;
 
 export function diskStorageServiceFactory(
-  opts: StorageServiceFactoryOptions
+  opts: DiskStorageServiceInitOptions
 ): AbstractStorageService {
   if (!opts.diskStorageService) {
     opts.diskStorageService = new BrowserLocalStorageService();
@@ -32,7 +32,7 @@ export function diskStorageServiceFactory(
 }
 
 export function secureStorageServiceFactory(
-  opts: StorageServiceFactoryOptions
+  opts: SecureStorageServiceInitOptions
 ): AbstractStorageService {
   if (!opts.secureStorageService) {
     opts.secureStorageService = new BrowserLocalStorageService();

--- a/apps/browser/src/background/service_factories/storage-service.factory.ts
+++ b/apps/browser/src/background/service_factories/storage-service.factory.ts
@@ -1,0 +1,56 @@
+import { AbstractStorageService } from "@bitwarden/common/abstractions/storage.service";
+import { MemoryStorageService } from "@bitwarden/common/services/memoryStorage.service";
+
+import BrowserLocalStorageService from "../../services/browserLocalStorage.service";
+import { LocalBackedSessionStorageService } from "../../services/localBackedSessionStorage.service";
+
+import { encryptServiceFactory, EncryptServiceInitOptions } from "./encrypt-service.factory";
+import {
+  keyGenerationServiceFactory,
+  KeyGenerationServiceInitOptions,
+} from "./key-generation-service.factory";
+
+type StorageServiceFactoryOptions = {
+  diskStorageService?: AbstractStorageService;
+  secureStorageService?: AbstractStorageService;
+  memoryStorageService?: AbstractStorageService;
+};
+
+export type DiskStorageServiceInitOptions = StorageServiceFactoryOptions;
+export type SecureStorageServiceInitOptions = StorageServiceFactoryOptions;
+export type MemoryStorageServiceInitOptions = StorageServiceFactoryOptions &
+  EncryptServiceInitOptions &
+  KeyGenerationServiceInitOptions;
+
+export function diskStorageServiceFactory(
+  opts: StorageServiceFactoryOptions
+): AbstractStorageService {
+  if (!opts.diskStorageService) {
+    opts.diskStorageService = new BrowserLocalStorageService();
+  }
+  return opts.diskStorageService;
+}
+
+export function secureStorageServiceFactory(
+  opts: StorageServiceFactoryOptions
+): AbstractStorageService {
+  if (!opts.secureStorageService) {
+    opts.secureStorageService = new BrowserLocalStorageService();
+  }
+  return opts.secureStorageService;
+}
+
+export function memoryStorageServiceFactory(
+  opts: MemoryStorageServiceInitOptions
+): AbstractStorageService {
+  if (!opts.memoryStorageService) {
+    opts.memoryStorageService =
+      chrome.runtime.getManifest().manifest_version == 3
+        ? new LocalBackedSessionStorageService(
+            encryptServiceFactory(opts),
+            keyGenerationServiceFactory(opts)
+          )
+        : new MemoryStorageService();
+  }
+  return opts.memoryStorageService;
+}

--- a/apps/browser/src/background/service_factories/storage-service.factory.ts
+++ b/apps/browser/src/background/service_factories/storage-service.factory.ts
@@ -5,19 +5,13 @@ import BrowserLocalStorageService from "../../services/browserLocalStorage.servi
 import { LocalBackedSessionStorageService } from "../../services/localBackedSessionStorage.service";
 
 import { encryptServiceFactory, EncryptServiceInitOptions } from "./encrypt-service.factory";
-import { factory, FactoryOptions } from "./factory-options";
+import { CachedServices, factory, FactoryOptions } from "./factory-options";
 import {
   keyGenerationServiceFactory,
   KeyGenerationServiceInitOptions,
 } from "./key-generation-service.factory";
 
-type StorageServiceFactoryOptions = FactoryOptions & {
-  instances: {
-    diskStorageService?: AbstractStorageService;
-    secureStorageService?: AbstractStorageService;
-    memoryStorageService?: AbstractStorageService;
-  };
-};
+type StorageServiceFactoryOptions = FactoryOptions;
 
 export type DiskStorageServiceInitOptions = StorageServiceFactoryOptions;
 export type SecureStorageServiceInitOptions = StorageServiceFactoryOptions;
@@ -26,25 +20,28 @@ export type MemoryStorageServiceInitOptions = StorageServiceFactoryOptions &
   KeyGenerationServiceInitOptions;
 
 export function diskStorageServiceFactory(
+  cache: { diskStorageService?: AbstractStorageService } & CachedServices,
   opts: DiskStorageServiceInitOptions
 ): AbstractStorageService {
-  return factory(opts, "diskStorageService", () => new BrowserLocalStorageService());
+  return factory(cache, "diskStorageService", opts, () => new BrowserLocalStorageService());
 }
 
 export function secureStorageServiceFactory(
+  cache: { secureStorageService?: AbstractStorageService } & CachedServices,
   opts: SecureStorageServiceInitOptions
 ): AbstractStorageService {
-  return factory(opts, "secureStorageService", () => new BrowserLocalStorageService());
+  return factory(cache, "secureStorageService", opts, () => new BrowserLocalStorageService());
 }
 
 export function memoryStorageServiceFactory(
+  cache: { memoryStorageService?: AbstractStorageService } & CachedServices,
   opts: MemoryStorageServiceInitOptions
 ): AbstractStorageService {
-  return factory(opts, "memoryStorageService", () => {
+  return factory(cache, "memoryStorageService", opts, () => {
     if (chrome.runtime.getManifest().manifest_version == 3) {
       return new LocalBackedSessionStorageService(
-        encryptServiceFactory(opts),
-        keyGenerationServiceFactory(opts)
+        encryptServiceFactory(cache, opts),
+        keyGenerationServiceFactory(cache, opts)
       );
     }
     return new MemoryStorageService();

--- a/apps/browser/src/flags.ts
+++ b/apps/browser/src/flags.ts
@@ -1,3 +1,5 @@
+import { GroupPolicyEnvironment } from "./types/group-policy-environment";
+
 function getFlags<T>(envFlags: string | T): T {
   if (typeof envFlags === "string") {
     return JSON.parse(envFlags) as T;
@@ -21,11 +23,13 @@ export function flagEnabled(flag: FlagName): boolean {
  */
 export type DevFlags = {
   storeSessionDecrypted?: boolean;
+  managedEnvironment?: GroupPolicyEnvironment;
 };
 
 export type DevFlagName = keyof DevFlags;
 
 /**
+ * Gets whether the given dev flag is truthy.
  * Gets the value of a dev flag from environment.
  * Will always return false unless in development.
  * @param flag The name of the dev flag to check
@@ -37,5 +41,21 @@ export function devFlagEnabled(flag: DevFlagName): boolean {
   }
 
   const devFlags = getFlags<DevFlags>(process.env.DEV_FLAGS);
-  return devFlags[flag] == null || devFlags[flag];
+  return devFlags[flag] == null || !!devFlags[flag];
+}
+
+/**
+ * Gets the value of a dev flag from environment.
+ * Will always return false unless in development.
+ * @param flag The name of the dev flag to check
+ * @returns The value of the flag
+ * @throws Error if the flag is not enabled
+ */
+export function devFlagValue<K extends DevFlagName>(flag: K): DevFlags[K] {
+  if (!devFlagEnabled(flag)) {
+    throw new Error(`This method should not be called, it is protected by a disabled dev flag.`);
+  }
+
+  const devFlags = getFlags<DevFlags>(process.env.DEV_FLAGS);
+  return devFlags[flag];
 }

--- a/apps/browser/src/listeners/onInstallListener.ts
+++ b/apps/browser/src/listeners/onInstallListener.ts
@@ -11,6 +11,7 @@ export function onInstallListener(details: chrome.runtime.InstalledDetails) {
     win: self,
     isDev: false,
     stateFactory: new StateFactory(GlobalState, Account),
+    instances: {},
   };
   const environmentService = environmentServiceFactory(opts);
 

--- a/apps/browser/src/listeners/onInstallListener.ts
+++ b/apps/browser/src/listeners/onInstallListener.ts
@@ -1,0 +1,26 @@
+import { StateFactory } from "@bitwarden/common/factories/stateFactory";
+import { GlobalState } from "@bitwarden/common/models/domain/globalState";
+
+import { environmentServiceFactory } from "../background/service_factories/environment-service.factory";
+import { BrowserApi } from "../browser/browserApi";
+import { Account } from "../models/account";
+
+export function onInstallListener(details: chrome.runtime.InstalledDetails) {
+  const opts = {
+    logMacFailures: false,
+    win: self,
+    isDev: false,
+    stateFactory: new StateFactory(GlobalState, Account),
+  };
+  const environmentService = environmentServiceFactory(opts);
+
+  setTimeout(async () => {
+    if (details.reason != null && details.reason === "install") {
+      BrowserApi.createNewTab("https://bitwarden.com/browser-start/");
+
+      if (await environmentService.hasManagedEnvironment()) {
+        await environmentService.setUrlsToManagedEnvironment();
+      }
+    }
+  }, 100);
+}

--- a/apps/browser/src/listeners/onInstallListener.ts
+++ b/apps/browser/src/listeners/onInstallListener.ts
@@ -6,14 +6,25 @@ import { BrowserApi } from "../browser/browserApi";
 import { Account } from "../models/account";
 
 export function onInstallListener(details: chrome.runtime.InstalledDetails) {
+  const cache = {};
   const opts = {
-    logMacFailures: false,
-    win: self,
-    isDev: false,
-    stateFactory: new StateFactory(GlobalState, Account),
-    instances: {},
+    encryptServiceOptions: {
+      logMacFailures: false,
+    },
+    cryptoFunctionServiceOptions: {
+      win: self,
+    },
+    logServiceOptions: {
+      isDev: false,
+    },
+    stateServiceOptions: {
+      stateFactory: new StateFactory(GlobalState, Account),
+    },
+    stateMigrationServiceOptions: {
+      stateFactory: new StateFactory(GlobalState, Account),
+    },
   };
-  const environmentService = environmentServiceFactory(opts);
+  const environmentService = environmentServiceFactory(cache, opts);
 
   setTimeout(async () => {
     if (details.reason != null && details.reason === "install") {

--- a/apps/browser/src/types/group-policy-environment.ts
+++ b/apps/browser/src/types/group-policy-environment.ts
@@ -1,0 +1,9 @@
+export type GroupPolicyEnvironment = {
+  base?: string;
+  webVault?: string;
+  api?: string;
+  identity?: string;
+  icons?: string;
+  notifications?: string;
+  events?: string;
+};


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix oninstall hook for manifest v3.

I'm also trying out a way of organizing Manifest V3 factories for command initialization. In effect, it's hiding the initialization specifics within a factory method and forcing only the minimum required parameters for all dependent services to be provided.

This is a reasonable pattern until services are decoupled to the point that we just want simple initializers.

## Code changes
Most of the changes are with creating factories. Other changes are:

- **background**: add onInstall listener
- **main.background**: use factories
- **onInstallListener**: Copied from runtime.background (It still exists there for mv2 usage).

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
