### PR TITLE
[SG-575] Send reference data on account creation

### DIFF
--- a/apps/web/src/app/accounts/register-form/register-form.component.ts
+++ b/apps/web/src/app/accounts/register-form/register-form.component.ts
@@ -15,6 +15,7 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/models/domain/masterPasswordPolicyOptions";
+import { ReferenceEventRequest } from "@bitwarden/common/models/request/referenceEventRequest";
 
 @Component({
   selector: "app-register-form",
@@ -23,6 +24,7 @@ import { MasterPasswordPolicyOptions } from "@bitwarden/common/models/domain/mas
 export class RegisterFormComponent extends BaseRegisterComponent {
   @Input() queryParamEmail: string;
   @Input() enforcedPolicyOptions: MasterPasswordPolicyOptions;
+  @Input() referenceDataValue: ReferenceEventRequest;
 
   showErrorSummary = false;
 
@@ -59,6 +61,7 @@ export class RegisterFormComponent extends BaseRegisterComponent {
 
   async ngOnInit() {
     await super.ngOnInit();
+    this.referenceData = this.referenceDataValue;
 
     if (this.queryParamEmail) {
       this.formGroup.get("email")?.setValue(this.queryParamEmail);

--- a/apps/web/src/app/accounts/register.component.html
+++ b/apps/web/src/app/accounts/register.component.html
@@ -115,6 +115,7 @@
                 <app-register-form
                   [queryParamEmail]="email"
                   [enforcedPolicyOptions]="enforcedPolicyOptions"
+                  [referenceDataValue]="referenceData"
                 ></app-register-form>
               </div>
             </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When creating the new reusable components, we missed sending the reference data on submit of the register form.

## Code changes

- **apps/web/src/app/accounts/register-form/register-form.component.ts:** Get referenceData as an input from parent component
- **apps/web/src/app/accounts/register.component.html:** Send referenceData from outer component to new register component.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
