### PR TITLE
[SG-832] Remove extra serialization call on SymmetricCryptoKey in native messaging service

### DIFF
--- a/apps/desktop/src/services/nativeMessageHandler.service.ts
+++ b/apps/desktop/src/services/nativeMessageHandler.service.ts
@@ -114,7 +114,7 @@ export class NativeMessageHandlerService {
 
       const secret = await this.cryptoFunctionService.randomBytes(64);
       this.ddgSharedSecret = new SymmetricCryptoKey(secret);
-      const sharedKeyB64 = new SymmetricCryptoKey(secret).toJSON().keyB64;
+      const sharedKeyB64 = new SymmetricCryptoKey(secret).keyB64;
 
       await this.stateService.setDuckDuckGoSharedKey(sharedKeyB64);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Reduce intermittent communication issues with native messages.

## Code changes

- **apps/desktop/src/services/nativeMessageHandler.service.ts:**  Remove extra call to toJSON() on SymmetricCryptoKey. There is no need to serialize it to get the `keyB64` property.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
