### PR TITLE
[SG-742]

### DIFF
--- a/apps/browser/src/popup/accounts/home.component.html
+++ b/apps/browser/src/popup/accounts/home.component.html
@@ -9,9 +9,18 @@
             <label for="email">{{ "emailAddress" | i18n }}</label>
             <input id="email" type="email" formControlName="email" appInputVerbatim="false" />
           </div>
-        </div>
-        <div class="box-footer no-margin" *ngIf="selfHostedDomain">
-          {{ "loggingInTo" | i18n: selfHostedDomain }}
+          <div class="box-footer no-margin" *ngIf="selfHostedDomain">
+            {{ "loggingInTo" | i18n: selfHostedDomain }}
+          </div>
+          <div class="remember-email-check">
+            <input
+              id="rememberEmail"
+              type="checkbox"
+              name="rememberEmail"
+              formControlName="rememberEmail"
+            />
+            <label for="rememberEmail">{{ "rememberEmail" | i18n }}</label>
+          </div>
         </div>
       </div>
       <div class="box">
@@ -22,10 +31,10 @@
     </form>
     <p class="createAccountLink">
       {{ "newAroundHere" | i18n }}
-      <a routerLink="/register">{{ "createAccount" | i18n }}</a>
+      <a routerLink="/register" (click)="setFormValues()">{{ "createAccount" | i18n }}</a>
     </p>
   </div>
 </div>
-<button type="button" routerLink="/environment" class="settings-icon">
+<button type="button" routerLink="/environment" class="settings-icon" (click)="setFormValues()">
   <i class="bwi bwi-cog-f bwi-lg" aria-hidden="true"></i><span>&nbsp;{{ "settings" | i18n }}</span>
 </button>

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -71,6 +71,7 @@ export class LoginComponent extends BaseLoginComponent {
   }
 
   async launchSsoBrowser() {
+    await this.loginService.saveEmailSettings();
     // Generate necessary sso params
     const passwordOptions: any = {
       type: "password",

--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -23,8 +23,6 @@ import { Utils } from "@bitwarden/common/misc/utils";
   templateUrl: "login.component.html",
 })
 export class LoginComponent extends BaseLoginComponent {
-  protected skipRememberEmail = true;
-
   constructor(
     apiService: ApiService,
     appIdService: AppIdService,

--- a/apps/browser/src/popup/scss/pages.scss
+++ b/apps/browser/src/popup/scss/pages.scss
@@ -144,8 +144,9 @@ body.body-full {
 }
 
 .remember-email-check {
+  padding-top: 8px;
   padding-left: 10px;
-  padding-bottom: 10px;
+  padding-bottom: 18px;
 }
 
 .login-buttons > button {

--- a/apps/browser/src/popup/scss/pages.scss
+++ b/apps/browser/src/popup/scss/pages.scss
@@ -143,6 +143,11 @@ body.body-full {
   padding: 30px 10px 0 10px;
 }
 
+.remember-email-check {
+  padding-left: 10px;
+  padding-bottom: 10px;
+}
+
 .login-buttons > button {
   margin: 15px 0 15px 0;
 }

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -357,6 +357,7 @@ function getBgService<T>(service: keyof MainBackground) {
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
     {
       provide: AbstractThemingService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -180,6 +180,7 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
   ],
 })

--- a/apps/web/src/app/accounts/login/login-with-device.component.ts
+++ b/apps/web/src/app/accounts/login/login-with-device.component.ts
@@ -206,7 +206,6 @@ export class LoginWithDeviceComponent
   private async setRememberEmailValues() {
     const rememberEmail = this.loginService.getRememberEmail();
     const rememberedEmail = this.loginService.getEmail();
-    await this.stateService.setRememberEmail(rememberEmail);
     await this.stateService.setRememberedEmail(rememberEmail ? rememberedEmail : null);
     this.loginService.clearValues();
   }

--- a/apps/web/src/app/accounts/login/login-with-device.component.ts
+++ b/apps/web/src/app/accounts/login/login-with-device.component.ts
@@ -142,7 +142,7 @@ export class LoginWithDeviceComponent
           this.router.navigate([this.forcePasswordResetRoute]);
         }
       } else {
-        await this.setRememberEmailValues();
+        await this.loginService.saveEmailSettings();
         if (this.onSuccessfulLogin != null) {
           this.onSuccessfulLogin();
         }
@@ -201,12 +201,5 @@ export class LoginWithDeviceComponent
       key,
       localHashedPassword
     );
-  }
-
-  private async setRememberEmailValues() {
-    const rememberEmail = this.loginService.getRememberEmail();
-    const rememberedEmail = this.loginService.getEmail();
-    await this.stateService.setRememberedEmail(rememberEmail ? rememberedEmail : null);
-    this.loginService.clearValues();
   }
 }

--- a/apps/web/src/app/accounts/login/login.component.html
+++ b/apps/web/src/app/accounts/login/login.component.html
@@ -120,7 +120,7 @@
   <div class="tw-mb-3">
     <a
       routerLink="/sso"
-      (click)="setFormValues()"
+      (click)="saveEmailSettings()"
       bitButton
       buttonType="secondary"
       class="tw-w-full"

--- a/apps/web/src/app/accounts/login/login.component.ts
+++ b/apps/web/src/app/accounts/login/login.component.ts
@@ -192,7 +192,6 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
   async submit() {
     const rememberEmail = this.formGroup.value.rememberEmail;
 
-    await this.stateService.setRememberEmail(rememberEmail);
     if (!rememberEmail) {
       await this.stateService.setRememberedEmail(null);
     }

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -103,6 +103,7 @@ import { WebPlatformUtilsService } from "./web-platform-utils.service";
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateService],
     },
   ],
 })

--- a/apps/web/src/app/core/state/state.service.ts
+++ b/apps/web/src/app/core/state/state.service.ts
@@ -48,23 +48,6 @@ export class StateService extends BaseStateService<GlobalState, Account> {
     await super.addAccount(account);
   }
 
-  async getRememberEmail(options?: StorageOptions) {
-    return (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.rememberEmail;
-  }
-
-  async setRememberEmail(value: boolean, options?: StorageOptions): Promise<void> {
-    const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-    );
-    globals.rememberEmail = value;
-    await this.saveGlobals(
-      globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-    );
-  }
-
   async getEncryptedCiphers(options?: StorageOptions): Promise<{ [id: string]: CipherData }> {
     options = this.reconcileOptions(options, await this.defaultInMemoryOptions());
     return await super.getEncryptedCiphers(options);

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -46,8 +46,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   protected twoFactorRoute = "2fa";
   protected successRoute = "vault";
   protected forcePasswordResetRoute = "update-temp-password";
-  protected alwaysRememberEmail = false;
-  protected skipRememberEmail = false;
 
   get loggedEmail() {
     return this.formGroup.value.email;
@@ -98,13 +96,11 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     if (!this.paramEmailSet) {
       this.formGroup.get("email")?.setValue(email ?? "");
     }
-    if (!this.alwaysRememberEmail) {
-      let rememberEmail = this.loginService.getRememberEmail();
-      if (rememberEmail == null) {
-        rememberEmail = (await this.stateService.getRememberedEmail()) != null;
-      }
-      this.formGroup.get("rememberEmail")?.setValue(rememberEmail);
+    let rememberEmail = this.loginService.getRememberEmail();
+    if (rememberEmail == null) {
+      rememberEmail = (await this.stateService.getRememberedEmail()) != null;
     }
+    this.formGroup.get("rememberEmail")?.setValue(rememberEmail);
   }
 
   async submit(showToast = true) {

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -83,6 +83,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
         const queryParamsEmail = params["email"];
         if (queryParamsEmail != null && queryParamsEmail.indexOf("@") > -1) {
           this.formGroup.get("email").setValue(queryParamsEmail);
+          this.loginService.setEmail(queryParamsEmail);
           this.paramEmailSet = true;
         }
       }
@@ -132,11 +133,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       this.formPromise = this.authService.logIn(credentials);
       const response = await this.formPromise;
       this.setFormValues();
-      if (data.rememberEmail) {
-        await this.stateService.setRememberedEmail(data.email);
-      } else {
-        await this.stateService.setRememberedEmail(null);
-      }
+      await this.loginService.saveEmailSettings();
       if (this.handleCaptchaRequired(response)) {
         return;
       } else if (response.requiresTwoFactor) {
@@ -154,7 +151,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       } else {
         const disableFavicon = await this.stateService.getDisableFavicon();
         await this.stateService.setDisableFavicon(!!disableFavicon);
-        this.loginService.clearValues();
         if (this.onSuccessfulLogin != null) {
           this.onSuccessfulLogin();
         }
@@ -181,6 +177,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   }
 
   async launchSsoBrowser(clientId: string, ssoRedirectUri: string) {
+    await this.saveEmailSettings();
     // Generate necessary sso params
     const passwordOptions: any = {
       type: "password",
@@ -233,6 +230,11 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   setFormValues() {
     this.loginService.setEmail(this.formGroup.value.email);
     this.loginService.setRememberEmail(this.formGroup.value.rememberEmail);
+  }
+
+  async saveEmailSettings() {
+    this.setFormValues();
+    await this.loginService.saveEmailSettings();
   }
 
   private getErrorToastMessage() {

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -105,10 +105,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       }
       this.formGroup.get("rememberEmail")?.setValue(rememberEmail);
     }
-
-    if (email) {
-      this.validateEmail();
-    }
   }
 
   async submit(showToast = true) {
@@ -140,7 +136,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       this.formPromise = this.authService.logIn(credentials);
       const response = await this.formPromise;
       this.setFormValues();
-      if (data.rememberEmail || this.alwaysRememberEmail) {
+      if (data.rememberEmail) {
         await this.stateService.setRememberedEmail(data.email);
       } else {
         await this.stateService.setRememberedEmail(null);

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -592,6 +592,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
   ],
 })

--- a/libs/common/src/abstractions/login.service.ts
+++ b/libs/common/src/abstractions/login.service.ts
@@ -4,4 +4,5 @@ export abstract class LoginService {
   setEmail: (value: string) => void;
   setRememberEmail: (value: boolean) => void;
   clearValues: () => void;
+  saveEmailSettings: () => Promise<void>;
 }

--- a/libs/common/src/services/login.service.ts
+++ b/libs/common/src/services/login.service.ts
@@ -1,8 +1,11 @@
 import { LoginService as LoginServiceAbstraction } from "../abstractions/login.service";
+import { StateService } from "../abstractions/state.service";
 
 export class LoginService implements LoginServiceAbstraction {
   private _email: string;
   private _rememberEmail: boolean;
+
+  constructor(private stateService: StateService) {}
 
   getEmail() {
     return this._email;
@@ -23,5 +26,10 @@ export class LoginService implements LoginServiceAbstraction {
   clearValues() {
     this._email = null;
     this._rememberEmail = null;
+  }
+
+  async saveEmailSettings() {
+    await this.stateService.setRememberedEmail(this._rememberEmail ? this._email : null);
+    this.clearValues();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
### Two Step Login Cleanup
- Remove `alwaysRemember` code from base Login Component
- Change flow to always land on email screen even if an email is remembered
- Add Remember Email functionality back to browser, now that it is feasible with all changes.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

### Libs
- **libs/angular/src/components/login.component.ts:** Remove `alwaysRememberEmail` functionality and landing on the password screen if an email is remembered.

### Web
- **Web State Service** Remove get and set `rememberEmail` state variable. We no longer need this with the presence of the LoginService. We can infer this value on initial load by the presence of a rememberedEmail.

### Browser
- **HomeComponent:** Add remember email option
- **LoginComponent:** Remove unused variable

## Screenshots

https://user-images.githubusercontent.com/8926729/205959961-28442966-4515-4f78-89c6-04e0d44d44b5.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
