### PR TITLE
[EC-569] Fix alignment for long filter names

### DIFF
--- a/apps/desktop/src/scss/left-nav.scss
+++ b/apps/desktop/src/scss/left-nav.scss
@@ -154,6 +154,10 @@
     margin-left: auto;
     margin-right: 5px;
   }
+
+  .filter-button {
+    white-space: nowrap;
+  }
 }
 
 .nav {

--- a/apps/web/src/scss/vault-filters.scss
+++ b/apps/web/src/scss/vault-filters.scss
@@ -104,6 +104,9 @@
   }
 
   .filter-button {
+    max-width: 90%;
+    white-space: nowrap;
+
     &:hover,
     &:focus,
     &:active {
@@ -112,7 +115,6 @@
       }
       text-decoration: none;
     }
-    max-width: 90%;
 
     &.disabled-organization {
       max-width: 78%;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix how we display long organization/collection/folder names in the vault filter. They should be truncated, but instead, they are being centered and wrapped.

This will be picked to rc.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This regression was caused by #3407, which removed the `white-space: nowrap` option for buttons generally. We just need to add back that setting for filter buttons specifically.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
