### PR TITLE
[PS-2247] correct typos in GB and IN localisations

### DIFF
--- a/apps/web/src/locales/en_GB/messages.json
+++ b/apps/web/src/locales/en_GB/messages.json
@@ -2157,7 +2157,7 @@
     "description": "Free as in 'free beer'."
   },
   "planDescFree": {
-    "message": "For testing or personal users to share with $COUNT$ other users.",
+    "message": "For testing or personal users to share with $COUNT$ other user.",
     "placeholders": {
       "count": {
         "content": "$1",

--- a/apps/web/src/locales/en_IN/messages.json
+++ b/apps/web/src/locales/en_IN/messages.json
@@ -2157,7 +2157,7 @@
     "description": "Free as in 'free beer'."
   },
   "planDescFree": {
-    "message": "For testing or personal users to share with $COUNT$ other users.",
+    "message": "For testing or personal users to share with $COUNT$ other user.",
     "placeholders": {
       "count": {
         "content": "$1",


### PR DESCRIPTION
## Type of change

```
- [ x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Correct typos in GB and IN localisations as described here:
https://bitwarden.atlassian.net/browse/PS-2247

## Code changes

2x typos to messages.json - 1 in GB, 1 in IN

- **en_GB message.json:** typo corrected
- **en_IN message.json:** typo corrected

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team

NA - typo correction only
