### PR TITLE
[EC-862] Member dialog collections tab fails to save when trying to remove collection access

### DIFF
--- a/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -312,10 +312,10 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
       userView.permissions ?? new PermissionsApi(),
       userView.type !== OrganizationUserType.Custom
     );
-    userView.collections = this.formGroup.controls.access.value
+    userView.collections = this.formGroup.value.access
       .filter((v) => v.type === AccessItemType.Collection)
       .map(convertToSelectionView);
-    userView.groups = this.formGroup.controls.groups.value.map((m) => m.id);
+    userView.groups = this.formGroup.value.groups.map((m) => m.id);
 
     if (this.editMode) {
       await this.userService.save(userView);
@@ -442,7 +442,7 @@ function mapCollectionToAccessItemView(
     id: group ? `${collection.id}-${group.id}` : collection.id,
     labelName: collection.name,
     listName: collection.name,
-    readonly: accessSelection !== undefined,
+    readonly: group !== undefined,
     readonlyPermission: accessSelection ? convertToPermission(accessSelection) : undefined,
     viaGroupName: group?.name,
   };

--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
@@ -229,6 +229,11 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
       if (!this.notifyOnChange || this.pauseChangeNotification) {
         return;
       }
+      if (this.selectionList.formArray.disabled) {
+        this.selectionList.formArray.clear({ emitEvent: false });
+        this.notifyOnChange([]);
+        return;
+      }
       this.notifyOnChange(v);
     });
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

### Problem
If a member belongs to a group that has collection access, and you attempt to remove access to an individual collection (that doesn’t belong necessarily to the group) from the member, then the modal ends up sending all collection details to the endpoint with malformed guids. This causes the server to through an exception and fail silently (with console error logs).

The problem only occurs when the member has access to multiple collections via groups (they show up as disabled controls) and a single collection with direct access (an enabled control). 

When a user removes the access to the single collection, the form array of access items then only contains disabled controls (via the groups). For some reason, when Angular detects that a form array only contains disabled controls [it marks the entire array as DISABLED](https://github.com/angular/angular/blob/8561868d4f23f5b93cd052b6c47ee1ae819e74fd/packages/forms/src/model/abstract_model.ts#L1074). This happens [before the value is updated](https://github.com/angular/angular/blob/8561868d4f23f5b93cd052b6c47ee1ae819e74fd/packages/forms/src/model/abstract_model.ts#L1044-L1045) and when the now disabled form array is updated, [ALL the disabled controls and their values](https://github.com/angular/angular/blob/8561868d4f23f5b93cd052b6c47ee1ae819e74fd/packages/forms/src/model/form_array.ts#L480) are emitted and set as the form array value. 

This breaks the access selector’s functionality of ignoring disabled controls and the “readonly” collection access information (with the malformed guids) is submitted to the API and causes exceptions.

### Solution

Add a check whenever the form array value changes, and if the array is disabled, forcefully clear the value instead.

Also force the member dialog to only reference the formGroup value instead of accessing the controls directly.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
