### PR TITLE
[Dev Design feedback] The collection name is not aligned with permission text

### DIFF
--- a/libs/components/src/table/cell.directive.ts
+++ b/libs/components/src/table/cell.directive.ts
@@ -5,6 +5,6 @@ import { HostBinding, Directive } from "@angular/core";
 })
 export class CellDirective {
   @HostBinding("class") get classList() {
-    return ["tw-p-3"];
+    return ["tw-p-3", "tw-align-middle"];
   }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Content in cells were not aligned correctly. 

## Code changes

This PR changes all cells across all tables to be vertically aligned to the middle. From what I can see we that's what we always want and I can't spot any places where it has any big impact.

I'm not sure if this is what we want though, so I'm putting this PR up to gather feedback. Alternatives are:

  - Add `@Input() align: string;` to `bitCell` directive
  - Use `class="tw-align-middle"` in places where it is needed

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/216068840-73c846e8-2d76-41c0-83e5-85b54f84b464.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
