### PR TITLE
Unlock Safari extension with Apple Watch for MacBook users in clamshell mode

### DIFF
--- a/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
@@ -86,7 +86,11 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             var error: NSError?
             let laContext = LAContext()
             
-            laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+            if #available(macOSApplicationExtension 10.15, *) {
+                laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometricsOrWatch, error: &error)
+            } else {
+                laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+            }
             
             if let e = error, e.code != kLAErrorBiometryLockout {
                 response.userInfo = [


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Allows unlocking of Safari extension with Apple Watch for MacBook users when in clamshell mode. Users who have a paired Apple Watch expect to unlock biometric prompts with their Apple Watch. Closes #2470

## Code changes

- **apps/browser/src/safari/safari/SafariWebExtensionHandler.swift:** Adds biometric unlock with Apple Watch `deviceOwnerAuthenticationWithBiometricsOrWatch` for users on OS versions that support it. We add a macOS version check and run the code on macOS 10.15 and above as the Xcode project supports 10.14.

## Screenshots

Currently the user is prompted with the following with their MacBook in clamshell mode and a paired Apple Watch

![Screenshot 2022-08-30 at 12 35 13](https://user-images.githubusercontent.com/5708685/187439763-a13a8905-f450-4b33-9e8e-fe192c1e5d2f.png)

With PR applied the user is shown the unlock with Apple Watch prompt when in clamshell mode.

![Screenshot 2022-08-30 at 13 38 22](https://user-images.githubusercontent.com/5708685/187439808-610962ef-926d-406f-9255-c9f0b44b3674.png)


## Before you submit

```
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
