### PR TITLE
[PS-1347] Fix "Check for Updates..." URL (for clients without auto-updater)

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -104,7 +104,7 @@ export class Main {
     this.updaterMain = new UpdaterMain(
       this.i18nService,
       this.windowMain,
-      "desktop",
+      "clients",
       null,
       null,
       null,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR fixes a small URL error in the updater. Currently a user is redirected to the old repository (https://github.com/bitwarden/desktop/releases) when clicking on "Check for Updates..." in the "Help" menu, if a client without auto-updater is used.

## Code changes
- **apps/desktop/src/main.ts:** Adjustment of the gitHubProject parameter passed to the updater (so the user will be redirected to the correct URL https://github.com/bitwarden/clients/releases).

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
