### PR TITLE
[PS-2072] Browser Badge fixes

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -603,7 +603,9 @@ export default class MainBackground {
     return new Promise<void>((resolve) => {
       setTimeout(async () => {
         await this.environmentService.setUrlsFromStorage();
-        await this.refreshBadge();
+        if (!this.isPrivateMode) {
+          await this.refreshBadge();
+        }
         this.fullSync(true);
         setTimeout(() => this.notificationsService.init(), 2500);
         resolve();

--- a/apps/browser/src/listeners/update-badge.ts
+++ b/apps/browser/src/listeners/update-badge.ts
@@ -164,7 +164,7 @@ export class UpdateBadge {
         38: "/images/icon38" + iconSuffix + ".png",
       },
     };
-    if (BrowserPlatformUtilsService.isFirefox()) {
+    if (windowId && BrowserPlatformUtilsService.isFirefox()) {
       options.windowId = windowId;
     }
 

--- a/apps/browser/src/listeners/update-badge.ts
+++ b/apps/browser/src/listeners/update-badge.ts
@@ -81,9 +81,6 @@ export class UpdateBadge {
 
     const authStatus = await this.authService.getAuthStatus();
 
-    const tab = await this.getTab(opts?.tabId, opts?.windowId);
-    const windowId = tab?.windowId;
-
     await this.setBadgeBackgroundColor();
 
     switch (authStatus) {
@@ -96,7 +93,8 @@ export class UpdateBadge {
         break;
       }
       case AuthenticationStatus.Unlocked: {
-        await this.setUnlocked({ tab, windowId });
+        const tab = await this.getTab(opts?.tabId, opts?.windowId);
+        await this.setUnlocked({ tab, windowId: tab?.windowId });
         break;
       }
     }

--- a/apps/browser/src/listeners/update-badge.ts
+++ b/apps/browser/src/listeners/update-badge.ts
@@ -124,7 +124,7 @@ export class UpdateBadge {
   async setUnlocked(opts: BadgeOptions) {
     await this.initServices();
 
-    await this.setBadgeIcon("", opts?.windowId);
+    await this.setBadgeIcon("");
 
     const disableBadgeCounter = await this.stateService.getDisableBadgeCounter();
     if (disableBadgeCounter) {

--- a/apps/browser/src/listeners/update-badge.ts
+++ b/apps/browser/src/listeners/update-badge.ts
@@ -88,11 +88,11 @@ export class UpdateBadge {
 
     switch (authStatus) {
       case AuthenticationStatus.LoggedOut: {
-        await this.setLoggedOut({ tab, windowId });
+        await this.setLoggedOut();
         break;
       }
       case AuthenticationStatus.Locked: {
-        await this.setLocked({ tab, windowId });
+        await this.setLocked();
         break;
       }
       case AuthenticationStatus.Unlocked: {
@@ -102,14 +102,25 @@ export class UpdateBadge {
     }
   }
 
-  async setLoggedOut(opts: BadgeOptions): Promise<void> {
-    await this.setBadgeIcon("_gray", opts?.windowId);
-    await this.setBadgeText("", opts?.tab?.id);
+  async setLoggedOut(): Promise<void> {
+    await this.setBadgeIcon("_gray");
+    await this.clearBadgeText();
   }
 
-  async setLocked(opts: BadgeOptions) {
-    await this.setBadgeIcon("_locked", opts?.windowId);
-    await this.setBadgeText("", opts?.tab?.id);
+  async setLocked() {
+    await this.setBadgeIcon("_locked");
+    await this.clearBadgeText();
+  }
+
+  private async clearBadgeText() {
+    const tabs = await BrowserApi.getActiveTabs();
+    if (tabs != null) {
+      tabs.forEach(async (tab) => {
+        if (tab.id != null) {
+          await this.setBadgeText("", tab.id);
+        }
+      });
+    }
   }
 
   async setUnlocked(opts: BadgeOptions) {

--- a/apps/browser/src/listeners/update-badge.ts
+++ b/apps/browser/src/listeners/update-badge.ts
@@ -44,15 +44,19 @@ export class UpdateBadge {
   ];
 
   static async tabsOnActivatedListener(activeInfo: chrome.tabs.TabActiveInfo) {
-    await new UpdateBadge(self).run({ tabId: activeInfo.tabId });
+    await new UpdateBadge(self).run({ tabId: activeInfo.tabId, windowId: activeInfo.windowId });
   }
 
   static async tabsOnReplacedListener(addedTabId: number, removedTabId: number) {
     await new UpdateBadge(self).run({ tabId: addedTabId });
   }
 
-  static async tabsOnUpdatedListener(tabId: number) {
-    await new UpdateBadge(self).run({ tabId });
+  static async tabsOnUpdatedListener(
+    tabId: number,
+    changeInfo: chrome.tabs.TabChangeInfo,
+    tab: chrome.tabs.Tab
+  ) {
+    await new UpdateBadge(self).run({ tabId, windowId: tab.windowId });
   }
 
   static async messageListener(
@@ -211,7 +215,9 @@ export class UpdateBadge {
   private async getTab(tabId?: number, windowId?: number) {
     return (
       (await BrowserApi.getTab(tabId)) ??
-      (await BrowserApi.tabsQueryFirst({ active: true, windowId })) ??
+      (windowId
+        ? await BrowserApi.tabsQueryFirst({ active: true, windowId })
+        : await BrowserApi.tabsQueryFirst({ active: true, currentWindow: true })) ??
       (await BrowserApi.tabsQueryFirst({ active: true, lastFocusedWindow: true })) ??
       (await BrowserApi.tabsQueryFirst({ active: true }))
     );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes #4260

The badge was not showing or updating it's state (logout/lock/match) across browser windows and also not always in private/incognito mode

## Code changes

I've tried to split up the commits and provide detailed explainations for the changes in the commit messages.
I also provided links to the old implementation prior to the update-badge work to show the regressions.

- **apps/browser/src/listeners/update-badge.ts:** Show and update badge on all windows (Chrome MV2/MV3 (both with and without incognito mode), Firefox: MV2 (with and without private mode)
- **apps/browser/src/background/main.background.ts:** Small fix for Firefox private mode

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
