### PR TITLE
[EC-823] Multiselect dropdown gets hidden inside dialog

### DIFF
--- a/apps/web/src/app/organizations/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/organizations/components/access-selector/access-selector.stories.ts
@@ -9,6 +9,7 @@ import {
   AvatarModule,
   BadgeModule,
   ButtonModule,
+  DialogModule,
   FormFieldModule,
   IconButtonModule,
   TableModule,
@@ -27,6 +28,7 @@ export default {
     moduleMetadata({
       declarations: [AccessSelectorComponent, UserTypePipe],
       imports: [
+        DialogModule,
         ButtonModule,
         FormFieldModule,
         AvatarModule,
@@ -118,6 +120,50 @@ const StandaloneAccessSelectorTemplate: Story<AccessSelectorComponent> = (
 `,
 });
 
+const DialogAccessSelectorTemplate: Story<AccessSelectorComponent> = (
+  args: AccessSelectorComponent
+) => ({
+  props: {
+    items: [],
+    valueChanged: actionsData.onValueChanged,
+    initialValue: [],
+    ...args,
+  },
+  template: `
+    <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
+      <span bitDialogTitle>Access selector</span>
+      <span bitDialogContent>
+        <bit-access-selector
+          (ngModelChange)="valueChanged($event)"
+          [ngModel]="initialValue"
+          [items]="items"
+          [disabled]="disabled"
+          [columnHeader]="columnHeader"
+          [showGroupColumn]="showGroupColumn"
+          [selectorLabelText]="selectorLabelText"
+          [selectorHelpText]="selectorHelpText"
+          [emptySelectionText]="emptySelectionText"
+          [permissionMode]="permissionMode"
+          [showMemberRoles]="showMemberRoles"
+        ></bit-access-selector>
+      </span>
+      <div bitDialogFooter class="tw-flex tw-items-center tw-flex-row tw-gap-2">
+        <button bitButton buttonType="primary">Save</button>
+        <button bitButton buttonType="secondary">Cancel</button>
+        <button
+          class="tw-ml-auto"
+          bitIconButton="bwi-trash"
+          buttonType="danger"
+          size="default"
+          title="Delete"
+          aria-label="Delete"></button>
+      </div>
+    </bit-dialog>
+`,
+});
+
+const dialogAccessItems = itemsFactory(10, AccessItemType.Collection);
+
 const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).concat([
   {
     id: "c1-group1",
@@ -138,6 +184,29 @@ const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).c
     readonly: true,
   },
 ]);
+
+export const Dialog = DialogAccessSelectorTemplate.bind({});
+Dialog.args = {
+  permissionMode: "edit",
+  showMemberRoles: false,
+  showGroupColumn: true,
+  columnHeader: "Collection",
+  selectorLabelText: "Select Collections",
+  selectorHelpText: "Some helper text describing what this does",
+  emptySelectionText: "No collections added",
+  disabled: false,
+  initialValue: [],
+  items: dialogAccessItems,
+};
+Dialog.story = {
+  parameters: {
+    docs: {
+      storyDescription: `
+        Example of an access selector for modifying the collections a member has access to inside of a dialog.
+      `,
+    },
+  },
+};
 
 export const MemberCollectionAccess = StandaloneAccessSelectorTemplate.bind({});
 MemberCollectionAccess.args = {

--- a/libs/components/src/multi-select/multi-select.component.html
+++ b/libs/components/src/multi-select/multi-select.component.html
@@ -17,6 +17,7 @@
   [disabled]="disabled"
   [clearSearchOnAdd]="true"
   [labelForId]="labelForId"
+  appendTo="body"
 >
   <ng-template ng-loadingspinner-tmp>
     <i class="bwi bwi-spinner bwi-spin tw-mr-1" [title]="loadingText" aria-hidden="true"></i>


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix multiselect dropdown gets hidden inside dialog.

Has been tested inside `feature/org-admin-refresh`

## Screenshots

Bug:
![image](https://user-images.githubusercontent.com/2285588/207867086-4e7adf10-e3c6-4fd9-bb57-b06080f7a199.png)

With fix:
![image](https://user-images.githubusercontent.com/2285588/207867169-9d4fff19-a286-4886-8468-caacdee55f19.png)

On feature branch
![image](https://user-images.githubusercontent.com/2285588/207874306-04de9b5f-1f34-4436-8d6d-504483feb864.png)

## Note

There's a related bug making the dropdown look a little weird [CL-75 Bug Multi-select dropdown has weird bottom border](https://bitwarden.atlassian.net/browse/CL-75)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[CL-75]: https://bitwarden.atlassian.net/browse/CL-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ