### PR TITLE
[SG-35] [SG-58] Replace the white user profile icon with the color + initials profile indicator

### DIFF
--- a/apps/web/src/app/components/dynamic-avatar.component.ts
+++ b/apps/web/src/app/components/dynamic-avatar.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnDestroy } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 
 import { AvatarUpdateService } from "@bitwarden/common/abstractions/account/avatar-update.service";
-type SizeTypes = "xlarge" | "large" | "default" | "small";
+type SizeTypes = "xlarge" | "large" | "default" | "small" | "xsmall";
 @Component({
   selector: "dynamic-avatar",
   template: `<span [title]="title">

--- a/apps/web/src/app/layouts/navbar.component.html
+++ b/apps/web/src/app/layouts/navbar.component.html
@@ -44,7 +44,7 @@
           [bitMenuTriggerFor]="accountMenu"
           class="tw-border-0 tw-bg-transparent tw-text-alt2 tw-opacity-70 hover:tw-opacity-90"
         >
-          <i class="bwi bwi-user-circle bwi-lg" aria-hidden="true"></i>
+          <dynamic-avatar [text]="name" size="xsmall" aria-hidden="true"></dynamic-avatar>
           <i class="bwi bwi-caret-down bwi-sm" aria-hidden="true"></i>
         </button>
         <bit-menu class="dropdown-menu" #accountMenu>

--- a/libs/components/src/avatar/avatar.component.ts
+++ b/libs/components/src/avatar/avatar.component.ts
@@ -3,13 +3,14 @@ import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 
 import { Utils } from "@bitwarden/common/misc/utils";
 
-type SizeTypes = "xlarge" | "large" | "default" | "small";
+type SizeTypes = "xlarge" | "large" | "default" | "small" | "xsmall";
 
 const SizeClasses: Record<SizeTypes, string[]> = {
   xlarge: ["tw-h-24", "tw-w-24"],
   large: ["tw-h-16", "tw-w-16"],
   default: ["tw-h-12", "tw-w-12"],
   small: ["tw-h-7", "tw-w-7"],
+  xsmall: ["tw-h-6", "tw-w-6"],
 };
 
 @Component({


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make the profile thing in the nav bar all colorful and stuff

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Added an even smaller size to the sizes and updated the navbar.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
<img width="160" alt="Screen Shot 2022-12-30 at 2 16 55 PM" src="https://user-images.githubusercontent.com/107377945/210105033-eb033618-10bc-4933-bc97-bfdbd67d4885.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
