### PR TITLE
[EC-1009] UI feedback adjust width on multi selects to remain consistent with menus

### DIFF
--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -1,5 +1,5 @@
 <div class="tw-flex">
-  <bit-form-field *ngIf="permissionMode == 'edit'" class="tw-mr-3">
+  <bit-form-field *ngIf="permissionMode == 'edit'" class="tw-mr-3 tw-shrink-0">
     <bit-label>{{ "permission" | i18n }}</bit-label>
     <!--
       Built-in select height differs between browsers, this fix makes sure we match bit-multi-select height.

--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -20,7 +20,7 @@
     </select>
   </bit-form-field>
 
-  <bit-form-field class="tw-flex-grow">
+  <bit-form-field class="tw-grow">
     <bit-label>{{ selectorLabelText }}</bit-label>
     <bit-multi-select
       class="tw-w-full"


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Make sure permission selector doesn't shrink when multi-select wants to grow

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/214841054-bf550703-8b7b-4809-93d0-a70eba9b71dc.png)

![image](https://user-images.githubusercontent.com/2285588/214841150-9c26345b-5fb6-40a3-bf33-6a7b3037d4b7.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
