### PR TITLE
Extract and fix trigger for PR auto responses (Translation-PRs)

### DIFF
--- a/.github/workflows/automatic-issue-responses.yml
+++ b/.github/workflows/automatic-issue-responses.yml
@@ -1,5 +1,5 @@
 ---
-name: Automatic responses
+name: Automatic issue responses
 on:
   issues:
     types:
@@ -62,14 +62,3 @@ jobs:
             As we haven’t heard from you about this problem in some time, this issue will now be closed.
 
             If this happens again or continues to be an problem, please respond to this issue with any additional detail to assist with reproduction and root cause analysis.
-      # Translation PR / Crowdin
-      - if: github.event.label.name == 'translation-pr'
-        name: Translation-PR
-        uses: peter-evans/close-issue@849549ba7c3a595a064c4b2c56f206ee78f93515  # v2.0.0
-        with:
-          comment: |
-            We really appreciate you taking the time to improve our translations.
-            
-            However we use a translation tool called [Crowdin](https://crowdin.com/) to help manage our localization efforts across many different languages. Our translations can only be updated using Crowdin, so we'll have to close this PR, but would really appreciate if you'd consider joining our awesome translation community over at Crowdin.
-            
-            More information can be found in the [localization section](https://contributing.bitwarden.com/contributing/#localization-l10n) of our [Contribution Guidelines](https://contributing.bitwarden.com/contributing/)

--- a/.github/workflows/automatic-pull-request-responses.yml
+++ b/.github/workflows/automatic-pull-request-responses.yml
@@ -9,7 +9,7 @@ jobs:
     name: 'Close pull request with automatic response'
     runs-on: ubuntu-20.04
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       # Translation PR / Crowdin
       - if: github.event.label.name == 'translation-pr'

--- a/.github/workflows/automatic-pull-request-responses.yml
+++ b/.github/workflows/automatic-pull-request-responses.yml
@@ -1,0 +1,24 @@
+---
+name: Automatic pull request responses
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  close-issue:
+    name: 'Close pull request with automatic response'
+    runs-on: ubuntu-20.04
+    permissions:
+      issues: write
+    steps:
+      # Translation PR / Crowdin
+      - if: github.event.label.name == 'translation-pr'
+        name: Translation-PR
+        uses: peter-evans/close-issue@849549ba7c3a595a064c4b2c56f206ee78f93515  # v2.0.0
+        with:
+          comment: |
+            We really appreciate you taking the time to improve our translations.
+            
+            However we use a translation tool called [Crowdin](https://crowdin.com/) to help manage our localization efforts across many different languages. Our translations can only be updated using Crowdin, so we'll have to close this PR, but would really appreciate if you'd consider joining our awesome translation community over at Crowdin.
+            
+            More information can be found in the [localization section](https://contributing.bitwarden.com/contributing/#localization-l10n) of our [Contribution Guidelines](https://contributing.bitwarden.com/contributing/)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
I previously added a workflow (#3730) to close **Community**-PRs that contains translations. Once labelled with `translation-pr` it was expected that those PRs got closed with a nice response to the contributor.

Today we received our first [PR](https://github.com/bitwarden/clients/pull/3991) where I added the label, but the job did not trigger. I figured out that the trigger was only operating on issues and not on pull-requests. [Documentation here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)

Instead of just adding the trigger, I decided to extract this into a separate workflow.

## Code changes

- **.github/workflows/automatic-issue-responses.yml:** Extended workflow name to differentiate between issues and pull request activated workflows.
- **.github/workflows/automatic-pull-request-responses.yml:** Move pull request workflow into a separate file

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
