### PR TITLE
Add Manifest v3 artifact to pipelines

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -143,6 +143,10 @@ jobs:
           npm run dist
           npm run test
 
+      - name: Build Manifest v3
+        run: |
+          npm run dist:chrome:mv3
+
       - name: Gulp
         run: gulp ci
 
@@ -179,6 +183,13 @@ jobs:
         with:
           name: dist-chrome-${{ env._BUILD_NUMBER }}.zip
           path: apps/browser/dist/dist-chrome.zip
+          if-no-files-found: error
+
+      - name: Upload Chrome MV3 artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # v3.0.0
+        with:
+          name: dist-chrome-MV3-${{ env._BUILD_NUMBER }}.zip
+          path: apps/browser/dist/dist-chrome-MV3.zip
           if-no-files-found: error
 
       - name: Upload Firefox artifact

--- a/apps/browser/gulpfile.js
+++ b/apps/browser/gulpfile.js
@@ -34,6 +34,9 @@ const filters = {
 
 function buildString() {
   var build = "";
+  if (process.env.MANIFEST_VERSION) {
+    build = `-mv${process.env.MANIFEST_VERSION}`;
+  }
   if (process.env.BUILD_NUMBER && process.env.BUILD_NUMBER !== "") {
     build = `-${process.env.BUILD_NUMBER}`;
   }

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -10,7 +10,7 @@
     "build:prod:watch": "cross-env NODE_ENV=production webpack --watch",
     "dist": "npm run build:prod && gulp dist",
     "dist:chrome": "npm run build:prod && gulp dist:chrome",
-    "dist:chrome:mv3": "cross-env MANIFEST_VERSION=3 npm run build:prod && gulp dist:chrome",
+    "dist:chrome:mv3": "cross-env MANIFEST_VERSION=3 npm run build:prod && cross-env MANIFEST_VERSION=3 gulp dist:chrome",
     "dist:firefox": "npm run build:prod && gulp dist:firefox",
     "dist:opera": "npm run build:prod && gulp dist:opera",
     "dist:safari": "npm run build:prod && gulp dist:safari",


### PR DESCRIPTION
This requires a second build due to the differences being handled in webpack.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds MV3 artifact to build pipelines

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
