### PR TITLE
[PS-1335] problem with dropped letters keypresses when searching vault from browser extension debounce

### DIFF
--- a/apps/browser/src/popup/vault/current-tab.component.html
+++ b/apps/browser/src/popup/vault/current-tab.component.html
@@ -17,7 +17,7 @@
       placeholder="{{ 'searchVault' | i18n }}"
       id="search"
       [(ngModel)]="searchText"
-      (input)="searchVault()"
+      (input)="search$.next()"
       autocomplete="off"
       (keydown)="closeOnEsc($event)"
     />

--- a/apps/browser/src/popup/vault/current-tab.component.html
+++ b/apps/browser/src/popup/vault/current-tab.component.html
@@ -20,6 +20,7 @@
       (input)="search$.next()"
       autocomplete="off"
       (keydown)="closeOnEsc($event)"
+      appAutofocus
     />
     <i class="bwi bwi-search" aria-hidden="true"></i>
   </div>

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -42,8 +42,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
   loaded = false;
   isLoading = false;
   showOrganizations = false;
-  search$ = new Subject<void>();
-  destroy$ = new Subject<void>();
+  protected search$ = new Subject<void>();
+  private destroy$ = new Subject<void>();
 
   private totpCode: string;
   private totpTimeout: number;

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
+import { Subject } from "rxjs";
+import { debounceTime, takeUntil } from "rxjs/operators";
 
 import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
@@ -40,6 +42,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
   loaded = false;
   isLoading = false;
   showOrganizations = false;
+  search$ = new Subject<void>();
+  destroy$ = new Subject<void>();
 
   private totpCode: string;
   private totpTimeout: number;
@@ -108,11 +112,18 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     window.setTimeout(() => {
       document.getElementById("search").focus();
     }, 100);
+
+    this.search$
+      .pipe(debounceTime(500), takeUntil(this.destroy$))
+      .subscribe(() => this.searchVault());
   }
 
   ngOnDestroy() {
     window.clearTimeout(this.loadedTimeout);
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   async refresh() {
@@ -179,15 +190,11 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
   }
 
   searchVault() {
-    if (this.searchTimeout != null) {
-      clearTimeout(this.searchTimeout);
-    }
     if (!this.searchService.isSearchable(this.searchText)) {
       return;
     }
-    this.searchTimeout = window.setTimeout(async () => {
-      this.router.navigate(["/tabs/vault"], { queryParams: { searchText: this.searchText } });
-    }, 200);
+
+    this.router.navigate(["/tabs/vault"], { queryParams: { searchText: this.searchText } });
   }
 
   closeOnEsc(e: KeyboardEvent) {

--- a/apps/browser/src/popup/vault/current-tab.component.ts
+++ b/apps/browser/src/popup/vault/current-tab.component.ts
@@ -109,10 +109,6 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
       }, 5000);
     }
 
-    window.setTimeout(() => {
-      document.getElementById("search").focus();
-    }, 100);
-
     this.search$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => this.searchVault());


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes #2371 

The goal is to reduce the likelihood of typed letters getting skipped when searching from the Current Tab page on the browser extension.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

Effectively, the only change should be increasing the debounce time of the search from 200ms to 500ms. 

The custom debounce implementation that used `window.setTimeout` has been replaced by an observables-based debounce implementation.

Also, the following autofocus implementation has been replaced with the `appAutofocus` directive. This is not related to the issue described in PS-1335; the intention was just to improve standardization. 
```
window.setTimeout(() => {
      document.getElementById("search").focus();
    }, 100);
```



This code changes in this PR do not completely eliminate the problem, but the frequency that it occurs should be greatly reduced. In order to resolve the issue completely, significant architectural refactoring would be required.

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
