### PR TITLE
[PS-1297] Fix about info not being selectable/copyable

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -406,6 +406,7 @@ img,
   user-select: none;
 }
 
+app-about .modal-body > *,
 app-vault-view .box-footer {
   user-select: auto;
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes #3300 

The change in selectable elements was changed with https://github.com/bitwarden/clients/pull/2674.

Small fix to get enable a user to select and copy th information of the about box.

## Code changes

- **apps/browser/src/popup/scss/misc.scss:** Add an exception for `app-about` to enable `user-select: auto` instead of `none`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
