### PR TITLE
[EC-662] fixed typo in event log

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2487,7 +2487,7 @@
     "message": "Logged in"
   },
   "changedPassword": {
-    "message": "Account password saved"
+    "message": "Changed account password"
   },
   "enabledUpdated2fa": {
     "message": "Two-step login saved"


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

fix typo in event log text

## Code changes



- locales/en/**messages.json:** updated "Account password saved" to "Changed account password"

## Screenshots
<img width="742" alt="Screen Shot 2022-11-03 at 1 11 00 PM" src="https://user-images.githubusercontent.com/43477473/199824241-8bb43b82-d52e-40e0-86f3-00be132ae7c0.png">

## Before you submit
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
