### PR TITLE
[SG-587] Enabled showTrial feature flag in cloud

### DIFF
--- a/apps/web/config/cloud.json
+++ b/apps/web/config/cloud.json
@@ -16,6 +16,6 @@
     "proxyEvents": "https://events.bitwarden.com"
   },
   "flags": {
-    "showTrial": false
+    "showTrial": true
   }
 }

--- a/apps/web/config/selfhosted.json
+++ b/apps/web/config/selfhosted.json
@@ -7,6 +7,6 @@
     "port": 8081
   },
   "flags": {
-    "showTrial": false
+    "showTrial": true
   }
 }

--- a/apps/web/config/selfhosted.json
+++ b/apps/web/config/selfhosted.json
@@ -7,6 +7,6 @@
     "port": 8081
   },
   "flags": {
-    "showTrial": true
+    "showTrial": false
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Enabled Trial Initiation in cloud.  It was disabled for the `2022.8` release but will be enabled for `2022.9`.

## Code changes

- **cloud.json:** Enabled showTrial feature flag

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
