### PR TITLE
[SG-910] Override self hosted check for desktop

### DIFF
--- a/apps/desktop/src/app/accounts/login/login.component.ts
+++ b/apps/desktop/src/app/accounts/login/login.component.ts
@@ -93,6 +93,7 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
 
   async ngOnInit() {
     await super.ngOnInit();
+    await this.checkSelfHosted();
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
       this.ngZone.run(() => {
         switch (message.command) {
@@ -136,9 +137,10 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
       this.showingModal = false;
     });
 
-    // eslint-disable-next-line rxjs-angular/prefer-takeuntil
-    childComponent.onSaved.subscribe(() => {
+    // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
+    childComponent.onSaved.subscribe(async () => {
       modal.close();
+      await this.checkSelfHosted();
     });
   }
 
@@ -174,5 +176,15 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
   private focusInput() {
     const email = this.loggedEmail;
     document.getElementById(email == null || email === "" ? "email" : "masterPassword").focus();
+  }
+
+  private async checkSelfHosted() {
+    const baseUrl = this.environmentService.getUrls().base;
+
+    this.selfHosted = this.environmentService.hasBaseUrl()
+      ? baseUrl !== "http://vault.qa.bitwarden.pw" && baseUrl != "https://vault.qa.bitwarden.pw"
+      : false;
+
+    await this.getLoginWithDevice(this.loggedEmail);
   }
 }

--- a/apps/desktop/src/app/accounts/login/login.component.ts
+++ b/apps/desktop/src/app/accounts/login/login.component.ts
@@ -179,11 +179,7 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
   }
 
   private async checkSelfHosted() {
-    const baseUrl = this.environmentService.getUrls().base;
-
-    this.selfHosted = this.environmentService.hasBaseUrl()
-      ? baseUrl !== "http://vault.qa.bitwarden.pw" && baseUrl != "https://vault.qa.bitwarden.pw"
-      : false;
+    this.selfHosted = this.environmentService.isSelfHosted();
 
     await this.getLoginWithDevice(this.loggedEmail);
   }

--- a/libs/angular/src/components/login.component.ts
+++ b/libs/angular/src/components/login.component.ts
@@ -32,7 +32,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   onSuccessfulLoginNavigate: () => Promise<any>;
   onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
   onSuccessfulLoginForceResetNavigate: () => Promise<any>;
-  private selfHosted = false;
+  selfHosted = false;
   showLoginWithDevice: boolean;
   validatedEmail = false;
   paramEmailSet = false;
@@ -271,7 +271,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     return `${error.controlName}${name}`;
   }
 
-  private async getLoginWithDevice(email: string) {
+  async getLoginWithDevice(email: string) {
     try {
       const deviceIdentifier = await this.appIdService.getAppId();
       const res = await this.apiService.getKnownDevice(email, deviceIdentifier);

--- a/libs/common/src/abstractions/environment.service.ts
+++ b/libs/common/src/abstractions/environment.service.ts
@@ -34,4 +34,9 @@ export abstract class EnvironmentService {
   setUrls: (urls: Urls) => Promise<Urls>;
   getUrls: () => Urls;
   isCloud: () => boolean;
+  /**
+   * @remarks For desktop and browser use only.
+   * For web, use PlatformUtilsService.isSelfHost()
+   */
+  isSelfHosted: () => boolean;
 }

--- a/libs/common/src/services/environment.service.ts
+++ b/libs/common/src/services/environment.service.ts
@@ -213,4 +213,13 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
       this.getApiUrl()
     );
   }
+
+  isSelfHosted(): boolean {
+    return ![
+      "http://vault.bitwarden.com",
+      "https://vault.bitwarden.com",
+      "http://vault.qa.bitwarden.pw",
+      "https://vault.qa.bitwarden.pw",
+    ].includes(this.getWebVaultUrl());
+  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Hide Login with device button for self hosted environments.
ElectronPlatformUtils service always returns false on the self hosted check, so this is a workaround to that.

## Code changes

- **apps/desktop/src/app/accounts/login/login.component.ts:** Add a method to check if it is self-hosted in desktop
- **libs/angular/src/components/login.component.ts** Remove private designation for methods that need to be used in desktop.
- **libs/common/src/abstractions/environment.service.ts:** Add method that can be used by Desktop and Browser to check if this is a self hosted environment.

## Screenshots

https://user-images.githubusercontent.com/8926729/211055028-1b4cfc47-ddc8-4b31-a02e-c9d26dc0310d.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
