### PR TITLE
[PS-2338] desktop: add basic keyboard navigation

### DIFF
--- a/apps/desktop/src/app/layout/nav.component.ts
+++ b/apps/desktop/src/app/layout/nav.component.ts
@@ -1,4 +1,5 @@
-import { Component } from "@angular/core";
+import { Component, HostListener } from "@angular/core";
+import { Router } from "@angular/router";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 
@@ -20,5 +21,36 @@ export class NavComponent {
     },
   ];
 
-  constructor(private i18nService: I18nService) {}
+  constructor(private i18nService: I18nService, private router: Router) {}
+
+  @HostListener("window:keydown", ["$event"])
+  async handleKeyDown(event: KeyboardEvent) {
+    if (event.ctrlKey && event.code == "ArrowLeft") {
+      this.navigateToPrevious();
+    } else if (event.ctrlKey && event.code == "ArrowRight") {
+      this.navigateToNext();
+    }
+  }
+
+  protected navigateToPrevious() {
+    const index = this.currentItemIndex();
+    if (index <= 0) {
+      return;
+    }
+
+    this.router.navigate([this.items[index - 1].link]);
+  }
+
+  protected navigateToNext() {
+    const index = this.currentItemIndex();
+    if (index < 0 || index + 1 >= this.items.length) {
+      return;
+    }
+
+    this.router.navigate([this.items[index + 1].link]);
+  }
+
+  protected currentItemIndex() {
+    return this.items.findIndex((item) => this.router.url.startsWith(item.link));
+  }
 }

--- a/apps/desktop/src/app/vault/vault-filter/vault-filter.component.ts
+++ b/apps/desktop/src/app/vault/vault-filter/vault-filter.component.ts
@@ -1,9 +1,40 @@
-import { Component } from "@angular/core";
+import { Component, HostListener, QueryList, ViewChildren } from "@angular/core";
 
 import { VaultFilterComponent as BaseVaultFilterComponent } from "@bitwarden/angular/vault/vault-filter/components/vault-filter.component";
+
+import { StatusFilterComponent } from "./filters/status-filter.component";
 
 @Component({
   selector: "app-vault-filter",
   templateUrl: "vault-filter.component.html",
 })
-export class VaultFilterComponent extends BaseVaultFilterComponent {}
+export class VaultFilterComponent extends BaseVaultFilterComponent {
+  @ViewChildren(StatusFilterComponent) components!: QueryList<StatusFilterComponent>;
+
+  protected getButtons(): HTMLElement[] {
+    return [...document.getElementsByClassName("filter-button")] as HTMLElement[];
+  }
+
+  protected currentButtonIndex(buttons: HTMLElement[]) {
+    return buttons.findIndex((button) => button.getAttribute("aria-pressed") == "true");
+  }
+
+  @HostListener("window:keydown", ["$event"])
+  async handleKeyDown(event: KeyboardEvent) {
+    if (event.ctrlKey && event.code == "ArrowUp") {
+      const buttons = this.getButtons();
+      const current = this.currentButtonIndex(buttons);
+
+      if (current > 0) {
+        buttons[current - 1].click();
+      }
+    } else if (event.ctrlKey && event.code == "ArrowDown") {
+      const buttons = this.getButtons();
+      const current = this.currentButtonIndex(buttons);
+
+      if (current >= 0 && current + 1 < buttons.length) {
+        buttons[current + 1].click();
+      }
+    }
+  }
+}

--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectorRef,
   Component,
+  HostListener,
   NgZone,
   OnDestroy,
   OnInit,
@@ -213,6 +214,29 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.searchBarService.setEnabled(false);
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
     document.body.classList.add("layout_frontend");
+  }
+
+  @HostListener("window:keydown", ["$event"])
+  async handleKeyDown(event: KeyboardEvent) {
+    if (!event.ctrlKey && event.code == "Escape") {
+      await this.closeCipher();
+    } else if (!event.ctrlKey && event.code == "ArrowUp") {
+      const cipher = this.vaultItemsComponent.previousCipher();
+      if (cipher) {
+        this.cipherId = cipher.id;
+        this.action = "view";
+        this.go();
+        await this.vaultItemsComponent.refresh();
+      }
+    } else if (!event.ctrlKey && event.code == "ArrowDown") {
+      const cipher = this.vaultItemsComponent.nextCipher();
+      if (cipher) {
+        this.cipherId = cipher.id;
+        this.action = "view";
+        this.go();
+        await this.vaultItemsComponent.refresh();
+      }
+    }
   }
 
   async load() {
@@ -433,6 +457,13 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async deletedCipher(cipher: CipherView) {
+    this.cipherId = null;
+    this.action = null;
+    this.go();
+    await this.vaultItemsComponent.refresh();
+  }
+
+  async closeCipher() {
     this.cipherId = null;
     this.action = null;
     this.go();

--- a/libs/angular/src/components/vault-items.component.ts
+++ b/libs/angular/src/components/vault-items.component.ts
@@ -89,6 +89,30 @@ export class VaultItemsComponent {
     return !this.searchPending && this.searchService.isSearchable(this.searchText);
   }
 
+  previousCipher() {
+    if (this.activeCipherId === null && this.ciphers.length > 0) {
+      return this.ciphers[this.ciphers.length - 1];
+    }
+
+    const current_id = this.currentCipherIndex();
+    if (current_id <= 0) {
+      return undefined;
+    }
+    return this.ciphers[current_id - 1];
+  }
+
+  nextCipher() {
+    if (this.activeCipherId === null && this.ciphers.length > 0) {
+      return this.ciphers[0];
+    }
+
+    const current_id = this.currentCipherIndex();
+    if (current_id < 0 || current_id + 1 >= this.ciphers.length) {
+      return undefined;
+    }
+    return this.ciphers[current_id + 1];
+  }
+
   protected deletedFilter: (cipher: CipherView) => boolean = (c) => c.isDeleted === this.deleted;
 
   protected async doSearch(indexedCiphers?: CipherView[]) {
@@ -97,5 +121,9 @@ export class VaultItemsComponent {
       [this.filter, this.deletedFilter],
       indexedCiphers
     );
+  }
+
+  protected currentCipherIndex() {
+    return this.ciphers.findIndex((cipher) => cipher.id == this.activeCipherId);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This implements a basic keyboard navigation which has been requested and attempted multiple times. For now this is for desktop clients only.

arrow up/down: scroll through vault items
ctrl + arrow up/down: scroll through filters
ctrl + arrow left/right: switch between `My vault` and `Send`
escape: remove vault item selection

## Code changes

The filter navigation can be considered quite hacky because it bypasses the angular framework but it works quite well and doesn't need any code changes. It's obviously not robust against future changes.

In general, the approach is to iterate certain lists to find the current item and switch to the previous/next item. That might be too slow when there's a lot of items.
