### PR TITLE
[PS-2395] Fix password generator preview overflow

### DIFF
--- a/apps/desktop/src/scss/misc.scss
+++ b/apps/desktop/src/scss/misc.scss
@@ -203,6 +203,7 @@ p.lead {
   .generated-wrapper {
     text-align: left;
     width: 100%;
+    word-break: break-all;
   }
 
   .action-buttons {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes password generator preview not wrapping characters correctly if password is longer than 33 characters.

## Code changes

Enables wrapping individual password characters in the preview container.

- **misc.scss:** Included additional CSS rule to `.generated-wrapper`.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/637799/215873117-c4747a7e-974e-4e48-a8c4-8279a787c3a6.png)

After:
![image](https://user-images.githubusercontent.com/637799/215873293-891bd6fe-64c1-42c5-bd6b-fb980c84ba3b.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
