### PR TITLE
[EC-744 / EC-745] Revert PolicyService back to clearing DecryptedPolicies on StateService

### DIFF
--- a/libs/common/src/services/policy/policy.service.ts
+++ b/libs/common/src/services/policy/policy.service.ts
@@ -222,11 +222,13 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
     policies[policy.id] = policy;
 
     await this.updateObservables(policies);
+    await this.stateService.setDecryptedPolicies(null);
     await this.stateService.setEncryptedPolicies(policies);
   }
 
   async replace(policies: { [id: string]: PolicyData }): Promise<void> {
     await this.updateObservables(policies);
+    await this.stateService.setDecryptedPolicies(null);
     await this.stateService.setEncryptedPolicies(policies);
   }
 
@@ -234,6 +236,7 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
     if (userId == null || userId == (await this.stateService.getUserId())) {
       this._policies.next([]);
     }
+    await this.stateService.setDecryptedPolicies(null, { userId: userId });
     await this.stateService.setEncryptedPolicies(null, { userId: userId });
   }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In the Policies refactor to use observables a bug was introduced which caused serviced that used the state service directly to not used refreshed values.

## Code changes

- **libs/common/src/services/policy/policy.service.ts:** Revert back to clearing the decrypted policies on the state service.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
