### PR TITLE
[EC-739 / EC-740] Add null check to policyFilter on PolicyService

### DIFF
--- a/libs/common/src/services/policy/policy.service.ts
+++ b/libs/common/src/services/policy/policy.service.ts
@@ -124,10 +124,7 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
     );
   }
 
-  policyAppliesToActiveUser$(
-    policyType: PolicyType,
-    policyFilter: (policy: Policy) => boolean = (p) => true
-  ) {
+  policyAppliesToActiveUser$(policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) {
     return this.policies$.pipe(
       concatMap(async (policies) => {
         const userId = await this.stateService.getUserId();

--- a/libs/common/src/services/policy/policy.service.ts
+++ b/libs/common/src/services/policy/policy.service.ts
@@ -257,12 +257,12 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
   private async checkPoliciesThatApplyToUser(
     policies: Policy[],
     policyType: PolicyType,
-    policyFilter: (policy: Policy) => boolean = (p) => true,
+    policyFilter?: (policy: Policy) => boolean,
     userId?: string
   ) {
     const organizations = await this.organizationService.getAll(userId);
     const filteredPolicies = policies.filter(
-      (p) => p.type === policyType && p.enabled && policyFilter(p)
+      (p) => p.type === policyType && p.enabled && (policyFilter == null || policyFilter(p))
     );
     const policySet = new Set(filteredPolicies.map((p) => p.organizationId));
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `PolicyService` method `policyAppliesToUser` was throwing an error on Desktop and Browser clients due to the parameter `policyFilter` being passed null.

## Code changes

- **libs/common/src/services/policy/policy.service.ts:** Added a null check to determine if the passed function should be executed

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
