### PR TITLE
[EC-824] Fix Group table opening two dialogs

### DIFF
--- a/apps/web/src/app/organizations/manage/groups.component.html
+++ b/apps/web/src/app/organizations/manage/groups.component.html
@@ -78,7 +78,7 @@
             <input type="checkbox" [(ngModel)]="g.checked" />
           </td>
           <td bitCell class="tw-cursor-pointer tw-font-bold" (click)="edit(g)">
-            <button (click)="edit(g); $event.stopPropagation()" bitLink>
+            <button bitLink>
               {{ g.details.name }}
             </button>
           </td>

--- a/apps/web/src/app/organizations/manage/groups.component.html
+++ b/apps/web/src/app/organizations/manage/groups.component.html
@@ -78,7 +78,7 @@
             <input type="checkbox" [(ngModel)]="g.checked" />
           </td>
           <td bitCell class="tw-cursor-pointer tw-font-bold" (click)="edit(g)">
-            <button (click)="edit(g)" bitLink>
+            <button (click)="edit(g); $event.stopPropagation()" bitLink>
               {{ g.details.name }}
             </button>
           </td>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes the two client event listeners from both firing if a user clicks on the button directly. Allows the user to either click the button (support for ARIA) and also optionally click the table cell.

## Code changes

Add `$event.stopPropagation()` to the button click event so it doesn't propagate up the DOM tree.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
