### PR TITLE
[EC-661] Add web worker code bundles to Safari browser extension

### DIFF
--- a/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
+++ b/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03100CAF291891F4008E14EF /* encrypt-worker.js in Resources */ = {isa = PBXBuildFile; fileRef = 03100CAE291891F4008E14EF /* encrypt-worker.js */; };
 		55E0374D2577FA6B00979016 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E0374C2577FA6B00979016 /* AppDelegate.swift */; };
 		55E037502577FA6B00979016 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55E0374E2577FA6B00979016 /* Main.storyboard */; };
 		55E037522577FA6B00979016 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E037512577FA6B00979016 /* ViewController.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		03100CAE291891F4008E14EF /* encrypt-worker.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "encrypt-worker.js"; path = "../../../build/encrypt-worker.js"; sourceTree = "<group>"; };
 		5508DD7926051B5900A85C58 /* libswiftAppKit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftAppKit.tbd; path = usr/lib/swift/libswiftAppKit.tbd; sourceTree = SDKROOT; };
 		55E037482577FA6B00979016 /* desktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = desktop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		55E0374B2577FA6B00979016 /* desktop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = desktop.entitlements; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 		55E0376F2577FA6F00979016 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				03100CAE291891F4008E14EF /* encrypt-worker.js */,
 				55E037702577FA6F00979016 /* popup */,
 				55E037712577FA6F00979016 /* background.js */,
 				55E037722577FA6F00979016 /* images */,
@@ -263,6 +266,7 @@
 				55E037802577FA6F00979016 /* background.html in Resources */,
 				55E0377A2577FA6F00979016 /* background.js in Resources */,
 				55E037792577FA6F00979016 /* popup in Resources */,
+				03100CAF291891F4008E14EF /* encrypt-worker.js in Resources */,
 				55E0377C2577FA6F00979016 /* notification in Resources */,
 				55E0377E2577FA6F00979016 /* vendor.js in Resources */,
 				55E0377D2577FA6F00979016 /* content in Resources */,

--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -138,6 +138,7 @@ const config = {
     "content/contextMenuHandler": "./src/content/contextMenuHandler.ts",
     "content/message_handler": "./src/content/message_handler.ts",
     "notification/bar": "./src/notification/bar.js",
+    "encrypt-worker": "../../libs/common/src/services/cryptography/encrypt.worker.ts",
   },
   optimization: {
     minimize: ENV !== "development",

--- a/libs/common/src/services/cryptography/multithread-encrypt.service.implementation.ts
+++ b/libs/common/src/services/cryptography/multithread-encrypt.service.implementation.ts
@@ -33,7 +33,11 @@ export class MultithreadEncryptServiceImplementation extends EncryptServiceImple
     this.logService.info("Starting decryption using multithreading");
 
     this.worker ??= new Worker(
-      new URL("@bitwarden/common/services/cryptography/encrypt.worker.ts", import.meta.url)
+      new URL(
+        /* webpackChunkName: 'encrypt-worker' */
+        "@bitwarden/common/services/cryptography/encrypt.worker.ts",
+        import.meta.url
+      )
     );
 
     this.restartTimeout();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the vault not loading on the Safari browser extension.

**This will need to be cherry-picked into rc**

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This was caused by the web workers changes. `libs/common/services/cryptography/encrypt.worker.ts` was being split by webpack into 2 files (named 447.js and 800.js), which were not included in the Xcode project (`desktop.xcodeproj`) used to bundle the app extension. As a result, Safari couldn't find them when the dynamic imports were evaluated at runtime.

To fix this I have:
* added `encrypt.worker.ts` as an explicit entrypoint in `webpack.config.js`, and also annotated the import statement with a [magic comment](https://webpack.js.org/api/module-methods/#magic-comments). The effect of this is that it the web worker code is bundled exactly once into a file called `encrypt-worker.js`. This is important because the Xcode project needs a stable file to refer to, it can't be changing based on path name, hash, filesize, etc.
  * I tried several variations on this: entrypoint only (bundled worker code twice), comment only (didn't bundle twice, but still resulted in the worker code being split), `cacheGroup` settings (no discernible effect), reading tea leaves, astrology, etc etc
  * other clients will process this comment as well, but that will just change the name of the chunk, no big deal. Nonetheless I will have QA do a quick smoke test on all clients to make sure
* added the output file, `encrypt-worker.js`, to the Safari Xcode project. It points to the file in the `build` dir, as with the other files in this project. It is under the Resources group in Xcode with other source files:

![Screen Shot 2022-11-07 at 11 11 39 am](https://user-images.githubusercontent.com/31796059/200207964-f2517030-64ff-4d8d-8679-a70606d244d1.png)

Running `npm run dist:safari` now works for me, although QA will test with the proper build artifact (bundled with desktop).

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
