### PR TITLE
[EC-1003] Make External ID in group modal to read-only

### DIFF
--- a/apps/web/src/app/organizations/core/services/group/group.service.ts
+++ b/apps/web/src/app/organizations/core/services/group/group.service.ts
@@ -64,7 +64,6 @@ export class GroupService {
   async save(group: GroupView): Promise<GroupView> {
     const request = new GroupRequest();
     request.name = group.name;
-    request.externalId = group.externalId;
     request.accessAll = group.accessAll;
     request.users = group.members;
     request.collections = group.collections.map(

--- a/apps/web/src/app/organizations/core/services/group/requests/group.request.ts
+++ b/apps/web/src/app/organizations/core/services/group/requests/group.request.ts
@@ -3,7 +3,6 @@ import { SelectionReadOnlyRequest } from "@bitwarden/common/models/request/selec
 export class GroupRequest {
   name: string;
   accessAll: boolean;
-  externalId: string;
   collections: SelectionReadOnlyRequest[] = [];
   users: string[] = [];
 }

--- a/apps/web/src/app/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/organizations/manage/group-add-edit.component.ts
@@ -92,7 +92,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
   groupForm = this.formBuilder.group({
     accessAll: [false],
     name: ["", [Validators.required, Validators.maxLength(100)]],
-    externalId: this.formBuilder.control({ value: "", disabled: true }, Validators.maxLength(300)),
+    externalId: this.formBuilder.control({ value: "", disabled: true }),
     members: [[] as AccessItemValue[]],
     collections: [[] as AccessItemValue[]],
   });
@@ -237,7 +237,6 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
 
     const formValue = this.groupForm.value;
     groupView.name = formValue.name;
-    groupView.externalId = formValue.externalId;
     groupView.accessAll = formValue.accessAll;
     groupView.members = formValue.members?.map((m) => m.id) ?? [];
 

--- a/apps/web/src/app/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/organizations/manage/group-add-edit.component.ts
@@ -92,7 +92,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
   groupForm = this.formBuilder.group({
     accessAll: [false],
     name: ["", [Validators.required, Validators.maxLength(100)]],
-    externalId: ["", Validators.maxLength(300)],
+    externalId: this.formBuilder.control({ value: "", disabled: true }, Validators.maxLength(300)),
     members: [[] as AccessItemValue[]],
     collections: [[] as AccessItemValue[]],
   });

--- a/apps/web/src/app/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/organizations/manage/group-add-edit.component.ts
@@ -1,6 +1,6 @@
 import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
 import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit } from "@angular/core";
-import { FormBuilder, FormControl, Validators } from "@angular/forms";
+import { FormBuilder, Validators } from "@angular/forms";
 import { catchError, combineLatest, from, map, of, Subject, switchMap, takeUntil } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -90,11 +90,11 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
   group: GroupView;
 
   groupForm = this.formBuilder.group({
-    accessAll: new FormControl(false),
-    name: new FormControl("", [Validators.required, Validators.maxLength(100)]),
-    externalId: new FormControl("", Validators.maxLength(300)),
-    members: new FormControl<AccessItemValue[]>([]),
-    collections: new FormControl<AccessItemValue[]>([]),
+    accessAll: [false],
+    name: ["", [Validators.required, Validators.maxLength(100)]],
+    externalId: ["", Validators.maxLength(300)],
+    members: [[] as AccessItemValue[]],
+    collections: [[] as AccessItemValue[]],
   });
 
   get groupId(): string | undefined {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
The external ID field in the group modal needs to be read-only. This is because edits to the group ID will break the SCIM connection (if SCIM is enabled).

## Code changes
Disable field, remove field from all data classes.

## Screenshots
![image](https://user-images.githubusercontent.com/2285588/212917479-da2cd6ca-ce13-427a-a0fb-6e5d461b9c2e.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
