### PR TITLE
[SM-330] Disable managed environments for safari

### DIFF
--- a/apps/browser/src/services/browser-environment.service.ts
+++ b/apps/browser/src/services/browser-environment.service.ts
@@ -20,6 +20,10 @@ export class BrowserEnvironmentService extends EnvironmentService {
   }
 
   async settingsHaveChanged() {
+    if (!(await this.hasManagedEnvironment())) {
+      return false;
+    }
+
     const env = await this.getManagedEnvironment();
 
     return (
@@ -37,6 +41,10 @@ export class BrowserEnvironmentService extends EnvironmentService {
     return devFlagEnabled("managedEnvironment")
       ? new Promise((resolve) => resolve(devFlagValue("managedEnvironment")))
       : new Promise((resolve, reject) => {
+          if (chrome.storage.managed == null) {
+            return resolve(null);
+          }
+
           chrome.storage.managed.get("environment", (result) => {
             if (chrome.runtime.lastError) {
               return reject(chrome.runtime.lastError);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Handles the errors caused by the managed environments in Safari. Note, does not solve the bug in EC 661 since the behaiour still occurs.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/services/browser-environment.service.ts:** Added a null check for when managed environments are not available, i.e. returning null. Also resolved an error that could appear in `settingsHaveChanged` by exiting early if there are no managed environments.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
