### PR TITLE
[EC-650] Revert observable usage from ImportComponent

### DIFF
--- a/apps/web/src/app/tools/import-export/import.component.html
+++ b/apps/web/src/app/tools/import-export/import.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h1>{{ "importData" | i18n }}</h1>
 </div>
-<app-callout type="info" *ngIf="importBlockedByPolicy$ | async">
+<app-callout type="info" *ngIf="importBlockedByPolicy">
   {{ "personalOwnershipPolicyInEffectImports" | i18n }}
 </app-callout>
 <form #form (ngSubmit)="submit()" ngNativeValidate>
@@ -14,7 +14,7 @@
           name="Format"
           [(ngModel)]="format"
           class="form-control"
-          [disabled]="importBlockedByPolicy$ | async"
+          [disabled]="importBlockedByPolicy"
           required
         >
           <option *ngFor="let o of featuredImportOptions" [ngValue]="o.id">{{ o.name }}</option>
@@ -296,7 +296,7 @@
           id="file"
           class="form-control-file"
           name="file"
-          [disabled]="importBlockedByPolicy$ | async"
+          [disabled]="importBlockedByPolicy"
         />
       </div>
     </div>
@@ -308,14 +308,14 @@
       class="form-control"
       name="FileContents"
       [(ngModel)]="fileContents"
-      [disabled]="importBlockedByPolicy$ | async"
+      [disabled]="importBlockedByPolicy"
     ></textarea>
   </div>
   <button
     type="submit"
     class="btn btn-primary btn-submit"
-    [disabled]="loading || (importBlockedByPolicy$ | async)"
-    [ngClass]="{ manual: importBlockedByPolicy$ | async }"
+    [disabled]="loading || importBlockedByPolicy"
+    [ngClass]="{ manual: importBlockedByPolicy }"
   >
     <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
     <span>{{ "importData" | i18n }}</span>


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The import button was not correctly displaying the loading animation. These changes revert the observable usage as that was possibly being blocked by the import.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/tools/import-export/import.component.html:** Updated variable name reference and removed async
- **apps/web/src/app/tools/import-export/import.component.ts:** Reverted observable usage

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
