### PR TITLE
[EC-891] Hide password character count button for hidden passwords

### DIFF
--- a/apps/web/src/app/vault/add-edit.component.html
+++ b/apps/web/src/app/vault/add-edit.component.html
@@ -134,6 +134,7 @@
                     appStopClick
                     [appA11yTitle]="'toggleCharacterCount' | i18n"
                     (click)="togglePasswordCount()"
+                    *ngIf="cipher.viewPassword"
                   >
                     <i class="bwi bwi-lg bwi-fw bwi-numbered-list" aria-hidden="true"></i>
                   </a>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Users without permission to views passwords were mistakenly show the button to view the password character count. This hides the button if the `viewPassword` flag is false.


## Screenshots
<img width="807" alt="image" src="https://user-images.githubusercontent.com/8764515/211946998-b923138d-9ae2-4977-ba10-ee6ac75b2e6a.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
