### PR TITLE
[PS-1892] Bump electron

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -19,7 +19,7 @@
     "**/node_modules/@bitwarden/desktop-native/index.js",
     "**/node_modules/@bitwarden/desktop-native/desktop_native.${platform}-${arch}*.node"
   ],
-  "electronVersion": "21.3.0",
+  "electronVersion": "21.3.1",
   "generateUpdatesFilesForAllChannels": true,
   "publish": {
     "provider": "generic",

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -19,7 +19,7 @@
     "**/node_modules/@bitwarden/desktop-native/index.js",
     "**/node_modules/@bitwarden/desktop-native/desktop_native.${platform}-${arch}*.node"
   ],
-  "electronVersion": "19.0.8",
+  "electronVersion": "21.3.0",
   "generateUpdatesFilesForAllChannels": true,
   "publish": {
     "provider": "generic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,7 @@
         "electron-notarize": "^1.2.1",
         "electron-rebuild": "^3.2.7",
         "electron-reload": "^2.0.0-alpha.1",
-        "electron-store": "^8.0.2",
+        "electron-store": "^8.1.0",
         "electron-updater": "^5.0.5",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
@@ -17841,9 +17841,9 @@
       }
     },
     "node_modules/conf": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.1.2.tgz",
-      "integrity": "sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.6.3",
@@ -20557,13 +20557,13 @@
       }
     },
     "node_modules/electron-store": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.2.tgz",
-      "integrity": "sha512-9GwUMv51w8ydbkaG7X0HrPlElXLApg63zYy1/VZ/a08ndl0gfm4iCoD3f0E1JvP3V16a+7KxqriCI0c122stiA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.1.0.tgz",
+      "integrity": "sha512-2clHg/juMjOH0GT9cQ6qtmIvK183B39ZXR0bUoPwKwYHJsEF3quqyDzMFUAu+0OP8ijmN2CbPRAelhNbWUbzwA==",
       "dev": true,
       "dependencies": {
-        "conf": "^10.1.2",
-        "type-fest": "^2.12.2"
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -56755,9 +56755,9 @@
       }
     },
     "conf": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.1.2.tgz",
-      "integrity": "sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
       "dev": true,
       "requires": {
         "ajv": "^8.6.3",
@@ -58876,13 +58876,13 @@
       }
     },
     "electron-store": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.2.tgz",
-      "integrity": "sha512-9GwUMv51w8ydbkaG7X0HrPlElXLApg63zYy1/VZ/a08ndl0gfm4iCoD3f0E1JvP3V16a+7KxqriCI0c122stiA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.1.0.tgz",
+      "integrity": "sha512-2clHg/juMjOH0GT9cQ6qtmIvK183B39ZXR0bUoPwKwYHJsEF3quqyDzMFUAu+0OP8ijmN2CbPRAelhNbWUbzwA==",
       "dev": true,
       "requires": {
-        "conf": "^10.1.2",
-        "type-fest": "^2.12.2"
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
       }
     },
     "electron-to-chromium": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.5.1",
         "del": "^6.0.0",
-        "electron": "21.3.0",
+        "electron": "21.3.1",
         "electron-builder": "22.11.10",
         "electron-log": "^4.4.8",
         "electron-notarize": "^1.2.2",
@@ -20180,9 +20180,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.0.tgz",
-      "integrity": "sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==",
+      "version": "21.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.1.tgz",
+      "integrity": "sha512-Ik/I9oFHA1h32JRtRm6GMgYdUctFpF/tPnHyATg4r3LXBTUT6habGh3GxSdmmTa5JgtA7uJUEm8EjjZItk7T3g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -58598,9 +58598,9 @@
       }
     },
     "electron": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.0.tgz",
-      "integrity": "sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==",
+      "version": "21.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.1.tgz",
+      "integrity": "sha512-Ik/I9oFHA1h32JRtRm6GMgYdUctFpF/tPnHyATg4r3LXBTUT6habGh3GxSdmmTa5JgtA7uJUEm8EjjZItk7T3g==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "electron-builder": "22.11.10",
         "electron-log": "^4.4.8",
         "electron-notarize": "^1.2.2",
-        "electron-rebuild": "^3.2.7",
+        "electron-rebuild": "^3.2.9",
         "electron-reload": "^2.0.0-alpha.1",
         "electron-store": "^8.1.0",
         "electron-updater": "^5.0.5",
@@ -20323,9 +20323,10 @@
       }
     },
     "node_modules/electron-rebuild": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.8.tgz",
-      "integrity": "sha512-+U/G5ZH9RNfvPQsEHevC3yDlgSB+wliNXnG6haqUeZBEq061pEgSTWK9ZBEfqMEq+PKxvniMNxfou/h6079s3A==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
+      "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
+      "deprecated": "Please use @electron/rebuild moving forward.  There is no API change, just a package name change",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -58713,9 +58714,9 @@
       }
     },
     "electron-rebuild": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.8.tgz",
-      "integrity": "sha512-+U/G5ZH9RNfvPQsEHevC3yDlgSB+wliNXnG6haqUeZBEq061pEgSTWK9ZBEfqMEq+PKxvniMNxfou/h6079s3A==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
+      "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.5.1",
         "del": "^6.0.0",
-        "electron": "19.0.8",
+        "electron": "21.3.0",
         "electron-builder": "22.11.10",
         "electron-log": "^4.4.8",
         "electron-notarize": "^1.2.1",
@@ -13342,6 +13342,16 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/zxcvbn": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.1.tgz",
@@ -20170,21 +20180,21 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
-      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
+      "version": "21.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.0.tgz",
+      "integrity": "sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
-        "extract-zip": "^1.0.3"
+        "extract-zip": "^2.0.1"
       },
       "bin": {
         "electron": "cli.js"
       },
       "engines": {
-        "node": ">= 8.6"
+        "node": ">= 10.17.0"
       }
     },
     "node_modules/electron-builder": {
@@ -22724,46 +22734,39 @@
       }
     },
     "node_modules/extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
         "extract-zip": "cli.js"
-      }
-    },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/extract-zip/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
       },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/extsprintf": {
       "version": "1.4.1",
@@ -53255,6 +53258,16 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/zxcvbn": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.1.tgz",
@@ -58583,14 +58596,14 @@
       }
     },
     "electron": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
-      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
+      "version": "21.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.3.0.tgz",
+      "integrity": "sha512-MGRpshN8fBcx4IRuBABIsGDv0tB/MclIFsyFHFFXsBCUc+vIXaE/E6vuWaniGIFSz5WyeuapfTH5IeRb+7yIfw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
-        "extract-zip": "^1.0.3"
+        "extract-zip": "^2.0.1"
       }
     },
     "electron-builder": {
@@ -60503,40 +60516,25 @@
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "pump": "^3.0.0"
           }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
         "electron-rebuild": "^3.2.9",
         "electron-reload": "^2.0.0-alpha.1",
         "electron-store": "^8.1.0",
-        "electron-updater": "^5.0.5",
+        "electron-updater": "^5.3.0",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^2.7.1",
@@ -20578,13 +20578,13 @@
       "dev": true
     },
     "node_modules/electron-updater": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.5.tgz",
-      "integrity": "sha512-YcKEI9zpU+c0sNXTpjw3UpzP8Pfuuwo70T42oLYm0hHc0dy41ih51oENlhxgooa2+uzzpXhoCOyrpG+w6CB0Pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.3.0.tgz",
+      "integrity": "sha512-iKEr7yQBcvnQUPnSDYGSWC9t0eF2YbZWeYYYZzYxdl+HiRejXFENjYMnYjoOm2zxyD6Cr2JTHZhp9pqxiXuCOw==",
       "dev": true,
       "dependencies": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.1.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -20601,9 +20601,9 @@
       "dev": true
     },
     "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+      "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -58894,13 +58894,13 @@
       "dev": true
     },
     "electron-updater": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.5.tgz",
-      "integrity": "sha512-YcKEI9zpU+c0sNXTpjw3UpzP8Pfuuwo70T42oLYm0hHc0dy41ih51oENlhxgooa2+uzzpXhoCOyrpG+w6CB0Pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.3.0.tgz",
+      "integrity": "sha512-iKEr7yQBcvnQUPnSDYGSWC9t0eF2YbZWeYYYZzYxdl+HiRejXFENjYMnYjoOm2zxyD6Cr2JTHZhp9pqxiXuCOw==",
       "dev": true,
       "requires": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.1.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -58917,9 +58917,9 @@
           "dev": true
         },
         "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+          "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
           "dev": true,
           "requires": {
             "debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "electron": "21.3.0",
         "electron-builder": "22.11.10",
         "electron-log": "^4.4.8",
-        "electron-notarize": "^1.2.1",
+        "electron-notarize": "^1.2.2",
         "electron-rebuild": "^3.2.7",
         "electron-reload": "^2.0.0-alpha.1",
         "electron-store": "^8.1.0",
@@ -20231,9 +20231,10 @@
       "dev": true
     },
     "node_modules/electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.2.tgz",
+      "integrity": "sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==",
+      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -58633,9 +58634,9 @@
       "dev": true
     },
     "electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.2.tgz",
+      "integrity": "sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "electron-builder": "22.11.10",
     "electron-log": "^4.4.8",
     "electron-notarize": "^1.2.2",
-    "electron-rebuild": "^3.2.7",
+    "electron-rebuild": "^3.2.9",
     "electron-reload": "^2.0.0-alpha.1",
     "electron-store": "^8.1.0",
     "electron-updater": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "electron-notarize": "^1.2.1",
     "electron-rebuild": "^3.2.7",
     "electron-reload": "^2.0.0-alpha.1",
-    "electron-store": "^8.0.2",
+    "electron-store": "^8.1.0",
     "electron-updater": "^5.0.5",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "del": "^6.0.0",
-    "electron": "19.0.8",
+    "electron": "21.3.0",
     "electron-builder": "22.11.10",
     "electron-log": "^4.4.8",
     "electron-notarize": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "electron-rebuild": "^3.2.9",
     "electron-reload": "^2.0.0-alpha.1",
     "electron-store": "^8.1.0",
-    "electron-updater": "^5.0.5",
+    "electron-updater": "^5.3.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "del": "^6.0.0",
-    "electron": "21.3.0",
+    "electron": "21.3.1",
     "electron-builder": "22.11.10",
     "electron-log": "^4.4.8",
     "electron-notarize": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "electron": "21.3.0",
     "electron-builder": "22.11.10",
     "electron-log": "^4.4.8",
-    "electron-notarize": "^1.2.1",
+    "electron-notarize": "^1.2.2",
     "electron-rebuild": "^3.2.7",
     "electron-reload": "^2.0.0-alpha.1",
     "electron-store": "^8.1.0",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Update `electron` to `21.3.1`
Update `electron-store` to `8.1.0`
Update `electron-notarize` to `1.2.2` -> Last version, package got renamed to `@electron/notarize`
Update `electron-rebuild` to `3.2.9` -> Last version, package got renamed to `@electron/rebuild`
Update `electron-updater` to `5.3.0`

There hasn't been any serious breaking changes in electron for these versions:
https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-200

Keeping `electron-builder` at `22.11.10` (still need to figure out how to fix the signing issues)

## Code changes
- **package.json:** Updating the versions as stated above
- **package-lock.json:** Changes after executing `npm i` after each change
- **apps/desktop/electron-builder.json:** Set `electronVersion` to `21.3.1` so the workflow does not complain

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
