### PR TITLE
[PS-1676] Resolve Send Filters being truncated

### DIFF
--- a/apps/web/src/app/send/send.component.html
+++ b/apps/web/src/app/send/send.component.html
@@ -23,7 +23,7 @@
             <ul class="filter-options">
               <li class="filter-option" [ngClass]="{ active: selectedAll }">
                 <span class="filter-buttons">
-                  <button bitButton class="filter-button" appStopClick (click)="selectAll()">
+                  <button class="filter-button" appStopClick (click)="selectAll()">
                     <i class="bwi bwi-fw bwi-filter"></i>{{ "allSends" | i18n }}
                   </button>
                 </span>
@@ -37,24 +37,14 @@
             <ul class="filter-options">
               <li class="filter-option" [ngClass]="{ active: selectedType === sendType.Text }">
                 <span class="filter-buttons">
-                  <button
-                    bitButton
-                    class="filter-button"
-                    appStopClick
-                    (click)="selectType(sendType.Text)"
-                  >
+                  <button class="filter-button" appStopClick (click)="selectType(sendType.Text)">
                     <i class="bwi bwi-fw bwi-file-text"></i>{{ "sendTypeText" | i18n }}
                   </button>
                 </span>
               </li>
               <li class="filter-option" [ngClass]="{ active: selectedType === sendType.File }">
                 <span class="filter-buttons">
-                  <button
-                    bitButton
-                    class="filter-button"
-                    appStopClick
-                    (click)="selectType(sendType.File)"
-                  >
+                  <button class="filter-button" appStopClick (click)="selectType(sendType.File)">
                     <i class="bwi bwi-fw bwi-file"></i>{{ "sendTypeFile" | i18n }}
                   </button>
                 </span>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The send filters got truncated due to their use of the `bitButton` component. Since the filters are not really buttons I've simply removed the component.

Resolves #3789 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

![image](https://user-images.githubusercontent.com/137855/195841793-ff745ab8-c8b9-4362-b182-1e7abfdcd401.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
