### PR TITLE
[SM-184] Remove manifest.storage in Firefox since it's not supported

### DIFF
--- a/apps/browser/gulpfile.js
+++ b/apps/browser/gulpfile.js
@@ -60,6 +60,7 @@ function dist(browserName, manifest) {
 function distFirefox() {
   return dist("firefox", (manifest) => {
     delete manifest.content_security_policy;
+    delete manifest.storage;
     removeShortcuts(manifest);
     return manifest;
   });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Resolves a warning in Firefox due to the storage manifest not being used in Firefox. It instead allows for arbitrary data.

Follow up to https://github.com/bitwarden/clients/pull/3120

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/gulpfile.js:** Delete the `storage` key from the Firefox manifest.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
