### PR TITLE
[SG-659] Classic 2019 plans no longer generating TOTP codes for Free users

### DIFF
--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -178,10 +178,7 @@
           </div>
         </div>
 
-        <div
-          class="box-content-row box-content-row-flex totp"
-          *ngIf="showPremiumRequiredTotp"
-        >
+        <div class="box-content-row box-content-row-flex totp" *ngIf="showPremiumRequiredTotp">
           <div class="row-main">
             <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>
             <span class="row-label">

--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -180,15 +180,7 @@
 
         <div
           class="box-content-row box-content-row-flex totp"
-          *ngIf="
-            cipher.login.totp &&
-            ((!organization && !cipher.organizationId) ||
-              (organization && !organization.useTotp) ||
-              (!organization &&
-                !canAccessPremium &&
-                cipher.organizationId &&
-                !cipher.organizationUseTotp))
-          "
+          *ngIf="showPremiumRequiredTotp"
         >
           <div class="row-main">
             <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>

--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -139,7 +139,7 @@
         <div
           class="box-content-row box-content-row-flex totp"
           [ngClass]="{ low: totpLow }"
-          *ngIf="cipher.login.totp && totpCode && canAccessPremium"
+          *ngIf="cipher.login.totp && totpCode"
         >
           <div class="row-main">
             <span
@@ -180,7 +180,15 @@
 
         <div
           class="box-content-row box-content-row-flex totp"
-          *ngIf="cipher.login.totp && !canAccessPremium"
+          *ngIf="
+            cipher.login.totp &&
+            ((!organization && !cipher.organizationId) ||
+              (organization && !organization.useTotp) ||
+              (!organization &&
+                !canAccessPremium &&
+                cipher.organizationId &&
+                !cipher.organizationUseTotp))
+          "
         >
           <div class="row-main">
             <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -138,10 +138,7 @@
               </button>
             </div>
           </div>
-          <div
-            class="box-content-row box-content-row-flex totp"
-            *ngIf="showPremiumRequiredTotp"
-          >
+          <div class="box-content-row box-content-row-flex totp" *ngIf="showPremiumRequiredTotp">
             <div class="row-main">
               <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>
               <span class="row-label">

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -100,7 +100,7 @@
           <div
             class="box-content-row box-content-row-flex totp"
             [ngClass]="{ low: totpLow }"
-            *ngIf="cipher.login.totp && totpCode && canAccessPremium"
+            *ngIf="cipher.login.totp && totpCode"
           >
             <div class="row-main">
               <span
@@ -140,7 +140,16 @@
           </div>
           <div
             class="box-content-row box-content-row-flex totp"
-            *ngIf="cipher.login.totp && !canAccessPremium"
+            *ngIf="
+              cipher.login.totp &&
+              !canAccessPremium &&
+              ((!organization && !cipher.organizationId) ||
+                (organization && !organization.useTotp) ||
+                (!organization &&
+                  !canAccessPremium &&
+                  cipher.organizationId &&
+                  !cipher.organizationUseTotp))
+            "
           >
             <div class="row-main">
               <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -140,16 +140,7 @@
           </div>
           <div
             class="box-content-row box-content-row-flex totp"
-            *ngIf="
-              cipher.login.totp &&
-              !canAccessPremium &&
-              ((!organization && !cipher.organizationId) ||
-                (organization && !organization.useTotp) ||
-                (!organization &&
-                  !canAccessPremium &&
-                  cipher.organizationId &&
-                  !cipher.organizationUseTotp))
-            "
+            *ngIf="showPremiumRequiredTotp"
           >
             <div class="row-main">
               <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>

--- a/apps/web/src/app/vault/add-edit.component.html
+++ b/apps/web/src/app/vault/add-edit.component.html
@@ -182,7 +182,7 @@
             <div class="tw-mb-4 tw-ml-4 tw-flex tw-w-1/2 tw-items-end" [ngClass]="{ low: totpLow }">
               <div
                 class="totp tw-flex tw-flex-row tw-items-center"
-                *ngIf="!cipher.login.totp || (cipher.login.totp && !canAccessPremium)"
+                *ngIf="!cipher.login.totp || !totpCode"
               >
                 <span class="totp-countdown">
                   <span class="totp-sec tw-text-muted">15</span>
@@ -237,7 +237,7 @@
                 </a>
               </div>
               <div
-                *ngIf="cipher.login.totp && totpCode && canAccessPremium"
+                *ngIf="cipher.login.totp && totpCode"
                 class="totp tw-flex tw-flex-row tw-items-center"
               >
                 <span class="totp-countdown">

--- a/libs/angular/src/components/view.component.ts
+++ b/libs/angular/src/components/view.component.ts
@@ -110,11 +110,8 @@ export class ViewComponent implements OnDestroy, OnInit {
     this.cipher = await cipher.decrypt();
     this.canAccessPremium = await this.stateService.getCanAccessPremium();
     this.showPremiumRequiredTotp =
-      this.cipher.login.totp &&
-      !this.canAccessPremium &&
-      (!this.cipher.organizationId ||
-        (this.cipher.organizationId && !this.cipher.organizationUseTotp) ||
-        (!this.cipher.organizationId && !this.cipher.organizationUseTotp));
+      this.cipher.login.totp && !this.canAccessPremium && !this.cipher.organizationUseTotp;
+
     if (
       this.cipher.type === CipherType.Login &&
       this.cipher.login.totp &&

--- a/libs/angular/src/components/view.component.ts
+++ b/libs/angular/src/components/view.component.ts
@@ -50,6 +50,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   showCardNumber: boolean;
   showCardCode: boolean;
   canAccessPremium: boolean;
+  showPremiumRequiredTotp : boolean;
   totpCode: string;
   totpCodeFormatted: string;
   totpDash: number;
@@ -108,7 +109,10 @@ export class ViewComponent implements OnDestroy, OnInit {
     const cipher = await this.cipherService.get(this.cipherId);
     this.cipher = await cipher.decrypt();
     this.canAccessPremium = await this.stateService.getCanAccessPremium();
-
+    this.showPremiumRequiredTotp = this.cipher.login.totp && !this.canAccessPremium && 
+          ((!this.cipher.organizationId) ||
+            (this.cipher.organizationId && !this.cipher.organizationUseTotp) ||
+            (!this.cipher.organizationId && !this.cipher.organizationUseTotp));
     if (
       this.cipher.type === CipherType.Login &&
       this.cipher.login.totp &&

--- a/libs/angular/src/components/view.component.ts
+++ b/libs/angular/src/components/view.component.ts
@@ -50,7 +50,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   showCardNumber: boolean;
   showCardCode: boolean;
   canAccessPremium: boolean;
-  showPremiumRequiredTotp : boolean;
+  showPremiumRequiredTotp: boolean;
   totpCode: string;
   totpCodeFormatted: string;
   totpDash: number;
@@ -109,10 +109,12 @@ export class ViewComponent implements OnDestroy, OnInit {
     const cipher = await this.cipherService.get(this.cipherId);
     this.cipher = await cipher.decrypt();
     this.canAccessPremium = await this.stateService.getCanAccessPremium();
-    this.showPremiumRequiredTotp = this.cipher.login.totp && !this.canAccessPremium && 
-          ((!this.cipher.organizationId) ||
-            (this.cipher.organizationId && !this.cipher.organizationUseTotp) ||
-            (!this.cipher.organizationId && !this.cipher.organizationUseTotp));
+    this.showPremiumRequiredTotp =
+      this.cipher.login.totp &&
+      !this.canAccessPremium &&
+      (!this.cipher.organizationId ||
+        (this.cipher.organizationId && !this.cipher.organizationUseTotp) ||
+        (!this.cipher.organizationId && !this.cipher.organizationUseTotp));
     if (
       this.cipher.type === CipherType.Login &&
       this.cipher.login.totp &&


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixed bug where free users with classic organizations were not able to see TOTP codes.

## Code changes
Removed the `canAccessPremium`.
Added validations for organizations.

## Screenshots
Browser:
<img width="373" alt="Screenshot 2022-09-13 at 15 59 19" src="https://user-images.githubusercontent.com/4648522/189942136-79722d0c-e0fa-4c6a-9b5b-7440fd815fc6.png">
<img width="371" alt="Screenshot 2022-09-13 at 15 59 11" src="https://user-images.githubusercontent.com/4648522/189942148-bece9552-7f70-4e71-98c5-f171d04bfdb4.png">
<img width="374" alt="Screenshot 2022-09-13 at 15 59 01" src="https://user-images.githubusercontent.com/4648522/189942151-54b7a8e0-2e71-4f3d-946f-edff0c59a246.png">
<img width="371" alt="Screenshot 2022-09-13 at 15 58 51" src="https://user-images.githubusercontent.com/4648522/189942159-d2e8d75c-40e5-4e7f-afe5-622c91450270.png">
<img width="374" alt="Screenshot 2022-09-13 at 15 58 42" src="https://user-images.githubusercontent.com/4648522/189942166-844d806a-c7a7-4dd3-9673-d2a1dbc4fd7b.png">
Web:
<img width="806" alt="Screenshot 2022-09-13 at 15 57 41" src="https://user-images.githubusercontent.com/4648522/189942170-76045b7c-1ce5-4c43-b29f-74af32fc2551.png">
<img width="806" alt="Screenshot 2022-09-13 at 15 57 32" src="https://user-images.githubusercontent.com/4648522/189942178-aae7070b-574c-4ba0-b564-012375972e0d.png">
<img width="800" alt="Screenshot 2022-09-13 at 15 56 03" src="https://user-images.githubusercontent.com/4648522/189942181-c7b35e0d-704d-48d8-9623-08ff3f0d9fd9.png">
<img width="813" alt="Screenshot 2022-09-13 at 15 55 56" src="https://user-images.githubusercontent.com/4648522/189942182-c35ebc03-6e64-450d-82b6-d9ac0f6d8e64.png">
<img width="876" alt="Screenshot 2022-09-13 at 15 55 43" src="https://user-images.githubusercontent.com/4648522/189942187-a7973e32-2b02-490c-aab4-a1fa302be6d7.png">
Desktop:
<img width="1431" alt="Screenshot 2022-09-13 at 15 55 22" src="https://user-images.githubusercontent.com/4648522/189942197-61165c9f-641a-4669-b546-fb98c89d4c43.png">
<img width="1435" alt="Screenshot 2022-09-13 at 15 55 14" src="https://user-images.githubusercontent.com/4648522/189942201-de254645-ed36-4dcd-808c-25cfb5634ad4.png">
<img width="1440" alt="Screenshot 2022-09-13 at 15 54 42" src="https://user-images.githubusercontent.com/4648522/189942204-2eb6905d-a2a1-457d-8208-27ffa49378d4.png">
<img width="1436" alt="Screenshot 2022-09-13 at 15 54 32" src="https://user-images.githubusercontent.com/4648522/189942212-c7ab6611-eac2-4a7d-a261-20595270f139.png">
<img width="1431" alt="Screenshot 2022-09-13 at 15 54 26" src="https://user-images.githubusercontent.com/4648522/189942216-f095697d-67d1-4a92-bffa-041b845abe9a.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
