### PR TITLE
[PS-1114] Fix active tab not showing selected while in child route

### DIFF
--- a/apps/web/src/app/organizations/guards/org-redirect.guard.ts
+++ b/apps/web/src/app/organizations/guards/org-redirect.guard.ts
@@ -16,9 +16,12 @@ export class OrganizationRedirectGuard implements CanActivate {
     const org = this.organizationService.get(route.params.organizationId);
 
     const customRedirect = route.data?.autoRedirectCallback;
-    const redirectPath = customRedirect(org);
     if (customRedirect) {
-      return this.router.createUrlTree([state.url, redirectPath]);
+      let redirectPath = customRedirect(org);
+      if (typeof redirectPath === "string") {
+        redirectPath = [redirectPath];
+      }
+      return this.router.createUrlTree([state.url, ...redirectPath]);
     }
     return canAccessOrgAdmin(org)
       ? this.router.createUrlTree(["/organizations", org.id])

--- a/apps/web/src/app/organizations/guards/org-redirect.guard.ts
+++ b/apps/web/src/app/organizations/guards/org-redirect.guard.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@angular/core";
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from "@angular/router";
+
+import {
+  canAccessOrgAdmin,
+  OrganizationService,
+} from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+
+@Injectable({
+  providedIn: "root",
+})
+export class OrganizationRedirectGuard implements CanActivate {
+  constructor(private router: Router, private organizationService: OrganizationService) {}
+
+  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    const org = this.organizationService.get(route.params.organizationId);
+
+    const customRedirect = route.data?.autoRedirectCallback;
+    const redirectPath = customRedirect(org);
+    if (customRedirect) {
+      return this.router.createUrlTree([state.url, redirectPath]);
+    }
+    return canAccessOrgAdmin(org)
+      ? this.router.createUrlTree(["/organizations", org.id])
+      : this.router.createUrlTree(["/"]);
+  }
+}

--- a/apps/web/src/app/organizations/layouts/organization-layout.component.html
+++ b/apps/web/src/app/organizations/layouts/organization-layout.component.html
@@ -8,13 +8,10 @@
       ></app-organization-switcher>
       <bit-tab-nav-bar class="-tw-mb-px">
         <bit-tab-link route="vault">{{ "vault" | i18n }}</bit-tab-link>
-        <bit-tab-link *ngIf="canShowManageTab(organization)" [route]="getManageRoute(organization)">
+        <bit-tab-link *ngIf="canShowManageTab(organization)" route="manage">
           {{ "manage" | i18n }}
         </bit-tab-link>
-        <bit-tab-link
-          *ngIf="canShowReportsTab(organization)"
-          [route]="getReportRoute(organization)"
-        >
+        <bit-tab-link *ngIf="canShowReportsTab(organization)" route="reporting">
           {{ getReportTabLabel(organization) | i18n }}
         </bit-tab-link>
         <bit-tab-link *ngIf="canShowBillingTab(organization)" route="billing">{{

--- a/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/organizations/reporting/organization-reporting-routing.module.ts
@@ -5,6 +5,7 @@ import { canAccessReportingTab } from "@bitwarden/common/abstractions/organizati
 import { Organization } from "@bitwarden/common/models/domain/organization";
 
 import { OrganizationPermissionsGuard } from "../guards/org-permissions.guard";
+import { OrganizationRedirectGuard } from "../guards/org-redirect.guard";
 import { EventsComponent } from "../manage/events.component";
 import { ExposedPasswordsReportComponent } from "../tools/exposed-passwords-report.component";
 import { InactiveTwoFactorReportComponent } from "../tools/inactive-two-factor-report.component";
@@ -22,7 +23,15 @@ const routes: Routes = [
     canActivate: [OrganizationPermissionsGuard],
     data: { organizationPermissions: canAccessReportingTab },
     children: [
-      { path: "", pathMatch: "full", redirectTo: "reports" },
+      {
+        path: "",
+        pathMatch: "full",
+        canActivate: [OrganizationRedirectGuard],
+        data: {
+          autoRedirectCallback: getReportRoute,
+        },
+        children: [], // This is required to make the auto redirect work,
+      },
       {
         path: "reports",
         component: ReportsHomeComponent,
@@ -80,6 +89,20 @@ const routes: Routes = [
     ],
   },
 ];
+
+function getReportRoute(organization: Organization): string {
+  let route: string;
+  switch (true) {
+    case organization.canAccessEventLogs:
+      route = "events";
+      break;
+    case organization.canAccessReports:
+      route = "reports";
+      break;
+  }
+  return route;
+}
+
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],

--- a/apps/web/src/app/organizations/reporting/reporting.component.ts
+++ b/apps/web/src/app/organizations/reporting/reporting.component.ts
@@ -22,7 +22,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
       .pipe(
         concatMap(async (params) => {
           this.organization = await this.organizationService.get(params.organizationId);
-          this.showLeftNav = this.organization.canAccessEventLogs;
+          this.showLeftNav =
+            this.organization.canAccessEventLogs && this.organization.canAccessReports;
         }),
         takeUntil(this.destroy$)
       )

--- a/apps/web/src/app/organizations/settings/organization-settings-routing.module.ts
+++ b/apps/web/src/app/organizations/settings/organization-settings-routing.module.ts
@@ -5,6 +5,7 @@ import { canAccessSettingsTab } from "@bitwarden/common/abstractions/organizatio
 import { Organization } from "@bitwarden/common/models/domain/organization";
 
 import { OrganizationPermissionsGuard } from "../guards/org-permissions.guard";
+import { OrganizationRedirectGuard } from "../guards/org-redirect.guard";
 import { PoliciesComponent } from "../policies";
 
 import { AccountComponent } from "./account.component";
@@ -18,7 +19,15 @@ const routes: Routes = [
     canActivate: [OrganizationPermissionsGuard],
     data: { organizationPermissions: canAccessSettingsTab },
     children: [
-      { path: "", pathMatch: "full", redirectTo: "account" },
+      {
+        path: "",
+        pathMatch: "full",
+        canActivate: [OrganizationRedirectGuard],
+        data: {
+          autoRedirectCallback: getSettingsRoute,
+        },
+        children: [], // This is required to make the auto redirect work,
+      },
       { path: "account", component: AccountComponent, data: { titleId: "organizationInfo" } },
       {
         path: "two-factor",
@@ -44,6 +53,28 @@ const routes: Routes = [
     ],
   },
 ];
+
+function getSettingsRoute(organization: Organization) {
+  let route: string | string[];
+  switch (true) {
+    case organization.isOwner:
+      route = "account";
+      break;
+    case organization.canManagePolicies:
+      route = "policies";
+      break;
+    case organization.canAccessImportExport:
+      route = ["tools", "import"];
+      break;
+    case organization.canManageSso:
+      route = "sso";
+      break;
+    case organization.canManageScim:
+      route = "scim";
+      break;
+  }
+  return route;
+}
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/apps/web/src/app/organizations/settings/settings.component.html
+++ b/apps/web/src/app/organizations/settings/settings.component.html
@@ -4,7 +4,12 @@
       <div class="card">
         <div class="card-header">{{ "settings" | i18n }}</div>
         <div class="list-group list-group-flush">
-          <a routerLink="account" class="list-group-item" routerLinkActive="active">
+          <a
+            routerLink="account"
+            class="list-group-item"
+            routerLinkActive="active"
+            *ngIf="organization?.isOwner"
+          >
             {{ "organizationInfo" | i18n }}
           </a>
           <a
@@ -19,7 +24,7 @@
             routerLink="two-factor"
             class="list-group-item"
             routerLinkActive="active"
-            *ngIf="organization?.use2fa"
+            *ngIf="organization?.use2fa && organization?.isOwner"
           >
             {{ "twoStepLogin" | i18n }}
           </a>

--- a/libs/common/src/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/abstractions/organization/organization.service.abstraction.ts
@@ -9,7 +9,13 @@ export function canAccessVaultTab(org: Organization): boolean {
 }
 
 export function canAccessSettingsTab(org: Organization): boolean {
-  return org.isOwner;
+  return (
+    org.isOwner ||
+    org.canManagePolicies ||
+    org.canManageSso ||
+    org.canManageScim ||
+    org.canAccessImportExport
+  );
 }
 
 export function canAccessMembersTab(org: Organization): boolean {

--- a/libs/components/src/tabs/tab-nav-bar/tab-link.component.html
+++ b/libs/components/src/tabs/tab-nav-bar/tab-link.component.html
@@ -2,6 +2,7 @@
   bitTabListItem
   [routerLink]="disabled ? null : route"
   routerLinkActive
+  [routerLinkActiveOptions]="routerLinkMatchOptions"
   #rla="routerLinkActive"
   [active]="rla.isActive"
   [disabled]="disabled"

--- a/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
@@ -1,6 +1,6 @@
 import { FocusableOption } from "@angular/cdk/a11y";
 import { AfterViewInit, Component, HostListener, Input, OnDestroy, ViewChild } from "@angular/core";
-import { RouterLinkActive } from "@angular/router";
+import { IsActiveMatchOptions, RouterLinkActive } from "@angular/router";
 import { Subject, takeUntil } from "rxjs";
 
 import { TabListItemDirective } from "../shared/tab-list-item.directive";
@@ -16,6 +16,13 @@ export class TabLinkComponent implements FocusableOption, AfterViewInit, OnDestr
 
   @ViewChild(TabListItemDirective) tabItem: TabListItemDirective;
   @ViewChild("rla") routerLinkActive: RouterLinkActive;
+
+  readonly routerLinkMatchOptions: IsActiveMatchOptions = {
+    queryParams: "ignored",
+    matrixParams: "ignored",
+    paths: "subset",
+    fragment: "ignored",
+  };
 
   @Input() route: string;
   @Input() disabled = false;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The active tab in the org vault was not showing as selected when a child route active. 

**Problem**
This was caused by giving each tab a specific route based off which routes were available as children. Ex. "manage" became "manage/members". The tab didn't recognize that other child routes, such as "manage/collections" were also under the current route, and deselected the tab.
**Solution**
In order to fix this, we had to stop setting the tab route dynamically and give it the correct route ("manage"), we then added options to make the tab active if it was a subset of the current route.

**Problem**
This caused a secondary problem where the route guard tried to redirect us to the first child component ("manage/members"), and if we didn't have the permissions to access it, it would deny us access and redirect us back to the  home page.
**Solution**
We created a new route guard called `OrganizationRedirectGuard`. This guard allowed us to place a callback on the base route ("manage") and dynamically redirected us to the first _available_ child route ("manage/collections"). 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **org-redirect.guard.ts:** new guard to redirect us to the correct child route based on permissions
- **organization-layout.component.html:** remove dynamically setting the route based on permission and hardcode it instead
- **settings.component.html:** hide 2fa and organization info in settings if the user is not an owner
- **tab-link.component.ts:** make `tab-link` active link check for a subset of the current route 
- **reporting.component.ts:** only show the left nav if user can access both reporting and events

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
**Before**
![image](https://user-images.githubusercontent.com/24985544/199830884-850453c8-4535-45e0-a7fa-a8eaff5e2ba0.png)

**After**
![image](https://user-images.githubusercontent.com/24985544/199830092-d655257a-2c70-42a7-8213-8d7756b454b3.png)




## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
