### PR TITLE
[EC-1027] The collection name within the modal table appears to be a smaller font than the permission label

### DIFF
--- a/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
+++ b/apps/web/src/app/organizations/shared/components/access-selector/access-selector.component.html
@@ -59,7 +59,7 @@
         <div class="tw-flex tw-items-center" *ngSwitchCase="itemType.Member">
           <bit-avatar size="small" class="tw-mr-3" text="{{ item.labelName }}"></bit-avatar>
           <div class="tw-flex tw-flex-col">
-            <div class="tw-text-sm">
+            <div>
               {{ item.labelName }}
               <span *ngIf="$any(item).status == 0" bitBadge badgeType="secondary">
                 {{ "invited" | i18n }}
@@ -71,7 +71,7 @@
           </div>
         </div>
 
-        <div class="tw-flex tw-items-center tw-text-sm" *ngSwitchDefault>
+        <div class="tw-flex tw-items-center" *ngSwitchDefault>
           <i
             class="bwi tw-mr-3 tw-px-0.5 tw-text-2xl"
             [ngClass]="item.icon || itemIcon(item)"


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix font size not matching figma.

Technically we were using the correct CSS classes so the issue is actually Figma not matching our deployment environment. Hopefully we'll remove bootstrap soon and stop having these issues.

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/216060587-64aed38c-7bc7-4fda-a54d-d3cc2e8c99b3.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
