### PR TITLE
[EC-822] All managed orgs are visible when Provider User creates an item

### DIFF
--- a/libs/angular/src/components/add-edit.component.ts
+++ b/libs/angular/src/components/add-edit.component.ts
@@ -9,7 +9,10 @@ import { FolderService } from "@bitwarden/common/abstractions/folder/folder.serv
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
-import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+import {
+  isNotProviderUser,
+  OrganizationService,
+} from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
 import { PasswordRepromptService } from "@bitwarden/common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { PolicyService } from "@bitwarden/common/abstractions/policy/policy.service.abstraction";
@@ -186,11 +189,14 @@ export class AddEditComponent implements OnInit, OnDestroy {
     }
 
     const orgs = await this.organizationService.getAll();
-    orgs.sort(Utils.getSortFunction(this.i18nService, "name")).forEach((o) => {
-      if (o.enabled && o.status === OrganizationUserStatusType.Confirmed) {
-        this.ownershipOptions.push({ name: o.name, value: o.id });
-      }
-    });
+    orgs
+      .filter(isNotProviderUser)
+      .sort(Utils.getSortFunction(this.i18nService, "name"))
+      .forEach((o) => {
+        if (o.enabled && o.status === OrganizationUserStatusType.Confirmed) {
+          this.ownershipOptions.push({ name: o.name, value: o.id });
+        }
+      });
     if (!this.allowPersonal) {
       this.organizationId = this.ownershipOptions[0].value;
     }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Currently all managed orgs are visible when Provider User creates an item. This PR fixes that bug by filtering the list. Solution follows existing fixes, eg: https://github.com/bitwarden/clients/pull/4147/files#diff-dc5367fd068ae86241ba5a5123e59aaac54ad3ab8897d42fde18599607ff613cR27 

Fix tested in following scenarios: 

- Provider user without any personal organizations (only clients)
- Provider user with both personal and client organizations

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
