### PR TITLE
[PS-2238] Hide get android submenu on MacStore release

### DIFF
--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -166,7 +166,7 @@ export class HelpMenu implements IMenubarMenu {
       {
         id: "android",
         label: "Android",
-        visible: !isMacAppStore(),
+        visible: !isMacAppStore(), // Apple Guideline 2.3.10 - Accurate Metadata
         click: () => {
           shell.openExternal(
             "https://play.google.com/store/apps/" + "details?id=com.x8bit.bitwarden"

--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -166,6 +166,7 @@ export class HelpMenu implements IMenubarMenu {
       {
         id: "android",
         label: "Android",
+        visible: !isMacAppStore(),
         click: () => {
           shell.openExternal(
             "https://play.google.com/store/apps/" + "details?id=com.x8bit.bitwarden"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
During the review of the 2022.12 desktop release by Apple it got rejected as it had references to a third-party platform

Apple's review:
> We noticed that your submission includes information about third-party platforms that may not be relevant for App Store users.
> Specifically, your app includes Android references in the Get Mobile app.
>Referencing thrid-party platforms in your app or its metadata is generally not relevant for App Store iusers, who are focused on the experiences offered by their current device.


## Code changes
- **apps/desktop/src/main/menu/menu.help.ts:** Hide the menu-item linking to the PlayStore to download our Android Mobile App from the MacAppStore Desktop version.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
