### PR TITLE
Enabled passwordless in Production

### DIFF
--- a/apps/web/config/cloud.json
+++ b/apps/web/config/cloud.json
@@ -17,6 +17,6 @@
   },
   "flags": {
     "showTrial": true,
-    "showPasswordless": false
+    "showPasswordless": true
   }
 }


### PR DESCRIPTION
## Type of change

Changed the feature flag for Passwordless to enable it on `cloud.json`, which is used in Production Cloud.

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Enable the feature flag so that we will start showing the "Login with Device" button in Production.

## Code changes

- **cloud.json:** Enabled Passwordless

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
