### PR TITLE
[PS-2270] Browser: restyle generator panel to be panel-like

### DIFF
--- a/apps/browser/src/popup/generator/generator.component.html
+++ b/apps/browser/src/popup/generator/generator.component.html
@@ -18,53 +18,59 @@
   <app-callout type="info" *ngIf="enforcedPasswordPolicyOptions?.inEffect() && type === 'password'">
     {{ "passwordGeneratorPolicyInEffect" | i18n }}
   </app-callout>
-  <div class="generated-block" *ngIf="type === 'password'">
-    <div class="generated-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
-    <div class="action-buttons">
-      <button
-        type="button"
-        class="row-btn"
-        appStopClick
-        appA11yTitle="{{ 'copyPassword' | i18n }}"
-        (click)="copy()"
-      >
-        <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
-      </button>
-      <button
-        type="button"
-        appStopClick
-        appA11yTitle="{{ 'regeneratePassword' | i18n }}"
-        (click)="regenerate()"
-      >
-        <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
-      </button>
-    </div>
-  </div>
-  <div class="generated-block" *ngIf="type === 'username'">
-    <div class="generated-wrapper" [innerHTML]="username | colorPassword" appSelectCopy></div>
-    <div class="action-buttons" #form [appApiAction]="usernameGeneratingPromise">
-      <button
-        type="button"
-        class="row-btn"
-        appStopClick
-        appA11yTitle="{{ 'copyUsername' | i18n }}"
-        (click)="copy()"
-      >
-        <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
-      </button>
-      <button
-        type="button"
-        appStopClick
-        appA11yTitle="{{ 'regenerateUsername' | i18n }}"
-        (click)="$any(form).loading ? false : regenerate()"
-        [attr.aria-disabled]="$any(form).loading ? 'true' : null"
-      >
-        <i
-          class="bwi bwi-lg bwi-generate"
-          [ngClass]="$any(form).loading ? 'bwi-spin' : ''"
-          aria-hidden="true"
-        ></i>
-      </button>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row generated-block" *ngIf="type === 'password'">
+        <div class="generated-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
+        <div class="action-buttons">
+          <button
+            type="button"
+            class="row-btn"
+            appStopClick
+            appA11yTitle="{{ 'copyPassword' | i18n }}"
+            (click)="copy()"
+          >
+            <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+          </button>
+          <button
+            type="button"
+            class="row-btn"
+            appStopClick
+            appA11yTitle="{{ 'regeneratePassword' | i18n }}"
+            (click)="regenerate()"
+          >
+            <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
+      <div class="box-content-row generated-block" *ngIf="type === 'username'">
+        <div class="generated-wrapper" [innerHTML]="username | colorPassword" appSelectCopy></div>
+        <div class="action-buttons" #form [appApiAction]="usernameGeneratingPromise">
+          <button
+            type="button"
+            class="row-btn"
+            appStopClick
+            appA11yTitle="{{ 'copyUsername' | i18n }}"
+            (click)="copy()"
+          >
+            <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+          </button>
+          <button
+            type="button"
+            class="row-btn"
+            appStopClick
+            appA11yTitle="{{ 'regenerateUsername' | i18n }}"
+            (click)="$any(form).loading ? false : regenerate()"
+            [attr.aria-disabled]="$any(form).loading ? 'true' : null"
+          >
+            <i
+              class="bwi bwi-lg bwi-generate"
+              [ngClass]="$any(form).loading ? 'bwi-spin' : ''"
+              aria-hidden="true"
+            ></i>
+          </button>
+        </div>
+      </div>
     </div>
   </div>
   <div class="box">

--- a/apps/browser/src/popup/scss/pages.scss
+++ b/apps/browser/src/popup/scss/pages.scss
@@ -14,13 +14,6 @@ app-generator .generated-block {
   margin: 8px;
   padding: 8px 10px 8px 0;
   display: flex;
-  border-radius: $border-radius;
-  border: 1px solid;
-
-  @include themify($themes) {
-    background-color: transparent;
-    border-color: themed("borderColorAlt");
-  }
 
   .generated-wrapper {
     text-align: left;
@@ -29,11 +22,6 @@ app-generator .generated-block {
     white-space: pre-wrap;
     word-break: break-all;
     padding: 15px;
-    border-radius: $border-radius;
-
-    @include themify($themes) {
-      background-color: themed("backgroundColor");
-    }
   }
 
   .action-buttons {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Changes the visual style for the generated username/password to be more consistent.

Currently, the generated block is the only UI element that uses the border with no background look across the whole extension.  This PR makes it look like any of the other `.box`/`.box-content`/`.box-content-row` panels.

This is the matching change to https://github.com/bitwarden/clients/pull/4480 for desktop

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/generator/generator.component.html:** wrap the `.generated-block` in a `.box` and `.box-content` container, add the `.box-content-row` class to the block, and add the `.row-btn` class to the refresh button
- **apps/browser/src/popup/scss/pages.scss:** remove the styles for the rounded border and background for the `.generated-block` and `.generated-wrapper`

## Screenshots

Before:

![screenshot of the generator tab as it currently appears, just with a border](https://user-images.githubusercontent.com/895831/212580880-1ea88f4e-994d-4e14-8fa9-e96f178a1837.png)

After:

![screenshot of the generator tab with this PR applied, styled as a box/panel like all other UI elements](https://user-images.githubusercontent.com/895831/212580939-bddd9ac6-7e28-45e8-b7d4-27db8a60d776.png)