### PR TITLE
[PS-1640] BEEEP: Add job to close translation PRs

### DIFF
--- a/.github/workflows/automatic-issue-responses.yml
+++ b/.github/workflows/automatic-issue-responses.yml
@@ -62,3 +62,14 @@ jobs:
             As we haven’t heard from you about this problem in some time, this issue will now be closed.
 
             If this happens again or continues to be an problem, please respond to this issue with any additional detail to assist with reproduction and root cause analysis.
+      # Translation PR / Crowdin
+      - if: github.event.label.name == 'translation-pr'
+        name: Translation-PR
+        uses: peter-evans/close-issue@849549ba7c3a595a064c4b2c56f206ee78f93515  # v2.0.0
+        with:
+          comment: |
+            We really appreciate you taking the time to improve our translations.
+            
+            However we use a translation tool called [Crowdin](https://crowdin.com/) to help manage our localization efforts across many different languages. Our translations can only be updated using Crowdin, so we'll have to close this PR, but would really appreciate if you'd consider joining our awesome translation community over at Crowdin.
+            
+            More information can be found in the [localization section](https://contributing.bitwarden.com/contributing/#localization-l10n) of our [Contribution Guidelines](https://contributing.bitwarden.com/contributing/)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

We regulary receive pull requests that update our translation files directly, instead of using Crowdin. This PR adds a job to close these PRs when the `translation-pr` label is added.

### Reply to the contributor
 

> We really appreciate you taking the time to improve our translations.
> 
>  However we use a translation tool called [Crowdin](https://crowdin.com/) to help manage our localization efforts across many 
> different languages. Our translations can only be updated using Crowdin, so we'll have to close this PR, but would really appreciate if you'd consider joining our awesome translation community over at Crowdin.
> 
> More information can be found in the [localization section](https://contributing.bitwarden.com/contributing/#localization-l10n) of our [Contribution Guidelines](https://contributing.bitwarden.com/contributing/)

## Code changes

- **.github/workflows/automatic-issue-responses.yml:** Added a new job that closes PR's labelled with `translation-pr`, 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team