### PR TITLE
Changed where website parameter is passed in to forwarding services

### DIFF
--- a/libs/common/src/services/usernameGeneration.service.ts
+++ b/libs/common/src/services/usernameGeneration.service.ts
@@ -117,17 +117,19 @@ export class UsernameGenerationService implements BaseUsernameGenerationService 
 
     let forwarder: Forwarder = null;
     const forwarderOptions = new ForwarderOptions();
-    forwarderOptions.website = o.website;
     if (o.forwardedService === "simplelogin") {
       forwarder = new SimpleLoginForwarder();
       forwarderOptions.apiKey = o.forwardedSimpleLoginApiKey;
+      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "anonaddy") {
       forwarder = new AnonAddyForwarder();
       forwarderOptions.apiKey = o.forwardedAnonAddyApiToken;
       forwarderOptions.anonaddy.domain = o.forwardedAnonAddyDomain;
+      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "firefoxrelay") {
       forwarder = new FirefoxRelayForwarder();
       forwarderOptions.apiKey = o.forwardedFirefoxApiToken;
+      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "fastmail") {
       forwarder = new FastmailForwarder();
       forwarderOptions.apiKey = o.forwardedFastmailApiToken;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The inputs to the various forwarding services was refactored to be a standard object in #3318.  However, only some of the services have a `website` property defined.  I moved this into the proper cases for services that require a website value.

## Code changes

- **usernameGeneration.service.ts:** `o.website` was not defined in all cases.  It is used in only some of the forwarding types.  Because the same Options object is used for all of them, it was resulting in an error when passed in to the fastmail generator.  This was refactored in #3318.

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
