### PR TITLE
[SG-652] Check for locked vault before generating password

### DIFF
--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -196,14 +196,9 @@ export class NativeMessageHandler {
         return ciphersResponse;
       }
       case "bw-credential-create": {
-        const activeUserId = await this.stateService.getUserId();
-        if (payload.userId !== activeUserId) {
-          return { error: "not-active-user" };
-        }
-
-        const authStatus = await this.authService.getAuthStatus(activeUserId);
-        if (authStatus !== AuthenticationStatus.Unlocked) {
-          return { error: "locked" };
+        const userStatus = await this.checkUserStatus(payload.userId);
+        if (userStatus !== "valid") {
+          return { error: userStatus };
         }
 
         const credentialCreatePayload = payload as CredentialCreatePayload;
@@ -239,14 +234,9 @@ export class NativeMessageHandler {
         }
       }
       case "bw-credential-update": {
-        const activeUserId = await this.stateService.getUserId();
-        if (payload.userId !== activeUserId) {
-          return { error: "not-active-user" };
-        }
-
-        const authStatus = await this.authService.getAuthStatus(activeUserId);
-        if (authStatus !== AuthenticationStatus.Unlocked) {
-          return { error: "locked" };
+        const userStatus = await this.checkUserStatus(payload.userId);
+        if (userStatus !== "valid") {
+          return { error: userStatus };
         }
 
         const credentialUpdatePayload = payload as CredentialUpdatePayload;
@@ -280,10 +270,9 @@ export class NativeMessageHandler {
         }
       }
       case "bw-generate-password": {
-        const activeUserId = await this.stateService.getUserId();
-
-        if (payload.userId !== activeUserId) {
-          return { error: "not-active-user" };
+        const userStatus = await this.checkUserStatus(payload.userId);
+        if (userStatus !== "valid") {
+          return { error: userStatus };
         }
 
         const options = (await this.passwordGenerationService.getOptions())[0];
@@ -296,6 +285,21 @@ export class NativeMessageHandler {
           error: "cannot-decrypt",
         };
     }
+  }
+
+  private async checkUserStatus(userId: string): Promise<string> {
+    const activeUserId = await this.stateService.getUserId();
+
+    if (userId !== activeUserId) {
+      return "not-active-user";
+    }
+
+    const authStatus = await this.authService.getAuthStatus(activeUserId);
+    if (authStatus !== AuthenticationStatus.Unlocked) {
+      return "locked";
+    }
+
+    return "valid";
   }
 
   private async encyptPayload(payload: any, key: SymmetricCryptoKey): Promise<EncString> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix bw-generate-password command not checking for locked vault state

## Code changes

- **apps/desktop/src/services/nativeMessageHandler.service.ts:** Refactor account status checks into method and call in `bw-credential-create`, `bw-credential-update`, and `bw-generate-password`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
