### PR TITLE
Added appAutofocus to email input

### DIFF
--- a/apps/desktop/src/app/accounts/login.component.html
+++ b/apps/desktop/src/app/accounts/login.component.html
@@ -34,6 +34,7 @@
                 formControlName="email"
                 appInputVerbatim="false"
                 (keyup.enter)="continue()"
+                appAutofocus
               />
             </div>
           </div>


### PR DESCRIPTION
Whenever I try to log in to the Bitwarden Extension, it doesn't automatically focus the `email` input. I added the `appAutofocus` prop to the input so that it auto focuses now