### PR TITLE
[EC-639] Replacing apostrophe char for email values in Policies API request

### DIFF
--- a/libs/common/src/services/policy/policy-api.service.ts
+++ b/libs/common/src/services/policy/policy-api.service.ts
@@ -56,7 +56,7 @@ export class PolicyApiService implements PolicyApiServiceAbstraction {
         "token=" +
         encodeURIComponent(token) +
         "&email=" +
-        encodeURIComponent(email) +
+        encodeURIComponent(email).replace(/'/g, "%27") +
         "&organizationUserId=" +
         organizationUserId,
       null,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix an error when inviting user where an apostrophe exists in the email to an Org where MPR policy auto-enrollment is active.

The API call to get the user's applicable master password policies was failing due to the apostrophe char not being encoded. `encodeURIComponent` does not encode that specific char https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description

## Code changes

- **libs/common/src/services/policy/policy-api.service.ts:** Encoding the apostrophe char before sending the request

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
