### PR TITLE
[EC-871] Fix collection group labels

### DIFF
--- a/apps/web/src/app/organizations/vault/group-badge/group-name-badge.component.html
+++ b/apps/web/src/app/organizations/vault/group-badge/group-name-badge.component.html
@@ -1,6 +1,1 @@
-<ng-container *ngFor="let c of shownGroups">
-  <span bitBadge badgeType="secondary">{{ c.id | groupNameFromId: allGroups }}</span>
-</ng-container>
-<ng-container *ngIf="showXMore">
-  <span bitBadge badgeType="secondary">+ {{ xMoreCount }} more</span>
-</ng-container>
+<bit-badge-list [items]="groupNames" [maxItems]="3" badgeType="secondary"></bit-badge-list>

--- a/apps/web/src/app/organizations/vault/group-badge/group-name-badge.component.ts
+++ b/apps/web/src/app/organizations/vault/group-badge/group-name-badge.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges } from "@angular/core";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/models/request/selection-read-only.request";
 
 import { GroupView } from "../../core";
@@ -8,19 +9,19 @@ import { GroupView } from "../../core";
   selector: "app-group-badge",
   templateUrl: "group-name-badge.component.html",
 })
-export class GroupNameBadgeComponent {
+export class GroupNameBadgeComponent implements OnChanges {
   @Input() selectedGroups: SelectionReadOnlyRequest[];
   @Input() allGroups: GroupView[];
 
-  get shownGroups(): SelectionReadOnlyRequest[] {
-    return this.showXMore ? this.selectedGroups.slice(0, 2) : this.selectedGroups;
-  }
+  protected groupNames: string[] = [];
 
-  get showXMore(): boolean {
-    return this.selectedGroups.length > 3;
-  }
+  constructor(private i18nService: I18nService) {}
 
-  get xMoreCount(): number {
-    return this.selectedGroups.length - 2;
+  ngOnChanges() {
+    this.groupNames = this.selectedGroups
+      .map((g) => {
+        return this.allGroups.find((o) => o.id === g.id)?.name;
+      })
+      .sort(this.i18nService.collator.compare);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The vault items component was using its own implementation of a badge list and it would sometimes fail to give enough spacing between badges. This updates the vault items component to use the CL badge list component so that it shares the same styles and appearance.

## Code changes

### group-name-badge.component.ts

- Remove the existing maxItems implementation
- Add an array of groupNames that is updated whenever the `@Input()`s change (group Ids or list of all groups)
- Sort the groupNames by name

## Screenshots

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/8764515/209884703-fa4ce976-cc32-42c6-be23-4015659ce908.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
