### PR TITLE
[EC-670] Update Members tab to support flex wrap

### DIFF
--- a/apps/web/src/app/organizations/manage/people.component.html
+++ b/apps/web/src/app/organizations/manage/people.component.html
@@ -1,6 +1,8 @@
-<div class="page-header d-flex">
-  <h1>{{ "members" | i18n }}</h1>
-  <div class="ml-auto d-flex">
+<div
+  class="-tw-mt-2 tw-mb-2 tw-flex tw-flex-wrap tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300 tw-pb-2.5"
+>
+  <h1 class="tw-mt-2 tw-mb-0 tw-grow tw-pr-3">{{ "members" | i18n }}</h1>
+  <div class="tw-mt-2 tw-flex tw-justify-start tw-space-x-3">
     <div class="btn-group btn-group-sm" role="group">
       <button
         type="button"
@@ -39,7 +41,7 @@
         <span bitBadge badgeType="info" *ngIf="revokedCount">{{ revokedCount }}</span>
       </button>
     </div>
-    <div class="ml-3">
+    <div class="tw-w-44">
       <label class="sr-only" for="search">{{ "search" | i18n }}</label>
       <input
         type="search"
@@ -49,7 +51,7 @@
         [(ngModel)]="searchText"
       />
     </div>
-    <div class="dropdown ml-3" appListDropdown>
+    <div class="dropdown" appListDropdown>
       <button
         class="btn btn-sm btn-outline-secondary dropdown-toggle"
         type="button"
@@ -98,7 +100,7 @@
         </button>
       </div>
     </div>
-    <button type="button" class="btn btn-sm btn-outline-primary ml-3" (click)="invite()">
+    <button type="button" class="btn btn-sm btn-outline-primary" (click)="invite()">
       <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
       {{ "inviteUser" | i18n }}
     </button>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Changing the text from "People" to "Members" caused the page heading to stack and remove spacing between elements. A solution was to update the page to use Tailwind classes to style the Members page header so that it supports wrapping the controls to a new line should they exceed the width of the container.

> Note: The rest of this page will be updated in OAVR V2.

## Code changes

- **people.component.html:** Use tailwind classes to style the page header
  - Replace `page-header d-flex` with Tailwind classes for border, margin, and flex
  - Have the `<h1>Members</h1>` tag grow to fill container width with right padding to ensure it never gets squished against the toggle controls.
  - Wrap the controls in their own flex container with spacing and top margin
  - Add fixed width to the search control as it was being sized differently between FF and Chromium
  - Remove margins on control items as its now taken care of via `tw-space-x-3`

## Screenshots

### No Line Wrap
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/8764515/200425666-8d85d2ee-accd-4fd3-830d-8aa18bd6eb44.png">

### With Line Wrap (caused by larger badges)
<img width="1014" alt="image" src="https://user-images.githubusercontent.com/8764515/200426264-c6ffbd0d-2a49-4810-a066-0f249b151599.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
