### PR TITLE
[SG-754] & [SG-764] Fix email and rememberEmail form values

### DIFF
--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -72,7 +72,7 @@
       </button>
       <div class="small">
         <p class="no-margin">{{ "loggingInAs" | i18n }} {{ loggedEmail }}</p>
-        <a routerLink="/home" (click)="clearRememberedEmail($event)">{{ "notYou" | i18n }}</a>
+        <a (click)="goBackToHome()">{{ "notYou" | i18n }}</a>
       </div>
     </div>
   </main>

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -110,9 +110,13 @@ export class LoginComponent extends BaseLoginComponent {
     );
   }
 
-  async clearRememberedEmail(e: Event) {
-    e.stopPropagation();
+  async goBackToHome() {
     await this.stateService.setRememberedEmail(null);
-    this.router.navigate(["home"]);
+    this.router.navigate(["home"], {
+      queryParams: {
+        email: this.formGroup.value.email,
+        rememberEmail: this.formGroup.value.rememberEmail,
+      },
+    });
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix email and rememberEmail form values not getting set properly on navigation
## Code changes

- **apps/browser/src/popup/accounts/home.component.ts:** Add route params for the email and rememberEmail form values.
- **apps/browser/src/popup/accounts/login.component.ts:** Send email and rememberEmail form values to home component on navigation

## Screenshots

https://user-images.githubusercontent.com/8926729/197846821-8e4142ed-36a7-454f-a4a6-968e0df13eb5.mov

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
