### PR TITLE
Fix links in README to our contrib guidelines

### DIFF
--- a/apps/browser/README.md
+++ b/apps/browser/README.md
@@ -19,4 +19,4 @@ The Bitwarden browser extension is written using the Web Extension API and Angul
 
 ## Documentation
 
-Please refer to the [Browser section](https://contributing.bitwarden.com/clients/browser/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.
+Please refer to the [Browser section](https://contributing.bitwarden.com/docs/clients/browser/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -11,7 +11,7 @@ The Bitwarden CLI is a powerful, full-featured command-line interface (CLI) tool
 
 ## Developer Documentation
 
-Please refer to the [CLI section](https://contributing.bitwarden.com/clients/cli/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.
+Please refer to the [CLI section](https://contributing.bitwarden.com/docs/clients/cli/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.
 
 ## User Documentation
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -12,4 +12,4 @@ The Bitwarden desktop app is written using Electron and Angular. The application
 
 ## Documentation
 
-Please refer to the [Desktop section](https://contributing.bitwarden.com/clients/desktop/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.
+Please refer to the [Desktop section](https://contributing.bitwarden.com/docs/clients/desktop/) of the [Contributing Documentation](https://contributing.bitwarden.com/) for build instructions, recommended tooling, code style tips, and lots of other great information to get you started.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixing our links in the specific client README's to our setup guides in our contribution docs.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
