### PR TITLE
[PS-1840] - fix for covered dropdown on empty vault

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -135,9 +135,9 @@ p.lead {
   border-radius: $border-radius;
 }
 
-.z10 {
+.select-index-top {
   position: relative;
-  z-index: 10;
+  z-index: 100;
 }
 
 .sr-only {

--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -135,6 +135,11 @@ p.lead {
   border-radius: $border-radius;
 }
 
+.z10 {
+  position: relative;
+  z-index: 10;
+}
+
 .sr-only {
   position: absolute !important;
   width: 1px !important;

--- a/apps/browser/src/popup/vault/vault-filter.component.html
+++ b/apps/browser/src/popup/vault/vault-filter.component.html
@@ -23,7 +23,10 @@
   </div>
 </header>
 <main tabindex="-1" cdk-scrollable>
-  <app-vault-select (onVaultSelectionChanged)="vaultFilterChanged()" class="z10"></app-vault-select>
+  <app-vault-select
+    (onVaultSelectionChanged)="vaultFilterChanged()"
+    class="select-index-top"
+  ></app-vault-select>
   <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
     <i class="bwi bwi-spinner bwi-spin bwi-3x" *ngIf="!loaded"></i>
     <ng-container *ngIf="loaded">

--- a/apps/browser/src/popup/vault/vault-filter.component.html
+++ b/apps/browser/src/popup/vault/vault-filter.component.html
@@ -23,7 +23,7 @@
   </div>
 </header>
 <main tabindex="-1" cdk-scrollable>
-  <app-vault-select (onVaultSelectionChanged)="vaultFilterChanged()"></app-vault-select>
+  <app-vault-select (onVaultSelectionChanged)="vaultFilterChanged()" class="z10"></app-vault-select>
   <div class="no-items" *ngIf="(!ciphers || !ciphers.length) && !showSearching()">
     <i class="bwi bwi-spinner bwi-spin bwi-3x" *ngIf="!loaded"></i>
     <ng-container *ngIf="loaded">


### PR DESCRIPTION
This could be done a number of ways. I think this might be the least problematic, but could also be done by just changing "position: absolute" to "relative on the ".no-items" class - misc.css:138 I'm unable to load the spinner to test this method since the style rules are linked.

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

.no-items element in the empty vault was overlapping the select box above it rendering it unclickable on the right side. Adding a z-index to the select box container fixed the issue.

## Code changes

classed the container with z10 and added appropriate styles to misc.css:138 of:
.z10 {
position: relative;
z-index: 10;
}

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
