### PR TITLE
[PS-2216] Feature/scrypt kdf

### DIFF
--- a/apps/web/src/app/settings/change-kdf.component.html
+++ b/apps/web/src/app/settings/change-kdf.component.html
@@ -79,7 +79,7 @@
             class="form-control"
             required
           >
-            <option *ngFor="let o of scryptWorkFactorOptions" [ngValue]="o">{{ o }}</option>
+            <option *ngFor="let o of scryptWorkFactorOptions" [ngValue]="o">2^{{ log2(o) }}</option>
           </select>
         </ng-container>
       </div>

--- a/apps/web/src/app/settings/change-kdf.component.html
+++ b/apps/web/src/app/settings/change-kdf.component.html
@@ -39,34 +39,62 @@
     </div>
     <div class="col-6">
       <div class="form-group mb-0">
-        <label for="kdfIterations">{{ "kdfIterations" | i18n }}</label>
-        <a
-          class="ml-auto"
-          href="https://bitwarden.com/help/what-encryption-is-used/#pbkdf2"
-          target="_blank"
-          rel="noopener"
-          appA11yTitle="{{ 'learnMore' | i18n }}"
-        >
-          <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-        </a>
-        <input
-          id="kdfIterations"
-          type="number"
-          min="5000"
-          max="2000000"
-          name="KdfIterations"
-          class="form-control"
-          [(ngModel)]="kdfIterations"
-          required
-        />
+        <ng-container *ngIf="kdf == 0">
+          <label for="kdfIterations">{{ "kdfIterations" | i18n }}</label>
+          <a
+            class="ml-auto"
+            href="https://bitwarden.com/help/what-encryption-is-used/#pbkdf2"
+            target="_blank"
+            rel="noopener"
+            appA11yTitle="{{ 'learnMore' | i18n }}"
+          >
+            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+          </a>
+          <input
+            id="kdfIterations"
+            type="number"
+            min="5000"
+            max="2000000"
+            name="KdfIterations"
+            class="form-control"
+            [(ngModel)]="kdfIterations"
+            required
+          />
+        </ng-container>
+        <ng-container *ngIf="kdf == 1">
+          <label for="scryptWorkFactor">{{ "scryptWorkFactor" | i18n }}</label>
+          <a
+            class="ml-auto"
+            href="https://bitwarden.com/help/what-encryption-is-used/#scrypt"
+            target="_blank"
+            rel="noopener"
+            appA11yTitle="{{ 'learnMore' | i18n }}"
+          >
+            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+          </a>
+          <select
+            id="scrypt-wf"
+            name="WF"
+            [(ngModel)]="scryptWorkFactor"
+            class="form-control"
+            required
+          >
+            <option *ngFor="let o of scryptWorkFactorOptions" [ngValue]="o">{{ o }}</option>
+          </select>
+        </ng-container>
       </div>
     </div>
     <div class="col-12">
       <div class="form-group">
         <div class="small form-text text-muted">
-          <p>{{ "kdfIterationsDesc" | i18n: (recommendedKdfIterations | number) }}</p>
-          <strong>{{ "warning" | i18n }}</strong
-          >: {{ "kdfIterationsWarning" | i18n: (50000 | number) }}
+          <ng-container *ngIf="kdf == 0">
+            <p>{{ "kdfIterationsDesc" | i18n: (recommendedKdfIterations | number) }}</p>
+            <strong>{{ "warning" | i18n }}</strong
+            >: {{ "kdfIterationsWarning" | i18n: (50000 | number) }}
+          </ng-container>
+          <ng-container *ngIf="kdf == 1">
+            <p>{{ "scryptWorkFactorDesc" | i18n: (65536 | number) }}</p>
+          </ng-container>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/settings/change-kdf.component.ts
+++ b/apps/web/src/app/settings/change-kdf.component.ts
@@ -29,6 +29,7 @@ export class ChangeKdfComponent implements OnInit {
   recommendedKdfIterations = DEFAULT_KDF_ITERATIONS;
   recommendedSCryptWorkFactor = DEFAULT_SCRYPT_WORK_FACTOR;
   scryptWorkFactorOptions = SCRYPT_WORK_FACTORS;
+  log2 = Math.log2;
 
   constructor(
     private apiService: ApiService,

--- a/apps/web/src/app/settings/change-kdf.component.ts
+++ b/apps/web/src/app/settings/change-kdf.component.ts
@@ -31,7 +31,10 @@ export class ChangeKdfComponent implements OnInit {
     private logService: LogService,
     private stateService: StateService
   ) {
-    this.kdfOptions = [{ name: "PBKDF2 SHA-256", value: KdfType.PBKDF2_SHA256 }];
+    this.kdfOptions = [
+      { name: "PBKDF2 SHA-256", value: KdfType.PBKDF2_SHA256 },
+      { name: "SCRYPT", value: KdfType.SCRYPT },
+    ];
   }
 
   async ngOnInit() {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1097,7 +1097,7 @@
     "message": "Scrypt Work Factor"
   },
   "scryptWorkFactorDesc": {
-    "message": "Higher Scrypt work factors can help protect your master password from being brute forced by an attacker. We recommend a value of $VALUE$ or more. It can only be a power of two.",
+    "message": "Higher Scrypt work factors can help protect your master password from being brute forced by an attacker. We recommend a value of $VALUE$ or more. Each level doubles the amount of memory and time consumed.",
     "placeholders": {
       "value": {
         "content": "$1",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1093,6 +1093,18 @@
       }
     }
   },
+  "scryptWorkFactor": {
+    "message": "Scrypt Work Factor"
+  },
+  "scryptWorkFactorDesc": {
+    "message": "Higher Scrypt work factors can help protect your master password from being brute forced by an attacker. We recommend a value of $VALUE$ or more. It can only be a power of two.",
+    "placeholders": {
+      "value": {
+        "content": "$1",
+        "example": "2^16"
+      }
+    }
+  },
   "changeKdf": {
     "message": "Change KDF"
   },

--- a/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
+++ b/libs/common/spec/web/services/webCryptoFunction.service.spec.ts
@@ -58,6 +58,14 @@ describe("WebCrypto Function Service", () => {
     testPbkdf2("sha512", regular512Key, utf8512Key, unicode512Key);
   });
 
+  describe("scrypt", () => {
+    const regularKey = "+S8MshS/IqnZoF3hSPR75nHzFqG55ABV0KCUJZSKoho=";
+    const utf8Key = "cJs9aV29D/QHMYCqEbkhilQpIHAwyTeYrzZllZO2yig=";
+    const unicodeKey = "wAaiECJmnUrcAMIB16HXnWTMiL8l7Rr7M9BcRu6YeOo=";
+
+    testScrypt(regularKey, utf8Key, unicodeKey);
+  });
+
   describe("hkdf", () => {
     const regular256Key = "qBUmEYtwTwwGPuw/z6bs/qYXXYNUlocFlyAuuANI8Pw=";
     const utf8256Key = "6DfJwW1R3txgiZKkIFTvVAb7qVlG7lKcmJGJoxR2GBU=";
@@ -397,6 +405,48 @@ function testPbkdf2(
     expect(Utils.fromBufferToB64(key)).toBe(regularKey);
   });
 }
+
+function testScrypt(regularKey: string, utf8Key: string, unicodeKey: string) {
+  const regularEmail = "user@example.com";
+  const utf8Email = "üser@example.com";
+
+  const regularPassword = "password";
+  const utf8Password = "pǻssword";
+  const unicodePassword = "😀password🙏";
+
+  it("should create valid scrypt key from regular input", async () => {
+    const cryptoFunctionService = getWebCryptoFunctionService();
+    const key = await cryptoFunctionService.scrypt(
+      regularPassword,
+      regularEmail,
+      2 ** 16,
+      8,
+      1,
+      32
+    );
+    expect(Utils.fromBufferToB64(key)).toBe(regularKey);
+  });
+
+  it("should create valid scrypt key from utf8 input", async () => {
+    const cryptoFunctionService = getWebCryptoFunctionService();
+    const key = await cryptoFunctionService.scrypt(utf8Password, utf8Email, 2 ** 16, 8, 1, 32);
+    expect(Utils.fromBufferToB64(key)).toBe(utf8Key);
+  });
+
+  it("should create valid scrypt key from unicode input", async () => {
+    const cryptoFunctionService = getWebCryptoFunctionService();
+    const key = await cryptoFunctionService.scrypt(
+      unicodePassword,
+      regularEmail,
+      2 ** 16,
+      8,
+      1,
+      32
+    );
+    expect(Utils.fromBufferToB64(key)).toBe(unicodeKey);
+  });
+}
+2;
 
 function testHkdf(
   algorithm: "sha256" | "sha512",

--- a/libs/common/src/abstractions/cryptoFunction.service.ts
+++ b/libs/common/src/abstractions/cryptoFunction.service.ts
@@ -11,10 +11,7 @@ export abstract class CryptoFunctionService {
   scrypt: (
     password: string | ArrayBuffer,
     salt: string | ArrayBuffer,
-    N: number,
-    r: number,
-    p: number,
-    dkLen: number
+    N: number
   ) => Promise<ArrayBuffer>;
   hkdf: (
     ikm: ArrayBuffer,

--- a/libs/common/src/abstractions/cryptoFunction.service.ts
+++ b/libs/common/src/abstractions/cryptoFunction.service.ts
@@ -8,6 +8,14 @@ export abstract class CryptoFunctionService {
     algorithm: "sha256" | "sha512",
     iterations: number
   ) => Promise<ArrayBuffer>;
+  scrypt: (
+    password: string | ArrayBuffer,
+    salt: string | ArrayBuffer,
+    N: number,
+    r: number,
+    p: number,
+    dkLen: number
+  ) => Promise<ArrayBuffer>;
   hkdf: (
     ikm: ArrayBuffer,
     salt: string | ArrayBuffer,

--- a/libs/common/src/enums/kdfType.ts
+++ b/libs/common/src/enums/kdfType.ts
@@ -6,3 +6,5 @@ export enum KdfType {
 export const DEFAULT_KDF_TYPE = KdfType.PBKDF2_SHA256;
 export const DEFAULT_KDF_ITERATIONS = 100000;
 export const SEND_KDF_ITERATIONS = 100000;
+export const DEFAULT_SCRYPT_WORK_FACTOR = 2 ** 16;
+export const SCRYPT_WORK_FACTORS = [2 ** 16, 2 ** 17, 2 ** 18, 2 ** 19, 2 ** 20, 2 ** 21, 2 ** 22];

--- a/libs/common/src/enums/kdfType.ts
+++ b/libs/common/src/enums/kdfType.ts
@@ -1,5 +1,6 @@
 export enum KdfType {
   PBKDF2_SHA256 = 0,
+  SCRYPT = 1,
 }
 
 export const DEFAULT_KDF_TYPE = KdfType.PBKDF2_SHA256;

--- a/libs/common/src/enums/kdfType.ts
+++ b/libs/common/src/enums/kdfType.ts
@@ -7,4 +7,13 @@ export const DEFAULT_KDF_TYPE = KdfType.PBKDF2_SHA256;
 export const DEFAULT_KDF_ITERATIONS = 100000;
 export const SEND_KDF_ITERATIONS = 100000;
 export const DEFAULT_SCRYPT_WORK_FACTOR = 2 ** 16;
-export const SCRYPT_WORK_FACTORS = [2 ** 16, 2 ** 17, 2 ** 18, 2 ** 19, 2 ** 20, 2 ** 21, 2 ** 22];
+export const SCRYPT_WORK_FACTORS = [
+  2 ** 15,
+  2 ** 16,
+  2 ** 17,
+  2 ** 18,
+  2 ** 19,
+  2 ** 20,
+  2 ** 21,
+  2 ** 22,
+];

--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -423,15 +423,12 @@ export class CryptoService implements CryptoServiceAbstraction {
         kdfIterations = DEFAULT_SCRYPT_WORK_FACTOR;
       } else if (kdfIterations < 2 ** 15) {
         throw new Error("PBKDF2 iteration minimum is 2^15.");
+      } else if (kdfIterations > 2 ** 22) {
+        throw new Error("PBKDF2 iteration maximum is 2^22.");
       }
+      const n = kdfIterations;
 
-      // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
-      const dkLen = 32; // output length in bytes, i.e 256 bits
-      const p = 1; // parallelization factor leads to a tradeoff between memory and CPU
-      const r = 8; // r is the block width, which scales linearly with memory usage
-      const n = kdfIterations; // n is the CPU/memory cost parameter, it needs to be a power of two
-
-      key = await this.cryptoFunctionService.scrypt(password, salt, n, r, p, dkLen);
+      key = await this.cryptoFunctionService.scrypt(password, salt, n);
     } else {
       throw new Error("Unknown Kdf.");
     }

--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -8,7 +8,7 @@ import { PlatformUtilsService } from "../abstractions/platformUtils.service";
 import { StateService } from "../abstractions/state.service";
 import { EncryptionType } from "../enums/encryptionType";
 import { HashPurpose } from "../enums/hashPurpose";
-import { KdfType } from "../enums/kdfType";
+import { KdfType, DEFAULT_SCRYPT_WORK_FACTOR } from "../enums/kdfType";
 import { KeySuffixOptions } from "../enums/keySuffixOptions";
 import { sequentialize } from "../misc/sequentialize";
 import { Utils } from "../misc/utils";
@@ -419,6 +419,12 @@ export class CryptoService implements CryptoServiceAbstraction {
       }
       key = await this.cryptoFunctionService.pbkdf2(password, salt, "sha256", kdfIterations);
     } else if (kdf === KdfType.SCRYPT) {
+      if (kdfIterations == null) {
+        kdfIterations = DEFAULT_SCRYPT_WORK_FACTOR;
+      } else if (kdfIterations < 2 ** 15) {
+        throw new Error("PBKDF2 iteration minimum is 2^15.");
+      }
+
       // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
       const dkLen = 32; // output length in bytes, i.e 256 bits
       const p = 1; // parallelization factor leads to a tradeoff between memory and CPU

--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -418,6 +418,8 @@ export class CryptoService implements CryptoServiceAbstraction {
         throw new Error("PBKDF2 iteration minimum is 5000.");
       }
       key = await this.cryptoFunctionService.pbkdf2(password, salt, "sha256", kdfIterations);
+    } else if (kdf === KdfType.SCRYPT) {
+      key = await this.cryptoFunctionService.scrypt(password, salt, 2 ** kdfIterations, 8, 1, 32);
     } else {
       throw new Error("Unknown Kdf.");
     }

--- a/libs/common/src/services/crypto.service.ts
+++ b/libs/common/src/services/crypto.service.ts
@@ -419,7 +419,13 @@ export class CryptoService implements CryptoServiceAbstraction {
       }
       key = await this.cryptoFunctionService.pbkdf2(password, salt, "sha256", kdfIterations);
     } else if (kdf === KdfType.SCRYPT) {
-      key = await this.cryptoFunctionService.scrypt(password, salt, 2 ** kdfIterations, 8, 1, 32);
+      // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
+      const dkLen = 32; // output length in bytes, i.e 256 bits
+      const p = 1; // parallelization factor leads to a tradeoff between memory and CPU
+      const r = 8; // r is the block width, which scales linearly with memory usage
+      const n = kdfIterations; // n is the CPU/memory cost parameter, it needs to be a power of two
+
+      key = await this.cryptoFunctionService.scrypt(password, salt, n, r, p, dkLen);
     } else {
       throw new Error("Unknown Kdf.");
     }

--- a/libs/common/src/services/webCryptoFunction.service.ts
+++ b/libs/common/src/services/webCryptoFunction.service.ts
@@ -1,3 +1,4 @@
+import { scryptAsync } from "@noble/hashes/scrypt";
 import * as forge from "node-forge";
 
 import { CryptoFunctionService } from "../abstractions/cryptoFunction.service";
@@ -40,6 +41,17 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
       ["deriveBits"]
     );
     return await this.subtle.deriveBits(pbkdf2Params, impKey, wcLen);
+  }
+
+  async scrypt(
+    password: string,
+    salt: string,
+    N: number,
+    r: number,
+    p: number,
+    dkLen: number
+  ): Promise<ArrayBuffer> {
+    return await scryptAsync(password, salt, { N, r, p, dkLen });
   }
 
   async hkdf(

--- a/libs/common/src/services/webCryptoFunction.service.ts
+++ b/libs/common/src/services/webCryptoFunction.service.ts
@@ -43,17 +43,17 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
     return await this.subtle.deriveBits(pbkdf2Params, impKey, wcLen);
   }
 
-  async scrypt(
-    password: string,
-    salt: string,
-    N: number,
-    r: number,
-    p: number,
-    dkLen: number
-  ): Promise<ArrayBuffer> {
+  async scrypt(password: string, salt: string, N: number): Promise<ArrayBuffer> {
     const passwordBuf = new Uint8Array(this.toBuf(password));
     const saltBuf = new Uint8Array(this.toBuf(salt));
-    return await scryptAsync(passwordBuf, saltBuf, { N, r, p, dkLen });
+
+    // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
+    const dkLen = 32; // output length in bytes, i.e 256 bits
+    const p = 1; // parallelization factor leads to a tradeoff between memory and CPU
+    const r = 8; // r is the block width, which scales linearly with memory usage
+    const maxmem = 2 ** 32 + 128 * 8 * 1; // set the maxmem such that N can be up to 2^22
+
+    return await scryptAsync(passwordBuf, saltBuf, { N, r, p, dkLen, maxmem });
   }
 
   async hkdf(

--- a/libs/common/src/services/webCryptoFunction.service.ts
+++ b/libs/common/src/services/webCryptoFunction.service.ts
@@ -51,7 +51,9 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
     p: number,
     dkLen: number
   ): Promise<ArrayBuffer> {
-    return await scryptAsync(password, salt, { N, r, p, dkLen });
+    const passwordBuf = new Uint8Array(this.toBuf(password));
+    const saltBuf = new Uint8Array(this.toBuf(salt));
+    return await scryptAsync(passwordBuf, saltBuf, { N, r, p, dkLen });
   }
 
   async hkdf(

--- a/libs/node/src/services/node-crypto-function.service.ts
+++ b/libs/node/src/services/node-crypto-function.service.ts
@@ -29,15 +29,14 @@ export class NodeCryptoFunctionService implements CryptoFunctionService {
     });
   }
 
-  async scrypt(
-    password: string,
-    salt: string,
-    N: number,
-    r: number,
-    p: number,
-    dkLen: number
-  ): Promise<ArrayBuffer> {
-    return await scryptAsync(password, salt, { N, r, p, dkLen });
+  async scrypt(password: string, salt: string, N: number): Promise<ArrayBuffer> {
+    // parameters selected according to https://words.filippo.io/the-scrypt-parameters/
+    const dkLen = 32; // output length in bytes, i.e 256 bits
+    const p = 1; // parallelization factor leads to a tradeoff between memory and CPU
+    const r = 8; // r is the block width, which scales linearly with memory usage
+    const maxmem = 2 ** 32 + 128 * 8 * 1; // set the maxmem such that N can be up to 2^22
+
+    return await scryptAsync(password, salt, { N, r, p, dkLen, maxmem });
   }
 
   // ref: https://tools.ietf.org/html/rfc5869

--- a/libs/node/src/services/node-crypto-function.service.ts
+++ b/libs/node/src/services/node-crypto-function.service.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
 
+import { scryptAsync } from "@noble/hashes/scrypt";
 import * as forge from "node-forge";
 
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
@@ -26,6 +27,17 @@ export class NodeCryptoFunctionService implements CryptoFunctionService {
         }
       });
     });
+  }
+
+  async scrypt(
+    password: string,
+    salt: string,
+    N: number,
+    r: number,
+    p: number,
+    dkLen: number
+  ): Promise<ArrayBuffer> {
+    return await scryptAsync(password, salt, { N, r, p, dkLen });
   }
 
   // ref: https://tools.ietf.org/html/rfc5869

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@microsoft/signalr": "^6.0.7",
     "@microsoft/signalr-protocol-msgpack": "^6.0.7",
     "@ng-select/ng-select": "^9.0.2",
+    "@noble/hashes": "^1.1.5",
     "big-integer": "^1.6.51",
     "bootstrap": "4.6.0",
     "braintree-web-drop-in": "^1.33.1",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This pull request implements the scrypt kdf as another choice for the vault's pbkdf. The idea with scrypt is that through a large internal state, it is not possible to use a GPU to parallelize the computation, and thus is more resistant against bruteforce attacks.

**Edit @djsmith85**: Community forum thread: https://community.bitwarden.com/t/scrypt-kdf-support/48148/1
## Code changes

There is also a pull request for the mobile implementation here: bitwarden/mobile/pull/2285

- messages.json, change-kdf-component.ts, change-kdf.component.html: Implement the UI for changing the kdf type. Since scrypt does not use iterations, but a work factor (which needs to be a power of 2), a drop-down menu made more sense for selection
- webCryptoFunction.service.spec.ts: Add unit tests for the scrypt function. The test strings were generated with GHCQ CyberChef
- kdfType.ts: Add the scrypt type to the enum, and the default work factor and work factor options (since other defaults seemed to also be located in this file)
- crypto.service.ts: Implement the case for the scrypt kdf type. The default scrypt work factor is 2^16, the minimum is 2^15. This and the other parameters are taken from this post: https://words.filippo.io/the-scrypt-parameters/
- node-crypto-function-service.ts, webCryptoFunction.service.ts, cryptoFunction.service.ts: Implement the function calls for scrypt
- package.json: Add the noble hashes library for the scrypt implementation, since the cryptographic libraries bitwarden was already dependent on, do not implement scrypt.

## Screenshots

![screenshot](https://user-images.githubusercontent.com/11866552/211439403-912c9b2d-2b8e-42a6-89ff-ad93ceb9bcaa.png)


