### PR TITLE
[SG-569] Native Messaging settings bug

### DIFF
--- a/apps/desktop/native-messaging-test-runner/src/test-ipc.ts
+++ b/apps/desktop/native-messaging-test-runner/src/test-ipc.ts
@@ -24,7 +24,9 @@ export default class TestIPC {
 
         ipc.of.bitwarden.on("error", (err: any) => {
           console.error("error", err);
-          console.log("\x1b[33m Please make sure the desktop app is running locally \x1b[0m");
+          console.log(
+            "\x1b[33m Please make sure the desktop app is running locally and 'Allow DuckDuckGo browser integration' setting is enabled \x1b[0m"
+          );
         });
 
         ipc.of.bitwarden.on("disconnect", () => {

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -444,7 +444,7 @@ export class SettingsComponent implements OnInit {
       this.enableDuckDuckGoBrowserIntegration
     );
     this.messagingService.send(
-      this.enableBrowserIntegration
+      this.enableDuckDuckGoBrowserIntegration
         ? "enableDuckDuckGoBrowserIntegration"
         : "disableDuckDuckGoBrowserIntegration"
     );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -173,7 +173,7 @@ export class Main {
 
         if (
           (await this.stateService.getEnableBrowserIntegration()) ||
-          this.stateService.getEnableDuckDuckGoBrowserIntegration()
+          (await this.stateService.getEnableDuckDuckGoBrowserIntegration())
         ) {
           this.nativeMessagingMain.listen();
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a bug where enabling browser setting was not starting native messaging service.

## Code changes

- **apps/desktop/src/app/accounts/settings.component.ts:** Send correct value to messaging service
- **apps/desktop/src/main.ts:** Wasn't causing issues, but fix missing await I noticed while investigating this
- **apps/desktop/native-messaging-test-runner/src/test-ipc.ts:** Update test runner error message with more context

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
