### PR TITLE
[SG-890] Fix routing to org members in trial confirmation

### DIFF
--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.spec.ts
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.spec.ts
@@ -51,7 +51,7 @@ describe("TrialInitiationComponent", () => {
             component: BlankComponent,
           },
           {
-            path: `organizations/${testOrgId}/manage/people`,
+            path: `organizations/${testOrgId}/manage/members`,
             component: BlankComponent,
           },
         ]),
@@ -301,7 +301,7 @@ describe("TrialInitiationComponent", () => {
     describe("navigateToOrgVault", () => {
       it("should call verticalStepper.previous()", fakeAsync(() => {
         component.navigateToOrgInvite();
-        expect(routerSpy).toHaveBeenCalledWith(["organizations", testOrgId, "manage", "people"]);
+        expect(routerSpy).toHaveBeenCalledWith(["organizations", testOrgId, "manage", "members"]);
       }));
     });
   });

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts
@@ -227,7 +227,7 @@ export class TrialInitiationComponent implements OnInit, OnDestroy {
   }
 
   navigateToOrgInvite() {
-    this.router.navigate(["organizations", this.orgId, "manage", "people"]);
+    this.router.navigate(["organizations", this.orgId, "manage", "members"]);
   }
 
   previousStep() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix routing to organization members when completing the Trial Initiation flow. This route was probably updated with the Admin refresh work.

## Code changes

- **apps/web/src/app/accounts/trial-initiation/trial-initiation.component.ts:** Route to updated org members route
- **apps/web/src/app/accounts/trial-initiation/trial-initiation.component.spec.ts** Adjust unit tests

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
