### PR TITLE
[PS-1469] Ensure the window is focused when prompting for biometrics

### DIFF
--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -30,6 +30,8 @@ windows = {version = "0.32.0", features = [
   "Win32_Foundation",
   "Win32_Security_Credentials",
   "Win32_System_WinRT",
+  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_WindowsAndMessaging",
 ]}
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/apps/desktop/desktop_native/src/biometric/windows.rs
+++ b/apps/desktop/desktop_native/src/biometric/windows.rs
@@ -7,8 +7,11 @@ use windows::{
         Foundation::HWND,
         System::WinRT::IUserConsentVerifierInterop,
         UI::{
-            Input::KeyboardAndMouse::{self, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, VK_MENU},
-            WindowsAndMessaging,
+            Input::KeyboardAndMouse::{
+                self, keybd_event, GetAsyncKeyState, SetFocus, KEYEVENTF_EXTENDEDKEY,
+                KEYEVENTF_KEYUP, VK_MENU,
+            },
+            WindowsAndMessaging::{self, SetForegroundWindow},
         },
     },
 };
@@ -44,18 +47,22 @@ pub fn available() -> Result<bool> {
 
 fn set_focus(window: HWND) {
     let mut pressed = false;
-    let bvk = VK_MENU.0 as u8;
 
     unsafe {
         // Simulate holding down Alt key to bypass windows limitations
-        if KeyboardAndMouse::GetAsyncKeyState(VK_MENU.0 as i32) == 0 {
+        if GetAsyncKeyState(VK_MENU.0 as i32) as u32 & 0x8000 == 0 {
             pressed = true;
-            KeyboardAndMouse::keybd_event(bvk, 0, KEYEVENTF_EXTENDEDKEY, 0);
+            keybd_event(VK_MENU.0 as u8, 0, KEYEVENTF_EXTENDEDKEY, 0);
         }
-        WindowsAndMessaging::SetForegroundWindow(window);
-        KeyboardAndMouse::SetFocus(window);
+        SetForegroundWindow(window);
+        SetFocus(window);
         if pressed {
-            KeyboardAndMouse::keybd_event(bvk, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+            keybd_event(
+                VK_MENU.0 as u8,
+                0,
+                KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP,
+                0,
+            );
         }
     }
 }

--- a/apps/desktop/desktop_native/src/biometric/windows.rs
+++ b/apps/desktop/desktop_native/src/biometric/windows.rs
@@ -50,7 +50,10 @@ fn set_focus(window: HWND) {
 
     unsafe {
         // Simulate holding down Alt key to bypass windows limitations
-        if GetAsyncKeyState(VK_MENU.0 as i32) as u32 & 0x8000 == 0 {
+        //  https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getasynckeystate#return-value
+        //  The most significant bit indicates if the key is currently being pressed. This means the
+        //  value will be negative if the key is pressed.
+        if GetAsyncKeyState(VK_MENU.0 as i32) >= 0 {
             pressed = true;
             keybd_event(VK_MENU.0 as u8, 0, KEYEVENTF_EXTENDEDKEY, 0);
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Windows Hello prompt now appears within the context of the application. This means we need to ensure the application is in the foreground and focused for best result.

This also seems to resolve the issue with Windows Hello appearing below other windows if the application is minimized. Unfortunately we can't decide the location of that Window, but it's better than it appearing below other windows.

Resolves https://github.com/bitwarden/clients/issues/3504

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/desktop_native/Cargo.toml:** Added two new Apis needed for `SetFocus` and `SetForegroundWindow`.
- **apps/desktop/desktop_native/src/biometric/windows.rs**: Added a new method `set_focus` which changes the foreground application + sets the focus.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
