### PR TITLE
[SG-979] Default Avatar Color Badge displayed on Vault Items if user's name is null

### DIFF
--- a/apps/web/src/app/vault/organization-badge/organization-name-badge.component.ts
+++ b/apps/web/src/app/vault/organization-badge/organization-name-badge.component.ts
@@ -33,7 +33,8 @@ export class OrganizationNameBadgeComponent implements OnInit {
     if (this.isMe) {
       this.color = await this.avatarService.loadColorFromState();
       if (this.color == null) {
-        const userName = await this.tokenService.getName();
+        const userName =
+          (await this.tokenService.getName()) ?? (await this.tokenService.getEmail());
         this.color = Utils.stringToColor(userName.toUpperCase());
       }
     } else {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Allow for users to have their color properly displayed when their username is null by falling back to the email first 2 chars; consistent with other places.

## Code changes

Updated to fallback to email.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
