### PR TITLE
[EC-780] Tabs page does not work in Safari: null is not an object

### DIFF
--- a/apps/browser/src/services/browser-organization.service.ts
+++ b/apps/browser/src/services/browser-organization.service.ts
@@ -8,5 +8,5 @@ import { browserSession, sessionSync } from "../decorators/session-sync-observab
 @browserSession
 export class BrowserOrganizationService extends OrganizationService {
   @sessionSync({ initializer: Organization.fromJSON, initializeAs: "array" })
-  protected _organizations: BehaviorSubject<Organization[]>;
+  protected _organizations = new BehaviorSubject<Organization[]>([]);
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix this bug:

> 1. run npm run dist:safari
> 2. open safari, unlock/login
> 3. observe: infinite spinner on the Tabs page
>
> Console error in the popup: 
> 
> Error: Uncaught (in promise): TypeError: null is not an object (evaluating 'this._organizations.getValue().length') hasOrganizations@safari-web-extension://B202BE7A-D467-447F-AD71-415A19116AE2/popup/main.js:1:986099

This is because the `OrganizationService._organizations` property is overridden in BrowserOrganizationService, but it doesn’t assign it a value. This error is thrown by `OrganizationService.hasOrganizations` when it checks `_organizations.getValue().length`.

This might be a problem for other, similar services (e.g. `FolderService`), but I haven't looked at these changes in depth so I'll defer to @MGibson1.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Give `BrowserOrganizationService._organizations` a value, i.e. a new BehaviorSubject (same as the base class).

@MGibson1 to confirm that this is compatible with the session syncing logic. This may not be an appropriate fix - I can't remember how all that internal plumbing works in detail.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
