### PR TITLE
[SG-626] Fix Desktop app not showing updated credentials from native messages

### DIFF
--- a/apps/desktop/native-messaging-test-runner/src/bw-credential-create.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-credential-create.ts
@@ -3,6 +3,8 @@ import "module-alias/register";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import { CredentialCreatePayload } from "../../src/models/nativeMessaging/credentialCreatePayload";
+
 import { LogUtils } from "./logUtils";
 import NativeMessageService from "./nativeMessageService";
 import * as config from "./variables";
@@ -28,8 +30,23 @@ const { name } = argv;
     return;
   }
 
+  // Get active account userId
+  const status = await nativeMessageService.checkStatus(handshakeResponse.sharedKey);
+
+  const activeUser = status.payload.filter((a) => a.active === true && a.status === "unlocked")[0];
+  if (activeUser === undefined) {
+    LogUtils.logError("No active or unlocked user");
+  }
+  LogUtils.logWarning("Active userId: " + activeUser.id);
+
   LogUtils.logSuccess("Handshake success response");
-  const response = await nativeMessageService.credentialCreation(handshakeResponse.sharedKey, name);
+  const response = await nativeMessageService.credentialCreation(handshakeResponse.sharedKey, {
+    name: name,
+    userName: "SuperAwesomeUser",
+    password: "dolhpin",
+    uri: "google.com",
+    userId: activeUser.id,
+  } as CredentialCreatePayload);
 
   if (response.payload.status === "failure") {
     LogUtils.logError("Failure response returned ");

--- a/apps/desktop/native-messaging-test-runner/src/bw-credential-update.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-credential-update.ts
@@ -3,6 +3,8 @@ import "module-alias/register";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import { CredentialUpdatePayload } from "../../src/models/nativeMessaging/credentialUpdatePayload";
+
 import { LogUtils } from "./logUtils";
 import NativeMessageService from "./nativeMessageService";
 import * as config from "./variables";
@@ -57,16 +59,15 @@ const { name, username, password, uri } = argv;
   }
   LogUtils.logWarning("Active userId: " + activeUser.id);
 
-  const response = await nativeMessageService.credentialUpdate(
-    handshakeResponse.sharedKey,
-    name,
-    password,
-    username,
-    uri,
-    activeUser.id,
+  const response = await nativeMessageService.credentialUpdate(handshakeResponse.sharedKey, {
+    name: name,
+    password: password,
+    userName: username,
+    uri: uri,
+    userId: activeUser.id,
     // Replace with credentialId you want to update
-    "2a08b546-fa9d-48cc-ae8e-ae7601207da9"
-  );
+    credentialId: "2a08b546-fa9d-48cc-ae8e-ae7601207da9",
+  } as CredentialUpdatePayload);
 
   if (response.payload.status === "failure") {
     LogUtils.logError("Failure response returned ");

--- a/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
@@ -89,16 +89,14 @@ export default class NativeMessageService {
     return this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
-  async credentialCreation(key: string, name: string): Promise<DecryptedCommandData> {
+  async credentialCreation(
+    key: string,
+    credentialData: CredentialCreatePayload
+  ): Promise<DecryptedCommandData> {
     const encryptedCommand = await this.encryptCommandData(
       {
         command: "bw-credential-create",
-        payload: {
-          name: name,
-          userName: "SuperAwesomeUser",
-          password: "dolhpin",
-          uri: "google.com",
-        } as CredentialCreatePayload,
+        payload: credentialData,
       },
       key
     );
@@ -111,24 +109,12 @@ export default class NativeMessageService {
 
   async credentialUpdate(
     key: string,
-    name: string,
-    password: string,
-    username: string,
-    uri: string,
-    userId: string,
-    credentialId: string
+    credentialData: CredentialUpdatePayload
   ): Promise<DecryptedCommandData> {
     const encryptedCommand = await this.encryptCommandData(
       {
         command: "bw-credential-update",
-        payload: {
-          userId: userId,
-          credentialId: credentialId,
-          userName: username,
-          uri: uri,
-          password: password,
-          name: name,
-        } as CredentialUpdatePayload,
+        payload: credentialData,
       },
       key
     );

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -14,7 +14,7 @@ import { AbstractThemingService } from "@bitwarden/angular/services/theming/them
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";
 import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/abstractions/auth.service";
 import { BroadcasterService as BroadcasterServiceAbstraction } from "@bitwarden/common/abstractions/broadcaster.service";
-import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
+import { CipherService as CipherServiceAbstraction } from "@bitwarden/common/abstractions/cipher.service";
 import { CryptoService as CryptoServiceAbstraction } from "@bitwarden/common/abstractions/crypto.service";
 import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from "@bitwarden/common/abstractions/cryptoFunction.service";
 import { FileDownloadService } from "@bitwarden/common/abstractions/fileDownload/fileDownload.service";
@@ -26,7 +26,7 @@ import {
 import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "@bitwarden/common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/abstractions/platformUtils.service";
-import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
+import { PolicyService as PolicyServiceAbstraction } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
 import { StateService as StateServiceAbstraction } from "@bitwarden/common/abstractions/state.service";
 import { StateMigrationService as StateMigrationServiceAbstraction } from "@bitwarden/common/abstractions/stateMigration.service";
 import { AbstractStorageService } from "@bitwarden/common/abstractions/storage.service";
@@ -158,8 +158,9 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
         AuthServiceAbstraction,
         CryptoServiceAbstraction,
         CryptoFunctionServiceAbstraction,
-        CipherService,
-        PolicyService,
+        CipherServiceAbstraction,
+        PolicyServiceAbstraction,
+        MessagingServiceAbstraction,
       ],
     },
   ],

--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -183,8 +183,11 @@ export class NativeMessageHandler {
       }
       case "bw-credential-create": {
         const activeUserId = await this.stateService.getUserId();
-        const authStatus = await this.authService.getAuthStatus(activeUserId);
+        if (payload.userId !== activeUserId) {
+          return { error: "not-active-user" };
+        }
 
+        const authStatus = await this.authService.getAuthStatus(activeUserId);
         if (authStatus !== AuthenticationStatus.Unlocked) {
           return { error: "locked" };
         }
@@ -223,8 +226,11 @@ export class NativeMessageHandler {
       }
       case "bw-credential-update": {
         const activeUserId = await this.stateService.getUserId();
-        const authStatus = await this.authService.getAuthStatus(activeUserId);
+        if (payload.userId !== activeUserId) {
+          return { error: "not-active-user" };
+        }
 
+        const authStatus = await this.authService.getAuthStatus(activeUserId);
         if (authStatus !== AuthenticationStatus.Unlocked) {
           return { error: "locked" };
         }

--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -4,6 +4,7 @@ import { ipcRenderer } from "electron";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
+import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
 import { AuthenticationStatus } from "@bitwarden/common/enums/authenticationStatus";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
@@ -39,7 +40,8 @@ export class NativeMessageHandler {
     private cryptoService: CryptoService,
     private cryptoFunctionService: CryptoFunctionService,
     private cipherService: CipherService,
-    private policyService: PolicyService
+    private policyService: PolicyService,
+    private messagingService: MessagingService
   ) {}
 
   async handleMessage(message: Message) {
@@ -209,6 +211,11 @@ export class NativeMessageHandler {
           const encrypted = await this.cipherService.encrypt(cipherView);
           await this.cipherService.saveWithServer(encrypted);
 
+          // Notify other clients of new login
+          await this.messagingService.send("addedCipher");
+          // Refresh Desktop ciphers list
+          await this.messagingService.send("refreshCiphers");
+
           return { status: "success" };
         } catch (error) {
           return { status: "failure" };
@@ -241,6 +248,11 @@ export class NativeMessageHandler {
           const encrypted = await this.cipherService.encrypt(cipherView);
 
           await this.cipherService.saveWithServer(encrypted);
+
+          // Notify other clients of update
+          await this.messagingService.send("editedCipher");
+          // Refresh Desktop ciphers list
+          await this.messagingService.send("refreshCiphers");
 
           return { status: "success" };
         } catch (error) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- Fix an issue found by QA where updating or creating a login isn't updating the desktop app or other clients until a refresh.
- Add check in credential update and create for userId

## Code changes

### Test Runner

- **apps/desktop/native-messaging-test-runner/src/bw-credential-create.ts:** Get and send activeUserId with request
- **apps/desktop/native-messaging-test-runner/src/bw-credential-update.ts:** Refactor credentialUpdate params
- **apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts:** Refactor and simplify params

### Desktop app native messaging

- **apps/desktop/src/app/services/services.module.ts:** Follow other services naming convention and inject messaging service
- **apps/desktop/src/services/nativeMessageHandler.service.ts:** Add userId checks to create and update commands, and also use messaging service to update both desktop app and other clients when there are credential creations and updates.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
