### PR TITLE
Do not use object constructors for names

### DIFF
--- a/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
@@ -19,7 +19,7 @@ describe("sessionSync decorator", () => {
     expect((testClass as any).__syncedItemMetadata).toEqual([
       expect.objectContaining({
         propertyKey: "testProperty",
-        sessionKey: "TestClass_testProperty",
+        sessionKey: "testProperty_0",
         ctor: ctor,
         initializer: initializer,
       }),

--- a/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.spec.ts
@@ -8,9 +8,12 @@ describe("sessionSync decorator", () => {
   class TestClass {
     @sessionSync({ ctor: ctor, initializer: initializer })
     private testProperty = new BehaviorSubject("");
+    @sessionSync({ ctor: ctor, initializer: initializer, initializeAs: "array" })
+    private secondTestProperty = new BehaviorSubject("");
 
     complete() {
       this.testProperty.complete();
+      this.secondTestProperty.complete();
     }
   }
 
@@ -23,7 +26,36 @@ describe("sessionSync decorator", () => {
         ctor: ctor,
         initializer: initializer,
       }),
-      testClass.complete(),
+      expect.objectContaining({
+        propertyKey: "secondTestProperty",
+        sessionKey: "secondTestProperty_1",
+        ctor: ctor,
+        initializer: initializer,
+        initializeAs: "array",
+      }),
     ]);
+    testClass.complete();
+  });
+
+  class TestClass2 {
+    @sessionSync({ ctor: ctor, initializer: initializer })
+    private testProperty = new BehaviorSubject("");
+
+    complete() {
+      this.testProperty.complete();
+    }
+  }
+
+  it("should maintain sessionKey index count for other test classes", () => {
+    const testClass = new TestClass2();
+    expect((testClass as any).__syncedItemMetadata).toEqual([
+      expect.objectContaining({
+        propertyKey: "testProperty",
+        sessionKey: "testProperty_2",
+        ctor: ctor,
+        initializer: initializer,
+      }),
+    ]);
+    testClass.complete();
   });
 });

--- a/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-sync.decorator.ts
@@ -9,6 +9,9 @@ class BuildOptions<T, TJson = Jsonify<T>> {
   initializeAs?: InitializeOptions;
 }
 
+// Used to ensure uniqueness for each synced observable
+let index = 0;
+
 /**
  * A decorator used to indicate the BehaviorSubject should be synced for this browser session across all contexts.
  *
@@ -44,7 +47,7 @@ export function sessionSync<T>(buildOptions: BuildOptions<T>) {
 
     p.__syncedItemMetadata.push({
       propertyKey,
-      sessionKey: `${prototype.constructor.name}_${propertyKey}`,
+      sessionKey: `${propertyKey}_${index++}`,
       ctor: buildOptions.ctor,
       initializer: buildOptions.initializer,
       initializeAs: buildOptions.initializeAs ?? "object",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Session-sync uses class names and property names to generate unique keys to sync values. However, minification was selecting different class names for different instances of services, which was causing them not to sync properly.

This was happening _only_ in production mode for some reason, perhaps due to minifying post chunking?

At any rate, I've removed constructor names and tacked on an index to the sync. A reminder that these decorators are run at definition-time and so the index is locked in only once per class declaration.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
