### PR TITLE
[PS-1829] Fix Service Worker Startup in MV3

### DIFF
--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -218,7 +218,6 @@ const mainConfig = {
 const configs = [];
 
 if (manifestVersion == 2) {
-  // We can have another cacheGroup in MV2 but this breaks MV3
   mainConfig.optimization.splitChunks.cacheGroups.commons2 = {
     test: /[\\/]node_modules[\\/]/,
     name: "vendor",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Service workers are unable to finish startup and therefore they won't work at all. This is because of the code webpack was generating after #3043 but this fixes that by targeting web worker for background in MV3 which is something that should probably happen regardless. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* Removed unneeded plugin from shared main config
* Added plugin back behind MV2 check
* Added background entry behind MV2 check
* Added totally new config for MV3 behind check
* Target `webworker` for MV3 background
* Export array of configs

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
