### PR TITLE
[SG-550] Import OrganizationBadgeModule in VaultModule

### DIFF
--- a/apps/web/src/app/vault/vault.module.ts
+++ b/apps/web/src/app/vault/vault.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from "@angular/core";
 
 import { CiphersComponent } from "./ciphers.component";
+import { OrganizationBadgeModule } from "./organization-badge/organization-badge.module";
 import { VaultSharedModule } from "./shared/vault-shared.module";
 import { VaultRoutingModule } from "./vault-routing.module";
 import { VaultComponent } from "./vault.component";
 
 @NgModule({
-  imports: [VaultSharedModule, VaultRoutingModule],
+  imports: [VaultSharedModule, VaultRoutingModule, OrganizationBadgeModule],
   declarations: [VaultComponent, CiphersComponent],
   exports: [VaultComponent],
 })


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-360

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The work to remove the `module/` folder left out an import, which is causing organization badges to not appear.

## Code changes
Import `OrganizationBadgeModule` in `VaultModule` where it is used.


<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
