### PR TITLE
[SM-340] Fix share modal not closing on cancel

### DIFF
--- a/apps/desktop/src/app/vault/share.component.html
+++ b/apps/desktop/src/app/vault/share.component.html
@@ -72,7 +72,7 @@
               aria-hidden="true"
             ></i>
           </button>
-          <button type="button" data-dismiss="modal">{{ "cancel" | i18n }}</button>
+          <button type="button" (click)="close()">{{ "cancel" | i18n }}</button>
         </div>
       </ng-container>
     </form>

--- a/apps/desktop/src/app/vault/share.component.ts
+++ b/apps/desktop/src/app/vault/share.component.ts
@@ -1,5 +1,6 @@
 import { Component } from "@angular/core";
 
+import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 import { ShareComponent as BaseShareComponent } from "@bitwarden/angular/components/share.component";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
@@ -19,7 +20,8 @@ export class ShareComponent extends BaseShareComponent {
     collectionService: CollectionService,
     platformUtilsService: PlatformUtilsService,
     logService: LogService,
-    organizationService: OrganizationService
+    organizationService: OrganizationService,
+    private modalRef: ModalRef
   ) {
     super(
       collectionService,
@@ -29,5 +31,9 @@ export class ShareComponent extends BaseShareComponent {
       logService,
       organizationService
     );
+  }
+
+  protected close() {
+    this.modalRef.close();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Resolves the share modal not closing correctly. This issue occurs because we previously relied on the `data-dismiss="modal"` which only works if the elements exists when the modal is opened. Since we use an `async` pipe the dismiss element appears later which causes the click handle to not exist.

Resolved by adding an explicit click handle on the component itself. In the future this will resolve itself once we migrate to the new dialog service.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
