### PR TITLE
[SM-387] fix org-switcher sorting

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
@@ -10,7 +10,10 @@ import type { Organization } from "@bitwarden/common/models/domain/organization"
   templateUrl: "org-switcher.component.html",
 })
 export class OrgSwitcherComponent {
-  protected organizations$: Observable<Organization[]> = this.organizationService.organizations$;
+  protected organizations$: Observable<Organization[]> =
+    this.organizationService.organizations$.pipe(
+      map((orgs) => orgs.sort((a, b) => a.name.localeCompare(b.name)))
+    );
   protected activeOrganization$: Observable<Organization> = combineLatest([
     this.route.paramMap,
     this.organizationService.organizations$,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `org-switcher` should sort organizations alphanumerically.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts`: Added Array.sort to organizations state

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
