### PR TITLE
[PS-1625] Auto-prompt french translation

### DIFF
--- a/apps/desktop/src/locales/fr/messages.json
+++ b/apps/desktop/src/locales/fr/messages.json
@@ -1385,10 +1385,10 @@
     "message": "déverouiller votre coffre"
   },
   "autoPromptWindowsHello": {
-    "message": "Ask for Windows Hello on launch"
+    "message": "Demander à Windows Hello au démarrage"
   },
   "autoPromptTouchId": {
-    "message": "Ask for Touch ID on launch"
+    "message": "Demander à Touch ID au démarrage"
   },
   "lockWithMasterPassOnRestart": {
     "message": "Verrouiller avec le mot de passe maître lors du redémarrage"


### PR DESCRIPTION
Add messages for french auto-prompts (Touch ID and Windows Hello).

## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Auto-prompt checkbox's label is not translated in french language.

## Code changes

Simple translation fix.

## Screenshots

<img width="505" alt="Capture d’écran 2022-10-06 à 15 31 51" src="https://user-images.githubusercontent.com/2973857/194326791-6f85ca98-ad11-46c6-9286-789832576b33.png">

