### PR TITLE
[PS-2263] Keeper CSV import: import TOTP to correct field

### DIFF
--- a/libs/common/spec/importers/keeper-csv-importer.spec.ts
+++ b/libs/common/spec/importers/keeper-csv-importer.spec.ts
@@ -1,0 +1,77 @@
+import { KeeperCsvImporter as Importer } from "@bitwarden/common/importers/keeper/keeper-csv-importer";
+
+import { testData as TestData } from "./test-data/keeper-csv/testdata.csv";
+
+describe("Keeper CSV Importer", () => {
+  let importer: Importer;
+  beforeEach(() => {
+    importer = new Importer();
+  });
+
+  it("should parse login data", async () => {
+    const result = await importer.parse(TestData);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.name).toEqual("Bar");
+    expect(cipher.login.username).toEqual("john.doe@example.com");
+    expect(cipher.login.password).toEqual("1234567890abcdef");
+    expect(cipher.login.uris.length).toEqual(1);
+    const uriView = cipher.login.uris.shift();
+    expect(uriView.uri).toEqual("https://example.com/");
+    expect(cipher.notes).toEqual("These are some notes.");
+
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.name).toEqual("Bar 1");
+    expect(cipher2.login.username).toEqual("john.doe1@example.com");
+    expect(cipher2.login.password).toEqual("234567890abcdef1");
+    expect(cipher2.login.uris.length).toEqual(1);
+    const uriView2 = cipher2.login.uris.shift();
+    expect(uriView2.uri).toEqual("https://an.example.com/");
+    expect(cipher2.notes).toBeNull();
+
+    const cipher3 = result.ciphers.shift();
+    expect(cipher3.name).toEqual("Bar 2");
+    expect(cipher3.login.username).toEqual("john.doe2@example.com");
+    expect(cipher3.login.password).toEqual("34567890abcdef12");
+    expect(cipher3.notes).toBeNull();
+    expect(cipher3.login.uris.length).toEqual(1);
+    const uriView3 = cipher3.login.uris.shift();
+    expect(uriView3.uri).toEqual("https://another.example.com/");
+  });
+
+  it("should import TOTP when present", async () => {
+    const result = await importer.parse(TestData);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.login.totp).toBeNull();
+
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.login.totp).toBeNull();
+
+    const cipher3 = result.ciphers.shift();
+    expect(cipher3.login.totp).toEqual(
+      "otpauth://totp/Amazon:me@company.com?secret=JBSWY3DPEHPK3PXP&issuer=Amazon&algorithm=SHA1&digits=6&period=30"
+    );
+  });
+
+  it("should parse custom fields", async () => {
+    const result = await importer.parse(TestData);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.fields).toBeNull();
+
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.fields.length).toBe(2);
+    expect(cipher2.fields[0].name).toEqual("Account ID");
+    expect(cipher2.fields[0].value).toEqual("12345");
+    expect(cipher2.fields[1].name).toEqual("Org ID");
+    expect(cipher2.fields[1].value).toEqual("54321");
+
+    const cipher3 = result.ciphers.shift();
+    expect(cipher3.fields[0].name).toEqual("Account ID");
+    expect(cipher3.fields[0].value).toEqual("23456");
+  });
+});

--- a/libs/common/spec/importers/test-data/keeper-csv/testdata.csv.ts
+++ b/libs/common/spec/importers/test-data/keeper-csv/testdata.csv.ts
@@ -1,0 +1,4 @@
+export const testData = `"Foo","Bar","john.doe@example.com","1234567890abcdef","https://example.com/","These are some notes.",""
+"Foo","Bar 1","john.doe1@example.com","234567890abcdef1","https://an.example.com/","","","Account ID","12345","Org ID","54321"
+"Foo\\Baz","Bar 2","john.doe2@example.com","34567890abcdef12","https://another.example.com/","","","Account ID","23456","TFC:Keeper","otpauth://totp/Amazon:me@company.com?secret=JBSWY3DPEHPK3PXP&issuer=Amazon&algorithm=SHA1&digits=6&period=30"
+`;

--- a/libs/common/src/importers/keeper/keeper-csv-importer.ts
+++ b/libs/common/src/importers/keeper/keeper-csv-importer.ts
@@ -27,7 +27,11 @@ export class KeeperCsvImporter extends BaseImporter implements Importer {
       if (value.length > 7) {
         // we have some custom fields.
         for (let i = 7; i < value.length; i = i + 2) {
-          this.processKvp(cipher, value[i], value[i + 1]);
+          if (value[i] == "TFC:Keeper") {
+            cipher.login.totp = value[i + 1];
+          } else {
+            this.processKvp(cipher, value[i], value[i + 1]);
+          }
         }
       }
 

--- a/libs/common/src/importers/keeper/keeper-csv-importer.ts
+++ b/libs/common/src/importers/keeper/keeper-csv-importer.ts
@@ -18,7 +18,12 @@ export class KeeperCsvImporter extends BaseImporter implements Importer {
 
       this.processFolder(result, value[0]);
       const cipher = this.initLoginCipher();
-      cipher.notes = this.getValueOrDefault(value[5]) + "\n";
+
+      const notes = this.getValueOrDefault(value[5]);
+      if (notes) {
+        cipher.notes = `${notes}\n`;
+      }
+
       cipher.name = this.getValueOrDefault(value[1], "--");
       cipher.login.username = this.getValueOrDefault(value[2]);
       cipher.login.password = this.getValueOrDefault(value[3]);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Keeper CSV importer imports TOTP values to the correct field. (See https://github.com/bitwarden/clients/blob/master/libs/common/src/importers/keeper/keeper-json-importer.ts#L29 for reference).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Keeper exports TOTP fields with the label `TFC:Keeper`, rather than insert it as a normal key/value field it sets `cipher.login.totp`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
