### PR TITLE
[EC-450] Added show SCIM key toggle button

### DIFF
--- a/bitwarden_license/bit-web/src/app/organizations/manage/scim.component.html
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/scim.component.html
@@ -52,7 +52,17 @@
 
   <bit-form-field *ngIf="showScimSettings">
     <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
-    <input bitInput type="text" formControlName="clientSecret" />
+    <input bitInput type="{{ showScimKey ? 'text' : 'password' }}" formControlName="clientSecret" />
+    <ng-container>
+      <button type="button" bitSuffix bitButton (click)="toggleScimKey()">
+        <i
+          aria-hidden="true"
+          class="bwi bwi-lg bwi-eye"
+          [ngClass]="{ 'bwi-eye': !showScimKey, 'bwi-eye-slash': showScimKey }"
+          [appA11yTitle]="'toggleVisibility' | i18n"
+        ></i>
+      </button>
+    </ng-container>
     <ng-container #rotateButton [appApiAction]="rotatePromise">
       <button
         [disabled]="rotateButton.loading"

--- a/bitwarden_license/bit-web/src/app/organizations/manage/scim.component.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/scim.component.ts
@@ -29,6 +29,7 @@ export class ScimComponent implements OnInit {
   rotatePromise: Promise<ApiKeyResponse>;
   enabled = new FormControl(false);
   showScimSettings = false;
+  showScimKey = false;
 
   formData = this.formBuilder.group({
     endpointUrl: new FormControl({ value: "", disabled: true }),
@@ -145,6 +146,11 @@ export class ScimComponent implements OnInit {
 
   getScimEndpointUrl() {
     return this.environmentService.getScimUrl() + "/" + this.organizationId;
+  }
+
+  toggleScimKey() {
+    this.showScimKey = !this.showScimKey;
+    document.getElementById("clientSecret").focus();
   }
 
   private async setConnectionFormValues(connection: OrganizationConnectionResponse<ScimConfigApi>) {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Added a button to toggle show/hide the SCIM API key.

## Code changes

- **bitwarden_license/bit-web/src/app/organizations/manage/scim.component.html:** Added the button toggle
- **bitwarden_license/bit-web/src/app/organizations/manage/scim.component.ts:** Added the property `showScimKey` to handle the key visibility status and added the method `toggleScimKey` to toggle its value.

## Screenshots

<img width="748" alt="image" src="https://user-images.githubusercontent.com/108268980/193872963-d18980a9-32c2-4ad6-bc9f-a862d0bb203c.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
