### PR TITLE
[EC-878] Fix access selector permission dropdown arrow

### DIFF
--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -92,9 +92,12 @@
                 {{ p.labelId | i18n }}
               </option>
             </select>
-            <div class="tw-absolute tw-inset-y-0 tw-right-4 tw-flex tw-items-center">
+            <label
+              [for]="'permission' + i"
+              class="tw-absolute tw-inset-y-0 tw-right-4 tw-mb-0 tw-block tw-flex tw-items-center"
+            >
               <i class="bwi bwi-sm bwi-angle-down tw-leading-[0]"></i>
-            </div>
+            </label>
           </div>
         </ng-container>
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The permission dropdown arrow was not properly activating the dropdown after we changed it to a bit icon. This PR changes the container to a `<label for="">` tag to provide click/hover support.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
