### PR TITLE
[EC-870] Cipher icon normalization

### DIFF
--- a/apps/web/src/scss/tables.scss
+++ b/apps/web/src/scss/tables.scss
@@ -135,3 +135,11 @@
     color: themed("tableColorHover");
   }
 }
+
+// Restrict app-vault-icon in new bit-table to max height of 24px
+// Can be removed when app-vault-icon is migrated to use Tailwind
+bit-table td app-vault-icon img {
+  @extend .rounded;
+  @extend .img-fluid;
+  max-height: 24px;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Updating the vault-items-component in Web to use the new `bit-table` CL component broke some of the styles for the `app-vault-icon` component. This PR adds a new CSS rule targeting the `app-vault-icon` when used within a `bit-table` component until `app-vault-icon` is updated/replaced and uses Tailwind.

## Screenshots

<img width="998" alt="image" src="https://user-images.githubusercontent.com/8764515/209974470-82322008-4c21-4a3b-a3db-62d3844fcd0e.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
