### PR TITLE
Rename anonymousHub route to anonymous-hub

### DIFF
--- a/libs/common/src/services/anonymousHub.service.ts
+++ b/libs/common/src/services/anonymousHub.service.ts
@@ -32,7 +32,7 @@ export class AnonymousHubService implements AnonymousHubServiceAbstraction {
     this.url = this.environmentService.getNotificationsUrl();
 
     this.anonHubConnection = new HubConnectionBuilder()
-      .withUrl(this.url + "/anonymousHub?Token=" + token, {
+      .withUrl(this.url + "/anonymous-hub?Token=" + token, {
         skipNegotiation: true,
         transport: HttpTransportType.WebSockets,
       })


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We hyphenate multi word routes as a rule, but the new AnonymousHub needed for passwordless broke this rule. This commit adjusts the route name used.

This depends on https://github.com/bitwarden/server/pull/2315/files

This commit will be cherry picked to rc.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
