### PR TITLE
[SG-853] Add variable defining default locale as english

### DIFF
--- a/libs/common/src/services/i18n.service.ts
+++ b/libs/common/src/services/i18n.service.ts
@@ -7,6 +7,7 @@ export class I18nService implements I18nServiceAbstraction {
   locale$: Observable<string> = this._locale.asObservable();
   // First locale is the default (English)
   supportedTranslationLocales: string[] = ["en"];
+  defaultLocale = "en";
   translationLocale: string;
   collator: Intl.Collator;
   localeNames = new Map<string, string>([
@@ -106,14 +107,14 @@ export class I18nService implements I18nServiceAbstraction {
       this.translationLocale = this.translationLocale.slice(0, 2);
 
       if (this.supportedTranslationLocales.indexOf(this.translationLocale) === -1) {
-        this.translationLocale = this.supportedTranslationLocales[0];
+        this.translationLocale = this.defaultLocale;
       }
     }
 
     if (this.localesDirectory != null) {
       await this.loadMessages(this.translationLocale, this.localeMessages);
-      if (this.translationLocale !== this.supportedTranslationLocales[0]) {
-        await this.loadMessages(this.supportedTranslationLocales[0], this.defaultMessages);
+      if (this.translationLocale !== this.defaultLocale) {
+        await this.loadMessages(this.defaultLocale, this.defaultMessages);
       }
     }
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Improve fragile logic for setting the default language to English if the user's chosen one is not supported or found.

## Code changes

- **libs/common/src/services/i18n.service.ts:** Add `defaultLocale` variable set to `en` and use it wherever we check for the default locale.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
