### PR TITLE
[SM-308] fix: add word break to table cells in SM

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list/projects-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list/projects-list.component.html
@@ -54,7 +54,7 @@
       <td bitCell class="tw-w-0 tw-pr-0">
         <i class="bwi bwi-collection tw-text-xl tw-text-muted" aria-hidden="true"></i>
       </td>
-      <td bitCell>
+      <td bitCell class="tw-break-all">
         <a [routerLink]="[project.id]">{{ project.name }}</a>
       </td>
       <td bitCell>{{ project.revisionDate | date: "medium" }}</td>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
@@ -52,7 +52,7 @@
         <i class="bwi bwi-wrench tw-text-xl tw-text-muted" aria-hidden="true"></i>
       </td>
       <td bitCell>
-        <a [routerLink]="serviceAccount.id">
+        <a [routerLink]="serviceAccount.id" class="tw-break-all">
           {{ serviceAccount.name }}
         </a>
       </td>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -55,7 +55,7 @@
       <td bitCell class="tw-w-0 tw-pr-0">
         <i class="bwi bwi-key tw-text-xl tw-text-muted" aria-hidden="true"></i>
       </td>
-      <td bitCell>{{ secret.name }}</td>
+      <td bitCell class="tw-break-all">{{ secret.name }}</td>
       <td bitCell>
         <span
           *ngFor="let project of secret.projects"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR prevents tables in SM from having long horizontal scroll due to text overflow. Long text will now wrap.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list`: Add `wordbreak: all` to `<td>`
- `bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list`: ^
- `bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list`: ^ 

## Screenshots

![image](https://user-images.githubusercontent.com/17113462/207748055-dee32d6d-1759-496c-a609-03b7343dba6b.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
