### PR TITLE
PS-2171 Revert "Ps/sync only when changed"

### DIFF
--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
@@ -32,7 +32,6 @@ describe("session syncer", () => {
     stateService = mock<BrowserStateService>();
     stateService.hasInSessionMemory.mockResolvedValue(false);
     sut = new SessionSyncer(behaviorSubject, stateService, metaData);
-    jest.spyOn(sut as any, "debounceMs", "get").mockReturnValue(0);
   });
 
   afterEach(() => {
@@ -89,7 +88,7 @@ describe("session syncer", () => {
 
       sut.init();
 
-      expect(sut["ignoreNUpdates"]).toBe(1);
+      expect(sut["ignoreNUpdates"]).toBe(3);
     });
 
     it("should ignore BehaviorSubject's initial value", () => {
@@ -129,40 +128,27 @@ describe("session syncer", () => {
   describe("a value is emitted on the observable", () => {
     let sendMessageSpy: jest.SpyInstance;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       sendMessageSpy = jest.spyOn(BrowserApi, "sendMessage");
 
       sut.init();
 
-      // allow initial value to be set
-      await awaitAsync();
       behaviorSubject.next("test");
     });
 
     it("should update the session memory", async () => {
       // await finishing of fire-and-forget operation
-      await awaitAsync();
+      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(stateService.setInSessionMemory).toHaveBeenCalledTimes(1);
       expect(stateService.setInSessionMemory).toHaveBeenCalledWith(sessionKey, "test");
     });
 
     it("should update sessionSyncers in other contexts", async () => {
       // await finishing of fire-and-forget operation
-      await awaitAsync();
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(sendMessageSpy).toHaveBeenCalledWith(`${sessionKey}_update`, { id: sut.id });
-    });
-
-    it("should debounce subject updates", async () => {
-      behaviorSubject.next("test2");
-      behaviorSubject.next("test3");
-
-      // await finishing of fire-and-forget operation
-      await awaitAsync();
-
-      expect(stateService.setInSessionMemory).toHaveBeenCalledTimes(1);
-      expect(stateService.setInSessionMemory).toHaveBeenCalledWith(sessionKey, "test3");
     });
   });
 


### PR DESCRIPTION
Reverts bitwarden/clients#4245

We're seeing stalled logout issues due to this commit. We need to rethink these debounces, probably add some time information to ensure ignoring out-of-date items rather than debounce.

Alternatively, we can look to reducing debounce time in the next release and see if that improves things. This doesn't seem super likely since the logout delay observed is ~10 seconds while debounce time is just 0.5 sec. It appears that the logout actions are being eaten, not delayed by debounce.