### PR TITLE
[PS-2377] Fix CLI sync command "[object Object]" error

### DIFF
--- a/apps/cli/src/commands/sync.command.ts
+++ b/apps/cli/src/commands/sync.command.ts
@@ -19,7 +19,7 @@ export class SyncCommand {
       const res = new MessageResponse("Syncing complete.", null);
       return Response.success(res);
     } catch (e) {
-      return Response.error("Syncing failed: " + e.toString());
+      return Response.error("Syncing failed: " + e.getSingleMessage());
     }
   }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

I got an error when running `bw sync`:

```
Syncing failed: [object Object]
```
This bug is likely related to #4587.

## Code changes

- **sync.command.ts:** Changed `e.toString()` to `e.getSingleMessage()`. It appears ErrorResponse doesn't implement `toString`. Another fix would be to implement it, but `getSingleMessage` is used elsewhere in the code in similar situations.

## Screenshots

After the change, I get:

```
Syncing failed: Traffic from your network looks unusual. Connect to a different network or try again later. [Error Code 6]
```

Giving me with a better error message and vague insecurity.

Thanks!