### PR TITLE
[PS-1137] Fix reseed storage

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -739,11 +739,9 @@ export default class MainBackground {
   }
 
   async reseedStorage() {
-    if (
-      !this.platformUtilsService.isChrome() &&
-      !this.platformUtilsService.isVivaldi() &&
-      !this.platformUtilsService.isOpera()
-    ) {
+    // Skipping Safari as it does not support retrieving all data from localStorage via an empty key
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
+    if (this.platformUtilsService.isSafari) {
       return;
     }
 

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -739,9 +739,11 @@ export default class MainBackground {
   }
 
   async reseedStorage() {
-    // Skipping Safari as it does not support retrieving all data from localStorage via an empty key
-    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
-    if (this.platformUtilsService.isSafari) {
+    if (
+      !this.platformUtilsService.isChrome() &&
+      !this.platformUtilsService.isVivaldi() &&
+      !this.platformUtilsService.isOpera()
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On logout we call stateService.clean to remove the account. The check for vault-timeout in reseedStorage will always return null as the account was already cleaned. The check needs to be done beforehand.

## Code changes
- **apps/browser/src/background/main.background.ts:** 
  - Retrieve vault-timeout set by user, before removing the account from stateService (`.clean()`)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
