### PR TITLE
Defect/web org domain claiming bugfixes

### DIFF
--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -459,6 +459,8 @@ export class EventService {
         return ["bwi-globe", this.i18nService.t("webVault") + " - Edge"];
       case DeviceType.IEBrowser:
         return ["bwi-globe", this.i18nService.t("webVault") + " - IE"];
+      case DeviceType.Server:
+        return ["bwi-server", this.i18nService.t("server")];
       case DeviceType.UnknownBrowser:
         return [
           "bwi-globe",

--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -397,6 +397,19 @@ export class EventService {
           this.getShortId(ev.providerOrganizationId)
         );
         break;
+      // Org Domain claiming events
+      case EventType.OrganizationDomain_Added:
+        msg = humanReadableMsg = this.i18nService.t("addedDomain", ev.domainName);
+        break;
+      case EventType.OrganizationDomain_Removed:
+        msg = humanReadableMsg = this.i18nService.t("removedDomain", ev.domainName);
+        break;
+      case EventType.OrganizationDomain_Verified:
+        msg = humanReadableMsg = this.i18nService.t("domainVerifiedEvent", ev.domainName);
+        break;
+      case EventType.OrganizationDomain_NotVerified:
+        msg = humanReadableMsg = this.i18nService.t("domainNotVerifiedEvent", ev.domainName);
+        break;
       default:
         break;
     }

--- a/apps/web/src/app/organizations/manage/events.component.ts
+++ b/apps/web/src/app/organizations/manage/events.component.ts
@@ -20,7 +20,7 @@ import { BaseEventsComponent } from "../../common/base.events.component";
 import { EventService } from "../../core";
 
 const EVENT_SYSTEM_USER_TO_TRANSLATION: Record<EventSystemUser, string> = {
-  [EventSystemUser.SCIM]: null,
+  [EventSystemUser.SCIM]: null, // SCIM acronym not able to be translated so just display SCIM
   [EventSystemUser.DomainVerification]: "domainVerification",
 };
 

--- a/apps/web/src/app/organizations/manage/events.component.ts
+++ b/apps/web/src/app/organizations/manage/events.component.ts
@@ -19,6 +19,11 @@ import { EventResponse } from "@bitwarden/common/models/response/event.response"
 import { BaseEventsComponent } from "../../common/base.events.component";
 import { EventService } from "../../core";
 
+const EVENT_SYSTEM_USER_TO_TRANSLATION: Record<EventSystemUser, string> = {
+  [EventSystemUser.SCIM]: null,
+  [EventSystemUser.DomainVerification]: "domainVerification",
+};
+
 @Component({
   selector: "app-org-events",
   templateUrl: "events.component.html",
@@ -134,9 +139,17 @@ export class EventsComponent extends BaseEventsComponent implements OnInit, OnDe
     }
 
     if (r.systemUser != null) {
-      return {
-        name: EventSystemUser[r.systemUser],
-      };
+      const systemUserI18nKey: string = EVENT_SYSTEM_USER_TO_TRANSLATION[r.systemUser];
+
+      if (systemUserI18nKey) {
+        return {
+          name: this.i18nService.t(systemUserI18nKey),
+        };
+      } else {
+        return {
+          name: EventSystemUser[r.systemUser],
+        };
+      }
     }
 
     return null;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6017,5 +6017,8 @@
         "example": "2"
       }
     }
+  },
+  "server": {
+    "message": "Server"
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5940,6 +5940,42 @@
   "domainFormInvalid": {
     "message": "There are form errors that need your attention"
   },
+  "addedDomain": {
+    "message": "Added domain $DOMAIN$",
+    "placeholders": {
+      "DOMAIN": {
+        "content": "$1",
+        "example": "bitwarden.com"
+      }
+    }
+  },
+  "removedDomain": {
+    "message": "Removed domain $DOMAIN$",
+    "placeholders": {
+      "DOMAIN": {
+        "content": "$1",
+        "example": "bitwarden.com"
+      }
+    }
+  },
+  "domainVerifiedEvent": {
+    "message": "$DOMAIN$ verified",
+    "placeholders": {
+      "DOMAIN": {
+        "content": "$1",
+        "example": "bitwarden.com"
+      }
+    }
+  },
+  "domainNotVerifiedEvent": {
+    "message": "$DOMAIN$ not verified",
+    "placeholders": {
+      "DOMAIN": {
+        "content": "$1",
+        "example": "bitwarden.com"
+      }
+    }
+  },
   "moreFromBitwarden": {
     "message": "More from Bitwarden"
   },

--- a/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
@@ -64,11 +64,10 @@
         bitIconButton="bwi-trash"
         buttonType="danger"
         size="default"
-        title="Delete"
+        title="{{ 'delete' | i18n }}"
         aria-label="Delete"
         [bitAction]="deleteDomain"
         type="submit"
-        bitButton
         bitFormButton
       ></button>
     </div>

--- a/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
@@ -206,6 +206,9 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
             message: this.i18nService.t("domainNotVerified", this.domainNameCtrl.value),
           },
         });
+        // For the case where user opens dialog and reverifies when domain name formControl disabled.
+        // The input directive only shows error if touched, so must manually mark as touched.
+        this.domainNameCtrl.markAsTouched();
         // Update this item so the last checked date gets updated.
         await this.updateOrgDomain();
       }

--- a/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
@@ -206,9 +206,13 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
             message: this.i18nService.t("domainNotVerified", this.domainNameCtrl.value),
           },
         });
+        // Update this item so the last checked date gets updated.
+        await this.updateOrgDomain();
       }
     } catch (e) {
       this.handleVerifyDomainError(e, this.domainNameCtrl.value);
+      // Update this item so the last checked date gets updated.
+      await this.updateOrgDomain();
     }
   };
 
@@ -231,6 +235,14 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
           break;
       }
     }
+  }
+
+  private async updateOrgDomain() {
+    // Update this item so the last checked date gets updated.
+    await this.orgDomainApiService.getByOrgIdAndOrgDomainId(
+      this.data.organizationId,
+      this.data.orgDomain.id
+    );
   }
 
   deleteDomain = async (): Promise<void> => {

--- a/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/validators/domain-name.validator.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/validators/domain-name.validator.ts
@@ -11,12 +11,24 @@ export function domainNameValidator(errorMessage: string): ValidatorFn {
     // Domain labels (sections) are only allowed to be 63 chars in length max
     // 1st and last chars cannot be hyphens per RFC 3696 (https://www.rfc-editor.org/rfc/rfc3696#section-2)
 
-    // /^[a-zA-Z0-9]         # The domain name must start with a letter or a number
-    // [a-zA-Z0-9-]{1,61}    # The domain name can have one to 61 characters that are letters, numbers, or hyphens
-    // [a-zA-Z0-9]           # The domain name must end with a letter or a number
-    // \.[a-zA-Z]{2,}$/      # The domain name must have a period followed by at least two letters (the domain extension)
+    // Must support top-level domains and any number of subdomains.
+    //   /                               # start regex
+    //   ^                               # start of string
+    //   [a-zA-Z0-9]                     # first character must be a letter or a number
+    //   [a-zA-Z0-9-]{0,61}              # domain name can have 0 to 61 characters that are letters, numbers, or hyphens
+    //   [a-zA-Z0-9]                     # domain name must end with a letter or a number
+    //   (?:                             # start of non-capturing group (subdomain sections are optional)
+    //     \.                               # subdomain must have a period
+    //     [a-zA-Z0-9]                      # first character of subdomain must be a letter or a number
+    //     [a-zA-Z0-9-]{0,61}               # subdomain can have 0 to 61 characters that are letters, numbers, or hyphens
+    //     [a-zA-Z0-9]                      # subdomain must end with a letter or a number
+    //   )*                              # end of non-capturing group (subdomain sections are optional)
+    //   \.                              # domain name must have a period
+    //   [a-zA-Z]{2,}                    # domain name must have at least two letters (the domain extension)
+    //   $/                              # end of string
 
-    const domainNameRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,}$/;
+    const domainNameRegex =
+      /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])*\.[a-zA-Z]{2,}$/;
 
     const invalid = !domainNameRegex.test(control.value);
 

--- a/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-verification.component.ts
+++ b/bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-verification.component.ts
@@ -117,10 +117,19 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
           null,
           this.i18nService.t("domainNotVerified", domainName)
         );
+        // Update this item so the last checked date gets updated.
+        await this.updateOrgDomain(orgDomainId);
       }
     } catch (e) {
       this.handleVerifyDomainError(e, domainName);
+      // Update this item so the last checked date gets updated.
+      await this.updateOrgDomain(orgDomainId);
     }
+  }
+
+  private async updateOrgDomain(orgDomainId: string) {
+    // Update this item so the last checked date gets updated.
+    await this.orgDomainApiService.getByOrgIdAndOrgDomainId(this.organizationId, orgDomainId);
   }
 
   private handleVerifyDomainError(e: any, domainName: string): void {

--- a/libs/common/src/enums/deviceType.ts
+++ b/libs/common/src/enums/deviceType.ts
@@ -20,4 +20,5 @@ export enum DeviceType {
   VivaldiBrowser = 18,
   VivaldiExtension = 19,
   SafariExtension = 20,
+  Server = 21,
 }

--- a/libs/common/src/enums/event-system-user.ts
+++ b/libs/common/src/enums/event-system-user.ts
@@ -1,4 +1,5 @@
 // Note: the enum key is used to describe the EventSystemUser in the UI. Be careful about changing it.
 export enum EventSystemUser {
   SCIM = 1,
+  DomainVerification = 2,
 }

--- a/libs/common/src/enums/eventType.ts
+++ b/libs/common/src/enums/eventType.ts
@@ -72,4 +72,9 @@ export enum EventType {
   ProviderOrganization_Added = 1901,
   ProviderOrganization_Removed = 1902,
   ProviderOrganization_VaultAccessed = 1903,
+
+  OrganizationDomain_Added = 1904,
+  OrganizationDomain_Removed = 1905,
+  OrganizationDomain_Verified = 1906,
+  OrganizationDomain_NotVerified = 1907,
 }

--- a/libs/common/src/models/response/event.response.ts
+++ b/libs/common/src/models/response/event.response.ts
@@ -22,6 +22,7 @@ export class EventResponse extends BaseResponse {
   ipAddress: string;
   installationId: string;
   systemUser: EventSystemUser;
+  domainName: string;
 
   constructor(response: any) {
     super(response);
@@ -42,5 +43,6 @@ export class EventResponse extends BaseResponse {
     this.ipAddress = this.getResponseProperty("IpAddress");
     this.installationId = this.getResponseProperty("InstallationId");
     this.systemUser = this.getResponseProperty("SystemUser");
+    this.domainName = this.getResponseProperty("DomainName");
   }
 }

--- a/libs/components/src/async-actions/form-button.directive.ts
+++ b/libs/components/src/async-actions/form-button.directive.ts
@@ -19,7 +19,8 @@ import { BitActionDirective } from ".";
  * - Disables the button while a `bitAction` directive on another button is being processed.
  * - Disables form submission while the `bitAction` directive is processing an async action.
  *
- * Note: you must use the bitButton directive along with this one in order to avoid provider errors.
+ * Note: you must use a directive that implements the ButtonLikeAbstraction (bitButton or bitIconButton for example)
+ * along with this one in order to avoid provider errors.
  */
 @Directive({
   selector: "button[bitFormButton]",


### PR DESCRIPTION
## Type of change
<!-- (mark with an `X`) -->
```
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding--> To fix all outstanding client defects in the `feature/web-organization-domain-claiming` branch


[SG-949] - OrgDomainVerification - Domain name validator now supports n levels of subdomains as well as top level domains.

- **bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/validators/domain-name.validator.ts:** Updated domain name regex in validator to support any number of subdomains

https://user-images.githubusercontent.com/116684653/212204602-6c3f510e-5ed1-445d-a298-3542fc45afd1.mov


[SG-955] - On domain verification error or failure, call to update the individual org domain item to get an updated last checked date on the client.

- **bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts, bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-verification.component.ts:** Update org domain items after verify success or failure. 

https://user-images.githubusercontent.com/116684653/212204886-aa132513-1bd3-4e6d-8cd2-4ff365d70170.mov


[SG-953] - In domain verification dialog edit, if verify called and failed, then manually mark domain name as touched so errors properly show up. 

- **bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts:** Manually mark domain name as touched on edit and reverify so errors can show up 

https://user-images.githubusercontent.com/116684653/212205198-88ba8662-6794-44fb-91ee-735cdbdb0a1a.mov


[SG-954] - Domain Verification edit dialog - Fixing delete button not having trash can icon show up anymore (+ added i18n translation for title property on the icon). 

- **bitwarden_license/bit-web/src/app/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html:** Update title & remove `bitButton` since you only need one `buttonLikeAbstraction` class 

<img width="866" alt="image" src="https://user-images.githubusercontent.com/116684653/212205356-c599c143-7cd4-42b5-b51d-a53f42b539d5.png">

[SG-956] - Fixing domain claiming event logs so that they show up on the client event logs screen
[SG-977](https://bitwarden.atlassian.net/browse/SG-977) - Event Log improvements: (1) Add new device type of server (2) Add EventSystemUser mapping to translated value. The end result is that both SCIM and Domain verification logs properly show server as the client and SCIM or Domain verification as the member.

- **apps/web/src/app/organizations/manage/events.component.ts:** Add translation dict mapping `EventSystemUser` to translation key
- **apps/web/src/app/core/event.service.ts :** (1) Add OrgDomain events (2) Add handling for new Server device type 
- **libs/common/src/enums/event-system-user.ts :**  Add  `DomainVerification` as new `EventSystemUser` value
- **libs/common/src/enums/deviceType.ts:** Add `DeviceType.Server`
- **libs/common/src/models/response/event.response.ts:** Add Domain Name to `EventResponse`

<img width="789" alt="image" src="https://user-images.githubusercontent.com/116684653/212205621-f12ff28a-5757-4f2f-9ac2-3b420b3b50a4.png">
...
<img width="776" alt="image" src="https://user-images.githubusercontent.com/116684653/212205635-b37874a5-6db9-4873-928c-a6db3822e0b7.png">


## Misc Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/async-actions/form-button.directive.ts:** Update comment to clarify `bitFormButton` directive usage.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[SG-949]: https://bitwarden.atlassian.net/browse/SG-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-955]: https://bitwarden.atlassian.net/browse/SG-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-953]: https://bitwarden.atlassian.net/browse/SG-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-954]: https://bitwarden.atlassian.net/browse/SG-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-956]: https://bitwarden.atlassian.net/browse/SG-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ