### PR TITLE
[SM-65] Fix first secret creation bug

### DIFF
--- a/bitwarden_license/bit-web/src/app/sm/secrets/secret.service.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secret.service.ts
@@ -35,22 +35,15 @@ export class SecretService {
   }
 
   async getSecrets(organizationId: string): Promise<SecretListView[]> {
-    try {
-      const r = await this.apiService.send(
-        "GET",
-        "/organizations/" + organizationId + "/secrets",
-        null,
-        true,
-        true
-      );
-      const results = new ListResponse(r, SecretListItemResponse);
-      return await this.createSecretsListView(organizationId, results.data);
-    } catch (e) {
-      if (e.statusCode == 404) {
-        return null;
-      }
-      throw e;
-    }
+    const r = await this.apiService.send(
+      "GET",
+      "/organizations/" + organizationId + "/secrets",
+      null,
+      true,
+      true
+    );
+    const results = new ListResponse(r, SecretListItemResponse);
+    return await this.createSecretsListView(organizationId, results.data);
   }
 
   async create(organizationId: string, secretView: SecretView) {

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secret.service.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secret.service.ts
@@ -71,25 +71,6 @@ export class SecretService {
     this._secret.next(await this.createSecretView(new SecretResponse(r)));
   }
 
-  async delete(secretIds: string[]) {
-    const r = await this.apiService.send("POST", "/secrets/delete", secretIds, true, true);
-
-    const responseErrors: string[] = [];
-    r.data.forEach((element: { error: string }) => {
-      if (element.error) {
-        responseErrors.push(element.error);
-      }
-    });
-
-    // TODO waiting to hear back on how to display multiple errors.
-    // for now send as a list of strings to be displayed in toast.
-    if (responseErrors?.length >= 1) {
-      throw new Error(responseErrors.join(","));
-    }
-
-    this._secret.next(null);
-  }
-
   private async getOrganizationKey(organizationId: string): Promise<SymmetricCryptoKey> {
     return await this.cryptoService.getOrgKey(organizationId);
   }

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.ts
@@ -48,7 +48,13 @@ export class SecretsComponent implements OnInit, OnDestroy {
   }
 
   private async getSecrets(): Promise<SecretListView[]> {
-    return await this.secretService.getSecrets(this.organizationId);
+    try {
+      return await this.secretService.getSecrets(this.organizationId);
+    } catch (e) {
+      if (e.statusCode == 404) {
+        return null;
+      }
+    }
   }
 
   openEditSecret(secretId: string) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This is a fix for when creating the first secret, the list would not populate until reloading the page.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/bit-web/src/app/sm/secrets/secret.service.ts

Return null if the status code is 404.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
