### PR TITLE
[EC-451] Org Admin Refresh Permissions Refactor

### DIFF
--- a/apps/web/src/app/organizations/billing/organization-billing-routing.module.ts
+++ b/apps/web/src/app/organizations/billing/organization-billing-routing.module.ts
@@ -25,19 +25,15 @@ const routes: Routes = [
       {
         path: "payment-method",
         component: PaymentMethodComponent,
-        canActivate: [OrganizationPermissionsGuard],
         data: {
           titleId: "paymentMethod",
-          organizationPermissions: (org: Organization) => org.canManageBilling,
         },
       },
       {
         path: "history",
         component: OrgBillingHistoryViewComponent,
-        canActivate: [OrganizationPermissionsGuard],
         data: {
           titleId: "billingHistory",
-          organizationPermissions: (org: Organization) => org.canManageBilling,
         },
       },
     ],

--- a/apps/web/src/app/organizations/billing/organization-billing-routing.module.ts
+++ b/apps/web/src/app/organizations/billing/organization-billing-routing.module.ts
@@ -1,10 +1,9 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
-import { Organization } from "@bitwarden/common/models/domain/organization";
-
 import { PaymentMethodComponent } from "../../settings/payment-method.component";
 import { OrganizationPermissionsGuard } from "../guards/org-permissions.guard";
+import { canAccessBillingTab } from "../navigation-permissions";
 
 import { OrgBillingHistoryViewComponent } from "./organization-billing-history-view.component";
 import { OrganizationBillingTabComponent } from "./organization-billing-tab.component";
@@ -15,7 +14,7 @@ const routes: Routes = [
     path: "",
     component: OrganizationBillingTabComponent,
     canActivate: [OrganizationPermissionsGuard],
-    data: { organizationPermissions: (org: Organization) => org.canManageBilling },
+    data: { organizationPermissions: canAccessBillingTab },
     children: [
       { path: "", pathMatch: "full", redirectTo: "subscription" },
       {

--- a/apps/web/src/app/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/organizations/layouts/organization-layout.component.ts
@@ -5,7 +5,13 @@ import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.s
 import { OrganizationService } from "@bitwarden/common/abstractions/organization.service";
 import { Organization } from "@bitwarden/common/models/domain/organization";
 
-import { canAccessSettingsTab } from "../navigation-permissions";
+import {
+  canAccessBillingTab,
+  canAccessGroupsTab,
+  canAccessMembersTab,
+  canAccessReportingTab,
+  canAccessSettingsTab,
+} from "../navigation-permissions";
 
 const BroadcasterSubscriptionId = "OrganizationLayoutComponent";
 
@@ -55,19 +61,19 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
   }
 
   get showMembersTab(): boolean {
-    return this.organization.canManageUsers;
+    return canAccessMembersTab(this.organization);
   }
 
   get showGroupsTab(): boolean {
-    return this.organization.canManageGroups;
+    return canAccessGroupsTab(this.organization);
   }
 
   get showReportsTab(): boolean {
-    return this.organization.canAccessReports;
+    return canAccessReportingTab(this.organization);
   }
 
   get showBillingTab(): boolean {
-    return this.organization.canManageBilling;
+    return canAccessBillingTab(this.organization);
   }
 
   get reportTabLabel(): string {

--- a/apps/web/src/app/organizations/navigation-permissions.ts
+++ b/apps/web/src/app/organizations/navigation-permissions.ts
@@ -20,29 +20,12 @@ export function canAccessSettingsTab(org: Organization): boolean {
   return org.isOwner;
 }
 
-export function canAccessManageTab(org: Organization): boolean {
-  return (
-    org.canCreateNewCollections ||
-    org.canEditAnyCollection ||
-    org.canDeleteAnyCollection ||
-    org.canEditAssignedCollections ||
-    org.canDeleteAssignedCollections ||
-    org.canAccessEventLogs ||
-    org.canManageGroups ||
-    org.canManageUsers ||
-    org.canManagePolicies ||
-    org.canManageSso ||
-    org.canManageScim
-  );
-}
-
 export function canAccessOrgAdmin(org: Organization): boolean {
   return (
     canAccessMembersTab(org) ||
     canAccessGroupsTab(org) ||
     canAccessReportingTab(org) ||
     canAccessBillingTab(org) ||
-    canAccessSettingsTab(org) ||
-    canAccessManageTab(org)
+    canAccessSettingsTab(org)
   );
 }

--- a/apps/web/src/app/organizations/navigation-permissions.ts
+++ b/apps/web/src/app/organizations/navigation-permissions.ts
@@ -1,7 +1,19 @@
 import { Organization } from "@bitwarden/common/models/domain/organization";
 
-export function canAccessToolsTab(org: Organization): boolean {
-  return org.canAccessImportExport || org.canAccessReports;
+export function canAccessMembersTab(org: Organization): boolean {
+  return org.canManageUsers || org.canManageUsersPassword;
+}
+
+export function canAccessGroupsTab(org: Organization): boolean {
+  return org.canManageGroups;
+}
+
+export function canAccessReportingTab(org: Organization): boolean {
+  return org.canAccessReports || org.canAccessEventLogs;
+}
+
+export function canAccessBillingTab(org: Organization): boolean {
+  return org.canManageBilling;
 }
 
 export function canAccessSettingsTab(org: Organization): boolean {
@@ -25,5 +37,12 @@ export function canAccessManageTab(org: Organization): boolean {
 }
 
 export function canAccessOrgAdmin(org: Organization): boolean {
-  return canAccessToolsTab(org) || canAccessSettingsTab(org) || canAccessManageTab(org);
+  return (
+    canAccessMembersTab(org) ||
+    canAccessGroupsTab(org) ||
+    canAccessReportingTab(org) ||
+    canAccessBillingTab(org) ||
+    canAccessSettingsTab(org) ||
+    canAccessManageTab(org)
+  );
 }

--- a/apps/web/src/app/organizations/organization-routing.module.ts
+++ b/apps/web/src/app/organizations/organization-routing.module.ts
@@ -2,13 +2,17 @@ import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
 import { AuthGuard } from "@bitwarden/angular/guards/auth.guard";
-import { Organization } from "@bitwarden/common/models/domain/organization";
 
 import { OrganizationPermissionsGuard } from "./guards/org-permissions.guard";
 import { OrganizationLayoutComponent } from "./layouts/organization-layout.component";
 import { GroupsComponent } from "./manage/groups.component";
 import { PeopleComponent } from "./manage/people.component";
-import { canAccessOrgAdmin, canAccessSettingsTab } from "./navigation-permissions";
+import {
+  canAccessGroupsTab,
+  canAccessMembersTab,
+  canAccessOrgAdmin,
+  canAccessSettingsTab,
+} from "./navigation-permissions";
 import { AccountComponent } from "./settings/account.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { TwoFactorSetupComponent } from "./settings/two-factor-setup.component";
@@ -49,7 +53,7 @@ const routes: Routes = [
         canActivate: [OrganizationPermissionsGuard],
         data: {
           titleId: "members",
-          organizationPermissions: (org: Organization) => org.canManageUsers,
+          organizationPermissions: canAccessMembersTab,
         },
       },
       {
@@ -58,7 +62,7 @@ const routes: Routes = [
         canActivate: [OrganizationPermissionsGuard],
         data: {
           titleId: "groups",
-          organizationPermissions: (org: Organization) => org.canManageGroups,
+          organizationPermissions: canAccessGroupsTab,
         },
       },
       {

--- a/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
@@ -1,10 +1,9 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
-import { Organization } from "@bitwarden/common/models/domain/organization";
-
 import { OrganizationPermissionsGuard } from "../guards/org-permissions.guard";
 import { EventsComponent } from "../manage/events.component";
+import { canAccessReportingTab } from "../navigation-permissions";
 import { ExposedPasswordsReportComponent } from "../tools/exposed-passwords-report.component";
 import { InactiveTwoFactorReportComponent } from "../tools/inactive-two-factor-report.component";
 import { ReusedPasswordsReportComponent } from "../tools/reused-passwords-report.component";
@@ -19,7 +18,7 @@ const routes: Routes = [
     path: "",
     component: ReportingComponent,
     canActivate: [OrganizationPermissionsGuard],
-    data: { organizationPermissions: (org: Organization) => org.canAccessReports },
+    data: { organizationPermissions: canAccessReportingTab },
     children: [
       { path: "", pathMatch: "full", redirectTo: "reports" },
       {

--- a/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
+import { Organization } from "@bitwarden/common/models/domain/organization";
+
 import { OrganizationPermissionsGuard } from "../guards/org-permissions.guard";
 import { EventsComponent } from "../manage/events.component";
 import { canAccessReportingTab } from "../navigation-permissions";
@@ -27,52 +29,41 @@ const routes: Routes = [
         canActivate: [OrganizationPermissionsGuard],
         data: {
           titleId: "reports",
-          organizationPermissions: (org: Organization) => org.canAccessReports,
         },
         children: [
           {
             path: "exposed-passwords-report",
             component: ExposedPasswordsReportComponent,
-            canActivate: [OrganizationPermissionsGuard],
             data: {
               titleId: "exposedPasswordsReport",
-              organizationPermissions: (org: Organization) => org.canAccessReports,
             },
           },
           {
             path: "inactive-two-factor-report",
             component: InactiveTwoFactorReportComponent,
-            canActivate: [OrganizationPermissionsGuard],
             data: {
               titleId: "inactive2faReport",
-              organizationPermissions: (org: Organization) => org.canAccessReports,
             },
           },
           {
             path: "reused-passwords-report",
             component: ReusedPasswordsReportComponent,
-            canActivate: [OrganizationPermissionsGuard],
             data: {
               titleId: "reusedPasswordsReport",
-              organizationPermissions: (org: Organization) => org.canAccessReports,
             },
           },
           {
             path: "unsecured-websites-report",
             component: UnsecuredWebsitesReportComponent,
-            canActivate: [OrganizationPermissionsGuard],
             data: {
               titleId: "unsecuredWebsitesReport",
-              organizationPermissions: (org: Organization) => org.canAccessReports,
             },
           },
           {
             path: "weak-passwords-report",
             component: WeakPasswordsReportComponent,
-            canActivate: [OrganizationPermissionsGuard],
             data: {
               titleId: "weakPasswordsReport",
-              organizationPermissions: (org: Organization) => org.canAccessReports,
             },
           },
         ],

--- a/bitwarden_license/bit-web/src/app/organizations/organizations-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/organizations-routing.module.ts
@@ -7,7 +7,6 @@ import { Organization } from "@bitwarden/common/models/domain/organization";
 import { OrganizationPermissionsGuard } from "src/app/organizations/guards/org-permissions.guard";
 import { OrganizationLayoutComponent } from "src/app/organizations/layouts/organization-layout.component";
 import { ManageComponent } from "src/app/organizations/manage/manage.component";
-import { canAccessManageTab } from "src/app/organizations/navigation-permissions";
 
 import { ScimComponent } from "./manage/scim.component";
 import { SsoComponent } from "./manage/sso.component";
@@ -21,10 +20,6 @@ const routes: Routes = [
       {
         path: "manage",
         component: ManageComponent,
-        canActivate: [OrganizationPermissionsGuard],
-        data: {
-          organizationPermissions: canAccessManageTab,
-        },
         children: [
           {
             path: "sso",


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#3252 refactored the organization routing permissions which were also modified as part of the org admin refresh. This PR properly brings those changes into `feature/org-admin-refresh` branch in order to account for the new tabs.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/billing/organization-billing-routing.module.ts:** Use the new `canAccessBillingTab` callback and remove redundant guards for child routes
- **apps/web/src/app/organizations/layouts/organization-layout.component.ts:** Use the new `canAccess<Tab>` callbacks
- **apps/web/src/app/organizations/navigation-permissions.ts:** Add new `canAccess<Tab>` callbacks for the new tabs added as part of the org admin refresh. And remove unused callbacks.
- **apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts:** Use the new `canAccessReportingTab` callback and remove redundant guards for child routes

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
