### PR TITLE
[PS-2118] Policy-Api: Remove dependency on OrgService

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -328,8 +328,7 @@ export default class MainBackground {
     this.policyApiService = new PolicyApiService(
       this.policyService,
       this.apiService,
-      this.stateService,
-      this.organizationService
+      this.stateService
     );
     this.keyConnectorService = new KeyConnectorService(
       this.stateService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -494,12 +494,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: PolicyApiServiceAbstraction,
       useClass: PolicyApiService,
-      deps: [
-        PolicyServiceAbstraction,
-        ApiServiceAbstraction,
-        StateServiceAbstraction,
-        OrganizationServiceAbstraction,
-      ],
+      deps: [PolicyServiceAbstraction, ApiServiceAbstraction, StateServiceAbstraction],
     },
     {
       provide: SendServiceAbstraction,

--- a/libs/common/src/services/policy/policy-api.service.ts
+++ b/libs/common/src/services/policy/policy-api.service.ts
@@ -1,7 +1,6 @@
 import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "../../abstractions/api.service";
-import { OrganizationService } from "../../abstractions/organization/organization.service.abstraction";
 import { PolicyApiServiceAbstraction } from "../../abstractions/policy/policy-api.service.abstraction";
 import { InternalPolicyService } from "../../abstractions/policy/policy.service.abstraction";
 import { StateService } from "../../abstractions/state.service";
@@ -16,8 +15,7 @@ export class PolicyApiService implements PolicyApiServiceAbstraction {
   constructor(
     private policyService: InternalPolicyService,
     private apiService: ApiService,
-    private stateService: StateService,
-    private organizationService: OrganizationService
+    private stateService: StateService
   ) {}
 
   async getPolicy(organizationId: string, type: PolicyType): Promise<PolicyResponse> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
During the refactoring of the PolicyServices the PolicyApiService received a dependency on OrganizationService.

It turns that this is unnecessary as the OrganizationService is never used.

This removes the unneeded dependency.

## Code changes
- **libs/common/src/services/policy/policy-api.service.ts:** Remove the constructor dependency on OrganizationService
- **apps/browser/src/background/main.background.ts:** Don't pass in the organizationService to the PolicyApiService
- **libs/angular/src/services/jslib-services.module.ts:** Remove dependency on OrganizationService when constructing the PolicyApiService

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
