### PR TITLE
[SG-782] Add login service to streamline login form data persistence

### DIFF
--- a/apps/browser/src/popup/accounts/hint.component.ts
+++ b/apps/browser/src/popup/accounts/hint.component.ts
@@ -1,47 +1,31 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 
 import { HintComponent as BaseHintComponent } from "@bitwarden/angular/components/hint.component";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 
 @Component({
   selector: "app-hint",
   templateUrl: "hint.component.html",
 })
-export class HintComponent extends BaseHintComponent implements OnInit {
-  private destroy$ = new Subject<void>();
-
+export class HintComponent extends BaseHintComponent {
   constructor(
     router: Router,
     platformUtilsService: PlatformUtilsService,
     i18nService: I18nService,
     apiService: ApiService,
     logService: LogService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    loginService: LoginService
   ) {
-    super(router, i18nService, apiService, platformUtilsService, logService);
+    super(router, i18nService, apiService, platformUtilsService, logService, loginService);
 
     super.onSuccessfulSubmit = async () => {
       this.router.navigate([this.successRoute]);
     };
-  }
-  ngOnInit() {
-    this.route?.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      if (params) {
-        const queryParamsEmail = params["email"];
-        if (queryParamsEmail != null && queryParamsEmail.indexOf("@") > -1) {
-          this.email = queryParamsEmail;
-        }
-      }
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -40,12 +40,7 @@
         </div>
       </div>
       <div class="box-footer">
-        <button
-          type="button"
-          class="btn link"
-          routerLink="/hint"
-          [queryParams]="{ email: loggedEmail }"
-        >
+        <button type="button" class="btn link" routerLink="/hint" (click)="setFormValues()">
           <b>{{ "getMasterPasswordHint" | i18n }}</b>
         </button>
       </div>

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -11,6 +11,7 @@ import { EnvironmentService } from "@bitwarden/common/abstractions/environment.s
 import { FormValidationErrorsService } from "@bitwarden/common/abstractions/formValidationErrors.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
@@ -40,7 +41,8 @@ export class LoginComponent extends BaseLoginComponent {
     ngZone: NgZone,
     formBuilder: FormBuilder,
     formValidationErrorService: FormValidationErrorsService,
-    route: ActivatedRoute
+    route: ActivatedRoute,
+    loginService: LoginService
   ) {
     super(
       apiService,
@@ -57,7 +59,8 @@ export class LoginComponent extends BaseLoginComponent {
       ngZone,
       formBuilder,
       formValidationErrorService,
-      route
+      route,
+      loginService
     );
     super.onSuccessfulLogin = async () => {
       await syncService.fullSync(true);

--- a/apps/browser/src/popup/accounts/two-factor.component.ts
+++ b/apps/browser/src/popup/accounts/two-factor.component.ts
@@ -10,6 +10,7 @@ import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.s
 import { EnvironmentService } from "@bitwarden/common/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
@@ -44,7 +45,8 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     private messagingService: MessagingService,
     logService: LogService,
     twoFactorService: TwoFactorService,
-    appIdService: AppIdService
+    appIdService: AppIdService,
+    loginService: LoginService
   ) {
     super(
       authService,
@@ -58,9 +60,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
       route,
       logService,
       twoFactorService,
-      appIdService
+      appIdService,
+      loginService
     );
     super.onSuccessfulLogin = () => {
+      this.loginService.clearValues();
       return syncService.fullSync(true);
     };
     super.successRoute = "/tabs/vault";

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -24,6 +24,7 @@ import { FolderService } from "@bitwarden/common/abstractions/folder/folder.serv
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { KeyConnectorService } from "@bitwarden/common/abstractions/keyConnector.service";
 import { LogService as LogServiceAbstraction } from "@bitwarden/common/abstractions/log.service";
+import { LoginService as LoginServiceAbstraction } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
@@ -48,6 +49,7 @@ import { VaultTimeoutService } from "@bitwarden/common/abstractions/vaultTimeout
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vaultTimeout/vaultTimeoutSettings.service";
 import { AuthService } from "@bitwarden/common/services/auth.service";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
+import { LoginService } from "@bitwarden/common/services/login.service";
 import { SearchService } from "@bitwarden/common/services/search.service";
 
 import MainBackground from "../../background/main.background";
@@ -308,6 +310,10 @@ function getBgService<T>(service: keyof MainBackground) {
     {
       provide: FileDownloadService,
       useClass: BrowserFileDownloadService,
+    },
+    {
+      provide: LoginServiceAbstraction,
+      useClass: LoginService,
     },
     {
       provide: AbstractThemingService,

--- a/apps/desktop/src/app/accounts/hint.component.ts
+++ b/apps/desktop/src/app/accounts/hint.component.ts
@@ -5,6 +5,7 @@ import { HintComponent as BaseHintComponent } from "@bitwarden/angular/component
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 
 @Component({
@@ -17,8 +18,9 @@ export class HintComponent extends BaseHintComponent {
     platformUtilsService: PlatformUtilsService,
     i18nService: I18nService,
     apiService: ApiService,
-    logService: LogService
+    logService: LogService,
+    loginService: LoginService
   ) {
-    super(router, i18nService, apiService, platformUtilsService, logService);
+    super(router, i18nService, apiService, platformUtilsService, logService, loginService);
   }
 }

--- a/apps/desktop/src/app/accounts/login.component.html
+++ b/apps/desktop/src/app/accounts/login.component.html
@@ -104,7 +104,12 @@
           <div class="box-content">
             <iframe id="hcaptcha_iframe" style="margin-top: 20px"></iframe>
             <div class="box-content-row">
-              <button class="btn block" type="button" routerLink="/accessibility-cookie">
+              <button
+                class="btn block"
+                type="button"
+                routerLink="/accessibility-cookie"
+                (click)="setFormValues()"
+              >
                 <i class="bwi bwi-universal-access" aria-hidden="true"></i>
                 {{ "loadAccessibilityCookie" | i18n }}
               </button>
@@ -132,7 +137,12 @@
           </div>
         </div>
         <div class="sub-options">
-          <button type="button" class="text text-primary password-hint-btn" routerLink="/hint">
+          <button
+            type="button"
+            class="text text-primary password-hint-btn"
+            routerLink="/hint"
+            (click)="setFormValues()"
+          >
             {{ "getMasterPasswordHint" | i18n }}
           </button>
           <div>

--- a/apps/desktop/src/app/accounts/login.component.ts
+++ b/apps/desktop/src/app/accounts/login.component.ts
@@ -13,6 +13,7 @@ import { EnvironmentService } from "@bitwarden/common/abstractions/environment.s
 import { FormValidationErrorsService } from "@bitwarden/common/abstractions/formValidationErrors.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -64,7 +65,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     logService: LogService,
     formBuilder: FormBuilder,
     formValidationErrorService: FormValidationErrorsService,
-    route: ActivatedRoute
+    route: ActivatedRoute,
+    loginService: LoginService
   ) {
     super(
       apiService,
@@ -81,7 +83,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
       ngZone,
       formBuilder,
       formValidationErrorService,
-      route
+      route,
+      loginService
     );
     super.onSuccessfulLogin = () => {
       return syncService.fullSync(true);

--- a/apps/desktop/src/app/accounts/two-factor.component.ts
+++ b/apps/desktop/src/app/accounts/two-factor.component.ts
@@ -9,6 +9,7 @@ import { AuthService } from "@bitwarden/common/abstractions/auth.service";
 import { EnvironmentService } from "@bitwarden/common/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { SyncService } from "@bitwarden/common/abstractions/sync/sync.service.abstraction";
@@ -41,7 +42,8 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     route: ActivatedRoute,
     logService: LogService,
     twoFactorService: TwoFactorService,
-    appIdService: AppIdService
+    appIdService: AppIdService,
+    loginService: LoginService
   ) {
     super(
       authService,
@@ -55,9 +57,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
       route,
       logService,
       twoFactorService,
-      appIdService
+      appIdService,
+      loginService
     );
     super.onSuccessfulLogin = () => {
+      this.loginService.clearValues();
       return syncService.fullSync(true);
     };
   }

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -23,6 +23,7 @@ import {
   LogService,
   LogService as LogServiceAbstraction,
 } from "@bitwarden/common/abstractions/log.service";
+import { LoginService as LoginServiceAbstraction } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordGenerationService as PasswordGenerationServiceAbstraction } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "@bitwarden/common/abstractions/passwordReprompt.service";
@@ -35,6 +36,7 @@ import { SystemService as SystemServiceAbstraction } from "@bitwarden/common/abs
 import { ClientType } from "@bitwarden/common/enums/clientType";
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
 import { GlobalState } from "@bitwarden/common/models/domain/global-state";
+import { LoginService } from "@bitwarden/common/services/login.service";
 import { MemoryStorageService } from "@bitwarden/common/services/memoryStorage.service";
 import { SystemService } from "@bitwarden/common/services/system.service";
 import { ElectronCryptoService } from "@bitwarden/electron/services/electronCrypto.service";
@@ -174,6 +176,10 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
         I18nServiceAbstraction,
         EncryptedMessageHandlerService,
       ],
+    },
+    {
+      provide: LoginServiceAbstraction,
+      useClass: LoginService,
     },
   ],
 })

--- a/apps/web/src/app/accounts/hint.component.ts
+++ b/apps/web/src/app/accounts/hint.component.ts
@@ -5,6 +5,7 @@ import { HintComponent as BaseHintComponent } from "@bitwarden/angular/component
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 
 @Component({
@@ -17,8 +18,9 @@ export class HintComponent extends BaseHintComponent {
     i18nService: I18nService,
     apiService: ApiService,
     platformUtilsService: PlatformUtilsService,
-    logService: LogService
+    logService: LogService,
+    loginService: LoginService
   ) {
-    super(router, i18nService, apiService, platformUtilsService, logService);
+    super(router, i18nService, apiService, platformUtilsService, logService, loginService);
   }
 }

--- a/apps/web/src/app/accounts/login/login.component.html
+++ b/apps/web/src/app/accounts/login/login.component.html
@@ -88,7 +88,7 @@
         ></i>
       </button>
       <bit-hint>
-        <a routerLink="/hint">{{ "getMasterPasswordHint" | i18n }}</a>
+        <a routerLink="/hint" (click)="setFormValues()">{{ "getMasterPasswordHint" | i18n }}</a>
       </bit-hint>
     </bit-form-field>
   </div>
@@ -116,7 +116,13 @@
   </div>
 
   <div class="tw-mb-3">
-    <a routerLink="/sso" bitButton buttonType="secondary" class="tw-w-full">
+    <a
+      routerLink="/sso"
+      (click)="setFormValues()"
+      bitButton
+      buttonType="secondary"
+      class="tw-w-full"
+    >
       <i class="bwi bwi-provider tw-mr-2"></i>
       {{ "enterpriseSingleSignOn" | i18n }}
     </a>

--- a/apps/web/src/app/accounts/login/login.component.ts
+++ b/apps/web/src/app/accounts/login/login.component.ts
@@ -179,6 +179,7 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
     if (previousUrl) {
       this.router.navigateByUrl(previousUrl);
     } else {
+      this.loginService.clearValues();
       this.router.navigate([this.successRoute]);
     }
   }

--- a/apps/web/src/app/accounts/login/login.component.ts
+++ b/apps/web/src/app/accounts/login/login.component.ts
@@ -13,6 +13,7 @@ import { EnvironmentService } from "@bitwarden/common/abstractions/environment.s
 import { FormValidationErrorsService } from "@bitwarden/common/abstractions/formValidationErrors.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -58,7 +59,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
     private messagingService: MessagingService,
     private routerService: RouterService,
     formBuilder: FormBuilder,
-    formValidationErrorService: FormValidationErrorsService
+    formValidationErrorService: FormValidationErrorsService,
+    loginService: LoginService
   ) {
     super(
       apiService,
@@ -75,7 +77,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
       ngZone,
       formBuilder,
       formValidationErrorService,
-      route
+      route,
+      loginService
     );
     this.onSuccessfulLogin = async () => {
       this.messagingService.send("setFullWidth");

--- a/apps/web/src/app/accounts/two-factor.component.ts
+++ b/apps/web/src/app/accounts/two-factor.component.ts
@@ -9,6 +9,7 @@ import { AuthService } from "@bitwarden/common/abstractions/auth.service";
 import { EnvironmentService } from "@bitwarden/common/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { TwoFactorService } from "@bitwarden/common/abstractions/twoFactor.service";
@@ -40,7 +41,8 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     logService: LogService,
     twoFactorService: TwoFactorService,
     appIdService: AppIdService,
-    private routerService: RouterService
+    private routerService: RouterService,
+    loginService: LoginService
   ) {
     super(
       authService,
@@ -54,7 +56,8 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
       route,
       logService,
       twoFactorService,
-      appIdService
+      appIdService,
+      loginService
     );
     this.onSuccessfulLoginNavigate = this.goAfterLogIn;
   }
@@ -79,6 +82,7 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
   }
 
   async goAfterLogIn() {
+    this.loginService.clearValues();
     const previousUrl = this.routerService.getPreviousUrl();
     if (previousUrl) {
       this.router.navigateByUrl(previousUrl);

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -13,6 +13,7 @@ import { JslibServicesModule } from "@bitwarden/angular/services/jslib-services.
 import { ModalService as ModalServiceAbstraction } from "@bitwarden/angular/services/modal.service";
 import { FileDownloadService } from "@bitwarden/common/abstractions/fileDownload/fileDownload.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/abstractions/i18n.service";
+import { LoginService as LoginServiceAbstraction } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "@bitwarden/common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -20,6 +21,7 @@ import { StateService as BaseStateServiceAbstraction } from "@bitwarden/common/a
 import { StateMigrationService as StateMigrationServiceAbstraction } from "@bitwarden/common/abstractions/stateMigration.service";
 import { AbstractStorageService } from "@bitwarden/common/abstractions/storage.service";
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
+import { LoginService } from "@bitwarden/common/services/login.service";
 import { MemoryStorageService } from "@bitwarden/common/services/memoryStorage.service";
 
 import { BroadcasterMessagingService } from "./broadcaster-messaging.service";
@@ -97,6 +99,10 @@ import { WebPlatformUtilsService } from "./web-platform-utils.service";
     {
       provide: FileDownloadService,
       useClass: WebFileDownloadService,
+    },
+    {
+      provide: LoginServiceAbstraction,
+      useClass: LoginService,
     },
   ],
 })

--- a/libs/angular/src/components/hint.component.ts
+++ b/libs/angular/src/components/hint.component.ts
@@ -1,12 +1,15 @@
+import { Directive, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { PasswordHintRequest } from "@bitwarden/common/models/request/password-hint.request";
 
-export class HintComponent {
+@Directive()
+export class HintComponent implements OnInit {
   email = "";
   formPromise: Promise<any>;
 
@@ -18,8 +21,13 @@ export class HintComponent {
     protected i18nService: I18nService,
     protected apiService: ApiService,
     protected platformUtilsService: PlatformUtilsService,
-    private logService: LogService
+    private logService: LogService,
+    private loginService: LoginService
   ) {}
+
+  ngOnInit(): void {
+    this.email = this.loginService.getEmail() ?? "";
+  }
 
   async submit() {
     if (this.email == null || this.email === "") {

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -99,7 +99,10 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       this.formGroup.get("email")?.setValue(email ?? "");
     }
     if (!this.alwaysRememberEmail) {
-      const rememberEmail = this.loginService.getRememberEmail();
+      let rememberEmail = this.loginService.getRememberEmail();
+      if (rememberEmail == null) {
+        rememberEmail = (await this.stateService.getRememberedEmail()) != null;
+      }
       this.formGroup.get("rememberEmail")?.setValue(rememberEmail);
     }
 
@@ -159,6 +162,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       } else {
         const disableFavicon = await this.stateService.getDisableFavicon();
         await this.stateService.setDisableFavicon(!!disableFavicon);
+        this.loginService.clearValues();
         if (this.onSuccessfulLogin != null) {
           this.onSuccessfulLogin();
         }

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -14,6 +14,7 @@ import {
 } from "@bitwarden/common/abstractions/formValidationErrors.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
@@ -34,6 +35,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   private selfHosted = false;
   showLoginWithDevice: boolean;
   validatedEmail = false;
+  paramEmailSet = false;
 
   formGroup = this.formBuilder.group({
     email: ["", [Validators.required, Validators.email]],
@@ -66,7 +68,8 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     protected ngZone: NgZone,
     protected formBuilder: FormBuilder,
     protected formValidationErrorService: FormValidationErrorsService,
-    protected route: ActivatedRoute
+    protected route: ActivatedRoute,
+    protected loginService: LoginService
   ) {
     super(environmentService, i18nService, platformUtilsService);
     this.selfHosted = platformUtilsService.isSelfHost();
@@ -82,20 +85,21 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
         const queryParamsEmail = params["email"];
         if (queryParamsEmail != null && queryParamsEmail.indexOf("@") > -1) {
           this.formGroup.get("email").setValue(queryParamsEmail);
+          this.paramEmailSet = true;
         }
       }
     });
-    let email = this.loggedEmail;
+    let email = this.loginService.getEmail();
+
     if (email == null || email === "") {
       email = await this.stateService.getRememberedEmail();
-      this.formGroup.get("email")?.setValue(email);
+    }
 
-      if (email == null) {
-        this.formGroup.get("email")?.setValue("");
-      }
+    if (!this.paramEmailSet) {
+      this.formGroup.get("email")?.setValue(email ?? "");
     }
     if (!this.alwaysRememberEmail) {
-      const rememberEmail = (await this.stateService.getRememberedEmail()) != null;
+      const rememberEmail = this.loginService.getRememberEmail();
       this.formGroup.get("rememberEmail")?.setValue(rememberEmail);
     }
 
@@ -132,6 +136,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       );
       this.formPromise = this.authService.logIn(credentials);
       const response = await this.formPromise;
+      this.setFormValues();
       if (data.rememberEmail || this.alwaysRememberEmail) {
         await this.stateService.setRememberedEmail(data.email);
       } else {
@@ -227,6 +232,11 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   toggleValidateEmail(value: boolean) {
     this.validatedEmail = value;
     this.formGroup.controls.masterPassword.reset();
+  }
+
+  setFormValues() {
+    this.loginService.setEmail(this.formGroup.value.email);
+    this.loginService.setRememberEmail(this.formGroup.value.rememberEmail);
   }
 
   private getErrorToastMessage() {

--- a/libs/angular/src/components/two-factor.component.ts
+++ b/libs/angular/src/components/two-factor.component.ts
@@ -9,6 +9,7 @@ import { AuthService } from "@bitwarden/common/abstractions/auth.service";
 import { EnvironmentService } from "@bitwarden/common/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService } from "@bitwarden/common/abstractions/login.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { TwoFactorService } from "@bitwarden/common/abstractions/twoFactor.service";
@@ -59,7 +60,8 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
     protected route: ActivatedRoute,
     protected logService: LogService,
     protected twoFactorService: TwoFactorService,
-    protected appIdService: AppIdService
+    protected appIdService: AppIdService,
+    protected loginService: LoginService
   ) {
     super(environmentService, i18nService, platformUtilsService);
     this.webAuthnSupported = this.platformUtilsService.supportsWebAuthn(win);
@@ -204,6 +206,7 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
       return;
     }
     if (this.onSuccessfulLogin != null) {
+      this.loginService.clearValues();
       this.onSuccessfulLogin();
     }
     if (response.resetMasterPassword) {
@@ -213,8 +216,10 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
       this.successRoute = "update-temp-password";
     }
     if (this.onSuccessfulLoginNavigate != null) {
+      this.loginService.clearValues();
       this.onSuccessfulLoginNavigate();
     } else {
+      this.loginService.clearValues();
       this.router.navigate([this.successRoute], {
         queryParams: {
           identifier: this.identifier,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -31,6 +31,7 @@ import { FormValidationErrorsService as FormValidationErrorsServiceAbstraction }
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/abstractions/i18n.service";
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from "@bitwarden/common/abstractions/keyConnector.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
+import { LoginService as LoginServiceAbstraction } from "@bitwarden/common/abstractions/login.service";
 import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/abstractions/messaging.service";
 import { NotificationsService as NotificationsServiceAbstraction } from "@bitwarden/common/abstractions/notifications.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/abstractions/organization/organization-api.service.abstraction";
@@ -86,6 +87,7 @@ import { FolderApiService } from "@bitwarden/common/services/folder/folder-api.s
 import { FolderService } from "@bitwarden/common/services/folder/folder.service";
 import { FormValidationErrorsService } from "@bitwarden/common/services/formValidationErrors.service";
 import { KeyConnectorService } from "@bitwarden/common/services/keyConnector.service";
+import { LoginService } from "@bitwarden/common/services/login.service";
 import { NotificationsService } from "@bitwarden/common/services/notifications.service";
 import { OrganizationApiService } from "@bitwarden/common/services/organization/organization-api.service";
 import { OrganizationService } from "@bitwarden/common/services/organization/organization.service";
@@ -572,6 +574,10 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
       provide: ValidationServiceAbstraction,
       useClass: ValidationService,
       deps: [I18nServiceAbstraction, PlatformUtilsServiceAbstraction],
+    },
+    {
+      provide: LoginServiceAbstraction,
+      useClass: LoginService,
     },
   ],
 })

--- a/libs/common/src/abstractions/login.service.ts
+++ b/libs/common/src/abstractions/login.service.ts
@@ -1,0 +1,6 @@
+export abstract class LoginService {
+  getEmail: () => string;
+  getRememberEmail: () => boolean;
+  setEmail: (value: string) => void;
+  setRememberEmail: (value: boolean) => void;
+}

--- a/libs/common/src/abstractions/login.service.ts
+++ b/libs/common/src/abstractions/login.service.ts
@@ -3,4 +3,5 @@ export abstract class LoginService {
   getRememberEmail: () => boolean;
   setEmail: (value: string) => void;
   setRememberEmail: (value: boolean) => void;
+  clearValues: () => void;
 }

--- a/libs/common/src/services/login.service.ts
+++ b/libs/common/src/services/login.service.ts
@@ -19,4 +19,9 @@ export class LoginService implements LoginServiceAbstraction {
   setRememberEmail(value: boolean) {
     this._rememberEmail = value;
   }
+
+  clearValues() {
+    this._email = null;
+    this._rememberEmail = null;
+  }
 }

--- a/libs/common/src/services/login.service.ts
+++ b/libs/common/src/services/login.service.ts
@@ -1,0 +1,22 @@
+import { LoginService as LoginServiceAbstraction } from "../abstractions/login.service";
+
+export class LoginService implements LoginServiceAbstraction {
+  _email: string;
+  _rememberEmail: boolean;
+
+  getEmail() {
+    return this._email;
+  }
+
+  getRememberEmail() {
+    return this._rememberEmail;
+  }
+
+  setEmail(value: string) {
+    this._email = value;
+  }
+
+  setRememberEmail(value: boolean) {
+    this._rememberEmail = value;
+  }
+}

--- a/libs/common/src/services/login.service.ts
+++ b/libs/common/src/services/login.service.ts
@@ -1,8 +1,8 @@
 import { LoginService as LoginServiceAbstraction } from "../abstractions/login.service";
 
 export class LoginService implements LoginServiceAbstraction {
-  _email: string;
-  _rememberEmail: boolean;
+  private _email: string;
+  private _rememberEmail: boolean;
 
   getEmail() {
     return this._email;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add a new LoginService to persist login form values during navigation to other components to and from the login component.

## Code changes

- **libs/services:** Add LoginService and LoginServiceAbstraction
- **Login Component** Inject LoginService into this component, save the values on navigation, and clear on successful login
- **Hint Component** Inject LoginService to get to refill the email
- **Two Factor Component** Inject LoginService to get to clear the values on successful login

## Screenshots

Desktop:
https://user-images.githubusercontent.com/8926729/198373537-b2059210-50e7-4094-b2e8-7cc7b5464780.mov

Web:
https://user-images.githubusercontent.com/8926729/198374018-8b4674be-3a89-4cb0-8efd-c04e60be708b.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
