### PR TITLE
[SG-753] Keep email after hint component is launched in browser

### DIFF
--- a/apps/browser/src/popup/accounts/hint.component.html
+++ b/apps/browser/src/popup/accounts/hint.component.html
@@ -1,7 +1,9 @@
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise">
   <header>
     <div class="left">
-      <button type="button" routerLink="/login">{{ "cancel" | i18n }}</button>
+      <button type="button" routerLink="/login" [state]="{ email: emailSent }">
+        {{ "cancel" | i18n }}
+      </button>
     </div>
     <h1 class="center">
       <span class="title">{{ "passwordHint" | i18n }}</span>

--- a/apps/browser/src/popup/accounts/hint.component.html
+++ b/apps/browser/src/popup/accounts/hint.component.html
@@ -1,7 +1,7 @@
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise">
   <header>
     <div class="left">
-      <button type="button" routerLink="/login" [state]="{ email: emailSent }">
+      <button type="button" routerLink="/login" [queryParams]="{ email: emailSent }">
         {{ "cancel" | i18n }}
       </button>
     </div>

--- a/apps/browser/src/popup/accounts/hint.component.ts
+++ b/apps/browser/src/popup/accounts/hint.component.ts
@@ -12,6 +12,8 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
   templateUrl: "hint.component.html",
 })
 export class HintComponent extends BaseHintComponent {
+  emailSent: string;
+
   constructor(
     router: Router,
     platformUtilsService: PlatformUtilsService,
@@ -20,5 +22,11 @@ export class HintComponent extends BaseHintComponent {
     logService: LogService
   ) {
     super(router, i18nService, apiService, platformUtilsService, logService);
+
+    this.emailSent = this.router.getCurrentNavigation().extras.state.email;
+    this.email = this.emailSent;
+    super.onSuccessfulSubmit = async () => {
+      this.router.navigateByUrl(this.successRoute, { state: { email: this.emailSent } });
+    };
   }
 }

--- a/apps/browser/src/popup/accounts/hint.component.ts
+++ b/apps/browser/src/popup/accounts/hint.component.ts
@@ -1,5 +1,6 @@
-import { Component } from "@angular/core";
-import { Router } from "@angular/router";
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Subject, takeUntil } from "rxjs";
 
 import { HintComponent as BaseHintComponent } from "@bitwarden/angular/components/hint.component";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -11,22 +12,37 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
   selector: "app-hint",
   templateUrl: "hint.component.html",
 })
-export class HintComponent extends BaseHintComponent {
+export class HintComponent extends BaseHintComponent implements OnInit {
   emailSent: string;
+  private destroy$ = new Subject<void>();
 
   constructor(
     router: Router,
     platformUtilsService: PlatformUtilsService,
     i18nService: I18nService,
     apiService: ApiService,
-    logService: LogService
+    logService: LogService,
+    private route: ActivatedRoute
   ) {
     super(router, i18nService, apiService, platformUtilsService, logService);
 
-    this.emailSent = this.router.getCurrentNavigation().extras.state.email;
-    this.email = this.emailSent;
     super.onSuccessfulSubmit = async () => {
-      this.router.navigateByUrl(this.successRoute, { state: { email: this.emailSent } });
+      this.router.navigate([this.successRoute], { queryParams: { email: this.emailSent } });
     };
+  }
+  ngOnInit() {
+    this.route?.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      if (params) {
+        const queryParamsEmail = params["email"];
+        if (queryParamsEmail != null && queryParamsEmail.indexOf("@") > -1) {
+          this.emailSent = this.email = queryParamsEmail;
+        }
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -54,7 +54,7 @@
         </div>
       </div>
       <div class="box-footer">
-        <button type="button" class="btn link" routerLink="/hint">
+        <button type="button" class="btn link" routerLink="/hint" [state]="{ email: loggedEmail }">
           <b>{{ "getMasterPasswordHint" | i18n }}</b>
         </button>
       </div>

--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -54,7 +54,12 @@
         </div>
       </div>
       <div class="box-footer">
-        <button type="button" class="btn link" routerLink="/hint" [state]="{ email: loggedEmail }">
+        <button
+          type="button"
+          class="btn link"
+          routerLink="/hint"
+          [queryParams]="{ email: loggedEmail }"
+        >
           <b>{{ "getMasterPasswordHint" | i18n }}</b>
         </button>
       </div>

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -63,6 +63,9 @@ export class LoginComponent extends BaseLoginComponent {
       await syncService.fullSync(true);
     };
     super.successRoute = "/tabs/vault";
+    if (this.router.getCurrentNavigation().extras?.state?.email != null) {
+      this.formGroup.patchValue({ email: this.router.getCurrentNavigation().extras.state.email });
+    }
   }
 
   settings() {

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -63,9 +63,6 @@ export class LoginComponent extends BaseLoginComponent {
       await syncService.fullSync(true);
     };
     super.successRoute = "/tabs/vault";
-    if (this.router.getCurrentNavigation().extras?.state?.email != null) {
-      this.formGroup.patchValue({ email: this.router.getCurrentNavigation().extras.state.email });
-    }
   }
 
   settings() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix issue where launching Master Password Hint would clear email.

## Code changes

Since the browser extension doesn't have traditional routes and the components are destroyed on navigation, I used navigation state data to achieve this.

- **apps/browser/src/popup/accounts/login.component.html:** Use state data to send email to hint component
- **apps/browser/src/popup/accounts/hint.component.ts:** Set email if present in route state data 
- **apps/browser/src/popup/accounts/hint.component.html:** Use state data to send email back to login component
- **apps/browser/src/popup/accounts/login.component.ts:** Set email if present in route state data (is sent from hint component)

## Screenshots


https://user-images.githubusercontent.com/8926729/197574162-984c0bb4-1ca6-4d27-9277-0f15badb59e3.mov



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
