### PR TITLE
SG-428 - Browser Extension - Send - Expiration / Deletion date calendar icon +…

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -104,6 +104,19 @@ input[type*="date"] {
   }
 }
 
+::-webkit-calendar-picker-indicator {
+  @include themify($themes) {
+    filter: themed("webkitCalendarPickerFilter");
+  }
+}
+
+::-webkit-calendar-picker-indicator:hover {
+  @include themify($themes) {
+    filter: themed("webkitCalendarPickerHoverFilter");
+  }
+  cursor: pointer;
+}
+
 select {
   width: 100%;
   padding: 0.35rem;

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -98,6 +98,12 @@ button {
   font-family: $font-family-sans-serif;
 }
 
+input[type*="date"] {
+  @include themify($themes) {
+    color-scheme: themed("dateInputColorScheme");
+  }
+}
+
 select {
   width: 100%;
   padding: 0.35rem;

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -114,6 +114,7 @@ $themes: (
     toastTextColor: #ffffff,
     svgSuffix: "-light.svg",
     transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: light,
   ),
   dark: (
     textColor: #ffffff,
@@ -168,6 +169,7 @@ $themes: (
     toastTextColor: #1f242e,
     svgSuffix: "-dark.svg",
     transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: dark,
   ),
   nord: (
     textColor: $nord5,
@@ -222,6 +224,7 @@ $themes: (
     toastTextColor: #ffffff,
     svgSuffix: "-dark.svg",
     transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: dark,
   ),
   solarizedDark: (
     textColor: $solarizedDarkBase2,
@@ -276,6 +279,7 @@ $themes: (
     toastTextColor: #ffffff,
     svgSuffix: "-solarized.svg",
     transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: dark,
   ),
 );
 

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -115,6 +115,11 @@ $themes: (
     svgSuffix: "-light.svg",
     transparentColor: rgba(0, 0, 0, 0),
     dateInputColorScheme: light,
+    // https://stackoverflow.com/a/53336754
+    webkitCalendarPickerFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
+      brightness(85%) contrast(103%),
+    webkitCalendarPickerHoverFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
+      brightness(85%) contrast(103%) // light has no hover so use same color,
   ),
   dark: (
     textColor: #ffffff,
@@ -170,6 +175,11 @@ $themes: (
     svgSuffix: "-dark.svg",
     transparentColor: rgba(0, 0, 0, 0),
     dateInputColorScheme: dark,
+    // https://stackoverflow.com/a/53336754 - must prepend brightness(0) saturate(100%) to dark themed date inputs
+    webkitCalendarPickerFilter: brightness(0) saturate(100%) invert(86%) sepia(19%) saturate(152%)
+      hue-rotate(184deg) brightness(87%) contrast(93%),
+    webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(100%) sepia(0%)
+      saturate(0%) hue-rotate(93deg) brightness(103%) contrast(103%),
   ),
   nord: (
     textColor: $nord5,
@@ -225,6 +235,11 @@ $themes: (
     svgSuffix: "-dark.svg",
     transparentColor: rgba(0, 0, 0, 0),
     dateInputColorScheme: dark,
+    webkitCalendarPickerFilter: brightness(0) saturate(100%) invert(94%) sepia(5%) saturate(454%)
+      hue-rotate(185deg) brightness(93%) contrast(96%),
+    webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(94%) sepia(5%)
+      saturate(454%) hue-rotate(185deg) brightness(93%) contrast(96%),
+    // has no hover so use same color
   ),
   solarizedDark: (
     textColor: $solarizedDarkBase2,
@@ -280,6 +295,10 @@ $themes: (
     svgSuffix: "-solarized.svg",
     transparentColor: rgba(0, 0, 0, 0),
     dateInputColorScheme: dark,
+    webkitCalendarPickerFilter: brightness(0) saturate(100%) invert(61%) sepia(13%) saturate(289%)
+      hue-rotate(138deg) brightness(92%) contrast(90%),
+    webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(94%) sepia(10%)
+      saturate(462%) hue-rotate(345deg) brightness(103%) contrast(87%),
   ),
 );
 

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -118,8 +118,9 @@ $themes: (
     // https://stackoverflow.com/a/53336754
     webkitCalendarPickerFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
       brightness(85%) contrast(103%),
+    // light has no hover so use same color
     webkitCalendarPickerHoverFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
-      brightness(85%) contrast(103%) // light has no hover so use same color,
+      brightness(85%) contrast(103%),
   ),
   dark: (
     textColor: #ffffff,
@@ -237,9 +238,9 @@ $themes: (
     dateInputColorScheme: dark,
     webkitCalendarPickerFilter: brightness(0) saturate(100%) invert(94%) sepia(5%) saturate(454%)
       hue-rotate(185deg) brightness(93%) contrast(96%),
+    // has no hover so use same color
     webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(94%) sepia(5%)
       saturate(454%) hue-rotate(185deg) brightness(93%) contrast(96%),
-    // has no hover so use same color
   ),
   solarizedDark: (
     textColor: $solarizedDarkBase2,


### PR DESCRIPTION
Browser Extension - Send - Expiration / Deletion date calendar icon + datepicker pop up now respect theme better in Chrome / Chromium based browsers and Safari (Firefox datepicker pop up doesn't seem to have an easy mechanism for theming)

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
For the browser extension, make the send iconography and calendar pop ups respect the user chosen theme better.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/base.scss** Added color-scheme style targeting all date inputs which changes based on user chosen theme
- **apps/browser/src/popup/scss/variables.scss** Added dateInputColorScheme property and value for each theme 

## Screenshots
Chrome before change
<img width="396" alt="Chrome - Pre change" src="https://user-images.githubusercontent.com/116684653/201218029-7fa75db4-70f2-4cac-9f6c-ebeec3b4acbf.png">
<img width="468" alt="Chrome - Datepicker Popup Pre change" src="https://user-images.githubusercontent.com/116684653/201218026-097e5712-fed2-40b6-b2e5-f7f91869dcb3.png">

Chrome after change
<img width="364" alt="Chrome - Post change" src="https://user-images.githubusercontent.com/116684653/201218028-5f864360-5fab-4c98-93dd-76b93aa4cadc.png">
<img width="442" alt="Chrome - Datepicker Popup Post change" src="https://user-images.githubusercontent.com/116684653/201218022-59ce8f6f-343b-49e9-b246-d046cc60a09b.png">

Safari before change
<img width="182" alt="Safari - Pre change" src="https://user-images.githubusercontent.com/116684653/201218034-5b82066f-378f-427c-8ce9-ec76d24b3612.png">

Safari after change
<img width="186" alt="Safari - Post change" src="https://user-images.githubusercontent.com/116684653/201218030-42579c78-9915-40b3-9e3b-45c8c59a6fef.png">

All other themes tested but not pictured. 

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
