### PR TITLE
Add type=button to dialog close

### DIFF
--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -9,6 +9,7 @@
       <ng-content select="[bitDialogTitle]"></ng-content>
     </h1>
     <button
+      type="button"
       bitIconButton="bwi-close"
       buttonType="main"
       size="default"


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Buttons default to `type=submit` meaning that adding a form around dialog causes it to close instead of submitting.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
