### PR TITLE
[EC-879] fix: close dialogs on vault lock

### DIFF
--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -1,9 +1,30 @@
-import { Dialog, DialogConfig, DialogRef } from "@angular/cdk/dialog";
-import { ComponentType } from "@angular/cdk/overlay";
-import { Injectable, TemplateRef } from "@angular/core";
+import {
+  DEFAULT_DIALOG_CONFIG,
+  Dialog,
+  DialogConfig,
+  DialogRef,
+  DIALOG_SCROLL_STRATEGY,
+} from "@angular/cdk/dialog";
+import { ComponentType, Overlay, OverlayContainer } from "@angular/cdk/overlay";
+import {
+  Inject,
+  Injectable,
+  Injector,
+  OnDestroy,
+  Optional,
+  SkipSelf,
+  TemplateRef,
+} from "@angular/core";
+import { NavigationEnd, Router } from "@angular/router";
+import { filter, Subject, switchMap, takeUntil } from "rxjs";
+
+import { AuthService } from "@bitwarden/common/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/enums/authenticationStatus";
 
 @Injectable()
-export class DialogService extends Dialog {
+export class DialogService extends Dialog implements OnDestroy {
+  private _destroy$ = new Subject<void>();
+
   override open<R = unknown, D = unknown, C = unknown>(
     componentOrTemplateRef: ComponentType<C> | TemplateRef<C>,
     config?: DialogConfig<D, DialogRef<R, C>>
@@ -14,5 +35,39 @@ export class DialogService extends Dialog {
     };
 
     return super.open(componentOrTemplateRef, config);
+  }
+
+  constructor(
+    /** Parent class constructor */
+    _overlay: Overlay,
+    _injector: Injector,
+    @Optional() @Inject(DEFAULT_DIALOG_CONFIG) _defaultOptions: DialogConfig,
+    @Optional() @SkipSelf() _parentDialog: Dialog,
+    _overlayContainer: OverlayContainer,
+    @Inject(DIALOG_SCROLL_STRATEGY) scrollStrategy: any,
+
+    /** Not in parent class */
+    @Optional() router: Router,
+    @Optional() authService: AuthService
+  ) {
+    super(_overlay, _injector, _defaultOptions, _parentDialog, _overlayContainer, scrollStrategy);
+
+    /** Close all open dialogs if the vault locks */
+    if (router && authService) {
+      router.events
+        .pipe(
+          filter((event) => event instanceof NavigationEnd),
+          switchMap(() => authService.getAuthStatus()),
+          filter((v) => v !== AuthenticationStatus.Unlocked),
+          takeUntil(this._destroy$)
+        )
+        .subscribe(() => this.closeAll());
+    }
+  }
+
+  override ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
+    super.ngOnDestroy();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR updates the component library's dialog service to close all open dialogs when the vault locks. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `libs/components/src/dialog/dialog.service.ts`: When this service is constructed, it will listen for auth status changes and if the vault is locked will call `this.closeAll()`

The alternative would be to just close dialogs on any route change, but this was decided against. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
