### PR TITLE
Add icons to dev proxies

### DIFF
--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -209,6 +209,12 @@ const devServer =
             secure: false,
             changeOrigin: true,
           },
+          "/icons": {
+            target: envConfig.dev?.proxyIcons,
+            pathRewrite: { "^/icons": "" },
+            secure: false,
+            changeOrigin: true,
+          },
         },
         headers: (req) => {
           if (!req.originalUrl.includes("connector.html")) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

I got tired of errors while watching my dev console, so I added an icon server proxy to our dev web server. To use, just start up the icons server project locally, run web, and watch as your errors disappear 🪄 ☁️ 
