### PR TITLE
catch fastmail errors in notCreated response prop

### DIFF
--- a/libs/common/src/emailForwarders/fastmailForwarder.ts
+++ b/libs/common/src/emailForwarders/fastmailForwarder.ts
@@ -54,7 +54,15 @@ export class FastmailForwarder implements Forwarder {
         json.methodResponses[0].length > 0
       ) {
         if (json.methodResponses[0][0] === "MaskedEmail/set") {
-          return json.methodResponses[0][1]?.created?.["new-masked-email"]?.email;
+          if (json.methodResponses[0][1]?.created?.["new-masked-email"] != null) {
+            return json.methodResponses[0][1]?.created?.["new-masked-email"]?.email;
+          }
+          if (json.methodResponses[0][1]?.notCreated?.["new-masked-email"] != null) {
+            throw (
+              "Fastmail error: " +
+              json.methodResponses[0][1]?.notCreated?.["new-masked-email"]?.description
+            );
+          }
         } else if (json.methodResponses[0][0] === "error") {
           throw "Fastmail error: " + json.methodResponses[0][1]?.description;
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
https://bitwarden.atlassian.net/browse/SG-515

Fix issue where Fastmail forwarding errors were not being parsed in certain situations. 

## Code changes

- **fastmailForwarder.ts:** Add condition to catch errors under notCreated response property.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
