### PR TITLE
[EC-1053] Link to an Item for Personal Vault results in an error

### DIFF
--- a/apps/web/src/app/vault/vault.component.ts
+++ b/apps/web/src/app/vault/vault.component.ts
@@ -131,12 +131,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             await this.editCipher(cipherView);
           }
         }),
-        takeUntil(this.destroy$)
-      )
-      .subscribe();
-
-    this.route.queryParams
-      .pipe(
+        switchMap(() => this.route.queryParams),
         switchMap(async (params) => {
           const cipherId = getCipherIdFromParams(params);
           if (cipherId) {


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix an issue where linking to an Item on Personal Vault results in an error “Unknown item, you may need to request permission to access this item.”.
This issue is happening due to the `this.route.queryParams` subscriptions being fired in the wrong order. The command `this.cipherService.get(cipherId)` was returning null because `this.syncService.fullSync(false)` was not yet executed.

## Code changes

- **apps/web/src/app/vault/vault.component.ts:** Combined both subscriptions to be executed in a certain order where `this.syncService.fullSync(false)` always runs first.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
