### PR TITLE
[PS-1674] Correct truncation of ciphers in browser

### DIFF
--- a/apps/browser/src/popup/components/cipher-row.component.html
+++ b/apps/browser/src/popup/components/cipher-row.component.html
@@ -15,23 +15,25 @@
     <app-vault-icon [cipher]="cipher"></app-vault-icon>
     <div class="row-main-content">
       <span class="text">
-        {{ cipher.name | ellipsis: 20 }}
-        <ng-container *ngIf="cipher.organizationId">
-          <i
-            class="bwi bwi-collection text-muted"
-            title="{{ 'shared' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "shared" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="cipher.hasAttachments">
-          <i
-            class="bwi bwi-paperclip text-muted"
-            title="{{ 'attachments' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "attachments" | i18n }}</span>
-        </ng-container>
+        <span class="truncate-box">
+          <span class="truncate">{{ cipher.name }}</span>
+          <ng-container *ngIf="cipher.organizationId">
+            <i
+              class="bwi bwi-collection text-muted"
+              title="{{ 'shared' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "shared" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="cipher.hasAttachments">
+            <i
+              class="bwi bwi-paperclip text-muted"
+              title="{{ 'attachments' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "attachments" | i18n }}</span>
+          </ng-container>
+        </span>
       </span>
       <span class="detail">{{ cipher.subTitle }}</span>
     </div>

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -695,6 +695,7 @@
 
 .truncate-box {
   display: flex;
+  align-items: center;
 }
 
 .truncate {

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -692,3 +692,15 @@
     }
   }
 }
+
+.truncate-box {
+  display: flex;
+}
+
+.truncate {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 5px;
+}

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -696,6 +696,7 @@
 .truncate-box {
   display: flex;
   align-items: center;
+  gap: 5px;
 }
 
 .truncate {
@@ -703,5 +704,4 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-right: 5px;
 }

--- a/apps/desktop/src/app/vault/ciphers.component.html
+++ b/apps/desktop/src/app/vault/ciphers.component.html
@@ -24,23 +24,25 @@
           <app-vault-icon [cipher]="c"></app-vault-icon>
           <div class="flex-cipher-list-item">
             <span class="text">
-              {{ c.name | ellipsis }}
-              <ng-container *ngIf="c.organizationId">
-                <i
-                  class="bwi bwi-collection text-muted"
-                  title="{{ 'shared' | i18n }}"
-                  aria-hidden="true"
-                ></i>
-                <span class="sr-only">{{ "shared" | i18n }}</span>
-              </ng-container>
-              <ng-container *ngIf="c.hasAttachments">
-                <i
-                  class="bwi bwi-paperclip text-muted"
-                  title="{{ 'attachments' | i18n }}"
-                  aria-hidden="true"
-                ></i>
-                <span class="sr-only">{{ "attachments" | i18n }}</span>
-              </ng-container>
+              <span class="truncate-box">
+                <span class="truncate">{{ c.name }}</span>
+                <ng-container *ngIf="c.organizationId">
+                  <i
+                    class="bwi bwi-collection text-muted"
+                    title="{{ 'shared' | i18n }}"
+                    aria-hidden="true"
+                  ></i>
+                  <span class="sr-only">{{ "shared" | i18n }}</span>
+                </ng-container>
+                <ng-container *ngIf="c.hasAttachments">
+                  <i
+                    class="bwi bwi-paperclip text-muted"
+                    title="{{ 'attachments' | i18n }}"
+                    aria-hidden="true"
+                  ></i>
+                  <span class="sr-only">{{ "attachments" | i18n }}</span>
+                </ng-container>
+              </span>
             </span>
             <span *ngIf="c.subTitle" class="detail">{{ c.subTitle }}</span>
           </div>

--- a/apps/desktop/src/scss/list.scss
+++ b/apps/desktop/src/scss/list.scss
@@ -152,3 +152,16 @@
   height: 100%;
   overflow-y: auto;
 }
+
+.truncate-box {
+  display: flex;
+  align-items: center;
+}
+
+.truncate {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 5px;
+}

--- a/apps/desktop/src/scss/list.scss
+++ b/apps/desktop/src/scss/list.scss
@@ -156,6 +156,7 @@
 .truncate-box {
   display: flex;
   align-items: center;
+  gap: 5px;
 }
 
 .truncate {
@@ -163,5 +164,4 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-right: 5px;
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Instead of using the `truncate` pipe we should truncate using CSS. This allows us to ensure the items take up the maximum amount of space instead of a fixed number of characters.

The CSS is slightly annoying but I didn't want to spend more time on this, it will all go away once we migrate to Tailwind either way.

Resolves #3788 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Browser:

![image](https://user-images.githubusercontent.com/137855/195852450-a831c380-4ec4-4a89-8f3d-1869223eabe6.png)

Desktop:

![image](https://user-images.githubusercontent.com/137855/195852477-ea6d095e-0a81-4347-8b52-faa094769d97.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
