### PR TITLE
[PS-1550] Fix #2806 - The "Import Data", "Premium Membership", "Subscription" and "Edit User" pages contain strings that cannot be translated (PARTIAL)

### DIFF
--- a/apps/web/src/app/organizations/manage/user-add-edit.component.html
+++ b/apps/web/src/app/organizations/manage/user-add-edit.component.html
@@ -135,7 +135,7 @@
           <div class="row">
             <div class="col-6">
               <div class="mb-3">
-                <label class="font-weight-bold mb-0">Manager Permissions</label>
+                <label class="font-weight-bold mb-0">{{ "managerPermissions" | i18n }}</label>
                 <hr class="my-0 mr-2" />
                 <app-nested-checkbox
                   parentId="manageAssignedCollections"
@@ -146,7 +146,7 @@
             </div>
             <div class="col-6">
               <div class="mb-3">
-                <label class="font-weight-bold mb-0">Admin Permissions</label>
+                <label class="font-weight-bold mb-0">{{ "adminPermissions" | i18n }}</label>
                 <hr class="my-0 mr-2" />
                 <div class="form-group mb-0">
                   <div class="form-check mt-1 form-check-block">

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4057,6 +4057,12 @@
   "permissions": {
     "message": "Permissions"
   },
+  "managerPermissions": {
+    "message": "Manager Permissions"
+  },
+  "adminPermissions": {
+    "message": "Admin Permissions"
+  },
   "accessEventLogs": {
     "message": "Access Event Logs"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Partial fix for #2806 to address the "Edit User" page's "Manager Permissions" and "Admin Permissions" not being able to be translated.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/manage/user-add-edit.component.html**
Changed "Manager Permissions" and "Admin Permissions" text to pull from `messages.json` translations.

- **apps/web/src/locales/en/messages.json**
Added English defaults for the new translatable text to grab from.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Organization Settings > Manage > People > Edit User (English)
![image](https://user-images.githubusercontent.com/20074034/189776767-31316939-8ea9-4ab0-b655-cc849b13379f.png)

Organization Settings > Manage > People > Edit User (Finnish - Finnish `messages.json` file reverted after testing)
![image](https://user-images.githubusercontent.com/20074034/189776779-bdcd6366-f500-477e-aef4-9796a5fe5ddf.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
