### PR TITLE
[EC-883] Fix badge list "+n more" message

### DIFF
--- a/apps/web/src/app/organizations/manage/groups.component.html
+++ b/apps/web/src/app/organizations/manage/groups.component.html
@@ -85,7 +85,7 @@
           <td bitCell (click)="edit(g, ModalTabType.Collections)" class="tw-cursor-pointer">
             <bit-badge-list
               [items]="g.collectionNames"
-              [maxItems]="2"
+              [maxItems]="3"
               badgeType="secondary"
             ></bit-badge-list>
           </td>

--- a/apps/web/src/app/organizations/members/people.component.html
+++ b/apps/web/src/app/organizations/members/people.component.html
@@ -176,7 +176,7 @@
               <bit-badge-list
                 *ngIf="organization.useGroups || !u.accessAll"
                 [items]="organization.useGroups ? u.groupNames : u.collectionNames"
-                [maxItems]="2"
+                [maxItems]="3"
                 badgeType="secondary"
               ></bit-badge-list>
               <span *ngIf="!organization.useGroups && u.accessAll">{{ "all" | i18n }}</span>

--- a/libs/components/src/badge-list/badge-list.component.ts
+++ b/libs/components/src/badge-list/badge-list.component.ts
@@ -25,10 +25,10 @@ export class BadgeListComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    if (this.maxItems == undefined) {
+    if (this.maxItems == undefined || this.items.length <= this.maxItems) {
       this.filteredItems = this.items;
     } else {
-      this.filteredItems = this.items.slice(0, this.maxItems);
+      this.filteredItems = this.items.slice(0, this.maxItems - 1);
     }
     this.isFiltered = this.items.length > this.filteredItems.length;
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When showing the `+n more` badge in the badge list, it didn't make sense to show `+1 more` when the actual value could be displayed instead. This updates the badge list logic to only show the `+n more` badge when there are 2 or more items than the maximum.

## Screenshots

<img width="991" alt="image" src="https://user-images.githubusercontent.com/8764515/209853809-77e763de-65e2-4a9a-b6fa-a45a43e0b63e.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
