### PR TITLE
Remove stateService from browserPlatformUtilsService

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -235,7 +235,6 @@ export default class MainBackground {
     });
     this.platformUtilsService = new BrowserPlatformUtilsService(
       this.messagingService,
-      this.stateService,
       (clipboardValue, clearMs) => {
         if (this.systemService != null) {
           this.systemService.clearClipboard(clipboardValue, clearMs);

--- a/apps/browser/src/listeners/onCommandListener.ts
+++ b/apps/browser/src/listeners/onCommandListener.ts
@@ -66,7 +66,6 @@ const doAutoFillLogin = async (tab: chrome.tabs.Tab): Promise<void> => {
 
   const platformUtils = new BrowserPlatformUtilsService(
     null, // MessagingService
-    stateService,
     null, // clipboardWriteCallback
     null // biometricCallback
   );

--- a/apps/browser/src/services/browserPlatformUtils.service.spec.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.spec.ts
@@ -16,7 +16,7 @@ describe("Browser Utils Service", () => {
     let browserPlatformUtilsService: BrowserPlatformUtilsService;
     beforeEach(() => {
       (window as any).matchMedia = jest.fn().mockReturnValueOnce({});
-      browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null, null, null);
+      browserPlatformUtilsService = new BrowserPlatformUtilsService(null, null, null);
     });
 
     afterEach(() => {

--- a/apps/browser/src/services/browserPlatformUtils.service.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.ts
@@ -5,7 +5,6 @@ import { DeviceType } from "@bitwarden/common/enums/deviceType";
 
 import { BrowserApi } from "../browser/browserApi";
 import { SafariApp } from "../browser/safariApp";
-import { StateService } from "../services/abstractions/state.service";
 
 const DialogPromiseExpiration = 600000; // 10 minutes
 
@@ -19,7 +18,6 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
 
   constructor(
     private messagingService: MessagingService,
-    private stateService: StateService,
     private clipboardWriteCallback: (clipboardValue: string, clearMs: number) => void,
     private biometricCallback: () => Promise<boolean>
   ) {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
With the introduction of a ThemingService with https://github.com/bitwarden/clients/pull/2943, the 
`browserPlatformUtilsService` no longer needs to depend on the `stateService`. This PR removes it as a dependency. 

## Code changes

- **apps/browser/src/services/browserPlatformUtils.service.ts:** Remove `stateService` (import & constructor)
- **Related changes to instantiation of BrowserPlatformUtilsService:**
  - apps/browser/src/background/main.background.ts,
  - apps/browser/src/listeners/onCommandListener.ts, 
  - apps/browser/src/services/browserPlatformUtils.service.spec.ts

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
