### PR TITLE
[License sync] [EC-1036] Show correct license sync date

### DIFF
--- a/apps/web/src/app/organizations/billing/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/organizations/billing/organization-subscription-selfhost.component.html
@@ -38,11 +38,7 @@
     <ng-container *ngIf="billingSyncSetUp">
       <dt>{{ "lastLicenseSync" | i18n }}</dt>
       <dd>
-        {{
-          userOrg.familySponsorshipLastSyncDate != null
-            ? (userOrg.familySponsorshipLastSyncDate | date: "medium")
-            : ("never" | i18n)
-        }}
+        {{ lastLicenseSync != null ? (lastLicenseSync | date: "medium") : ("never" | i18n) }}
       </dd>
     </ng-container>
   </dl>

--- a/apps/web/src/app/organizations/billing/organization-subscription-selfhost.component.ts
+++ b/apps/web/src/app/organizations/billing/organization-subscription-selfhost.component.ts
@@ -109,10 +109,12 @@ export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDest
   }
 
   async loadOrganizationConnection() {
-    const cloudCommunicationEnabled = await this.apiService.getCloudCommunicationsEnabled();
+    if (!this.firstLoaded) {
+      const cloudCommunicationEnabled = await this.apiService.getCloudCommunicationsEnabled();
+      this.disableLicenseSyncControl = !cloudCommunicationEnabled;
+    }
 
-    if (!cloudCommunicationEnabled) {
-      this.disableLicenseSyncControl = true;
+    if (this.disableLicenseSyncControl) {
       return;
     }
 
@@ -153,6 +155,7 @@ export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDest
     await this.organizationApiService.selfHostedSyncLicense(this.organizationId);
 
     this.load();
+    await this.loadOrganizationConnection();
     this.messagingService.send("updatedOrgLicense");
     this.platformUtilsService.showToast("success", null, this.i18nService.t("licenseSyncSuccess"));
   };
@@ -167,5 +170,9 @@ export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDest
 
   get updateMethod() {
     return this.form.get("updateMethod").value;
+  }
+
+  get lastLicenseSync() {
+    return this.existingBillingSyncConnection?.config?.lastLicenseSync;
   }
 }

--- a/libs/common/src/models/api/billing-sync-config.api.ts
+++ b/libs/common/src/models/api/billing-sync-config.api.ts
@@ -2,6 +2,7 @@ import { BaseResponse } from "../response/base.response";
 
 export class BillingSyncConfigApi extends BaseResponse {
   billingSyncKey: string;
+  lastLicenseSync: Date;
 
   constructor(data: any) {
     super(data);
@@ -9,5 +10,10 @@ export class BillingSyncConfigApi extends BaseResponse {
       return;
     }
     this.billingSyncKey = this.getResponseProperty("BillingSyncKey");
+
+    const lastLicenseSyncString = this.getResponseProperty("LastLicenseSync");
+    if (lastLicenseSyncString) {
+      this.lastLicenseSync = new Date(lastLicenseSyncString);
+    }
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The Last License Sync date was still showing the F4E sync date, which is separate.

Update to show the last license sync date received from server

Goes with https://github.com/bitwarden/server/pull/2626

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- add new license sync date property to the response object
- update the template to display this date
- adjust loading logic so that we reload the organizationConnection after a sync (to get the new sync date). But only do this if cloud communication is enabled. (And we only need to check whether cloud communication is enabled on the first load, because you need to restart the self-hosted instance to change that.)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
