### PR TITLE
Remove setup job from Staged Rollout Desktop workflow

### DIFF
--- a/.github/workflows/staged-rollout-desktop.yml
+++ b/.github/workflows/staged-rollout-desktop.yml
@@ -15,26 +15,9 @@ defaults:
     shell: bash
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Branch check
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc-desktop" ]]; then
-            echo "==================================="
-            echo "[!] Can only increase rollout from the 'rc' or 'hotfix-rc-desktop' branches"
-            echo "==================================="
-            exit 1
-          fi
-
   rollout:
     name: Update Rollout Percentage
     runs-on: ubuntu-22.04
-    needs: setup
     steps:
       - name: Login to Azure
         uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR removes the `setup` job requirement from the `Staged Rollout Desktop` workflow.  This change is due to not being able to run the workflow today with the `rc` branch already deleted.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/staged-rollout-desktop.yml:** Removed the `setup` job.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
