### PR TITLE
[TDL-216] Reports remove unneeded dependency on stateService

### DIFF
--- a/apps/web/src/app/organizations/tools/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/organizations/tools/exposed-passwords-report.component.ts
@@ -7,7 +7,6 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { Cipher } from "@bitwarden/common/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
@@ -27,19 +26,11 @@ export class ExposedPasswordsReportComponent extends BaseExposedPasswordsReportC
     auditService: AuditService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     private organizationService: OrganizationService,
     private route: ActivatedRoute,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(
-      cipherService,
-      auditService,
-      modalService,
-      messagingService,
-      stateService,
-      passwordRepromptService
-    );
+    super(cipherService, auditService, modalService, messagingService, passwordRepromptService);
   }
 
   ngOnInit() {

--- a/apps/web/src/app/organizations/tools/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/organizations/tools/inactive-two-factor-report.component.ts
@@ -7,7 +7,6 @@ import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
 // eslint-disable-next-line no-restricted-imports
@@ -23,20 +22,12 @@ export class InactiveTwoFactorReportComponent extends BaseInactiveTwoFactorRepor
     cipherService: CipherService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     private route: ActivatedRoute,
     logService: LogService,
     passwordRepromptService: PasswordRepromptService,
     private organizationService: OrganizationService
   ) {
-    super(
-      cipherService,
-      modalService,
-      messagingService,
-      stateService,
-      logService,
-      passwordRepromptService
-    );
+    super(cipherService, modalService, messagingService, logService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/organizations/tools/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/organizations/tools/unsecured-websites-report.component.ts
@@ -6,7 +6,6 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
 // eslint-disable-next-line no-restricted-imports
@@ -22,12 +21,11 @@ export class UnsecuredWebsitesReportComponent extends BaseUnsecuredWebsitesRepor
     cipherService: CipherService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(cipherService, modalService, messagingService, stateService, passwordRepromptService);
+    super(cipherService, modalService, messagingService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/organizations/tools/weak-passwords-report.component.ts
+++ b/apps/web/src/app/organizations/tools/weak-passwords-report.component.ts
@@ -7,7 +7,6 @@ import { MessagingService } from "@bitwarden/common/abstractions/messaging.servi
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { Cipher } from "@bitwarden/common/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
@@ -27,7 +26,6 @@ export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportCompone
     passwordGenerationService: PasswordGenerationService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
@@ -37,7 +35,6 @@ export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportCompone
       passwordGenerationService,
       modalService,
       messagingService,
-      stateService,
       passwordRepromptService
     );
   }

--- a/apps/web/src/app/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/reports/pages/cipher-report.component.ts
@@ -3,7 +3,6 @@ import { Directive, ViewChild, ViewContainerRef } from "@angular/core";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherRepromptType } from "@bitwarden/common/enums/cipherRepromptType";
 import { Organization } from "@bitwarden/common/models/domain/organization";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
@@ -25,7 +24,6 @@ export class CipherReportComponent {
     private modalService: ModalService,
     protected messagingService: MessagingService,
     public requiresPaid: boolean,
-    private stateService: StateService,
     protected passwordRepromptService: PasswordRepromptService
   ) {}
 

--- a/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
@@ -5,7 +5,6 @@ import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
@@ -23,10 +22,9 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     protected auditService: AuditService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, stateService, passwordRepromptService);
+    super(modalService, messagingService, true, passwordRepromptService);
   }
 
   ngOnInit() {

--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -5,7 +5,6 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
 import { Utils } from "@bitwarden/common/misc/utils";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
@@ -24,11 +23,10 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     protected cipherService: CipherService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     private logService: LogService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, stateService, passwordRepromptService);
+    super(modalService, messagingService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
@@ -24,7 +24,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, stateService, passwordRepromptService);
+    super(modalService, messagingService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
@@ -4,7 +4,6 @@ import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 
@@ -19,10 +18,9 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
     protected cipherService: CipherService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, stateService, passwordRepromptService);
+    super(modalService, messagingService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
@@ -5,7 +5,6 @@ import { CipherService } from "@bitwarden/common/abstractions/cipher.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { PasswordGenerationService } from "@bitwarden/common/abstractions/passwordGeneration.service";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
-import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
 import { CipherView } from "@bitwarden/common/models/view/cipher.view";
 import { BadgeTypes } from "@bitwarden/components";
@@ -26,10 +25,9 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     protected passwordGenerationService: PasswordGenerationService,
     modalService: ModalService,
     messagingService: MessagingService,
-    stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, stateService, passwordRepromptService);
+    super(modalService, messagingService, true, passwordRepromptService);
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The cipher-report.component has a dependency on stateService which it doesn’t use. As this is a base-component for a lot of the reports, the dependency on stateService is dragged into the other constructors.

This aims to remove the unneeded dependency on stateService

## Code changes
- **apps/web/src/app/reports/pages/cipher-report.component.ts:** Remove unneeded dependency on `stateService` which in turn can be removed from:
  - **apps/web/src/app/reports/pages/reused-passwords-report.component.ts**
  -
  - **apps/web/src/app/reports/pages/exposed-passwords-report.component.ts:** 
  - **apps/web/src/app/organizations/tools/exposed-passwords-report.component.ts:** 
  -
  - **apps/web/src/app/organizations/tools/inactive-two-factor-report.component.ts:**
  - **apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts:**
  -
  - **apps/web/src/app/reports/pages/unsecured-websites-report.component.ts:**
  - **apps/web/src/app/organizations/tools/unsecured-websites-report.component.ts:** 
  -
  - **apps/web/src/app/reports/pages/weak-passwords-report.component.ts:**
  - **apps/web/src/app/organizations/tools/weak-passwords-report.component.ts:** 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
