### PR TITLE
[EC-645] fix web payment component breaking storybook compilation

### DIFF
--- a/apps/web/src/app/settings/payment.component.ts
+++ b/apps/web/src/app/settings/payment.component.ts
@@ -5,14 +5,6 @@ import { AbstractThemingService } from "@bitwarden/angular/services/theming/them
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { PaymentMethodType } from "@bitwarden/common/enums/paymentMethodType";
-import { ThemeType } from "@bitwarden/common/enums/themeType";
-
-import ThemeVariables from "../../scss/export.module.scss";
-
-const lightInputColor = ThemeVariables.lightInputColor;
-const lightInputPlaceholderColor = ThemeVariables.lightInputPlaceholderColor;
-const darkInputColor = ThemeVariables.darkInputColor;
-const darkInputPlaceholderColor = ThemeVariables.darkInputPlaceholderColor;
 
 @Component({
   selector: "app-payment",
@@ -96,7 +88,7 @@ export class PaymentComponent implements OnInit, OnDestroy {
       this.hideBank = this.method !== PaymentMethodType.BankAccount;
       this.hideCredit = this.method !== PaymentMethodType.Credit;
     }
-    await this.setTheme();
+    this.subscribeToTheme();
     window.document.head.appendChild(this.stripeScript);
     if (!this.hidePaypal) {
       window.document.head.appendChild(this.btScript);
@@ -280,17 +272,17 @@ export class PaymentComponent implements OnInit, OnDestroy {
     }, 50);
   }
 
-  private async setTheme() {
-    this.themingService.theme$.pipe(takeUntil(this.destroy$)).subscribe((theme) => {
-      if (theme.effectiveTheme === ThemeType.Dark) {
-        this.StripeElementStyle.base.color = darkInputColor;
-        this.StripeElementStyle.base["::placeholder"].color = darkInputPlaceholderColor;
-        this.StripeElementStyle.invalid.color = darkInputColor;
-      } else {
-        this.StripeElementStyle.base.color = lightInputColor;
-        this.StripeElementStyle.base["::placeholder"].color = lightInputPlaceholderColor;
-        this.StripeElementStyle.invalid.color = lightInputColor;
-      }
+  private subscribeToTheme() {
+    this.themingService.theme$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      const style = getComputedStyle(document.documentElement);
+      this.StripeElementStyle.base.color = `rgb(${style.getPropertyValue("--color-text-main")})`;
+      this.StripeElementStyle.base["::placeholder"].color = `rgb(${style.getPropertyValue(
+        "--color-text-muted"
+      )})`;
+      this.StripeElementStyle.invalid.color = `rgb(${style.getPropertyValue("--color-text-main")})`;
+      this.StripeElementStyle.invalid.borderColor = `rgb(${style.getPropertyValue(
+        "--color-danger-500"
+      )})`;
     });
   }
 }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The component uses a special webpack loader to load scss variables and programmatically apply them to stripe. The loader is not supported by storybook which breaks all components that depend on SharedModule or LooseComponentsModule

## Code changes

Remove references to scss code

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/198285668-75e709ae-008e-418f-a46f-200eedec8364.png)


![image](https://user-images.githubusercontent.com/2285588/198285686-27c979bf-db8b-4e33-88b8-ca1830f89e1d.png)

Inspiration from Figma

![image](https://user-images.githubusercontent.com/2285588/198285807-37851e36-25f2-43aa-b560-39c761099310.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
