### PR TITLE
[EC-277] Remove SHA-1 encryption from SSO Outbound and Minimum Signing Algorithm lists

### DIFF
--- a/bitwarden_license/bit-web/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/sso.component.ts
@@ -49,7 +49,6 @@ export class SsoComponent implements OnInit, OnDestroy {
     "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
     "http://www.w3.org/2000/09/xmldsig#rsa-sha384",
     "http://www.w3.org/2000/09/xmldsig#rsa-sha512",
-    "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
   ];
 
   readonly saml2SigningBehaviourOptions: SelectOptions[] = [


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Remove SHA-1 encryption from SSO Outbound and Minimum Signing Algorithm lists as it is not supported.

## Code changes

- **bitwarden_license/bit-web/src/app/organizations/manage/sso.component.ts:** Removed the sha-1 entry from the algorithm list

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
