### PR TITLE
[EC-735] Add organization-options menu to single org (again)

### DIFF
--- a/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
+++ b/apps/web/src/app/vault/vault-filter/organization-filter/organization-filter.component.html
@@ -97,6 +97,14 @@
           <i class="bwi bwi-fw bwi-business" aria-hidden="true"></i>
           {{ organizations[0].name }}
         </button>
+        <span class="tw-ml-auto">
+          <button [bitMenuTriggerFor]="orgMenu" class="org-options">
+            <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
+          </button>
+          <bit-menu class="filter-organization-options" #orgMenu>
+            <app-organization-options [organization]="organizations[0]"></app-organization-options>
+          </bit-menu>
+        </span>
       </div>
     </ng-container>
     <ng-container *ngSwitchDefault>


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bug:

> I was going to test manually enrolling in Admin Password Reset and realized my user could not see the 3 dot menu.
Enterprise Org with the following policies enabled:
> 
> master password reset
> 
> single organization
> 
> remove individual vault
> 
> steps to reproduce:
> 
> as a user in an Organization configured like above > log into web vault
> 
> on the vault screen, observe there is no menu beside the org name
> 
> expected:
> 
> 3 dot menu that lets you leave the Org, link SSO if configured, enroll in admin password reset if configured
> 
> disabling the remove individual vault policy seems to bring the menu back however?

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Re-apply commit 7c3255d (#3678) which was accidentally reverted by the Org Admin Refresh changes in commit 09c3bc8 (#3925).

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
