### PR TITLE
[SM-408] [BEEEP] refactor: add until-destroy

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,7 +67,12 @@
         "pathGroupsExcludedImportTypes": ["builtin"]
       }
     ],
-    "rxjs-angular/prefer-takeuntil": "error",
+    "rxjs-angular/prefer-takeuntil": [
+      "error",
+      {
+        "alias": ["untilDestroyed"]
+      }
+    ],
     "rxjs/no-exposed-subjects": ["error", { "allowProtected": true }],
     "no-restricted-syntax": [
       "error",

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/new-menu.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/new-menu.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 import { DialogService } from "@bitwarden/components";
 
@@ -18,25 +18,20 @@ import {
   ServiceAccountOperation,
 } from "../service-accounts/dialog/service-account-dialog.component";
 
+@UntilDestroy()
 @Component({
   selector: "sm-new-menu",
   templateUrl: "./new-menu.component.html",
 })
-export class NewMenuComponent implements OnInit, OnDestroy {
+export class NewMenuComponent implements OnInit {
   private organizationId: string;
-  private destroy$: Subject<void> = new Subject<void>();
 
   constructor(private route: ActivatedRoute, private dialogService: DialogService) {}
 
   ngOnInit() {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: any) => {
+    this.route.params.pipe(untilDestroyed(this)).subscribe((params: any) => {
       this.organizationId = params.organizationId;
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   openSecretDialog() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list/projects-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/projects-list/projects-list.component.ts
@@ -1,14 +1,15 @@
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 import { ProjectListView } from "../../models/view/project-list.view";
 
+@UntilDestroy()
 @Component({
   selector: "sm-projects-list",
   templateUrl: "./projects-list.component.html",
 })
-export class ProjectsListComponent implements OnDestroy {
+export class ProjectsListComponent {
   @Input()
   get projects(): ProjectListView[] {
     return this._projects;
@@ -25,19 +26,12 @@ export class ProjectsListComponent implements OnDestroy {
   @Output() onProjectCheckedEvent = new EventEmitter<string[]>();
   @Output() newProjectEvent = new EventEmitter();
 
-  private destroy$: Subject<void> = new Subject<void>();
-
   selection = new SelectionModel<string>(true, []);
 
   constructor() {
     this.selection.changed
-      .pipe(takeUntil(this.destroy$))
+      .pipe(untilDestroyed(this))
       .subscribe((_) => this.onProjectCheckedEvent.emit(this.selection.selected));
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isAllSelected() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/expiration-options.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/expiration-options.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe } from "@angular/common";
-import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -11,8 +11,9 @@ import {
   Validator,
   Validators,
 } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
+@UntilDestroy()
 @Component({
   selector: "sm-expiration-options",
   templateUrl: "./expiration-options.component.html",
@@ -29,11 +30,7 @@ import { Subject, takeUntil } from "rxjs";
     },
   ],
 })
-export class ExpirationOptionsComponent
-  implements ControlValueAccessor, Validator, OnInit, OnDestroy
-{
-  private destroy$ = new Subject<void>();
-
+export class ExpirationOptionsComponent implements ControlValueAccessor, Validator, OnInit {
   @Input() expirationDayOptions: number[];
 
   @Input() set touched(val: boolean) {
@@ -52,14 +49,9 @@ export class ExpirationOptionsComponent
   constructor(private datePipe: DatePipe) {}
 
   async ngOnInit() {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+    this.form.valueChanges.pipe(untilDestroyed(this)).subscribe(() => {
       this._onChange(this.getExpiresDate());
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private _onChange = (_value: Date | null): void => undefined;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
@@ -1,14 +1,15 @@
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 import { ServiceAccountView } from "../models/view/service-account.view";
 
+@UntilDestroy()
 @Component({
   selector: "sm-service-accounts-list",
   templateUrl: "./service-accounts-list.component.html",
 })
-export class ServiceAccountsListComponent implements OnDestroy {
+export class ServiceAccountsListComponent {
   @Input()
   get serviceAccounts(): ServiceAccountView[] {
     return this._serviceAccounts;
@@ -23,19 +24,12 @@ export class ServiceAccountsListComponent implements OnDestroy {
   @Output() deleteServiceAccountsEvent = new EventEmitter<string[]>();
   @Output() onServiceAccountCheckedEvent = new EventEmitter<string[]>();
 
-  private destroy$: Subject<void> = new Subject<void>();
-
   selection = new SelectionModel<string>(true, []);
 
   constructor() {
     this.selection.changed
-      .pipe(takeUntil(this.destroy$))
+      .pipe(untilDestroyed(this))
       .subscribe((_) => this.onServiceAccountCheckedEvent.emit(this.selection.selected));
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isAllSelected() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
@@ -1,14 +1,15 @@
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 import { SecretListView } from "../models/view/secret-list.view";
 
+@UntilDestroy()
 @Component({
   selector: "sm-secrets-list",
   templateUrl: "./secrets-list.component.html",
 })
-export class SecretsListComponent implements OnDestroy {
+export class SecretsListComponent {
   @Input()
   get secrets(): SecretListView[] {
     return this._secrets;
@@ -27,19 +28,12 @@ export class SecretsListComponent implements OnDestroy {
   @Output() deleteSecretsEvent = new EventEmitter<string[]>();
   @Output() newSecretEvent = new EventEmitter();
 
-  private destroy$: Subject<void> = new Subject<void>();
-
   selection = new SelectionModel<string>(true, []);
 
   constructor() {
     this.selection.changed
-      .pipe(takeUntil(this.destroy$))
+      .pipe(untilDestroyed(this))
       .subscribe((_) => this.onSecretCheckedEvent.emit(this.selection.selected));
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isAllSelected() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@microsoft/signalr": "^6.0.7",
         "@microsoft/signalr-protocol-msgpack": "^6.0.7",
         "@ng-select/ng-select": "^9.0.2",
+        "@ngneat/until-destroy": "^9.2.2",
         "big-integer": "^1.6.51",
         "bootstrap": "4.6.0",
         "braintree-web-drop-in": "^1.33.1",
@@ -5231,6 +5232,18 @@
         "@angular/common": "<15.0.0",
         "@angular/core": "<15.0.0",
         "@angular/forms": "<15.0.0"
+      }
+    },
+    "node_modules/@ngneat/until-destroy": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-9.2.2.tgz",
+      "integrity": "sha512-pD5idTgUdF0XZMuaV1n0BZTnE2BvxymutoXhwfZbO3uxjh63wS6Pzzzwv+pkXalKhuSwdf6uA1gRx7DOvlj/Kw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=13",
+        "rxjs": "^6.4.0 || ^7.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -46878,6 +46891,14 @@
       "integrity": "sha512-xdNiz/kgkMWYW1qFtk/337xDk/cmfEbSVtTFxWIM2OnIX1XsQOnTlGiBYces1TsMfqS68HjAvljEkj8QIGN2Lg==",
       "requires": {
         "tslib": "^2.3.1"
+      }
+    },
+    "@ngneat/until-destroy": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-9.2.2.tgz",
+      "integrity": "sha512-pD5idTgUdF0XZMuaV1n0BZTnE2BvxymutoXhwfZbO3uxjh63wS6Pzzzwv+pkXalKhuSwdf6uA1gRx7DOvlj/Kw==",
+      "requires": {
+        "tslib": "^2.3.0"
       }
     },
     "@ngtools/webpack": {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@microsoft/signalr": "^6.0.7",
     "@microsoft/signalr-protocol-msgpack": "^6.0.7",
     "@ng-select/ng-select": "^9.0.2",
+    "@ngneat/until-destroy": "^9.2.2",
     "big-integer": "^1.6.51",
     "bootstrap": "4.6.0",
     "braintree-web-drop-in": "^1.33.1",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Manual subscriptions to observables requires adding extra safe guards to prevent memory leaks:

```ts
@Component()
class MyComp implements OnInit, OnDestroy {
  
  private _destroy$ = new Subject<void>();

  ngOnInit() {
    someSub$.pipe(takeUntil(this._destroy$)).subscribe(...);
  }

  ngOnDestroy() {
    this._destroy$.next();
    this._destroy$.complete();
  }
}
```

We are using this pattern in at least ~50 files (found by searching for “destroy.complete” or “destroy$.complete”). Abstracting this into a reusable utility would reduce repetition and noise in components. 

Using https://github.com/ngneat/until-destroy :


```ts
@UntilDestroy()
@Component()
class MyComp implements OnInit {

  ngOnInit() {
    someSub$.pipe(untilDestroyed(this)).subscribe(...);
  }
}
```
## Code changes

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
