### PR TITLE
Fix nested collections

### DIFF
--- a/apps/web/src/app/vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/app/vault/vault-filter/services/vault-filter.service.ts
@@ -184,17 +184,20 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
       return headNode;
     }
     const nodes: TreeNode<CollectionFilter>[] = [];
-    collections.forEach((c) => {
-      const collectionCopy = new CollectionView() as CollectionFilter;
-      collectionCopy.id = c.id;
-      collectionCopy.organizationId = c.organizationId;
-      collectionCopy.icon = "bwi-collection";
-      if (c instanceof CollectionAdminView) {
-        collectionCopy.groups = c.groups;
-      }
-      const parts = c.name != null ? c.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];
-      ServiceUtils.nestedTraverse(nodes, 0, parts, collectionCopy, null, NestingDelimiter);
-    });
+    collections
+      .sort((a, b) => this.i18nService.collator.compare(a.name, b.name))
+      .forEach((c) => {
+        const collectionCopy = new CollectionView() as CollectionFilter;
+        collectionCopy.id = c.id;
+        collectionCopy.organizationId = c.organizationId;
+        collectionCopy.icon = "bwi-collection";
+        if (c instanceof CollectionAdminView) {
+          collectionCopy.groups = c.groups;
+        }
+        const parts =
+          c.name != null ? c.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];
+        ServiceUtils.nestedTraverse(nodes, 0, parts, collectionCopy, null, NestingDelimiter);
+      });
     nodes.forEach((n) => {
       n.parent = headNode;
       headNode.children.push(n);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The vault filter service would not always properly nest collections depending on the order the collections were created. This PR forces the collections to first be sorted alphabetically before building the node tree to ensure proper nesting.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
