### PR TITLE
Change NPM api key in CLI release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -266,7 +266,7 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@c3b3285993151c5af47cefcb3b9134c28ab479af
         with:
           keyvault: "bitwarden-prod-kv"
-          secrets: "cli-npm-api-key"
+          secrets: "npm-api-key"
 
       - name: Download artifacts
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
@@ -293,7 +293,7 @@ jobs:
           echo 'registry="https://registry.npmjs.org/"' > ./.npmrc
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ./.npmrc
         env:
-          NPM_TOKEN: ${{ steps.retrieve-secrets.outputs.cli-npm-api-key }}
+          NPM_TOKEN: ${{ steps.retrieve-secrets.outputs.npm-api-key }}
 
       - name: Install Husky
         run: npm install -g husky


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Change NPM api key in CLI release workflow so that it doesn't suggest that it is/can be used only for cli.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/release-cli.yml:** Change name for NPM API key secret from `cli-npm-api-key` to `npm-api-key` as it's general key not tied to CLI npm package.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
