### PR TITLE
Add eslint rule to forbid buttons without type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,109 +4,122 @@
     "browser": true,
     "webextensions": true
   },
-  "plugins": ["@typescript-eslint", "rxjs", "rxjs-angular", "import"],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "project": ["./tsconfig.eslint.json"],
-    "sourceType": "module"
-  },
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:import/recommended",
-    "plugin:import/typescript",
-    "prettier",
-    "plugin:rxjs/recommended"
-  ],
-  "settings": {
-    "import/parsers": {
-      "@typescript-eslint/parser": [".ts"]
-    },
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true
-      }
-    }
-  },
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "off", // TODO: This should be re-enabled
-    "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
-    "@typescript-eslint/explicit-member-accessibility": [
-      "error",
-      {
-        "accessibility": "no-public"
-      }
-    ],
-    "@typescript-eslint/no-this-alias": [
-      "error",
-      {
-        "allowedNames": ["self"]
-      }
-    ],
-    "no-console": "error",
-    "import/no-unresolved": "off", // TODO: Look into turning off once each package is an actual package.
-    "import/order": [
-      "error",
-      {
-        "alphabetize": {
-          "order": "asc"
+  "ignorePatterns": ["**/*.js"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "plugins": ["@typescript-eslint", "rxjs", "rxjs-angular", "import"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": ["./tsconfig.eslint.json"],
+        "sourceType": "module"
+      },
+      "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:import/recommended",
+        "plugin:import/typescript",
+        "prettier",
+        "plugin:rxjs/recommended"
+      ],
+      "settings": {
+        "import/parsers": {
+          "@typescript-eslint/parser": [".ts"]
         },
-        "newlines-between": "always",
-        "pathGroups": [
+        "import/resolver": {
+          "typescript": {
+            "alwaysTryTypes": true
+          }
+        }
+      },
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off", // TODO: This should be re-enabled
+        "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
+        "@typescript-eslint/explicit-member-accessibility": [
+          "error",
           {
-            "pattern": "@bitwarden/**",
-            "group": "external",
-            "position": "after"
-          },
-          {
-            "pattern": "src/**/*",
-            "group": "parent",
-            "position": "before"
+            "accessibility": "no-public"
           }
         ],
-        "pathGroupsExcludedImportTypes": ["builtin"]
-      }
-    ],
-    "rxjs-angular/prefer-takeuntil": "error",
-    "no-restricted-syntax": [
-      "error",
-      {
-        "message": "Calling `svgIcon` directly is not allowed",
-        "selector": "CallExpression[callee.name='svgIcon']"
-      },
-      {
-        "message": "Accessing FormGroup using `get` is not allowed, use `.value` instead",
-        "selector": "ChainExpression[expression.object.callee.property.name='get'][expression.property.name='value']"
-      }
-    ],
-    "curly": ["error", "all"],
-    "import/namespace": ["off"], // This doesn't resolve namespace imports correctly, but TS will throw for this anyway
-    "import/no-restricted-paths": [
-      "error",
-      {
-        "zones": [
-          // Do not allow angular/node/electron code to be imported into common
+        "@typescript-eslint/no-this-alias": [
+          "error",
           {
-            "target": "./libs/common/**/*",
-            "from": "./libs/angular/**/*"
-          },
-          {
-            "target": "./libs/common/**/*",
-            "from": "./libs/node/**/*"
-          },
-          {
-            "target": "./libs/common/**/*",
-            "from": "./libs/electron/**/*"
+            "allowedNames": ["self"]
           }
+        ],
+        "no-console": "error",
+        "import/no-unresolved": "off", // TODO: Look into turning off once each package is an actual package.
+        "import/order": [
+          "error",
+          {
+            "alphabetize": {
+              "order": "asc"
+            },
+            "newlines-between": "always",
+            "pathGroups": [
+              {
+                "pattern": "@bitwarden/**",
+                "group": "external",
+                "position": "after"
+              },
+              {
+                "pattern": "src/**/*",
+                "group": "parent",
+                "position": "before"
+              }
+            ],
+            "pathGroupsExcludedImportTypes": ["builtin"]
+          }
+        ],
+        "rxjs-angular/prefer-takeuntil": "error",
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "Calling `svgIcon` directly is not allowed",
+            "selector": "CallExpression[callee.name='svgIcon']"
+          },
+          {
+            "message": "Accessing FormGroup using `get` is not allowed, use `.value` instead",
+            "selector": "ChainExpression[expression.object.callee.property.name='get'][expression.property.name='value']"
+          }
+        ],
+        "curly": ["error", "all"],
+        "import/namespace": ["off"], // This doesn't resolve namespace imports correctly, but TS will throw for this anyway
+        "import/no-restricted-paths": [
+          "error",
+          {
+            "zones": [
+              // Do not allow angular/node/electron code to be imported into common
+              {
+                "target": "./libs/common/**/*",
+                "from": "./libs/angular/**/*"
+              },
+              {
+                "target": "./libs/common/**/*",
+                "from": "./libs/node/**/*"
+              },
+              {
+                "target": "./libs/common/**/*",
+                "from": "./libs/electron/**/*"
+              }
+            ]
+          }
+        ],
+        "no-restricted-imports": [
+          "error",
+          { "patterns": ["src/**/*"], "paths": ["@fluffy-spoon/substitute"] }
         ]
       }
-    ],
-    "no-restricted-imports": [
-      "error",
-      { "patterns": ["src/**/*"], "paths": ["@fluffy-spoon/substitute"] }
-    ]
-  },
-  "overrides": [
+    },
+    {
+      "files": ["*.html"],
+      "parser": "@angular-eslint/template-parser",
+      "plugins": ["@angular-eslint/template"],
+      "rules": {
+        "@angular-eslint/template/banana-in-box": "error",
+        "@angular-eslint/template/button-has-type": "error"
+      }
+    },
     {
       "files": ["libs/common/src/**/*.ts"],
       "rules": {

--- a/apps/browser/src/popup/vault/vault-select.component.html
+++ b/apps/browser/src/popup/vault/vault-select.component.html
@@ -3,6 +3,7 @@
     <ng-container *ngIf="selectedVault$ | async as vaultFilterDisplay">
       <button
         #toggleVaults
+        type="button"
         class="org-filter"
         (click)="openOverlay()"
         aria-haspopup="menu"
@@ -28,6 +29,7 @@
         aria-modal="true"
       >
         <button
+          type="button"
           appStopClick
           (click)="selectAllVaults()"
           [ngClass]="{ active: !myVaultOnly && !selectOrganizationId }"
@@ -35,11 +37,17 @@
           <i class="bwi bwi-fw bwi-filter" aria-hidden="true"></i>
           &nbsp;{{ "allVaults" | i18n }}
         </button>
-        <button *ngIf="!enforcePersonalOwnwership" appStopClick (click)="selectMyVault()">
+        <button
+          type="button"
+          *ngIf="!enforcePersonalOwnwership"
+          appStopClick
+          (click)="selectMyVault()"
+        >
           <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
           &nbsp;{{ "myVault" | i18n }}
         </button>
         <button
+          type="button"
           *ngFor="let organization of organizations"
           appStopClick
           (click)="selectOrganization(organization)"

--- a/apps/browser/src/popup/vault/view.component.html
+++ b/apps/browser/src/popup/vault/view.component.html
@@ -633,6 +633,7 @@
       <div *ngIf="cipher.hasPasswordHistory">
         <b class="font-weight-semibold">{{ "passwordHistory" | i18n }}:</b>
         <button
+          type="button"
           routerLink="/cipher-password-history"
           [queryParams]="{ cipherId: cipher.id }"
           appStopClick

--- a/apps/desktop/src/app/layout/account-switcher.component.html
+++ b/apps/desktop/src/app/layout/account-switcher.component.html
@@ -1,4 +1,5 @@
 <button
+  type="button"
   class="account-switcher"
   (click)="toggle()"
   cdkOverlayOrigin
@@ -51,6 +52,7 @@
   >
     <div class="accounts" *ngIf="numberOfAccounts > 0">
       <button
+        type="button"
         *ngFor="let a of accounts | keyvalue"
         class="account"
         (click)="switch(a.key)"

--- a/apps/desktop/src/app/send/send.component.html
+++ b/apps/desktop/src/app/send/send.component.html
@@ -7,6 +7,7 @@
           <li class="filter-option" [ngClass]="{ active: selectedAll }">
             <span class="filter-buttons">
               <button
+                type="button"
                 class="filter-button"
                 (click)="selectAll()"
                 [attr.aria-pressed]="selectedAll === true"
@@ -27,6 +28,7 @@
           <li class="filter-option" [ngClass]="{ active: selectedType === sendType.Text }">
             <span class="filter-buttons">
               <button
+                type="button"
                 class="filter-button"
                 (click)="selectType(sendType.Text)"
                 [attr.aria-pressed]="selectedType === sendType.Text"
@@ -40,6 +42,7 @@
           <li class="filter-option" [ngClass]="{ active: selectedType === sendType.File }">
             <span class="filter-buttons">
               <button
+                type="button"
                 class="filter-button"
                 (click)="selectType(sendType.File)"
                 [attr.aria-pressed]="selectedType === sendType.File"
@@ -59,6 +62,7 @@
     <div class="content">
       <div class="list full-height" *ngIf="filteredSends.length">
         <button
+          type="button"
           *ngFor="let s of filteredSends"
           appStopClick
           (click)="selectSend(s.id)"

--- a/apps/desktop/src/app/vault/ciphers.component.html
+++ b/apps/desktop/src/app/vault/ciphers.component.html
@@ -52,10 +52,13 @@
     <div class="no-items" *ngIf="!ciphers.length">
       <img class="no-items-image" aria-hidden="true" />
       <p>{{ "noItemsInList" | i18n }}</p>
-      <button (click)="addCipher()" class="btn block primary link">{{ "addItem" | i18n }}</button>
+      <button type="button" (click)="addCipher()" class="btn block primary link">
+        {{ "addItem" | i18n }}
+      </button>
     </div>
     <div class="footer">
       <button
+        type="button"
         (click)="addCipher()"
         (contextmenu)="addCipherOptions()"
         class="block primary"

--- a/apps/desktop/src/app/vault/vault-filter/filters/collection-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/collection-filter.component.html
@@ -2,6 +2,7 @@
   <div class="filter-heading">
     <h2>
       <button
+        type="button"
         class="no-btn"
         [attr.aria-expanded]="!isCollapsed(collectionsGrouping)"
         aria-controls="collection-filters"
@@ -28,6 +29,7 @@
       >
         <span class="filter-buttons">
           <button
+            type="button"
             *ngIf="c.children.length"
             class="toggle-button"
             [attr.aria-expanded]="!isCollapsed(c.node)"
@@ -45,6 +47,7 @@
             ></i>
           </button>
           <button
+            type="button"
             class="filter-button"
             (click)="applyFilter(c.node)"
             [attr.aria-pressed]="c.node.id === activeFilter.selectedCollectionId"

--- a/apps/desktop/src/app/vault/vault-filter/filters/folder-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/folder-filter.component.html
@@ -2,6 +2,7 @@
   <div class="filter-heading">
     <h2>
       <button
+        type="button"
         class="toggle-button"
         [attr.aria-expanded]="!isCollapsed(foldersGrouping)"
         aria-controls="folder-filters"
@@ -18,7 +19,12 @@
         &nbsp;{{ foldersGrouping.name | i18n }}
       </button>
     </h2>
-    <button class="add-button" (click)="addFolder()" appA11yTitle="{{ 'addFolder' | i18n }}">
+    <button
+      type="button"
+      class="add-button"
+      (click)="addFolder()"
+      appA11yTitle="{{ 'addFolder' | i18n }}"
+    >
       <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     </button>
   </div>
@@ -33,6 +39,7 @@
       >
         <span class="filter-buttons">
           <button
+            type="button"
             class="toggle-button"
             *ngIf="f.children.length"
             (click)="toggleCollapse(f.node)"
@@ -50,6 +57,7 @@
             ></i>
           </button>
           <button
+            type="button"
             class="filter-button"
             (click)="applyFilter(f.node)"
             [attr.aria-pressed]="
@@ -60,6 +68,7 @@
             &nbsp;{{ f.node.name }}
           </button>
           <button
+            type="button"
             class="edit-button"
             *ngIf="f.node.id"
             (click)="editFolder(f.node)"

--- a/apps/desktop/src/app/vault/vault-filter/filters/organization-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/organization-filter.component.html
@@ -3,6 +3,7 @@
     <ng-container *ngSwitchCase="'personalOwnershipPolicy'">
       <div class="filter-heading" [ngClass]="{ active: !hasActiveFilter }">
         <button
+          type="button"
           class="toggle-button"
           appA11yTitle="{{ 'toggleCollapse' | i18n }} {{ organizationGrouping.name | i18n }}"
           (click)="toggleCollapse()"
@@ -21,6 +22,7 @@
         &nbsp;
         <h2>
           <button
+            type="button"
             class="filter-button"
             (click)="clearFilter()"
             [attr.aria-pressed]="!hasActiveFilter"
@@ -38,6 +40,7 @@
         >
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               (click)="applyOrganizationFilter(organization)"
               [attr.aria-pressed]="activeFilter.myVaultOnly"
@@ -53,6 +56,7 @@
     <ng-container *ngSwitchDefault>
       <div class="filter-heading" [ngClass]="{ active: !hasActiveFilter }">
         <button
+          type="button"
           appA11yTitle="{{ 'toggleCollapse' | i18n }} {{ organizationGrouping.name | i18n }}"
           (click)="toggleCollapse()"
           [attr.aria-expanded]="!isCollapsed"
@@ -70,6 +74,7 @@
         &nbsp;
         <h2>
           <button
+            type="button"
             class="filter-button"
             (click)="clearFilter()"
             [attr.aria-pressed]="!hasActiveFilter"
@@ -83,6 +88,7 @@
         <li class="filter-option" [ngClass]="{ active: activeFilter.myVaultOnly }">
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               (click)="applyMyVaultFilter()"
               [attr.aria-pressed]="activeFilter.myVaultOnly"
@@ -100,6 +106,7 @@
         >
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               (click)="applyOrganizationFilter(organization)"
               appA11yTitle="{{ 'vault' | i18n }}: {{ organization.name }}"

--- a/apps/desktop/src/app/vault/vault-filter/filters/status-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/status-filter.component.html
@@ -4,6 +4,7 @@
     <li class="filter-option" [ngClass]="{ active: activeFilter.status === 'all' }">
       <span class="filter-buttons">
         <button
+          type="button"
           class="filter-button"
           (click)="applyFilter('all')"
           [attr.aria-pressed]="activeFilter.status === 'all'"
@@ -19,6 +20,7 @@
     >
       <span class="filter-buttons">
         <button
+          type="button"
           class="filter-button"
           (click)="applyFilter('favorites')"
           [attr.aria-pressed]="activeFilter.status === 'favorites'"
@@ -34,6 +36,7 @@
     >
       <span class="filter-buttons">
         <button
+          type="button"
           class="filter-button"
           (click)="applyFilter('trash')"
           [attr.aria-pressed]="activeFilter.status === 'trash'"

--- a/apps/desktop/src/app/vault/vault-filter/filters/type-filter.component.html
+++ b/apps/desktop/src/app/vault/vault-filter/filters/type-filter.component.html
@@ -1,6 +1,7 @@
 <div class="filter-heading">
   <h2>
     <button
+      type="button"
       class="no-btn"
       (click)="toggleCollapse()"
       [attr.aria-expanded]="!isCollapsed"
@@ -25,6 +26,7 @@
   >
     <span class="filter-buttons">
       <button
+        type="button"
         class="filter-button"
         (click)="applyFilter(cipherTypeEnum.Login)"
         [attr.aria-pressed]="activeFilter.cipherType === cipherTypeEnum.Login"
@@ -36,6 +38,7 @@
   <li class="filter-option" [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.Card }">
     <span class="filter-buttons">
       <button
+        type="button"
         class="filter-button"
         (click)="applyFilter(cipherTypeEnum.Card)"
         [attr.aria-pressed]="activeFilter.cipherType === cipherTypeEnum.Card"
@@ -50,6 +53,7 @@
   >
     <span class="filter-buttons">
       <button
+        type="button"
         class="filter-button"
         (click)="applyFilter(cipherTypeEnum.Identity)"
         [attr.aria-pressed]="activeFilter.cipherType === cipherTypeEnum.Identity"
@@ -64,6 +68,7 @@
   >
     <span class="filter-buttons">
       <button
+        type="button"
         class="filter-button"
         (click)="applyFilter(cipherTypeEnum.SecureNote)"
         [attr.aria-pressed]="activeFilter.cipherType === cipherTypeEnum.SecureNote"

--- a/apps/desktop/src/app/vault/view.component.html
+++ b/apps/desktop/src/app/vault/view.component.html
@@ -500,6 +500,7 @@
 </div>
 <div class="footer" *ngIf="cipher">
   <button
+    type="button"
     class="primary"
     (click)="edit()"
     appA11yTitle="{{ 'edit' | i18n }}"
@@ -508,6 +509,7 @@
     <i class="bwi bwi-pencil bwi-fw bwi-lg" aria-hidden="true"></i>
   </button>
   <button
+    type="button"
     class="primary"
     (click)="restore()"
     appA11yTitle="{{ 'restore' | i18n }}"
@@ -516,6 +518,7 @@
     <i class="bwi bwi-undo bwi-fw bwi-lg" aria-hidden="true"></i>
   </button>
   <button
+    type="button"
     class="primary"
     *ngIf="!cipher?.organizationId && !cipher.isDeleted"
     (click)="clone()"

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
@@ -60,6 +60,7 @@
             <app-vertical-step label="Organization Information" [subLabel]="orgInfoSubLabel">
               <app-org-info [nameOnly]="true" [formGroup]="orgInfoFormGroup"></app-org-info>
               <button
+                type="button"
                 bitButton
                 buttonType="primary"
                 [disabled]="orgInfoFormGroup.get('name').hasError('required')"
@@ -84,10 +85,11 @@
                 [orgLabel]="orgLabel"
               ></app-trial-confirmation-details>
               <div class="tw-mb-3 tw-flex">
-                <button bitButton buttonType="primary" (click)="navigateToOrgVault()">
+                <button type="button" bitButton buttonType="primary" (click)="navigateToOrgVault()">
                   Get Started
                 </button>
                 <button
+                  type="button"
                   bitButton
                   buttonType="secondary"
                   (click)="navigateToOrgInvite()"

--- a/apps/web/src/app/accounts/trial-initiation/vertical-stepper/vertical-step-content.component.html
+++ b/apps/web/src/app/accounts/trial-initiation/vertical-stepper/vertical-step-content.component.html
@@ -1,5 +1,6 @@
 <div class="tw-m-2.5 tw-h-16 tw-text-center">
   <button
+    type="button"
     (click)="selectStep()"
     [disabled]="disabled"
     class="tw-flex tw-w-full tw-items-center tw-border-none tw-bg-transparent"

--- a/apps/web/src/app/components/user-verification-prompt.component.html
+++ b/apps/web/src/app/components/user-verification-prompt.component.html
@@ -17,7 +17,7 @@
         <button bitButton buttonType="primary" type="submit" appBlurClick>
           <span>{{ confirmButtonText | i18n }}</span>
         </button>
-        <button bitButton buttonType="secondary" data-dismiss="modal">
+        <button type="button" bitButton buttonType="secondary" data-dismiss="modal">
           {{ "cancel" | i18n }}
         </button>
       </div>

--- a/apps/web/src/app/layouts/navbar.component.html
+++ b/apps/web/src/app/layouts/navbar.component.html
@@ -41,6 +41,7 @@
     <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
       <li>
         <button
+          type="button"
           [bitMenuTriggerFor]="accountMenu"
           class="tw-border-0 tw-bg-transparent tw-text-alt2 tw-opacity-70 hover:tw-opacity-90"
         >

--- a/apps/web/src/app/organizations/manage/people.component.html
+++ b/apps/web/src/app/organizations/manage/people.component.html
@@ -62,11 +62,12 @@
         <i class="bwi bwi-cog" aria-hidden="true"></i>
       </button>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="bulkActionsButton">
-        <button class="dropdown-item" appStopClick (click)="bulkReinvite()">
+        <button type="button" class="dropdown-item" appStopClick (click)="bulkReinvite()">
           <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
           {{ "reinviteSelected" | i18n }}
         </button>
         <button
+          type="button"
           class="dropdown-item text-success"
           appStopClick
           (click)="bulkConfirm()"
@@ -75,24 +76,24 @@
           <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
           {{ "confirmSelected" | i18n }}
         </button>
-        <button class="dropdown-item" appStopClick (click)="bulkRestore()">
+        <button type="button" class="dropdown-item" appStopClick (click)="bulkRestore()">
           <i class="bwi bwi-fw bwi-plus-circle" aria-hidden="true"></i>
           {{ "restoreAccess" | i18n }}
         </button>
-        <button class="dropdown-item" appStopClick (click)="bulkRevoke()">
+        <button type="button" class="dropdown-item" appStopClick (click)="bulkRevoke()">
           <i class="bwi bwi-fw bwi-minus-circle" aria-hidden="true"></i>
           {{ "revokeAccess" | i18n }}
         </button>
-        <button class="dropdown-item text-danger" appStopClick (click)="bulkRemove()">
+        <button type="button" class="dropdown-item text-danger" appStopClick (click)="bulkRemove()">
           <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
           {{ "remove" | i18n }}
         </button>
         <div class="dropdown-divider"></div>
-        <button class="dropdown-item" appStopClick (click)="selectAll(true)">
+        <button type="button" class="dropdown-item" appStopClick (click)="selectAll(true)">
           <i class="bwi bwi-fw bwi-check-square" aria-hidden="true"></i>
           {{ "selectAll" | i18n }}
         </button>
-        <button class="dropdown-item" appStopClick (click)="selectAll(false)">
+        <button type="button" class="dropdown-item" appStopClick (click)="selectAll(false)">
           <i class="bwi bwi-fw bwi-minus-square" aria-hidden="true"></i>
           {{ "unselectAll" | i18n }}
         </button>

--- a/apps/web/src/app/organizations/settings/organization-billing.component.html
+++ b/apps/web/src/app/organizations/settings/organization-billing.component.html
@@ -3,6 +3,7 @@
     {{ "billing" | i18n }}
   </h1>
   <button
+    type="button"
     (click)="load()"
     class="btn btn-sm btn-outline-primary ml-auto"
     *ngIf="firstLoaded"

--- a/apps/web/src/app/send/send.component.html
+++ b/apps/web/src/app/send/send.component.html
@@ -23,7 +23,7 @@
             <ul class="filter-options">
               <li class="filter-option" [ngClass]="{ active: selectedAll }">
                 <span class="filter-buttons">
-                  <button class="filter-button" appStopClick (click)="selectAll()">
+                  <button type="button" class="filter-button" appStopClick (click)="selectAll()">
                     <i class="bwi bwi-fw bwi-filter"></i>{{ "allSends" | i18n }}
                   </button>
                 </span>
@@ -37,14 +37,24 @@
             <ul class="filter-options">
               <li class="filter-option" [ngClass]="{ active: selectedType === sendType.Text }">
                 <span class="filter-buttons">
-                  <button class="filter-button" appStopClick (click)="selectType(sendType.Text)">
+                  <button
+                    type="button"
+                    class="filter-button"
+                    appStopClick
+                    (click)="selectType(sendType.Text)"
+                  >
                     <i class="bwi bwi-fw bwi-file-text"></i>{{ "sendTypeText" | i18n }}
                   </button>
                 </span>
               </li>
               <li class="filter-option" [ngClass]="{ active: selectedType === sendType.File }">
                 <span class="filter-buttons">
-                  <button class="filter-button" appStopClick (click)="selectType(sendType.File)">
+                  <button
+                    type="button"
+                    class="filter-button"
+                    appStopClick
+                    (click)="selectType(sendType.File)"
+                  >
                     <i class="bwi bwi-fw bwi-file"></i>{{ "sendTypeFile" | i18n }}
                   </button>
                 </span>
@@ -150,15 +160,20 @@
                 <i class="bwi bwi-ellipsis-v bwi-lg" aria-hidden="true"></i>
               </button>
               <bit-menu #sendOptions>
-                <button bitMenuItem (click)="copy(s)">
+                <button type="button" bitMenuItem (click)="copy(s)">
                   <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
                   {{ "copySendLink" | i18n }}
                 </button>
-                <button bitMenuItem (click)="removePassword(s)" *ngIf="s.password && !disableSend">
+                <button
+                  type="button"
+                  bitMenuItem
+                  (click)="removePassword(s)"
+                  *ngIf="s.password && !disableSend"
+                >
                   <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
                   {{ "removePassword" | i18n }}
                 </button>
-                <button bitMenuItem (click)="delete(s)">
+                <button type="button" bitMenuItem (click)="delete(s)">
                   <span class="tw-text-danger">
                     <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
                     {{ "delete" | i18n }}
@@ -181,7 +196,12 @@
         <ng-container *ngIf="loaded">
           <img class="no-items-image" aria-hidden="true" />
           <p>{{ "noSendsInList" | i18n }}</p>
-          <button (click)="addSend()" class="btn btn-outline-primary" [disabled]="disableSend">
+          <button
+            type="button"
+            (click)="addSend()"
+            class="btn btn-outline-primary"
+            [disabled]="disableSend"
+          >
             <i class="bwi bwi-plus bwi-fw"></i>{{ "createSend" | i18n }}
           </button>
         </ng-container>

--- a/apps/web/src/app/settings/account.component.html
+++ b/apps/web/src/app/settings/account.component.html
@@ -14,13 +14,13 @@
 <div class="card border-danger">
   <div class="card-body">
     <p>{{ "dangerZoneDesc" | i18n }}</p>
-    <button bitButton buttonType="danger" (click)="deauthorizeSessions()">
+    <button type="button" bitButton buttonType="danger" (click)="deauthorizeSessions()">
       {{ "deauthorizeSessions" | i18n }}
     </button>
-    <button bitButton buttonType="danger" (click)="purgeVault()">
+    <button type="button" bitButton buttonType="danger" (click)="purgeVault()">
       {{ "purgeVault" | i18n }}
     </button>
-    <button bitButton buttonType="danger" (click)="deleteAccount()">
+    <button type="button" bitButton buttonType="danger" (click)="deleteAccount()">
       {{ "deleteAccount" | i18n }}
     </button>
   </div>

--- a/apps/web/src/app/settings/emergency-access.component.html
+++ b/apps/web/src/app/settings/emergency-access.component.html
@@ -85,6 +85,7 @@
         </button>
         <bit-menu #trustedContactOptions>
           <button
+            type="button"
             bitMenuItem
             *ngIf="c.status === emergencyAccessStatusType.Invited"
             (click)="reinvite(c)"
@@ -93,6 +94,7 @@
             {{ "resendInvitation" | i18n }}
           </button>
           <button
+            type="button"
             bitMenuItem
             *ngIf="c.status === emergencyAccessStatusType.Accepted"
             (click)="confirm(c)"
@@ -101,6 +103,7 @@
             {{ "confirm" | i18n }}
           </button>
           <button
+            type="button"
             bitMenuItem
             *ngIf="c.status === emergencyAccessStatusType.RecoveryInitiated"
             (click)="approve(c)"
@@ -109,6 +112,7 @@
             {{ "approve" | i18n }}
           </button>
           <button
+            type="button"
             bitMenuItem
             *ngIf="
               c.status === emergencyAccessStatusType.RecoveryInitiated ||
@@ -119,7 +123,7 @@
             <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
             {{ "reject" | i18n }}
           </button>
-          <button bitMenuItem (click)="remove(c)">
+          <button type="button" bitMenuItem (click)="remove(c)">
             <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
             {{ "remove" | i18n }}
           </button>
@@ -200,6 +204,7 @@
         </button>
         <bit-menu #grantedContactOptions>
           <button
+            type="button"
             bitMenuItem
             *ngIf="c.status === emergencyAccessStatusType.Confirmed"
             (click)="requestAccess(c)"
@@ -208,6 +213,7 @@
             {{ "requestAccess" | i18n }}
           </button>
           <button
+            type="button"
             bitMenuItem
             *ngIf="
               c.status === emergencyAccessStatusType.RecoveryApproved &&
@@ -219,6 +225,7 @@
             {{ "takeover" | i18n }}
           </button>
           <button
+            type="button"
             bitMenuItem
             *ngIf="
               c.status === emergencyAccessStatusType.RecoveryApproved &&
@@ -229,7 +236,7 @@
             <i class="bwi bwi-fw bwi-eye" aria-hidden="true"></i>
             {{ "view" | i18n }}
           </button>
-          <button bitMenuItem (click)="remove(c)">
+          <button type="button" bitMenuItem (click)="remove(c)">
             <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
             {{ "remove" | i18n }}
           </button>

--- a/apps/web/src/app/settings/payment-method.component.html
+++ b/apps/web/src/app/settings/payment-method.component.html
@@ -3,6 +3,7 @@
     {{ "paymentMethod" | i18n }}
   </h1>
   <button
+    type="button"
     bitButton
     buttonType="secondary"
     (click)="load()"
@@ -28,7 +29,13 @@
     <strong>{{ creditOrBalance | currency: "$" }}</strong>
   </p>
   <p>{{ "creditAppliedDesc" | i18n }}</p>
-  <button bitButton buttonType="secondary" (click)="addCredit()" *ngIf="!showAddCredit">
+  <button
+    type="button"
+    bitButton
+    buttonType="secondary"
+    (click)="addCredit()"
+    *ngIf="!showAddCredit"
+  >
     {{ "addCredit" | i18n }}
   </button>
   <app-add-credit
@@ -56,7 +63,13 @@
       {{ paymentSource.description }}
     </p>
   </ng-container>
-  <button bitButton buttonType="secondary" (click)="changePayment()" *ngIf="!showAdjustPayment">
+  <button
+    type="button"
+    bitButton
+    buttonType="secondary"
+    (click)="changePayment()"
+    *ngIf="!showAdjustPayment"
+  >
     {{ (paymentSource ? "changePaymentMethod" : "addPaymentMethod") | i18n }}
   </button>
   <app-adjust-payment

--- a/apps/web/src/app/settings/security-keys.component.html
+++ b/apps/web/src/app/settings/security-keys.component.html
@@ -8,10 +8,10 @@
 <p>
   {{ "userApiKeyDesc" | i18n }}
 </p>
-<button bitButton buttonType="secondary" (click)="viewUserApiKey()">
+<button type="button" bitButton buttonType="secondary" (click)="viewUserApiKey()">
   {{ "viewApiKey" | i18n }}
 </button>
-<button bitButton buttonType="secondary" (click)="rotateUserApiKey()">
+<button type="button" bitButton buttonType="secondary" (click)="rotateUserApiKey()">
   {{ "rotateApiKey" | i18n }}
 </button>
 <ng-template #viewUserApiKeyTemplate></ng-template>

--- a/apps/web/src/app/settings/sponsoring-org-row.component.html
+++ b/apps/web/src/app/settings/sponsoring-org-row.component.html
@@ -22,6 +22,7 @@
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
       <button
         #resendEmailBtn
+        type="button"
         *ngIf="!isSelfHosted && !sponsoringOrg.familySponsorshipValidUntil"
         [appApiAction]="resendEmailPromise"
         class="dropdown-item btn-submit"
@@ -34,6 +35,7 @@
       </button>
       <button
         #revokeSponsorshipBtn
+        type="button"
         [appApiAction]="revokeSponsorshipPromise"
         class="dropdown-item text-danger btn-submit"
         [disabled]="revokeSponsorshipBtn.loading"

--- a/apps/web/src/app/settings/two-factor-setup.component.html
+++ b/apps/web/src/app/settings/two-factor-setup.component.html
@@ -5,7 +5,7 @@
 <p *ngIf="organizationId">{{ "twoStepLoginOrganizationDesc" | i18n }}</p>
 <bit-callout type="warning" *ngIf="!organizationId">
   <p>{{ "twoStepLoginRecoveryWarning" | i18n }}</p>
-  <button bitButton buttonType="secondary" (click)="recoveryCode()">
+  <button type="button" bitButton buttonType="secondary" (click)="recoveryCode()">
     {{ "viewRecoveryCode" | i18n }}
   </button>
 </bit-callout>
@@ -45,6 +45,7 @@
     </div>
     <div class="ml-auto">
       <button
+        type="button"
         bitButton
         buttonType="secondary"
         [disabled]="!canAccessPremium && p.premium"

--- a/apps/web/src/app/settings/user-billing-history.component.html
+++ b/apps/web/src/app/settings/user-billing-history.component.html
@@ -3,6 +3,7 @@
     {{ "billingHistory" | i18n }}
   </h1>
   <button
+    type="button"
     bitButton
     buttonType="secondary"
     (click)="load()"

--- a/apps/web/src/app/tools/password-generator-history.component.html
+++ b/apps/web/src/app/tools/password-generator-history.component.html
@@ -25,6 +25,7 @@
             </div>
             <div class="ml-auto">
               <button
+                type="button"
                 class="btn btn-link"
                 appA11yTitle="{{ 'copyPassword' | i18n }}"
                 (click)="copy(h.password)"

--- a/apps/web/src/app/vault/bulk-actions.component.html
+++ b/apps/web/src/app/vault/bulk-actions.component.html
@@ -12,6 +12,7 @@
   </button>
   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="bulkActionsButton">
     <button
+      type="button"
       class="dropdown-item"
       appStopClick
       (click)="bulkMove()"
@@ -21,6 +22,7 @@
       {{ "moveSelected" | i18n }}
     </button>
     <button
+      type="button"
       class="dropdown-item"
       appStopClick
       (click)="bulkShare()"
@@ -29,20 +31,25 @@
       <i class="bwi bwi-fw bwi-arrow-circle-right" aria-hidden="true"></i>
       {{ "moveSelectedToOrg" | i18n }}
     </button>
-    <button class="dropdown-item" (click)="bulkRestore()" *ngIf="deleted && !organization">
+    <button
+      type="button"
+      class="dropdown-item"
+      (click)="bulkRestore()"
+      *ngIf="deleted && !organization"
+    >
       <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
       {{ "restoreSelected" | i18n }}
     </button>
-    <button class="dropdown-item text-danger" (click)="bulkDelete()">
+    <button type="button" class="dropdown-item text-danger" (click)="bulkDelete()">
       <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
       {{ (deleted ? "permanentlyDeleteSelected" : "deleteSelected") | i18n }}
     </button>
     <div class="dropdown-divider"></div>
-    <button class="dropdown-item" appStopClick (click)="selectAll(true)">
+    <button type="button" class="dropdown-item" appStopClick (click)="selectAll(true)">
       <i class="bwi bwi-fw bwi-check-square" aria-hidden="true"></i>
       {{ "selectAll" | i18n }}
     </button>
-    <button class="dropdown-item" appStopClick (click)="selectAll(false)">
+    <button type="button" class="dropdown-item" appStopClick (click)="selectAll(false)">
       <i class="bwi bwi-fw bwi-minus-square" aria-hidden="true"></i>
       {{ "unselectAll" | i18n }}
     </button>

--- a/apps/web/src/app/vault/ciphers.component.html
+++ b/apps/web/src/app/vault/ciphers.component.html
@@ -55,6 +55,7 @@
         </td>
         <td class="table-list-options">
           <button
+            type="button"
             [bitMenuTriggerFor]="cipherOptions"
             class="tw-border-none tw-bg-transparent tw-text-main"
             type="button"
@@ -64,11 +65,16 @@
           </button>
           <bit-menu #cipherOptions>
             <ng-container *ngIf="c.type === cipherType.Login && !c.isDeleted">
-              <button bitMenuItem (click)="copy(c, c.login.username, 'username', 'Username')">
+              <button
+                type="button"
+                bitMenuItem
+                (click)="copy(c, c.login.username, 'username', 'Username')"
+              >
                 <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
                 {{ "copyUsername" | i18n }}
               </button>
               <button
+                type="button"
                 bitMenuItem
                 (click)="copy(c, c.login.password, 'password', 'Password')"
                 *ngIf="c.viewPassword"
@@ -77,6 +83,7 @@
                 {{ "copyPassword" | i18n }}
               </button>
               <button
+                type="button"
                 bitMenuItem
                 (click)="copy(c, c.login.totp, 'verificationCodeTotp', 'TOTP')"
                 *ngIf="displayTotpCopyButton(c)"
@@ -84,16 +91,23 @@
                 <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
                 {{ "copyVerificationCode" | i18n }}
               </button>
-              <button bitMenuItem *ngIf="c.login.canLaunch" (click)="launch(c.login.launchUri)">
+              <button
+                type="button"
+                bitMenuItem
+                *ngIf="c.login.canLaunch"
+                (click)="launch(c.login.launchUri)"
+              >
                 <i class="bwi bwi-fw bwi-share-square" aria-hidden="true"></i>
                 {{ "launch" | i18n }}
               </button>
             </ng-container>
-            <button bitMenuItem (click)="attachments(c)">
+            <button type="button" bitMenuItem (click)="attachments(c)">
               <i class="bwi bwi-fw bwi-paperclip" aria-hidden="true"></i>
               {{ "attachments" | i18n }}
             </button>
             <button
+              type="button"
+              type="button"
               bitMenuItem
               *ngIf="((!organization && !c.organizationId) || organization) && !c.isDeleted"
               (click)="clone(c)"
@@ -102,6 +116,7 @@
               {{ "clone" | i18n }}
             </button>
             <button
+              type="button"
               bitMenuItem
               *ngIf="!organization && !c.organizationId && !c.isDeleted"
               (click)="share(c)"
@@ -109,19 +124,29 @@
               <i class="bwi bwi-fw bwi-arrow-circle-right" aria-hidden="true"></i>
               {{ "moveToOrganization" | i18n }}
             </button>
-            <button bitMenuItem *ngIf="c.organizationId && !c.isDeleted" (click)="collections(c)">
+            <button
+              type="button"
+              bitMenuItem
+              *ngIf="c.organizationId && !c.isDeleted"
+              (click)="collections(c)"
+            >
               <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
               {{ "collections" | i18n }}
             </button>
-            <button bitMenuItem *ngIf="c.organizationId && accessEvents" (click)="events(c)">
+            <button
+              type="button"
+              bitMenuItem
+              *ngIf="c.organizationId && accessEvents"
+              (click)="events(c)"
+            >
               <i class="bwi bwi-fw bwi-file-text" aria-hidden="true"></i>
               {{ "eventLogs" | i18n }}
             </button>
-            <button bitMenuItem (click)="restore(c)" *ngIf="c.isDeleted">
+            <button type="button" bitMenuItem (click)="restore(c)" *ngIf="c.isDeleted">
               <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
               {{ "restore" | i18n }}
             </button>
-            <button bitMenuItem (click)="delete(c)">
+            <button type="button" bitMenuItem (click)="delete(c)">
               <span class="tw-text-danger">
                 <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
                 {{ (c.isDeleted ? "permanentlyDelete" : "delete") | i18n }}
@@ -144,7 +169,12 @@
     <ng-container *ngIf="loaded">
       <img class="no-items-image" aria-hidden="true" />
       <p>{{ "noItemsInList" | i18n }}</p>
-      <button (click)="addCipher()" class="btn btn-outline-primary" *ngIf="showAddNew">
+      <button
+        type="button"
+        (click)="addCipher()"
+        class="btn btn-outline-primary"
+        *ngIf="showAddNew"
+      >
         <i class="bwi bwi-plus bwi-fw"></i>{{ "addItem" | i18n }}
       </button>
     </ng-container>

--- a/apps/web/src/app/vault/organization-badge/organization-name-badge.component.html
+++ b/apps/web/src/app/vault/organization-badge/organization-name-badge.component.html
@@ -1,5 +1,6 @@
 <button
   bitBadge
+  type="button"
   [style.color]="textColor"
   [style.background-color]="color"
   appA11yTitle="{{ organizationName }}"

--- a/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
@@ -5,6 +5,7 @@
         <li class="filter-option active">
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               [attr.aria-pressed]="activeFilter.myVaultOnly"
               appA11yTitle="{{ 'vault' | i18n }}: {{ 'myVault' | i18n }}"
@@ -27,6 +28,7 @@
     <ng-container *ngSwitchCase="'personalOwnershipPolicy'">
       <div class="filter-heading">
         <button
+          type="button"
           (click)="toggleCollapse()"
           title="{{ 'toggleCollapse' | i18n }}"
           class="toggle-button"
@@ -43,6 +45,7 @@
           ></i>
         </button>
         <button
+          type="button"
           class="filter-button"
           (click)="clearFilter()"
           [ngClass]="{ active: !hasActiveFilter }"
@@ -59,6 +62,7 @@
         >
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               (click)="applyOrganizationFilter(organization)"
               [attr.aria-pressed]="activeFilter.selectedOrganizationId === organization.id"
@@ -68,7 +72,7 @@
               {{ organization.name }}
             </button>
             <ng-container *ngIf="organization.id === activeFilter.selectedOrganizationId">
-              <button [bitMenuTriggerFor]="orgMenu" class="org-options ml-auto">
+              <button type="button" [bitMenuTriggerFor]="orgMenu" class="org-options ml-auto">
                 <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
               </button>
               <bit-menu class="filter-organization-options" #orgMenu>
@@ -90,6 +94,7 @@
     <ng-container *ngSwitchCase="'singleOrganizationAndPersonalOwnershipPolicies'">
       <div class="filter-heading">
         <button
+          type="button"
           class="filter-button active"
           [attr.aria-pressed]="activeFilter.selectedOrganizationId === organizations[0].id"
           appA11yTitle="{{ 'vault' | i18n }}: {{ organizations[0].name }}"
@@ -98,7 +103,7 @@
           {{ organizations[0].name }}
         </button>
         <span class="tw-ml-auto">
-          <button [bitMenuTriggerFor]="orgMenu" class="org-options">
+          <button type="button" [bitMenuTriggerFor]="orgMenu" class="org-options">
             <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
           </button>
           <bit-menu class="filter-organization-options" #orgMenu>
@@ -110,6 +115,7 @@
     <ng-container *ngSwitchDefault>
       <div class="filter-heading">
         <button
+          type="button"
           class="toggle-button"
           title="{{ 'toggleCollapse' | i18n }}"
           (click)="toggleCollapse()"
@@ -126,6 +132,7 @@
           ></i>
         </button>
         <button
+          type="button"
           class="filter-button"
           (click)="clearFilter()"
           [ngClass]="{ active: !hasActiveFilter }"
@@ -138,6 +145,7 @@
         <li class="filter-option" [ngClass]="{ active: activeFilter.myVaultOnly }">
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               (click)="applyMyVaultFilter()"
               appA11yTitle="{{ 'vault' | i18n }}: {{ 'myVault' | i18n }}"
@@ -155,6 +163,7 @@
         >
           <span class="filter-buttons">
             <button
+              type="button"
               class="filter-button"
               [ngClass]="{ 'disabled-organization': !organization.enabled }"
               (click)="applyOrganizationFilter(organization)"
@@ -170,7 +179,7 @@
                 aria-label="{{ 'organizationIsDisabled' | i18n }}"
                 appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
               ></i
-              ><button [bitMenuTriggerFor]="orgMenu" class="org-options">
+              ><button type="button" [bitMenuTriggerFor]="orgMenu" class="org-options">
                 <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
               </button>
               <bit-menu class="filter-organization-options" #orgMenu>

--- a/apps/web/src/app/vault/vault-filter/organization-filter/organization-options.component.html
+++ b/apps/web/src/app/vault/vault-filter/organization-filter/organization-options.component.html
@@ -12,6 +12,7 @@
   [appApiAction]="actionPromise"
 >
   <button
+    type="button"
     *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
     class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
     (click)="toggleResetPasswordEnrollment(organization)"
@@ -20,6 +21,7 @@
     {{ "enrollPasswordReset" | i18n }}
   </button>
   <button
+    type="button"
     *ngIf="allowEnrollmentChanges(organization) && organization.resetPasswordEnrolled"
     class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
     (click)="toggleResetPasswordEnrollment(organization)"
@@ -29,6 +31,7 @@
   </button>
   <ng-container *ngIf="organization.useSso && organization.identifier">
     <button
+      type="button"
       *ngIf="organization.ssoBound; else linkSso"
       class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
       (click)="unlinkSso(organization)"
@@ -41,6 +44,7 @@
     </ng-template>
   </ng-container>
   <button
+    type="button"
     class="text-danger tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
     (click)="leave(organization)"
   >

--- a/apps/web/src/app/vault/vault-filter/shared/collection-filter/collection-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/shared/collection-filter/collection-filter.component.html
@@ -1,6 +1,7 @@
 <ng-container *ngIf="show">
   <div class="filter-heading">
     <button
+      type="button"
       (click)="toggleCollapse(collectionsGrouping)"
       [attr.aria-expanded]="!isCollapsed(collectionsGrouping)"
       aria-controls="collection-filters"
@@ -29,6 +30,7 @@
       >
         <span class="filter-buttons">
           <button
+            type="button"
             class="toggle-button"
             *ngIf="c.children.length"
             (click)="toggleCollapse(c.node)"
@@ -45,7 +47,7 @@
               aria-hidden="true"
             ></i>
           </button>
-          <button class="filter-button" (click)="applyFilter(c.node)">
+          <button type="button" class="filter-button" (click)="applyFilter(c.node)">
             <i
               *ngIf="c.children.length === 0"
               class="bwi bwi-collection bwi-fw"

--- a/apps/web/src/app/vault/vault-filter/shared/folder-filter/folder-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/shared/folder-filter/folder-filter.component.html
@@ -1,6 +1,7 @@
 <ng-container *ngIf="!hide">
   <div class="filter-heading">
     <button
+      type="button"
       class="toggle-button"
       (click)="toggleCollapse(foldersGrouping)"
       [attr.aria-expanded]="!isCollapsed(foldersGrouping)"
@@ -18,6 +19,7 @@
     </button>
     <h3 class="filter-title">&nbsp;{{ "folders" | i18n }}</h3>
     <button
+      type="button"
       class="text-muted ml-auto add-button"
       (click)="addFolder()"
       appA11yTitle="{{ 'addFolder' | i18n }}"
@@ -36,6 +38,7 @@
       >
         <span class="filter-buttons">
           <button
+            type="button"
             *ngIf="f.children.length"
             title="{{ 'toggleCollapse' | i18n }}"
             (click)="toggleCollapse(f.node)"
@@ -52,11 +55,12 @@
               aria-hidden="true"
             ></i>
           </button>
-          <button class="filter-button" (click)="applyFilter(f.node)">
+          <button type="button" class="filter-button" (click)="applyFilter(f.node)">
             <i *ngIf="f.children.length === 0" class="bwi bwi-fw bwi-folder" aria-hidden="true"></i
             >&nbsp;{{ f.node.name }}
           </button>
           <button
+            type="button"
             class="edit-button"
             (click)="editFolder(f.node)"
             appA11yTitle="{{ 'editFolder' | i18n }}"

--- a/apps/web/src/app/vault/vault-filter/shared/status-filter/status-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/shared/status-filter/status-filter.component.html
@@ -2,7 +2,7 @@
   <ul class="filter-options">
     <li class="filter-option" [ngClass]="{ active: activeFilter.status === 'all' }">
       <span class="filter-buttons">
-        <button class="filter-button" (click)="applyFilter('all')">
+        <button type="button" class="filter-button" (click)="applyFilter('all')">
           <i class="bwi bwi-fw bwi-filter" aria-hidden="true"></i>&nbsp;{{ "allItems" | i18n }}
         </button>
       </span>
@@ -13,7 +13,7 @@
       [ngClass]="{ active: activeFilter.status === 'favorites' }"
     >
       <span class="filter-buttons">
-        <button class="filter-button" (click)="applyFilter('favorites')">
+        <button type="button" class="filter-button" (click)="applyFilter('favorites')">
           <i class="bwi bwi-fw bwi-star" aria-hidden="true"></i>&nbsp;{{ "favorites" | i18n }}
         </button>
       </span>
@@ -24,7 +24,7 @@
       [ngClass]="{ active: activeFilter.status === 'trash' }"
     >
       <span class="filter-buttons">
-        <button class="filter-button" (click)="applyFilter('trash')">
+        <button type="button" class="filter-button" (click)="applyFilter('trash')">
           <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>&nbsp;{{ "trash" | i18n }}
         </button>
       </span>

--- a/apps/web/src/app/vault/vault-filter/shared/type-filter/type-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/shared/type-filter/type-filter.component.html
@@ -1,5 +1,6 @@
 <div class="filter-heading">
   <button
+    type="button"
     class="toggle-button"
     [attr.aria-expanded]="!isCollapsed"
     aria-controls="type-filters"
@@ -23,14 +24,14 @@
     [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.Login }"
   >
     <span class="filter-buttons">
-      <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Login)">
+      <button type="button" class="filter-button" (click)="applyFilter(cipherTypeEnum.Login)">
         <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>&nbsp;{{ "typeLogin" | i18n }}
       </button>
     </span>
   </li>
   <li class="filter-option" [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.Card }">
     <span class="filter-buttons">
-      <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Card)">
+      <button type="button" class="filter-button" (click)="applyFilter(cipherTypeEnum.Card)">
         <i class="bwi bwi-fw bwi-credit-card" aria-hidden="true"></i>&nbsp;{{ "typeCard" | i18n }}
       </button>
     </span>
@@ -40,7 +41,7 @@
     [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.Identity }"
   >
     <span class="filter-buttons">
-      <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Identity)">
+      <button type="button" class="filter-button" (click)="applyFilter(cipherTypeEnum.Identity)">
         <i class="bwi bwi-fw bwi-id-card" aria-hidden="true"></i>&nbsp;{{ "typeIdentity" | i18n }}
       </button>
     </span>
@@ -50,7 +51,7 @@
     [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.SecureNote }"
   >
     <span class="filter-buttons">
-      <button class="filter-button" (click)="applyFilter(cipherTypeEnum.SecureNote)">
+      <button type="button" class="filter-button" (click)="applyFilter(cipherTypeEnum.SecureNote)">
         <i class="bwi bwi-fw bwi-sticky-note" aria-hidden="true"></i>&nbsp;{{
           "typeSecureNote" | i18n
         }}

--- a/apps/web/src/connectors/webauthn-fallback.html
+++ b/apps/web/src/connectors/webauthn-fallback.html
@@ -28,7 +28,7 @@
               </div>
               <hr />
               <p class="text-center mb-0">
-                <button id="webauthn-button" class="btn btn-primary btn-lg"></button>
+                <button type="button" id="webauthn-button" class="btn btn-primary btn-lg"></button>
               </p>
             </div>
           </div>

--- a/apps/web/src/connectors/webauthn-mobile.html
+++ b/apps/web/src/connectors/webauthn-mobile.html
@@ -22,7 +22,7 @@
           <img src="../images/u2fkey-mobile.jpg" class="rounded img-fluid" />
         </picture>
         <div class="text-center mt-4">
-          <button id="webauthn-button" class="btn btn-primary btn-lg"></button>
+          <button type="button" id="webauthn-button" class="btn btn-primary btn-lg"></button>
         </div>
       </div>
     </div>

--- a/apps/web/src/connectors/webauthn.html
+++ b/apps/web/src/connectors/webauthn.html
@@ -12,7 +12,7 @@
       <img src="../images/u2fkey.jpg" class="rounded img-fluid mb-3" />
     </picture>
     <div class="text-center">
-      <button id="webauthn-button" class="btn btn-primary"></button>
+      <button type="button" id="webauthn-button" class="btn btn-primary"></button>
     </div>
   </body>
 </html>

--- a/bitwarden_license/bit-web/src/app/providers/clients/add-organization.component.html
+++ b/bitwarden_license/bit-web/src/app/providers/clients/add-organization.component.html
@@ -30,6 +30,7 @@
               </td>
               <td>
                 <button
+                  type="button"
                   class="btn btn-outline-secondary pull-right"
                   (click)="add(o)"
                   [disabled]="formPromise"

--- a/bitwarden_license/bit-web/src/app/providers/clients/clients.component.html
+++ b/bitwarden_license/bit-web/src/app/providers/clients/clients.component.html
@@ -17,6 +17,7 @@
       {{ "newClientOrganization" | i18n }}
     </a>
     <button
+      type="button"
       class="btn btn-sm btn-outline-primary ml-3"
       (click)="addExistingOrganization()"
       *ngIf="manageOrganizations && showAddExisting"

--- a/bitwarden_license/bit-web/src/app/providers/manage/people.component.html
+++ b/bitwarden_license/bit-web/src/app/providers/manage/people.component.html
@@ -53,11 +53,12 @@
         <i class="bwi bwi-cog" aria-hidden="true"></i>
       </button>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="bulkActionsButton">
-        <button class="dropdown-item" appStopClick (click)="bulkReinvite()">
+        <button type="button" class="dropdown-item" appStopClick (click)="bulkReinvite()">
           <i class="bwi bwi-fw bwi-envelope" aria-hidden="true"></i>
           {{ "reinviteSelected" | i18n }}
         </button>
         <button
+          type="button"
           class="dropdown-item text-success"
           appStopClick
           (click)="bulkConfirm()"
@@ -66,16 +67,16 @@
           <i class="bwi bwi-fw bwi-check" aria-hidden="true"></i>
           {{ "confirmSelected" | i18n }}
         </button>
-        <button class="dropdown-item text-danger" appStopClick (click)="bulkRemove()">
+        <button type="button" class="dropdown-item text-danger" appStopClick (click)="bulkRemove()">
           <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
           {{ "remove" | i18n }}
         </button>
         <div class="dropdown-divider"></div>
-        <button class="dropdown-item" appStopClick (click)="selectAll(true)">
+        <button type="button" class="dropdown-item" appStopClick (click)="selectAll(true)">
           <i class="bwi bwi-fw bwi-check-square" aria-hidden="true"></i>
           {{ "selectAll" | i18n }}
         </button>
-        <button class="dropdown-item" appStopClick (click)="selectAll(false)">
+        <button type="button" class="dropdown-item" appStopClick (click)="selectAll(false)">
           <i class="bwi bwi-fw bwi-minus-square" aria-hidden="true"></i>
           {{ "unselectAll" | i18n }}
         </button>

--- a/libs/components/src/banner/banner.component.html
+++ b/libs/components/src/banner/banner.component.html
@@ -12,6 +12,7 @@
     bitIconButton="bwi-close"
     buttonType="contrast"
     size="default"
+    type="button"
     (click)="onClose.emit()"
     [attr.title]="'close' | i18n"
     [attr.aria-label]="'close' | i18n"

--- a/libs/components/src/banner/banner.component.html
+++ b/libs/components/src/banner/banner.component.html
@@ -9,10 +9,10 @@
     <ng-content></ng-content>
   </span>
   <button
+    type="button"
     bitIconButton="bwi-close"
     buttonType="contrast"
     size="default"
-    type="button"
     (click)="onClose.emit()"
     [attr.title]="'close' | i18n"
     [attr.aria-label]="'close' | i18n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,9 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^14.0.6",
+        "@angular-eslint/eslint-plugin": "^14.1.2",
+        "@angular-eslint/eslint-plugin-template": "^14.1.2",
+        "@angular-eslint/template-parser": "^14.1.2",
         "@angular/cli": "^14.0.6",
         "@angular/compiler-cli": "^14.0.6",
         "@angular/elements": "^14.0.6",
@@ -769,6 +772,392 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-14.1.2.tgz",
+      "integrity": "sha512-d5/jTKXP+t9hNSucj3m8zZYBl62fZ2xFMVNbAOArYAkA7WwwX3D7Gae57BNW54cd2fl2/is7Dn6UgYhu1wqkSQ==",
+      "dev": true
+    },
+    "node_modules/@angular-eslint/eslint-plugin": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-14.1.2.tgz",
+      "integrity": "sha512-5pJaTcFfM7yDHNtMxw3uNTpBTLjNYH9mlOLX5FFQ9EahAuycwCtV8VJkIntK2ZiOTdRVJYA9/PEdD/xVxX02rw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-eslint/utils": "14.1.2",
+        "@typescript-eslint/utils": "5.37.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-14.1.2.tgz",
+      "integrity": "sha512-gMgYJ8ZwPvq2H/YEzPztVRAK2NYs2cJFUDZD4iGjSRtDgYq9OHjyTo+r6tkcyjcK2qvesy0RccHQKh+x3hYMTA==",
+      "dev": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
+        "aria-query": "5.0.2",
+        "axobject-query": "3.0.1"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/type-utils": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/types": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/utils": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/template-parser": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-14.1.2.tgz",
+      "integrity": "sha512-bQI+poQDIyR3OU9EQzJeLYRtmsvjFGtV5dc+4XPJ6eIyRAc8baCG/0V/cOrpofIdSf7e/sCV8H7rXcFg6tSdUw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "eslint-scope": "^5.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/utils": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-14.1.2.tgz",
+      "integrity": "sha512-EtblG9zO0+kWG9EHsoEshFKvsH5DMSK1DqwQsNOVGAF0Aa5DFOqrwouJUyBNJ0d4fSWI9QcuzVkZ1x9JyLIeXQ==",
+      "dev": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "@typescript-eslint/utils": "5.37.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@angular-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-eslint/utils/node_modules/@typescript-eslint/utils": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.37.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@angular/animations": {
       "version": "14.1.0",
@@ -14544,6 +14933,15 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.2.tgz",
+      "integrity": "sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -15202,6 +15600,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.0.1.tgz",
+      "integrity": "sha512-vy5JPSOibF9yAeC2PoemRdA1MuSXX7vX5osdoxKf/6OUeppAWekZ3JIJVNWFMH6wgj7uHYyqZUSqE/b/3JLV1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/babel-jest": {
@@ -43507,6 +43914,238 @@
         }
       }
     },
+    "@angular-eslint/bundled-angular-compiler": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-14.1.2.tgz",
+      "integrity": "sha512-d5/jTKXP+t9hNSucj3m8zZYBl62fZ2xFMVNbAOArYAkA7WwwX3D7Gae57BNW54cd2fl2/is7Dn6UgYhu1wqkSQ==",
+      "dev": true
+    },
+    "@angular-eslint/eslint-plugin": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-14.1.2.tgz",
+      "integrity": "sha512-5pJaTcFfM7yDHNtMxw3uNTpBTLjNYH9mlOLX5FFQ9EahAuycwCtV8VJkIntK2ZiOTdRVJYA9/PEdD/xVxX02rw==",
+      "dev": true,
+      "requires": {
+        "@angular-eslint/utils": "14.1.2",
+        "@typescript-eslint/utils": "5.37.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+          "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.37.0",
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/typescript-estree": "5.37.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
+      }
+    },
+    "@angular-eslint/eslint-plugin-template": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-14.1.2.tgz",
+      "integrity": "sha512-gMgYJ8ZwPvq2H/YEzPztVRAK2NYs2cJFUDZD4iGjSRtDgYq9OHjyTo+r6tkcyjcK2qvesy0RccHQKh+x3hYMTA==",
+      "dev": true,
+      "requires": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
+        "aria-query": "5.0.2",
+        "axobject-query": "3.0.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0"
+          }
+        },
+        "@typescript-eslint/type-utils": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+          "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/typescript-estree": "5.37.0",
+            "@typescript-eslint/utils": "5.37.0",
+            "debug": "^4.3.4",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+          "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.37.0",
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/typescript-estree": "5.37.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
+      }
+    },
+    "@angular-eslint/template-parser": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-14.1.2.tgz",
+      "integrity": "sha512-bQI+poQDIyR3OU9EQzJeLYRtmsvjFGtV5dc+4XPJ6eIyRAc8baCG/0V/cOrpofIdSf7e/sCV8H7rXcFg6tSdUw==",
+      "dev": true,
+      "requires": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "eslint-scope": "^5.1.0"
+      }
+    },
+    "@angular-eslint/utils": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-14.1.2.tgz",
+      "integrity": "sha512-EtblG9zO0+kWG9EHsoEshFKvsH5DMSK1DqwQsNOVGAF0Aa5DFOqrwouJUyBNJ0d4fSWI9QcuzVkZ1x9JyLIeXQ==",
+      "dev": true,
+      "requires": {
+        "@angular-eslint/bundled-angular-compiler": "14.1.2",
+        "@typescript-eslint/utils": "5.37.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/visitor-keys": "5.37.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+          "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.37.0",
+            "@typescript-eslint/types": "5.37.0",
+            "@typescript-eslint/typescript-estree": "5.37.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.37.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.37.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
+      }
+    },
     "@angular/animations": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-14.1.0.tgz",
@@ -54130,6 +54769,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.2.tgz",
+      "integrity": "sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -54609,6 +55254,12 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "dev": true
+    },
+    "axobject-query": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.0.1.tgz",
+      "integrity": "sha512-vy5JPSOibF9yAeC2PoemRdA1MuSXX7vX5osdoxKf/6OUeppAWekZ3JIJVNWFMH6wgj7uHYyqZUSqE/b/3JLV1A==",
       "dev": true
     },
     "babel-jest": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   ],
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.0.6",
+    "@angular-eslint/eslint-plugin": "^14.1.2",
+    "@angular-eslint/eslint-plugin-template": "^14.1.2",
+    "@angular-eslint/template-parser": "^14.1.2",
     "@angular/cli": "^14.0.6",
     "@angular/compiler-cli": "^14.0.6",
     "@angular/elements": "^14.0.6",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Adds an eslint rule which forbids the use of buttons without a type. Buttons default to submit which is seldom the behavior we want. Being strict about which type is used will assist in ensuring we use the correct types.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.eslintrc.json:** Moved default logic into overrides which behaves better when you have rules for `html`.  Added a rule to ignore `.js` files since we seldom care about their rules and the previous change broke linting in them. Lastly added the `@angular-eslint/template` with `button-has-type` and `banana-in-box` rules.
- Rest: Added `type="button"` unless in form in which case it got `type="submit"`. Each button should either have a click handler or a directive which handles the click action for it to be considered to have type button.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
