### PR TITLE
[EC-906] add bitLink to item names

### DIFF
--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -86,7 +86,7 @@
             <i class="bwi bwi-fw bwi-lg bwi-collection"></i>
           </div>
         </td>
-        <td bitCell class="tw-font-bold" (click)="selectRow(col)">
+        <td bitCell (click)="selectRow(col)">
           <button bitLink linkType="secondary" (click)="navigateCollection(col)">
             {{ col.node.name }}
           </button>
@@ -157,14 +157,15 @@
           <app-vault-icon [cipher]="c"></app-vault-icon>
         </td>
         <td bitCell (click)="selectRow(c)">
-          <a
-            appStopProp
+          <button
+            bitLink
             [routerLink]="[]"
             [queryParams]="{ itemId: c.id }"
             queryParamsHandling="merge"
             title="{{ 'editItem' | i18n }}"
-            >{{ c.name }}</a
           >
+            {{ c.name }}
+          </button>
           <ng-container *ngIf="c.hasAttachments">
             <i
               class="bwi bwi-paperclip"


### PR DESCRIPTION

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Item names weren't using the `bitLink` directive, causing them to use the default font style.
I also noticed that `a` tags couldn't be navigated into with the keyboard. Even though the item link uses the URL to navigate to the edit modal, I decided to change it to a `button` since it doesn't navigate away from the current location.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/24985544/210633967-c1bd9ba1-6c4a-4d91-a9e3-966146b36e8e.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
