### PR TITLE
Add organization-options menu to single org

### DIFF
--- a/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
@@ -97,6 +97,14 @@
           <i class="bwi bwi-fw bwi-business" aria-hidden="true"></i>
           {{ organizations[0].name }}
         </button>
+        <span class="tw-ml-auto">
+          <button [bitMenuTriggerFor]="orgMenu" class="org-options">
+            <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
+          </button>
+          <bit-menu class="filter-organization-options tw-ml-auto" #orgMenu>
+            <app-organization-options [organization]="organizations[0]"></app-organization-options>
+          </bit-menu>
+        </span>
       </div>
     </ng-container>
     <ng-container *ngSwitchDefault>

--- a/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
@@ -101,7 +101,7 @@
           <button [bitMenuTriggerFor]="orgMenu" class="org-options">
             <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
           </button>
-          <bit-menu class="filter-organization-options tw-ml-auto" #orgMenu>
+          <bit-menu class="filter-organization-options" #orgMenu>
             <app-organization-options [organization]="organizations[0]"></app-organization-options>
           </bit-menu>
         </span>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix:

> How to reproduce:
> Enable Single-org & disable personal vault. 
> Go to my vault and the 3-dot menu is missing. Users couldn't leave, enroll in master reset, etc.

This will be picked to rc.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

The `organization-filter.component` has a switch statement, which shows different layouts depending on (among other things) whether the Single Org and/or Personal Vault policy applies. This particular case was missing the template code for the organization options menu. Copy + paste it across from elsewhere in the template.

This is being rewritten as part of #3440, so this is just a basic job to fix the regression for this release.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:
![Screen Shot 2022-10-04 at 10 36 04 am](https://user-images.githubusercontent.com/31796059/193710045-1d58a1d4-4a7c-4650-988b-34b41a51c498.png)

After:
![Screen Shot 2022-10-04 at 10 30 31 am](https://user-images.githubusercontent.com/31796059/193710058-31d727fb-be0c-49f7-9091-f80dc6d0304a.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
