### PR TITLE
[SG-927] Pull the user's selected avatar color from the state store and display on Emergency Contacts page

### DIFF
--- a/apps/web/src/app/settings/emergency-access.component.html
+++ b/apps/web/src/app/settings/emergency-access.component.html
@@ -34,7 +34,12 @@
   <tbody>
     <tr *ngFor="let c of trustedContacts; let i = index">
       <td width="30">
-        <bit-avatar [text]="c | userName" [id]="c.granteeId" size="small"></bit-avatar>
+        <bit-avatar
+          [text]="c | userName"
+          [id]="c.granteeId"
+          [color]="c.avatarColor"
+          size="small"
+        ></bit-avatar>
       </td>
       <td>
         <a href="#" appStopClick (click)="edit(c)">{{ c.email }}</a>
@@ -142,7 +147,12 @@
   <tbody>
     <tr *ngFor="let c of grantedContacts; let i = index">
       <td width="30">
-        <bit-avatar [text]="c | userName" [id]="c.grantorId" size="small"></bit-avatar>
+        <bit-avatar
+          [text]="c | userName"
+          [id]="c.grantorId"
+          [color]="c.avatarColor"
+          size="small"
+        ></bit-avatar>
       </td>
       <td>
         <span>{{ c.email }}</span>

--- a/libs/common/src/models/response/emergency-access.response.ts
+++ b/libs/common/src/models/response/emergency-access.response.ts
@@ -14,6 +14,7 @@ export class EmergencyAccessGranteeDetailsResponse extends BaseResponse {
   status: EmergencyAccessStatusType;
   waitTimeDays: number;
   creationDate: string;
+  avatarColor: string;
 
   constructor(response: any) {
     super(response);
@@ -25,6 +26,7 @@ export class EmergencyAccessGranteeDetailsResponse extends BaseResponse {
     this.status = this.getResponseProperty("Status");
     this.waitTimeDays = this.getResponseProperty("WaitTimeDays");
     this.creationDate = this.getResponseProperty("CreationDate");
+    this.avatarColor = this.getResponseProperty("AvatarColor");
   }
 }
 
@@ -37,6 +39,7 @@ export class EmergencyAccessGrantorDetailsResponse extends BaseResponse {
   status: EmergencyAccessStatusType;
   waitTimeDays: number;
   creationDate: string;
+  avatarColor: string;
 
   constructor(response: any) {
     super(response);
@@ -48,6 +51,7 @@ export class EmergencyAccessGrantorDetailsResponse extends BaseResponse {
     this.status = this.getResponseProperty("Status");
     this.waitTimeDays = this.getResponseProperty("WaitTimeDays");
     this.creationDate = this.getResponseProperty("CreationDate");
+    this.avatarColor = this.getResponseProperty("AvatarColor");
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

To fully support the avatar colors, we need to show the right color in all the right pages, this page included.

## Code changes
Backend: https://github.com/bitwarden/server/pull/2582
~ apps/web/src/app/settings/emergency-access.component.html: added references to new props
~ libs/common/src/models/response/emergency-access.response.ts: added new props

## Screenshots

![image](https://user-images.githubusercontent.com/107377945/212519149-523cb65c-f089-4374-ac76-a0279de4d165.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
