### PR TITLE
[EC-1062] Convert bar.js to TS and refactor

### DIFF
--- a/apps/browser/src/autofill/notification/bar.html
+++ b/apps/browser/src/autofill/notification/bar.html
@@ -35,7 +35,7 @@
       <div id="add-text"></div>
       <div>
         <button type="button" id="never-save" class="link"></button>
-        <select id="select-folder" isVaultLocked="false"></select>
+        <select id="select-folder"></select>
         <button type="button" id="add-save"></button>
       </div>
     </div>

--- a/apps/browser/src/autofill/notification/bar.html
+++ b/apps/browser/src/autofill/notification/bar.html
@@ -28,21 +28,25 @@
         </button>
       </div>
     </div>
-    <div id="templates" style="display: none">
-      <div class="inner-wrapper" id="template-add">
-        <div class="add-text"></div>
-        <div class="add-buttons">
-          <button type="button" class="never-save link"></button>
-          <select class="select-folder" isVaultLocked="false"></select>
-          <button type="button" class="add-save"></button>
-        </div>
-      </div>
-      <div class="inner-wrapper" id="template-change">
-        <div class="change-text"></div>
-        <div class="change-buttons">
-          <button type="button" class="change-save"></button>
-        </div>
+  </body>
+
+  <template id="template-add">
+    <div class="inner-wrapper">
+      <div id="add-text"></div>
+      <div>
+        <button type="button" id="never-save" class="link"></button>
+        <select id="select-folder" isVaultLocked="false"></select>
+        <button type="button" id="add-save"></button>
       </div>
     </div>
-  </body>
+  </template>
+
+  <template id="template-change">
+    <div class="inner-wrapper">
+      <div id="change-text"></div>
+      <div>
+        <button type="button" id="change-save"></button>
+      </div>
+    </div>
+  </template>
 </html>

--- a/apps/browser/src/autofill/notification/bar.scss
+++ b/apps/browser/src/autofill/notification/bar.scss
@@ -130,12 +130,12 @@ button {
   font-family: $font-family-sans-serif;
 }
 
-.select-folder[isVaultLocked="true"] {
+#select-folder[data-is-vault-locked="true"] {
   display: none;
 }
 
 @media screen and (max-width: 768px) {
-  .select-folder {
+  #select-folder {
     display: none;
   }
 }

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -1,48 +1,51 @@
-// eslint-disable-next-line
+import type { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+
 require("./bar.scss");
 
 document.addEventListener("DOMContentLoaded", () => {
+  contentLoaded();
+});
+
+function contentLoaded() {
   const theme = getQueryVariable("theme");
   document.documentElement.classList.add("theme_" + theme);
 
-  let i18n = {};
-  let lang = window.navigator.language;
-
-  i18n.appName = chrome.i18n.getMessage("appName");
-  i18n.close = chrome.i18n.getMessage("close");
-  i18n.never = chrome.i18n.getMessage("never");
-  i18n.folder = chrome.i18n.getMessage("folder");
-  i18n.notificationAddSave = chrome.i18n.getMessage("notificationAddSave");
-  i18n.notificationAddDesc = chrome.i18n.getMessage("notificationAddDesc");
-  i18n.notificationChangeSave = chrome.i18n.getMessage("notificationChangeSave");
-  i18n.notificationChangeDesc = chrome.i18n.getMessage("notificationChangeDesc");
-  lang = chrome.i18n.getUILanguage(); // eslint-disable-line
+  const i18n = {
+    appName: chrome.i18n.getMessage("appName"),
+    close: chrome.i18n.getMessage("close"),
+    never: chrome.i18n.getMessage("never"),
+    folder: chrome.i18n.getMessage("folder"),
+    notificationAddSave: chrome.i18n.getMessage("notificationAddSave"),
+    notificationAddDesc: chrome.i18n.getMessage("notificationAddDesc"),
+    notificationChangeSave: chrome.i18n.getMessage("notificationChangeSave"),
+    notificationChangeDesc: chrome.i18n.getMessage("notificationChangeDesc"),
+  };
 
   // delay 50ms so that we get proper body dimensions
   setTimeout(load, 50);
 
   function load() {
     const isVaultLocked = getQueryVariable("isVaultLocked") == "true";
-    document.getElementById("logo").src = isVaultLocked
+    (document.getElementById("logo") as HTMLImageElement).src = isVaultLocked
       ? chrome.runtime.getURL("images/icon38_locked.png")
       : chrome.runtime.getURL("images/icon38.png");
 
     document.getElementById("logo-link").title = i18n.appName;
 
-    var neverButton = document.querySelector("#template-add .never-save");
+    const neverButton = document.querySelector("#template-add .never-save");
     neverButton.textContent = i18n.never;
 
-    var selectFolder = document.querySelector("#template-add .select-folder");
+    const selectFolder = document.querySelector("#template-add .select-folder");
     selectFolder.setAttribute("aria-label", i18n.folder);
     selectFolder.setAttribute("isVaultLocked", isVaultLocked.toString());
 
-    var addButton = document.querySelector("#template-add .add-save");
+    const addButton = document.querySelector("#template-add .add-save");
     addButton.textContent = i18n.notificationAddSave;
 
-    var changeButton = document.querySelector("#template-change .change-save");
+    const changeButton = document.querySelector("#template-change .change-save");
     changeButton.textContent = i18n.notificationChangeSave;
 
-    var closeButton = document.getElementById("close-button");
+    const closeButton = document.getElementById("close-button");
     closeButton.title = i18n.close;
     closeButton.setAttribute("aria-label", i18n.close);
 
@@ -67,12 +70,12 @@ document.addEventListener("DOMContentLoaded", () => {
     adjustHeight();
   }
 
-  function getQueryVariable(variable) {
-    var query = window.location.search.substring(1);
-    var vars = query.split("&");
+  function getQueryVariable(variable: string) {
+    const query = window.location.search.substring(1);
+    const vars = query.split("&");
 
-    for (var i = 0; i < vars.length; i++) {
-      var pair = vars[i].split("=");
+    for (let i = 0; i < vars.length; i++) {
+      const pair = vars[i].split("=");
       if (pair[0] === variable) {
         return pair[1];
       }
@@ -81,7 +84,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return null;
   }
 
-  function handleTypeAdd(isVaultLocked) {
+  function handleTypeAdd(isVaultLocked: boolean) {
     setContent(document.getElementById("template-add"));
 
     var addButton = document.querySelector("#template-add-clone .add-save"), // eslint-disable-line
@@ -90,7 +93,9 @@ document.addEventListener("DOMContentLoaded", () => {
     addButton.addEventListener("click", (e) => {
       e.preventDefault();
 
-      const folderId = document.querySelector("#template-add-clone .select-folder").value;
+      const folderId = (
+        document.querySelector("#template-add-clone .select-folder") as HTMLSelectElement
+      ).value;
 
       const bgAddSaveMessage = {
         command: "bgAddSave",
@@ -133,22 +138,22 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  function setContent(element) {
+  function setContent(element: HTMLElement) {
     const content = document.getElementById("content");
     while (content.firstChild) {
       content.removeChild(content.firstChild);
     }
 
-    var newElement = element.cloneNode(true);
+    const newElement = element.cloneNode(true) as HTMLElement;
     newElement.id = newElement.id + "-clone";
     content.appendChild(newElement);
   }
 
-  function sendPlatformMessage(msg) {
+  function sendPlatformMessage(msg: unknown) {
     chrome.runtime.sendMessage(msg);
   }
 
-  function fillSelectorWithFolders(folders) {
+  function fillSelectorWithFolders(folders: FolderView[]) {
     const select = document.querySelector("#template-add-clone .select-folder");
     select.appendChild(new Option(chrome.i18n.getMessage("selectFolder"), null, true));
     folders.forEach((folder) => {
@@ -165,4 +170,4 @@ document.addEventListener("DOMContentLoaded", () => {
       },
     });
   }
-});
+}

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -42,7 +42,7 @@ function contentLoaded() {
 
     const selectFolder = addTemplate.content.getElementById("select-folder");
     selectFolder.setAttribute("aria-label", i18n.folder);
-    selectFolder.setAttribute("isVaultLocked", isVaultLocked.toString());
+    selectFolder.dataset.isVaultLocked = isVaultLocked.toString();
 
     const addButton = addTemplate.content.getElementById("add-save");
     addButton.textContent = i18n.notificationAddSave;

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -151,7 +151,7 @@ function setContent(template: HTMLTemplateElement) {
   content.appendChild(newElement);
 }
 
-function sendPlatformMessage(msg: Record<string, any>) {
+function sendPlatformMessage(msg: Record<string, unknown>) {
   chrome.runtime.sendMessage(msg);
 }
 

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -1,3 +1,5 @@
+import type { Jsonify } from "type-fest";
+
 import type { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 
 require("./bar.scss");
@@ -149,15 +151,15 @@ function contentLoaded() {
     content.appendChild(newElement);
   }
 
-  function sendPlatformMessage(msg: unknown) {
+  function sendPlatformMessage(msg: Record<string, any>) {
     chrome.runtime.sendMessage(msg);
   }
 
-  function fillSelectorWithFolders(folders: FolderView[]) {
+  function fillSelectorWithFolders(folders: Jsonify<FolderView[]>) {
     const select = document.querySelector("#template-add-clone .select-folder");
     select.appendChild(new Option(chrome.i18n.getMessage("selectFolder"), null, true));
     folders.forEach((folder) => {
-      //Select "No Folder" (id=null) folder by default
+      // Select "No Folder" (id=null) folder by default
       select.appendChild(new Option(folder.name, folder.id || "", false));
     });
   }

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -5,12 +5,18 @@ import type { FolderView } from "@bitwarden/common/vault/models/view/folder.view
 require("./bar.scss");
 
 document.addEventListener("DOMContentLoaded", () => {
-  contentLoaded();
+  // delay 50ms so that we get proper body dimensions
+  setTimeout(load, 50);
 });
 
-function contentLoaded() {
+function load() {
   const theme = getQueryVariable("theme");
   document.documentElement.classList.add("theme_" + theme);
+
+  const isVaultLocked = getQueryVariable("isVaultLocked") == "true";
+  (document.getElementById("logo") as HTMLImageElement).src = isVaultLocked
+    ? chrome.runtime.getURL("images/icon38_locked.png")
+    : chrome.runtime.getURL("images/icon38.png");
 
   const i18n = {
     appName: chrome.i18n.getMessage("appName"),
@@ -23,156 +29,146 @@ function contentLoaded() {
     notificationChangeDesc: chrome.i18n.getMessage("notificationChangeDesc"),
   };
 
-  // delay 50ms so that we get proper body dimensions
-  setTimeout(load, 50);
+  document.getElementById("logo-link").title = i18n.appName;
 
-  function load() {
-    const isVaultLocked = getQueryVariable("isVaultLocked") == "true";
-    (document.getElementById("logo") as HTMLImageElement).src = isVaultLocked
-      ? chrome.runtime.getURL("images/icon38_locked.png")
-      : chrome.runtime.getURL("images/icon38.png");
+  // i18n for "Add" template
+  const addTemplate = document.getElementById("template-add") as HTMLTemplateElement;
 
-    document.getElementById("logo-link").title = i18n.appName;
+  const neverButton = addTemplate.content.getElementById("never-save");
+  neverButton.textContent = i18n.never;
 
-    // i18n for "Add" template
-    const addTemplate = document.getElementById("template-add") as HTMLTemplateElement;
+  const selectFolder = addTemplate.content.getElementById("select-folder");
+  selectFolder.setAttribute("aria-label", i18n.folder);
+  selectFolder.dataset.isVaultLocked = isVaultLocked.toString();
 
-    const neverButton = addTemplate.content.getElementById("never-save");
-    neverButton.textContent = i18n.never;
+  const addButton = addTemplate.content.getElementById("add-save");
+  addButton.textContent = i18n.notificationAddSave;
 
-    const selectFolder = addTemplate.content.getElementById("select-folder");
-    selectFolder.setAttribute("aria-label", i18n.folder);
-    selectFolder.dataset.isVaultLocked = isVaultLocked.toString();
+  addTemplate.content.getElementById("add-text").textContent = i18n.notificationAddDesc;
 
-    const addButton = addTemplate.content.getElementById("add-save");
-    addButton.textContent = i18n.notificationAddSave;
+  // i18n for "Change" (update password) template
+  const changeTemplate = document.getElementById("template-change") as HTMLTemplateElement;
 
-    addTemplate.content.getElementById("add-text").textContent = i18n.notificationAddDesc;
+  const changeButton = changeTemplate.content.getElementById("change-save");
+  changeButton.textContent = i18n.notificationChangeSave;
 
-    // i18n for "Change" (update password) template
-    const changeTemplate = document.getElementById("template-change") as HTMLTemplateElement;
+  changeTemplate.content.getElementById("change-text").textContent = i18n.notificationChangeDesc;
 
-    const changeButton = changeTemplate.content.getElementById("change-save");
-    changeButton.textContent = i18n.notificationChangeSave;
+  // i18n for body content
+  const closeButton = document.getElementById("close-button");
+  closeButton.title = i18n.close;
 
-    changeTemplate.content.getElementById("change-text").textContent = i18n.notificationChangeDesc;
-
-    // i18n for body content
-    const closeButton = document.getElementById("close-button");
-    closeButton.title = i18n.close;
-
-    if (getQueryVariable("type") === "add") {
-      handleTypeAdd(isVaultLocked);
-    } else if (getQueryVariable("type") === "change") {
-      handleTypeChange();
-    }
-
-    closeButton.addEventListener("click", (e) => {
-      e.preventDefault();
-      sendPlatformMessage({
-        command: "bgCloseNotificationBar",
-      });
-    });
-
-    window.addEventListener("resize", adjustHeight);
-    adjustHeight();
+  if (getQueryVariable("type") === "add") {
+    handleTypeAdd(isVaultLocked);
+  } else if (getQueryVariable("type") === "change") {
+    handleTypeChange();
   }
 
-  function getQueryVariable(variable: string) {
-    const query = window.location.search.substring(1);
-    const vars = query.split("&");
-
-    for (let i = 0; i < vars.length; i++) {
-      const pair = vars[i].split("=");
-      if (pair[0] === variable) {
-        return pair[1];
-      }
-    }
-
-    return null;
-  }
-
-  function handleTypeAdd(isVaultLocked: boolean) {
-    setContent(document.getElementById("template-add") as HTMLTemplateElement);
-
-    const addButton = document.getElementById("add-save");
-    const neverButton = document.getElementById("never-save");
-
-    addButton.addEventListener("click", (e) => {
-      e.preventDefault();
-
-      const folderId = (document.getElementById("select-folder") as HTMLSelectElement).value;
-
-      const bgAddSaveMessage = {
-        command: "bgAddSave",
-        folder: folderId,
-      };
-      sendPlatformMessage(bgAddSaveMessage);
-    });
-
-    neverButton.addEventListener("click", (e) => {
-      e.preventDefault();
-      sendPlatformMessage({
-        command: "bgNeverSave",
-      });
-    });
-
-    if (!isVaultLocked) {
-      const responseFoldersCommand = "notificationBarGetFoldersList";
-      chrome.runtime.onMessage.addListener((msg) => {
-        if (msg.command === responseFoldersCommand && msg.data) {
-          fillSelectorWithFolders(msg.data.folders);
-        }
-      });
-      sendPlatformMessage({
-        command: "bgGetDataForTab",
-        responseCommand: responseFoldersCommand,
-      });
-    }
-  }
-
-  function handleTypeChange() {
-    setContent(document.getElementById("template-change") as HTMLTemplateElement);
-    const changeButton = document.getElementById("change-save");
-    changeButton.addEventListener("click", (e) => {
-      e.preventDefault();
-
-      const bgChangeSaveMessage = {
-        command: "bgChangeSave",
-      };
-      sendPlatformMessage(bgChangeSaveMessage);
-    });
-  }
-
-  function setContent(template: HTMLTemplateElement) {
-    const content = document.getElementById("content");
-    while (content.firstChild) {
-      content.removeChild(content.firstChild);
-    }
-
-    const newElement = template.content.cloneNode(true) as HTMLElement;
-    content.appendChild(newElement);
-  }
-
-  function sendPlatformMessage(msg: Record<string, any>) {
-    chrome.runtime.sendMessage(msg);
-  }
-
-  function fillSelectorWithFolders(folders: Jsonify<FolderView[]>) {
-    const select = document.getElementById("select-folder");
-    select.appendChild(new Option(chrome.i18n.getMessage("selectFolder"), null, true));
-    folders.forEach((folder) => {
-      // Select "No Folder" (id=null) folder by default
-      select.appendChild(new Option(folder.name, folder.id || "", false));
-    });
-  }
-
-  function adjustHeight() {
+  closeButton.addEventListener("click", (e) => {
+    e.preventDefault();
     sendPlatformMessage({
-      command: "bgAdjustNotificationBar",
-      data: {
-        height: document.querySelector("body").scrollHeight,
-      },
+      command: "bgCloseNotificationBar",
+    });
+  });
+
+  window.addEventListener("resize", adjustHeight);
+  adjustHeight();
+}
+
+function getQueryVariable(variable: string) {
+  const query = window.location.search.substring(1);
+  const vars = query.split("&");
+
+  for (let i = 0; i < vars.length; i++) {
+    const pair = vars[i].split("=");
+    if (pair[0] === variable) {
+      return pair[1];
+    }
+  }
+
+  return null;
+}
+
+function handleTypeAdd(isVaultLocked: boolean) {
+  setContent(document.getElementById("template-add") as HTMLTemplateElement);
+
+  const addButton = document.getElementById("add-save");
+  const neverButton = document.getElementById("never-save");
+
+  addButton.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    const folderId = (document.getElementById("select-folder") as HTMLSelectElement).value;
+
+    const bgAddSaveMessage = {
+      command: "bgAddSave",
+      folder: folderId,
+    };
+    sendPlatformMessage(bgAddSaveMessage);
+  });
+
+  neverButton.addEventListener("click", (e) => {
+    e.preventDefault();
+    sendPlatformMessage({
+      command: "bgNeverSave",
+    });
+  });
+
+  if (!isVaultLocked) {
+    const responseFoldersCommand = "notificationBarGetFoldersList";
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg.command === responseFoldersCommand && msg.data) {
+        fillSelectorWithFolders(msg.data.folders);
+      }
+    });
+    sendPlatformMessage({
+      command: "bgGetDataForTab",
+      responseCommand: responseFoldersCommand,
     });
   }
+}
+
+function handleTypeChange() {
+  setContent(document.getElementById("template-change") as HTMLTemplateElement);
+  const changeButton = document.getElementById("change-save");
+  changeButton.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    const bgChangeSaveMessage = {
+      command: "bgChangeSave",
+    };
+    sendPlatformMessage(bgChangeSaveMessage);
+  });
+}
+
+function setContent(template: HTMLTemplateElement) {
+  const content = document.getElementById("content");
+  while (content.firstChild) {
+    content.removeChild(content.firstChild);
+  }
+
+  const newElement = template.content.cloneNode(true) as HTMLElement;
+  content.appendChild(newElement);
+}
+
+function sendPlatformMessage(msg: Record<string, any>) {
+  chrome.runtime.sendMessage(msg);
+}
+
+function fillSelectorWithFolders(folders: Jsonify<FolderView[]>) {
+  const select = document.getElementById("select-folder");
+  select.appendChild(new Option(chrome.i18n.getMessage("selectFolder"), null, true));
+  folders.forEach((folder) => {
+    // Select "No Folder" (id=null) folder by default
+    select.appendChild(new Option(folder.name, folder.id || "", false));
+  });
+}
+
+function adjustHeight() {
+  sendPlatformMessage({
+    command: "bgAdjustNotificationBar",
+    data: {
+      height: document.querySelector("body").scrollHeight,
+    },
+  });
 }

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -34,26 +34,32 @@ function contentLoaded() {
 
     document.getElementById("logo-link").title = i18n.appName;
 
-    const neverButton = document.querySelector("#template-add .never-save");
+    // i18n for "Add" template
+    const addTemplate = document.getElementById("template-add") as HTMLTemplateElement;
+
+    const neverButton = addTemplate.content.getElementById("never-save");
     neverButton.textContent = i18n.never;
 
-    const selectFolder = document.querySelector("#template-add .select-folder");
+    const selectFolder = addTemplate.content.getElementById("select-folder");
     selectFolder.setAttribute("aria-label", i18n.folder);
     selectFolder.setAttribute("isVaultLocked", isVaultLocked.toString());
 
-    const addButton = document.querySelector("#template-add .add-save");
+    const addButton = addTemplate.content.getElementById("add-save");
     addButton.textContent = i18n.notificationAddSave;
 
-    const changeButton = document.querySelector("#template-change .change-save");
+    addTemplate.content.getElementById("add-text").textContent = i18n.notificationAddDesc;
+
+    // i18n for "Change" (update password) template
+    const changeTemplate = document.getElementById("template-change") as HTMLTemplateElement;
+
+    const changeButton = changeTemplate.content.getElementById("change-save");
     changeButton.textContent = i18n.notificationChangeSave;
 
+    changeTemplate.content.getElementById("change-text").textContent = i18n.notificationChangeDesc;
+
+    // i18n for body content
     const closeButton = document.getElementById("close-button");
     closeButton.title = i18n.close;
-    closeButton.setAttribute("aria-label", i18n.close);
-
-    document.querySelector("#template-add .add-text").textContent = i18n.notificationAddDesc;
-    document.querySelector("#template-change .change-text").textContent =
-      i18n.notificationChangeDesc;
 
     if (getQueryVariable("type") === "add") {
       handleTypeAdd(isVaultLocked);
@@ -87,17 +93,15 @@ function contentLoaded() {
   }
 
   function handleTypeAdd(isVaultLocked: boolean) {
-    setContent(document.getElementById("template-add"));
+    setContent(document.getElementById("template-add") as HTMLTemplateElement);
 
-    var addButton = document.querySelector("#template-add-clone .add-save"), // eslint-disable-line
-      neverButton = document.querySelector("#template-add-clone .never-save"); // eslint-disable-line
+    const addButton = document.getElementById("add-save");
+    const neverButton = document.getElementById("never-save");
 
     addButton.addEventListener("click", (e) => {
       e.preventDefault();
 
-      const folderId = (
-        document.querySelector("#template-add-clone .select-folder") as HTMLSelectElement
-      ).value;
+      const folderId = (document.getElementById("select-folder") as HTMLSelectElement).value;
 
       const bgAddSaveMessage = {
         command: "bgAddSave",
@@ -128,8 +132,8 @@ function contentLoaded() {
   }
 
   function handleTypeChange() {
-    setContent(document.getElementById("template-change"));
-    var changeButton = document.querySelector("#template-change-clone .change-save"); // eslint-disable-line
+    setContent(document.getElementById("template-change") as HTMLTemplateElement);
+    const changeButton = document.getElementById("change-save");
     changeButton.addEventListener("click", (e) => {
       e.preventDefault();
 
@@ -140,14 +144,13 @@ function contentLoaded() {
     });
   }
 
-  function setContent(element: HTMLElement) {
+  function setContent(template: HTMLTemplateElement) {
     const content = document.getElementById("content");
     while (content.firstChild) {
       content.removeChild(content.firstChild);
     }
 
-    const newElement = element.cloneNode(true) as HTMLElement;
-    newElement.id = newElement.id + "-clone";
+    const newElement = template.content.cloneNode(true) as HTMLElement;
     content.appendChild(newElement);
   }
 
@@ -156,7 +159,7 @@ function contentLoaded() {
   }
 
   function fillSelectorWithFolders(folders: Jsonify<FolderView[]>) {
-    const select = document.querySelector("#template-add-clone .select-folder");
+    const select = document.getElementById("select-folder");
     select.appendChild(new Option(chrome.i18n.getMessage("selectFolder"), null, true));
     folders.forEach((folder) => {
       // Select "No Folder" (id=null) folder by default

--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -146,7 +146,7 @@ const mainConfig = {
     "content/notificationBar": "./src/autofill/content/notification-bar.ts",
     "content/contextMenuHandler": "./src/autofill/content/context-menu-handler.ts",
     "content/message_handler": "./src/autofill/content/message_handler.ts",
-    "notification/bar": "./src/autofill/notification/bar.js",
+    "notification/bar": "./src/autofill/notification/bar.ts",
     "encrypt-worker": "../../libs/common/src/services/cryptography/encrypt.worker.ts",
   },
   optimization: {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Getting in some low-hanging tech debt before starting on save prompt improvements. It'll be easiest to review this commit-by-commit to see each step individually. I also recommend hiding whitespace in the diff.

This is being merged into a feature branch to minimise QA's testing load, but it shouldn't be too long lived.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- convert `bar.js` to typescript (cherry-picked from @justindbaur, thank you!)
- use native [template elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) for the notification bar template content, instead of hiding it in hidden divs. Elements within templates are not returned by `getElementById` or `querySelector` calls (unless called explicitly on `template.content`), so we can use proper ids instead of misusing classnames to identify content. (and adding `-clone` to cloned content, etc etc)
- use [HTML data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) for the `isVaultLocked` attribute on the folder selector. This is what data attributes are intended for and is preferable to making up our own HTML attributes
- un-nest all the `bar.ts` functions. I assume these were nested in one big function to avoid namespace clashes, but [content scripts are already isolated](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#isolated_world), so I don't think it's necessary.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
