### PR TITLE
[EC-836] Trying to confirm 2018 user account to organization returns 404

### DIFF
--- a/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
@@ -1,6 +1,4 @@
 // eslint-disable-next-line no-restricted-imports
-import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
-
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
 import { AuthService } from "@bitwarden/common/abstractions/auth.service";
@@ -23,6 +21,7 @@ import { TokenTwoFactorRequest } from "@bitwarden/common/models/request/identity
 import { IdentityCaptchaResponse } from "@bitwarden/common/models/response/identity-captcha.response";
 import { IdentityTokenResponse } from "@bitwarden/common/models/response/identity-token.response";
 import { IdentityTwoFactorResponse } from "@bitwarden/common/models/response/identity-two-factor.response";
+import { mock, MockProxy } from "jest-mock-extended";
 
 const email = "hello@world.com";
 const masterPassword = "password";
@@ -67,33 +66,34 @@ export function identityTokenResponseFactory() {
 }
 
 describe("LogInStrategy", () => {
-  let cryptoService: SubstituteOf<CryptoService>;
-  let apiService: SubstituteOf<ApiService>;
-  let tokenService: SubstituteOf<TokenService>;
-  let appIdService: SubstituteOf<AppIdService>;
-  let platformUtilsService: SubstituteOf<PlatformUtilsService>;
-  let messagingService: SubstituteOf<MessagingService>;
-  let logService: SubstituteOf<LogService>;
-  let stateService: SubstituteOf<StateService>;
-  let twoFactorService: SubstituteOf<TwoFactorService>;
-  let authService: SubstituteOf<AuthService>;
+  let cryptoService: MockProxy<CryptoService>;
+  let apiService: MockProxy<ApiService>;
+  let tokenService: MockProxy<TokenService>;
+  let appIdService: MockProxy<AppIdService>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let messagingService: MockProxy<MessagingService>;
+  let logService: MockProxy<LogService>;
+  let stateService: MockProxy<StateService>;
+  let twoFactorService: MockProxy<TwoFactorService>;
+  let authService: MockProxy<AuthService>;
 
   let passwordLogInStrategy: PasswordLogInStrategy;
   let credentials: PasswordLogInCredentials;
 
   beforeEach(async () => {
-    cryptoService = Substitute.for<CryptoService>();
-    apiService = Substitute.for<ApiService>();
-    tokenService = Substitute.for<TokenService>();
-    appIdService = Substitute.for<AppIdService>();
-    platformUtilsService = Substitute.for<PlatformUtilsService>();
-    messagingService = Substitute.for<MessagingService>();
-    logService = Substitute.for<LogService>();
-    stateService = Substitute.for<StateService>();
-    twoFactorService = Substitute.for<TwoFactorService>();
-    authService = Substitute.for<AuthService>();
+    cryptoService = mock<CryptoService>();
+    apiService = mock<ApiService>();
+    tokenService = mock<TokenService>();
+    appIdService = mock<AppIdService>();
+    platformUtilsService = mock<PlatformUtilsService>();
+    messagingService = mock<MessagingService>();
+    logService = mock<LogService>();
+    stateService = mock<StateService>();
+    twoFactorService = mock<TwoFactorService>();
+    authService = mock<AuthService>();
 
-    appIdService.getAppId().resolves(deviceId);
+    appIdService.getAppId.mockResolvedValue(deviceId);
+    tokenService.decodeToken.calledWith(accessToken).mockResolvedValue(decodedToken);
 
     // The base class is abstract so we test it via PasswordLogInStrategy
     passwordLogInStrategy = new PasswordLogInStrategy(
@@ -113,12 +113,11 @@ describe("LogInStrategy", () => {
 
   describe("base class", () => {
     it("sets the local environment after a successful login", async () => {
-      apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
-      tokenService.decodeToken(accessToken).resolves(decodedToken);
+      apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
 
       await passwordLogInStrategy.logIn(credentials);
 
-      stateService.received(1).addAccount(
+      expect(stateService.addAccount).toHaveBeenCalledWith(
         new Account({
           profile: {
             ...new AccountProfile(),
@@ -140,10 +139,9 @@ describe("LogInStrategy", () => {
           },
         })
       );
-      cryptoService.received(1).setEncKey(encKey);
-      cryptoService.received(1).setEncPrivateKey(privateKey);
-
-      messagingService.received(1).send("loggedIn");
+      expect(cryptoService.setEncKey).toHaveBeenCalledWith(encKey);
+      expect(cryptoService.setEncPrivateKey).toHaveBeenCalledWith(privateKey);
+      expect(messagingService.send).toHaveBeenCalledWith("loggedIn");
     });
 
     it("builds AuthResult", async () => {
@@ -151,16 +149,16 @@ describe("LogInStrategy", () => {
       tokenResponse.forcePasswordReset = true;
       tokenResponse.resetMasterPassword = true;
 
-      apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
       const result = await passwordLogInStrategy.logIn(credentials);
 
-      const expected = new AuthResult();
-      expected.forcePasswordReset = true;
-      expected.resetMasterPassword = true;
-      expected.twoFactorProviders = null;
-      expected.captchaSiteKey = "";
-      expect(result).toEqual(expected);
+      expect(result).toEqual({
+        forcePasswordReset: true,
+        resetMasterPassword: true,
+        twoFactorProviders: null,
+        captchaSiteKey: "",
+      } as AuthResult);
     });
 
     it("rejects login if CAPTCHA is required", async () => {
@@ -171,12 +169,12 @@ describe("LogInStrategy", () => {
         HCaptcha_SiteKey: captchaSiteKey,
       });
 
-      apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
       const result = await passwordLogInStrategy.logIn(credentials);
 
-      stateService.didNotReceive().addAccount(Arg.any());
-      messagingService.didNotReceive().send(Arg.any());
+      expect(stateService.addAccount).not.toHaveBeenCalled();
+      expect(messagingService.send).not.toHaveBeenCalled();
 
       const expected = new AuthResult();
       expected.captchaSiteKey = captchaSiteKey;
@@ -186,13 +184,13 @@ describe("LogInStrategy", () => {
     it("makes a new public and private key for an old account", async () => {
       const tokenResponse = identityTokenResponseFactory();
       tokenResponse.privateKey = null;
-      cryptoService.makeKeyPair(Arg.any()).resolves(["PUBLIC_KEY", new EncString("PRIVATE_KEY")]);
+      cryptoService.makeKeyPair.mockResolvedValue(["PUBLIC_KEY", new EncString("PRIVATE_KEY")]);
 
-      apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
       await passwordLogInStrategy.logIn(credentials);
 
-      apiService.received(1).postAccountKeys(Arg.any());
+      expect(apiService.postAccountKeys).toHaveBeenCalled();
     });
   });
 
@@ -206,12 +204,12 @@ describe("LogInStrategy", () => {
         error_description: "Two factor required.",
       });
 
-      apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
       const result = await passwordLogInStrategy.logIn(credentials);
 
-      stateService.didNotReceive().addAccount(Arg.any());
-      messagingService.didNotReceive().send(Arg.any());
+      expect(stateService.addAccount).not.toHaveBeenCalled();
+      expect(messagingService.send).not.toHaveBeenCalled();
 
       const expected = new AuthResult();
       expected.twoFactorProviders = new Map<TwoFactorProviderType, { [key: string]: string }>();
@@ -220,26 +218,25 @@ describe("LogInStrategy", () => {
     });
 
     it("sends stored 2FA token to server", async () => {
-      tokenService.getTwoFactorToken().resolves(twoFactorToken);
-      apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+      tokenService.getTwoFactorToken.mockResolvedValue(twoFactorToken);
+      apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
 
       await passwordLogInStrategy.logIn(credentials);
 
-      apiService.received(1).postIdentityToken(
-        Arg.is((actual) => {
-          const passwordTokenRequest = actual as any;
-          return (
-            passwordTokenRequest.twoFactor.provider === TwoFactorProviderType.Remember &&
-            passwordTokenRequest.twoFactor.token === twoFactorToken &&
-            passwordTokenRequest.twoFactor.remember === false
-          );
+      expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          twoFactor: {
+            provider: TwoFactorProviderType.Remember,
+            token: twoFactorToken,
+            remember: false,
+          } as TokenTwoFactorRequest,
         })
       );
     });
 
     it("sends 2FA token provided by user to server (single step)", async () => {
       // This occurs if the user enters the 2FA code as an argument in the CLI
-      apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+      apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
       credentials.twoFactor = new TokenTwoFactorRequest(
         twoFactorProviderType,
         twoFactorToken,
@@ -248,14 +245,13 @@ describe("LogInStrategy", () => {
 
       await passwordLogInStrategy.logIn(credentials);
 
-      apiService.received(1).postIdentityToken(
-        Arg.is((actual) => {
-          const passwordTokenRequest = actual as any;
-          return (
-            passwordTokenRequest.twoFactor.provider === twoFactorProviderType &&
-            passwordTokenRequest.twoFactor.token === twoFactorToken &&
-            passwordTokenRequest.twoFactor.remember === twoFactorRemember
-          );
+      expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          twoFactor: {
+            provider: twoFactorProviderType,
+            token: twoFactorToken,
+            remember: twoFactorRemember,
+          } as TokenTwoFactorRequest,
         })
       );
     });
@@ -269,21 +265,20 @@ describe("LogInStrategy", () => {
         null
       );
 
-      apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+      apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
 
       await passwordLogInStrategy.logInTwoFactor(
         new TokenTwoFactorRequest(twoFactorProviderType, twoFactorToken, twoFactorRemember),
         null
       );
 
-      apiService.received(1).postIdentityToken(
-        Arg.is((actual) => {
-          const passwordTokenRequest = actual as any;
-          return (
-            passwordTokenRequest.twoFactor.provider === twoFactorProviderType &&
-            passwordTokenRequest.twoFactor.token === twoFactorToken &&
-            passwordTokenRequest.twoFactor.remember === twoFactorRemember
-          );
+      expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          twoFactor: {
+            provider: twoFactorProviderType,
+            token: twoFactorToken,
+            remember: twoFactorRemember,
+          } as TokenTwoFactorRequest,
         })
       );
     });

--- a/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
@@ -190,6 +190,13 @@ describe("LogInStrategy", () => {
 
       await passwordLogInStrategy.logIn(credentials);
 
+      // User key must be set before the new RSA keypair is generated, otherwise we can't decrypt the EncKey
+      expect(cryptoService.setKey).toHaveBeenCalled();
+      expect(cryptoService.makeKeyPair).toHaveBeenCalled();
+      expect(cryptoService.setKey.mock.invocationCallOrder[0]).toBeLessThan(
+        cryptoService.makeKeyPair.mock.invocationCallOrder[0]
+      );
+
       expect(apiService.postAccountKeys).toHaveBeenCalled();
     });
   });

--- a/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/logIn.strategy.spec.ts
@@ -1,4 +1,5 @@
-// eslint-disable-next-line no-restricted-imports
+import { mock, MockProxy } from "jest-mock-extended";
+
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
 import { AuthService } from "@bitwarden/common/abstractions/auth.service";
@@ -21,7 +22,6 @@ import { TokenTwoFactorRequest } from "@bitwarden/common/models/request/identity
 import { IdentityCaptchaResponse } from "@bitwarden/common/models/response/identity-captcha.response";
 import { IdentityTokenResponse } from "@bitwarden/common/models/response/identity-token.response";
 import { IdentityTwoFactorResponse } from "@bitwarden/common/models/response/identity-two-factor.response";
-import { mock, MockProxy } from "jest-mock-extended";
 
 const email = "hello@world.com";
 const masterPassword = "password";

--- a/libs/common/spec/misc/logInStrategies/passwordLogIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/passwordLogIn.strategy.spec.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
@@ -31,41 +30,43 @@ const preloginKey = new SymmetricCryptoKey(
 const deviceId = Utils.newGuid();
 
 describe("PasswordLogInStrategy", () => {
-  let cryptoService: SubstituteOf<CryptoService>;
-  let apiService: SubstituteOf<ApiService>;
-  let tokenService: SubstituteOf<TokenService>;
-  let appIdService: SubstituteOf<AppIdService>;
-  let platformUtilsService: SubstituteOf<PlatformUtilsService>;
-  let messagingService: SubstituteOf<MessagingService>;
-  let logService: SubstituteOf<LogService>;
-  let stateService: SubstituteOf<StateService>;
-  let twoFactorService: SubstituteOf<TwoFactorService>;
-  let authService: SubstituteOf<AuthService>;
+  let cryptoService: MockProxy<CryptoService>;
+  let apiService: MockProxy<ApiService>;
+  let tokenService: MockProxy<TokenService>;
+  let appIdService: MockProxy<AppIdService>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let messagingService: MockProxy<MessagingService>;
+  let logService: MockProxy<LogService>;
+  let stateService: MockProxy<StateService>;
+  let twoFactorService: MockProxy<TwoFactorService>;
+  let authService: MockProxy<AuthService>;
 
   let passwordLogInStrategy: PasswordLogInStrategy;
   let credentials: PasswordLogInCredentials;
 
   beforeEach(async () => {
-    cryptoService = Substitute.for<CryptoService>();
-    apiService = Substitute.for<ApiService>();
-    tokenService = Substitute.for<TokenService>();
-    appIdService = Substitute.for<AppIdService>();
-    platformUtilsService = Substitute.for<PlatformUtilsService>();
-    messagingService = Substitute.for<MessagingService>();
-    logService = Substitute.for<LogService>();
-    stateService = Substitute.for<StateService>();
-    twoFactorService = Substitute.for<TwoFactorService>();
-    authService = Substitute.for<AuthService>();
+    cryptoService = mock<CryptoService>();
+    apiService = mock<ApiService>();
+    tokenService = mock<TokenService>();
+    appIdService = mock<AppIdService>();
+    platformUtilsService = mock<PlatformUtilsService>();
+    messagingService = mock<MessagingService>();
+    logService = mock<LogService>();
+    stateService = mock<StateService>();
+    twoFactorService = mock<TwoFactorService>();
+    authService = mock<AuthService>();
 
-    appIdService.getAppId().resolves(deviceId);
-    tokenService.getTwoFactorToken().resolves(null);
+    appIdService.getAppId.mockResolvedValue(deviceId);
+    tokenService.decodeToken.mockResolvedValue({});
 
-    authService.makePreloginKey(Arg.any(), Arg.any()).resolves(preloginKey);
+    authService.makePreloginKey.mockResolvedValue(preloginKey);
 
-    cryptoService.hashPassword(masterPassword, Arg.any()).resolves(hashedPassword);
-    cryptoService
-      .hashPassword(masterPassword, Arg.any(), HashPurpose.LocalAuthorization)
-      .resolves(localHashedPassword);
+    cryptoService.hashPassword
+      .calledWith(masterPassword, expect.anything(), undefined)
+      .mockResolvedValue(hashedPassword);
+    cryptoService.hashPassword
+      .calledWith(masterPassword, expect.anything(), HashPurpose.LocalAuthorization)
+      .mockResolvedValue(localHashedPassword);
 
     passwordLogInStrategy = new PasswordLogInStrategy(
       cryptoService,
@@ -81,23 +82,24 @@ describe("PasswordLogInStrategy", () => {
     );
     credentials = new PasswordLogInCredentials(email, masterPassword);
 
-    apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+    apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
   });
 
   it("sends master password credentials to the server", async () => {
     await passwordLogInStrategy.logIn(credentials);
 
-    apiService.received(1).postIdentityToken(
-      Arg.is((actual) => {
-        const passwordTokenRequest = actual as any; // Need to access private fields
-        return (
-          passwordTokenRequest.email === email &&
-          passwordTokenRequest.masterPasswordHash === hashedPassword &&
-          passwordTokenRequest.device.identifier === deviceId &&
-          passwordTokenRequest.twoFactor.provider == null &&
-          passwordTokenRequest.twoFactor.token == null &&
-          passwordTokenRequest.captchaResponse == null
-        );
+    expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: email,
+        masterPasswordHash: hashedPassword,
+        device: expect.objectContaining({
+          identifier: deviceId,
+        }),
+        twoFactor: expect.objectContaining({
+          provider: null,
+          token: null,
+        }),
+        captchaResponse: undefined,
       })
     );
   });
@@ -105,7 +107,7 @@ describe("PasswordLogInStrategy", () => {
   it("sets the local environment after a successful login", async () => {
     await passwordLogInStrategy.logIn(credentials);
 
-    cryptoService.received(1).setKey(preloginKey);
-    cryptoService.received(1).setKeyHash(localHashedPassword);
+    expect(cryptoService.setKey).toHaveBeenCalledWith(preloginKey);
+    expect(cryptoService.setKeyHash).toHaveBeenCalledWith(localHashedPassword);
   });
 });

--- a/libs/common/spec/misc/logInStrategies/ssoLogIn.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/ssoLogIn.strategy.spec.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
@@ -18,23 +17,21 @@ import { SsoLogInCredentials } from "@bitwarden/common/models/domain/log-in-cred
 import { identityTokenResponseFactory } from "./logIn.strategy.spec";
 
 describe("SsoLogInStrategy", () => {
-  let cryptoService: SubstituteOf<CryptoService>;
-  let apiService: SubstituteOf<ApiService>;
-  let tokenService: SubstituteOf<TokenService>;
-  let appIdService: SubstituteOf<AppIdService>;
-  let platformUtilsService: SubstituteOf<PlatformUtilsService>;
-  let messagingService: SubstituteOf<MessagingService>;
-  let logService: SubstituteOf<LogService>;
-  let keyConnectorService: SubstituteOf<KeyConnectorService>;
-  let stateService: SubstituteOf<StateService>;
-  let twoFactorService: SubstituteOf<TwoFactorService>;
+  let cryptoService: MockProxy<CryptoService>;
+  let apiService: MockProxy<ApiService>;
+  let tokenService: MockProxy<TokenService>;
+  let appIdService: MockProxy<AppIdService>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let messagingService: MockProxy<MessagingService>;
+  let logService: MockProxy<LogService>;
+  let stateService: MockProxy<StateService>;
+  let twoFactorService: MockProxy<TwoFactorService>;
+  let keyConnectorService: MockProxy<KeyConnectorService>;
 
   let ssoLogInStrategy: SsoLogInStrategy;
   let credentials: SsoLogInCredentials;
 
   const deviceId = Utils.newGuid();
-  const encKey = "ENC_KEY";
-  const privateKey = "PRIVATE_KEY";
   const keyConnectorUrl = "KEY_CONNECTOR_URL";
 
   const ssoCode = "SSO_CODE";
@@ -43,19 +40,20 @@ describe("SsoLogInStrategy", () => {
   const ssoOrgId = "SSO_ORG_ID";
 
   beforeEach(async () => {
-    cryptoService = Substitute.for<CryptoService>();
-    apiService = Substitute.for<ApiService>();
-    tokenService = Substitute.for<TokenService>();
-    appIdService = Substitute.for<AppIdService>();
-    platformUtilsService = Substitute.for<PlatformUtilsService>();
-    messagingService = Substitute.for<MessagingService>();
-    logService = Substitute.for<LogService>();
-    stateService = Substitute.for<StateService>();
-    keyConnectorService = Substitute.for<KeyConnectorService>();
-    twoFactorService = Substitute.for<TwoFactorService>();
+    cryptoService = mock<CryptoService>();
+    apiService = mock<ApiService>();
+    tokenService = mock<TokenService>();
+    appIdService = mock<AppIdService>();
+    platformUtilsService = mock<PlatformUtilsService>();
+    messagingService = mock<MessagingService>();
+    logService = mock<LogService>();
+    stateService = mock<StateService>();
+    twoFactorService = mock<TwoFactorService>();
+    keyConnectorService = mock<KeyConnectorService>();
 
-    tokenService.getTwoFactorToken().resolves(null);
-    appIdService.getAppId().resolves(deviceId);
+    tokenService.getTwoFactorToken.mockResolvedValue(null);
+    appIdService.getAppId.mockResolvedValue(deviceId);
+    tokenService.decodeToken.mockResolvedValue({});
 
     ssoLogInStrategy = new SsoLogInStrategy(
       cryptoService,
@@ -73,21 +71,22 @@ describe("SsoLogInStrategy", () => {
   });
 
   it("sends SSO information to server", async () => {
-    apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+    apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
 
     await ssoLogInStrategy.logIn(credentials);
 
-    apiService.received(1).postIdentityToken(
-      Arg.is((actual) => {
-        const ssoTokenRequest = actual as any;
-        return (
-          ssoTokenRequest.code === ssoCode &&
-          ssoTokenRequest.codeVerifier === ssoCodeVerifier &&
-          ssoTokenRequest.redirectUri === ssoRedirectUrl &&
-          ssoTokenRequest.device.identifier === deviceId &&
-          ssoTokenRequest.twoFactor.provider == null &&
-          ssoTokenRequest.twoFactor.token == null
-        );
+    expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: ssoCode,
+        codeVerifier: ssoCodeVerifier,
+        redirectUri: ssoRedirectUrl,
+        device: expect.objectContaining({
+          identifier: deviceId,
+        }),
+        twoFactor: expect.objectContaining({
+          provider: null,
+          token: null,
+        }),
       })
     );
   });
@@ -95,23 +94,23 @@ describe("SsoLogInStrategy", () => {
   it("does not set keys for new SSO user flow", async () => {
     const tokenResponse = identityTokenResponseFactory();
     tokenResponse.key = null;
-    apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+    apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
     await ssoLogInStrategy.logIn(credentials);
 
-    cryptoService.didNotReceive().setEncPrivateKey(privateKey);
-    cryptoService.didNotReceive().setEncKey(encKey);
+    expect(cryptoService.setEncPrivateKey).not.toHaveBeenCalled();
+    expect(cryptoService.setEncKey).not.toHaveBeenCalled();
   });
 
   it("gets and sets KeyConnector key for enrolled user", async () => {
     const tokenResponse = identityTokenResponseFactory();
     tokenResponse.keyConnectorUrl = keyConnectorUrl;
 
-    apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+    apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
     await ssoLogInStrategy.logIn(credentials);
 
-    keyConnectorService.received(1).getAndSetKey(keyConnectorUrl);
+    expect(keyConnectorService.getAndSetKey).toHaveBeenCalledWith(keyConnectorUrl);
   });
 
   it("converts new SSO user to Key Connector on first login", async () => {
@@ -119,10 +118,13 @@ describe("SsoLogInStrategy", () => {
     tokenResponse.keyConnectorUrl = keyConnectorUrl;
     tokenResponse.key = null;
 
-    apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
+    apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
     await ssoLogInStrategy.logIn(credentials);
 
-    keyConnectorService.received(1).convertNewSsoUserToKeyConnector(tokenResponse, ssoOrgId);
+    expect(keyConnectorService.convertNewSsoUserToKeyConnector).toHaveBeenCalledWith(
+      tokenResponse,
+      ssoOrgId
+    );
   });
 });

--- a/libs/common/spec/misc/logInStrategies/user-api-login.strategy.spec.ts
+++ b/libs/common/spec/misc/logInStrategies/user-api-login.strategy.spec.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
@@ -19,17 +18,17 @@ import { UserApiLogInCredentials } from "@bitwarden/common/models/domain/log-in-
 import { identityTokenResponseFactory } from "./logIn.strategy.spec";
 
 describe("UserApiLogInStrategy", () => {
-  let cryptoService: SubstituteOf<CryptoService>;
-  let apiService: SubstituteOf<ApiService>;
-  let tokenService: SubstituteOf<TokenService>;
-  let appIdService: SubstituteOf<AppIdService>;
-  let platformUtilsService: SubstituteOf<PlatformUtilsService>;
-  let messagingService: SubstituteOf<MessagingService>;
-  let logService: SubstituteOf<LogService>;
-  let environmentService: SubstituteOf<EnvironmentService>;
-  let keyConnectorService: SubstituteOf<KeyConnectorService>;
-  let stateService: SubstituteOf<StateService>;
-  let twoFactorService: SubstituteOf<TwoFactorService>;
+  let cryptoService: MockProxy<CryptoService>;
+  let apiService: MockProxy<ApiService>;
+  let tokenService: MockProxy<TokenService>;
+  let appIdService: MockProxy<AppIdService>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let messagingService: MockProxy<MessagingService>;
+  let logService: MockProxy<LogService>;
+  let stateService: MockProxy<StateService>;
+  let twoFactorService: MockProxy<TwoFactorService>;
+  let keyConnectorService: MockProxy<KeyConnectorService>;
+  let environmentService: MockProxy<EnvironmentService>;
 
   let apiLogInStrategy: UserApiLogInStrategy;
   let credentials: UserApiLogInCredentials;
@@ -40,20 +39,21 @@ describe("UserApiLogInStrategy", () => {
   const apiClientSecret = "API_CLIENT_SECRET";
 
   beforeEach(async () => {
-    cryptoService = Substitute.for<CryptoService>();
-    apiService = Substitute.for<ApiService>();
-    tokenService = Substitute.for<TokenService>();
-    appIdService = Substitute.for<AppIdService>();
-    platformUtilsService = Substitute.for<PlatformUtilsService>();
-    messagingService = Substitute.for<MessagingService>();
-    logService = Substitute.for<LogService>();
-    environmentService = Substitute.for<EnvironmentService>();
-    stateService = Substitute.for<StateService>();
-    keyConnectorService = Substitute.for<KeyConnectorService>();
-    twoFactorService = Substitute.for<TwoFactorService>();
+    cryptoService = mock<CryptoService>();
+    apiService = mock<ApiService>();
+    tokenService = mock<TokenService>();
+    appIdService = mock<AppIdService>();
+    platformUtilsService = mock<PlatformUtilsService>();
+    messagingService = mock<MessagingService>();
+    logService = mock<LogService>();
+    stateService = mock<StateService>();
+    twoFactorService = mock<TwoFactorService>();
+    keyConnectorService = mock<KeyConnectorService>();
+    environmentService = mock<EnvironmentService>();
 
-    appIdService.getAppId().resolves(deviceId);
-    tokenService.getTwoFactorToken().resolves(null);
+    appIdService.getAppId.mockResolvedValue(deviceId);
+    tokenService.getTwoFactorToken.mockResolvedValue(null);
+    tokenService.decodeToken.mockResolvedValue({});
 
     apiLogInStrategy = new UserApiLogInStrategy(
       cryptoService,
@@ -73,43 +73,43 @@ describe("UserApiLogInStrategy", () => {
   });
 
   it("sends api key credentials to the server", async () => {
-    apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+    apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
     await apiLogInStrategy.logIn(credentials);
 
-    apiService.received(1).postIdentityToken(
-      Arg.is((actual) => {
-        const apiTokenRequest = actual as any;
-        return (
-          apiTokenRequest.clientId === apiClientId &&
-          apiTokenRequest.clientSecret === apiClientSecret &&
-          apiTokenRequest.device.identifier === deviceId &&
-          apiTokenRequest.twoFactor.provider == null &&
-          apiTokenRequest.twoFactor.token == null &&
-          apiTokenRequest.captchaResponse == null
-        );
+    expect(apiService.postIdentityToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: apiClientId,
+        clientSecret: apiClientSecret,
+        device: expect.objectContaining({
+          identifier: deviceId,
+        }),
+        twoFactor: expect.objectContaining({
+          provider: null,
+          token: null,
+        }),
       })
     );
   });
 
   it("sets the local environment after a successful login", async () => {
-    apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
+    apiService.postIdentityToken.mockResolvedValue(identityTokenResponseFactory());
 
     await apiLogInStrategy.logIn(credentials);
 
-    stateService.received(1).setApiKeyClientId(apiClientId);
-    stateService.received(1).setApiKeyClientSecret(apiClientSecret);
-    stateService.received(1).addAccount(Arg.any());
+    expect(stateService.setApiKeyClientId).toHaveBeenCalledWith(apiClientId);
+    expect(stateService.setApiKeyClientSecret).toHaveBeenCalledWith(apiClientSecret);
+    expect(stateService.addAccount).toHaveBeenCalled();
   });
 
   it("gets and sets the Key Connector key from environmentUrl", async () => {
     const tokenResponse = identityTokenResponseFactory();
     tokenResponse.apiUseKeyConnector = true;
 
-    apiService.postIdentityToken(Arg.any()).resolves(tokenResponse);
-    environmentService.getKeyConnectorUrl().returns(keyConnectorUrl);
+    apiService.postIdentityToken.mockResolvedValue(tokenResponse);
+    environmentService.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
 
     await apiLogInStrategy.logIn(credentials);
 
-    keyConnectorService.received(1).getAndSetKey(keyConnectorUrl);
+    expect(keyConnectorService.getAndSetKey).toHaveBeenCalledWith(keyConnectorUrl);
   });
 });

--- a/libs/common/src/misc/logInStrategies/logIn.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/logIn.strategy.ts
@@ -134,6 +134,9 @@ export abstract class LogInStrategy {
       await this.tokenService.setTwoFactorToken(response);
     }
 
+    await this.onSuccessfulLogin(response);
+
+    // Must come after the user Key is set, otherwise createKeyPairForOldAccount will fail
     const newSsoUser = response.key == null;
     if (!newSsoUser) {
       await this.cryptoService.setEncKey(response.key);
@@ -141,8 +144,6 @@ export abstract class LogInStrategy {
         response.privateKey ?? (await this.createKeyPairForOldAccount())
       );
     }
-
-    await this.onSuccessfulLogin(response);
 
     this.messagingService.send("loggedIn");
 

--- a/libs/common/src/misc/logInStrategies/logIn.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/logIn.strategy.ts
@@ -50,6 +50,9 @@ export abstract class LogInStrategy {
       | PasswordlessLogInCredentials
   ): Promise<AuthResult>;
 
+  // The user key comes from different sources depending on the login strategy
+  protected abstract setUserKey(response: IdentityTokenResponse): Promise<void>;
+
   async logInTwoFactor(
     twoFactor: TokenTwoFactorRequest,
     captchaResponse: string = null
@@ -72,11 +75,6 @@ export abstract class LogInStrategy {
     }
 
     throw new Error("Invalid response object.");
-  }
-
-  protected onSuccessfulLogin(response: IdentityTokenResponse): Promise<void> {
-    // Implemented in subclass if required
-    return null;
   }
 
   protected async buildDeviceRequest() {
@@ -134,7 +132,7 @@ export abstract class LogInStrategy {
       await this.tokenService.setTwoFactorToken(response);
     }
 
-    await this.onSuccessfulLogin(response);
+    await this.setUserKey(response);
 
     // Must come after the user Key is set, otherwise createKeyPairForOldAccount will fail
     const newSsoUser = response.key == null;

--- a/libs/common/src/misc/logInStrategies/passwordLogin.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/passwordLogin.strategy.ts
@@ -56,7 +56,7 @@ export class PasswordLogInStrategy extends LogInStrategy {
     );
   }
 
-  async onSuccessfulLogin() {
+  async setUserKey() {
     await this.cryptoService.setKey(this.key);
     await this.cryptoService.setKeyHash(this.localHashedPassword);
   }

--- a/libs/common/src/misc/logInStrategies/passwordlessLogin.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/passwordlessLogin.strategy.ts
@@ -56,7 +56,7 @@ export class PasswordlessLogInStrategy extends LogInStrategy {
     );
   }
 
-  async onSuccessfulLogin() {
+  async setUserKey() {
     await this.cryptoService.setKey(this.passwordlessCredentials.decKey);
     await this.cryptoService.setKeyHash(this.passwordlessCredentials.localPasswordHash);
   }

--- a/libs/common/src/misc/logInStrategies/ssoLogin.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/ssoLogin.strategy.ts
@@ -43,7 +43,7 @@ export class SsoLogInStrategy extends LogInStrategy {
     );
   }
 
-  async onSuccessfulLogin(tokenResponse: IdentityTokenResponse) {
+  async setUserKey(tokenResponse: IdentityTokenResponse) {
     const newSsoUser = tokenResponse.key == null;
 
     if (tokenResponse.keyConnectorUrl != null) {

--- a/libs/common/src/misc/logInStrategies/user-api-login.strategy.ts
+++ b/libs/common/src/misc/logInStrategies/user-api-login.strategy.ts
@@ -44,7 +44,7 @@ export class UserApiLogInStrategy extends LogInStrategy {
     );
   }
 
-  async onSuccessfulLogin(tokenResponse: IdentityTokenResponse) {
+  async setUserKey(tokenResponse: IdentityTokenResponse) {
     if (tokenResponse.apiUseKeyConnector) {
       const keyConnectorUrl = this.environmentService.getKeyConnectorUrl();
       await this.keyConnectorService.getAndSetKey(keyConnectorUrl);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix this bug:

> User is trying to confirm an account created in 2018 to their organization but receive no visible errors, just inactivity after clicking confirm.
> The dev tools show a 404 error

**Analysis:**

The 404 is occurring because the first step of the key exchange is to fetch the user’s public key, which doesn’t exist.

I was able to reproduce this locally by creating a new user and then nulling out the User.PrivateKey and User.PublicKey fields in the db.

We have migration logic in `logIn.strategy.ts` for old users who don't have RSA keys (specifically `createKeyPairForOldAccount`), but it fails because the user’s master key isn’t set yet. This means that we can't decrypt the `EncKey` which we need to encrypt the new private key once it's generated.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **libs/common/src/misc/logInStrategies/logIn.strategy.ts** - the user's key is set in `onSuccessfulLogin` by each subclass/strategy. It turns out that's the only thing this method is used for, so rename it to `setUserKey`, make it abstract (to force subclasses to implement it), and move it to immediately before the migration logic instead of immediately after it. This should be OK because simply setting the user's key does not require the `encKey` or keypair that is set in the code in between the old & new locations.

* all other files - update method name in subclasses

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
