### PR TITLE
[SM-303] feat: add fadeIn animation to bit-dialog

### DIFF
--- a/libs/components/src/dialog/animations.ts
+++ b/libs/components/src/dialog/animations.ts
@@ -1,0 +1,11 @@
+import { style, animate, trigger, transition, group } from "@angular/animations";
+
+export const fadeIn = trigger("fadeIn", [
+  transition(":enter", [
+    style({ opacity: 0, transform: "translateY(-50px)" }),
+    group([
+      animate("0.15s linear", style({ opacity: 1 })),
+      animate("0.3s ease-out", style({ transform: "none" })),
+    ]),
+  ]),
+]);

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -1,6 +1,7 @@
 <div
   [ngClass]="width"
   class="tw-my-4 tw-flex tw-max-h-screen tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
+  @fadeIn
 >
   <div
     class="tw-flex tw-items-center tw-gap-4 tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300 tw-p-4"

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -1,9 +1,12 @@
 import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { Component, Input } from "@angular/core";
 
+import { fadeIn } from "../animations";
+
 @Component({
   selector: "bit-dialog",
   templateUrl: "./dialog.component.html",
+  animations: [fadeIn],
 })
 export class DialogComponent {
   @Input() dialogSize: "small" | "default" | "large" = "default";

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -1,5 +1,6 @@
 <div
   class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
+  @fadeIn
 >
   <div class="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-px-4 tw-pt-4 tw-text-center">
     <ng-content *ngIf="hasIcon; else elseBlock" select="[bit-dialog-icon]"></ng-content>

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.ts
@@ -1,11 +1,14 @@
 import { Component, ContentChild, Directive } from "@angular/core";
 
+import { fadeIn } from "../animations";
+
 @Directive({ selector: "[bit-dialog-icon]" })
 export class IconDirective {}
 
 @Component({
   selector: "bit-simple-dialog",
   templateUrl: "./simple-dialog.component.html",
+  animations: [fadeIn],
 })
 export class SimpleDialogComponent {
   @ContentChild(IconDirective) icon!: IconDirective;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR adds a fade-in effect to `bit-dialog` that mimics Bootstrap modals:

https://github.com/twbs/bootstrap/blob/main/dist/css/bootstrap.css#L3190

https://github.com/twbs/bootstrap/blob/main/dist/css/bootstrap.css#L5312

This PR does **not**  add a _fade-out_ effect. Adding a fade-out effect will require a more significant overhaul of the dialog components to support closing after an `animationend` callback. I don't believe this is easily doable with `@angular/cdk/dialog` and we would need to build something from `@angular/cdk/overlay` instead.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `libs/components/src/dialog/animations.ts`: `@fadeIn` animation for use in `bit-dialog` and `bit-simple-dialog`

## Screenshots

<video src="https://user-images.githubusercontent.com/17113462/209240392-3cda05d4-12ec-43f0-9e6a-2115ffc60cf4.mov">https://user-images.githubusercontent.com/17113462/209240392-3cda05d4-12ec-43f0-9e6a-2115ffc60cf4.mov</video>

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
