### PR TITLE
[SM-384] fix: close org-switcher on click

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
@@ -29,5 +29,6 @@ export class OrgSwitcherComponent {
   protected toggle(event?: MouseEvent) {
     event?.stopPropagation();
     this.open = !this.open;
+    this.openChange.emit(this.open);
   }
 }

--- a/libs/components/src/navigation/nav-group.component.ts
+++ b/libs/components/src/navigation/nav-group.component.ts
@@ -42,6 +42,7 @@ export class NavGroupComponent extends NavBaseComponent implements AfterContentI
   protected toggle(event?: MouseEvent) {
     event?.stopPropagation();
     this.open = !this.open;
+    this.openChange.emit(this.open);
   }
 
   /**


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `org-switcher` component should close when an organization is clicked. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts`: Emit `openChange` when the `toggle` method is fired
- `libs/components/src/navigation/nav-group.component.ts`: Same change as `org-switcher`
## Screenshots

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
