### PR TITLE
[EC-877] Fix missing collection breadcrumbs

### DIFF
--- a/apps/web/src/app/organizations/vault/vault.component.html
+++ b/apps/web/src/app/organizations/vault/vault.component.html
@@ -24,7 +24,7 @@
         >
           <!-- First node in the tree contains a translation key. The rest come from user input. -->
           <ng-container *ngIf="first">{{ collection.node.name | i18n }}</ng-container>
-          <ng-template *ngIf="!first">{{ collection.node.name }}</ng-template>
+          <ng-container *ngIf="!first">{{ collection.node.name }}</ng-container>
         </bit-breadcrumb>
       </bit-breadcrumbs>
       <div class="tw-mb-4 tw-flex">

--- a/apps/web/src/app/organizations/vault/vault.component.ts
+++ b/apps/web/src/app/organizations/vault/vault.component.ts
@@ -318,10 +318,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       collections.push(collections[collections.length - 1].parent);
     }
 
-    return collections
-      .map((c) => c)
-      .slice(1) // 1 for self
-      .reverse();
+    return collections.map((c) => c).reverse();
   }
 
   protected applyCollectionFilter(collection: TreeNode<CollectionFilter>) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The collection names were missing from the breadcrumbs due to `ng-template` being used instead of `ng-container`. 
Additionally, remove the breadcrumb array `slice(1)` to always include showing the current collection in the vault header.

## Screenshots

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/8764515/209874003-eba76ee5-641f-4775-825f-3a5190beac83.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
