### PR TITLE
[PS-1962] Fix typo for DuckDuckGo form field

### DIFF
--- a/apps/browser/src/popup/generator/generator.component.html
+++ b/apps/browser/src/popup/generator/generator.component.html
@@ -351,7 +351,7 @@
             <input
               id="duckduckgo-apikey"
               type="password"
-              name="DuckDudkGoApiKey"
+              name="DuckDuckGoApiKey"
               [(ngModel)]="usernameOptions.forwardedDuckDuckGoToken"
               (blur)="saveUsernameOptions()"
             />

--- a/apps/desktop/src/app/vault/generator.component.html
+++ b/apps/desktop/src/app/vault/generator.component.html
@@ -384,7 +384,7 @@
                   <input
                     id="duckduckgo-apikey"
                     type="password"
-                    name="DuckDudkGoApiKey"
+                    name="DuckDuckGoApiKey"
                     [(ngModel)]="usernameOptions.forwardedDuckDuckGoToken"
                     (blur)="saveUsernameOptions()"
                   />

--- a/apps/web/src/app/tools/generator.component.html
+++ b/apps/web/src/app/tools/generator.component.html
@@ -299,7 +299,7 @@
           id="duckduckgo-apikey"
           class="form-control"
           type="password"
-          name="DuckDudkGoApiKey"
+          name="DuckDuckGoApiKey"
           [(ngModel)]="usernameOptions.forwardedDuckDuckGoToken"
           (blur)="saveUsernameOptions()"
         />


### PR DESCRIPTION
## Type of change

Fix what I assume is a typo `name="DuckDudkGoApiKey"` > `name="DuckDuckGoApiKey"`

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Noticed while fixing a merge conflict on https://github.com/bitwarden/clients/pull/3405 ... I assume this `name` is wrong?

## Code changes

- **apps/browser/src/popup/generator/generator.component.html**, **apps/desktop/src/app/vault/generator.component.html**, **apps/web/src/app/tools/generator.component.html**:  fix typo `name="DuckDudkGoApiKey"` > `name="DuckDuckGoApiKey"`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
