### PR TITLE
[EC-882] Show "All" in Group collections column

### DIFF
--- a/apps/web/src/app/organizations/manage/groups.component.html
+++ b/apps/web/src/app/organizations/manage/groups.component.html
@@ -84,10 +84,12 @@
           </td>
           <td bitCell (click)="edit(g, ModalTabType.Collections)" class="tw-cursor-pointer">
             <bit-badge-list
+              *ngIf="!g.details.accessAll"
               [items]="g.collectionNames"
               [maxItems]="2"
               badgeType="secondary"
             ></bit-badge-list>
+            <span *ngIf="g.details.accessAll">{{ "all" | i18n }}</span>
           </td>
           <td bitCell>
             <button


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Update the Collections column in the Groups table to show "All" when a group has "access to all current and future collections" enabled.

## Screenshots

<img width="992" alt="image" src="https://user-images.githubusercontent.com/8764515/209856890-169d03c1-1978-484f-8961-9615a3ee4cc9.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
