### PR TITLE
[PS-2159] import/apply changes from https://github.com/bitwarden/web/pull/1277

### DIFF
--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -7,6 +7,70 @@
     [infiniteScrollDisabled]="!isPaging()"
     (scrolled)="loadMore()"
   >
+    <thead id="sort-ciphers-table">
+      <tr>
+        <th scope="col">
+          <input (click)="selectAll()" type="checkbox" />
+        </th>
+        <th
+          colspan="2"
+          *ngIf="sortedDescending; else elseBlock1"
+          scope="col"
+          class="show-arrow-on-hover user-select-none"
+        >
+          <i
+            (click)="sortCiphers('name')"
+            class="sorting-arrow sort-name-arrow bwi-arrow-down"
+            aria-hidden="true"
+          ></i
+          >{{ "name" | i18n }}
+        </th>
+        <ng-template #elseBlock1>
+          <th colspan="2" scope="col" class="show-arrow-on-hover user-select-none">
+            <i
+              (click)="sortCiphers('name')"
+              class="sorting-arrow sort-name-arrow bwi-arrow-up"
+              aria-hidden="true"
+            ></i
+            >{{ "name" | i18n }}
+          </th>
+        </ng-template>
+        <th
+          scope="col"
+          colspan="2"
+          class="show-arrow-on-hover table-col-sort cipher-sort-table-header"
+        >
+          <div class="input-group m-0 font-weight-bold">
+            <div
+              (click)="sortCiphers(option.value)"
+              *ngIf="sortedDescending; else elseBlock2"
+              class="input-group-prepend no-bg"
+            >
+              <label class="input-group-text bg-transparent border-0" for="sortOptions"
+                ><i class="sorting-arrow bwi bwi-angle-down" aria-hidden="true"></i
+              ></label>
+            </div>
+            <ng-template #elseBlock2>
+              <div (click)="sortCiphers(option.value)" class="input-group-prepend">
+                <label class="input-group-text bg-transparent border-0" for="sortOptions"
+                  ><i class="sorting-arrow bwi bwi-chevron-up" aria-hidden="true"></i
+                ></label>
+              </div>
+            </ng-template>
+            <select
+              #option
+              (change)="changeDataToShow(option.value)"
+              class="border-0 custom-select bg-transparent font-weight-bold"
+              id="sortOptions"
+            >
+              <option value="owner">{{ "owner" | i18n }}</option>
+              <option value="dateCreated">{{ "dateCreated" | i18n }}</option>
+              <option value="lastEdited">{{ "lastEdited" | i18n }}</option>
+            </select>
+          </div>
+        </th>
+      </tr>
+    </thead>
     <tbody>
       <tr *ngFor="let c of filteredCiphers">
         <td (click)="checkCipher(c)" class="table-list-checkbox">
@@ -44,6 +108,13 @@
           </ng-container>
           <br />
           <small appStopProp>{{ c.subTitle }}</small>
+        </td>
+        <td>
+          <small appStopProp>
+            <span *ngIf="showData === 'owner'">{{ getOrganizationById(c) }}</span>
+            <span *ngIf="showData === 'dateCreated'"></span>
+            <span *ngIf="showData === 'lastEdited'">{{ revisionDate(c.revisionDate) }}</span>
+          </small>
         </td>
         <td *ngIf="organizations.length > 0 && !organization" class="tw-w-28">
           <app-org-badge

--- a/apps/web/src/app/vault/vault-items.component.ts
+++ b/apps/web/src/app/vault/vault-items.component.ts
@@ -41,6 +41,9 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
   organizations: Organization[] = [];
   profileName: string;
   noItemIcon = Icons.Search;
+  sortedDescending = true;
+  sortBy: string = "name";
+  showData: string = "owner";
 
   private didScroll = false;
   private pagedCiphersCount = 0;
@@ -58,6 +61,7 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     private logService: LogService,
     private organizationService: OrganizationService,
     private tokenService: TokenService
+
   ) {
     super(searchService);
   }
@@ -92,6 +96,79 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     this.pagedCiphersCount = this.pagedCiphers.length;
     this.didScroll = this.pagedCiphers.length > this.pageSize;
   }
+
+  getOrganizationById(c: CipherView): string {
+    return c.organizationId != null
+      ? this.organizationNames.get(c.organizationId)
+      : this.i18nService.t("myVault");
+  }
+
+  async loadOrganizationNames(): Promise<Map<string, string>> {
+    const organizationNames = new Map<string, string>();
+
+    organizations.forEach((this.organization) => {
+      organizationNames.set(organization.id, organization.name);
+    });
+
+    return organizationNames;
+  }
+
+  sortCiphers(sortBy: string): void {
+    if (sortBy === this.sortBy) {
+      this.sortedDescending = !this.sortedDescending;
+    } else {
+      this.sortBy = sortBy;
+      this.sortedDescending = true;
+    }
+
+    if (sortBy === "lastEdited") {
+      if (this.sortedDescending) {
+        this.ciphers.sort((a: CipherView, b: CipherView) => {
+          return b.revisionDate.valueOf() - a.revisionDate.valueOf();
+        });
+      } else {
+        this.ciphers.sort((a: CipherView, b: CipherView) => {
+          return a.revisionDate.valueOf() - b.revisionDate.valueOf();
+        });
+      }
+      this.showData = "lastEdited";
+    } else if (sortBy === "dateCreated") {
+      // TO-DO
+    } else if (sortBy === "owner") {
+      this.ciphers.sort((a: CipherView, b: CipherView) => {
+        const sortingValue1 =
+          a.organizationId == null ? "Personal" : this.organizationNames.get(a.organizationId);
+        const sortingValue2 =
+          b.organizationId == null ? "Personal" : this.organizationNames.get(b.organizationId);
+
+        if (this.sortedDescending) {
+          return sortingValue1.localeCompare(sortingValue2);
+        } else {
+          return sortingValue2.localeCompare(sortingValue1);
+        }
+      });
+      this.showData = "owner";
+    } else if (sortBy === "name") {
+      if (this.sortedDescending) {
+        this.ciphers.sort((a, b) => a.name.localeCompare(b.name));
+      } else {
+        this.ciphers.sort((a, b) => b.name.localeCompare(a.name));
+      }
+    }
+  }
+
+  reverseSort(): void {
+    this.sortCiphers(this.sortBy);
+  }
+
+  changeDataToShow(type: string): void {
+    this.showData = type;
+  }
+
+  revisionDate(date: Date): string {
+    return date ? date.toLocaleDateString("en-US") : null;
+  }
+
 
   async refresh() {
     try {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5863,5 +5863,14 @@
         "example": "2"
       }
     }
+  },
+  "dateCreated": {
+    "message": "Date created"
+  },
+  "lastEdited": {
+    "message": "Last edited"
+  },
+  "lastUsed": {
+    "message": "Last used"
   }
 }

--- a/apps/web/src/scss/tables.scss
+++ b/apps/web/src/scss/tables.scss
@@ -83,6 +83,27 @@
     }
   }
 
+  #sort-ciphers-table {
+    tr > th {
+      cursor: pointer;
+    }
+    tr > .cipher-sort-table-header {
+      padding-bottom: 4px;
+    }
+    .sorting-arrow {
+      opacity: 0;
+      transition: 0.3s;
+    }
+    .show-arrow-on-hover:hover {
+      .sorting-arrow {
+        opacity: 1;
+      }
+    }
+    .sort-name-arrow {
+      margin-right: 15px;
+    }
+  }
+
   td.table-list-icon {
     max-width: 45px;
     text-align: center;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Not the original author here -- simply trying to capture and apply changes that were in an open PR:
- https://github.com/bitwarden/web/pull/1277

Hoping to faithfully track repo+filename changes, and compensate for any changes made to the UI since Feb 2022.
---

Original Objective from web/pull/1277:
> This feature adds sorting of the ciphers. It is possible to sort by `name`, `owner` (organization), and `lastEdited` by selecting the desired sorting method or clicking the header `Name`. Reverse sorting is also supported for all methods by pressing the arrow or clicking on the header again. Sorting by `dateCreated` is not yet implemented.
> 
> The addition of this feature has been frequently asked for on the community forum.

Examples:
- https://community.bitwarden.com/t/sort-all-items-in-types-based-on-name-date-created-last-modified-used-and-more/33444
- https://community.bitwarden.com/t/sort-items-by-date-of-modification-addition-last-use-etc/2484


## Code changes

- apps/web/src/app/vault/vault-items.component.html: a new column has been added with a sorting option in the header and the respective sorting information in the column. A select all button has also been added above the name of the cipher in the header of the table.

- apps/web/src/app/vault/vault-items.component.ts: the functionality for the sorting has been added. I've tried to write as good typescript as I can but of course this might need improvement. Here, the sort by dateCreated has not been implemented yet.

- apps/web/src/app/vault/bulk-actions.component.html: the select all option has been removed since it now resides in the table. [ this may be a stale comment ]

- apps/web/src/locales/en/messages.json: added three english translations for the sorting methods.

- apps/web/src/scss/tables.scss: some specific CSS has been added to match the provided Figma design.



## Screenshots

[ images are from the original pull request ]

![](https://user-images.githubusercontent.com/26228321/140430207-f6906b5f-d215-4cab-86b7-fa413e3493e6.png)

![](https://user-images.githubusercontent.com/26228321/140430227-7a07034e-94da-4be7-bea8-49416484fca1.png)


## Testing requirements
- All sorting methods needs to be tested. Both normal order and reverse.
- Ciphers with empty or no data might need to be tested.
- Testing with a user that has several organizations and ciphers would be good.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team

## Todo for PR author:
- [ ] review and respond to all PR review comments and suggestions in original PR, there was a batch of comments at the end that do not appear to have been addressed.