### PR TITLE
[SM-73] fix defects

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5649,6 +5649,9 @@
    "customColor": {
     "message": "Custom Color"
   },
+  "selectPlaceholder": {
+    "message": "-- Select --"
+  },
   "multiSelectPlaceholder": {
     "message": "-- Type to filter --"
   },
@@ -5704,6 +5707,9 @@
   },
   "typeOrSelectProject" :{
     "message": "Type or select project"
+  },
+  "selectProjects": {
+    "message": "Select projects"
   },
   "project":{
     "message": "Project"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5702,12 +5702,6 @@
   "secretProjectAssociationDescription" :{
     "message": "Select projects that the secret will be associated with. Only organization users with access to these projects will be able to see the secret."
   },
-  "typeOrSelectProjects" :{
-    "message": "Type or select projects"
-  },
-  "typeOrSelectProject" :{
-    "message": "Type or select project"
-  },
   "selectProjects": {
     "message": "Select projects"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5700,10 +5700,10 @@
     "message": "Select projects that the secret will be associated with. Only organization users with access to these projects will be able to see the secret."
   },
   "typeOrSelectProjects" :{
-    "message": "Type or select Projects"
+    "message": "Type or select projects"
   },
   "typeOrSelectProject" :{
-    "message": "Type or select Project"
+    "message": "Type or select project"
   },
   "project":{
     "message": "Project"

--- a/apps/web/src/scss/tailwind.css
+++ b/apps/web/src/scss/tailwind.css
@@ -3,3 +3,11 @@
 @tailwind utilities;
 
 @import "../../../../libs/components/src/tw-theme.css";
+
+/** 
+ * tw-break-words does not work with table cells:
+ * https://github.com/tailwindlabs/tailwindcss/issues/835
+ */
+td.tw-break-words {
+  overflow-wrap: anywhere;
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
@@ -29,7 +29,7 @@ export class SecretDeleteDialogComponent {
 
   delete = async () => {
     await this.secretService.delete(this.data.secretIds);
-    this.dialogRef.close();
+    this.dialogRef.close(this.data.secretIds);
     const message =
       this.data.secretIds.length === 1 ? "softDeleteSuccessToast" : "softDeletesSuccessToast";
     this.platformUtilsService.showToast("success", null, this.i18nService.t(message));

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -27,27 +27,32 @@
           <bit-label class="tw-text-md">{{
             "secretProjectAssociationDescription" | i18n
           }}</bit-label>
-          <bit-form-field class="tw-mt-3">
+          <bit-form-field class="tw-mt-3 tw-mb-0">
             <bit-label>{{ "project" | i18n }}</bit-label>
             <select bitInput name="project" formControlName="project">
+              <option value="">{{ "multiSelectPlaceholder" | i18n }}</option>
               <option *ngFor="let f of projects" [value]="f.id" (change)="updateProjectList()">
                 {{ f.name }}
               </option>
             </select>
           </bit-form-field>
-          <small class="form-text text-muted">{{ "typeOrSelectProject" | i18n }}</small>
+          <small class="form-text text-muted tw-mb-6">{{ "typeOrSelectProject" | i18n }}</small>
 
           <bit-table>
             <ng-container header>
               <tr>
-                <th bitCell>{{ "project" | i18n }}</th>
+                <th bitCell class="tw-text-sm">{{ "project" | i18n }}</th>
                 <th bitCell></th>
               </tr>
             </ng-container>
             <ng-template body *ngIf="selectedProjects != null">
               <tr bitRow *ngFor="let e of selectedProjects">
                 <!-- tw-break-words does not work with table cells: https://github.com/tailwindlabs/tailwindcss/issues/835 -->
-                <td bitCell class="tw-overflow-hidden" [ngStyle]="{ 'word-break': 'break-word' }">
+                <td
+                  bitCell
+                  class="tw-overflow-hidden tw-text-sm"
+                  [ngStyle]="{ 'word-break': 'break-word' }"
+                >
                   {{ e.name }}
                 </td>
                 <td bitCell class="tw-w-0">

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -46,7 +46,10 @@
             </ng-container>
             <ng-template body *ngIf="selectedProjects != null">
               <tr bitRow *ngFor="let e of selectedProjects">
-                <td bitCell>{{ e.name }}</td>
+                <!-- tw-break-words does not work with table cells: https://github.com/tailwindlabs/tailwindcss/issues/835 -->
+                <td bitCell class="tw-overflow-hidden" [ngStyle]="{ 'word-break': 'break-word' }">
+                  {{ e.name }}
+                </td>
                 <td bitCell class="tw-w-0">
                   <button
                     (click)="removeProjectAssociation(e.id)"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -30,18 +30,18 @@
           <bit-form-field class="tw-mt-3 tw-mb-0">
             <bit-label>{{ "project" | i18n }}</bit-label>
             <select bitInput name="project" formControlName="project">
-              <option value="">{{ "multiSelectPlaceholder" | i18n }}</option>
+              <option value="">{{ "selectPlaceholder" | i18n }}</option>
               <option *ngFor="let f of projects" [value]="f.id" (change)="updateProjectList()">
                 {{ f.name }}
               </option>
             </select>
           </bit-form-field>
-          <small class="form-text text-muted tw-mb-6">{{ "typeOrSelectProject" | i18n }}</small>
+          <small class="form-text text-muted tw-mb-6">{{ "selectProjects" | i18n }}</small>
 
           <bit-table>
             <ng-container header>
               <tr>
-                <th bitCell class="tw-text-sm">{{ "project" | i18n }}</th>
+                <th bitCell>{{ "project" | i18n }}</th>
                 <th bitCell></th>
               </tr>
             </ng-container>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -72,6 +72,15 @@
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
+      <button
+        *ngIf="deleteButtonIsVisible"
+        class="tw-ml-auto"
+        type="button"
+        bitIconButton="bwi-trash"
+        buttonType="danger"
+        bitFormButton
+        (click)="openDeleteSecretDialog()"
+      ></button>
     </div>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -47,12 +47,7 @@
             </ng-container>
             <ng-template body *ngIf="selectedProjects != null">
               <tr bitRow *ngFor="let e of selectedProjects">
-                <!-- tw-break-words does not work with table cells: https://github.com/tailwindlabs/tailwindcss/issues/835 -->
-                <td
-                  bitCell
-                  class="tw-overflow-hidden tw-text-sm"
-                  [ngStyle]="{ 'word-break': 'break-word' }"
-                >
+                <td bitCell class="tw-overflow-hidden tw-break-words tw-text-sm">
                   {{ e.name }}
                 </td>
                 <td bitCell class="tw-w-0">

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -1,16 +1,19 @@
 import { DialogRef, DIALOG_DATA } from "@angular/cdk/dialog";
 import { Component, Inject, OnInit } from "@angular/core";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
+import { lastValueFrom, Subject, takeUntil } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
+import { DialogService } from "@bitwarden/components";
 
 import { ProjectListView } from "../../models/view/project-list.view";
 import { SecretProjectView } from "../../models/view/secret-project.view";
 import { SecretView } from "../../models/view/secret.view";
 import { ProjectService } from "../../projects/project.service";
 import { SecretService } from "../secret.service";
+
+import { SecretDeleteDialogComponent, SecretDeleteOperation } from "./secret-delete.component";
 
 export enum OperationType {
   Add,
@@ -47,7 +50,8 @@ export class SecretDialogComponent implements OnInit {
     private secretService: SecretService,
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
-    private projectService: ProjectService
+    private projectService: ProjectService,
+    private dialogService: DialogService
   ) {}
 
   async ngOnInit() {
@@ -136,6 +140,26 @@ export class SecretDialogComponent implements OnInit {
     }
     this.dialogRef.close();
   };
+
+  get deleteButtonIsVisible(): boolean {
+    return this.data.operation === OperationType.Edit;
+  }
+
+  protected openDeleteSecretDialog() {
+    const dialogRef = this.dialogService.open<unknown, SecretDeleteOperation>(
+      SecretDeleteDialogComponent,
+      {
+        data: {
+          secretIds: [this.data.secretId],
+        },
+      }
+    );
+
+    // If the secret is deleted, chain close this dialog after the delete dialog
+    lastValueFrom(dialogRef.closed).then(
+      (closeData) => closeData !== undefined && this.dialogRef.close()
+    );
+  }
 
   private async createSecret(secretView: SecretView) {
     await this.secretService.create(this.data.organizationId, secretView);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -51,7 +51,9 @@ export class SecretDialogComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
-    this.projects = await this.projectService.getProjects(this.data.organizationId);
+    this.projects = await this.projectService
+      .getProjects(this.data.organizationId)
+      .then((projects) => projects.sort((a, b) => a.name.localeCompare(b.name)));
 
     if (this.data.operation === OperationType.Edit && this.data.secretId) {
       await this.loadData();

--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -33,7 +33,8 @@ export class DialogService extends Dialog implements OnDestroy {
     "tw-bg-black",
     "tw-bg-opacity-30",
     "tw-inset-0",
-    "tw-z-40",
+    // CDK dialog panels have a default z-index of 1000. Matching this allows us to easily stack dialogs.
+    "tw-z-[1000]",
   ];
 
   constructor(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR fixes misc issues with the secret dialog in SM:

- Add a delete button to the dialog
  - (The delete button stacks a delete confirmation dialog on top of the secret dialog.)
- Alphabetize projects in project list
- Fix project name overflow in table
- Fix small style issues

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- `libs/components/src/dialog/dialog.service.ts`: Update dialog overlay to work with stacked/nested dialogs
- `bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts`: delete confirmation dialog returns an array of IDs that were deleted
- `bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component`: style fixes; add delete button; close dialog if the secret is deleted

## Screenshots

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/17113462/214765285-0771471a-128b-45c6-a3b6-99ac8cae7a10.png">

Stacked dialog:

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/17113462/214765329-e73ef2f8-8295-4755-9100-555c93175f63.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
