### PR TITLE
[PS-2125] Update year in copyrights

### DIFF
--- a/apps/browser/src/safari/desktop/Info.plist
+++ b/apps/browser/src/safari/desktop/Info.plist
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.productivity</string>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2022 Bitwarden Inc. All rights reserved.</string>
-	<key>NSMainStoryboardFile</key>
-	<string>Main</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-</dict>
+	<dict>
+		<key>LSApplicationCategoryType</key>
+		<string>public.app-category.productivity</string>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<key>CFBundleExecutable</key>
+		<string>$(EXECUTABLE_NAME)</string>
+		<key>CFBundleIconFile</key>
+		<string></string>
+		<key>CFBundleIdentifier</key>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundleName</key>
+		<string>$(PRODUCT_NAME)</string>
+		<key>CFBundlePackageType</key>
+		<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+		<key>NSHumanReadableCopyright</key>
+		<string>Copyright © 2015-2023 Bitwarden Inc. All rights reserved.</string>
+		<key>NSMainStoryboardFile</key>
+		<string>Main</string>
+		<key>NSPrincipalClass</key>
+		<string>NSApplication</string>
+	</dict>
 </plist>

--- a/apps/browser/src/safari/safari/Info.plist
+++ b/apps/browser/src/safari/safari/Info.plist
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>Bitwarden</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
-	<key>CFBundleVersion</key>
-	<string>0.0.2</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.Safari.web-extension</string>
-		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<key>CFBundleDisplayName</key>
+		<string>Bitwarden</string>
+		<key>CFBundleExecutable</key>
+		<string>$(EXECUTABLE_NAME)</string>
+		<key>CFBundleIdentifier</key>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundleName</key>
+		<string>$(PRODUCT_NAME)</string>
+		<key>CFBundlePackageType</key>
+		<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+		<key>CFBundleShortVersionString</key>
+		<string>0.0.1</string>
+		<key>CFBundleVersion</key>
+		<string>0.0.2</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+		<key>NSExtension</key>
+		<dict>
+			<key>NSExtensionPointIdentifier</key>
+			<string>com.apple.Safari.web-extension</string>
+			<key>NSExtensionPrincipalClass</key>
+			<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+		</dict>
+		<key>NSHumanReadableCopyright</key>
+		<string>Copyright © 2015-2023 Bitwarden Inc. All rights reserved.</string>
+		<key>NSHumanReadableDescription</key>
+		<string>A secure and free password manager for all of your devices.</string>
+		<key>SFSafariAppExtensionBundleIdentifiersToReplace</key>
+		<array>
+			<string>com.bitwarden.desktop.safari</string>
+		</array>
 	</dict>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2022 Bitwarden Inc. All rights reserved.</string>
-	<key>NSHumanReadableDescription</key>
-	<string>A secure and free password manager for all of your devices.</string>
-	<key>SFSafariAppExtensionBundleIdentifiersToReplace</key>
-	<array>
-		<string>com.bitwarden.desktop.safari</string>
-	</array>
-</dict>
 </plist>

--- a/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
+++ b/apps/cli/stores/chocolatey/bitwarden-cli.nuspec
@@ -10,7 +10,7 @@
     <authors>Bitwarden Inc.</authors>
     <projectUrl>https://bitwarden.com/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/bitwarden/brand/master/icons/256x256.png</iconUrl>
-    <copyright>Copyright © 2015-2022 Bitwarden Inc.</copyright>
+    <copyright>Copyright © 2015-2023 Bitwarden Inc.</copyright>
     <projectSourceUrl>https://github.com/bitwarden/clients/</projectSourceUrl>
     <docsUrl>https://help.bitwarden.com/article/cli/</docsUrl>
     <bugTrackerUrl>https://github.com/bitwarden/clients/issues</bugTrackerUrl>

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -5,7 +5,7 @@
   "productName": "Bitwarden",
   "appId": "com.bitwarden.desktop",
   "buildDependenciesFromSource": true,
-  "copyright": "Copyright © 2015-2022 Bitwarden Inc.",
+  "copyright": "Copyright © 2015-2023 Bitwarden Inc.",
   "directories": {
     "buildResources": "resources",
     "output": "dist",

--- a/apps/desktop/stores/chocolatey/bitwarden.nuspec
+++ b/apps/desktop/stores/chocolatey/bitwarden.nuspec
@@ -10,7 +10,7 @@
     <authors>Bitwarden Inc.</authors>
     <projectUrl>https://bitwarden.com/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/bitwarden/brand/master/icons/256x256.png</iconUrl>
-    <copyright>Copyright © 2015-2022 Bitwarden Inc.</copyright>
+    <copyright>Copyright © 2015-2023 Bitwarden Inc.</copyright>
     <projectSourceUrl>https://github.com/bitwarden/clients/</projectSourceUrl>
     <docsUrl>https://bitwarden.com/help/</docsUrl>
     <bugTrackerUrl>https://github.com/bitwarden/clients/issues</bugTrackerUrl>

--- a/apps/web/src/404.html
+++ b/apps/web/src/404.html
@@ -47,6 +47,6 @@
         <a href="https://bitwarden.com/contact/">contact us</a>.
       </p>
     </div>
-    <div class="container footer text-muted content">© Copyright 2022 Bitwarden, Inc.</div>
+    <div class="container footer text-muted content">© Copyright 2023 Bitwarden, Inc.</div>
   </body>
 </html>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
It's almost 2023 and time again to bump our copyright to be up-to-date for the next client releases.

Searched for 2022 and copyright and updated the year.
## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
