### PR TITLE
Correct 'Solarized dark' to 'Solarized Dark'

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -642,7 +642,7 @@
     "description": "Light color"
   },
   "solarizedDark": {
-    "message": "Solarized dark",
+    "message": "Solarized Dark",
     "description": "'Solarized' is a noun and the name of a color scheme. It should not be translated."
   },
   "exportVault": {


### PR DESCRIPTION
As the title of a theme, it should be capitalized rather than sentence case.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix (Typo)
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

To correct the title of a theme to title case rather than sentence case. 

## Code changes

Changing 'Solarized dark' to 'Solarized Dark'