### PR TITLE
[SM-63] Display dates based off Figma

### DIFF
--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -39,7 +39,7 @@
         <!-- TODO dynamically add project badge associated with specific secret once projects are implemented-->
         <span bitBadge badgeType="secondary"> web app </span>
       </td>
-      <td bitCell>{{ secret.revisionDate }}</td>
+      <td bitCell>{{ secret.revisionDate | date: "MM/dd/yyyy hh:mm a" }}</td>
       <td bitCell>
         <button
           class="tw-rounded tw-border tw-border-transparent tw-bg-transparent tw-text-main hover:tw-border-secondary-700 focus:tw-border-secondary-700"

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -39,7 +39,7 @@
         <!-- TODO dynamically add project badge associated with specific secret once projects are implemented-->
         <span bitBadge badgeType="secondary"> web app </span>
       </td>
-      <td bitCell>{{ secret.revisionDate | date: "MM/dd/yyyy hh:mm a" }}</td>
+      <td bitCell>{{ secret.revisionDate | date: "short" }}</td>
       <td bitCell>
         <button
           class="tw-rounded tw-border tw-border-transparent tw-bg-transparent tw-text-main hover:tw-border-secondary-700 focus:tw-border-secondary-700"

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -39,7 +39,7 @@
         <!-- TODO dynamically add project badge associated with specific secret once projects are implemented-->
         <span bitBadge badgeType="secondary"> web app </span>
       </td>
-      <td bitCell>{{ secret.revisionDate | date: "short" }}</td>
+      <td bitCell>{{ secret.revisionDate | date: "medium" }}</td>
       <td bitCell>
         <button
           class="tw-rounded tw-border tw-border-transparent tw-bg-transparent tw-text-main hover:tw-border-secondary-700 focus:tw-border-secondary-700"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to fix displaying dates in the secrets list overview.
The dates were not being displayed as requested in the Figma examples.

This is dependent on the server side change in https://github.com/bitwarden/server/pull/2206

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
Sending the date to the angular date pipe for formatting and localization.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/43214426/186439870-1b610b51-2ba9-4d82-9aef-b7641e9637b5.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
