### PR TITLE
[SG-884] Fix Remember Email functionality for Login with SSO

### DIFF
--- a/apps/browser/src/popup/accounts/login.component.ts
+++ b/apps/browser/src/popup/accounts/login.component.ts
@@ -71,6 +71,7 @@ export class LoginComponent extends BaseLoginComponent {
   }
 
   async launchSsoBrowser() {
+    await this.loginService.saveEmailSettings();
     // Generate necessary sso params
     const passwordOptions: any = {
       type: "password",

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -357,6 +357,7 @@ function getBgService<T>(service: keyof MainBackground) {
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
     {
       provide: AbstractThemingService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -180,6 +180,7 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
   ],
 })

--- a/apps/web/src/app/accounts/login/login-with-device.component.ts
+++ b/apps/web/src/app/accounts/login/login-with-device.component.ts
@@ -142,7 +142,7 @@ export class LoginWithDeviceComponent
           this.router.navigate([this.forcePasswordResetRoute]);
         }
       } else {
-        await this.setRememberEmailValues();
+        await this.loginService.saveEmailSettings();
         if (this.onSuccessfulLogin != null) {
           this.onSuccessfulLogin();
         }
@@ -201,12 +201,5 @@ export class LoginWithDeviceComponent
       key,
       localHashedPassword
     );
-  }
-
-  private async setRememberEmailValues() {
-    const rememberEmail = this.loginService.getRememberEmail();
-    const rememberedEmail = this.loginService.getEmail();
-    await this.stateService.setRememberedEmail(rememberEmail ? rememberedEmail : null);
-    this.loginService.clearValues();
   }
 }

--- a/apps/web/src/app/accounts/login/login.component.html
+++ b/apps/web/src/app/accounts/login/login.component.html
@@ -120,7 +120,7 @@
   <div class="tw-mb-3">
     <a
       routerLink="/sso"
-      (click)="setFormValues()"
+      (click)="saveEmailSettings()"
       bitButton
       buttonType="secondary"
       class="tw-w-full"

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -103,6 +103,7 @@ import { WebPlatformUtilsService } from "./web-platform-utils.service";
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateService],
     },
   ],
 })

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -83,6 +83,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
         const queryParamsEmail = params["email"];
         if (queryParamsEmail != null && queryParamsEmail.indexOf("@") > -1) {
           this.formGroup.get("email").setValue(queryParamsEmail);
+          this.loginService.setEmail(queryParamsEmail);
           this.paramEmailSet = true;
         }
       }
@@ -132,11 +133,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       this.formPromise = this.authService.logIn(credentials);
       const response = await this.formPromise;
       this.setFormValues();
-      if (data.rememberEmail) {
-        await this.stateService.setRememberedEmail(data.email);
-      } else {
-        await this.stateService.setRememberedEmail(null);
-      }
+      await this.loginService.saveEmailSettings();
       if (this.handleCaptchaRequired(response)) {
         return;
       } else if (response.requiresTwoFactor) {
@@ -154,7 +151,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       } else {
         const disableFavicon = await this.stateService.getDisableFavicon();
         await this.stateService.setDisableFavicon(!!disableFavicon);
-        this.loginService.clearValues();
         if (this.onSuccessfulLogin != null) {
           this.onSuccessfulLogin();
         }
@@ -181,6 +177,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   }
 
   async launchSsoBrowser(clientId: string, ssoRedirectUri: string) {
+    await this.saveEmailSettings();
     // Generate necessary sso params
     const passwordOptions: any = {
       type: "password",
@@ -233,6 +230,11 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   setFormValues() {
     this.loginService.setEmail(this.formGroup.value.email);
     this.loginService.setRememberEmail(this.formGroup.value.rememberEmail);
+  }
+
+  async saveEmailSettings() {
+    this.setFormValues();
+    await this.loginService.saveEmailSettings();
   }
 
   private getErrorToastMessage() {

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -592,6 +592,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: LoginServiceAbstraction,
       useClass: LoginService,
+      deps: [StateServiceAbstraction],
     },
   ],
 })

--- a/libs/common/src/abstractions/login.service.ts
+++ b/libs/common/src/abstractions/login.service.ts
@@ -4,4 +4,5 @@ export abstract class LoginService {
   setEmail: (value: string) => void;
   setRememberEmail: (value: boolean) => void;
   clearValues: () => void;
+  saveEmailSettings: () => Promise<void>;
 }

--- a/libs/common/src/services/login.service.ts
+++ b/libs/common/src/services/login.service.ts
@@ -1,8 +1,11 @@
 import { LoginService as LoginServiceAbstraction } from "../abstractions/login.service";
+import { StateService } from "../abstractions/state.service";
 
 export class LoginService implements LoginServiceAbstraction {
   private _email: string;
   private _rememberEmail: boolean;
+
+  constructor(private stateService: StateService) {}
 
   getEmail() {
     return this._email;
@@ -23,5 +26,10 @@ export class LoginService implements LoginServiceAbstraction {
   clearValues() {
     this._email = null;
     this._rememberEmail = null;
+  }
+
+  async saveEmailSettings() {
+    await this.stateService.setRememberedEmail(this._rememberEmail ? this._email : null);
+    this.clearValues();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix rememberEmail functionality for Logging in with SSO.
I decided to do some light refactoring here and added a method to LoginService to handle this functionality that started to be duplicated in multiple places.

## Code changes

- **LoginService:** Add `saveEmailSettings()` method to set the `rememberedEmail` value in state service.
- **Login Components:** Replace old ways of doing this manually with method from login service

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
