### PR TITLE
Fix MultiSelect component styles and CSP error

### DIFF
--- a/apps/web/src/scss/styles.scss
+++ b/apps/web/src/scss/styles.scss
@@ -2,6 +2,7 @@
 @import "./variables";
 @import "../../../../libs/angular/src/scss/bwicons/styles/style.scss";
 @import "../../../../libs/angular/src/scss/icons.scss";
+@import "../../../../libs/components/src/multi-select/scss/bw.theme";
 @import "@angular/cdk/overlay-prebuilt.css";
 
 //@import "~bootstrap/scss/bootstrap";

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -269,6 +269,7 @@ const devServer =
                   https://client-analytics.braintreegateway.com
                   https://*.braintree-api.com
                   https://*.blob.core.windows.net
+                  http://127.0.0.1:10000
                   https://app.simplelogin.io/api/alias/random/new
                   https://quack.duckduckgo.com/api/email/addresses
                   https://app.anonaddy.com/api/v1/aliases

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -234,6 +234,7 @@ const devServer =
                   'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
                   'sha256-JVRXyYPueLWdwGwY9m/7u4QlZ1xeQdqUj2t8OVIzZE4='
                   'sha256-or0p3LaHetJ4FRq+flVORVFFNsOjQGWrDvX8Jf7ACWg='
+                  'sha256-Oca9ZYU1dwNscIhdNV7tFBsr4oqagBhZx9/p4w8GOcg='
                 ;img-src
                   'self'
                   data:
@@ -268,7 +269,6 @@ const devServer =
                   https://client-analytics.braintreegateway.com
                   https://*.braintree-api.com
                   https://*.blob.core.windows.net
-                  http://127.0.0.1:10000
                   https://app.simplelogin.io/api/alias/random/new
                   https://quack.duckduckgo.com/api/email/addresses
                   https://app.anonaddy.com/api/v1/aliases

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -7,6 +7,7 @@ export * from "./form-field";
 export * from "./icon";
 export * from "./icon-button";
 export * from "./menu";
+export * from "./multi-select";
 export * from "./dialog";
 export * from "./link";
 export * from "./tabs";

--- a/libs/components/src/multi-select/index.ts
+++ b/libs/components/src/multi-select/index.ts
@@ -1,0 +1,1 @@
+export * from "./multi-select.module";


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- Include the MultiSelect module in the Component Library's barrel file 
- Import the MultiSelect ngSelect theme (`components/src/multi-select/scss/bw.theme.scss`) into the Web `styles.scss` 
- Add the necessary sha256 hash to webpack config CSP policy to support ngSelect inline styles

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
