### PR TITLE
[PS-1804] Display Organization tab for users with custom permissions

### DIFF
--- a/libs/common/src/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/abstractions/organization/organization.service.abstraction.ts
@@ -48,7 +48,8 @@ export function canAccessOrgAdmin(org: Organization): boolean {
     canAccessReportingTab(org) ||
     canAccessBillingTab(org) ||
     canAccessSettingsTab(org) ||
-    canAccessVaultTab(org)
+    canAccessVaultTab(org) ||
+    canAccessManageTab(org)
   );
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

**This fix will need to be cherry picked to `rc`**

The Organization tab was not being displayed for custom users with manage groups, users, or assigned collections permissions. When the Manage tab was re-added for OAVR V1, the `canAccessOrgAdmin` helper was not updated to check for the Manage tab, and this PR corrects that.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organization.service.abstraction.ts:** Check if the user can access the manageTab when determining if they can access the org admin console.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
