### PR TITLE
[SG-656\ Don't try and parse a json response if one is not received

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -2323,7 +2323,9 @@ export class ApiService implements ApiServiceAbstraction {
     requestInit.headers = headers;
     const response = await this.fetch(new Request(requestUrl, requestInit));
 
-    if (hasResponse && response.status === 200) {
+    const responseType = response.headers.get("content-type");
+    const responseIsJson = responseType != null && responseType.indexOf("application/json") !== -1;
+    if (hasResponse && response.status === 200 && responseIsJson) {
       const responseJson = await response.json();
       return responseJson;
     } else if (response.status !== 200) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Through the ongoing work to fix [SG-656](https://bitwarden.atlassian.net/jira/software/c/projects/SG/boards/71?modal=detail&selectedIssue=SG-656) we have created a backwards compatibility issue. 

On https://github.com/bitwarden/clients/pull/3531/files I changed the `postRegister()` api service method to expect a response body to come back from the server. A sibling PR modified the server to send a response.

The backwards compatibility issue comes up when a new client that expects a response from `register` calls an old server that doesn't send one. This throws a json parsing error and doesn't continue. This PR addresses this backwards compatibility issue.

## Code changes
* Add logic to the `apiSerice.send()` method that checks to see if an api response had a body in it before trying to parse it to json. This allows an old server to send an empty body while enabling new clients to adapt to that unexpected situation and skip the parsing step.

## Screenshots
Tested on a local build of `master` connected to the production cloud server. I used the extension to easily connect to an old server version (prod). This combo of client/server was also how the issue was discovered.

https://user-images.githubusercontent.com/15897251/191514360-98816949-b044-4993-abc5-1794a0dfa538.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
