### PR TITLE
SM Fix typescript errors on secrets initialization 

### DIFF
--- a/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html
@@ -1,5 +1,9 @@
+<div *ngIf="!secrets" class="tw-items-center tw-justify-center tw-pt-64 tw-text-center">
+  <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
+</div>
+
 <div
-  *ngIf="secrets.length == 0"
+  *ngIf="secrets?.length == 0"
   class="tw-mx-auto tw-flex tw-max-w-xs tw-flex-col tw-items-center tw-justify-center tw-pt-6 tw-text-center"
 >
   <img class="no-items-image" aria-hidden="true" />
@@ -19,7 +23,7 @@
   </div>
 </div>
 
-<bit-table *ngIf="secrets.length >= 1">
+<bit-table *ngIf="secrets?.length >= 1">
   <ng-container header>
     <tr>
       <th bitCell class="tw-w-0">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR is for fixing the typescript errors occurring at secrets-list.component when first loading. 

The change will display a spinning loading icon while the secrets list is initialized.


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/bit-web/src/app/sm/secrets/secrets-list.component.html

Check that secrets is initialized before displaying data. If not, display the spinning loading icon.

## Screenshots

Loading Icon displayed

![image](https://user-images.githubusercontent.com/43214426/193082299-0331ed04-3dcf-45e2-bf14-d074db23c5ae.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
