### PR TITLE
[PS-2303] MV3 Service Cache Enhancements

### DIFF
--- a/apps/browser/src/background.ts
+++ b/apps/browser/src/background.ts
@@ -21,7 +21,12 @@ if (BrowserApi.manifestVersion === 3) {
   chrome.tabs.onReplaced.addListener(tabsOnReplacedListener);
   chrome.tabs.onUpdated.addListener(tabsOnUpdatedListener);
   chrome.contextMenus.onClicked.addListener(contextMenusClickedListener);
-  BrowserApi.messageListener("runtime.background", runtimeMessageListener);
+  BrowserApi.messageListener(
+    "runtime.background",
+    (message: { command: string }, sender, sendResponse) => {
+      runtimeMessageListener(message, sender);
+    }
+  );
 } else {
   const bitwardenMain = ((window as any).bitwardenMain = new MainBackground());
   bitwardenMain.bootstrap().then(() => {

--- a/apps/browser/src/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/browser/cipher-context-menu-handler.ts
@@ -120,13 +120,24 @@ export class CipherContextMenuHandler {
     await cipherContextMenuHandler.update(tab.url);
   }
 
-  static async messageListener(message: { command: string }, cachedServices: CachedServices) {
+  static async messageListener(
+    message: { command: string },
+    sender: chrome.runtime.MessageSender,
+    cachedServices: CachedServices
+  ) {
+    if (!CipherContextMenuHandler.shouldListen(message)) {
+      return;
+    }
     const cipherContextMenuHandler = await CipherContextMenuHandler.create(cachedServices);
     await cipherContextMenuHandler.messageListener(message);
   }
 
-  async messageListener(message: { command: string }) {
-    if (!LISTENED_TO_COMMANDS.includes(message.command)) {
+  private static shouldListen(message: { command: string }) {
+    return LISTENED_TO_COMMANDS.includes(message.command);
+  }
+
+  async messageListener(message: { command: string }, sender?: chrome.runtime.MessageSender) {
+    if (!CipherContextMenuHandler.shouldListen(message)) {
       return;
     }
 

--- a/apps/browser/src/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/browser/context-menu-clicked-handler.ts
@@ -126,6 +126,7 @@ export class ContextMenuClickedHandler {
 
   static async messageListener(
     message: { command: string; data: LockedVaultPendingNotificationsItem },
+    sender: chrome.runtime.MessageSender,
     cachedServices: CachedServices
   ) {
     if (

--- a/apps/browser/src/listeners/combine.spec.ts
+++ b/apps/browser/src/listeners/combine.spec.ts
@@ -1,22 +1,24 @@
 import { combine } from "./combine";
 
 describe("combine", () => {
-  it("runs", () => {
+  it("runs", async () => {
     const combined = combine([
       (arg: Record<string, unknown>, serviceCache: Record<string, unknown>) => {
         arg["one"] = true;
         serviceCache["one"] = true;
+        return Promise.resolve();
       },
       (arg: Record<string, unknown>, serviceCache: Record<string, unknown>) => {
         if (serviceCache["one"] !== true) {
           throw new Error("One should have ran.");
         }
         arg["two"] = true;
+        return Promise.resolve();
       },
     ]);
 
     const arg: Record<string, unknown> = {};
-    combined(arg);
+    await combined(arg);
 
     expect(arg["one"]).toBeTruthy();
 

--- a/apps/browser/src/listeners/combine.ts
+++ b/apps/browser/src/listeners/combine.ts
@@ -1,15 +1,15 @@
 import { CachedServices } from "../background/service_factories/factory-options";
 
-type Listener<T extends unknown[]> = (...args: [...T, CachedServices]) => void;
+type Listener<T extends unknown[]> = (...args: [...T, CachedServices]) => Promise<void>;
 
 export const combine = <T extends unknown[]>(
   listeners: Listener<T>[],
   startingServices: CachedServices = {}
 ) => {
-  return (...args: T) => {
+  return async (...args: T) => {
     const cachedServices = { ...startingServices };
     for (const listener of listeners) {
-      listener(...[...args, cachedServices]);
+      await listener(...[...args, cachedServices]);
     }
   };
 };

--- a/apps/browser/src/listeners/index.ts
+++ b/apps/browser/src/listeners/index.ts
@@ -23,7 +23,10 @@ const tabsOnUpdatedListener = combine([
 
 const contextMenusClickedListener = ContextMenuClickedHandler.onClickedListener;
 
-const runtimeMessageListener = combine([
+// TODO: All message listeners should be RuntimeMessage in Notifications follow up then this type annotation can be inferred
+const runtimeMessageListener = combine<
+  [message: { command: string }, sender: chrome.runtime.MessageSender]
+>([
   UpdateBadge.messageListener,
   CipherContextMenuHandler.messageListener,
   ContextMenuClickedHandler.messageListener,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The combined listener was sending the `(response: any) => void` callback into the 3rd argument on all the listeners instead of what the listeners were expecting, which was the `CachedServices`. They could all still work just fine because all listeners will just create their own services but they should really try to use the cached services. 



## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/background.ts:** Manually setup the message listener so we can disregard the `sendResponse` argument. 
- **apps/browser/src/browser/cipher-context-menu-handler.ts:** Change it to expect all 3 arguments that will be passed in. Also add a gate before initializing any of the services that will check if this listener will need to do anything anyways.
- **apps/browser/src/browser/context-menu-clicked-handler.ts:** Expect all 3 arguments.
- **apps/browser/src/listeners/combine.ts:** Change combine to expect all inputs to be `await`able and then actually await each listener so that it is less fire-and-forget and then the service cache will generally be more hydrated on follow-up actions.
- **apps/browser/src/listeners/combine.spec.ts:** Change tests to expect an async combine method.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
