### PR TITLE
Hide menu bar

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -122,6 +122,7 @@ export class WindowMain {
       show: false,
       backgroundColor: "#fff",
       alwaysOnTop: this.enableAlwaysOnTop,
+      autoHideMenuBar: true,
       webPreferences: {
         spellcheck: false,
         nodeIntegration: true,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Press `Alt` to toggle. Addresses https://github.com/bitwarden/desktop/issues/43 and https://community.bitwarden.com/t/hide-top-menu-bar-option/4423. Currently there's no way to hide the menu bar, taking up screen space for no purpose. [Documentation](https://www.electronjs.org/docs/api/browser-window#new-browserwindowoptions). Previously submitted as https://github.com/bitwarden/jslib/pull/226.