### PR TITLE
adjust default kdf iterations to 350k

### DIFF
--- a/libs/common/spec/services/export.service.spec.ts
+++ b/libs/common/spec/services/export.service.spec.ts
@@ -7,7 +7,7 @@ import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { CryptoFunctionService } from "@bitwarden/common/abstractions/cryptoFunction.service";
 import { FolderService } from "@bitwarden/common/abstractions/folder/folder.service.abstraction";
 import { CipherType } from "@bitwarden/common/enums/cipherType";
-import { KdfType } from "@bitwarden/common/enums/kdfType";
+import { KdfType, DEFAULT_KDF_ITERATIONS } from "@bitwarden/common/enums/kdfType";
 import { Utils } from "@bitwarden/common/misc/utils";
 import { Cipher } from "@bitwarden/common/models/domain/cipher";
 import { EncString } from "@bitwarden/common/models/domain/enc-string";
@@ -232,7 +232,7 @@ describe("ExportService", () => {
       });
 
       it("specifies kdfIterations", () => {
-        expect(exportObject.kdfIterations).toEqual(100000);
+        expect(exportObject.kdfIterations).toEqual(DEFAULT_KDF_ITERATIONS);
       });
 
       it("has kdfType", () => {

--- a/libs/common/src/enums/kdfType.ts
+++ b/libs/common/src/enums/kdfType.ts
@@ -3,5 +3,5 @@ export enum KdfType {
 }
 
 export const DEFAULT_KDF_TYPE = KdfType.PBKDF2_SHA256;
-export const DEFAULT_KDF_ITERATIONS = 100000;
+export const DEFAULT_KDF_ITERATIONS = 350000;
 export const SEND_KDF_ITERATIONS = 100000;


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-2273

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

[Latest OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2) suggest at least 310k iterations for PBKDF2 now. This PR adjusts our default to 350k.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **kdfType.ts:** Increase iterations default.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
