### PR TITLE
[SM-198] Empty Secrets View

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5415,10 +5415,10 @@
   "importSecrets":{
     "message":"Import Secrets"
   },
-  "emptyListTitle":{
+  "secretsEmptyListTitle":{
     "message":"Nothing to show yet"
   },
-  "emptyListMessage":{
+  "secretsEmptyListMessage":{
     "message": "Add a new secret or import secrets to get started"
   },
   "searchSecrets":{

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5409,6 +5409,18 @@
   "secretCreated":{
     "message":"Secret created"
   },
+  "newSecret":{
+    "message":"New Secret"
+  },
+  "importSecrets":{
+    "message":"Import Secrets"
+  },
+  "emptyListTitle":{
+    "message":"Nothing to show yet"
+  },
+  "emptyListMessage":{
+    "message": "Add a new secret or import secrets to get started"
+  },
   "searchSecrets":{
     "message":"Search Secrets"
   }

--- a/apps/web/src/scss/base.scss
+++ b/apps/web/src/scss/base.scss
@@ -314,10 +314,10 @@ a i.bwi {
   justify-content: center;
   align-items: center;
   text-align: center;
+}
 
-  .no-items-image {
-    @include themify($themes) {
-      content: url("../images/search-web" + themed("svgSuffix"));
-    }
+.no-items-image {
+  @include themify($themes) {
+    content: url("../images/search-web" + themed("svgSuffix"));
   }
 }

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -11,7 +11,7 @@
       <i class="bwi bwi-plus" aria-hidden="true"></i>
       {{ "newSecret" | i18n }}
     </button>
-    <button bitButton buttonType="secondary">
+    <button bitButton buttonType="secondary" (click)="this.openImportSecretsDialogEvent.emit()">
       <i class="bwi bwi-save tw-rotate-180" aria-hidden="true"></i>
       {{ "importSecrets" | i18n }}
     </button>

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -1,4 +1,24 @@
-<bit-table>
+<div *ngIf="secrets.length == 0" class="no-items tw-justify-start tw-pt-6">
+  <img class="no-items-image" aria-hidden="true" />
+  <div class="tw-max-w-xs">
+    <h3 class="tw-font-semibold">
+      {{ "emptyListTitle" | i18n }}
+    </h3>
+    <p>{{ "emptyListMessage" | i18n }}</p>
+  </div>
+  <div class="tw-space-x-2">
+    <button bitButton buttonType="secondary" (click)="this.openNewSecretDialogEvent.emit()">
+      <i class="bwi bwi-plus" aria-hidden="true"></i>
+      {{ "newSecret" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary">
+      <i class="bwi bwi-save tw-rotate-180" aria-hidden="true"></i>
+      {{ "importSecrets" | i18n }}
+    </button>
+  </div>
+</div>
+
+<bit-table *ngIf="secrets.length >= 1">
   <ng-container header>
     <tr>
       <th bitCell class="tw-w-0">

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -1,17 +1,18 @@
-<div *ngIf="secrets.length == 0" class="no-items tw-justify-start tw-pt-6">
+<div
+  *ngIf="secrets.length == 0"
+  class="tw-mx-auto tw-flex tw-max-w-xs tw-flex-col tw-items-center tw-justify-center tw-pt-6 tw-text-center"
+>
   <img class="no-items-image" aria-hidden="true" />
-  <div class="tw-max-w-xs">
-    <h3 class="tw-font-semibold">
-      {{ "emptyListTitle" | i18n }}
-    </h3>
-    <p>{{ "emptyListMessage" | i18n }}</p>
-  </div>
+  <h3 class="tw-font-semibold">
+    {{ "secretsEmptyListTitle" | i18n }}
+  </h3>
+  <p>{{ "secretsEmptyListMessage" | i18n }}</p>
   <div class="tw-space-x-2">
-    <button bitButton buttonType="secondary" (click)="this.openNewSecretDialogEvent.emit()">
+    <button bitButton buttonType="secondary" (click)="newSecretEvent.emit()">
       <i class="bwi bwi-plus" aria-hidden="true"></i>
       {{ "newSecret" | i18n }}
     </button>
-    <button bitButton buttonType="secondary" (click)="this.openImportSecretsDialogEvent.emit()">
+    <button bitButton buttonType="secondary" (click)="importSecretsEvent.emit()">
       <i class="bwi bwi-save tw-rotate-180" aria-hidden="true"></i>
       {{ "importSecrets" | i18n }}
     </button>

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
@@ -17,6 +17,7 @@ export class SecretsListComponent implements OnDestroy {
   @Output() projectsEvent = new EventEmitter<string>();
   @Output() deleteSecretEvent = new EventEmitter<string>();
   @Output() onSecretCheckedEvent = new EventEmitter<string[]>();
+  @Output() openNewSecretDialogEvent = new EventEmitter();
 
   private destroy$: Subject<void> = new Subject<void>();
 

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
@@ -17,8 +17,8 @@ export class SecretsListComponent implements OnDestroy {
   @Output() projectsEvent = new EventEmitter<string>();
   @Output() deleteSecretEvent = new EventEmitter<string>();
   @Output() onSecretCheckedEvent = new EventEmitter<string[]>();
-  @Output() openNewSecretDialogEvent = new EventEmitter();
-  @Output() openImportSecretsDialogEvent = new EventEmitter();
+  @Output() newSecretEvent = new EventEmitter();
+  @Output() importSecretsEvent = new EventEmitter();
 
   private destroy$: Subject<void> = new Subject<void>();
 

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts
@@ -18,6 +18,7 @@ export class SecretsListComponent implements OnDestroy {
   @Output() deleteSecretEvent = new EventEmitter<string>();
   @Output() onSecretCheckedEvent = new EventEmitter<string[]>();
   @Output() openNewSecretDialogEvent = new EventEmitter();
+  @Output() openImportSecretsDialogEvent = new EventEmitter();
 
   private destroy$: Subject<void> = new Subject<void>();
 

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
@@ -1,2 +1,6 @@
 <sm-header title="secrets" searchTitle="searchSecrets"></sm-header>
-<sm-secrets-list (editSecretEvent)="openEditSecret($event)" [secrets]="secrets"></sm-secrets-list>
+<sm-secrets-list
+  (openNewSecretDialogEvent)="openNewSecretDialog()"
+  (editSecretEvent)="openEditSecret($event)"
+  [secrets]="secrets"
+></sm-secrets-list>

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
@@ -1,6 +1,6 @@
 <sm-header title="secrets" searchTitle="searchSecrets"></sm-header>
 <sm-secrets-list
-  (openNewSecretDialogEvent)="openNewSecretDialog()"
+  (newSecretEvent)="openNewSecretDialog()"
   (editSecretEvent)="openEditSecret($event)"
   [secrets]="secrets"
 ></sm-secrets-list>

--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.ts
@@ -60,4 +60,13 @@ export class SecretsComponent implements OnInit, OnDestroy {
       },
     });
   }
+
+  openNewSecretDialog() {
+    this.dialogService.open<unknown, SecretOperation>(SecretDialogComponent, {
+      data: {
+        organizationId: this.organizationId,
+        operation: OperationType.Add,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is for creating a view for when no secrets are available. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- apps/web/src/locales/en/messages.json

Adding new messages for empty secrets view

- bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html

Display empty secrets view if no secrets are passed in as input.

- bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.ts

Add event emitters for when buttons are clicked for empty secret view.

- bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.ts

Handle launching new secret dialog

## Screenshots

![image](https://user-images.githubusercontent.com/43214426/191618593-ee00fcbe-1360-4ae1-a1da-60089d6c4969.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
