### PR TITLE
SG-647 Handle special serialization case for native messaging.

### DIFF
--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -238,7 +238,18 @@ export class NativeMessagingBackground {
   private postMessage(message: OuterMessage) {
     // Wrap in try-catch to when the port disconnected without triggering `onDisconnect`.
     try {
-      this.port.postMessage(message);
+      const msg: any = message;
+      if (message.message instanceof EncString) {
+        // Alternative, backwards-compatible serialization of EncString
+        msg.message = {
+          encryptedString: message.message.encryptedString,
+          encryptionType: message.message.encryptionType,
+          data: message.message.data,
+          iv: message.message.iv,
+          mac: message.message.mac,
+        };
+      }
+      this.port.postMessage(msg);
     } catch (e) {
       this.logService.error("NativeMessaging port disconnected, disconnecting.");
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Introduced serialization of `EncStrings` directly to the encrypted string. Native Messaging exchange with Desktop expects a full serialization object, rather than a string it can init from. It would be nice to fix this by processing the encString properly in Desktop, but that wouldn't be backwards compatible with existing installs.

## Code changes
Bootstrap the old serialization method in in Native messaging.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
