### PR TITLE
fix: ring around bitLink in web vault

### DIFF
--- a/libs/components/src/link/link.directive.ts
+++ b/libs/components/src/link/link.directive.ts
@@ -56,7 +56,7 @@ const commonStyles = [
   "before:-tw-inset-x-[0.1em]",
   "before:tw-rounded-md",
   "before:tw-transition",
-  "before:tw-ring-2",
+  "focus-visible:before:tw-ring-2",
   "focus-visible:before:tw-ring-text-contrast",
   "focus-visible:tw-z-10",
 ];


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

On web the bit links get a ring around them for some reason. This fixes the issue

## Screenshots

Before fix (on a feature branch)
![image](https://user-images.githubusercontent.com/2285588/208612584-1700a7b9-424c-46e8-a2cd-012628dc4383.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
