### PR TITLE
Revert PR #3393 because it was not the right solution

### DIFF
--- a/libs/common/src/services/usernameGeneration.service.ts
+++ b/libs/common/src/services/usernameGeneration.service.ts
@@ -117,19 +117,17 @@ export class UsernameGenerationService implements BaseUsernameGenerationService 
 
     let forwarder: Forwarder = null;
     const forwarderOptions = new ForwarderOptions();
+    forwarderOptions.website = o.website;
     if (o.forwardedService === "simplelogin") {
       forwarder = new SimpleLoginForwarder();
       forwarderOptions.apiKey = o.forwardedSimpleLoginApiKey;
-      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "anonaddy") {
       forwarder = new AnonAddyForwarder();
       forwarderOptions.apiKey = o.forwardedAnonAddyApiToken;
       forwarderOptions.anonaddy.domain = o.forwardedAnonAddyDomain;
-      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "firefoxrelay") {
       forwarder = new FirefoxRelayForwarder();
       forwarderOptions.apiKey = o.forwardedFirefoxApiToken;
-      forwarderOptions.website = o.website;
     } else if (o.forwardedService === "fastmail") {
       forwarder = new FastmailForwarder();
       forwarderOptions.apiKey = o.forwardedFastmailApiToken;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This reverts commit 8dd15a1ff3d681baab9f691d48b3ac5966e28a0e.  I mistakenly changed to not pass in `o.website` for the Fastmail provider.  In my testing I didn't catch that the `website` parameter was being used in Fastmail.

## Code changes

- **userNameGeneration.service.ts:** Reverted the change to only pass in the `website` parameter for some providers.

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
