### PR TITLE
Remove jasmine related npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,6 @@
         "html-webpack-injector": "^1.1.4",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^8.0.1",
-        "jasmine-core": "^3.7.1",
         "jest-mock-extended": "2.0.6",
         "jest-preset-angular": "^12.1.0",
         "lint-staged": "^13.0.3",
@@ -27258,12 +27257,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/jasmine-core": {
-      "version": "3.99.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.1.tgz",
-      "integrity": "sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==",
-      "dev": true
     },
     "node_modules/jest": {
       "version": "28.1.3",
@@ -63650,12 +63643,6 @@
           }
         }
       }
-    },
-    "jasmine-core": {
-      "version": "3.99.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.1.tgz",
-      "integrity": "sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==",
-      "dev": true
     },
     "jest": {
       "version": "28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,6 @@
         "html-webpack-plugin": "^5.5.0",
         "husky": "^8.0.1",
         "jasmine-core": "^3.7.1",
-        "jasmine-spec-reporter": "^7.0.0",
         "jest-mock-extended": "2.0.6",
         "jest-preset-angular": "^12.1.0",
         "lint-staged": "^13.0.3",
@@ -27265,15 +27264,6 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.1.tgz",
       "integrity": "sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==",
       "dev": true
-    },
-    "node_modules/jasmine-spec-reporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-7.0.0.tgz",
-      "integrity": "sha512-OtC7JRasiTcjsaCBPtMO0Tl8glCejM4J4/dNuOJdA8lBjz4PmWjYQ6pzb0uzpBNAWJMDudYuj9OdXJWqM2QTJg==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.4.0"
-      }
     },
     "node_modules/jest": {
       "version": "28.1.3",
@@ -63666,15 +63656,6 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.1.tgz",
       "integrity": "sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==",
       "dev": true
-    },
-    "jasmine-spec-reporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-7.0.0.tgz",
-      "integrity": "sha512-OtC7JRasiTcjsaCBPtMO0Tl8glCejM4J4/dNuOJdA8lBjz4PmWjYQ6pzb0uzpBNAWJMDudYuj9OdXJWqM2QTJg==",
-      "dev": true,
-      "requires": {
-        "colors": "1.4.0"
-      }
     },
     "jest": {
       "version": "28.1.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "html-webpack-plugin": "^5.5.0",
     "husky": "^8.0.1",
     "jasmine-core": "^3.7.1",
-    "jasmine-spec-reporter": "^7.0.0",
     "jest-mock-extended": "2.0.6",
     "jest-preset-angular": "^12.1.0",
     "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "html-webpack-injector": "^1.1.4",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^8.0.1",
-    "jasmine-core": "^3.7.1",
     "jest-mock-extended": "2.0.6",
     "jest-preset-angular": "^12.1.0",
     "lint-staged": "^13.0.3",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We have moved over to using `jest` as our testing framework. This PR only removes the no longer needed npm packages for `jasmine`

## Code changes

- **package.json && package-lock.json:** Ran `npm uninstall jasmine-spec-reporter` and `npm uninstall jasmine-core`

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
