### PR TITLE
[PS-1856] Added Mastodon to follow us menu

### DIFF
--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -126,6 +126,11 @@ export class HelpMenu implements IMenubarMenu {
         label: "GitHub",
         click: () => shell.openExternal("https://github.com/bitwarden"),
       },
+      {
+        id: "mastodon",
+        label: "Mastodon",
+        click: () => shell.openExternal("https://fosstodon.org/@bitwarden"),
+      },
     ];
   }
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ x ] Other
```

## Objective

Add Mastodon to the Help -> Follow Us menu in the desktop app

## Code changes

- **apps/desktop/src/main/menu/menu.help.ts:** Added section for Mastodon

## Screenshots

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/7056951/201071025-e3a38e2c-8642-4d89-ba77-bb5ac0df6f2c.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required) - N/A
- If this change requires a **documentation update** - notify the documentation team - N/A
- If this change has particular **deployment requirements** - notify the DevOps team - N/A
