### PR TITLE
[EC-743] Call super to ngOnInit to include policy observable changes

### DIFF
--- a/apps/browser/src/popup/send/send-add-edit.component.ts
+++ b/apps/browser/src/popup/send/send-add-edit.component.ts
@@ -108,7 +108,7 @@ export class SendAddEditComponent extends BaseAddEditComponent {
         const type = parseInt(params.type, null);
         this.type = type;
       }
-      await this.load();
+      await super.ngOnInit();
     });
 
     window.setTimeout(() => {


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> Browser extension was incorrectly overriding `ngOnInit` method and not allowing the superclass to run its code to properly setup the policy observables while adding/editing a send.

## Code changes
- **send-add-edit.component.ts**: Replace call to load with `super.ngOnInit()` to properly init observables
