### PR TITLE
[EC-838] fix: CSP issues with inline styles

### DIFF
--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -7,18 +7,6 @@ import { BitFormControlAbstraction } from "../form-control";
   selector: "input[type=checkbox][bitCheckbox]",
   template: "",
   providers: [{ provide: BitFormControlAbstraction, useExisting: CheckboxComponent }],
-  styles: [
-    `
-      :host:checked:before {
-        -webkit-mask-image: url('data:image/svg+xml,%3Csvg class="svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="8" height="8" viewBox="0 0 10 10"%3E%3Cpath d="M0.5 6.2L2.9 8.6L9.5 1.4" fill="none" stroke="white" stroke-width="2"%3E%3C/path%3E%3C/svg%3E');
-        mask-image: url('data:image/svg+xml,%3Csvg class="svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="8" height="8" viewBox="0 0 10 10"%3E%3Cpath d="M0.5 6.2L2.9 8.6L9.5 1.4" fill="none" stroke="white" stroke-width="2"%3E%3C/path%3E%3C/svg%3E');
-        -webkit-mask-position: center;
-        mask-position: center;
-        -webkit-mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-      }
-    `,
-  ],
 })
 export class CheckboxComponent implements BitFormControlAbstraction {
   @HostBinding("class")
@@ -63,6 +51,9 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "[&>label:hover]:checked:tw-border-primary-700",
 
     "checked:before:tw-bg-text-contrast",
+    "checked:before:tw-mask-image-[var(--mask-image)]",
+    "checked:before:tw-mask-position-[center]",
+    "checked:before:tw-mask-repeat-[no-repeat]",
 
     "checked:disabled:tw-border-secondary-100",
     "checked:disabled:tw-bg-secondary-100",
@@ -71,6 +62,9 @@ export class CheckboxComponent implements BitFormControlAbstraction {
   ];
 
   constructor(@Optional() @Self() private ngControl?: NgControl) {}
+
+  @HostBinding("style.--mask-image")
+  protected maskImage = `url('data:image/svg+xml,%3Csvg class="svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="8" height="8" viewBox="0 0 10 10"%3E%3Cpath d="M0.5 6.2L2.9 8.6L9.5 1.4" fill="none" stroke="white" stroke-width="2"%3E%3C/path%3E%3C/svg%3E')`;
 
   @HostBinding()
   @Input()

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 const colors = require("tailwindcss/colors");
+const plugin = require("tailwindcss/plugin");
 
 function rgba(color) {
   return "rgb(var(" + color + ") / <alpha-value>)";
@@ -94,5 +95,25 @@ module.exports = {
       }),
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ matchUtilities, theme, addUtilities, addComponents, e, config }) {
+      matchUtilities(
+        {
+          "mask-image": (value) => ({
+            "-webkit-mask-image": value,
+            "mask-image": value,
+          }),
+          "mask-position": (value) => ({
+            "-webkit-mask-position": value,
+            "mask-position": value,
+          }),
+          "mask-repeat": (value) => ({
+            "-webkit-mask-repeat": value,
+            "mask-repeat": value,
+          }),
+        },
+        {}
+      );
+    }),
+  ],
 };


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Inline styles added by angular are not added to CSP header and so do not work in browsers. This PR uses an alternative method of styling the checkbox.

## Code changes

- **libs/components/src/checkbox/checkbox.component.ts** Remove styles from angular decorators and bind them to the host element directly.
- **libs/components/tailwind.config.base.js** Add basic support for mask-image to tailwind

## Screenshots

There should be no graphical changes.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
