### PR TITLE
Expand serve origin protection warning

### DIFF
--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -478,7 +478,7 @@ export class Program extends BaseProgram {
       .option("--port <port>", "The port to run your API webserver on.")
       .option(
         "--disable-origin-protection",
-        "If set, allows requests with origin header. Not recommended!"
+        "If set, allows requests with origin header. Warning, this option exists for backwards compatibility reasons and exposes your environment to known CSRF attacks."
       )
       .on("--help", () => {
         writeLn("\n  Notes:");


### PR DESCRIPTION
This warning was kept vague during fix rollout, but now that we're more than a release past, we can expand the explanation.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

cli-v2022.9.0 updated defaults to the `serve` command which closed a CSRF vulnerability in the command. An option was included to allow for backwards compatibility in non-standard deployments, but the explanation was left relatively terse in hopes to give people a chance to update without too many hints on how to exploit.

This PR expands the warning message to explain why it is probably a bad idea to disable origin protection.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
