### PR TITLE
[PS-1901] Add menu item to remove a previously set password from a Send

### DIFF
--- a/apps/desktop/src/app/send/send.component.ts
+++ b/apps/desktop/src/app/send/send.component.ts
@@ -136,8 +136,10 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
       label: this.i18nService.t("removePassword"),
       click: async () => {
         await this.removePassword(send);
-        this.sendId = null;
-        this.selectSend(send.id);
+        if (this.sendId === send.id) {
+          this.sendId = null;
+          this.selectSend(send.id);
+        }
       },
     });
     menu.push({

--- a/apps/desktop/src/app/send/send.component.ts
+++ b/apps/desktop/src/app/send/send.component.ts
@@ -132,16 +132,18 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
       label: this.i18nService.t("copyLink"),
       click: () => this.copy(send),
     });
-    menu.push({
-      label: this.i18nService.t("removePassword"),
-      click: async () => {
-        await this.removePassword(send);
-        if (this.sendId === send.id) {
-          this.sendId = null;
-          this.selectSend(send.id);
-        }
-      },
-    });
+    if (send.password && !send.disabled) {
+      menu.push({
+        label: this.i18nService.t("removePassword"),
+        click: async () => {
+          await this.removePassword(send);
+          if (this.sendId === send.id) {
+            this.sendId = null;
+            this.selectSend(send.id);
+          }
+        },
+      });
+    }
     menu.push({
       label: this.i18nService.t("delete"),
       click: async () => {

--- a/apps/desktop/src/app/send/send.component.ts
+++ b/apps/desktop/src/app/send/send.component.ts
@@ -133,6 +133,14 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
       click: () => this.copy(send),
     });
     menu.push({
+      label: this.i18nService.t("removePassword"),
+      click: async () => {
+        await this.removePassword(send);
+        this.sendId = null;
+        this.selectSend(send.id);
+      },
+    });
+    menu.push({
       label: this.i18nService.t("delete"),
       click: async () => {
         await this.delete(send);

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1779,6 +1779,15 @@
   "disabled": {
     "message": "Disabled"
   },
+  "removePassword": {
+    "message": "Remove password"
+  },
+  "removedPassword": {
+    "message": "Password removed"
+  },
+  "removePasswordConfirmation": {
+    "message": "Are you sure you want to remove the password?"
+  },  
   "maxAccessCountReached": {
     "message": "Max access count reached"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes https://github.com/bitwarden/clients/issues/4096

Adds a menu item to remove a previously set password from a Send.

## Code changes
- **apps/desktop/src/app/send/send.component.ts:** Add menu item to "Remove password"
- **apps/desktop/src/locales/en/messages.json:** Add entries to messages.json for menu item, message box and toast notifcation

## Screenshots
BEFORE:
![image](https://user-images.githubusercontent.com/2670567/203317653-30d089c1-c398-49e9-bf49-08c7094241db.png)

AFTER:
![image](https://user-images.githubusercontent.com/2670567/203317020-3a178b62-6b04-4d5c-aaf1-b4f0900cb804.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
