### PR TITLE
[PS-1447] Fix issues with CLI stores (npm/choco/snapcraft)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://bitwarden.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bitwarden/cli"
+    "url": "https://github.com/bitwarden/clients"
   },
   "license": "GPL-3.0-only",
   "scripts": {

--- a/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
+++ b/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
@@ -1,21 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bitwarden-cli</id>
     <version>0.0.0</version>
-    <packageSourceUrl>https://github.com/bitwarden/cli/tree/master/stores/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/bitwarden/clients/tree/master/apps/cli/stores/chocolatey</packageSourceUrl>
     <owners>kspearrin</owners>
     <title>Bitwarden CLI</title>
     <authors>Bitwarden Inc.</authors>
     <projectUrl>https://bitwarden.com/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/bitwarden/desktop/51dd1341/resources/icon.png</iconUrl>
     <copyright>Copyright © 2015-2022 Bitwarden Inc.</copyright>
-    <projectSourceUrl>https://github.com/bitwarden/cli/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/bitwarden/clients/</projectSourceUrl>
     <docsUrl>https://help.bitwarden.com/article/cli/</docsUrl>
-    <bugTrackerUrl>https://github.com/bitwarden/cli/issues</bugTrackerUrl>
-    <releaseNotes>https://github.com/bitwarden/cli/releases</releaseNotes>
-    <licenseUrl>https://github.com/bitwarden/cli/blob/master/LICENSE.txt</licenseUrl>
+    <bugTrackerUrl>https://github.com/bitwarden/clients/issues</bugTrackerUrl>
+    <releaseNotes>https://github.com/bitwarden/clients/releases</releaseNotes>
+    <licenseUrl>https://github.com/bitwarden/clients/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>bitwarden password manager cli</tags>
     <summary>A secure and free password manager for all of your devices.</summary>

--- a/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
+++ b/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
@@ -24,15 +24,31 @@
 
       -----------------
 
-      Bitwarden is the easiest and safest way to store all of your logins and passwords while conveniently keeping them synced between all of your devices.
-
-      Password theft is a serious problem. The websites and apps that you use are under attack every day. Security breaches occur and your passwords are stolen. When you reuse the same passwords across apps and websites hackers can easily access your email, bank, and other important accounts.
-
-      Security experts recommend that you use a different, randomly generated password for every account that you create. But how do you manage all those passwords? Bitwarden makes it easy for you to create, store, and access your passwords.
-
-      Bitwarden stores all of your logins in an encrypted vault that syncs across all of your devices. Since it's fully encrypted before it ever leaves your device, only you have access to your data. Not even the team at Bitwarden can read your data, even if we wanted to. Your data is sealed with AES-256 bit encryption, salted hashing, and PBKDF2 SHA-256.
-
-      Bitwarden is 100% open source software. The source code for Bitwarden is hosted on GitHub and everyone is free to review, audit, and contribute to the Bitwarden codebase.
+      Bitwarden, Inc. is the parent company of 8bit Solutions LLC.
+      
+      NAMED BEST PASSWORD MANAGER BY THE VERGE, U.S. NEWS &amp; WORLD REPORT, CNET, AND MORE.
+      
+      Manage, store, secure, and share unlimited passwords across unlimited devices from anywhere. Bitwarden delivers open source password management solutions to everyone, whether at  home, at work, or on the go.
+      
+      Generate strong, unique, and random passwords based on security requirements for every website you frequent.
+      
+      Bitwarden Send quickly transmits encrypted information --- files and plaintext -- directly to anyone.
+      
+      Bitwarden offers Teams and Enterprise plans for companies so you can securely share passwords with colleagues.
+      
+      Why Choose Bitwarden:
+      
+      World-Class Encryption
+      Passwords are protected with advanced end-to-end encryption (AES-256 bit, salted hashing, and PBKDF2 SHA-256) so your data stays secure and private.
+      
+      Built-in Password Generator
+      Generate strong, unique, and random passwords based on security requirements for every website you frequent.
+      
+      Global Translations 
+      Bitwarden translations exist in 40 languages and are growing, thanks to our global community.
+      
+      Cross-Platform Applications
+      Secure and share sensitive data within your Bitwarden Vault from any browser, mobile device, or desktop OS, and more.
     </description>
   </metadata>
   <files>

--- a/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
+++ b/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
@@ -9,7 +9,7 @@
     <title>Bitwarden CLI</title>
     <authors>Bitwarden Inc.</authors>
     <projectUrl>https://bitwarden.com/</projectUrl>
-    <iconUrl>https://cdn.rawgit.com/bitwarden/desktop/51dd1341/resources/icon.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/bitwarden/brand/master/icons/256x256.png</iconUrl>
     <copyright>Copyright © 2015-2022 Bitwarden Inc.</copyright>
     <projectSourceUrl>https://github.com/bitwarden/clients/</projectSourceUrl>
     <docsUrl>https://help.bitwarden.com/article/cli/</docsUrl>

--- a/apps/cli/stores/snap/snapcraft.yaml
+++ b/apps/cli/stores/snap/snapcraft.yaml
@@ -1,7 +1,32 @@
 name: bw
 version: __version__
-summary: Bitwarden CLI
-description: A secure and free password manager for all of your devices.
+summary: Bitwarden CLI - A secure and free password manager for all of your devices.
+description: |
+  Bitwarden, Inc. is the parent company of 8bit Solutions LLC.
+
+  NAMED BEST PASSWORD MANAGER BY THE VERGE, U.S. NEWS &amp; WORLD REPORT, CNET, AND MORE.
+      
+  Manage, store, secure, and share unlimited passwords across unlimited devices from anywhere. Bitwarden delivers open source password management solutions to everyone, whether at  home, at work, or on the go.
+      
+  Generate strong, unique, and random passwords based on security requirements for every website you frequent.
+      
+  Bitwarden Send quickly transmits encrypted information --- files and plaintext -- directly to anyone.
+      
+  Bitwarden offers Teams and Enterprise plans for companies so you can securely share passwords with colleagues.
+      
+  Why Choose Bitwarden:
+      
+  World-Class Encryption
+  Passwords are protected with advanced end-to-end encryption (AES-256 bit, salted hashing, and PBKDF2 SHA-256) so your data stays secure and private.
+      
+  Built-in Password Generator
+  Generate strong, unique, and random passwords based on security requirements for every website you frequent.
+      
+  Global Translations 
+  Bitwarden translations exist in 40 languages and are growing, thanks to our global community.
+      
+  Cross-Platform Applications
+  Secure and share sensitive data within your Bitwarden Vault from any browser, mobile device, or desktop OS, and more.
 confinement: strict
 base: core18
 apps:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
While doing some updates in our Crowdin projects regarding the store descriptions, I noticed that the CLI's description wasn't set beside also still having links to the old repo.

- Update all links from `github.com/bitwarden/cli` to `github.com/bitwarden/clients`

- Updated an old logo (replaced it with the one we use on desktop (bitwarden.nuspec)

- Fixed the description for the stores ([chocolately](https://community.chocolatey.org/packages/bitwarden-cli) and [snapcraft](https://snapcraft.io/bw)) 

Adding Devops to also review this, as I would like to ensure this does not affect the upload to the stores on a release.

Relates to [RELEASE-325](https://bitwarden.atlassian.net/browse/RELEASE-325)

## Code changes

Commits have been split to show each individual change.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
