### PR TITLE
[EC 657] Defect payment method and billing history pages not hidden

### DIFF
--- a/apps/web/src/app/organizations/billing/organization-billing-tab.component.html
+++ b/apps/web/src/app/organizations/billing/organization-billing-tab.component.html
@@ -7,10 +7,20 @@
           <a routerLink="subscription" class="list-group-item" routerLinkActive="active">
             {{ "subscription" | i18n }}
           </a>
-          <a routerLink="payment-method" class="list-group-item" routerLinkActive="active">
+          <a
+            *ngIf="showPaymentAndHistory"
+            routerLink="payment-method"
+            class="list-group-item"
+            routerLinkActive="active"
+          >
             {{ "paymentMethod" | i18n }}
           </a>
-          <a routerLink="history" class="list-group-item" routerLinkActive="active">
+          <a
+            *ngIf="showPaymentAndHistory"
+            routerLink="history"
+            class="list-group-item"
+            routerLinkActive="active"
+          >
             {{ "billingHistory" | i18n }}
           </a>
         </div>

--- a/apps/web/src/app/organizations/billing/organization-billing-tab.component.ts
+++ b/apps/web/src/app/organizations/billing/organization-billing-tab.component.ts
@@ -1,7 +1,14 @@
 import { Component } from "@angular/core";
 
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
+
 @Component({
   selector: "app-org-billing-tab",
   templateUrl: "organization-billing-tab.component.html",
 })
-export class OrganizationBillingTabComponent {}
+export class OrganizationBillingTabComponent {
+  showPaymentAndHistory: boolean;
+  constructor(private platformUtilsService: PlatformUtilsService) {
+    this.showPaymentAndHistory = !this.platformUtilsService.isSelfHost();
+  }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Update the Billing tab so that the Payment Method and Billing History pages are no longer visible for self hosted instances.

## Code changes

- **organization-billing-tab.component.html:** Add flag for rendering the Payment Method and Billing History tabs that depends on the `platformUtilsService.isSelfHost()` method.

## Screenshots
### Self Host Example 
![image](https://user-images.githubusercontent.com/8764515/199117561-a0427809-5e0c-4027-a5e0-78015830c2de.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
