### PR TITLE
[PS-2253] Fix Password & Username generator wrapper

### DIFF
--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -202,7 +202,8 @@ p.lead {
 
   .generated-wrapper {
     text-align: left;
-    width: 100%;
+    width: 80%;
+    word-wrap: break-word;
   }
 
   .action-buttons {


### PR DESCRIPTION
Changed width to 80% and added `word-wrap: break-word`

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixing issue  #4469 by changing the `generated-wrapper` class

## Code changes

Changed width from `100%` to `80%` and added `word-wrap: break-word;`
to the `generated-wrapper` class in `misc.scss`

## Screenshots

### Before:
![Screenshot 2023-01-13 at 18 09 05](https://user-images.githubusercontent.com/55046135/212379323-7e5a96d2-64b5-4af7-b549-b1c3035d60fd.png)

### After:
![Screenshot 2023-01-13 at 18 17 30](https://user-images.githubusercontent.com/55046135/212379807-b56251db-b290-44a4-a960-02fa8ff6d5ec.png)
