### PR TITLE
[EC-659] Fix undefined property error in event logs

### DIFF
--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, OnDestroy, OnInit } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { Injectable } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
@@ -10,21 +9,13 @@ import { Policy } from "@bitwarden/common/models/domain/policy";
 import { EventResponse } from "@bitwarden/common/models/response/event.response";
 
 @Injectable()
-export class EventService implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class EventService {
   private policies: Policy[];
 
-  constructor(private i18nService: I18nService, private policyService: PolicyService) {}
-
-  ngOnInit(): void {
-    this.policyService.policies$.pipe(takeUntil(this.destroy$)).subscribe((policies) => {
+  constructor(private i18nService: I18nService, policyService: PolicyService) {
+    policyService.policies$.subscribe((policies) => {
       this.policies = policies;
     });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   getDefaultDateFilters() {


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bug:

> When I try to view event logs for an Organization, I get a red error toast: “this.policies is undefined”. This prevents events from loading.

**This affects rc and the fix will need to be cherry-picked.**

## Code changes

EventService.policies was `undefined` because the service was using ngOnInit to subscribe to the policies observable. However, ngOnInit is for components, not services. We should use the constructor instead and leave the subscription running for the lifetime of the service.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
