### PR TITLE
[SM-185] Use feature flags for secrets

### DIFF
--- a/apps/web/config/development.json
+++ b/apps/web/config/development.json
@@ -10,6 +10,7 @@
     "proxyNotifications": "http://localhost:61840"
   },
   "flags": {
-    "showTrial": true
+    "showTrial": true,
+    "secretsManager": true
   }
 }

--- a/apps/web/config/qa.json
+++ b/apps/web/config/qa.json
@@ -10,6 +10,7 @@
     "proxyEvents": "https://events.qa.bitwarden.pw"
   },
   "flags": {
-    "showTrial": true
+    "showTrial": true,
+    "secretsManager": true
   }
 }

--- a/apps/web/src/utils/flags.ts
+++ b/apps/web/src/utils/flags.ts
@@ -1,5 +1,6 @@
 export type Flags = {
   showTrial?: boolean;
+  secretsManager?: boolean;
 };
 
 export type FlagName = keyof Flags;

--- a/bitwarden_license/bit-web/src/app/sm/sm-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/sm/sm-routing.module.ts
@@ -1,13 +1,15 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
+import { buildFlaggedRoute } from "src/app/oss-routing.module";
+
 import { LayoutComponent } from "./layout/layout.component";
 import { NavigationComponent } from "./layout/navigation.component";
 import { SecretsModule } from "./secrets/secrets.module";
 import { SMGuard } from "./sm.guard";
 
 const routes: Routes = [
-  {
+  buildFlaggedRoute("secretsManager", {
     path: ":organizationId",
     component: LayoutComponent,
     canActivate: [SMGuard],
@@ -27,7 +29,7 @@ const routes: Routes = [
         pathMatch: "full",
       },
     ],
-  },
+  }),
 ];
 
 @NgModule({

--- a/bitwarden_license/bit-web/src/app/sm/sm-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/sm/sm-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
+import { OrganizationPermissionsGuard } from "src/app/organizations/guards/org-permissions.guard";
 import { buildFlaggedRoute } from "src/app/oss-routing.module";
 
 import { LayoutComponent } from "./layout/layout.component";
@@ -12,7 +13,7 @@ const routes: Routes = [
   buildFlaggedRoute("secretsManager", {
     path: ":organizationId",
     component: LayoutComponent,
-    canActivate: [SMGuard],
+    canActivate: [OrganizationPermissionsGuard, SMGuard],
     children: [
       {
         path: "",

--- a/bitwarden_license/bit-web/src/app/sm/sm.guard.ts
+++ b/bitwarden_license/bit-web/src/app/sm/sm.guard.ts
@@ -1,13 +1,10 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot, CanActivate } from "@angular/router";
 
-import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
-
 @Injectable()
 export class SMGuard implements CanActivate {
-  constructor(private platformUtilsService: PlatformUtilsService) {}
-
   async canActivate(route: ActivatedRouteSnapshot) {
-    return this.platformUtilsService.isDev();
+    // TODO: Verify org
+    return true;
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Use the feature flag functionality in order to use EE.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/utils/flags.ts:** Adds a new secrets manager flag.
- **bitwarden_license/bit-web/src/app/sm/sm-routing.module.ts**: Use the `buildFlaggedRoute` functionality.
- **bitwarden_license/bit-web/src/app/sm/sm.guard.ts**: Temporarily disable, we should use this to verify the organization or something.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
