### PR TITLE
[EC-675] Display the Event for “Viewed Card Number for item item-identifier”

### DIFF
--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -138,6 +138,13 @@ export class EventService {
           this.getShortId(ev.cipherId)
         );
         break;
+      case EventType.Cipher_ClientToggledCardNumberVisible:
+        msg = this.i18nService.t("viewedCardNumberItemId", this.formatCipherId(ev, options));
+        humanReadableMsg = this.i18nService.t(
+          "viewedCardNumberItemId",
+          this.getShortId(ev.cipherId)
+        );
+        break;
       case EventType.Cipher_ClientToggledCardCodeVisible:
         msg = this.i18nService.t("viewedSecurityCodeItemId", this.formatCipherId(ev, options));
         humanReadableMsg = this.i18nService.t(

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2596,6 +2596,15 @@
       }
     }
   },
+  "viewedCardNumberItemId": {
+    "message": "Viewed Card Number for item $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "Google"
+      }
+    }
+  },
   "viewedSecurityCodeItemId": {
     "message": "Viewed security code for item $ID$.",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2601,7 +2601,7 @@
     "placeholders": {
       "id": {
         "content": "$1",
-        "example": "Google"
+        "example": "Unique ID"
       }
     }
   },

--- a/libs/angular/src/components/view.component.ts
+++ b/libs/angular/src/components/view.component.ts
@@ -257,7 +257,7 @@ export class ViewComponent implements OnDestroy, OnInit {
 
     this.showCardNumber = !this.showCardNumber;
     if (this.showCardNumber) {
-      this.eventService.collect(EventType.Cipher_ClientToggledCardCodeVisible, this.cipherId);
+      this.eventService.collect(EventType.Cipher_ClientToggledCardNumberVisible, this.cipherId);
     }
   }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The Event “Viewed Card Number for item item-identifier” is not being displayed on the Events logs list.

## Code changes

This pull request has related changes on [this server pull request](https://github.com/bitwarden/server/pull/2381).

- **apps/web/src/app/core/event.service.ts:** Added missing enum to display text for card view event
- **apps/web/src/locales/en/messages.json:** Added message for “Viewed Card Number for item item-identifier”
- **libs/angular/src/components/view.component.ts:** Fixed clients to capture correct event type 'Cipher_ClientToggledCardNumberVisible'

## Screenshots

<img width="741" alt="image" src="https://user-images.githubusercontent.com/108268980/200002738-f6813822-36b0-4510-bce5-596e1757ccab.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
