### PR TITLE
[PS-1942] Add Provider Filters

### DIFF
--- a/apps/web/src/app/components/organization-switcher.component.ts
+++ b/apps/web/src/app/components/organization-switcher.component.ts
@@ -4,7 +4,7 @@ import { map, Observable } from "rxjs";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import {
   canAccessAdmin,
-  notProvider,
+  isNotProviderUser,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { Utils } from "@bitwarden/common/misc/utils";
@@ -24,7 +24,7 @@ export class OrganizationSwitcherComponent implements OnInit {
 
   async ngOnInit() {
     this.organizations$ = this.organizationService.organizations$.pipe(
-      map((orgs) => orgs.filter(notProvider)),
+      map((orgs) => orgs.filter(isNotProviderUser)),
       canAccessAdmin(this.i18nService),
       map((orgs) => orgs.sort(Utils.getSortFunction(this.i18nService, "name")))
     );

--- a/apps/web/src/app/components/organization-switcher.component.ts
+++ b/apps/web/src/app/components/organization-switcher.component.ts
@@ -4,6 +4,7 @@ import { map, Observable } from "rxjs";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import {
   canAccessAdmin,
+  notProvider,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { Utils } from "@bitwarden/common/misc/utils";
@@ -23,6 +24,7 @@ export class OrganizationSwitcherComponent implements OnInit {
 
   async ngOnInit() {
     this.organizations$ = this.organizationService.organizations$.pipe(
+      map((orgs) => orgs.filter(notProvider)),
       canAccessAdmin(this.i18nService),
       map((orgs) => orgs.sort(Utils.getSortFunction(this.i18nService, "name")))
     );

--- a/apps/web/src/app/layouts/navbar.component.ts
+++ b/apps/web/src/app/layouts/navbar.component.ts
@@ -5,7 +5,7 @@ import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import {
   canAccessAdmin,
-  notProvider,
+  isNotProviderUser,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -55,7 +55,7 @@ export class NavbarComponent implements OnInit {
     this.providers = await this.providerService.getAll();
 
     this.organizations$ = this.organizationService.organizations$.pipe(
-      map((orgs) => orgs.filter(notProvider)),
+      map((orgs) => orgs.filter(isNotProviderUser)),
       canAccessAdmin(this.i18nService)
     );
   }

--- a/apps/web/src/app/layouts/navbar.component.ts
+++ b/apps/web/src/app/layouts/navbar.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from "@angular/core";
-import { Observable } from "rxjs";
+import { map, Observable } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import {
   canAccessAdmin,
+  notProvider,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -54,6 +55,7 @@ export class NavbarComponent implements OnInit {
     this.providers = await this.providerService.getAll();
 
     this.organizations$ = this.organizationService.organizations$.pipe(
+      map((orgs) => orgs.filter(notProvider)),
       canAccessAdmin(this.i18nService)
     );
   }

--- a/libs/angular/src/components/share.component.ts
+++ b/libs/angular/src/components/share.component.ts
@@ -5,7 +5,10 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
-import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+import {
+  notProvider,
+  OrganizationService,
+} from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { OrganizationUserStatusType } from "@bitwarden/common/enums/organizationUserStatusType";
 import { Utils } from "@bitwarden/common/misc/utils";
@@ -54,7 +57,9 @@ export class ShareComponent implements OnInit, OnDestroy {
     this.organizations$ = this.organizationService.organizations$.pipe(
       map((orgs) => {
         return orgs
-          .filter((o) => o.enabled && o.status === OrganizationUserStatusType.Confirmed)
+          .filter(
+            (o) => o.enabled && o.status === OrganizationUserStatusType.Confirmed && notProvider(o)
+          )
           .sort(Utils.getSortFunction(this.i18nService, "name"));
       })
     );

--- a/libs/angular/src/components/share.component.ts
+++ b/libs/angular/src/components/share.component.ts
@@ -6,7 +6,7 @@ import { CollectionService } from "@bitwarden/common/abstractions/collection.ser
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import {
-  notProvider,
+  isNotProviderUser,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -58,7 +58,8 @@ export class ShareComponent implements OnInit, OnDestroy {
       map((orgs) => {
         return orgs
           .filter(
-            (o) => o.enabled && o.status === OrganizationUserStatusType.Confirmed && notProvider(o)
+            (o) =>
+              o.enabled && o.status === OrganizationUserStatusType.Confirmed && isNotProviderUser(o)
           )
           .sort(Utils.getSortFunction(this.i18nService, "name"));
       })

--- a/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
+++ b/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
@@ -5,7 +5,7 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
 import {
-  notProvider,
+  isNotProviderUser,
   OrganizationService,
 } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
@@ -44,7 +44,7 @@ export class VaultFilterService {
     let organizations = await this.organizationService.getAll();
     if (organizations != null) {
       organizations = organizations
-        .filter(notProvider)
+        .filter(isNotProviderUser)
         .sort((a, b) => a.name.localeCompare(b.name));
     }
 

--- a/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
+++ b/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
@@ -4,7 +4,10 @@ import { firstValueFrom, from, mergeMap, Observable } from "rxjs";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/abstractions/collection.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
-import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+import {
+  notProvider,
+  OrganizationService,
+} from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { PolicyType } from "@bitwarden/common/enums/policyType";
@@ -40,7 +43,9 @@ export class VaultFilterService {
   async buildOrganizations(): Promise<Organization[]> {
     let organizations = await this.organizationService.getAll();
     if (organizations != null) {
-      organizations = organizations.sort((a, b) => a.name.localeCompare(b.name));
+      organizations = organizations
+        .filter(notProvider)
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
 
     return organizations;

--- a/libs/common/src/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/abstractions/organization/organization.service.abstraction.ts
@@ -70,7 +70,7 @@ export function canAccessAdmin(i18nService: I18nService) {
   );
 }
 
-export function notProvider(org: Organization): boolean {
+export function isNotProviderUser(org: Organization): boolean {
   return !org.isProviderUser;
 }
 

--- a/libs/common/src/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/abstractions/organization/organization.service.abstraction.ts
@@ -70,6 +70,10 @@ export function canAccessAdmin(i18nService: I18nService) {
   );
 }
 
+export function notProvider(org: Organization): boolean {
+  return !org.isProviderUser;
+}
+
 export abstract class OrganizationService {
   organizations$: Observable<Organization[]>;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make each component own their own organization filtering and apply the provider filter on components that used to have this filter built into them from `OrganizationService.getAll()`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/abstractions/organization/organization.service.abstraction.ts:** Add a helper for filtering out provider organizations.
- Utilize the filter in various places that it is needed based on who used to call `getAll` from before #3462 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
