### PR TITLE
Restore full extension window size in Safari (revert workaround from #1531)

### DIFF
--- a/apps/browser/src/popup/scss/environment.scss
+++ b/apps/browser/src/popup/scss/environment.scss
@@ -1,18 +1,6 @@
 @import "variables.scss";
 
 html.browser_safari {
-  body {
-    height: 360px !important;
-
-    &.body-xs {
-      height: 300px !important;
-    }
-
-    &.body-full {
-      height: 100% !important;
-    }
-  }
-
   header {
     .search .bwi {
       left: 20px;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When we converted to using Safari App Extensions, we had UI flickering/refresh issues in the bottom half of the extension window. As a workaround, we limited the window height in https://github.com/bitwarden/clients/pull/1531.

There are reports in the tracking issue #1692 that the issue has now been solved. A quick test looks good to me. This PR reverts the workaround, but we'll get QA to give it a good going over before merge.

Closes #1692.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/environment.scss** - revert Safari-specific styling that affects the dimensions of the `body` element.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
