### PR TITLE
[SG-792] Added focus to master password field on browser and desktop

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -8,6 +8,7 @@ on:
       - 'cf-pages'
     paths:
       - 'apps/desktop/**'
+      - 'libs/**'
       - '*'
       - '!*.md'
       - '!*.txt'

--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -16,6 +16,7 @@
               class="monospaced"
               formControlName="masterPassword"
               appInputVerbatim
+              appAutofocus
             />
           </div>
           <div class="action-buttons">

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -275,4 +275,9 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       this.showLoginWithDevice = false;
     }
   }
+
+  protected focusInput() {
+    const email = this.loggedEmail;
+    document.getElementById(email == null || email === "" ? "email" : "masterPassword").focus();
+  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Due to the introduction of the two-step login flow, the clients need to have a `focus` on the master password field.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/accounts/login.component.html** Added the `appAutoFocus` directive to the login template on the browser.
- **apps/desktop/src/app/accounts/login.component.ts:** On the `continue` button, click the `focusInput` method is called to focus on the `masterPassword` field.
- **libs/angular/src/components/login.component.ts:** Removed the `focusInput` method on the base `loginComponent`.

## Screenshots

https://user-images.githubusercontent.com/13024008/199129315-2b8381ab-900b-4e88-9e43-81ef24a26fa1.mov

https://user-images.githubusercontent.com/13024008/199298107-5af285cc-3488-499c-a04e-2487b6ca97b1.mov


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
