### PR TITLE
Don't prevent whitespace wrapping in links/buttons, widen desktop pages

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -99,7 +99,6 @@ button {
 }
 
 button {
-  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -323,7 +322,6 @@ header {
         padding: 7px 0;
         text-decoration: none;
         font-size: 12px;
-        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         width: 100%;

--- a/apps/browser/src/popup/scss/buttons.scss
+++ b/apps/browser/src/popup/scss/buttons.scss
@@ -5,7 +5,6 @@
   padding: 7px 15px;
   border: 1px solid #000000;
   font-size: $font-size-base;
-  white-space: nowrap;
   text-align: center;
   cursor: pointer;
 

--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -85,7 +85,6 @@ button {
   border: none;
   background: transparent;
   color: inherit;
-  white-space: nowrap;
   cursor: pointer;
 }
 

--- a/apps/desktop/src/scss/buttons.scss
+++ b/apps/desktop/src/scss/buttons.scss
@@ -7,7 +7,6 @@
   padding: 7px 15px;
   border: 1px solid #000000;
   font-size: $font-size-base;
-  white-space: nowrap;
   text-align: center;
   cursor: pointer;
 
@@ -176,7 +175,6 @@ button.no-btn {
   @include themify($themes) {
     color: themed("textColor");
   }
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/apps/desktop/src/scss/pages.scss
+++ b/apps/desktop/src/scss/pages.scss
@@ -54,7 +54,7 @@
 #lock-page,
 #update-temp-password-page {
   .content {
-    width: 300px;
+    width: 325px;
     transition: width 0.25s linear;
 
     p {
@@ -112,7 +112,7 @@
 
 #sso-page {
   .content {
-    width: 300px;
+    width: 325px;
 
     .box {
       margin-top: 30px;

--- a/apps/web/src/scss/buttons.scss
+++ b/apps/web/src/scss/buttons.scss
@@ -191,7 +191,6 @@ button.no-btn {
   border: none;
   padding: 0;
   color: inherit;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Allowing whitespace to wrap solves the issue of long link/button text awkwardly breaking out of controls
Widening desktop "pages" prevents some unnecessary wrapping in places like the "Create account" button on the login screen, whose content is slightly wider than it should be (but this is currently masked by the `nowrap`)

Closes https://github.com/bitwarden/clients/issues/2620

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/base.scss**, **apps/browser/src/popup/scss/buttons.scss**,  **apps/desktop/src/scss/base.scss**, **apps/desktop/src/scss/buttons.scss**, **apps/web/src/scss/buttons.scss**: remove `white-space: nowrap` from the various button/link styles, allowing overly-long content to wrap rather than break out
- **apps/desktop/src/scss/pages.scss**: bump the width of desktop pages from `300px` to `325px` (admittedly, this makes them go out of sync with small modals?)

## Screenshots

Before (taken from https://github.com/bitwarden/clients/issues/2620):

![screenshot of desktop login, with the SSO button text escaping the button](https://user-images.githubusercontent.com/895831/187099334-45eef4c0-eba2-4b86-be04-317254f4a79d.png)

After:

![screenshot of the desktop login, slightly wider by 25px, but with the SSO button text wrapping over two lines instead of breaking out](https://user-images.githubusercontent.com/895831/187099354-80a5b758-e849-4e28-b461-c10cc6eaf27e.png)

I had a look around the desktop, web, and popup versions with this change applied, and did not come across any other changes/adverse effects - though recommend giving them a thorough once-over, just in case some situation/screen did rely on the `nowrap`

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
