### PR TITLE
[EC-896] Fix bulk group deletion message count

### DIFF
--- a/apps/web/src/app/organizations/core/services/group/group.service.ts
+++ b/apps/web/src/app/organizations/core/services/group/group.service.ts
@@ -25,19 +25,14 @@ export class GroupService {
     );
   }
 
-  async deleteMany(orgId: string, groupIds: string[]): Promise<GroupView[]> {
-    const request = new OrganizationGroupBulkRequest(groupIds);
-
-    const r = await this.apiService.send(
+  async deleteMany(orgId: string, groupIds: string[]): Promise<void> {
+    await this.apiService.send(
       "DELETE",
       "/organizations/" + orgId + "/groups",
-      request,
+      new OrganizationGroupBulkRequest(groupIds),
       true,
       true
     );
-    const listResponse = new ListResponse(r, GroupResponse);
-
-    return listResponse.data?.map((gr) => GroupView.fromResponse(gr)) ?? [];
   }
 
   async get(orgId: string, groupId: string): Promise<GroupView> {

--- a/apps/web/src/app/organizations/manage/groups.component.ts
+++ b/apps/web/src/app/organizations/manage/groups.component.ts
@@ -277,14 +277,14 @@ export class GroupsComponent implements OnInit, OnDestroy {
     }
 
     try {
-      const result = await this.groupService.deleteMany(
+      await this.groupService.deleteMany(
         this.organizationId,
         groupsToDelete.map((g) => g.details.id)
       );
       this.platformUtilsService.showToast(
         "success",
         null,
-        this.i18nService.t("deletedManyGroups", result.length.toString())
+        this.i18nService.t("deletedManyGroups", groupsToDelete.length.toString())
       );
 
       groupsToDelete.forEach((g) => this.removeGroup(g.details.id));


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The success toast for bulk group deletion was trying to use a server response that was never added (it was ultimately unnecessary) so update the service to not expect a result and success toast to use the requested group count instead. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/core/services/group/group.service.ts:** Remove response type and cleanup
- **apps/web/src/app/organizations/manage/groups.component.ts:** Use the request group count instead and remove the result

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
