### PR TITLE
[SM-301] fix: associate labels with inputs

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list.component.html
@@ -19,12 +19,15 @@
   <ng-container header>
     <tr>
       <th bitCell class="tw-w-0">
-        <input
-          type="checkbox"
-          (change)="$event ? toggleAll() : null"
-          [checked]="selection.hasValue() && isAllSelected()"
-          [indeterminate]="selection.hasValue() && !isAllSelected()"
-        />
+        <label class="!tw-mb-0 tw-flex tw-w-fit tw-gap-2 !tw-font-bold !tw-text-muted">
+          <input
+            type="checkbox"
+            (change)="$event ? toggleAll() : null"
+            [checked]="selection.hasValue() && isAllSelected()"
+            [indeterminate]="selection.hasValue() && !isAllSelected()"
+          />
+          {{ "all" | i18n }}
+        </label>
       </th>
       <th bitCell colspan="2">{{ "name" | i18n }}</th>
       <th bitCell>{{ "lastEdited" | i18n }}</th>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets-list.component.html
@@ -19,7 +19,7 @@
   <ng-container header>
     <tr>
       <th bitCell class="tw-w-0">
-        <div class="tw-flex tw-w-fit tw-gap-2">
+        <label class="!tw-mb-0 tw-flex tw-w-fit tw-gap-2 !tw-font-bold !tw-text-muted">
           <input
             type="checkbox"
             (change)="$event ? toggleAll() : null"
@@ -27,7 +27,7 @@
             [indeterminate]="selection.hasValue() && !isAllSelected()"
           />
           {{ "all" | i18n }}
-        </div>
+        </label>
       </th>
       <th bitCell colspan="2">{{ "name" | i18n }}</th>
       <th bitCell>{{ "projects" | i18n }}</th>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
@@ -15,7 +15,7 @@
   <ng-container header>
     <tr>
       <th bitCell class="tw-w-0">
-        <div class="tw-flex tw-w-fit tw-gap-2">
+        <label class="!tw-mb-0 tw-flex tw-w-fit tw-gap-2 !tw-font-bold !tw-text-muted">
           <input
             type="checkbox"
             (change)="$event ? toggleAll() : null"
@@ -23,7 +23,7 @@
             [indeterminate]="selection.hasValue() && !isAllSelected()"
           />
           {{ "all" | i18n }}
-        </div>
+        </label>
       </th>
       <th bitCell colspan="2">{{ "name" | i18n }}</th>
       <th bitCell>{{ "secrets" | i18n }}</th>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Inputs should be associated with descriptive labels for better screen reader support.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **`/app/secrets-manager/secrets/secrets-list.component.html`:** Associated existing label
- **`/app/secrets-manager/projects/projects-list.component.html`:** Added new label
- **`/app/secrets-manager/service-accounts/service-accounts-list.component.html`:** Associated existing label

## Screenshots

Updated list header for Projects, Secrets, & Service Accounts:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/17113462/201712715-0c41f3fa-f36f-4a4d-9976-0254a1933238.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
