### PR TITLE
Forbid substitute

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,7 +101,10 @@
         ]
       }
     ],
-    "no-restricted-imports": ["error", { "patterns": ["src/**/*"] }]
+    "no-restricted-imports": [
+      "error",
+      { "patterns": ["src/**/*"], "paths": ["@fluffy-spoon/substitute"] }
+    ]
   },
   "overrides": [
     {

--- a/apps/browser/src/services/localBackedSessionStorage.service.spec.ts
+++ b/apps/browser/src/services/localBackedSessionStorage.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { Utils } from "@bitwarden/common/misc/utils";

--- a/apps/browser/src/services/state.service.spec.ts
+++ b/apps/browser/src/services/state.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { LogService } from "@bitwarden/common/abstractions/log.service";

--- a/apps/desktop/src/app/vault/generator.component.spec.ts
+++ b/apps/desktop/src/app/vault/generator.component.spec.ts
@@ -1,6 +1,7 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
+// eslint-disable-next-line no-restricted-imports
 import { Substitute } from "@fluffy-spoon/substitute";
 import { mock, MockProxy } from "jest-mock-extended";
 

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -12,7 +12,8 @@
           "**/app/shared/*",
           "@bitwarden/web-vault/*",
           "src/**/*"
-        ]
+        ],
+        "paths": ["@fluffy-spoon/substitute"]
       }
     ]
   }

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.spec.ts
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.spec.ts
@@ -5,6 +5,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testin
 import { FormBuilder, UntypedFormBuilder } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+// eslint-disable-next-line no-restricted-imports
 import { Substitute } from "@fluffy-spoon/substitute";
 import { BehaviorSubject } from "rxjs";
 

--- a/libs/common/spec/importers/bitwardenJsonImporter.spec.ts
+++ b/libs/common/spec/importers/bitwardenJsonImporter.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";

--- a/libs/common/spec/importers/bitwardenPasswordProtectedImporter.spec.ts
+++ b/libs/common/spec/importers/bitwardenPasswordProtectedImporter.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";

--- a/libs/common/spec/misc/logInStrategies/apiLogIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/apiLogIn.strategy.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/misc/logInStrategies/passwordLogIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/passwordLogIn.strategy.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/misc/logInStrategies/ssoLogIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/ssoLogIn.strategy.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/models/domain/cipher.spec.ts
+++ b/libs/common/spec/models/domain/cipher.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg } from "@fluffy-spoon/substitute";
 import { Jsonify } from "type-fest";
 

--- a/libs/common/spec/models/domain/encString.spec.ts
+++ b/libs/common/spec/models/domain/encString.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg } from "@fluffy-spoon/substitute";
 import { mock, MockProxy } from "jest-mock-extended";
 

--- a/libs/common/spec/models/domain/login.spec.ts
+++ b/libs/common/spec/models/domain/login.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { UriMatchType } from "@bitwarden/common/enums/uriMatchType";

--- a/libs/common/spec/models/domain/send.spec.ts
+++ b/libs/common/spec/models/domain/send.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { AbstractEncryptService } from "@bitwarden/common/abstractions/abstractEncrypt.service";

--- a/libs/common/spec/models/domain/sendAccess.spec.ts
+++ b/libs/common/spec/models/domain/sendAccess.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { SendType } from "@bitwarden/common/enums/sendType";

--- a/libs/common/spec/services/cipher.service.spec.ts
+++ b/libs/common/spec/services/cipher.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/services/export.service.spec.ts
+++ b/libs/common/spec/services/export.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 import { BehaviorSubject } from "rxjs";
 

--- a/libs/common/spec/services/folder.service.spec.ts
+++ b/libs/common/spec/services/folder.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 import { BehaviorSubject, firstValueFrom } from "rxjs";
 

--- a/libs/common/spec/services/import.service.spec.ts
+++ b/libs/common/spec/services/import.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";

--- a/libs/common/spec/services/settings.service.spec.ts
+++ b/libs/common/spec/services/settings.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 import { BehaviorSubject, firstValueFrom } from "rxjs";
 

--- a/libs/common/spec/services/stateMigration.service.spec.ts
+++ b/libs/common/spec/services/stateMigration.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { AbstractStorageService } from "@bitwarden/common/abstractions/storage.service";

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute, Arg } from "@fluffy-spoon/substitute";
 
 import { EncString } from "@bitwarden/common/models/domain/encString";

--- a/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
+++ b/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Substitute } from "@fluffy-spoon/substitute";
 
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We've made the decision to replace substitute with jest mock extend. To assist in this this PR adds an eslit rule which forbids the imports of `@fluffy-spoon/substitute`. Existing imports are ignored.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
