### PR TITLE
[PS-2260] Support locking the vault on screen-lock on (some) linux systems

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,5 +54,11 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:watch:all": "jest --watchAll"
+  },
+  "devDependencies": {
+    "electron-rebuild": "^3.2.9"
+  },
+  "dependencies": {
+    "dbus-next": "^0.10.2"
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -55,9 +55,7 @@
     "test:watch": "jest --watch",
     "test:watch:all": "jest --watchAll"
   },
-  "devDependencies": {
-    "electron-rebuild": "^3.2.9"
-  },
+  "devDependencies": {},
   "dependencies": {
     "dbus-next": "^0.10.2"
   }

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -118,11 +118,8 @@ export class SettingsComponent implements OnInit {
       { name: i18nService.t("fourHours"), value: 240 },
       { name: i18nService.t("onIdle"), value: -4 },
       { name: i18nService.t("onSleep"), value: -3 },
+      { name: i18nService.t("onLocked"), value: -2 },
     ];
-
-    if (this.platformUtilsService.getDevice() !== DeviceType.LinuxDesktop) {
-      this.vaultTimeouts.push({ name: i18nService.t("onLocked"), value: -2 });
-    }
 
     this.vaultTimeouts = this.vaultTimeouts.concat([
       { name: i18nService.t("onRestart"), value: -1 },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import { StateService } from "@bitwarden/common/services/state.service";
 
 import { BiometricMain } from "./main/biometric/biometric.main";
 import { DesktopCredentialStorageListener } from "./main/desktop-credential-storage-listener";
+import { LinuxLockMain } from "./main/linux-lock.main";
 import { MenuMain } from "./main/menu/menu.main";
 import { MessagingMain } from "./main/messaging.main";
 import { NativeMessagingMain } from "./main/native-messaging.main";
@@ -36,6 +37,7 @@ export class Main {
   updaterMain: UpdaterMain;
   menuMain: MenuMain;
   powerMonitorMain: PowerMonitorMain;
+  linuxLockMain: LinuxLockMain;
   trayMain: TrayMain;
   biometricMain: BiometricMain;
   nativeMessagingMain: NativeMessagingMain;
@@ -108,6 +110,7 @@ export class Main {
     this.updaterMain = new UpdaterMain(this.i18nService, this.windowMain, "bitwarden");
     this.menuMain = new MenuMain(this);
     this.powerMonitorMain = new PowerMonitorMain(this);
+    this.linuxLockMain = new LinuxLockMain(this);
     this.trayMain = new TrayMain(this.windowMain, this.i18nService, this.stateService);
 
     this.messagingService = new ElectronMainMessagingService(this.windowMain, (message) => {
@@ -162,6 +165,7 @@ export class Main {
           this.trayMain.hideToTray();
         }
         this.powerMonitorMain.init();
+        await this.linuxLockMain.init();
         await this.updaterMain.init();
         if (this.biometricMain != null) {
           await this.biometricMain.init();

--- a/apps/desktop/src/main/linux-lock.main.ts
+++ b/apps/desktop/src/main/linux-lock.main.ts
@@ -1,0 +1,101 @@
+import { sessionBus } from "dbus-next";
+
+import { Main } from "../main";
+
+type DbusInterface = {
+  service: string;
+  objectPath: string;
+  interfaceName: string;
+};
+
+type InterfaceBinding = {
+  interface: DbusInterface;
+  signal: string;
+  validData: (msg: any) => boolean;
+};
+
+const listeners: InterfaceBinding[] = [
+  {
+    interface: {
+      service: "org.freedesktop.ScreenSaver",
+      objectPath: "/org/freedesktop/ScreenSaver",
+      interfaceName: "org.freedesktop.ScreenSaver",
+    },
+    signal: "ActiveChanged",
+    validData: (msg: any) => msg,
+  },
+  {
+    interface: {
+      service: "org.cinnamon.ScreenSaver",
+      objectPath: "/org/cinnamon/ScreenSaver",
+      interfaceName: "org.cinnamon.ScreenSaver",
+    },
+    signal: "ActiveChanged",
+    validData: (msg: any) => msg,
+  },
+  {
+    interface: {
+      service: "org.gnome.ScreenSaver",
+      objectPath: "/org/gnome/ScreenSaver",
+      interfaceName: "org.gnome.ScreenSaver",
+    },
+    signal: "ActiveChanged",
+    validData: (msg: any) => true,
+  },
+  {
+    interface: {
+      service: "org.gnome.SessionManager",
+      objectPath: "/org/gnome/SessionManager/Presence",
+      interfaceName: "org.gnome.SessionManager.Presence",
+    },
+    signal: "ActiveChanged",
+    validData: (msg: any) => msg != 0,
+  },
+  {
+    interface: {
+      service: "org.xfce.ScreenSaver",
+      objectPath: "/org/freedesktop/login1",
+      interfaceName: "org.xfce.ScreenSaver",
+    },
+    signal: "ActiveChanged",
+    validData: (msg: any) => true,
+  },
+  {
+    interface: {
+      service: "com.canonical.Unity",
+      objectPath: "/com/canonical/Unity/Session",
+      interfaceName: "com.canonical.Unity.Session",
+    },
+    signal: "Locked",
+    validData: (msg: any) => true,
+  },
+];
+
+export class LinuxLockMain {
+  constructor(private main: Main) {}
+
+  async init() {
+    if (process.platform === "linux") {
+      const sessBus = sessionBus();
+
+      for (const listener of listeners) {
+        const { service, interfaceName, objectPath } = listener.interface;
+        try {
+          const obj = await sessBus.getProxyObject(service, objectPath);
+          try {
+            const iface = obj.getInterface(interfaceName);
+            iface.on(listener.signal, (changed) => {
+              if (listener.validData(changed)) {
+                this.main.messagingService.send("systemLocked");
+              }
+            });
+          } catch (e) {
+            // ignore non existent interface
+          }
+        } catch (e) {
+          // ignore non existent object
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

On Windows and Mac, the user has the option to automatically lock their vault when they lock their PC (e.g. press `Win` + `L`). This option is forcefully disabled on Linux since Electron only provides the "lock API" for Win/Mac. Ideally, one would contribute to Electron, but I have added the code here for now. I just looked up how [KeepassXC](https://github.com/keepassxreboot/keepassxc/blob/develop/src/gui/osutils/nixutils/ScreenLockListenerDBus.cpp) does it. (I did not implement L-65 to L-74) since I didn't know how to do it with the Javascript DBus library I used. 

The list of desktop environments may not be exhaustive. 

Tested on Linux Mint 20.3 Cinnamon

## Code changes

- **apps/desktop/package.json** Add dbus library
- **apps/desktop/src/app/accounts/settings.component.ts** Always show "onLocked" option in settings dropdown
- **apps/desktop/src/main.ts** Call Linux lock-screen listener
- **apps/desktop/src/main/linux-lock.main.ts** Lock-screen event listener
