### PR TITLE
Align icons with images and make all muted color

### DIFF
--- a/libs/angular/src/components/icon.component.html
+++ b/libs/angular/src/components/icon.component.html
@@ -7,5 +7,5 @@
     decoding="async"
     loading="lazy"
   />
-  <i class="bwi bwi-fw bwi-lg {{ icon }}" *ngIf="!imageEnabled || !image"></i>
+  <i class="tw-text-muted bwi bwi-lg {{ icon }}" *ngIf="!imageEnabled || !image"></i>
 </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Vault item icons were misaligned and different colors. The fallback image for logins was text-muted, but the icon itself was using the regular text color. 

This PR removes `bwi-fw` to align the icons with images, and makes all icons muted text color.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
**Before**
![image](https://user-images.githubusercontent.com/24985544/213260452-fd75ac51-90d9-47db-9bd9-b453bab05928.png)

**After**
![image](https://user-images.githubusercontent.com/24985544/213260553-cc23ee37-5fcf-4848-9701-04315c3410f9.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
