### PR TITLE
[EC-626] Don't refresh org vault on filter change

### DIFF
--- a/apps/web/src/app/organizations/vault/vault.component.ts
+++ b/apps/web/src/app/organizations/vault/vault.component.ts
@@ -166,10 +166,16 @@ export class VaultComponent implements OnInit, OnDestroy {
   async applyVaultFilter(vaultFilter: VaultFilter) {
     this.ciphersComponent.showAddNew = vaultFilter.status !== "trash";
     this.activeFilter = vaultFilter;
-    await this.ciphersComponent.reload(
-      this.activeFilter.buildFilter(),
-      vaultFilter.status === "trash"
-    );
+
+    // Hack to avoid calling cipherService.getAllFromApiForOrganization every time the vault filter changes.
+    // Call CiphersComponent.applyFilter directly instead of going through CiphersComponent.reload, which
+    // reloads all the ciphers unnecessarily. Will be fixed properly by EC-14.
+    this.ciphersComponent.loaded = false;
+    this.ciphersComponent.deleted = vaultFilter.status === "trash" || false;
+    await this.ciphersComponent.applyFilter(this.activeFilter.buildFilter());
+    this.ciphersComponent.loaded = true;
+    // End hack
+
     this.vaultFilterComponent.searchPlaceholder =
       this.vaultService.calculateSearchBarLocalizationString(this.activeFilter);
     this.go();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Currently we reload all ciphers when a vault filter changes. This is fine if the ciphers are in local sync data, but for admins, this means they're fetching & decrypting ciphers from the server every time.

This will be solved by EC-14, but I wanted to get a fix in in the meantime. #3532 will allow the user to switch filters rapidly, potentially queuing up a lot of decryption.

@jlf0dev and @coroiu Requesting your review specifically as you're probably the most across this area of the code currently.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/vault/vault.component.ts** - previously this called `CiphersComponent.reload`, which called `CiphersComponent.load` (which has the api call in it), which then called `CiphersComponent.ApplyFilter`. This basically just calls `ApplyFilter` directly to avoid the api call, and pulls out a few bits of logic that we still needed from the intermediate methods.

This seemed the safest way to avoid the issue without altering any other callers. Note that ciphers are still fully reloaded on sync or when editing a cipher (creating/deleting/etc), that's why I changed the code here and not in `CiphersComponent`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
