### PR TITLE
Add 'search' as a valid InputType

### DIFF
--- a/libs/components/src/form-field/form-field-control.ts
+++ b/libs/components/src/form-field/form-field-control.ts
@@ -1,4 +1,11 @@
-export type InputTypes = "text" | "password" | "number" | "datetime-local" | "email" | "checkbox";
+export type InputTypes =
+  | "text"
+  | "password"
+  | "number"
+  | "datetime-local"
+  | "email"
+  | "checkbox"
+  | "search";
 
 export abstract class BitFormFieldControl {
   ariaDescribedBy: string;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The new search input component uses input [`type="search"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search) which was not an allowed type for the `bitInput` directive and caused the web build to fail.

## Code changes

- **libs/components/src/form-field/form-field-control.ts** Add "search" as a valid type to the `InputTypes` enum

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
