### PR TITLE
[CL-62] Fix Content Tab Keyboard Navigation

### DIFF
--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -1,10 +1,12 @@
-import { DialogModule, DialogRef, DIALOG_DATA } from "@angular/cdk/dialog";
+import { DIALOG_DATA, DialogModule, DialogRef } from "@angular/cdk/dialog";
 import { Component, Inject } from "@angular/core";
 import { Meta, moduleMetadata, Story } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 
 import { ButtonModule } from "../button";
+import { IconButtonModule } from "../icon-button";
+import { SharedModule } from "../shared";
 import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { DialogService } from "./dialog.service";
@@ -35,7 +37,7 @@ class StoryDialogComponent {
 @Component({
   selector: "story-dialog-content",
   template: `
-    <bit-dialog [dialogSize]="large">
+    <bit-dialog dialogSize="large">
       <span bitDialogTitle>Dialog Title</span>
       <span bitDialogContent>
         Dialog body text goes here.
@@ -68,7 +70,7 @@ export default {
         DialogTitleContainerDirective,
         StoryDialogContentComponent,
       ],
-      imports: [ButtonModule, DialogModule],
+      imports: [SharedModule, ButtonModule, DialogModule, IconButtonModule],
       providers: [
         DialogService,
         {

--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -1,12 +1,17 @@
 import { DIALOG_DATA, DialogModule, DialogRef } from "@angular/cdk/dialog";
-import { Component, Inject } from "@angular/core";
+import { ComponentType } from "@angular/cdk/overlay";
+import { Component, Inject, Input } from "@angular/core";
+import { action } from "@storybook/addon-actions";
 import { Meta, moduleMetadata, Story } from "@storybook/angular";
+import { firstValueFrom } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 
 import { ButtonModule } from "../button";
+import { FormFieldModule } from "../form-field";
 import { IconButtonModule } from "../icon-button";
 import { SharedModule } from "../shared";
+import { TabsModule } from "../tabs";
 import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { DialogService } from "./dialog.service";
@@ -18,19 +23,28 @@ interface Animal {
   animal: string;
 }
 
+const actionsData = {
+  onDialogClosed: action("onDialogClosed"),
+};
+
 @Component({
   selector: "app-story-dialog",
-  template: `<button bitButton (click)="openDialog()">Open Dialog</button>`,
+  template: `<button bitButton (click)="openDialog()">{{ buttonText }}</button>`,
 })
 class StoryDialogComponent {
+  @Input() dialogContentComponent: ComponentType<unknown> = StoryDialogContentComponent;
+  @Input() buttonText = "Open Dialog";
+
   constructor(public dialogService: DialogService) {}
 
-  openDialog() {
-    this.dialogService.open(StoryDialogContentComponent, {
+  async openDialog() {
+    const ref = this.dialogService.open(this.dialogContentComponent, {
       data: {
         animal: "panda",
       },
     });
+    const result = await firstValueFrom(ref.closed);
+    actionsData.onDialogClosed(result);
   }
 }
 
@@ -59,6 +73,41 @@ class StoryDialogContentComponent {
   }
 }
 
+@Component({
+  selector: "story-tabbed-dialog-content",
+  template: `
+    <bit-dialog dialogSize="large" disablePadding>
+      <span bitDialogTitle>Tabbed Dialog Title</span>
+      <span bitDialogContent>
+        <bit-tab-group>
+          <bit-tab label="First Tab">
+            <p>
+              You can navigate through all tab labels, form inputs, and the dialog controls via the
+              keyboard.
+            </p>
+            <bit-form-field>
+              <bit-label>First Input</bit-label>
+              <input type="text" bitInput />
+            </bit-form-field>
+            <bit-form-field>
+              <bit-label>Second Input</bit-label>
+              <input type="text" bitInput />
+            </bit-form-field>
+          </bit-tab>
+          <bit-tab label="Second Tab">Second Tab Content</bit-tab>
+        </bit-tab-group>
+      </span>
+      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+        <button bitButton buttonType="primary" (click)="dialogRef.close()">Save</button>
+        <button bitButton buttonType="secondary" bitDialogClose>Cancel</button>
+      </div>
+    </bit-dialog>
+  `,
+})
+class StoryTabbedDialogContentComponent {
+  constructor(public dialogRef: DialogRef) {}
+}
+
 export default {
   title: "Component Library/Dialogs/Service",
   component: StoryDialogComponent,
@@ -69,8 +118,16 @@ export default {
         DialogComponent,
         DialogTitleContainerDirective,
         StoryDialogContentComponent,
+        StoryTabbedDialogContentComponent,
       ],
-      imports: [SharedModule, ButtonModule, DialogModule, IconButtonModule],
+      imports: [
+        SharedModule,
+        ButtonModule,
+        DialogModule,
+        IconButtonModule,
+        TabsModule,
+        FormFieldModule,
+      ],
       providers: [
         DialogService,
         {
@@ -97,3 +154,13 @@ const Template: Story<StoryDialogComponent> = (args: StoryDialogComponent) => ({
 });
 
 export const Default = Template.bind({});
+
+const TabbedTemplate: Story<StoryDialogComponent> = (args: StoryDialogComponent) => ({
+  props: {
+    ...args,
+    dialogContentComponent: StoryTabbedDialogContentComponent,
+    buttonText: "Open Tabbed Dialog",
+  },
+});
+
+export const TabbedDialogService = TabbedTemplate.bind({});

--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -32,8 +32,8 @@ const actionsData = {
   template: `<button bitButton (click)="openDialog()">{{ buttonText }}</button>`,
 })
 class StoryDialogComponent {
-  @Input() dialogContentComponent: ComponentType<unknown> = StoryDialogContentComponent;
-  @Input() buttonText = "Open Dialog";
+  @Input() dialogContentComponent: ComponentType<unknown>;
+  @Input() buttonText: string;
 
   constructor(public dialogService: DialogService) {}
 
@@ -150,7 +150,11 @@ export default {
 } as Meta;
 
 const Template: Story<StoryDialogComponent> = (args: StoryDialogComponent) => ({
-  props: args,
+  props: {
+    ...args,
+    dialogContentComponent: StoryDialogContentComponent,
+    buttonText: "Open Dialog",
+  },
 });
 
 export const Default = Template.bind({});
@@ -163,4 +167,4 @@ const TabbedTemplate: Story<StoryDialogComponent> = (args: StoryDialogComponent)
   },
 });
 
-export const TabbedDialogService = TabbedTemplate.bind({});
+export const TabbedContent = TabbedTemplate.bind({});

--- a/libs/components/src/tabs/tab-group/tab-group.component.html
+++ b/libs/components/src/tabs/tab-group/tab-group.component.html
@@ -34,7 +34,6 @@
     role="tabpanel"
     *ngFor="let tab of tabs; let i = index"
     [id]="getTabContentId(i)"
-    [attr.tabindex]="selectedIndex === i ? 0 : -1"
     [attr.labeledby]="getTabLabelId(i)"
     [active]="tab.isActive"
     [content]="tab.content"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix the Content Tab component to support keyboard navigation when placed within a Dialog component. The `tabpanel` does not require a `tabIndex` and was incorrectly being assigned `0` or `-1` depending on the tabs active status. This was preventing the dialog from being fully keyboard accessible in some browsers (Firefox/Safari).

Adds a new DialogService story that provides an example of a Dialog with tabbed content and fixes a few other small bugs in the dialog service stories (missing `SharedModule` and `IconButtonModule` and fixes the dialogSize attribute)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **tab-group.component.html:** Remove the `tabIndex` attribute from the `tabPanel` to avoid interfering with keyboard navigation
- **dialog.service.stories.ts:** Add a new tabbed dialog service story and fix some other storybook bugs.

## Screenshots

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/8764515/199335247-dd3dd7c4-cdf8-40a5-a97f-cd5e6746f978.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
