### PR TITLE
Split session key and synced item property key

### DIFF
--- a/apps/browser/src/decorators/session-sync-observable/browser-session.decorator.ts
+++ b/apps/browser/src/decorators/session-sync-observable/browser-session.decorator.ts
@@ -39,7 +39,7 @@ export function browserSession<TCtor extends Constructor<any>>(constructor: TCto
     }
 
     buildSyncer(metadata: SyncedItemMetadata, stateService: StateService) {
-      const syncer = new SessionSyncer((this as any)[metadata.key], stateService, metadata);
+      const syncer = new SessionSyncer((this as any)[metadata.propertyKey], stateService, metadata);
       syncer.init();
       return syncer;
     }

--- a/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
@@ -14,7 +14,8 @@ describe("sessionSync decorator", () => {
     const testClass = new TestClass();
     expect((testClass as any).__syncedItemMetadata).toEqual([
       expect.objectContaining({
-        key: "TestClass_testProperty",
+        propertyKey: "testProperty",
+        sessionKey: "TestClass_testProperty",
         ctor: ctor,
         initializer: initializer,
       }),

--- a/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.ts
@@ -42,7 +42,8 @@ export function sessionSync<T>(buildOptions: BuildOptions<T>) {
     }
 
     p.__syncedItemMetadata.push({
-      key: `${prototype.constructor.name}_${propertyKey}`,
+      propertyKey,
+      sessionKey: `${prototype.constructor.name}_${propertyKey}`,
       ctor: buildOptions.ctor,
       initializer: buildOptions.initializer,
       initializeAsArray: buildOptions.initializeAsArray,

--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
@@ -62,18 +62,18 @@ export class SessionSyncer {
     if (message.command != this.updateMessageCommand || message.id === this.id) {
       return;
     }
-    const keyValuePair = await this.stateService.getFromSessionMemory(this.metaData.key);
+    const keyValuePair = await this.stateService.getFromSessionMemory(this.metaData.sessionKey);
     const value = SyncedItemMetadata.buildFromKeyValuePair(keyValuePair, this.metaData);
     this.ignoreNextUpdate = true;
     this.behaviorSubject.next(value);
   }
 
   private async updateSession(value: any) {
-    await this.stateService.setInSessionMemory(this.metaData.key, value);
+    await this.stateService.setInSessionMemory(this.metaData.sessionKey, value);
     await BrowserApi.sendMessage(this.updateMessageCommand, { id: this.id });
   }
 
   private get updateMessageCommand() {
-    return `${this.metaData.key}_update`;
+    return `${this.metaData.sessionKey}_update`;
   }
 }

--- a/apps/browser/src/decorators/session-sync-observable/sync-item-metadata.ts
+++ b/apps/browser/src/decorators/session-sync-observable/sync-item-metadata.ts
@@ -1,5 +1,6 @@
 export class SyncedItemMetadata {
-  key: string;
+  propertyKey: string;
+  sessionKey: string;
   ctor?: new () => any;
   initializer?: (keyValuePair: any) => any;
   initializeAsArray?: boolean;

--- a/apps/browser/src/decorators/session-sync-observable/synced-item-metadata.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/synced-item-metadata.spec.ts
@@ -1,6 +1,7 @@
 import { SyncedItemMetadata } from "./sync-item-metadata";
 
 describe("build from key value pair", () => {
+  const propertyKey = "propertyKey";
   const key = "key";
   const initializer = (s: any) => "used initializer";
   class TestClass {}
@@ -10,7 +11,8 @@ describe("build from key value pair", () => {
     const actual = SyncedItemMetadata.buildFromKeyValuePair(
       {},
       {
-        key: "key",
+        propertyKey,
+        sessionKey: "key",
         initializer: initializer,
       }
     );
@@ -21,7 +23,8 @@ describe("build from key value pair", () => {
   it("should call ctor if provided", () => {
     const expected = { provided: "value" };
     const actual = SyncedItemMetadata.buildFromKeyValuePair(expected, {
-      key: key,
+      propertyKey,
+      sessionKey: key,
       ctor: ctor,
     });
 
@@ -33,7 +36,8 @@ describe("build from key value pair", () => {
     const actual = SyncedItemMetadata.buildFromKeyValuePair(
       {},
       {
-        key: key,
+        propertyKey,
+        sessionKey: key,
         initializer: initializer,
         ctor: ctor,
       }
@@ -44,7 +48,8 @@ describe("build from key value pair", () => {
 
   it("should honor initialize as array", () => {
     const actual = SyncedItemMetadata.buildFromKeyValuePair([1, 2], {
-      key: key,
+      propertyKey,
+      sessionKey: key,
       initializer: initializer,
       initializeAsArray: true,
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

A PR review improvement introduced some issues I didn't catch with sync item keys. This corrects those oversights.