### PR TITLE
Fix linting issue caused by #3259

### DIFF
--- a/libs/common/spec/services/policy.service.spec.ts
+++ b/libs/common/spec/services/policy.service.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 import { BehaviorSubject, firstValueFrom } from "rxjs";
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
With https://github.com/bitwarden/clients/pull/3734 we introduced a eslint rule to forbid the usage of `@fluffy-spoon/substitute`. With merging https://github.com/bitwarden/clients/pull/3259 this still had an instance where the linter complained. This PR adds an ignore for that import.

## Code changes

- **libs/common/spec/services/policy.service.spec.ts:** Ignore the eslint rule for importing `@fluffy-spoon/substitute`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
