### PR TITLE
[EC-905] Vault row alignment

### DIFF
--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -71,7 +71,7 @@
       </tr>
     </ng-container>
     <ng-container body>
-      <tr bitRow *ngFor="let col of filteredCollections">
+      <tr bitRow *ngFor="let col of filteredCollections" alignContent="middle">
         <td bitCell (click)="selectRow(col)">
           <input
             *ngIf="organization && col.node.id !== null"
@@ -149,7 +149,7 @@
           </bit-menu>
         </td>
       </tr>
-      <tr bitRow *ngFor="let c of filteredCiphers">
+      <tr bitRow *ngFor="let c of filteredCiphers" alignContent="middle">
         <td bitCell (click)="selectRow(c)">
           <input type="checkbox" [(ngModel)]="$any(c).checked" appStopProp />
         </td>

--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -87,7 +87,12 @@
           </div>
         </td>
         <td bitCell (click)="selectRow(col)">
-          <button bitLink linkType="secondary" (click)="navigateCollection(col)">
+          <button
+            bitLink
+            class="tw-text-start"
+            linkType="secondary"
+            (click)="navigateCollection(col)"
+          >
             {{ col.node.name }}
           </button>
         </td>
@@ -159,6 +164,7 @@
         <td bitCell class="tw-break-all" (click)="selectRow(c)">
           <button
             bitLink
+            class="tw-text-start"
             [routerLink]="[]"
             [queryParams]="{ itemId: c.id }"
             queryParamsHandling="merge"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Vault row contents were not properly following the alignment rules specified in Figma. Row contents are now middle aligned and item names are now `text-align: start` to avoid centering text when wrapping item names onto multiple lines.  

## Screenshots

### Item Names Alignment

Row content remains middle aligned vertically

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8764515/210904137-fea24b9e-7f68-490e-ad70-57e44746e710.png">

### Collection Names Alignment

Row content remains middle aligned vertically and text aligned at the start of the column
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/8764515/210904305-e35b9d2b-5d3f-4ddb-a5f6-8dc35f14b8f4.png">
 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
