### PR TITLE
[SG-769] Removed avatar and close button from the password screen

### DIFF
--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -1,22 +1,8 @@
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" [formGroup]="formGroup">
   <header>
-    <div class="left">
-      <button type="button" routerLink="/home">{{ "close" | i18n }}</button>
-    </div>
-    <h1 class="center">
+    <h1 class="login-center">
       <span class="title">{{ "logIn" | i18n }}</span>
     </h1>
-    <div class="right">
-      <app-avatar
-        [data]="loggedEmail"
-        [email]="loggedEmail"
-        [circle]="true"
-        dynamic="true"
-        fontSize="16"
-        size="30"
-      >
-      </app-avatar>
-    </div>
   </header>
   <main tabindex="-1">
     <div class="box">

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -188,6 +188,10 @@ header {
     min-width: 0;
   }
 
+  .login-center {
+    margin: auto;
+  }
+
   app-pop-out > button,
   div > button,
   div > a {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The `product` team recommended minor changes to the UI for the browser extension; The close button and avatar are not needed because of the two-step login flow.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->


## Screenshots

https://user-images.githubusercontent.com/13024008/198112337-5f82aaf8-2e40-4674-ba71-a94449f86d7d.mov


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
