### PR TITLE
[EC-861] Add external id to member modal

### DIFF
--- a/apps/web/src/app/organizations/core/services/user-admin.service.ts
+++ b/apps/web/src/app/organizations/core/services/user-admin.service.ts
@@ -70,6 +70,7 @@ export class UserAdminService {
       view.userId = u.userId;
       view.type = u.type;
       view.status = u.status;
+      view.externalId = u.externalId;
       view.accessAll = u.accessAll;
       view.permissions = u.permissions;
       view.resetPasswordEnrolled = u.resetPasswordEnrolled;

--- a/apps/web/src/app/organizations/core/views/organization-user-admin-view.ts
+++ b/apps/web/src/app/organizations/core/views/organization-user-admin-view.ts
@@ -10,6 +10,7 @@ export class OrganizationUserAdminView {
   organizationId: string;
   type: OrganizationUserType;
   status: OrganizationUserStatusType;
+  externalId: string;
   accessAll: boolean;
   permissions: PermissionsApi;
   resetPasswordEnrolled: boolean;

--- a/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.html
@@ -26,7 +26,7 @@
               <bit-hint>{{ "inviteMultipleEmailDesc" | i18n: "20" }}</bit-hint>
             </bit-form-field>
           </ng-container>
-          <fieldset role="radiogroup" aria-labelledby="roleGroupLabel">
+          <fieldset role="radiogroup" aria-labelledby="roleGroupLabel" class="tw-mb-6">
             <legend
               id="roleGroupLabel"
               class="tw-mb-2 tw-block tw-text-base tw-font-semibold tw-text-main"
@@ -105,7 +105,7 @@
                 </div>
               </label>
             </div>
-            <div class="tw-mb-2 tw-flex tw-items-baseline">
+            <div class="tw-flex tw-items-baseline">
               <input
                 type="radio"
                 id="userTypeCustom"
@@ -134,6 +134,11 @@
               </label>
             </div>
           </fieldset>
+          <bit-form-field>
+            <bit-label>{{ "externalId" | i18n }}</bit-label>
+            <input bitInput type="text" formControlName="externalId" />
+            <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+          </bit-form-field>
           <ng-container *ngIf="customUserTypeSelected">
             <h3 class="mt-4 d-flex tw-font-semibold">
               {{ "permissions" | i18n }}

--- a/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -77,6 +77,7 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
   protected formGroup = this.formBuilder.group({
     emails: ["", [Validators.required]],
     type: OrganizationUserType.User,
+    externalId: this.formBuilder.control({ value: "", disabled: true }),
     accessAllCollections: false,
     access: [[] as AccessItemValue[]],
     groups: [[] as AccessItemValue[]],

--- a/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -227,6 +227,7 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
           this.formGroup.removeControl("emails");
           this.formGroup.patchValue({
             type: userDetails.type,
+            externalId: userDetails.externalId,
             accessAllCollections: userDetails.accessAll,
             access: accessSelections,
             groups: groupAccessSelections,

--- a/libs/common/src/abstractions/organization-user/responses/organization-user.response.ts
+++ b/libs/common/src/abstractions/organization-user/responses/organization-user.response.ts
@@ -10,6 +10,7 @@ export class OrganizationUserResponse extends BaseResponse {
   userId: string;
   type: OrganizationUserType;
   status: OrganizationUserStatusType;
+  externalId: string;
   accessAll: boolean;
   permissions: PermissionsApi;
   resetPasswordEnrolled: boolean;
@@ -23,6 +24,7 @@ export class OrganizationUserResponse extends BaseResponse {
     this.type = this.getResponseProperty("Type");
     this.status = this.getResponseProperty("Status");
     this.permissions = new PermissionsApi(this.getResponseProperty("Permissions"));
+    this.externalId = this.getResponseProperty("ExternalId");
     this.accessAll = this.getResponseProperty("AccessAll");
     this.resetPasswordEnrolled = this.getResponseProperty("ResetPasswordEnrolled");
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add readonly external id field to member dialog.

See server PR: https://github.com/bitwarden/server/pull/2594

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/213198984-94a6bd97-5c3c-4223-84af-870aced5f6ad.png)

![image](https://user-images.githubusercontent.com/2285588/213199056-5cd2a662-bc0d-4f82-8ff8-6eb08b13691e.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
