### PR TITLE
[PS-1303] Desktop/browser: tweak `.box-header-expandable` styles

### DIFF
--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -33,7 +33,7 @@
     }
 
     &:hover,
-    &:focus,
+    &:focus-visible,
     &.active {
       @include themify($themes) {
         background-color: themed("boxBackgroundHoverColor");

--- a/apps/desktop/src/scss/box.scss
+++ b/apps/desktop/src/scss/box.scss
@@ -48,7 +48,7 @@
     }
 
     &:hover,
-    &:focus,
+    &:focus-visible,
     &.active {
       @include themify($themes) {
         background-color: themed("boxBackgroundHoverColor");

--- a/apps/desktop/src/scss/box.scss
+++ b/apps/desktop/src/scss/box.scss
@@ -77,6 +77,10 @@
 
     &.box-content-padded {
       padding: 10px 15px;
+
+      .box-header-expandable[aria-expanded="true"] {
+        margin-bottom: 1rem;
+      }
     }
 
     &.condensed .box-content-row,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

A slight layout/styling tweak for `.box-header-expandable` - one specific to desktop, and one for both desktop and browser:

Currently, on desktop, the "Settings" modal looks very awkwards and cramped - the content of the three panels ("Security", "Preferences", "App Settings") looks a bit too close to the expandable header button, making it feel quite untidy.

![Screenshot of the "Security" panel, open, with the "Vault timeout" first label very close to the "Security" expandable header button](https://user-images.githubusercontent.com/895831/184554198-90509f2d-e046-4ddc-ad69-6fa12adca3d4.png)

![Screenshot of the "Preferences" panel, open, with the "Clear clipboard" first label very close to the "Preferences" expandable header button](https://user-images.githubusercontent.com/895831/184554215-c0f413d6-fc94-4329-92f9-7975852a7391.png)

![Screenshot of the "App Settings" panel, open, with the "Enable tray icon" checkbox very close to the "App Settings" expandable header button](https://user-images.githubusercontent.com/895831/184554232-56a5cdd4-9164-49c1-a4bb-9aa369f7cde4.png)

this PR adds a bit more bottom margin to the `.box-header-expandable` button when it's expanded (`[aria-expanded=true]`).

---

On both desktop and browser extension, clicking on a `.box-header-expandable` with the mouse/touch leads to the background colour changing and remaining "stuck" until focus is moved to another control. This looks a bit awkward.

Animated gif showing how the background gets "stuck" on the desktop settings:

![Animated gif of opening/closing box headers with the mouse in the desktop app - background remains stuck once moving mouse away from it](https://user-images.githubusercontent.com/895831/184555128-0d85acdd-0e99-45b7-b60a-b1bc5e99bc0a.gif)

Same happens in the browser extension:

![Animated gif of opening/closing box headers with the mouse in the browser extension - background remains stuck once moving mouse away from it](https://user-images.githubusercontent.com/895831/184555213-6af8ef3f-0018-44e6-84d0-468de4b7c32f.gif)


This PR changes the selector that sets the background from `:focus` to `:focus-visible`, so it only kicks in when navigating with a keyboard, and not as a result of a mouse click or touch tap

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps\desktop\src\scss\box.scss**: add extra bottom margin when ` .box-header-expandable[aria-expanded="true"]` inside `.box-content-padded`
- **apps\browser\src\popup\scss\box.scss** and **apps\desktop\src\scss\box.scss**: change the selector to set the `boxBackgroundHoverColor` from `:focus` to `:focus-visible` so it will only kick in when navigating with the keyboard, not when the header button receives focus from a mouse click or touch tap

## Screenshots

The desktop settings panels, with the added bottom margin on the header button once expanded

![Screenshot of the "Security" panel, open, with more padding before the first form field](https://user-images.githubusercontent.com/895831/184554420-6486a4d8-8e93-434f-9ae3-ce7524628d3c.png)

![Screenshot of the "Preferences" panel, open, with more padding before the first form field](https://user-images.githubusercontent.com/895831/184554432-a0f3152f-34dd-41ec-89df-45d4305baa33.png)

![Screenshot of the "App Settings" panel, open, with more padding before the first form field](https://user-images.githubusercontent.com/895831/184554424-2b7ad78a-4ae4-4765-a71d-3e504907914d.png)

---

Animated GIF showing that changing `:focus` to `:focus-visible` means the background doesn't get "stuck" in the desktop app when clicking with the mouse (it still shows on `:hover` and `:active` as before).

On desktop:

![Animated gif of opening/closing box headers with the mouse on desktop - background doesn't remain stuck once moving mouse away from it](https://user-images.githubusercontent.com/895831/184554876-a4dfb97c-b59f-411e-89e1-cb2df20eb8c1.gif)

And in the browser - in addition, this also shows how `:focus-visible` does kick in when navigating with keyboard

![Animated gif of opening/closing box headers with the mouse in browser - background doesn't remain stuck once moving mouse away from it; also shows navigation with keyboard, where :focus-visibile correctly kicks in](https://user-images.githubusercontent.com/895831/184555392-47fd175b-567c-4056-beaa-0d1e5ae81bd9.gif)


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
