### PR TITLE
Rename web vault imports from src to web-vault

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -6,7 +6,7 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["**/app/core/*", "**/reports/*", "**/app/shared/*"]
+        "patterns": ["**/app/core/*", "**/reports/*", "**/app/shared/*", "@bitwarden/web-vault/*"]
       }
     ]
   }

--- a/apps/web/src/app/accounts/login/login.component.ts
+++ b/apps/web/src/app/accounts/login/login.component.ts
@@ -22,8 +22,7 @@ import { Policy } from "@bitwarden/common/models/domain/policy";
 import { ListResponse } from "@bitwarden/common/models/response/listResponse";
 import { PolicyResponse } from "@bitwarden/common/models/response/policyResponse";
 
-import { flagEnabled } from "src/utils/flags";
-
+import { flagEnabled } from "../../../utils/flags";
 import { RouterService, StateService } from "../../core";
 
 @Component({

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "paths": {
       "tldjs": ["../../libs/common/src/misc/tldjs.noop"],
-      "src/*": ["src/*"],
+      "@bitwarden/web-vault/*": ["src/*"],
       "@bitwarden/common/*": ["../../libs/common/src/*"],
       "@bitwarden/angular/*": ["../../libs/angular/src/*"],
       "@bitwarden/components": ["../../libs/components/src"]

--- a/bitwarden_license/bit-web/src/app/app.component.ts
+++ b/bitwarden_license/bit-web/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 
-import { AppComponent as BaseAppComponent } from "src/app/app.component";
+import { AppComponent as BaseAppComponent } from "@bitwarden/web-vault/app/app.component";
 
 import { DisablePersonalVaultExportPolicy } from "./policies/disable-personal-vault-export.component";
 import { MaximumVaultTimeoutPolicy } from "./policies/maximum-vault-timeout.component";

--- a/bitwarden_license/bit-web/src/app/app.module.ts
+++ b/bitwarden_license/bit-web/src/app/app.module.ts
@@ -7,11 +7,10 @@ import { RouterModule } from "@angular/router";
 import { InfiniteScrollModule } from "ngx-infinite-scroll";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-
-import { CoreModule } from "src/app/core";
-import { OssRoutingModule } from "src/app/oss-routing.module";
-import { OssModule } from "src/app/oss.module";
-import { WildcardRoutingModule } from "src/app/wildcard-routing.module";
+import { CoreModule } from "@bitwarden/web-vault/app/core";
+import { OssRoutingModule } from "@bitwarden/web-vault/app/oss-routing.module";
+import { OssModule } from "@bitwarden/web-vault/app/oss.module";
+import { WildcardRoutingModule } from "@bitwarden/web-vault/app/wildcard-routing.module";
 
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";

--- a/bitwarden_license/bit-web/src/app/organizations/organizations-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/organizations-routing.module.ts
@@ -3,11 +3,10 @@ import { RouterModule, Routes } from "@angular/router";
 
 import { AuthGuard } from "@bitwarden/angular/guards/auth.guard";
 import { Organization } from "@bitwarden/common/models/domain/organization";
-
-import { OrganizationPermissionsGuard } from "src/app/organizations/guards/org-permissions.guard";
-import { OrganizationLayoutComponent } from "src/app/organizations/layouts/organization-layout.component";
-import { ManageComponent } from "src/app/organizations/manage/manage.component";
-import { canAccessManageTab } from "src/app/organizations/navigation-permissions";
+import { OrganizationPermissionsGuard } from "@bitwarden/web-vault/app/organizations/guards/org-permissions.guard";
+import { OrganizationLayoutComponent } from "@bitwarden/web-vault/app/organizations/layouts/organization-layout.component";
+import { ManageComponent } from "@bitwarden/web-vault/app/organizations/manage/manage.component";
+import { canAccessManageTab } from "@bitwarden/web-vault/app/organizations/navigation-permissions";
 
 import { ScimComponent } from "./manage/scim.component";
 import { SsoComponent } from "./manage/sso.component";

--- a/bitwarden_license/bit-web/src/app/organizations/organizations.module.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/organizations.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 
-import { SharedModule } from "src/app/shared/shared.module";
+import { SharedModule } from "@bitwarden/web-vault/app/shared/shared.module";
 
 import { InputCheckboxComponent } from "./components/input-checkbox.component";
 import { InputTextReadOnlyComponent } from "./components/input-text-readonly.component";

--- a/bitwarden_license/bit-web/src/app/policies/disable-personal-vault-export.component.ts
+++ b/bitwarden_license/bit-web/src/app/policies/disable-personal-vault-export.component.ts
@@ -1,11 +1,10 @@
 import { Component } from "@angular/core";
 
 import { PolicyType } from "@bitwarden/common/enums/policyType";
-
 import {
   BasePolicy,
   BasePolicyComponent,
-} from "src/app/organizations/policies/base-policy.component";
+} from "@bitwarden/web-vault/app/organizations/policies/base-policy.component";
 
 export class DisablePersonalVaultExportPolicy extends BasePolicy {
   name = "disablePersonalVaultExport";

--- a/bitwarden_license/bit-web/src/app/policies/maximum-vault-timeout.component.ts
+++ b/bitwarden_license/bit-web/src/app/policies/maximum-vault-timeout.component.ts
@@ -4,11 +4,10 @@ import { UntypedFormBuilder } from "@angular/forms";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PolicyType } from "@bitwarden/common/enums/policyType";
 import { PolicyRequest } from "@bitwarden/common/models/request/policyRequest";
-
 import {
   BasePolicy,
   BasePolicyComponent,
-} from "src/app/organizations/policies/base-policy.component";
+} from "@bitwarden/web-vault/app/organizations/policies/base-policy.component";
 
 export class MaximumVaultTimeoutPolicy extends BasePolicy {
   name = "maximumVaultTimeout";

--- a/bitwarden_license/bit-web/src/app/providers/clients/create-organization.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/clients/create-organization.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 
-import { OrganizationPlansComponent } from "src/app/settings/organization-plans.component";
+import { OrganizationPlansComponent } from "@bitwarden/web-vault/app/settings/organization-plans.component";
 
 @Component({
   selector: "app-create-organization",

--- a/bitwarden_license/bit-web/src/app/providers/manage/accept-provider.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/accept-provider.component.ts
@@ -6,8 +6,7 @@ import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { ProviderUserAcceptRequest } from "@bitwarden/common/models/request/provider/providerUserAcceptRequest";
-
-import { BaseAcceptComponent } from "src/app/common/base.accept.component";
+import { BaseAcceptComponent } from "@bitwarden/web-vault/app/common/base.accept.component";
 
 @Component({
   selector: "app-accept-provider",

--- a/bitwarden_license/bit-web/src/app/providers/manage/bulk/bulk-confirm.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/bulk/bulk-confirm.component.ts
@@ -3,9 +3,8 @@ import { Component, Input } from "@angular/core";
 import { ProviderUserStatusType } from "@bitwarden/common/enums/providerUserStatusType";
 import { ProviderUserBulkConfirmRequest } from "@bitwarden/common/models/request/provider/providerUserBulkConfirmRequest";
 import { ProviderUserBulkRequest } from "@bitwarden/common/models/request/provider/providerUserBulkRequest";
-
-import { BulkConfirmComponent as OrganizationBulkConfirmComponent } from "src/app/organizations/manage/bulk/bulk-confirm.component";
-import { BulkUserDetails } from "src/app/organizations/manage/bulk/bulk-status.component";
+import { BulkConfirmComponent as OrganizationBulkConfirmComponent } from "@bitwarden/web-vault/app/organizations/manage/bulk/bulk-confirm.component";
+import { BulkUserDetails } from "@bitwarden/web-vault/app/organizations/manage/bulk/bulk-status.component";
 
 @Component({
   templateUrl:

--- a/bitwarden_license/bit-web/src/app/providers/manage/bulk/bulk-remove.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/bulk/bulk-remove.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input } from "@angular/core";
 
 import { ProviderUserBulkRequest } from "@bitwarden/common/models/request/provider/providerUserBulkRequest";
-
-import { BulkRemoveComponent as OrganizationBulkRemoveComponent } from "src/app/organizations/manage/bulk/bulk-remove.component";
+import { BulkRemoveComponent as OrganizationBulkRemoveComponent } from "@bitwarden/web-vault/app/organizations/manage/bulk/bulk-remove.component";
 
 @Component({
   templateUrl:

--- a/bitwarden_license/bit-web/src/app/providers/manage/events.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/events.component.ts
@@ -10,9 +10,8 @@ import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { ProviderService } from "@bitwarden/common/abstractions/provider.service";
 import { EventResponse } from "@bitwarden/common/models/response/eventResponse";
-
-import { BaseEventsComponent } from "src/app/common/base.events.component";
-import { EventService } from "src/app/core";
+import { BaseEventsComponent } from "@bitwarden/web-vault/app/common/base.events.component";
+import { EventService } from "@bitwarden/web-vault/app/core";
 
 @Component({
   selector: "provider-events",

--- a/bitwarden_license/bit-web/src/app/providers/manage/people.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/manage/people.component.ts
@@ -21,10 +21,9 @@ import { ProviderUserConfirmRequest } from "@bitwarden/common/models/request/pro
 import { ListResponse } from "@bitwarden/common/models/response/listResponse";
 import { ProviderUserBulkResponse } from "@bitwarden/common/models/response/provider/providerUserBulkResponse";
 import { ProviderUserUserDetailsResponse } from "@bitwarden/common/models/response/provider/providerUserResponse";
-
-import { BasePeopleComponent } from "src/app/common/base.people.component";
-import { BulkStatusComponent } from "src/app/organizations/manage/bulk/bulk-status.component";
-import { EntityEventsComponent } from "src/app/organizations/manage/entity-events.component";
+import { BasePeopleComponent } from "@bitwarden/web-vault/app/common/base.people.component";
+import { BulkStatusComponent } from "@bitwarden/web-vault/app/organizations/manage/bulk/bulk-status.component";
+import { EntityEventsComponent } from "@bitwarden/web-vault/app/organizations/manage/entity-events.component";
 
 import { BulkConfirmComponent } from "./bulk/bulk-confirm.component";
 import { BulkRemoveComponent } from "./bulk/bulk-remove.component";

--- a/bitwarden_license/bit-web/src/app/providers/providers-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/providers/providers-routing.module.ts
@@ -3,9 +3,8 @@ import { RouterModule, Routes } from "@angular/router";
 
 import { AuthGuard } from "@bitwarden/angular/guards/auth.guard";
 import { Provider } from "@bitwarden/common/models/domain/provider";
-
-import { FrontendLayoutComponent } from "src/app/layouts/frontend-layout.component";
-import { ProvidersComponent } from "src/app/providers/providers.component";
+import { FrontendLayoutComponent } from "@bitwarden/web-vault/app/layouts/frontend-layout.component";
+import { ProvidersComponent } from "@bitwarden/web-vault/app/providers/providers.component";
 
 import { ClientsComponent } from "./clients/clients.component";
 import { CreateOrganizationComponent } from "./clients/create-organization.component";

--- a/bitwarden_license/bit-web/src/app/providers/providers.module.ts
+++ b/bitwarden_license/bit-web/src/app/providers/providers.module.ts
@@ -4,8 +4,7 @@ import { FormsModule } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-
-import { OssModule } from "src/app/oss.module";
+import { OssModule } from "@bitwarden/web-vault/app/oss.module";
 
 import { AddOrganizationComponent } from "./clients/add-organization.component";
 import { ClientsComponent } from "./clients/clients.component";

--- a/bitwarden_license/bit-web/src/app/providers/setup/setup-provider.component.ts
+++ b/bitwarden_license/bit-web/src/app/providers/setup/setup-provider.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 import { Params } from "@angular/router";
 
-import { BaseAcceptComponent } from "src/app/common/base.accept.component";
+import { BaseAcceptComponent } from "@bitwarden/web-vault/app/common/base.accept.component";
 
 @Component({
   selector: "app-setup-provider",

--- a/bitwarden_license/bit-web/src/app/sm/sm.module.ts
+++ b/bitwarden_license/bit-web/src/app/sm/sm.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 
-import { SharedModule } from "src/app/shared";
+import { SharedModule } from "@bitwarden/web-vault/app/shared";
 
 import { LayoutComponent } from "./layout/layout.component";
 import { NavigationComponent } from "./layout/navigation.component";

--- a/bitwarden_license/bit-web/src/main.ts
+++ b/bitwarden_license/bit-web/src/main.ts
@@ -5,8 +5,8 @@ import "bootstrap";
 import "jquery";
 import "popper.js";
 
-require("src/scss/styles.scss");
-require("src/scss/tailwind.css");
+require("@bitwarden/web-vault/scss/styles.scss");
+require("@bitwarden/web-vault/scss/tailwind.css");
 
 import { AppModule } from "./app/app.module";
 

--- a/bitwarden_license/bit-web/tsconfig.json
+++ b/bitwarden_license/bit-web/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../apps/web/tsconfig",
   "compilerOptions": {
     "paths": {
+      "@bitwarden/web-vault/*": ["../../apps/web/src/*"],
       "@bitwarden/common/*": ["../../libs/common/src/*"],
       "@bitwarden/angular/*": ["../../libs/angular/src/*"],
       "@bitwarden/components": ["../../libs/components/src"]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Rename the web vault imports from `src` to `@bitwarden/web-vault`. This is for a couple of reasons.

* Identify that it should not be used internally within the web app.
* Follow our existing standardized import pattern.
* Required to support storybook stories in the bitwarden licensed code.

I also added the `@bitwarden/web-vault` to the forbidden eslint list.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
