### PR TITLE
[SG-720] Trim c null characters getting padded at end of messages

### DIFF
--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -232,15 +232,19 @@ export class NativeMessageHandlerService {
     ipcRenderer.send("nativeMessagingReply", response);
   }
 
+  // Trim all null bytes padded at the end of messages. This happens with C encryption libraries.
   private trimNullCharsFromMessage(message: string): string {
-    // Trim all null bytes padded at the end of messages. This happens with C encryption libraries.
+    const charNull = 0;
+    const charRightCurlyBrace = 125;
+    const charRightBracket = 93;
+
     for (let i = message.length - 1; i >= 0; i--) {
-      // char code 0 is null
-      if (message.charCodeAt(i) === 0) {
+      if (message.charCodeAt(i) === charNull) {
         message = message.substring(0, message.length - 1);
-      }
-      // char code 125 is } and 93 is ] which are valid json ending characters, stop checking
-      else if (message.charCodeAt(i) === 125 || message.charCodeAt(i) === 93) {
+      } else if (
+        message.charCodeAt(i) === charRightCurlyBrace ||
+        message.charCodeAt(i) === charRightBracket
+      ) {
         break;
       }
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Trim C null bytes added to messages added by C encryption libraries. 
There is not a way to do this using `trim()`, so achieved this by looking at the last index of `}` in the resulting string and remove anything after that before parsing it. 
`replace()` works as well, but that replaces values in the entire string so I decided on this approach.

## Code changes

- **apps/desktop/src/services/nativeMessageHandler.service.ts:** Trim any characters after the last occurrences of `}` or `]` from the decrypted result. Also add this into a try catch to send a `cannot-decrypt` message if there is an error. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
