### PR TITLE
[PS-1299] Fix 3293: Add tooltip text for long collection name

### DIFF
--- a/apps/desktop/src/app/vault/vault-filter/filters/collection-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/collection-filter.component.html
@@ -46,6 +46,8 @@
           </button>
           <button
             class="filter-button"
+            data-bs-toggle="tooltip"
+            title="{{c.node.name}}"
             (click)="applyFilter(c.node)"
             [attr.aria-pressed]="c.node.id === activeFilter.selectedCollectionId"
           >


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
To fix issue #3293

## Code changes

- **collection-filter.component.html:** For adding tooltip on collection filter button. The tooltip will show  non trimmed collection name

## Screenshots
![image](https://user-images.githubusercontent.com/36285899/184521596-c1ad944f-0fe9-4ab0-bfb8-b8a839db0f44.png)

## Before you submit
```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
```
