### PR TITLE
[PS-2094] Dashlane-csv-importer: Set month on import

### DIFF
--- a/libs/common/spec/importers/dashlane-csv-importer.spec.ts
+++ b/libs/common/spec/importers/dashlane-csv-importer.spec.ts
@@ -79,8 +79,8 @@ describe("Dashlane CSV Importer", () => {
     expect(cipher2.card.cardholderName).toBe("John Doe");
     expect(cipher2.card.number).toBe("41111111111111111");
     expect(cipher2.card.code).toBe("123");
-    expect(cipher2.card.expMonth).toBe("01");
-    expect(cipher2.card.expYear).toBe("23");
+    expect(cipher2.card.expMonth).toBe("1");
+    expect(cipher2.card.expYear).toBe("2023");
 
     expect(cipher2.fields.length).toBe(2);
 

--- a/libs/common/src/importers/dashlane/dashlane-csv-importer.ts
+++ b/libs/common/src/importers/dashlane/dashlane-csv-importer.ts
@@ -137,8 +137,7 @@ export class DashlaneCsvImporter extends BaseImporter implements Importer {
         cipher.card.number = row.cc_number;
         cipher.card.brand = this.getCardBrand(cipher.card.number);
         cipher.card.code = row.code;
-        cipher.card.expMonth = row.expiration_month;
-        cipher.card.expYear = row.expiration_year.substring(2, 4);
+        this.setCardExpiration(cipher, `${row.expiration_month}/${row.expiration_year}`);
 
         // If you add more mapped fields please extend this
         mappedValues = [


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes #4282 

The month wasn't set properly on import, as we expect to receive the number of month without a leading zero. The year isn't as strict on import as we assume it being 20XX.

Using the `base.setCardExpiration` helper method takes care of all identifying and substringing.


## Code changes

- **libs/common/src/importers/dashlane/dashlane-csv-importer.ts:** Use `base.setCardExpiration` to set the `expMonth` and `expYear`.
- **libs/common/spec/importers/dashlane-csv-importer.spec.ts:** Adjusted expected test result after manual test

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
