### PR TITLE
Inform that we track issues outside of Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/browser.yml
+++ b/.github/ISSUE_TEMPLATE/browser.yml
@@ -91,11 +91,11 @@ body:
       description: What version of our software are you running? (go to "Settings" → "About" in the extension)
     validations:
       required: true
-  - type: input
+  - type: checkboxes
     id: issue-tracking-info
     attributes:
       label: Issue Tracking Info
       description: |
-        Please don't change this value, it's intended to inform you and anyone who reads this issue.
-      value: |
-        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/browser.yml
+++ b/.github/ISSUE_TEMPLATE/browser.yml
@@ -91,3 +91,11 @@ body:
       description: What version of our software are you running? (go to "Settings" → "About" in the extension)
     validations:
       required: true
+  - type: input
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Please don't change this value, it's intended to inform you and anyone who reads this issue.
+      value: |
+        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.

--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -80,11 +80,11 @@ body:
       description: What version of our software are you running? (run `bw --version`)
     validations:
       required: true
-  - type: input
+  - type: checkboxes
     id: issue-tracking-info
     attributes:
       label: Issue Tracking Info
       description: |
-        Please don't change this value, it's intended to inform you and anyone who reads this issue.
-      value: |
-        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -80,3 +80,11 @@ body:
       description: What version of our software are you running? (run `bw --version`)
     validations:
       required: true
+  - type: input
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Please don't change this value, it's intended to inform you and anyone who reads this issue.
+      value: |
+        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.

--- a/.github/ISSUE_TEMPLATE/desktop.yml
+++ b/.github/ISSUE_TEMPLATE/desktop.yml
@@ -83,11 +83,11 @@ body:
       description: What version of our software are you running? (go to "Help" → "About Bitwarden" in the app)
     validations:
       required: true
-  - type: input
+  - type: checkboxes
     id: issue-tracking-info
     attributes:
       label: Issue Tracking Info
       description: |
-        Please don't change this value, it's intended to inform you and anyone who reads this issue.
-      value: |
-        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/desktop.yml
+++ b/.github/ISSUE_TEMPLATE/desktop.yml
@@ -83,3 +83,11 @@ body:
       description: What version of our software are you running? (go to "Help" → "About Bitwarden" in the app)
     validations:
       required: true
+  - type: input
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Please don't change this value, it's intended to inform you and anyone who reads this issue.
+      value: |
+        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.

--- a/.github/ISSUE_TEMPLATE/web.yml
+++ b/.github/ISSUE_TEMPLATE/web.yml
@@ -91,3 +91,11 @@ body:
       description: What version of our software are you running? (Bottom of the page)
     validations:
       required: true
+  - type: input
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Please don't change this value, it's intended to inform you and anyone who reads this issue.
+      value: |
+        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.

--- a/.github/ISSUE_TEMPLATE/web.yml
+++ b/.github/ISSUE_TEMPLATE/web.yml
@@ -91,11 +91,11 @@ body:
       description: What version of our software are you running? (Bottom of the page)
     validations:
       required: true
-  - type: input
+  - type: checkboxes
     id: issue-tracking-info
     attributes:
       label: Issue Tracking Info
       description: |
-        Please don't change this value, it's intended to inform you and anyone who reads this issue.
-      value: |
-        Note that we track work outside of Github, we'll link a PR to this issue should one be opened to address this, but we don't use fields like "assigned", "milestone", or "project" to track progress. We'll do our best to respond to and provide updates through comments.
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.


### PR DESCRIPTION
Updates our issues templates to inform that we track work outside of Github and to not expect Github tracking data.