### PR TITLE
[SG-656] Fix Trial Initiation Captcha Issue

### DIFF
--- a/apps/web/src/app/accounts/register-form/register-form.component.html
+++ b/apps/web/src/app/accounts/register-form/register-form.component.html
@@ -113,16 +113,21 @@
     </div>
 
     <div class="tw-mb-3 tw-flex">
-      <bit-submit-button [loading]="form.loading">{{ "createAccount" | i18n }}</bit-submit-button>
-      <a
-        bitButton
-        buttonType="secondary"
-        routerLink="/login"
-        class="tw-ml-3 tw-inline-flex tw-items-center tw-px-3"
-      >
-        <i class="bwi bwi-sign-in tw-mr-2"></i>
-        {{ "logIn" | i18n }}
-      </a>
+      <ng-container *ngIf="!accountCreated">
+        <bit-submit-button [loading]="form.loading">{{ "createAccount" | i18n }}</bit-submit-button>
+        <a
+          bitButton
+          buttonType="secondary"
+          routerLink="/login"
+          class="tw-ml-3 tw-inline-flex tw-items-center tw-px-3"
+        >
+          <i class="bwi bwi-sign-in tw-mr-2"></i>
+          {{ "logIn" | i18n }}
+        </a>
+      </ng-container>
+      <ng-container *ngIf="accountCreated">
+        <bit-submit-button [loading]="form.loading">{{ "logIn" | i18n }}</bit-submit-button>
+      </ng-container>
     </div>
     <bit-error-summary *ngIf="showErrorSummary" [formGroup]="formGroup"></bit-error-summary>
   </div>

--- a/libs/angular/src/components/register.component.ts
+++ b/libs/angular/src/components/register.component.ts
@@ -96,21 +96,9 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
     let name = this.formGroup.get("name")?.value;
     name = name === "" ? null : name; // Why do we do this?
     const masterPassword = this.formGroup.get("masterPassword")?.value;
-
     await this.validateForm(showToast);
-    const registerRequest = await this.buildRegisterRequest(email, masterPassword, name);
     try {
-      this.formPromise = this.apiService.postRegister(registerRequest);
-      try {
-        await this.formPromise;
-      } catch (e) {
-        if (this.handleCaptchaRequired(e)) {
-          return;
-        } else {
-          throw e;
-        }
-      }
-
+      await this.registerAccount(await this.buildRegisterRequest(email, masterPassword, name));
       if (this.isInTrialFlow) {
         this.platformUtilsService.showToast(
           "success",
@@ -257,5 +245,18 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
       request.organizationUserId = orgInvite.organizationUserId;
     }
     return request;
+  }
+
+  private async registerAccount(request: RegisterRequest): Promise<void> {
+    this.formPromise = this.apiService.postRegister(request);
+    try {
+      await this.formPromise;
+    } catch (e) {
+      if (this.handleCaptchaRequired(e)) {
+        return;
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/libs/angular/src/components/register.component.ts
+++ b/libs/angular/src/components/register.component.ts
@@ -110,11 +110,13 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
         this.accountCreated = true;
       }
       if (this.isInTrialFlow) {
-        this.platformUtilsService.showToast(
-          "success",
-          null,
-          this.i18nService.t("trialAccountCreated")
-        );
+        if (!this.accountCreated) {
+          this.platformUtilsService.showToast(
+            "success",
+            null,
+            this.i18nService.t("trialAccountCreated")
+          );
+        }
         const loginResponse = await this.logIn(email, masterPassword, this.captchaToken);
         if (loginResponse.captchaRequired) {
           return;

--- a/libs/angular/src/components/register.component.ts
+++ b/libs/angular/src/components/register.component.ts
@@ -92,14 +92,14 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
 
   async submit(showToast = true) {
     let email = this.formGroup.get("email")?.value;
+    email = email.trim().toLowerCase();
     let name = this.formGroup.get("name")?.value;
+    name = name === "" ? null : name; // Why do we do this?
     const masterPassword = this.formGroup.get("masterPassword")?.value;
     const hint = this.formGroup.get("hint")?.value;
 
     await this.validateForm(showToast);
 
-    name = name === "" ? null : name;
-    email = email.trim().toLowerCase();
     const kdf = DEFAULT_KDF_TYPE;
     const kdfIterations = DEFAULT_KDF_ITERATIONS;
     const key = await this.cryptoService.makeKey(masterPassword, email, kdf, kdfIterations);

--- a/libs/angular/src/components/register.component.ts
+++ b/libs/angular/src/components/register.component.ts
@@ -96,42 +96,7 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
     const masterPassword = this.formGroup.get("masterPassword")?.value;
     const hint = this.formGroup.get("hint")?.value;
 
-    this.formGroup.markAllAsTouched();
-    this.showErrorSummary = true;
-
-    if (this.formGroup.get("acceptPolicies").hasError("required")) {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        this.i18nService.t("acceptPoliciesRequired")
-      );
-      return;
-    }
-
-    //web
-    if (this.formGroup.invalid && !showToast) {
-      return;
-    }
-
-    //desktop, browser
-    if (this.formGroup.invalid && showToast) {
-      const errorText = this.getErrorToastMessage();
-      this.platformUtilsService.showToast("error", this.i18nService.t("errorOccurred"), errorText);
-      return;
-    }
-
-    if (this.passwordStrengthResult != null && this.passwordStrengthResult.score < 3) {
-      const result = await this.platformUtilsService.showDialog(
-        this.i18nService.t("weakMasterPasswordDesc"),
-        this.i18nService.t("weakMasterPassword"),
-        this.i18nService.t("yes"),
-        this.i18nService.t("no"),
-        "warning"
-      );
-      if (!result) {
-        return;
-      }
-    }
+    await this.validateForm(showToast);
 
     name = name === "" ? null : name;
     email = email.trim().toLowerCase();
@@ -246,5 +211,44 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
 
       return !ctrlValue && this.showTerms ? { required: true } : null;
     };
+  }
+
+  private async validateForm(showToast: boolean) {
+    this.formGroup.markAllAsTouched();
+    this.showErrorSummary = true;
+
+    if (this.formGroup.get("acceptPolicies").hasError("required")) {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("acceptPoliciesRequired")
+      );
+      return;
+    }
+
+    //web
+    if (this.formGroup.invalid && !showToast) {
+      return;
+    }
+
+    //desktop, browser
+    if (this.formGroup.invalid && showToast) {
+      const errorText = this.getErrorToastMessage();
+      this.platformUtilsService.showToast("error", this.i18nService.t("errorOccurred"), errorText);
+      return;
+    }
+
+    if (this.passwordStrengthResult != null && this.passwordStrengthResult.score < 3) {
+      const result = await this.platformUtilsService.showDialog(
+        this.i18nService.t("weakMasterPasswordDesc"),
+        this.i18nService.t("weakMasterPassword"),
+        this.i18nService.t("yes"),
+        this.i18nService.t("no"),
+        "warning"
+      );
+      if (!result) {
+        return;
+      }
+    }
   }
 }

--- a/libs/angular/src/components/register.component.ts
+++ b/libs/angular/src/components/register.component.ts
@@ -106,14 +106,7 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
           this.i18nService.t("trialAccountCreated")
         );
         //login user here
-        const credentials = new PasswordLogInCredentials(
-          email,
-          masterPassword,
-          this.captchaToken,
-          null
-        );
-        await this.authService.logIn(credentials);
-
+        await this.logIn(email, masterPassword, this.captchaToken);
         this.createdAccount.emit(this.formGroup.get("email")?.value);
       } else {
         this.platformUtilsService.showToast(
@@ -258,5 +251,15 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
         throw e;
       }
     }
+  }
+
+  private async logIn(email: string, masterPassword: string, captchaBypassToken: string) {
+    const credentials = new PasswordLogInCredentials(
+      email,
+      masterPassword,
+      captchaBypassToken,
+      null
+    );
+    await this.authService.logIn(credentials);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The objective of this PR is to get trial initiation working in an environment where captcha is enabled. Currently the flow stops if a captcha is not requested when registering, but is when logging in. This PR should enable captchas to fire whenever the heck they want and still be handled by the trial initiation component. 

## Code changes
See commits and descriptions. I did a bit of restructuring in this PR that won't make any sense on the full diff. The first handful of commits break up the `submit()` function on the `RegistrationComponent` into a couple of sizable chunks. I didn't modify any lines of logic in these. The final commit, [[fix] Check for captchas during login from trial initiation](https://github.com/bitwarden/clients/commit/47f621666353e3227a7fd0b957bba7a0982b5d4f), creates the logic needed for captcha to work when requested by the login endpoint.

## Screenshots
https://user-images.githubusercontent.com/15897251/189421739-d2560497-59eb-4109-965a-25146f097aa2.mov


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
