### PR TITLE
[PS-2135] Fix Inactive two-step login check

### DIFF
--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -86,7 +86,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     if (this.services.size > 0) {
       return;
     }
-    const response = await fetch(new Request("https://2fa.directory/api/v3/totp.json"));
+    const response = await fetch(new Request("https://api.2fa.directory/v3/totp.json"));
     if (response.status !== 200) {
       throw new Error();
     }

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -261,7 +261,7 @@ const devServer =
                   https://notifications.bitwarden.com
                   https://cdn.bitwarden.net
                   https://api.pwnedpasswords.com
-                  https://2fa.directory/api/v3/totp.json
+                  https://api.2fa.directory/v3/totp.json
                   https://api.stripe.com
                   https://www.paypal.com
                   https://api.braintreegateway.com


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Checking the vault for inactive two-step logins is broken, because 2fa.directory has changed there API endpoint.
According to https://2fa.directory/api/ it now uses `api.2fa.directory` instead of `2fa.directory/api`.


## Code changes

Changed the API endpoint to the new working endpoint.

## Server side PR

https://github.com/bitwarden/server/pull/2523

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
