### PR TITLE
Defect/sg 650 desktop pw gen not auto updating on param change

### DIFF
--- a/apps/desktop/src/app/vault/generator.component.html
+++ b/apps/desktop/src/app/vault/generator.component.html
@@ -268,7 +268,7 @@
                     type="number"
                     min="0"
                     max="9"
-                    (blur)="savePasswordOptions()"
+                    (change)="savePasswordOptions()"
                     [(ngModel)]="passwordOptions.minNumber"
                   />
                 </div>
@@ -279,7 +279,7 @@
                     type="number"
                     min="0"
                     max="9"
-                    (blur)="savePasswordOptions()"
+                    (change)="savePasswordOptions()"
                     [(ngModel)]="passwordOptions.minSpecial"
                   />
                 </div>

--- a/apps/desktop/src/app/vault/generator.component.html
+++ b/apps/desktop/src/app/vault/generator.component.html
@@ -151,7 +151,7 @@
                   type="number"
                   min="3"
                   max="20"
-                  (blur)="savePasswordOptions()"
+                  (change)="savePasswordOptions()"
                   [(ngModel)]="passwordOptions.numWords"
                 />
               </div>


### PR DESCRIPTION
Desktop - Pw/Passphrase Generation - Min value ctrls use (change) instead of (blur) for better responsiveness when using arrows on input or arrow keys. This makes Desktop consistent with the browser extension, but the web vault uses (blur) still. 

Note: (input) has change detection issues for resetting the value to either max pw length or max value of 9.  (input) is also not used in other clients.  
Note 2: The passwordGeneration.service logic possibly needs refactoring to either enforce max of 9 or not

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Desktop Password / Passphrase generation min # or min special character inputs needed new event handlers to be more responsive to user changes. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **clients/apps/desktop/src/app/vault/generator.component.html** Changed (blur) to (change) for better password / passphrase generation responsiveness

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
