### PR TITLE
[SG-797] Fix Safari extension logo height

### DIFF
--- a/apps/browser/src/popup/accounts/home.component.html
+++ b/apps/browser/src/popup/accounts/home.component.html
@@ -1,5 +1,5 @@
 <div class="center-content">
-  <div class="content">
+  <div class="content login-page">
     <div class="logo-image"></div>
     <p class="lead text-center">{{ "loginOrCreateNewAccount" | i18n }}</p>
     <form #form [formGroup]="formGroup" (ngSubmit)="submit()">

--- a/apps/browser/src/popup/scss/environment.scss
+++ b/apps/browser/src/popup/scss/environment.scss
@@ -23,6 +23,12 @@ html.browser_safari {
     }
   }
 
+  .content {
+    &.login-page {
+      padding-top: 100px;
+    }
+  }
+
   app-root {
     border-width: 1px;
     border-style: solid;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix the Bitwarden logo getting cut off on the Safari browser extension

## Code changes

- **apps/browser/src/popup/accounts/home.component.html:** Add `login-page` 
- **apps/browser/src/popup/scss/environment.scss:** Add `login-page` specific rules for `browser_safari`

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/8926729/199567947-4643f539-e2fd-41e1-bbe8-e3b6ddb7932c.png)

After:
![Screen Shot 2022-11-02 at 2 03 08 PM](https://user-images.githubusercontent.com/8926729/199568006-4e58bbd9-d7e0-47fd-8c7c-4c370df52334.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
