### PR TITLE
[SM-385] filter orgs in SM org-switcher

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.html
@@ -2,7 +2,7 @@
   <bit-icon [icon]="logo" class="tw-w-full tw-text-alt2"></bit-icon>
 </a>
 
-<org-switcher></org-switcher>
+<org-switcher [filter]="orgFilter"></org-switcher>
 <bit-nav-item icon="bwi-collection" text="Projects" route="projects"></bit-nav-item>
 <bit-nav-item icon="bwi-key" text="Secrets" route="secrets"></bit-nav-item>
 <bit-nav-item icon="bwi-wrench" text="Service Accounts" route="service-accounts"></bit-nav-item>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.ts
@@ -1,5 +1,7 @@
 import { Component } from "@angular/core";
 
+import { Organization } from "@bitwarden/common/models/domain/organization";
+
 import { SecretsManagerLogo } from "./secrets-manager-logo";
 
 @Component({
@@ -8,4 +10,6 @@ import { SecretsManagerLogo } from "./secrets-manager-logo";
 })
 export class NavigationComponent {
   protected readonly logo = SecretsManagerLogo;
+
+  protected orgFilter = (org: Organization) => org.canAccessSecretsManager;
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
@@ -10,11 +10,21 @@ import type { Organization } from "@bitwarden/common/models/domain/organization"
   templateUrl: "org-switcher.component.html",
 })
 export class OrgSwitcherComponent {
-  protected organizations$: Observable<Organization[]> = this.organizationService.organizations$;
+  protected organizations$: Observable<Organization[]> =
+    this.organizationService.organizations$.pipe(map((orgs) => orgs.filter(this.filter)));
   protected activeOrganization$: Observable<Organization> = combineLatest([
     this.route.paramMap,
-    this.organizationService.organizations$,
+    this.organizations$,
   ]).pipe(map(([params, orgs]) => orgs.find((org) => org.id === params.get("organizationId"))));
+
+  /**
+   * Filter function for displayed organizations in the `org-switcher`
+   * @example
+   * const smFilter = (org: Organization) => org.canAccessSecretsManager
+   * // <org-switcher [filter]="smFilter">
+   */
+  @Input()
+  filter: (org: Organization) => boolean = () => true;
 
   /**
    * Is `true` if the expanded content is visible


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `org-switcher` should only show organizations with access to Secrets Manager.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `clients/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts`: Added a generic `filter` function Input
- `clients/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html`: Updated the SM navigation to pass the `org-switcher` a filter that only shows orgs with access to SM

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
