### PR TITLE
[EC-907] set name font size to normal

### DIFF
--- a/apps/web/src/app/organizations/members/people.component.html
+++ b/apps/web/src/app/organizations/members/people.component.html
@@ -144,22 +144,25 @@
                   class="tw-mr-3"
                 ></bit-avatar>
                 <div class="tw-flex tw-flex-col">
-                  <div class="tw-text-sm tw-font-bold tw-text-primary-500">
+                  <div class="tw-font-bold tw-text-primary-500">
                     {{ u.name ?? u.email }}
                     <span
                       bitBadge
+                      class="tw-text-xs"
                       badgeType="secondary"
                       *ngIf="u.status === userStatusType.Invited"
                       >{{ "invited" | i18n }}</span
                     >
                     <span
                       bitBadge
+                      class="tw-text-xs"
                       badgeType="warning"
                       *ngIf="u.status === userStatusType.Accepted"
                       >{{ "needsConfirmation" | i18n }}</span
                     >
                     <span
                       bitBadge
+                      class="tw-text-xs"
                       badgeType="secondary"
                       *ngIf="u.status === userStatusType.Revoked"
                       >{{ "revoked" | i18n }}</span


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The member name font size should be `base`. It was set to `xs`


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/24985544/211084476-2b99a462-fdde-49ff-9d9a-64eb39ebe111.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
