### PR TITLE
[EC-623] Reusable Search Input Component

### DIFF
--- a/apps/web/src/app/organizations/organization.module.ts
+++ b/apps/web/src/app/organizations/organization.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from "@angular/core";
 
-import { SharedModule } from "../shared";
-
 import { AccessSelectorModule } from "./components/access-selector";
 import { OrganizationsRoutingModule } from "./organization-routing.module";
+import { SharedOrganizationModule } from "./shared";
 
 @NgModule({
-  imports: [SharedModule, AccessSelectorModule, OrganizationsRoutingModule],
+  imports: [SharedOrganizationModule, AccessSelectorModule, OrganizationsRoutingModule],
 })
 export class OrganizationModule {}

--- a/apps/web/src/app/organizations/shared/components/search-input/search-input.component.html
+++ b/apps/web/src/app/organizations/shared/components/search-input/search-input.component.html
@@ -1,0 +1,21 @@
+<label class="tw-sr-only" [for]="id">{{ "search" | i18n }}</label>
+<div class="tw-relative tw-flex tw-items-center">
+  <label
+    [for]="id"
+    aria-hidden="true"
+    class="tw-absolute tw-left-2 tw-z-20 !tw-mb-0 tw-cursor-text"
+  >
+    <i class="bwi bwi-search bwi-fw tw-text-muted"></i>
+  </label>
+  <input
+    bitInput
+    type="search"
+    [id]="id"
+    [placeholder]="placeholder ?? ('search' | i18n)"
+    class="tw-rounded-l tw-pl-9"
+    [ngModel]="searchText"
+    (ngModelChange)="onChange($event)"
+    (blur)="onTouch()"
+    [disabled]="disabled"
+  />
+</div>

--- a/apps/web/src/app/organizations/shared/components/search-input/search-input.component.ts
+++ b/apps/web/src/app/organizations/shared/components/search-input/search-input.component.ts
@@ -4,7 +4,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 let nextId = 0;
 
 @Component({
-  selector: "bit-search-input",
+  selector: "app-search-input",
   templateUrl: "./search-input.component.html",
   providers: [
     {

--- a/apps/web/src/app/organizations/shared/components/search-input/search-input.component.ts
+++ b/apps/web/src/app/organizations/shared/components/search-input/search-input.component.ts
@@ -1,0 +1,54 @@
+import { Component, Input } from "@angular/core";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
+
+let nextId = 0;
+
+@Component({
+  selector: "bit-search-input",
+  templateUrl: "./search-input.component.html",
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: SearchInputComponent,
+    },
+  ],
+})
+export class SearchInputComponent implements ControlValueAccessor {
+  private notifyOnChange: (v: string) => void;
+  private notifyOnTouch: () => void;
+
+  protected id = `search-id-${nextId++}`;
+  protected searchText: string;
+
+  @Input() disabled: boolean;
+  @Input() placeholder: string;
+
+  onChange(searchText: string) {
+    if (this.notifyOnChange != undefined) {
+      this.notifyOnChange(searchText);
+    }
+  }
+
+  onTouch() {
+    if (this.notifyOnTouch != undefined) {
+      this.notifyOnTouch();
+    }
+  }
+
+  registerOnChange(fn: (v: string) => void): void {
+    this.notifyOnChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.notifyOnTouch = fn;
+  }
+
+  writeValue(searchText: string): void {
+    this.searchText = searchText;
+  }
+
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+}

--- a/apps/web/src/app/organizations/shared/components/search-input/search-input.stories.ts
+++ b/apps/web/src/app/organizations/shared/components/search-input/search-input.stories.ts
@@ -1,0 +1,36 @@
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { Meta, moduleMetadata, Story } from "@storybook/angular";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { InputModule } from "@bitwarden/components/src/input/input.module";
+
+import { PreloadedEnglishI18nModule } from "../../../../tests/preloaded-english-i18n.module";
+
+import { SearchInputComponent } from "./search-input.component";
+
+export default {
+  title: "Web/Organizations/Search Input",
+  component: SearchInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        InputModule,
+        FormsModule,
+        ReactiveFormsModule,
+        PreloadedEnglishI18nModule,
+        JslibModule,
+      ],
+      providers: [],
+    }),
+  ],
+} as Meta;
+
+const Template: Story<SearchInputComponent> = (args: SearchInputComponent) => ({
+  props: args,
+  template: `
+    <bit-search-input [(ngModel)]="searchText" [placeholder]="placeholder" [disabled]="disabled"></bit-search-input>
+  `,
+});
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/apps/web/src/app/organizations/shared/components/search-input/search-input.stories.ts
+++ b/apps/web/src/app/organizations/shared/components/search-input/search-input.stories.ts
@@ -28,7 +28,7 @@ export default {
 const Template: Story<SearchInputComponent> = (args: SearchInputComponent) => ({
   props: args,
   template: `
-    <bit-search-input [(ngModel)]="searchText" [placeholder]="placeholder" [disabled]="disabled"></bit-search-input>
+    <app-search-input [(ngModel)]="searchText" [placeholder]="placeholder" [disabled]="disabled"></app-search-input>
   `,
 });
 

--- a/apps/web/src/app/organizations/shared/index.ts
+++ b/apps/web/src/app/organizations/shared/index.ts
@@ -1,0 +1,1 @@
+export * from "./shared-organization.module";

--- a/apps/web/src/app/organizations/shared/shared-organization.module.ts
+++ b/apps/web/src/app/organizations/shared/shared-organization.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from "@angular/core";
+
+import { SharedModule } from "../../shared";
+
+import { SearchInputComponent } from "./components/search-input/search-input.component";
+
+@NgModule({
+  imports: [SharedModule],
+  declarations: [SearchInputComponent],
+  exports: [SharedModule, SearchInputComponent],
+})
+export class SharedOrganizationModule {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

During OAVR work, we found a case for creating a common “search” component for the org admin console screens. This adds the new search component to a new `SharedOrganizationModule` to be used by the `OrganizationModule`.

The new `SharedOrganizationModule` will allow us to easily add new shared components that are only used by the Organization admin console screens without polluting the component library.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organizations/shared/shared-organization.module.ts:** Add the new `SharedOrganizationModule`
- **organizations/organization.module.ts:** Use the new shared module
- **organizations/shared/components/search-input/search-input.component.ts:** The new search input component 

## Screenshots

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/8764515/203461394-f9b57382-020a-4f13-a29f-3be169a3c874.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
