### PR TITLE
[EC-570] eslint: Prevent angular/node/electron imports into libs/common

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "browser": true,
     "webextensions": true
   },
-  "plugins": ["@typescript-eslint", "rxjs", "rxjs-angular"],
+  "plugins": ["@typescript-eslint", "rxjs", "rxjs-angular", "import"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": ["./tsconfig.eslint.json"],
@@ -18,6 +18,16 @@
     "prettier",
     "plugin:rxjs/recommended"
   ],
+  "settings": {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts"]
+    },
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      }
+    }
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off", // TODO: This should be re-enabled
     "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
@@ -65,6 +75,27 @@
         "selector": "CallExpression[callee.name='svgIcon']"
       }
     ],
-    "curly": ["error", "all"]
+    "curly": ["error", "all"],
+    "import/namespace": ["off"], // This doesn't resolve namespace imports correctly, but TS will throw for this anyway
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          // Do not allow angular/node/electron code to be imported into common
+          {
+            "target": "./libs/common/**/*",
+            "from": "./libs/angular/**/*"
+          },
+          {
+            "target": "./libs/common/**/*",
+            "from": "./libs/node/**/*"
+          },
+          {
+            "target": "./libs/common/**/*",
+            "from": "./libs/electron/**/*"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/libs/common/spec/importers/bitwardenPasswordProtectedImporter.spec.ts
+++ b/libs/common/spec/importers/bitwardenPasswordProtectedImporter.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg, SubstituteOf } from "@fluffy-spoon/substitute";
+import { Substitute, Arg, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";

--- a/libs/common/spec/models/domain/cipher.spec.ts
+++ b/libs/common/spec/models/domain/cipher.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg } from "@fluffy-spoon/substitute";
+import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { CipherRepromptType } from "@bitwarden/common/enums/cipherRepromptType";
 import { CipherType } from "@bitwarden/common/enums/cipherType";

--- a/libs/common/spec/models/domain/encString.spec.ts
+++ b/libs/common/spec/models/domain/encString.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg } from "@fluffy-spoon/substitute";
+import { Substitute, Arg } from "@fluffy-spoon/substitute";
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";

--- a/libs/common/spec/models/domain/login.spec.ts
+++ b/libs/common/spec/models/domain/login.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg } from "@fluffy-spoon/substitute";
+import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { UriMatchType } from "@bitwarden/common/enums/uriMatchType";
 import { LoginData } from "@bitwarden/common/models/data/loginData";

--- a/libs/common/spec/models/domain/send.spec.ts
+++ b/libs/common/spec/models/domain/send.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg, SubstituteOf } from "@fluffy-spoon/substitute";
+import { Substitute, Arg, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";

--- a/libs/common/spec/models/domain/sendAccess.spec.ts
+++ b/libs/common/spec/models/domain/sendAccess.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg } from "@fluffy-spoon/substitute";
+import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { SendType } from "@bitwarden/common/enums/sendType";
 import { SendAccess } from "@bitwarden/common/models/domain/sendAccess";

--- a/libs/common/spec/services/import.service.spec.ts
+++ b/libs/common/spec/services/import.service.spec.ts
@@ -1,4 +1,4 @@
-import Substitute, { SubstituteOf } from "@fluffy-spoon/substitute";
+import { Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -1,4 +1,4 @@
-import Substitute, { Arg } from "@fluffy-spoon/substitute";
+import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { EncString } from "@bitwarden/common/models/domain/encString";
 

--- a/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
+++ b/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
@@ -1,4 +1,4 @@
-import Substitute from "@fluffy-spoon/substitute";
+import { Substitute } from "@fluffy-spoon/substitute";
 
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { Utils } from "@bitwarden/common/misc/utils";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
* add an eslint rule to prohibit electron/node/angular code being imported into libs/common.
* bonus: fix the eslint Typescript parser, which was not configured properly

We could also apply similar rules to the other `libs/` directories, or even clients, but it didn't seem worth building up a large ruleset for. `libs/common` is usually the main offender.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**.eslintrc.json**
* add `eslint-plugin-import` to the plugins array so we can use it
* add the eslint Typescript parser settings, [per the docs](https://github.com/import-js/eslint-import-resolver-typescript#configuration), so that it can resolve import paths correctly (e.g. our `@bitwarden/*` mapping). As soon as I did this I got a bunch of linting errors (see below), so I think this was a bug in our existing config.
* add the [import/no-restricted-paths rule](https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/no-restricted-paths.md), which does the main work of this PR - throw a linting error if we import electron/node/angular code into libs/common. Note that the next release will support an array of `from` values to avoid repeating this config, but not yet.
* once I fixed the TS parsing, it threw errors for the [import/namespace rule](https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/docs/rules/namespace.md) - for some reason it's not resolving modules like `inquirer` or `commander`. I just disabled it because I couldn't figure it out, but TS will not let us compile if these imports are wrong anyway.

All other files: fix import statements to fix linting errors.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
