### PR TITLE
[EC-969] "New" button border color

### DIFF
--- a/apps/web/src/app/organizations/vault/vault.component.html
+++ b/apps/web/src/app/organizations/vault/vault.component.html
@@ -47,19 +47,13 @@
               bitButton
               buttonType="primary"
               type="button"
-              data-toggle="dropdown"
+              [bitMenuTriggerFor]="addOptions"
               id="newItemDropdown"
-              aria-haspopup="true"
-              aria-expanded="false"
               appA11yTitle="{{ 'new' | i18n }}"
             >
               {{ "new" | i18n }}<i class="bwi bwi-angle-down tw-ml-2" aria-hidden="true"></i>
             </button>
-            <div
-              id="dropdown"
-              class="dropdown-menu dropdown-menu-right tw-mt-2"
-              aria-labelledby="newItemDropdown"
-            >
+            <bit-menu #addOptions aria-labelledby="newItemDropdown">
               <button class="dropdown-item" appStopClick (click)="addCipher()">
                 <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>
                 {{ "item" | i18n }}
@@ -68,7 +62,7 @@
                 <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
                 {{ "collection" | i18n }}
               </button>
-            </div>
+            </bit-menu>
           </div>
           <button
             *ngIf="!organization?.canCreateNewCollections"

--- a/apps/web/src/app/organizations/vault/vault.component.html
+++ b/apps/web/src/app/organizations/vault/vault.component.html
@@ -44,7 +44,6 @@
         <div *ngIf="!activeFilter.isDeleted" class="ml-auto d-flex">
           <div *ngIf="organization.canCreateNewCollections" class="dropdown mr-2" appListDropdown>
             <button
-              class="btn"
               bitButton
               buttonType="primary"
               type="button"

--- a/apps/web/src/app/vault/vault-items.component.html
+++ b/apps/web/src/app/vault/vault-items.component.html
@@ -102,6 +102,7 @@
               organizationName="{{ col.node.organizationId | orgNameFromId: organizations }}"
               [profileName]="profileName"
               (onOrganizationClicked)="onOrganizationClicked(col.node.organizationId)"
+              appStopProp
             >
             </app-org-badge>
           </ng-container>
@@ -113,7 +114,7 @@
             ></app-group-badge>
           </ng-container>
         </td>
-        <td bitCell class="tw-text-right">
+        <td bitCell class="tw-text-right" (click)="selectRow(col)">
           <button
             *ngIf="canEditCollection(col.node) || canDeleteCollection(col.node)"
             [bitMenuTriggerFor]="collectionOptions"
@@ -121,6 +122,7 @@
             bitIconButton="bwi-ellipsis-v"
             type="button"
             appA11yTitle="{{ 'options' | i18n }}"
+            appStopProp
           ></button>
           <bit-menu #collectionOptions>
             <button
@@ -191,12 +193,13 @@
           <br />
           <span class="tw-text-sm tw-text-muted" appStopProp>{{ c.subTitle }}</span>
         </td>
-        <td bitCell>
+        <td bitCell (click)="selectRow(c)">
           <ng-container *ngIf="!organization">
             <app-org-badge
               organizationName="{{ c.organizationId | orgNameFromId: organizations }}"
               profileName="{{ profileName }}"
               (onOrganizationClicked)="onOrganizationClicked(c.organizationId)"
+              appStopProp
             >
             </app-org-badge>
           </ng-container>
@@ -208,13 +211,14 @@
             ></app-collection-badge>
           </ng-container>
         </td>
-        <td bitCell class="tw-text-right">
+        <td bitCell class="tw-text-right" (click)="selectRow(c)">
           <button
             [bitMenuTriggerFor]="cipherOptions"
             size="small"
             bitIconButton="bwi-ellipsis-v"
             type="button"
             appA11yTitle="{{ 'options' | i18n }}"
+            appStopProp
           ></button>
           <bit-menu #cipherOptions>
             <ng-container *ngIf="c.type === cipherType.Login && !c.isDeleted">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We were still using the bootstrap dropdown in the Admin Console, this PR uses our new `bit-menu` component instead.

We also had the old boostrap `btn` class applied to our "New" dropdown in the Admin Console. Removing this fixes the weird border showing when selected.

I have also applied more click handlers to the rows in the vault table. You can now tap anywhere to select the row, and interactable elements won't propagate that click down.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/24985544/213018839-8a9b4b43-2409-43df-849b-73d35fee3310.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
