### PR TITLE
fix variable typo: EEFLongWordList -> EFFLongWordList

### DIFF
--- a/libs/common/src/misc/wordlist.ts
+++ b/libs/common/src/misc/wordlist.ts
@@ -1,5 +1,5 @@
 // EFF's Long Wordlist from https://www.eff.org/dice
-export const EEFLongWordList = [
+export const EFFLongWordList = [
   "abacus",
   "abdomen",
   "abdominal",

--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -12,7 +12,7 @@ import { KdfType } from "../enums/kdfType";
 import { KeySuffixOptions } from "../enums/keySuffixOptions";
 import { sequentialize } from "../misc/sequentialize";
 import { Utils } from "../misc/utils";
-import { EEFLongWordList } from "../misc/wordlist";
+import { EFFLongWordList } from "../misc/wordlist";
 import { EncryptedOrganizationKeyData } from "../models/data/encryptedOrganizationKeyData";
 import { EncArrayBuffer } from "../models/domain/encArrayBuffer";
 import { EncString } from "../models/domain/encString";
@@ -734,7 +734,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   private async hashPhrase(hash: ArrayBuffer, minimumEntropy = 64) {
-    const entropyPerWord = Math.log(EEFLongWordList.length) / Math.log(2);
+    const entropyPerWord = Math.log(EFFLongWordList.length) / Math.log(2);
     let numWords = Math.ceil(minimumEntropy / entropyPerWord);
 
     const hashArr = Array.from(new Uint8Array(hash));
@@ -746,9 +746,9 @@ export class CryptoService implements CryptoServiceAbstraction {
     const phrase: string[] = [];
     let hashNumber = bigInt.fromArray(hashArr, 256);
     while (numWords--) {
-      const remainder = hashNumber.mod(EEFLongWordList.length);
-      hashNumber = hashNumber.divide(EEFLongWordList.length);
-      phrase.push(EEFLongWordList[remainder as any]);
+      const remainder = hashNumber.mod(EFFLongWordList.length);
+      hashNumber = hashNumber.divide(EFFLongWordList.length);
+      phrase.push(EFFLongWordList[remainder as any]);
     }
     return phrase;
   }

--- a/libs/common/src/services/passwordGeneration.service.ts
+++ b/libs/common/src/services/passwordGeneration.service.ts
@@ -6,7 +6,7 @@ import { PasswordGenerationService as PasswordGenerationServiceAbstraction } fro
 import { PolicyService } from "../abstractions/policy/policy.service.abstraction";
 import { StateService } from "../abstractions/state.service";
 import { PolicyType } from "../enums/policyType";
-import { EEFLongWordList } from "../misc/wordlist";
+import { EFFLongWordList } from "../misc/wordlist";
 import { EncString } from "../models/domain/encString";
 import { GeneratedPasswordHistory } from "../models/domain/generatedPasswordHistory";
 import { PasswordGeneratorPolicyOptions } from "../models/domain/passwordGeneratorPolicyOptions";
@@ -161,14 +161,14 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
       o.includeNumber = false;
     }
 
-    const listLength = EEFLongWordList.length - 1;
+    const listLength = EFFLongWordList.length - 1;
     const wordList = new Array(o.numWords);
     for (let i = 0; i < o.numWords; i++) {
       const wordIndex = await this.cryptoService.randomNumber(0, listLength);
       if (o.capitalize) {
-        wordList[i] = this.capitalize(EEFLongWordList[wordIndex]);
+        wordList[i] = this.capitalize(EFFLongWordList[wordIndex]);
       } else {
-        wordList[i] = EEFLongWordList[wordIndex];
+        wordList[i] = EFFLongWordList[wordIndex];
       }
     }
 

--- a/libs/common/src/services/usernameGeneration.service.ts
+++ b/libs/common/src/services/usernameGeneration.service.ts
@@ -9,7 +9,7 @@ import { FirefoxRelayForwarder } from "../emailForwarders/firefoxRelayForwarder"
 import { Forwarder } from "../emailForwarders/forwarder";
 import { ForwarderOptions } from "../emailForwarders/forwarderOptions";
 import { SimpleLoginForwarder } from "../emailForwarders/simpleLoginForwarder";
-import { EEFLongWordList } from "../misc/wordlist";
+import { EFFLongWordList } from "../misc/wordlist";
 
 const DefaultOptions = {
   type: "word",
@@ -50,8 +50,8 @@ export class UsernameGenerationService implements BaseUsernameGenerationService 
       o.wordIncludeNumber = true;
     }
 
-    const wordIndex = await this.cryptoService.randomNumber(0, EEFLongWordList.length - 1);
-    let word = EEFLongWordList[wordIndex];
+    const wordIndex = await this.cryptoService.randomNumber(0, EFFLongWordList.length - 1);
+    let word = EFFLongWordList[wordIndex];
     if (o.wordCapitalize) {
       word = word.charAt(0).toUpperCase() + word.slice(1);
     }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Fix variable typo: EEFLongWordList -> EFFLongWordList, as the organization is the "**E**lectronic **F**ronteir **F**oundation", or "EFF" for short.

## Code changes

- **file.ext:** Description of what was changed and why
- **libs/common/src/misc/wordlist.ts:** EEFLongWordList -> EFFLongWordList
- **libs/common/src/services/crypto.service.ts:** EEFLongWordList -> EFFLongWordList
- **libs/common/src/services/passwordGeneration.service.ts:** EEFLongWordList -> EFFLongWordList
- **libs/common/src/services/usernameGeneration.service.ts:** EEFLongWordList -> EFFLongWordList