### PR TITLE
[SM-403] fix: NG0100 in Product Switcher

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/product-switcher.component.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { AfterViewInit, ChangeDetectorRef, Component, Input } from "@angular/core";
 
 import { IconButtonType } from "@bitwarden/components/src/icon-button/icon-button.component";
 
@@ -8,7 +8,7 @@ import { flagEnabled } from "../../../utils/flags";
   selector: "product-switcher",
   templateUrl: "./product-switcher.component.html",
 })
-export class ProductSwitcherComponent {
+export class ProductSwitcherComponent implements AfterViewInit {
   protected isEnabled = flagEnabled("secretsManager");
 
   /**
@@ -16,4 +16,15 @@ export class ProductSwitcherComponent {
    */
   @Input()
   buttonType: IconButtonType = "main";
+
+  ngAfterViewInit() {
+    /**
+     * Resolves https://angular.io/errors/NG0100 [SM-403]
+     *
+     * Caused by `[bitMenuTriggerFor]="content?.menu"` in template
+     */
+    this.changeDetector.detectChanges();
+  }
+
+  constructor(private changeDetector: ChangeDetectorRef) {}
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR prevents [Angular error NG0100 ](https://angular.io/errors/NG0100) in the `product-switcher`

## Code changes

- `apps/web/src/app/layouts/product-switcher/product-switcher.component.ts`: Manually run change detection in `ngAfterViewInit`