### PR TITLE
[SG-768] Hide Login with Device button on Self-Hosted

### DIFF
--- a/apps/web/src/app/accounts/login/login.component.html
+++ b/apps/web/src/app/accounts/login/login.component.html
@@ -103,7 +103,7 @@
     </button>
   </div>
 
-  <div class="tw-mb-3" *ngIf="showLoginWithDevice">
+  <div class="tw-mb-3" *ngIf="showLoginWithDevice && showPasswordless">
     <button
       bitButton
       type="button"

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -31,7 +31,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   onSuccessfulLoginNavigate: () => Promise<any>;
   onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
   onSuccessfulLoginForceResetNavigate: () => Promise<any>;
-  selfHosted = false;
+  private selfHosted = false;
   showLoginWithDevice: boolean;
   validatedEmail = false;
 
@@ -255,7 +255,8 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     try {
       const deviceIdentifier = await this.appIdService.getAppId();
       const res = await this.apiService.getKnownDevice(email, deviceIdentifier);
-      this.showLoginWithDevice = res;
+      //ensure the application is not self-hosted
+      this.showLoginWithDevice = res && !this.selfHosted;
     } catch (e) {
       this.showLoginWithDevice = false;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The `Log in with device` button should be hidden if the environment is self-hosted
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/angular/src/components/login.component.ts:** Added extra condition to the `showLoginWithDevice` variable to check if the environment is self-hosted or not.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
