### PR TITLE
[PS-1519] Correct bw send get -h internal CLI documentation

### DIFF
--- a/apps/cli/src/send.program.ts
+++ b/apps/cli/src/send.program.ts
@@ -176,12 +176,12 @@ export class SendProgram extends Program {
         writeLn("");
         writeLn("  Examples:");
         writeLn("");
-        writeLn("    bw get send searchText");
-        writeLn("    bw get send id");
-        writeLn("    bw get send searchText --text");
-        writeLn("    bw get send searchText --file");
-        writeLn("    bw get send searchText --file --output ../Photos/photo.jpg");
-        writeLn("    bw get send searchText --file --raw");
+        writeLn("    bw send get searchText");
+        writeLn("    bw send get id");
+        writeLn("    bw send get searchText --text");
+        writeLn("    bw send get searchText --file");
+        writeLn("    bw send get searchText --file --output ../Photos/photo.jpg");
+        writeLn("    bw send get searchText --file --raw");
         writeLn("", true);
       })
       .action(async (id: string, options: program.OptionValues) => {


### PR DESCRIPTION
# Type of change

- [ x ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

# Objective

https://bitwarden.atlassian.net/browse/PS-1519 - Correct documentation so that it states:

_Examples:

bw send get searchText
bw send get id
bw send get searchText --text
bw send get searchText --file
bw send get searchText --file --output ../Photos/photo.jpg
bw send get searchText --file --raw_

# Code changes

    send.programs.ts: command order corrected in internal documentation

# Before you submit

    If this change requires a documentation update - notify the documentation team

No documentation changes required - this changes the internal documentation to correctly reflect the documentation on the website.
