### PR TITLE
SG-725 - Desktop - Moved DuckDuckGo setting down so that the Biometri…

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -309,23 +309,6 @@
                 </div>
                 <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
               </div>
-              <div class="form-group" *ngIf="showDuckDuckGoIntegrationOption">
-                <div class="checkbox">
-                  <label for="enableDuckDuckGoBrowserIntegration">
-                    <input
-                      id="enableDuckDuckGoBrowserIntegration"
-                      type="checkbox"
-                      name="enableDuckDuckGoBrowserIntegration"
-                      [(ngModel)]="enableDuckDuckGoBrowserIntegration"
-                      (change)="saveDdgBrowserIntegration()"
-                    />
-                    {{ "enableDuckDuckGoBrowserIntegration" | i18n }}
-                  </label>
-                </div>
-                <small class="help-block">{{
-                  "enableDuckDuckGoBrowserIntegrationDesc" | i18n
-                }}</small>
-              </div>
               <div class="form-group">
                 <div class="checkbox">
                   <label for="enableBrowserIntegrationFingerprint">
@@ -342,6 +325,23 @@
                 </div>
                 <small class="help-block">{{
                   "enableBrowserIntegrationFingerprintDesc" | i18n
+                }}</small>
+              </div>
+              <div class="form-group" *ngIf="showDuckDuckGoIntegrationOption">
+                <div class="checkbox">
+                  <label for="enableDuckDuckGoBrowserIntegration">
+                    <input
+                      id="enableDuckDuckGoBrowserIntegration"
+                      type="checkbox"
+                      name="enableDuckDuckGoBrowserIntegration"
+                      [(ngModel)]="enableDuckDuckGoBrowserIntegration"
+                      (change)="saveDdgBrowserIntegration()"
+                    />
+                    {{ "enableDuckDuckGoBrowserIntegration" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{
+                  "enableDuckDuckGoBrowserIntegrationDesc" | i18n
                 }}</small>
               </div>
               <div class="form-group">


### PR DESCRIPTION
SG-725 - Desktop - Moved DuckDuckGo setting down so that the Biometric browser settings are not separated

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Move DuckDuckGo setting down so that the Biometric browser settings are not separated

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **clients/apps/desktop/src/app/accounts/settings.component.html:** Moved checkbox down one form-group.
## Screenshots
Before fix:
![SG-725-Desktop-settings-pre-fix](https://user-images.githubusercontent.com/116684653/201745697-d6eeb4e9-b10c-47cb-855f-6866cbab9f88.jpg)
After fix:
![SG-725-Desktop-settings-post-fix](https://user-images.githubusercontent.com/116684653/201745718-eb01c772-46e1-4b4d-9d15-7d7ef3ddd0d3.jpg)

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
