### PR TITLE
[SG-798] & [SG-799] Use correct provider icon instead of bank icon

### DIFF
--- a/apps/browser/src/popup/accounts/login.component.html
+++ b/apps/browser/src/popup/accounts/login.component.html
@@ -55,7 +55,7 @@
         <i class="bwi bwi-spinner bwi-lg bwi-spin" [hidden]="!form.loading" aria-hidden="true"></i>
       </button>
       <button type="button" (click)="launchSsoBrowser()" class="btn block">
-        <i class="bwi bwi-bank" aria-hidden="true"></i> {{ "enterpriseSingleSignOn" | i18n }}
+        <i class="bwi bwi-provider" aria-hidden="true"></i> {{ "enterpriseSingleSignOn" | i18n }}
       </button>
       <div class="small">
         <p class="no-margin">{{ "loggingInAs" | i18n }} {{ loggedEmail }}</p>

--- a/apps/desktop/src/app/accounts/login.component.html
+++ b/apps/desktop/src/app/accounts/login.component.html
@@ -132,7 +132,8 @@
               (click)="launchSsoBrowser('desktop', 'bitwarden://sso-callback')"
               class="btn block"
             >
-              <i class="bwi bwi-bank" aria-hidden="true"></i> {{ "enterpriseSingleSignOn" | i18n }}
+              <i class="bwi bwi-provider" aria-hidden="true"></i>
+              {{ "enterpriseSingleSignOn" | i18n }}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Use correct provider icons for login page in Browser and Desktop

## Code changes

- **apps/browser/src/popup/accounts/login.component.html:** `bwi-bank` -> `bwi-provider`
- **apps/desktop/src/app/accounts/login.component.html:** `bwi-bank` -> `bwi-provider`

## Screenshots
![Screen Shot 2022-11-02 at 2 31 44 PM](https://user-images.githubusercontent.com/8926729/199576590-58b8cdd6-b374-409d-9de2-d1d7294ed212.png)

![Screen Shot 2022-11-02 at 2 42 43 PM](https://user-images.githubusercontent.com/8926729/199576604-e7fcc2d9-c6bf-4f23-ac30-24a7f03ee177.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
