### PR TITLE
[EC-862] Avoid clearing disabled form array in access selector

### DIFF
--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
@@ -229,6 +229,8 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
       if (!this.notifyOnChange || this.pauseChangeNotification) {
         return;
       }
+      // Disabled form arrays emit values for disabled controls, we override this to emit an empty array to avoid
+      // emitting values for disabled controls that are "readonly" in the table
       if (this.selectionList.formArray.disabled) {
         this.notifyOnChange([]);
         return;

--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.ts
@@ -230,7 +230,6 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
         return;
       }
       if (this.selectionList.formArray.disabled) {
-        this.selectionList.formArray.clear({ emitEvent: false });
         this.notifyOnChange([]);
         return;
       }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The [prior fix](https://github.com/bitwarden/clients/pull/4313) for EC-862 cleared the from array control when it was disabled which broke the access selector afterwards. It was unnecessary, only an empty `[]` needs to be emitted by the control in that instance to avoid saving bad values.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **access-selector.component.ts:** Add comments explaining the fix for EC-862 and remove the line that clears the form array control.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
