### PR TITLE
[SG-664] Add org name length validation to inputs

### DIFF
--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
@@ -62,7 +62,7 @@
               <button
                 bitButton
                 buttonType="primary"
-                [disabled]="orgInfoFormGroup.get('name').hasError('required')"
+                [disabled]="orgInfoFormGroup.get('name').invalid"
                 cdkStepperNext
               >
                 Next

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
@@ -149,9 +149,11 @@ export class TrialInitiationComponent implements OnInit, OnDestroy {
         });
     }
 
-    this.orgInfoFormGroup.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.orgInfoFormGroup.controls.name.markAsTouched();
-    });
+    this.orgInfoFormGroup.controls.name.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.orgInfoFormGroup.controls.name.markAsTouched();
+      });
   }
 
   ngOnDestroy(): void {

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
@@ -42,7 +42,7 @@ export class TrialInitiationComponent implements OnInit, OnDestroy {
   @ViewChild("stepper", { static: false }) verticalStepper: VerticalStepperComponent;
 
   orgInfoFormGroup = this.formBuilder.group({
-    name: ["", [Validators.required]],
+    name: ["", { validators: [Validators.required, Validators.maxLength(50)], updateOn: "change" }],
     email: [""],
   });
 
@@ -148,6 +148,10 @@ export class TrialInitiationComponent implements OnInit, OnDestroy {
           this.enforcedPolicyOptions = enforcedPasswordPolicyOptions;
         });
     }
+
+    this.orgInfoFormGroup.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.orgInfoFormGroup.controls.name.markAsTouched();
+    });
   }
 
   ngOnDestroy(): void {

--- a/apps/web/src/app/settings/organization-plans.component.ts
+++ b/apps/web/src/app/settings/organization-plans.component.ts
@@ -121,7 +121,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
     }
 
     if (this.createOrganization) {
-      this.formGroup.controls.name.addValidators(Validators.required);
+      this.formGroup.controls.name.addValidators([Validators.required, Validators.maxLength(50)]);
       this.formGroup.controls.billingEmail.addValidators(Validators.required);
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add a validator to check that the organization name does not exceed 51 characters

## Code changes
- **apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html:** Disable 'next' button on org name step if there are any validation errors
- **apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts** Add maxLength validator to org name field and subscribe to org name field changes so error can be displayed while the user is typing.
- **apps/web/src/app/settings/organization-plans.component.ts:** Add maxLength validator to the normal organization creation flow as well.

## Screenshots

https://user-images.githubusercontent.com/8926729/203579714-38ebd6ef-9d8c-47b2-a69e-cd4813babcf7.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
