### PR TITLE
Only show configured keys in WebAuthn config

### DIFF
--- a/apps/web/src/app/settings/two-factor-webauthn.component.html
+++ b/apps/web/src/app/settings/two-factor-webauthn.component.html
@@ -71,6 +71,7 @@
               </ng-container>
             </li>
           </ul>
+          <p>{{ "configuredXOfYAllowedKeys" | i18n: keysConfiguredCount:keysMax }}</p>
           <hr />
           <p>{{ "twoFactorWebAuthnAdd" | i18n }}:</p>
           <ol>

--- a/apps/web/src/app/settings/two-factor-webauthn.component.ts
+++ b/apps/web/src/app/settings/two-factor-webauthn.component.ts
@@ -35,6 +35,7 @@ export class TwoFactorWebAuthnComponent extends TwoFactorBaseComponent {
   keys: Key[];
   keyIdAvailable: number = null;
   keysConfiguredCount = 0;
+  keysMax = 5;
   webAuthnError: boolean;
   webAuthnListening: boolean;
   webAuthnResponse: PublicKeyCredential;
@@ -155,8 +156,9 @@ export class TwoFactorWebAuthnComponent extends TwoFactorBaseComponent {
     this.keyIdAvailable = null;
     this.name = null;
     this.keysConfiguredCount = 0;
-    for (let i = 1; i <= 5; i++) {
-      if (response.keys != null) {
+    this.keysMax = 5;
+    if (response.keys != null) {
+      for (let i = 1; i <= this.keysMax; i++) {
         const key = response.keys.filter((k) => k.id === i);
         if (key.length > 0) {
           this.keysConfiguredCount++;
@@ -169,11 +171,12 @@ export class TwoFactorWebAuthnComponent extends TwoFactorBaseComponent {
           });
           continue;
         }
+        if (this.keyIdAvailable == null) {
+          this.keyIdAvailable = i;
+        }
       }
-      this.keys.push({ id: i, name: null, configured: false, removePromise: null });
-      if (this.keyIdAvailable == null) {
-        this.keyIdAvailable = i;
-      }
+    } else {
+      this.keyIdAvailable = 1;
     }
     this.enabled = response.enabled;
   }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1422,6 +1422,19 @@
       }
     }
   },
+  "configuredXOfYAllowedKeys": {
+    "message": "Configured $KEY_COUNT$ / $MAX_KEYS$ allowed keys.",
+    "placeholders": {
+      "key_count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "max_keys": {
+        "content": "$2",
+        "example": "5"
+      }
+    }
+  },
   "nfcSupport": {
     "message": "NFC Support"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Don't fill empty key slots with dummy `WebAuthn Key $INDEX$` names. Those dummy/ghost keys were indistinguishable form configured keys. This could lead to questions like *Why do I see security keys that I didn't add and how can I remove them?*.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/settings/two-factor-webauthn.component.html:** Show number of configured keys and key limit
- **apps/web/src/app/settings/two-factor-webauthn.component.ts:** Don't fill slot with null data if slot is empty
- **apps/web/src/locales/en/messages.json:** Number of keys and key limit message

## Screenshots
![Screenshot 2022-09-01 at 20-47-52 Identification en deux étapes Coffre web Bitwarden](https://user-images.githubusercontent.com/8530546/187989983-d9a85b4a-1fbd-4d60-9529-1f520160abdd.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
