### PR TITLE
[EC-669] Hide Clone menu item for organization items

### DIFF
--- a/apps/desktop/src/app/vault/vault.component.ts
+++ b/apps/desktop/src/app/vault/vault.component.ts
@@ -274,13 +274,15 @@ export class VaultComponent implements OnInit, OnDestroy {
             this.editCipher(cipher);
           }),
       });
-      menu.push({
-        label: this.i18nService.t("clone"),
-        click: () =>
-          this.functionWithChangeDetection(() => {
-            this.cloneCipher(cipher);
-          }),
-      });
+      if (!cipher.organizationId) {
+        menu.push({
+          label: this.i18nService.t("clone"),
+          click: () =>
+            this.functionWithChangeDetection(() => {
+              this.cloneCipher(cipher);
+            }),
+        });
+      }
     }
 
     switch (cipher.type) {


### PR DESCRIPTION

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The right click context menu in the desktop client was incorrectly showing the "Clone" menu option for items that belong to an organization. The desktop client does not support cloning organization items and this was causing inconsistent behaviors.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/app/vault/vault.component.ts:** Exclude the "Clone" menu item for vault items that belong to an organization.

## Screenshots

<img width="380" alt="image" src="https://user-images.githubusercontent.com/8764515/214391564-4c59f77b-491b-4fdc-af45-3990454e9ced.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
