### PR TITLE
[EC-1051] Add TailwindCSS linting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,9 +111,20 @@
     {
       "files": ["*.html"],
       "parser": "@angular-eslint/template-parser",
-      "plugins": ["@angular-eslint/template"],
+      "plugins": ["@angular-eslint/template", "tailwindcss"],
       "rules": {
-        "@angular-eslint/template/button-has-type": "error"
+        "@angular-eslint/template/button-has-type": "error",
+        "tailwindcss/no-custom-classname": [
+          "error",
+          {
+            // uses negative lookahead to whitelist any class that doesn't start with "tw-"
+            // in other words: classnames that start with tw- must be valid TailwindCSS classes
+            "whitelist": ["(?!(tw)\\-).*"]
+          }
+        ],
+        "tailwindcss/enforces-negative-arbitrary-values": "error",
+        "tailwindcss/enforces-shorthand": "error",
+        "tailwindcss/no-contradicting-classname": "error"
       }
     },
     {

--- a/apps/web/src/app/accounts/login/login-with-device.component.html
+++ b/apps/web/src/app/accounts/login/login-with-device.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div
   class="tw-mx-auto tw-mt-5 tw-flex tw-max-w-lg tw-flex-col tw-items-center tw-justify-center tw-p-8"
 >

--- a/apps/web/src/app/accounts/register-form/register-form.component.html
+++ b/apps/web/src/app/accounts/register-form/register-form.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <form
   #form
   (ngSubmit)="submit()"

--- a/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/accounts/trial-initiation/trial-initiation.component.html
@@ -1,5 +1,6 @@
 <!-- Please remove this disable statement when editing this file! -->
 <!-- eslint-disable @angular-eslint/template/button-has-type -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div *ngIf="accountCreateOnly" class="">
   <h1 class="tw-mt-12 tw-text-center tw-text-xl">{{ "createAccount" | i18n }}</h1>
   <div

--- a/apps/web/src/app/accounts/trial-initiation/vertical-stepper/vertical-step-content.component.html
+++ b/apps/web/src/app/accounts/trial-initiation/vertical-stepper/vertical-step-content.component.html
@@ -1,5 +1,6 @@
 <!-- Please remove this disable statement when editing this file! -->
 <!-- eslint-disable @angular-eslint/template/button-has-type -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div class="tw-m-2.5 tw-h-16 tw-text-center">
   <button
     (click)="selectStep()"

--- a/apps/web/src/app/components/user-verification-prompt.component.html
+++ b/apps/web/src/app/components/user-verification-prompt.component.html
@@ -3,7 +3,7 @@
 <div class="modal fade" role="dialog" aria-modal="true" aria-labelledby="confirmUserTitle">
   <div class="modal-dialog modal-dialog-scrollable" role="document">
     <form class="modal-content" #form (ngSubmit)="submit()">
-      <h2 class="tw-mt-6 tw-mb-6 tw-pl-3.5 tw-pr-3.5 tw-font-semibold" id="modalTitle | i18n ">
+      <h2 class="tw-my-6 tw-px-3.5 tw-font-semibold" id="modalTitle | i18n ">
         {{ modalTitle | i18n | uppercase }}
       </h2>
       <div class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-p-3.5">

--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div class="tw-flex">
   <bit-form-field *ngIf="permissionMode == 'edit'" class="tw-mr-3">
     <bit-label>{{ "permission" | i18n }}</bit-label>

--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -100,7 +100,7 @@
             </select>
             <label
               [for]="'permission' + i"
-              class="tw-absolute tw-inset-y-0 tw-right-4 tw-mb-0 tw-block tw-flex tw-items-center"
+              class="tw-absolute tw-inset-y-0 tw-right-4 tw-mb-0 tw-flex tw-items-center"
             >
               <i class="bwi bwi-sm bwi-angle-down tw-leading-[0]"></i>
             </label>

--- a/apps/web/src/app/settings/change-avatar.component.html
+++ b/apps/web/src/app/settings/change-avatar.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div class="modal fade" role="dialog" aria-modal="true" aria-labelledby="customizeTitle">
   <div class="modal-dialog modal-dialog-scrollable tw-w-[600px] tw-max-w-none" role="document">
     <div class="modal-content">

--- a/apps/web/src/app/settings/change-avatar.component.html
+++ b/apps/web/src/app/settings/change-avatar.component.html
@@ -44,7 +44,7 @@
                 '!tw-outline-[3px] tw-outline-primary-500 hover:tw-outline-[3px] hover:tw-outline-primary-500':
                   customColorSelected
               }"
-              class="tw-outline-solid tw-bg-white tw-relative tw-inline-block tw-flex tw-h-24 tw-w-24 tw-cursor-pointer tw-place-content-center tw-content-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-secondary-500 tw-outline tw-outline-0 tw-outline-offset-1 hover:tw-outline-1 hover:tw-outline-primary-300 focus:tw-outline-2 focus:tw-outline-primary-500"
+              class="tw-outline-solid tw-bg-white tw-relative tw-flex tw-h-24 tw-w-24 tw-cursor-pointer tw-place-content-center tw-content-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-secondary-500 tw-outline tw-outline-0 tw-outline-offset-1 hover:tw-outline-1 hover:tw-outline-primary-300 focus:tw-outline-2 focus:tw-outline-primary-500"
               [style.background-color]="customColor$ | async"
             >
               <i

--- a/apps/web/src/app/settings/change-avatar.component.html
+++ b/apps/web/src/app/settings/change-avatar.component.html
@@ -21,7 +21,7 @@
           {{ error }}
         </app-callout>
         <p class="tw-text-lg">{{ "pickAnAvatarColor" | i18n }}</p>
-        <div class="tw-flex tw-flex-wrap tw-justify-center tw-gap-8 tw-gap-y-8">
+        <div class="tw-flex tw-flex-wrap tw-justify-center tw-gap-8">
           <ng-container *ngFor="let c of defaultColorPalette">
             <selectable-avatar
               appStopClick

--- a/apps/web/src/app/tools/import-export/export.component.html
+++ b/apps/web/src/app/tools/import-export/export.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <form
   #form
   (ngSubmit)="submit()"

--- a/apps/web/src/app/tools/import-export/export.component.html
+++ b/apps/web/src/app/tools/import-export/export.component.html
@@ -48,7 +48,7 @@
               />
             </div>
             <div>
-              <label class="tw-semi-bold tw-text-md tw-ml-1 tw-mt-1 tw-mb-1" for="AccountEncrypted">
+              <label class="tw-semi-bold tw-text-md tw-my-1 tw-ml-1" for="AccountEncrypted">
                 {{ "accountRestricted" | i18n }}
               </label>
             </div>
@@ -71,7 +71,7 @@
               />
             </div>
             <div>
-              <label class="tw-semi-bold tw-text-md tw-ml-1 tw-mt-1 tw-mb-1" for="FileEncrypted">{{
+              <label class="tw-semi-bold tw-text-md tw-my-1 tw-ml-1" for="FileEncrypted">{{
                 "passwordProtected" | i18n
               }}</label>
             </div>

--- a/apps/web/src/app/tools/import-export/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/file-password-prompt.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <div
   class="modal fade"
   role="dialog"

--- a/apps/web/src/app/tools/import-export/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/file-password-prompt.component.html
@@ -7,11 +7,11 @@
   <div class="modal-dialog modal-dialog-scrollable" role="document">
     <form #form (ngSubmit)="submit()">
       <div class="form-group modal-content">
-        <h2 class="tw-mt-6 tw-mb-6 tw-ml-3.5 tw-font-semibold" id="confirmVaultImport">
+        <h2 class="tw-my-6 tw-ml-3.5 tw-font-semibold" id="confirmVaultImport">
           {{ "confirmVaultImport" | i18n | uppercase }}
         </h2>
         <div
-          class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-pr-3.5 tw-pt-3.5 tw-pl-3.5"
+          class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-px-3.5 tw-pt-3.5"
         >
           {{ "confirmVaultImportDesc" | i18n }}
           <bit-form-field class="tw-pt-3.5">
@@ -28,7 +28,7 @@
           </bit-form-field>
         </div>
         <div
-          class="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-pl-3.5 tw-pr-3.5 tw-pb-3.5 tw-pt-4 tw-pl-4 tw-pr-4"
+          class="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-px-3.5 tw-px-4 tw-pb-3.5 tw-pt-4"
         >
           <button bitButton buttonType="primary" class="tw-mr-2" type="submit" appBlurClick>
             <span>{{ "importData" | i18n }}</span>

--- a/apps/web/src/app/tools/import-export/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/file-password-prompt.component.html
@@ -28,7 +28,7 @@
           </bit-form-field>
         </div>
         <div
-          class="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-px-3.5 tw-px-4 tw-pb-3.5 tw-pt-4"
+          class="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-px-3.5 tw-pb-3.5 tw-pt-4"
         >
           <button bitButton buttonType="primary" class="tw-mr-2" type="submit" appBlurClick>
             <span>{{ "importData" | i18n }}</span>

--- a/apps/web/src/vault/app/vault/add-edit.component.html
+++ b/apps/web/src/vault/app/vault/add-edit.component.html
@@ -282,7 +282,7 @@
                   </svg>
                 </span>
                 <span
-                  class="totp-code tw-mr-2 tw-ml-2 tw-mt-1"
+                  class="totp-code tw-mx-2 tw-mt-1"
                   title="{{ 'verificationCodeTotp' | i18n }}"
                   >{{ totpCodeFormatted }}</span
                 >

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -1,5 +1,6 @@
 <!-- Please remove this disable statement when editing this file! -->
 <!-- eslint-disable @angular-eslint/template/button-has-type -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default" disablePadding>
     <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>

--- a/libs/components/src/table/table.component.html
+++ b/libs/components/src/table/table.component.html
@@ -1,3 +1,5 @@
+<!-- Please remove this disable statement when editing this file! -->
+<!-- eslint-disable tailwindcss/no-custom-classname -->
 <table class="tw-w-full tw-table-auto tw-leading-normal tw-text-main">
   <thead
     class="tw-text-bold tw-border-0 tw-border-b-2 tw-border-solid tw-border-secondary-300 tw-text-muted"

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-rxjs": "^5.0.2",
         "eslint-plugin-rxjs-angular": "^2.0.0",
+        "eslint-plugin-tailwindcss": "^3.8.3",
         "gulp": "^4.0.2",
         "gulp-filter": "^7.0.0",
         "gulp-if": "^3.0.0",
@@ -22393,6 +22394,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.8.3.tgz",
+      "integrity": "sha512-wfzfCmc9yONNW+TqfR+QWZ+syFPQ8zMOrIGx500lS4XITEm0HJYGyKh1sC1tQ9+Wmt58bnHzW3Yc31vy5RlJww==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.2.2"
       }
     },
     "node_modules/eslint-scope": {
@@ -60931,6 +60948,16 @@
         "eslint-etc": "^5.0.0",
         "requireindex": "~1.2.0",
         "tslib": "^2.0.0"
+      }
+    },
+    "eslint-plugin-tailwindcss": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.8.3.tgz",
+      "integrity": "sha512-wfzfCmc9yONNW+TqfR+QWZ+syFPQ8zMOrIGx500lS4XITEm0HJYGyKh1sC1tQ9+Wmt58bnHzW3Yc31vy5RlJww==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4"
       }
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-rxjs": "^5.0.2",
     "eslint-plugin-rxjs-angular": "^2.0.0",
+    "eslint-plugin-tailwindcss": "^3.8.3",
     "gulp": "^4.0.2",
     "gulp-filter": "^7.0.0",
     "gulp-if": "^3.0.0",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Note: this is branched from #3825 to avoid conflicts. That can be merged first and this will automatically update to target master.

Use [eslint-plugin-tailwindcss](https://github.com/francoismassart/eslint-plugin-tailwindcss) to lint our Tailwind classes. This specifically enables the following rules (list below copy/pasted from the README):

* [enforces-negative-arbitrary-values](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/enforces-negative-arbitrary-values.md): make sure to use negative arbitrary values classname without the negative classname e.g. -top-[5px] should become top-[-5px]
* [enforces-shorthand](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/enforces-shorthand.md): merge multiple classnames into shorthand if possible e.g. mx-5 my-5 should become m-5
* [no-custom-classname](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/no-custom-classname.md): only allow classnames from Tailwind CSS and the values from the whitelist option
* [no-contradicting-classname](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/no-contradicting-classname.md): e.g. avoid p-2 p-3, different Tailwind CSS classnames (pt-2 & pt-3) but targeting the same property several times for the same variant.

I have not enabled the following rules:

* [classnames-order](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/classnames-order.md): order classnames for consistency and it makes merge conflict a bit easier to resolve - **I think our tools already do this?**
 * [migration-from-tailwind-2](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/migration-from-tailwind-2.md) for easy upgrade from Tailwind CSS v2 to v3. - **not applicable to us**
* [no-arbitrary-value](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/no-arbitrary-value.md): forbid using arbitrary values in classnames (turned off by default) - **we use arbitrary values sometimes**

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* install the plugin and enable rules
* fix conflicting classes automatically with `lint:fix`
* add exceptions for invalid classes, following @Hinton's practice when enabling new linting rules. This isn't a huge task but it is time consuming to clean these up. See TDL-217 to track this work.
* manually fix conflicting classes. In each component, I used the inspector to see which class is actually being applied (i.e. which class is winning out in the conflict), and then removed the other one. See screenshots below showing before/after, which includes the inspector so you can see what rules are being applied.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

**apps/web/src/app/tools/import-export/file-password-prompt.component.html**

Before:
![Screenshot 2023-01-31 at 9 04 06 am](https://user-images.githubusercontent.com/31796059/215623259-ab72fb9c-13fd-4cfd-9ffa-3d15d12b708c.png)

After:
![Screenshot 2023-01-31 at 9 05 02 am](https://user-images.githubusercontent.com/31796059/215623267-2170536c-0805-437d-8ef7-bf1615d7e6ef.png)

**apps/web/src/app/settings/change-avatar.component.html**

Before:
![Screenshot 2023-01-31 at 9 08 27 am](https://user-images.githubusercontent.com/31796059/215623316-e600d5e7-11a8-464a-84d8-d82ab230a6e8.png)

After:
![Screenshot 2023-01-31 at 9 09 01 am](https://user-images.githubusercontent.com/31796059/215623327-c4f04402-4d61-4217-9f4c-5bf0d6624894.png)

**apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html**

Before:
![Screenshot 2023-01-31 at 9 13 53 am](https://user-images.githubusercontent.com/31796059/215623352-3d779058-1900-4edd-827b-d63b5f30ebe3.png)

After:
![Screenshot 2023-01-31 at 9 14 44 am](https://user-images.githubusercontent.com/31796059/215623375-3c32b419-f096-48a0-ae21-02c3f6b35ea7.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
