### PR TITLE
[SM-326] fix: keep bit-menu on screen

### DIFF
--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -49,7 +49,7 @@ export class MenuTriggerForDirective implements OnDestroy {
       ])
       .withLockedPosition(true)
       .withFlexibleDimensions(false)
-      .withPush(false),
+      .withPush(true),
   };
   private closedEventsSub: Subscription;
   private keyDownEventsSub: Subscription;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`bit-menu` should always be visible on screen.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `libs/components/src/menu/menu-trigger-for.directive.ts`: change overlay's `withPush` to true

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
