### PR TITLE
[SM-260] Fix #2800 - Handle already verified email when resending verification email

### DIFF
--- a/apps/web/src/app/settings/verify-email.component.ts
+++ b/apps/web/src/app/settings/verify-email.component.ts
@@ -40,7 +40,9 @@ export class VerifyEmailComponent {
 
     try {
       this.actionPromise = this.getIsVerified();
-      if ((await this.actionPromise) as Promise<boolean>) {return;}
+      if (await (this.actionPromise as Promise<boolean>)) {
+        return;
+      }
 
       this.actionPromise = this.apiService.postAccountVerifyEmail();
       await this.actionPromise;

--- a/apps/web/src/app/settings/verify-email.component.ts
+++ b/apps/web/src/app/settings/verify-email.component.ts
@@ -23,14 +23,19 @@ export class VerifyEmailComponent {
     private tokenService: TokenService
   ) {}
 
-  async getIsVerified(): Promise<boolean> {
+  async verifyEmail(): Promise<void> {
     await this.apiService.refreshIdentityToken();
     if (await this.tokenService.getEmailVerified()) {
       this.onVerified.emit(true);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("emailVerified"));
-      return true;
+    } else {
+      await this.apiService.postAccountVerifyEmail();
+      this.platformUtilsService.showToast(
+        "success",
+        null,
+        this.i18nService.t("checkInboxForVerification")
+      );
     }
-    return false;
   }
 
   async send() {
@@ -39,18 +44,8 @@ export class VerifyEmailComponent {
     }
 
     try {
-      this.actionPromise = this.getIsVerified();
-      if (await (this.actionPromise as Promise<boolean>)) {
-        return;
-      }
-
-      this.actionPromise = this.apiService.postAccountVerifyEmail();
+      this.actionPromise = this.verifyEmail();
       await this.actionPromise;
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("checkInboxForVerification")
-      );
     } catch (e) {
       this.logService.error(e);
     }

--- a/apps/web/src/app/settings/verify-email.component.ts
+++ b/apps/web/src/app/settings/verify-email.component.ts
@@ -23,18 +23,25 @@ export class VerifyEmailComponent {
     private tokenService: TokenService
   ) {}
 
-  async send() {
-    if (this.actionPromise != null) {
-      return;
-    }
+  async getIsVerified(): Promise<boolean> {
     await this.apiService.refreshIdentityToken();
     if (await this.tokenService.getEmailVerified()) {
       this.onVerified.emit(true);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("emailVerified"));
+      return true;
+    }
+    return false;
+  }
+
+  async send() {
+    if (this.actionPromise != null) {
       return;
     }
 
     try {
+      this.actionPromise = this.getIsVerified();
+      if ((await this.actionPromise) as Promise<boolean>) {return;}
+
       this.actionPromise = this.apiService.postAccountVerifyEmail();
       await this.actionPromise;
       this.platformUtilsService.showToast(

--- a/apps/web/src/app/settings/verify-email.component.ts
+++ b/apps/web/src/app/settings/verify-email.component.ts
@@ -28,14 +28,15 @@ export class VerifyEmailComponent {
     if (await this.tokenService.getEmailVerified()) {
       this.onVerified.emit(true);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("emailVerified"));
-    } else {
-      await this.apiService.postAccountVerifyEmail();
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("checkInboxForVerification")
-      );
+      return;
     }
+
+    await this.apiService.postAccountVerifyEmail();
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("checkInboxForVerification")
+    );
   }
 
   async send() {

--- a/apps/web/src/app/settings/verify-email.component.ts
+++ b/apps/web/src/app/settings/verify-email.component.ts
@@ -13,7 +13,7 @@ import { TokenService } from "@bitwarden/common/abstractions/token.service";
 export class VerifyEmailComponent {
   actionPromise: Promise<unknown>;
 
-  @Output() verifiedEmitter = new EventEmitter<boolean>();
+  @Output() onVerified = new EventEmitter<boolean>();
 
   constructor(
     private apiService: ApiService,
@@ -29,7 +29,7 @@ export class VerifyEmailComponent {
     }
     await this.apiService.refreshIdentityToken();
     if (await this.tokenService.getEmailVerified()) {
-      this.verifiedEmitter.emit(true);
+      this.onVerified.emit(true);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("emailVerified"));
       return;
     }

--- a/apps/web/src/app/vault/vault.component.html
+++ b/apps/web/src/app/vault/vault.component.html
@@ -78,7 +78,12 @@
           </button>
         </div>
       </div>
-      <app-verify-email *ngIf="showVerifyEmail" class="d-block mb-4"></app-verify-email>
+      <app-verify-email
+        *ngIf="showVerifyEmail"
+        class="d-block mb-4"
+        (verifiedEmitter)="updateVerifyEmail($event)"
+      ></app-verify-email>
+
       <div class="card border-warning mb-4" *ngIf="showBrowserOutdated">
         <div class="card-header bg-warning text-white">
           <i class="bwi bwi-exclamation-triangle bwi-fw" aria-hidden="true"></i>

--- a/apps/web/src/app/vault/vault.component.html
+++ b/apps/web/src/app/vault/vault.component.html
@@ -81,7 +81,7 @@
       <app-verify-email
         *ngIf="showVerifyEmail"
         class="d-block mb-4"
-        (verifiedEmitter)="updateVerifyEmail($event)"
+        (onVerified)="updateVerifyEmail($event)"
       ></app-verify-email>
 
       <div class="card border-warning mb-4" *ngIf="showBrowserOutdated">

--- a/apps/web/src/app/vault/vault.component.html
+++ b/apps/web/src/app/vault/vault.component.html
@@ -81,7 +81,7 @@
       <app-verify-email
         *ngIf="showVerifyEmail"
         class="d-block mb-4"
-        (onVerified)="updateVerifyEmail($event)"
+        (onVerified)="emailVerified($event)"
       ></app-verify-email>
 
       <div class="card border-warning mb-4" *ngIf="showBrowserOutdated">

--- a/apps/web/src/app/vault/vault.component.ts
+++ b/apps/web/src/app/vault/vault.component.ts
@@ -169,8 +169,8 @@ export class VaultComponent implements OnInit, OnDestroy {
     );
   }
 
-  updateVerifyEmail(bool: boolean) {
-    this.showVerifyEmail = !bool;
+  emailVerified(verified: boolean) {
+    this.showVerifyEmail = !verified;
   }
 
   ngOnDestroy() {

--- a/apps/web/src/app/vault/vault.component.ts
+++ b/apps/web/src/app/vault/vault.component.ts
@@ -169,6 +169,10 @@ export class VaultComponent implements OnInit, OnDestroy {
     );
   }
 
+  updateVerifyEmail(bool: boolean) {
+    this.showVerifyEmail = !bool;
+  }
+
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix for #2800 where clicking the "Send Email" button in the warning box pops up an error telling the user that the email is already verified.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/settings/verify-email.component.ts**
Added some logic to check if an email is already verified or not when a user clicks on the "Send Email" button.
Added an EventEmitter to the verify-email component so that it can let its parent know that the email's already verified and that it can close the warning box.
Added code to pop-up a Toast briefly letting the user know that their email is verified.

- **apps/web/src/app/vault/vault.component.html**
Added the EventEmitter to the template to call a new function `updateVerifyEmail`.

- **apps/web/src/app/vault/vault.component.ts**
Added new function `updateVerifyEmail` to update `this.showVerifyEmail` variable.

Feel free to let me know if naming could be better 😅

## Screenshots

I'm getting better at this but the quality is poop.

https://user-images.githubusercontent.com/20074034/190708338-59206a2e-9f3b-4bd8-b601-32ea758a0e72.mp4

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
