### PR TITLE
[ps-2003] Ps/ps 1854 fix pin

### DIFF
--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
@@ -1,4 +1,4 @@
-import { awaitAsync as flushAsyncObservables } from "@bitwarden/angular/../test-utils";
+import { awaitAsync, awaitAsync as flushAsyncObservables } from "@bitwarden/angular/../test-utils";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, ReplaySubject } from "rxjs";
 
@@ -30,6 +30,7 @@ describe("session syncer", () => {
     });
 
     stateService = mock<BrowserStateService>();
+    stateService.hasInSessionMemory.mockResolvedValue(false);
     sut = new SessionSyncer(behaviorSubject, stateService, metaData);
   });
 
@@ -101,24 +102,26 @@ describe("session syncer", () => {
       expect(sut["ignoreNUpdates"]).toBe(1);
     });
 
-    it("should grab an initial value from storage if it exists", () => {
+    it("should grab an initial value from storage if it exists", async () => {
       stateService.hasInSessionMemory.mockResolvedValue(true);
       //Block a call to update
       const updateSpy = jest.spyOn(sut as any, "update").mockImplementation();
 
       sut.init();
+      await awaitAsync();
 
       expect(updateSpy).toHaveBeenCalledWith();
     });
 
-    it("should not grab an initial value from storage if it does not exist", () => {
+    it("should not grab an initial value from storage if it does not exist", async () => {
       stateService.hasInSessionMemory.mockResolvedValue(false);
       //Block a call to update
       const updateSpy = jest.spyOn(sut as any, "update").mockImplementation();
 
       sut.init();
+      await awaitAsync();
 
-      expect(updateSpy).toHaveBeenCalledWith();
+      expect(updateSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
@@ -42,9 +42,12 @@ export class SessionSyncer {
     }
 
     this.observe();
-    if (this.stateService.hasInSessionMemory(this.metaData.sessionKey)) {
-      this.update();
-    }
+    // must be synchronous
+    this.stateService.hasInSessionMemory(this.metaData.sessionKey).then((hasInSessionMemory) => {
+      if (hasInSessionMemory) {
+        this.update();
+      }
+    });
 
     this.listenForUpdates();
   }

--- a/apps/browser/src/services/browser-state.service.ts
+++ b/apps/browser/src/services/browser-state.service.ts
@@ -28,6 +28,11 @@ export class BrowserStateService
   protected activeAccountSubject: BehaviorSubject<string>;
   @sessionSync({ ctor: Boolean })
   protected activeAccountUnlockedSubject: BehaviorSubject<boolean>;
+  @sessionSync({
+    initializer: Account.fromJSON as any, // TODO: Remove this any when all any types are removed from Account
+    initializeAs: "record",
+  })
+  protected accountDiskCache: BehaviorSubject<Record<string, Account>>;
 
   protected accountDeserializer = Account.fromJSON;
 

--- a/libs/common/src/services/memoryStorage.service.ts
+++ b/libs/common/src/services/memoryStorage.service.ts
@@ -18,7 +18,7 @@ export class MemoryStorageService
   }
 
   async has(key: string): Promise<boolean> {
-    return this.get(key) != null;
+    return (await this.get(key)) != null;
   }
 
   save(key: string, obj: any): Promise<any> {

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2397,9 +2397,7 @@ export class StateService<
         ))
       : await this.storageService.get<TAccount>(options.userId, options);
 
-    if (this.useAccountCache) {
-      this.setDiskCache(options.userId, account);
-    }
+    this.setDiskCache(options.userId, account);
     return account;
   }
 
@@ -2430,9 +2428,7 @@ export class StateService<
 
     await storageLocation.save(`${options.userId}`, account, options);
 
-    if (this.useAccountCache) {
-      this.deleteDiskCache(options.userId);
-    }
+    this.deleteDiskCache(options.userId);
   }
 
   protected async saveAccountToMemory(account: TAccount): Promise<void> {
@@ -2643,9 +2639,7 @@ export class StateService<
       userId = userId ?? state.activeUserId;
       delete state.accounts[userId];
 
-      if (this.useAccountCache) {
-        this.deleteDiskCache(userId);
-      }
+      this.deleteDiskCache(userId);
 
       return state;
     });

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -79,7 +79,7 @@ export class StateService<
   private hasBeenInited = false;
   private isRecoveredSession = false;
 
-  private accountDiskCache = new Map<string, TAccount>();
+  protected accountDiskCache = new BehaviorSubject<Record<string, TAccount>>({});
 
   // default account serializer, must be overridden by child class
   protected accountDeserializer = Account.fromJSON as (json: Jsonify<TAccount>) => TAccount;
@@ -2383,7 +2383,7 @@ export class StateService<
     }
 
     if (this.useAccountCache) {
-      const cachedAccount = this.accountDiskCache.get(options.userId);
+      const cachedAccount = this.accountDiskCache.value[options.userId];
       if (cachedAccount != null) {
         return cachedAccount;
       }
@@ -2398,7 +2398,7 @@ export class StateService<
       : await this.storageService.get<TAccount>(options.userId, options);
 
     if (this.useAccountCache) {
-      this.accountDiskCache.set(options.userId, account);
+      this.setDiskCache(options.userId, account);
     }
     return account;
   }
@@ -2431,7 +2431,7 @@ export class StateService<
     await storageLocation.save(`${options.userId}`, account, options);
 
     if (this.useAccountCache) {
-      this.accountDiskCache.delete(options.userId);
+      this.deleteDiskCache(options.userId);
     }
   }
 
@@ -2644,7 +2644,7 @@ export class StateService<
       delete state.accounts[userId];
 
       if (this.useAccountCache) {
-        this.accountDiskCache.delete(userId);
+        this.deleteDiskCache(userId);
       }
 
       return state;
@@ -2769,6 +2769,20 @@ export class StateService<
 
       await this.setState(updatedState);
     });
+  }
+
+  private setDiskCache(key: string, value: TAccount, options?: StorageOptions) {
+    if (this.useAccountCache) {
+      this.accountDiskCache.value[key] = value;
+      this.accountDiskCache.next(this.accountDiskCache.value);
+    }
+  }
+
+  private deleteDiskCache(key: string) {
+    if (this.useAccountCache) {
+      delete this.accountDiskCache.value[key];
+      this.accountDiskCache.next(this.accountDiskCache.value);
+    }
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix account disk cache sync between background and visualizers. One known bug caused by this was strange behavior when setting a pin in browser for the first time, then reloading the popup. This fixes the issue by syncing the account disk cache used by background and serializers.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
