### PR TITLE
[EC 911] Prevent Table from overflowing

### DIFF
--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -21,7 +21,7 @@
           }}</label>
         </th>
         <th bitCell class="tw-w-1/2">{{ "name" | i18n }}</th>
-        <th bitCell class="tw-w-1/2">
+        <th bitCell class="tw-w-max">
           <ng-container *ngIf="!organization">{{ "owner" | i18n }}</ng-container>
           <ng-container *ngIf="organization">
             {{ (activeFilter.selectedCollectionNode ? "groups" : "collections") | i18n }}

--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -156,7 +156,7 @@
         <td bitCell (click)="selectRow(c)">
           <app-vault-icon [cipher]="c"></app-vault-icon>
         </td>
-        <td bitCell (click)="selectRow(c)">
+        <td bitCell class="tw-break-all" (click)="selectRow(c)">
           <a
             appStopProp
             [routerLink]="[]"

--- a/libs/components/src/badge/badge.directive.ts
+++ b/libs/components/src/badge/badge.directive.ts
@@ -26,7 +26,7 @@ const hoverStyles: Record<BadgeTypes, string[]> = {
 export class BadgeDirective {
   @HostBinding("class") get classList() {
     return [
-      "tw-inline",
+      "tw-inline-block",
       "tw-py-0.5",
       "tw-px-1.5",
       "tw-font-bold",

--- a/libs/components/src/badge/badge.directive.ts
+++ b/libs/components/src/badge/badge.directive.ts
@@ -26,7 +26,7 @@ const hoverStyles: Record<BadgeTypes, string[]> = {
 export class BadgeDirective {
   @HostBinding("class") get classList() {
     return [
-      "tw-inline-block",
+      "tw-inline",
       "tw-py-0.5",
       "tw-px-1.5",
       "tw-font-bold",
@@ -35,7 +35,7 @@ export class BadgeDirective {
       "tw-rounded",
       "tw-border-none",
       "tw-box-border",
-      "tw-whitespace-no-wrap",
+      "tw-whitespace-nowrap",
       "tw-text-xs",
       "hover:tw-no-underline",
       "focus:tw-outline-none",

--- a/libs/components/src/table/table.component.html
+++ b/libs/components/src/table/table.component.html
@@ -1,4 +1,7 @@
-<table class="tw-w-full tw-table-auto tw-leading-normal tw-text-main">
+<table
+  class="tw-w-full tw-table-auto tw-break-words tw-leading-normal"
+  [style.word-break]="'break-word'"
+>
   <thead
     class="tw-text-bold tw-border-0 tw-border-b-2 tw-border-solid tw-border-secondary-300 tw-text-muted"
   >

--- a/libs/components/src/table/table.component.html
+++ b/libs/components/src/table/table.component.html
@@ -1,7 +1,4 @@
-<table
-  class="tw-w-full tw-table-auto tw-break-words tw-leading-normal"
-  [style.word-break]="'break-word'"
->
+<table class="tw-w-full tw-table-auto tw-leading-normal tw-text-main">
   <thead
     class="tw-text-bold tw-border-0 tw-border-b-2 tw-border-solid tw-border-secondary-300 tw-text-muted"
   >


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Whenever an item was added with a long name, our vault table would expand to accommodate instead of wrapping the text. This caused issues when we had notification boxes on the side.

This PR should prevent this behavior.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


- **table.component.html:** Set the style `word-break: break-word`. We can't use the tailwind version of this because they use `overflow-wrap: break-word` which doesn't seem to work on tables.
- **vault-items.component.html:** Allow the badge column in the table to shrink instead of splitting it 50/50 with the name column
- **badge.directive.ts:** Adding the `word-break: break-word` on the table would also apply this to the badges. We need to prevent badges from wrapping anyway, so i've set them to be `inline-block` in the directive.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Before:
![image](https://user-images.githubusercontent.com/24985544/210601213-bd875875-8f33-4eb9-81e0-792af11c3d2d.png)

After:
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/24985544/210601349-43eb4d70-a578-4be5-b5cd-99db39e13552.png">

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/24985544/210601468-89f1caea-43ef-4c2d-bd83-f6c52b9f4629.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
