### PR TITLE
[SG-757] Move hint button out of the form field

### DIFF
--- a/apps/web/src/app/accounts/login/login.component.html
+++ b/apps/web/src/app/accounts/login/login.component.html
@@ -72,8 +72,8 @@
 </form>
 
 <ng-template [formGroup]="formGroup" #loginPage>
-  <div class="tw-mb-3">
-    <bit-form-field>
+  <div class="tw-mb-6 tw-h-28">
+    <bit-form-field class="!tw-mb-1">
       <bit-label>{{ "masterPass" | i18n }}</bit-label>
       <input
         id="login_input_master-password"
@@ -89,10 +89,10 @@
           [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
         ></i>
       </button>
-      <bit-hint>
-        <a routerLink="/hint" (click)="setFormValues()">{{ "getMasterPasswordHint" | i18n }}</a>
-      </bit-hint>
     </bit-form-field>
+    <a class="-tw-mt-2" routerLink="/hint" (mousedown)="goToHint()" (click)="setFormValues()">{{
+      "getMasterPasswordHint" | i18n
+    }}</a>
   </div>
 
   <div [hidden]="!showCaptcha()">

--- a/apps/web/src/app/accounts/login/login.component.ts
+++ b/apps/web/src/app/accounts/login/login.component.ts
@@ -184,6 +184,11 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
     }
   }
 
+  goToHint() {
+    this.setFormValues();
+    this.router.navigateByUrl("/hint");
+  }
+
   async submit() {
     const rememberEmail = this.formGroup.value.rememberEmail;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix master password hint not being clickable because of form errors

## Code changes

- **apps/web/src/app/accounts/login/login.component.html:** Move the hint button out of form field and adjust spacing
- **apps/web/src/app/accounts/login/login.component.ts:** Add method for manual navigation

## Screenshots

https://user-images.githubusercontent.com/8926729/199808923-4136f12d-6a54-4382-9e1d-23b81185228b.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
