### PR TITLE
[CSA-28] Use path normalization in API requests

### DIFF
--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -209,7 +209,7 @@ const mainConfig = {
       util: require.resolve("util/"),
       url: require.resolve("url/"),
       fs: false,
-      path: false,
+      path: require.resolve("path-browserify"),
     },
   },
   output: {

--- a/apps/cli/webpack.config.js
+++ b/apps/cli/webpack.config.js
@@ -67,6 +67,9 @@ const webpackConfig = {
     symlinks: false,
     modules: [path.resolve("../../node_modules")],
     plugins: [new TsconfigPathsPlugin({ configFile: "./tsconfig.json" })],
+    fallback: {
+      path: require.resolve("path-browserify"),
+    },
   },
   output: {
     filename: "[name].js",

--- a/apps/cli/webpack.config.js
+++ b/apps/cli/webpack.config.js
@@ -67,9 +67,6 @@ const webpackConfig = {
     symlinks: false,
     modules: [path.resolve("../../node_modules")],
     plugins: [new TsconfigPathsPlugin({ configFile: "./tsconfig.json" })],
-    fallback: {
-      path: require.resolve("path-browserify"),
-    },
   },
   output: {
     filename: "[name].js",

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -355,9 +355,9 @@ const webpackConfig = {
       util: require.resolve("util/"),
       assert: false,
       url: false,
-      path: false,
       fs: false,
       process: false,
+      path: require.resolve("path-browserify"),
     },
   },
   output: {

--- a/libs/common/spec/misc/utils.spec.ts
+++ b/libs/common/spec/misc/utils.spec.ts
@@ -328,7 +328,19 @@ describe("Utils Service", () => {
   });
 
   describe("normalizePath", () => {
-    it("returns normalized paths devoid of traversals", () => {
+    it("removes a single traversal", () => {
+      expect(Utils.normalizePath("../test")).toBe("test");
+    });
+
+    it("removes deep traversals", () => {
+      expect(Utils.normalizePath("../../test")).toBe("test");
+    });
+
+    it("removes intermediate traversals", () => {
+      expect(Utils.normalizePath("test/../test")).toBe("test");
+    });
+
+    it("removes multiple encoded traversals", () => {
       expect(
         Utils.normalizePath("api/sends/access/..%2f..%2f..%2fapi%2fsends%2faccess%2fsendkey")
       ).toBe("api/sends/access/sendkey");

--- a/libs/common/spec/misc/utils.spec.ts
+++ b/libs/common/spec/misc/utils.spec.ts
@@ -326,4 +326,12 @@ describe("Utils Service", () => {
       );
     });
   });
+
+  describe("normalizePath", () => {
+    it("returns normalized paths devoid of traversals", () => {
+      expect(
+        Utils.normalizePath("api/sends/access/..%2f..%2f..%2fapi%2fsends%2faccess%2fsendkey")
+      ).toBe("api/sends/access/sendkey");
+    });
+  });
 });

--- a/libs/common/src/misc/utils.ts
+++ b/libs/common/src/misc/utils.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-useless-escape */
+import * as path from "path";
+
 import { getHostname, parse } from "tldts";
 import { Merge } from "type-fest";
 
@@ -496,6 +498,15 @@ export class Utils {
       /[!'()*]/g,
       (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
     );
+  }
+
+  /**
+   * Normalizes a path for defense against attacks like traversals
+   * @param denormalizedPath
+   * @returns
+   */
+  static normalizePath(denormalizedPath: string): string {
+    return path.normalize(decodeURIComponent(denormalizedPath)).replace(/^(\.\.(\/|\\|$))+/, "");
   }
 
   private static isMobile(win: Window) {

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1962,11 +1962,8 @@ export class ApiService implements ApiServiceAbstraction {
   ): Promise<any> {
     apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.environmentService.getApiUrl() : apiUrl;
 
-    const requestUrl = apiUrl + path;
     // Prevent directory traversal from malicious paths
-    if (new URL(requestUrl).href !== requestUrl) {
-      return Promise.reject("Invalid request url path.");
-    }
+    const requestUrl = apiUrl + Utils.normalizePath(path);
 
     const headers = new Headers({
       "Device-Type": this.deviceType,


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Improve the URL path inspection process with API calls. Utilizes the native Node path normalization method to 
process traversals before it becomes an actual URL request.

## Code changes

- **apps/*/webpack.config.js:** Fallback configuration to use webpack's native support for the path library
- **libs/common/spec/misc/utils.spec.ts:** Test for the new utility
- **libs/common/src/misc/utils.ts:** New utility method for path normalization
- **libs/common/src/services/api.service.ts:** Usage of new utility method in favor of insufficient URL comparison

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
