### PR TITLE
SM Fix double edit secret dialog

### DIFF
--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html
@@ -1,6 +1,5 @@
 <sm-header title="secrets" searchTitle="searchSecrets"></sm-header>
 <sm-secrets-list
-  (editSecretEvent)="openEditSecret($event)"
   (deleteSecretsEvent)="openDeleteSecret($event)"
   (newSecretEvent)="openNewSecretDialog()"
   (editSecretEvent)="openEditSecret($event)"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR is for removing one of the `(editSecretEvent)="openEditSecret($event)"`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/bit-web/src/app/sm/secrets/secrets.component.html

Remove one occurrence of `(editSecretEvent)="openEditSecret($event)"`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
