### PR TITLE
[SM-360] Fix access token display dialog for never expiring tokens

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.ts
@@ -21,7 +21,7 @@ export interface AccessTokenOperation {
 })
 export class AccessTokenCreateDialogComponent implements OnInit {
   protected formGroup = new FormGroup({
-    name: new FormControl("", [Validators.required]),
+    name: new FormControl("", [Validators.required, Validators.maxLength(80)]),
     expirationDateControl: new FormControl(null),
   });
   protected loading = false;
@@ -72,7 +72,7 @@ export class AccessTokenCreateDialogComponent implements OnInit {
   private openAccessTokenDialog(
     serviceAccountName: string,
     accessToken: string,
-    expirationDate: Date
+    expirationDate?: Date
   ) {
     this.dialogService.open<unknown, AccessTokenDetails>(AccessTokenDialogComponent, {
       data: {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -9,14 +9,16 @@
   <div bitDialogContent>
     <bit-callout type="info" [title]="'accessTokenCallOutTitle' | i18n">
       {{ "downloadAccessToken" | i18n }}<br />
-      {{ "expiresOnAccessToken" | i18n }} {{ data.expirationDate | date: "medium" }}
+      {{ "expiresOnAccessToken" | i18n }}
+      {{ data.expirationDate === null ? ("never" | i18n) : (data.expirationDate | date: "medium") }}
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">
       <bit-label>{{ "accessToken" | i18n }}</bit-label>
       <textarea bitInput disabled rows="4">{{ data.accessToken }}</textarea>
     </bit-form-field>
-    {{ "expiresOnAccessToken" | i18n }} {{ data.expirationDate | date: "medium" }}
+    {{ "expiresOnAccessToken" | i18n }}
+    {{ data.expirationDate === null ? ("never" | i18n) : (data.expirationDate | date: "medium") }}
   </div>
 
   <div bitDialogFooter class="tw-flex tw-gap-2">

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.ts
@@ -6,7 +6,7 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
 
 export interface AccessTokenDetails {
   subTitle: string;
-  expirationDate: Date;
+  expirationDate?: Date;
   accessToken: string;
 }
 
@@ -24,7 +24,7 @@ export class AccessTokenDialogComponent implements OnInit {
 
   ngOnInit(): void {
     // TODO remove null checks once strictNullChecks in TypeScript is turned on.
-    if (!this.data.subTitle || !this.data.expirationDate || !this.data.accessToken) {
+    if (!this.data.subTitle || !this.data.accessToken) {
       this.dialogRef.close();
       throw new Error("The access token dialog was not called with the appropriate values.");
     }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.ts
@@ -20,7 +20,9 @@ export class AccessTokenDialogComponent implements OnInit {
     @Inject(DIALOG_DATA) public data: AccessTokenDetails,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService
-  ) {}
+  ) {
+    this.dialogRef.disableClose = true;
+  }
 
   ngOnInit(): void {
     // TODO remove null checks once strictNullChecks in TypeScript is turned on.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to: 
 
 - Fix the access token display dialog for never expiring tokens.
 - Add a maximum input of 80 characters to the name form field in the create access token dialog

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.ts
bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.ts

Support never expiring tokens 

- bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.ts

Input validator


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

![image](https://user-images.githubusercontent.com/43214426/205118883-c58b371c-7a81-4680-aeba-60363f9f5957.png)

![image](https://user-images.githubusercontent.com/43214426/205118933-35c259a3-89df-4201-a641-8672f6989fc2.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
