### PR TITLE
[PS-1735] Do not autofill if sandboxed

### DIFF
--- a/apps/browser/src/content/autofill.js
+++ b/apps/browser/src/content/autofill.js
@@ -641,6 +641,11 @@
                   0 == confirmResult)) ? true : false;
       }
 
+      // Check if sandboxed
+      function isSandboxed() {
+          return self.origin == null || self.origin === 'null';
+      }
+
       function doFill(fillScript) {
           var fillScriptOps,
               theOpIds = [],
@@ -653,7 +658,7 @@
               fillScriptProperties.delay_between_operations &&
               (operationDelayMs = fillScriptProperties.delay_between_operations);
 
-          if (urlNotSecure(fillScript.savedURL)) {
+          if (isSandboxed() || urlNotSecure(fillScript.savedURL)) {
               return;
           }
 

--- a/apps/browser/src/content/autofill.js
+++ b/apps/browser/src/content/autofill.js
@@ -40,6 +40,7 @@
   7. Remove "some useful globals" on window
   8. Add ability to autofill span[data-bwautofill] elements
   9. Add new handler, for new command that responds with page details in response callback
+  10. Handle sandbox iframe and sandbox rule in CSP
   */
 
   function collect(document, undefined) {

--- a/apps/browser/src/content/autofill.js
+++ b/apps/browser/src/content/autofill.js
@@ -641,8 +641,9 @@
                   0 == confirmResult)) ? true : false;
       }
 
-      // Check if sandboxed
+      // Detect if within an iframe, and the iframe is sandboxed
       function isSandboxed() {
+          // self.origin is 'null' if inside a frame with sandboxed csp or iframe tag
           return self.origin == null || self.origin === 'null';
       }
 


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Honor the sandbox attribute of CSP and iframes.

Note: `self.origin` is 'null' if inside a frame with sandboxed csp or iframe tag

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
