### PR TITLE
[EC-887] Fix Managers can see options to edit/delete Collections they aren't assigned to

### DIFF
--- a/apps/web/src/app/organizations/core/services/collection-admin.service.ts
+++ b/apps/web/src/app/organizations/core/services/collection-admin.service.ts
@@ -87,6 +87,7 @@ export class CollectionAdminService {
       if (isCollectionAccessDetailsResponse(c)) {
         view.groups = c.groups;
         view.users = c.users;
+        view.assigned = c.assigned;
       }
 
       return view;

--- a/apps/web/src/app/organizations/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/organizations/core/views/collection-admin.view.ts
@@ -7,6 +7,11 @@ export class CollectionAdminView extends CollectionView {
   groups: CollectionAccessSelectionView[] = [];
   users: CollectionAccessSelectionView[] = [];
 
+  /**
+   * Flag indicating the user has been explicitly assigned to this Collection
+   */
+  assigned: boolean;
+
   constructor(response?: CollectionAccessDetailsResponse) {
     super(response);
 
@@ -21,5 +26,7 @@ export class CollectionAdminView extends CollectionView {
     this.users = response.users
       ? response.users.map((g) => new CollectionAccessSelectionView(g))
       : [];
+
+    this.assigned = response.assigned;
   }
 }

--- a/apps/web/src/app/organizations/vault/vault-items.component.ts
+++ b/apps/web/src/app/organizations/vault/vault-items.component.ts
@@ -219,6 +219,21 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     }
   }
 
+  get showMissingCollectionPermissionMessage(): boolean {
+    // Not filtering by collections, so no need to show message
+    if (this.activeFilter.selectedCollectionNode == null) {
+      return false;
+    }
+
+    // Filtering by all collections, so no need to show message
+    if (this.activeFilter.selectedCollectionNode.node.id == "AllCollections") {
+      return false;
+    }
+
+    // Filtering by a collection, so show message if user is not assigned
+    return !this.activeFilter.selectedCollectionNode.node.assigned;
+  }
+
   canDeleteCollection(c: CollectionAdminView): boolean {
     // Only delete collections if we're in the org vault and not deleting "Unassigned"
     if (this.organization === undefined || c.id === null) {

--- a/apps/web/src/app/organizations/vault/vault-items.component.ts
+++ b/apps/web/src/app/organizations/vault/vault-items.component.ts
@@ -27,9 +27,10 @@ import {
 import { VaultFilterService } from "../../vault/vault-filter/services/abstractions/vault-filter.service";
 import { CollectionFilter } from "../../vault/vault-filter/shared/models/vault-filter.type";
 import {
-  VaultItemsComponent as BaseVaultItemsComponent,
   VaultItemRow,
+  VaultItemsComponent as BaseVaultItemsComponent,
 } from "../../vault/vault-items.component";
+import { CollectionAdminView } from "../core";
 import { GroupService } from "../core/services/group/group.service";
 import {
   CollectionDialogResult,
@@ -170,6 +171,12 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     if (item instanceof TreeNode && item.node.name == "Unassigned") {
       return;
     }
+
+    // Do not allow checking a collection we cannot delete
+    if (item instanceof TreeNode && !this.canDeleteCollection(item.node)) {
+      return;
+    }
+
     item.checked = select ?? !item.checked;
   }
 
@@ -182,6 +189,19 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
 
   get selectedCollectionIds(): string[] {
     return this.selectedCollections.map((c) => c.node.id);
+  }
+
+  canEditCollection(c: CollectionAdminView): boolean {
+    // Only edit collections if we're in the org vault and not editing "Unassigned"
+    if (this.organization === undefined || c.id === null) {
+      return false;
+    }
+
+    // Otherwise, check if we can edit the specified collection
+    return (
+      this.organization.canEditAnyCollection ||
+      (this.organization.canEditAssignedCollections && c.assigned)
+    );
   }
 
   async editCollection(c: CollectionView, tab: "info" | "access"): Promise<void> {
@@ -197,6 +217,19 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
       await this.actionPromise;
       this.actionPromise = null;
     }
+  }
+
+  canDeleteCollection(c: CollectionAdminView): boolean {
+    // Only delete collections if we're in the org vault and not deleting "Unassigned"
+    if (this.organization === undefined || c.id === null) {
+      return false;
+    }
+
+    // Otherwise, check if we can delete the specified collection
+    return (
+      this.organization?.canDeleteAnyCollection ||
+      (this.organization?.canDeleteAssignedCollections && c.assigned)
+    );
   }
 
   async deleteCollection(collection: CollectionView): Promise<void> {

--- a/apps/web/src/app/organizations/vault/vault-items.component.ts
+++ b/apps/web/src/app/organizations/vault/vault-items.component.ts
@@ -168,7 +168,7 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
   }
 
   checkRow(item: VaultItemRow, select?: boolean) {
-    if (item instanceof TreeNode && item.node.name == "Unassigned") {
+    if (item instanceof TreeNode && item.node.id == null) {
       return;
     }
 

--- a/apps/web/src/app/vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/app/vault/vault-filter/services/vault-filter.service.ts
@@ -193,6 +193,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
         collectionCopy.icon = "bwi-collection";
         if (c instanceof CollectionAdminView) {
           collectionCopy.groups = c.groups;
+          collectionCopy.assigned = c.assigned;
         }
         const parts =
           c.name != null ? c.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];

--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -74,7 +74,7 @@
       <tr bitRow *ngFor="let col of filteredCollections">
         <td bitCell (click)="selectRow(col)">
           <input
-            *ngIf="organization && col.node.id !== null"
+            *ngIf="canDeleteCollection(col.node)"
             class="tw-cursor-pointer"
             type="checkbox"
             [(ngModel)]="$any(col).checked"
@@ -110,7 +110,7 @@
         </td>
         <td bitCell>
           <button
-            *ngIf="organization && col.node.id !== null"
+            *ngIf="canEditCollection(col.node) || canDeleteCollection(col.node)"
             [bitMenuTriggerFor]="collectionOptions"
             size="small"
             bitIconButton="bwi-ellipsis-v"
@@ -119,7 +119,7 @@
           ></button>
           <bit-menu #collectionOptions>
             <button
-              *ngIf="organization?.canEditAssignedCollections || organization?.canEditAnyCollection"
+              *ngIf="canEditCollection(col.node)"
               bitMenuItem
               (click)="editCollection(col.node, 'info')"
             >
@@ -127,7 +127,7 @@
               {{ "editInfo" | i18n }}
             </button>
             <button
-              *ngIf="organization?.canEditAssignedCollections || organization?.canEditAnyCollection"
+              *ngIf="canEditCollection(col.node)"
               bitMenuItem
               (click)="editCollection(col.node, 'access')"
             >
@@ -135,9 +135,7 @@
               {{ "access" | i18n }}
             </button>
             <button
-              *ngIf="
-                organization?.canDeleteAssignedCollections || organization?.canDeleteAnyCollection
-              "
+              *ngIf="canDeleteCollection(col.node)"
               bitMenuItem
               (click)="deleteCollection(col.node)"
             >

--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -284,7 +284,13 @@
       </tr>
     </ng-container>
   </bit-table>
-  <div class="no-items" *ngIf="!filteredCiphers.length && !filteredCollections.length">
+  <div
+    class="tw-mt-6 tw-flex tw-h-full tw-flex-col tw-items-center tw-justify-start"
+    *ngIf="
+      showMissingCollectionPermissionMessage ||
+      (!filteredCiphers.length && !filteredCollections.length)
+    "
+  >
     <ng-container *ngIf="!loaded">
       <i
         class="bwi bwi-spinner bwi-spin text-muted"
@@ -295,10 +301,15 @@
     </ng-container>
     <ng-container *ngIf="loaded">
       <bit-icon [icon]="noItemIcon" aria-hidden="true"></bit-icon>
-      <p>{{ "noItemsInList" | i18n }}</p>
-      <button (click)="addCipher()" class="btn btn-outline-primary" *ngIf="showAddNew">
-        <i class="bwi bwi-plus bwi-fw"></i>{{ "addItem" | i18n }}
-      </button>
+      <ng-container *ngIf="showMissingCollectionPermissionMessage">
+        <p>{{ "noPermissionToViewAllCollectionItems" | i18n }}</p>
+      </ng-container>
+      <ng-container *ngIf="!showMissingCollectionPermissionMessage">
+        <p>{{ "noItemsInList" | i18n }}</p>
+        <button (click)="addCipher()" class="btn btn-outline-primary" *ngIf="showAddNew">
+          <i class="bwi bwi-plus bwi-fw"></i>{{ "addItem" | i18n }}
+        </button>
+      </ng-container>
     </ng-container>
   </div>
 </ng-container>

--- a/apps/web/src/app/vault/vault-items.component.ts
+++ b/apps/web/src/app/vault/vault-items.component.ts
@@ -539,6 +539,11 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     // TODO: This should be removed but is needed since we reuse the same template
   }
 
+  get showMissingCollectionPermissionMessage(): boolean {
+    // TODO: This should be removed but is needed since we reuse the same template
+    return false; // Always return false for non org vault
+  }
+
   protected updateSearchedCollections(collections: TreeNode<CollectionFilter>[]) {
     if (this.searchService.isSearchable(this.searchText)) {
       this.searchedCollections = this.searchPipe.transform(

--- a/apps/web/src/app/vault/vault-items.component.ts
+++ b/apps/web/src/app/vault/vault-items.component.ts
@@ -23,7 +23,7 @@ import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 import { CollectionView } from "@bitwarden/common/models/view/collection.view";
 import { DialogService, Icons } from "@bitwarden/components";
 
-import { GroupView } from "../organizations/core";
+import { CollectionAdminView, GroupView } from "../organizations/core";
 
 import {
   BulkDeleteDialogResult,
@@ -521,8 +521,18 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     // TODO: This should be removed but is needed since we reuse the same template
   }
 
+  canDeleteCollection(c: CollectionAdminView): boolean {
+    // TODO: This should be removed but is needed since we reuse the same template
+    return false; // Always return false for non org vault
+  }
+
   async deleteCollection(collection: CollectionView): Promise<void> {
     // TODO: This should be removed but is needed since we reuse the same template
+  }
+
+  canEditCollection(c: CollectionAdminView): boolean {
+    // TODO: This should be removed but is needed since we reuse the same template
+    return false; // Always return false for non org vault
   }
 
   async editCollection(c: CollectionView, tab: "info" | "access"): Promise<void> {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -743,6 +743,9 @@
   "noItemsInList": {
     "message": "There are no items to list."
   },
+  "noPermissionToViewAllCollectionItems": {
+    "message": "You do not have permission to view all items in this collection."
+  },
   "noCollectionsInList": {
     "message": "There are no collections to list."
   },

--- a/libs/common/src/models/response/collection.response.ts
+++ b/libs/common/src/models/response/collection.response.ts
@@ -29,8 +29,15 @@ export class CollectionAccessDetailsResponse extends CollectionResponse {
   groups: SelectionReadOnlyResponse[] = [];
   users: SelectionReadOnlyResponse[] = [];
 
+  /**
+   * Flag indicating the user has been explicitly assigned to this Collection
+   */
+  assigned: boolean;
+
   constructor(response: any) {
     super(response);
+    this.assigned = this.getResponseProperty("Assigned") || false;
+
     const groups = this.getResponseProperty("Groups");
     if (groups != null) {
       this.groups = groups.map((g: any) => new SelectionReadOnlyResponse(g));


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

It was discovered that Manager users would still see collections in the vault that the did not have access to. This is the intended behavior, as Managers have permission to create Collections by default. However, even though Managers can view all collections, they do not always have permission to edit all collections, so this PR removes the edit/delete controls when they do not have the appropriate permissions. It also introduces a new warning message indicating they do not have sufficient privileges to view all the items in a collection they do not have access to. 

There is a required server change for this PR: https://github.com/bitwarden/server/pull/2542

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/vault/vault-items.component:** Add logic to the component to hide controls for collections that are read only for a user. Also, show new "missing permission" message in case a user filters to a collection they do not have access to view items in.
- **collection-admin.service.ts and view/response:** Add the new `assigned` property for determining user access

## Screenshots

### Showing disabled controls 
User only has access to collection "Another One" so it is the only row that shows the checkbox and 3 dots menu
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/8764515/210892387-5fd11db8-efd6-44d3-988a-b67e18bc937b.png">

### Missing permission to view all items
The User does not have access to the "Alpha" collection, but they still have permission to view all collections so a message is displayed below the table indicating that they do not have permission to view all items. _Note: They also do not have access to "Nest" or "Test" so the controls are hidden for those rows_
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/8764515/210892469-3b1dfe7b-c577-4f8c-9c6c-c78e13e5d8b5.png">

### Viewing an assigned nested collection
The User has access to "Charlie" so they can see all the items within.
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/8764515/210892934-e2ff52c7-2ebc-4010-a1ef-3d30fa3c8523.png">

### Viewing an assigned collection with no items
The User has access to "Another One" but it contains no items, so the normal "no items" message is displayed.
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/8764515/210893118-6372e652-683e-4101-a2e2-83f73212640e.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
