### PR TITLE
Use new icon for no item

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/no-items.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/no-items.component.html
@@ -2,7 +2,7 @@
   class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-pt-6 tw-text-center"
 >
   <div class="tw-max-w-sm">
-    <img class="no-items-image" aria-hidden="true" />
+    <bit-icon [icon]="icon" aria-hidden="true"></bit-icon>
     <h3 class="tw-font-semibold">
       <ng-content select="[title]"></ng-content>
     </h3>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/no-items.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/no-items.component.ts
@@ -1,7 +1,11 @@
 import { Component } from "@angular/core";
 
+import { Icons } from "@bitwarden/components";
+
 @Component({
   selector: "sm-no-items",
   templateUrl: "./no-items.component.html",
 })
-export class NoItemsComponent {}
+export class NoItemsComponent {
+  protected icon = Icons.Search;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

After the merge to master the css class `no-items-image` was replaced by the icon directive. Updating secrets manager to use the new way.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
