### PR TITLE
[SM-224] Change the simple dialog width

### DIFF
--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -1,5 +1,5 @@
 <div
-  class="tw-my-4 tw-flex tw-max-h-screen tw-max-w-sm tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
+  class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
 >
   <div class="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-px-4 tw-pt-4 tw-text-center">
     <ng-content *ngIf="hasIcon; else elseBlock" select="[bit-dialog-icon]"></ng-content>

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -78,6 +78,9 @@ module.exports = {
         "50vw": "50vw",
         "75vw": "75vw",
       },
+      maxWidth: {
+        "90vw": "90vw",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The simple dialogs didn't have a width set. This changes them to always use `w-96` and also adds a max-width of `90vw`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

![image](https://user-images.githubusercontent.com/137855/189314446-e648618f-20c5-4496-b0e2-1f5eb1cb2e0c.png)

![image](https://user-images.githubusercontent.com/137855/189314532-866aceb0-aec3-42be-9788-45dfba583815.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
