### PR TITLE
[EC-526] Default to Event Logs page for Reporting Tab

### DIFF
--- a/apps/web/src/app/organizations/layouts/organization-layout.component.html
+++ b/apps/web/src/app/organizations/layouts/organization-layout.component.html
@@ -14,7 +14,7 @@
         <bit-tab-item *ngIf="showGroupsTab" [route]="['groups']">{{
           "groups" | i18n
         }}</bit-tab-item>
-        <bit-tab-item *ngIf="showReportsTab" [route]="['reporting']">{{
+        <bit-tab-item *ngIf="showReportsTab" [route]="[reportRoute]">{{
           reportTabLabel | i18n
         }}</bit-tab-item>
         <bit-tab-item *ngIf="showBillingTab" [route]="['billing']">{{

--- a/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
@@ -22,7 +22,7 @@ const routes: Routes = [
     canActivate: [OrganizationPermissionsGuard],
     data: { organizationPermissions: canAccessReportingTab },
     children: [
-      { path: "", pathMatch: "full", redirectTo: "reports" },
+      { path: "", pathMatch: "full", redirectTo: "events" },
       {
         path: "reports",
         component: ReportsHomeComponent,

--- a/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
@@ -22,7 +22,7 @@ const routes: Routes = [
     canActivate: [OrganizationPermissionsGuard],
     data: { organizationPermissions: canAccessReportingTab },
     children: [
-      { path: "", pathMatch: "full", redirectTo: "events" },
+      { path: "", pathMatch: "full", redirectTo: "reports" },
       {
         path: "reports",
         component: ReportsHomeComponent,


### PR DESCRIPTION

## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Update the Reporting tab link to take enterprise customers directly to the Event Logs page by default (instead of the Reports page).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organizations/layouts/organization-layout.component.ts:** Add dynamic report route based on organizations `useEvents` flag. Also fixes RxJS lint warnings.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
