### PR TITLE
[SG-649] Add confirmation dialog and tweak shared key retrieval 

### DIFF
--- a/apps/desktop/native-messaging-test-runner/src/bw-credential-create.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-credential-create.ts
@@ -26,8 +26,8 @@ const { name } = argv;
   LogUtils.logInfo("Sending Handshake");
   const handshakeResponse = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
 
-  if (handshakeResponse.status !== "success") {
-    LogUtils.logError(" Handshake failed. Status was:", handshakeResponse.status);
+  if (!handshakeResponse.status) {
+    LogUtils.logError(" Handshake failed. Error was: " + handshakeResponse.error);
     nativeMessageService.disconnect();
     return;
   }

--- a/apps/desktop/native-messaging-test-runner/src/bw-credential-retrieval.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-credential-retrieval.ts
@@ -24,8 +24,8 @@ const { uri } = argv;
   LogUtils.logInfo("Sending Handshake");
   const handshakeResponse = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
 
-  if (handshakeResponse.status !== "success") {
-    LogUtils.logError(" Handshake failed. Status was:", handshakeResponse.status);
+  if (!handshakeResponse.status) {
+    LogUtils.logError(" Handshake failed. Error was: " + handshakeResponse.error);
     nativeMessageService.disconnect();
     return;
   }

--- a/apps/desktop/native-messaging-test-runner/src/bw-credential-update.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-credential-update.ts
@@ -45,8 +45,8 @@ const { name, username, password, uri } = argv;
   LogUtils.logInfo("Sending Handshake");
   const handshakeResponse = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
 
-  if (handshakeResponse.status !== "success") {
-    LogUtils.logError(" Handshake failed. Status was:", handshakeResponse.status);
+  if (!handshakeResponse.status) {
+    LogUtils.logError(" Handshake failed. Error was: " + handshakeResponse.error);
     nativeMessageService.disconnect();
     return;
   }

--- a/apps/desktop/native-messaging-test-runner/src/bw-generate-password.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-generate-password.ts
@@ -24,8 +24,8 @@ const { userId } = argv;
   LogUtils.logInfo("Sending Handshake");
   const handshakeResponse = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
 
-  if (handshakeResponse.status !== "success") {
-    LogUtils.logError("Handshake failed. Status was:", handshakeResponse.status);
+  if (!handshakeResponse.status) {
+    LogUtils.logError(" Handshake failed. Error was: " + handshakeResponse.error);
     nativeMessageService.disconnect();
     return;
   }

--- a/apps/desktop/native-messaging-test-runner/src/bw-handshake.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-handshake.ts
@@ -13,6 +13,8 @@ import * as config from "./variables";
   LogUtils.logSuccess("Received response to handshake request");
   if (response.status === "success") {
     LogUtils.logSuccess("Handshake success response");
+  } else if (response.error === "canceled") {
+    LogUtils.logWarning("Handshake canceled by user");
   } else {
     LogUtils.logError("Handshake failure response");
   }

--- a/apps/desktop/native-messaging-test-runner/src/bw-handshake.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-handshake.ts
@@ -11,7 +11,7 @@ import * as config from "./variables";
 
   const response = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
   LogUtils.logSuccess("Received response to handshake request");
-  if (response.status === "success") {
+  if (response.status) {
     LogUtils.logSuccess("Handshake success response");
   } else if (response.error === "canceled") {
     LogUtils.logWarning("Handshake canceled by user");

--- a/apps/desktop/native-messaging-test-runner/src/bw-status.ts
+++ b/apps/desktop/native-messaging-test-runner/src/bw-status.ts
@@ -13,8 +13,8 @@ import * as config from "./variables";
   const handshakeResponse = await nativeMessageService.sendHandshake(config.testRsaPublicKey);
   LogUtils.logSuccess("Received response to handshake request");
 
-  if (handshakeResponse.status !== "success") {
-    LogUtils.logError(" Handshake failed. Status was:", handshakeResponse.status);
+  if (!handshakeResponse.status) {
+    LogUtils.logError(" Handshake failed. Error was: " + handshakeResponse.error);
     nativeMessageService.disconnect();
     return;
   }

--- a/apps/desktop/native-messaging-test-runner/src/ipcService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/ipcService.ts
@@ -13,7 +13,7 @@ NodeIPC.config.maxRetries = 0;
 NodeIPC.config.silent = true;
 
 const DESKTOP_APP_PATH = `${homedir}/tmp/app.bitwarden`;
-const DEFAULT_MESSAGE_TIMEOUT = 10 * 1500; // 15 seconds
+const DEFAULT_MESSAGE_TIMEOUT = 10 * 1000; // 10 seconds
 
 export type MessageHandler = (MessageCommon) => void;
 
@@ -22,6 +22,10 @@ export enum IPCConnectionState {
   Connecting = "connecting",
   Connected = "connected",
 }
+
+export type IPCOptions = {
+  overrideTimeout?: number;
+};
 
 export default class IPCService {
   // The current connection state of the socket.
@@ -104,7 +108,10 @@ export default class IPCService {
     }
   }
 
-  async sendMessage(message: MessageCommon): Promise<UnencryptedMessageResponse> {
+  async sendMessage(
+    message: MessageCommon,
+    options: IPCOptions = {}
+  ): Promise<UnencryptedMessageResponse> {
     console.log("[IPCService] sendMessage");
     if (this.pendingMessages.has(message.messageId)) {
       throw new Error(`A message with the id: ${message.messageId} has already been sent.`);
@@ -125,7 +132,7 @@ export default class IPCService {
       // on messages
       return race({
         promise: deferred.getPromise(),
-        timeout: DEFAULT_MESSAGE_TIMEOUT,
+        timeout: options?.overrideTimeout ?? DEFAULT_MESSAGE_TIMEOUT,
         error: new Error(`Message: ${message.messageId} timed out`),
       });
     } catch (error) {

--- a/apps/desktop/native-messaging-test-runner/src/ipcService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/ipcService.ts
@@ -13,7 +13,7 @@ NodeIPC.config.maxRetries = 0;
 NodeIPC.config.silent = true;
 
 const DESKTOP_APP_PATH = `${homedir}/tmp/app.bitwarden`;
-const DEFAULT_MESSAGE_TIMEOUT = 10 * 1000; // 10 seconds
+const DEFAULT_MESSAGE_TIMEOUT = 10 * 1500; // 15 seconds
 
 export type MessageHandler = (MessageCommon) => void;
 

--- a/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
@@ -18,7 +18,7 @@ import { MessageCommon } from "../../src/models/nativeMessaging/messageCommon";
 import { UnencryptedMessage } from "../../src/models/nativeMessaging/unencryptedMessage";
 import { UnencryptedMessageResponse } from "../../src/models/nativeMessaging/unencryptedMessageResponse";
 
-import IPCService from "./ipcService";
+import IPCService, { IPCOptions } from "./ipcService";
 import * as config from "./variables";
 
 type HandshakeResponse = {
@@ -26,6 +26,8 @@ type HandshakeResponse = {
   sharedKey: string;
   error?: "canceled" | "cannot-decrypt";
 };
+
+const CONFIRMATION_MESSAGE_TIMEOUT = 100 * 1000; // 100 seconds
 
 export default class NativeMessageService {
   private ipcService: IPCService;
@@ -49,12 +51,17 @@ export default class NativeMessageService {
   // Commands
 
   async sendHandshake(publicKey: string): Promise<HandshakeResponse> {
-    const rawResponse = await this.sendUnencryptedMessage({
-      command: "bw-handshake",
-      payload: {
-        publicKey,
+    const rawResponse = await this.sendUnencryptedMessage(
+      {
+        command: "bw-handshake",
+        payload: {
+          publicKey,
+        },
       },
-    });
+      {
+        overrideTimeout: CONFIRMATION_MESSAGE_TIMEOUT,
+      }
+    );
     return rawResponse.payload as HandshakeResponse;
   }
 
@@ -146,23 +153,26 @@ export default class NativeMessageService {
   // Private message sending
 
   private async sendEncryptedMessage(
-    message: Omit<EncryptedMessage, keyof MessageCommon>
+    message: Omit<EncryptedMessage, keyof MessageCommon>,
+    options: IPCOptions = {}
   ): Promise<EncryptedMessageResponse> {
-    const result = await this.sendMessage(message);
+    const result = await this.sendMessage(message, options);
     return result as EncryptedMessageResponse;
   }
 
   private async sendUnencryptedMessage(
-    message: Omit<UnencryptedMessage, keyof MessageCommon>
+    message: Omit<UnencryptedMessage, keyof MessageCommon>,
+    options: IPCOptions = {}
   ): Promise<UnencryptedMessageResponse> {
-    const result = await this.sendMessage(message);
+    const result = await this.sendMessage(message, options);
     return result as UnencryptedMessageResponse;
   }
 
   private async sendMessage(
     message:
       | Omit<UnencryptedMessage, keyof MessageCommon>
-      | Omit<EncryptedMessage, keyof MessageCommon>
+      | Omit<EncryptedMessage, keyof MessageCommon>,
+    options: IPCOptions
   ): Promise<EncryptedMessageResponse | UnencryptedMessageResponse> {
     // Attempt to connect before sending any messages. If the connection has already
     // been made, this is a NOOP within the IPCService.
@@ -180,7 +190,7 @@ export default class NativeMessageService {
 
     console.log(`[NativeMessageService] sendMessage with id: ${fullMessage.messageId}`);
 
-    const response = await this.ipcService.sendMessage(fullMessage);
+    const response = await this.ipcService.sendMessage(fullMessage, options);
 
     console.log(`[NativeMessageService] received response for message: ${fullMessage.messageId}`);
 

--- a/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
@@ -21,10 +21,10 @@ import { UnencryptedMessageResponse } from "../../src/models/nativeMessaging/une
 import IPCService from "./ipcService";
 import * as config from "./variables";
 
-type HandshakePayload = {
-  status?: "success";
-  error?: "canceled";
-  sharedKey?: string;
+type HandshakeResponse = {
+  status: boolean;
+  sharedKey: string;
+  error?: "canceled" | "cannot-decrypt";
 };
 
 export default class NativeMessageService {
@@ -48,14 +48,14 @@ export default class NativeMessageService {
 
   // Commands
 
-  async sendHandshake(publicKey: string): Promise<HandshakePayload> {
+  async sendHandshake(publicKey: string): Promise<HandshakeResponse> {
     const rawResponse = await this.sendUnencryptedMessage({
       command: "bw-handshake",
       payload: {
         publicKey,
       },
     });
-    return rawResponse.payload as HandshakePayload;
+    return rawResponse.payload as HandshakeResponse;
   }
 
   async checkStatus(key: string): Promise<DecryptedCommandData> {

--- a/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
+++ b/apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts
@@ -22,7 +22,8 @@ import IPCService from "./ipcService";
 import * as config from "./variables";
 
 type HandshakePayload = {
-  status: "success" | "canceled";
+  status?: "success";
+  error?: "canceled";
   sharedKey?: string;
 };
 

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -445,6 +445,11 @@ export class SettingsComponent implements OnInit {
     await this.stateService.setEnableDuckDuckGoBrowserIntegration(
       this.enableDuckDuckGoBrowserIntegration
     );
+
+    if (!this.enableBrowserIntegration) {
+      await this.stateService.setDuckDuckGoSharedKey(null);
+    }
+
     this.messagingService.send(
       this.enableDuckDuckGoBrowserIntegration
         ? "enableDuckDuckGoBrowserIntegration"

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -163,6 +163,7 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
         PolicyServiceAbstraction,
         MessagingServiceAbstraction,
         PasswordGenerationService,
+        I18nServiceAbstraction,
       ],
     },
   ],

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1604,10 +1604,10 @@
     "message": "Please ensure the shown fingerprint is identical to the fingerprint showed in the browser extension."
   },
   "verifyDDGBrowserTitle": {
-    "message": "Confirm DuckDuckGo browser connection"
+    "message": "DuckDuckGo browser wants to connect to Bitwarden"
   },
   "verifyDDGBrowserDesc": {
-    "message": "Connect with DuckDuckGo browser?"
+    "message": "Would you like to approve this request?"
   },
   "biometricsNotEnabledTitle": {
     "message": "Biometrics not enabled"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1603,6 +1603,12 @@
   "verifyBrowserDesc": {
     "message": "Please ensure the shown fingerprint is identical to the fingerprint showed in the browser extension."
   },
+  "verifyDDGBrowserTitle": {
+    "message": "Confirm DuckDuckGo browser connection"
+  },
+  "verifyDDGBrowserDesc": {
+    "message": "Connect with DuckDuckGo browser?"
+  },
   "biometricsNotEnabledTitle": {
     "message": "Biometrics not enabled"
   },

--- a/apps/desktop/src/models/nativeMessaging/unencryptedMessageResponse.ts
+++ b/apps/desktop/src/models/nativeMessaging/unencryptedMessageResponse.ts
@@ -4,18 +4,13 @@ export type UnencryptedMessageResponse = MessageCommon &
   (
     | {
         payload: {
-          status: "canceled";
-        };
-      }
-    | {
-        payload: {
           status: "success";
           sharedKey: string;
         };
       }
     | {
         payload: {
-          error: "locked" | "cannot-decrypt" | "version-discrepancy";
+          error: "canceled" | "locked" | "cannot-decrypt" | "version-discrepancy";
         };
       }
   );

--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from "@angular/core";
 import { ipcRenderer } from "electron";
+import Swal from "sweetalert2";
 
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
@@ -44,8 +46,8 @@ export class NativeMessageHandler {
     private cipherService: CipherService,
     private policyService: PolicyService,
     private messagingService: MessagingService,
-
-    private passwordGenerationService: PasswordGenerationService
+    private passwordGenerationService: PasswordGenerationService,
+    private i18nService: I18nService
   ) {}
 
   async handleMessage(message: Message) {
@@ -68,7 +70,6 @@ export class NativeMessageHandler {
   }
 
   private async handleDecryptedMessage(message: UnencryptedMessage) {
-    let encryptedSecret: ArrayBuffer;
     const { messageId, payload } = message;
     const { publicKey } = payload;
     if (!publicKey) {
@@ -91,20 +92,56 @@ export class NativeMessageHandler {
           messageId: messageId,
           version: NativeMessagingVersion.Latest,
           payload: {
-            status: "canceled",
+            error: "canceled",
           },
         });
 
         return;
       }
 
+      // Ask for confirmation from user
+      this.messagingService.send("setFocus");
+      const submitted = await Swal.fire({
+        titleText: this.i18nService.t("verifyDDGBrowserTitle"),
+        html: this.i18nService.t("verifyDDGBrowserDesc"),
+        showCancelButton: true,
+        cancelButtonText: this.i18nService.t("cancel"),
+        showConfirmButton: true,
+        confirmButtonText: this.i18nService.t("approve"),
+        allowOutsideClick: false,
+      });
+
+      if (submitted.value !== true) {
+        this.sendResponse({
+          messageId: messageId,
+          version: NativeMessagingVersion.Latest,
+          payload: {
+            error: "canceled",
+          },
+        });
+        return;
+      }
+
       const secret = await this.cryptoFunctionService.randomBytes(64);
       this.ddgSharedSecret = new SymmetricCryptoKey(secret);
-      encryptedSecret = await this.cryptoFunctionService.rsaEncrypt(
+      const sharedKeyB64 = new SymmetricCryptoKey(secret).toJSON().keyB64;
+
+      await this.stateService.setDuckDuckGoSharedKey(sharedKeyB64);
+
+      const encryptedSecret = await this.cryptoFunctionService.rsaEncrypt(
         secret,
         remotePublicKey,
         EncryptionAlgorithm
       );
+
+      this.sendResponse({
+        messageId: messageId,
+        version: NativeMessagingVersion.Latest,
+        payload: {
+          status: "success",
+          sharedKey: Utils.fromBufferToB64(encryptedSecret),
+        },
+      });
     } catch (error) {
       this.sendResponse({
         messageId: messageId,
@@ -114,17 +151,6 @@ export class NativeMessageHandler {
         },
       });
     }
-
-    await this.stateService.setDuckDuckGoSharedKey(Utils.fromBufferToB64(encryptedSecret));
-
-    this.sendResponse({
-      messageId: messageId,
-      version: NativeMessagingVersion.Latest,
-      payload: {
-        status: "success",
-        sharedKey: Utils.fromBufferToB64(encryptedSecret),
-      },
-    });
   }
 
   private async handleEncryptedMessage(message: EncryptedMessage) {
@@ -304,14 +330,18 @@ export class NativeMessageHandler {
 
   private async decryptPayload(message: EncryptedMessage): Promise<DecryptedCommandData> {
     if (!this.ddgSharedSecret) {
-      this.sendResponse({
-        messageId: message.messageId,
-        version: NativeMessagingVersion.Latest,
-        payload: {
-          error: "cannot-decrypt",
-        },
-      });
-      return;
+      const storedKey = await this.stateService.getDuckDuckGoSharedKey();
+      if (storedKey == null) {
+        this.sendResponse({
+          messageId: message.messageId,
+          version: NativeMessagingVersion.Latest,
+          payload: {
+            error: "cannot-decrypt",
+          },
+        });
+        return;
+      }
+      this.ddgSharedSecret = SymmetricCryptoKey.fromJSON({ keyB64: storedKey });
     }
 
     return JSON.parse(

--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -105,9 +105,9 @@ export class NativeMessageHandler {
         titleText: this.i18nService.t("verifyDDGBrowserTitle"),
         html: this.i18nService.t("verifyDDGBrowserDesc"),
         showCancelButton: true,
-        cancelButtonText: this.i18nService.t("cancel"),
+        cancelButtonText: this.i18nService.t("no"),
         showConfirmButton: true,
-        confirmButtonText: this.i18nService.t("approve"),
+        confirmButtonText: this.i18nService.t("yes"),
         allowOutsideClick: false,
       });
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add a confirmation dialog when completing a handshake with the DuckDuckGoBrowser

## Code changes

### Test Runner
- **apps/desktop/native-messaging-test-runner/src/bw-handshake.ts:** Add message to handle canceled response in test.
- **apps/desktop/native-messaging-test-runner/src/ipcService.ts:** Increase timeout for messages slightly to account for having to accept connection.
- **apps/desktop/native-messaging-test-runner/src/nativeMessageService.ts:** Fix status return

### Desktop
- **apps/desktop/src/app/accounts/settings.component.ts:** Set DDG Shared key to null if disabling setting
- **apps/desktop/src/app/services/services.module.ts:** Add i18n Service
- **apps/desktop/src/locales/en/messages.json:** Add new messages for dialog
- **apps/desktop/src/models/nativeMessaging/unencryptedMessageResponse.ts:** Fix status responses
- **apps/desktop/src/services/nativeMessageHandler.service.ts:** Most of the changes are here
    - Add confirmation dialog
    - Save secret to storage not encrypted, but in secure storage still (I was encrypting it, but there's no way for us to decrypt without the private key which DDG will have)
    - Get stored secret when decrypting payload and send cannot-decrypt back if it doesn't exist


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
