### PR TITLE
[workflows] Decouple hotfix-rc branches

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -16,7 +16,7 @@ on:
     branches:
       - 'master'
       - 'rc'
-      - 'hotfix-rc'
+      - 'hotfix-rc-browser'
     paths:
       - 'apps/browser/**'
       - 'libs/**'
@@ -347,7 +347,7 @@ jobs:
 
   trigger-desktop-build:
     name: Trigger desktop build
-    if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || github.ref != 'refs/heads/hotfix-rc' }}
+    if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || github.ref != 'refs/heads/hotfix-rc-browser' }}
     runs-on: ubuntu-20.04
     needs:
       - build

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -17,7 +17,7 @@ on:
     branches:
       - 'master'
       - 'rc'
-      - 'hotfix-rc'
+      - 'hotfix-rc-cli'
     paths:
       - 'apps/cli/**'
       - 'libs/**'

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,7 +16,7 @@ on:
     branches:
       - 'master'
       - 'rc'
-      - 'hotfix-rc'
+      - 'hotfix-rc-desktop'
     paths:
       - 'apps/desktop/**'
       - 'libs/**'
@@ -121,7 +121,7 @@ jobs:
             echo "::set-output name=rc_branch_exists::0"
           fi
 
-          if [[ $(git ls-remote --heads origin hotfix-rc) ]]; then
+          if [[ $(git ls-remote --heads origin hotfix-rc-desktop) ]]; then
             echo "::set-output name=hotfix_branch_exists::1"
           else
             echo "::set-output name=hotfix_branch_exists::0"
@@ -744,13 +744,13 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Download artifact from hotfix-rc
-        if: github.ref == 'refs/heads/hotfix-rc'
+      - name: Download artifact from hotfix-rc-desktop
+        if: github.ref == 'refs/heads/hotfix-rc-desktop'
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: hotfix-rc
+          branch: hotfix-rc-desktop
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from rc
@@ -763,7 +763,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && github.ref != 'refs/heads/hotfix-rc' }}
+        if: ${{ github.ref != 'refs/heads/rc' && github.ref != 'refs/heads/hotfix-rc-desktop' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -962,13 +962,13 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
 
-      - name: Download artifact from hotfix-rc
-        if: github.ref == 'refs/heads/hotfix-rc'
+      - name: Download artifact from hotfix-rc-desktop
+        if: github.ref == 'refs/heads/hotfix-rc-desktop'
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
           workflow_conclusion: success
-          branch: hotfix-rc
+          branch: hotfix-rc-desktop
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from rc
@@ -981,7 +981,7 @@ jobs:
           path: ${{ github.workspace }}/browser-build-artifacts
 
       - name: Download artifact from master
-        if: ${{ github.ref != 'refs/heads/rc' && github.ref != 'refs/heads/hotfix-rc' }}
+        if: ${{ github.ref != 'refs/heads/rc' && github.ref != 'refs/heads/hotfix-rc-desktop' }}
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2.19.0
         with:
           workflow: build-browser.yml
@@ -1022,7 +1022,7 @@ jobs:
               && needs.setup.outputs.rc_branch_exists == 0
               && needs.setup.outputs.hotfix_branch_exists == 0)
             || (github.ref == 'refs/heads/rc' && needs.setup.outputs.hotfix_branch_exists == 0)
-            || github.ref == 'refs/heads/hotfix-rc'
+            || github.ref == 'refs/heads/hotfix-rc-desktop'
         run: npm run upload:mas
 
 

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -17,7 +17,7 @@ on:
     branches:
       - 'master'
       - 'rc'
-      - 'hotfix-rc'
+      - 'hotfix-rc-web'
     paths:
       - 'apps/web/**'
       - 'libs/**'
@@ -182,7 +182,7 @@ jobs:
           echo "GitHub event: $GITHUB_EVENT"
 
       - name: Setup DCT
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc-web'
         id: setup-dct
         uses: bitwarden/gh-actions/setup-docker-trust@a8c384a05a974c05c48374c818b004be221d43ff
         with:
@@ -225,11 +225,11 @@ jobs:
         run: docker tag bitwarden/web bitwarden/web:dev
 
       - name: Tag hotfix branch
-        if: github.ref == 'refs/heads/hotfix-rc'
-        run: docker tag bitwarden/web bitwarden/web:hotfix-rc
+        if: github.ref == 'refs/heads/hotfix-rc-web'
+        run: docker tag bitwarden/web bitwarden/web:hotfix-rc-web
 
       - name: List Docker images
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc-web'
         run: docker images
 
       - name: Push rc image
@@ -247,14 +247,14 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
 
       - name: Push hotfix image
-        if: github.ref == 'refs/heads/hotfix-rc'
-        run: docker push bitwarden/web:hotfix-rc
+        if: github.ref == 'refs/heads/hotfix-rc-web'
+        run: docker push bitwarden/web:hotfix-rc-web
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
 
       - name: Log out of Docker
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc-web'
         run: |
           docker logout
           echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV

--- a/.github/workflows/release-browser.yml
+++ b/.github/workflows/release-browser.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Branch check
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc-browser ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+            echo "[!] Can only release from the 'rc' or 'hotfix-rc-browser' branches"
             echo "==================================="
             exit 1
           fi

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Branch check
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc-cli ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+            echo "[!] Can only release from the 'rc' or 'hotfix-rc-cli' branches"
             echo "==================================="
             exit 1
           fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Branch check
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != refs/heads/hotfix-rc-desktop ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+            echo "[!] Can only release from the 'rc' or 'hotfix-rc-desktop' branches"
             echo "==================================="
             exit 1
           fi

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Branch check
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != "refs/heads/hotfix-rc" ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ $GITHUB_REF != "refs/heads/hotfix-rc-web" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix-rc' branches"
+            echo "[!] Can only release from the 'rc' or 'hotfix-rc-web' branches"
             echo "==================================="
             exit 1
           fi


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

With every hotfix for Web, Cli, and Browser we push out on the shared `hotfix-rc` branch, we block Desktop TestFlight publishing on `master` and `rc`. As we near the start of release preparation, hotfixes on Web, Cli, and Browser jeopardize the testing time of Desktop since the latest version cannot be published to TestFlight for testing.

This change decouples the hotfix-rc branch from the clients by creating one branch for each client. This solution maintains the same hotfix branching strategy for all clients in this repo while fixing the problem of the other clients holding up Desktop.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/*-browser.yml:** Replaced all instances of `hotfix-rc` with `hotfix-rc-browser`
- **.github/workflows/*-cli.yml:** Replaced all instances of `hotfix-rc` with `hotfix-rc-cli`
- **.github/workflows/*-desktop.yml:** Replaced all instances of `hotfix-rc` with `hotfix-rc-desktop`
- **.github/workflows/*-web.yml:** Replaced all instances of `hotfix-rc` with `hotfix-rc-web`

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
