### PR TITLE
[PS-1763] - handle undefined locale value in desktop app

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -171,7 +171,7 @@ export class SettingsComponent implements OnInit {
     this.showAlwaysShowDock = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
     this.openAtLogin = await this.stateService.getOpenAtLogin();
 
-    this.locale = await this.stateService.getLocale();
+    this.locale = (await this.stateService.getLocale()) ?? null;
     this.theme = await this.stateService.getTheme();
 
     if ((await this.stateService.getUserId()) == null) {


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If a user has not set their language, the language value in the dropdown on the Preferences page in the desktop app is blank. The fix in this PR will display "Default" in that case instead of blank. 
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- Added nullish coalescing. If the user has not yet set a language, the getLocale function returns `undefined`, but in order to display correctly in the dropdown the locale value must be `null`. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
