### PR TITLE
add csp and only pass hostname to duo init

### DIFF
--- a/apps/web/src/connectors/duo.html
+++ b/apps/web/src/connectors/duo.html
@@ -6,6 +6,10 @@
       name="viewport"
       content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com;"
+    />
     <title>Bitwarden Duo Connector</title>
   </head>
 

--- a/apps/web/src/connectors/duo.html
+++ b/apps/web/src/connectors/duo.html
@@ -8,7 +8,7 @@
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com;"
+      content="default-src 'self'; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com;"
     />
     <title>Bitwarden Duo Connector</title>
   </head>

--- a/apps/web/src/connectors/duo.html
+++ b/apps/web/src/connectors/duo.html
@@ -8,7 +8,7 @@
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com;"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com;"
     />
     <title>Bitwarden Duo Connector</title>
   </head>

--- a/apps/web/src/connectors/duo.ts
+++ b/apps/web/src/connectors/duo.ts
@@ -23,7 +23,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   DuoWebSDK.init({
     iframe: "duo_iframe",
-    host: hostParam,
+    host: hostUrl.hostname,
     sig_request: requestParam,
     submit_callback: (form: any) => {
       invokeCSCode(form.elements.sig_response.value);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Prevent iframe src loads invoked by Duo Web SDK `init` from executing hostnames outside of Duo trusted domains.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **duo.html:** Add CSP limited to duo hostnames.
- **duo.ts:** Only pass hostname value of the parsed `host` parameter.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
