### PR TITLE
[EC-828] Fix misaligned selects

### DIFF
--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -1,7 +1,13 @@
 <div class="tw-flex">
   <bit-form-field *ngIf="permissionMode == 'edit'">
     <bit-label>{{ "permission" | i18n }}</bit-label>
+    <!--
+      Built-in select height differs between browsers, this fix makes sure we match bit-multi-select height.
+      We might want to reconsider this fix when/if we implement
+      [CL-78] [Improvement] Completely restyled selects (https://bitwarden.atlassian.net/browse/CL-78)
+    -->
     <select
+      class="tw-h-[35px]"
       bitInput
       [disabled]="disabled"
       [(ngModel)]="initialPermission"


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Second attempt at fixing misaligned selects.

## Code changes

Added explicit height to regular `select` that matches `ng-select` `min-height`. I honestly tried to fix this properly and I have a refactored `ng-select` theme that doesn't use `min-height` on my computer. But the issue is that the regular `select` element height is calculated differently depending on browsers. We need to look into [CL-78 [Improvement] Completely restyled selects](https://bitwarden.atlassian.net/browse/CL-78) before we attempt removing the `height` rules.

## Screenshots

### Firefox
![image](https://user-images.githubusercontent.com/2285588/210750841-1a263cf5-e422-438d-8173-dfafe044b51a.png)

### Chrome
![image](https://user-images.githubusercontent.com/2285588/210750882-558449cb-66ca-4efc-8108-0d9d88c9bcc5.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
