### PR TITLE
[PM-1036] [PS-2393] Add purple colorscheme for browser extension

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -645,6 +645,9 @@
     "message": "Solarized dark",
     "description": "'Solarized' is a noun and the name of a color scheme. It should not be translated."
   },
+  "purpleDark": {
+    "message": "Purple dark"
+  },
   "exportVault": {
     "message": "Export vault"
   },

--- a/apps/browser/src/notification/variables.scss
+++ b/apps/browser/src/notification/variables.scss
@@ -1,4 +1,4 @@
-﻿@import "~nord/src/sass/nord.scss";
+@import "~nord/src/sass/nord.scss";
 
 $font-family-sans-serif: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-size-base: 14px;
@@ -16,6 +16,11 @@ $solarizedDarkBase01: #586e75;
 $solarizedDarkBase2: #eee8d5;
 $solarizedDarkCyan: #2aa198;
 $solarizedDarkGreen: #859900;
+
+$purpleDarkBackground: #16121f;
+$purpleDarkBackgroundAlt: #110e18;
+$purpleDarkPrimary: #d5d6e8;
+$purpleDarkAccent: #747e9d;
 
 $themes: (
   light: (
@@ -53,6 +58,15 @@ $themes: (
     textContrast: $solarizedDarkBase02,
     inputBorderColor: rgba($solarizedDarkBase2, 0.2),
     inputBackgroundColor: $solarizedDarkBase01,
+  ),
+  purpleDark: (
+    textColor: $purpleDarkPrimary,
+    backgroundColor: $purpleDarkBackground,
+    buttonPrimaryColor: $purpleDarkAccent,
+    primaryColor: $purpleDarkAccent,
+    textContrast: $purpleDarkBackgroundAlt,
+    inputBorderColor: rgba($purpleDarkPrimary, 0.2),
+    inputBackgroundColor: $purpleDarkBackgroundAlt,
   ),
 );
 

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -1,4 +1,4 @@
-﻿@import "~nord/src/sass/nord.scss";
+@import "~nord/src/sass/nord.scss";
 
 $dark-icon-themes: "theme_dark", "theme_solarizedDark", "theme_nord";
 
@@ -59,6 +59,11 @@ $solarizedDarkViolet: #6c71c4;
 $solarizedDarkBlue: #268bd2;
 $solarizedDarkCyan: #2aa198;
 $solarizedDarkGreen: #859900;
+
+$purpleDarkBackground: #16121f;
+$purpleDarkBackgroundAlt: #110e18;
+$purpleDarkPrimary: #d5d6e8;
+$purpleDarkAccent: #747e9d;
 
 $themes: (
   light: (
@@ -304,6 +309,66 @@ $themes: (
       hue-rotate(138deg) brightness(92%) contrast(90%),
     webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(94%) sepia(10%)
       saturate(462%) hue-rotate(345deg) brightness(103%) contrast(87%),
+  ),
+  purpleDark: (
+    textColor: $purpleDarkPrimary,
+    hoverColorTransparent: rgba($text-color, 0.15),
+    borderColor: $purpleDarkBackground,
+    backgroundColor: $purpleDarkBackground,
+    borderColorAlt: lighten($purpleDarkBackground, 10%),
+    backgroundColorAlt: $purpleDarkBackgroundAlt,
+    scrollbarColor: lighten($purpleDarkBackground, 15%),
+    scrollbarHoverColor: $purpleDarkPrimary,
+    boxBackgroundColor: $purpleDarkBackgroundAlt,
+    boxBackgroundHoverColor: lighten($purpleDarkBackgroundAlt, 10%),
+    boxBorderColor: $purpleDarkBackgroundAlt,
+    tabBackgroundColor: $purpleDarkBackgroundAlt,
+    tabBackgroundHoverColor: lighten($purpleDarkBackground, 10%),
+    headerColor: lighten($purpleDarkPrimary, 15%),
+    headerBackgroundColor: $purpleDarkBackgroundAlt,
+    headerBackgroundHoverColor: lighten($purpleDarkBackground, 10%),
+    headerBorderColor: $purpleDarkBackground,
+    headerInputBackgroundColor: lighten($purpleDarkBackground, 10%),
+    headerInputBackgroundFocusColor: lighten($purpleDarkBackground, 20%),
+    headerInputColor: $purpleDarkPrimary,
+    headerInputPlaceholderColor: darken($purpleDarkPrimary, 10%),
+    listItemBackgroundHoverColor: lighten($purpleDarkBackgroundAlt, 10%),
+    disabledIconColor: lighten($purpleDarkBackground, 15%),
+    disabledBoxOpacity: 0.5,
+    headingColor: lighten($purpleDarkBackground, 20%),
+    labelColor: lighten($purpleDarkBackground, 20%),
+    mutedColor: lighten($purpleDarkBackground, 30%),
+    totpStrokeColor: lighten($purpleDarkBackground, 15%),
+    boxRowButtonColor: lighten($purpleDarkBackground, 15%),
+    boxRowButtonHoverColor: $purpleDarkPrimary,
+    inputBorderColor: $purpleDarkBackground,
+    inputBackgroundColor: lighten($purpleDarkBackground, 10%),
+    inputPlaceholderColor: lighten($purpleDarkBackground, 30%),
+    buttonBackgroundColor: lighten($purpleDarkBackground, 15%),
+    buttonBorderColor: $purpleDarkBackground,
+    buttonColor: $purpleDarkPrimary,
+    buttonPrimaryColor: $purpleDarkAccent,
+    buttonDangerColor: $brand-danger,
+    primaryColor: $purpleDarkAccent,
+    primaryAccentColor: $purpleDarkAccent,
+    dangerColor: $brand-danger,
+    successColor: $purpleDarkAccent,
+    infoColor: $purpleDarkAccent,
+    warningColor: $brand-warning,
+    logoSuffix: "white",
+    passwordNumberColor: $purpleDarkAccent,
+    passwordSpecialColor: $brand-warning,
+    passwordCountText: $purpleDarkPrimary,
+    calloutBorderColor: $purpleDarkBackground,
+    calloutBackgroundColor: lighten($purpleDarkBackground, 10%),
+    toastTextColor: $purpleDarkPrimary,
+    svgSuffix: "-dark.svg",
+    transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: dark,
+    webkitCalendarPickerFilter: brightness(0) saturate(100%) invert(86%) sepia(19%) saturate(152%)
+      hue-rotate(184deg) brightness(87%) contrast(93%),
+    webkitCalendarPickerHoverFilter: brightness(0) saturate(100%) invert(100%) sepia(0%)
+      saturate(0%) hue-rotate(93deg) brightness(103%) contrast(103%),
   ),
 );
 

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -48,6 +48,7 @@ export class OptionsComponent implements OnInit {
       { name: i18nService.t("dark"), value: ThemeType.Dark },
       { name: "Nord", value: ThemeType.Nord },
       { name: i18nService.t("solarizedDark"), value: ThemeType.SolarizedDark },
+      { name: i18nService.t("purpleDark"), value: ThemeType.PurpleDark },
     ];
     this.uriMatchOptions = [
       { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },

--- a/libs/common/src/enums/themeType.ts
+++ b/libs/common/src/enums/themeType.ts
@@ -4,4 +4,5 @@ export enum ThemeType {
   Dark = "dark",
   Nord = "nord",
   SolarizedDark = "solarizedDark",
+  PurpleDark = "purpleDark",
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR adds a dark theme with a purple tint to the browser extension. Tested in Firefox and Chromium

## Code changes

- **apps/browser/src/popup/scss/variables.scss,** 
- **apps/browser/src/notification/variables.scss:** Defining the theme
- **apps/browser/src/_locales/en/messages.json:** Adding the theme name in the English locale
- **libs/common/src/enums/themeType.ts:** Adding theme as a ThemeType enum variant
- **apps/browser/src/popup/settings/options.component.ts:** Adding theme to the theme picker in options

## Screenshots

![image](https://user-images.githubusercontent.com/53269550/215852605-4292285c-9101-4d13-b01b-4bb63a227168.png)
![image](https://user-images.githubusercontent.com/53269550/215852686-4866ed70-26e8-4045-a1a4-1a675eec7a50.png)

## Known issues
- After the theme is selected, it is not possible to switch to another theme without reloading the extension. I'm not sure if this happens outside of debug builds, but it does not log any errors/warnings. I did grep for `solarized` and `nord` through the repository and made sure that my theme is defined in every place that other themes are defined in.
- I have not been able to test this on other monitors yet. Please let me know if there are any contrast issues.