### PR TITLE
[EC-746] Call BaseAddEditComponent.ngOnInit on Desktop AddEditComponent

### DIFF
--- a/apps/desktop/src/app/vault/add-edit.component.ts
+++ b/apps/desktop/src/app/vault/add-edit.component.ts
@@ -61,6 +61,7 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
   }
 
   async ngOnInit() {
+    await super.ngOnInit();
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
       this.ngZone.run(() => {
         switch (message.command) {
@@ -75,7 +76,6 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
   }
 
   async ngOnChanges() {
-    await super.init();
     await this.load();
   }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The Desktop AddEditComponent was not calling BaseAddEditComponent.ngOnInit which checks if the user has any policy that disables 'Personal Ownership'.

## Code changes

- **apps/desktop/src/app/vault/add-edit.component.ts:** Call BaseAddEditComponent.ngOnInit

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
