### PR TITLE
[PS-1290] Client fails to render vault when switching between accounts

### DIFF
--- a/libs/angular/src/components/lock.component.ts
+++ b/libs/angular/src/components/lock.component.ts
@@ -58,8 +58,6 @@ export class LockComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
-    // Load the first and observe updates
-    await this.load();
     this.activeAccountSubscription = this.stateService.activeAccount$.subscribe(async () => {
       await this.load();
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This fixes a bug where the lock component gets stuck in a loading state while switching between accounts.

Although the bug only occurs on desktop because of account switching, the change was made in libs which affects also web and browser. I have verified that there are no negative effects from removing the initial `this.load`

This was likely introduced due to my changes with https://github.com/bitwarden/clients/pull/3268 which fixed the subscription to `activeAccount$`

## Code changes

- **libs/angular/src/components/lock.component.ts**: Do not call `this.load` on the ngOnInit twice. 

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
