### PR TITLE
[SG-901] Relocate Autofill on page load setting

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -32,7 +32,7 @@ import { SendAddEditComponent } from "./send/send-add-edit.component";
 import { SendGroupingsComponent } from "./send/send-groupings.component";
 import { SendTypeComponent } from "./send/send-type.component";
 import { DebounceNavigationService } from "./services/debounceNavigationService";
-import { AutofillComponent } from './settings/autofill.component';
+import { AutofillComponent } from "./settings/autofill.component";
 import { ExcludedDomainsComponent } from "./settings/excluded-domains.component";
 import { ExportComponent } from "./settings/export.component";
 import { FolderAddEditComponent } from "./settings/folder-add-edit.component";

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -32,6 +32,7 @@ import { SendAddEditComponent } from "./send/send-add-edit.component";
 import { SendGroupingsComponent } from "./send/send-groupings.component";
 import { SendTypeComponent } from "./send/send-type.component";
 import { DebounceNavigationService } from "./services/debounceNavigationService";
+import { AutofillComponent } from './settings/autofill.component';
 import { ExcludedDomainsComponent } from "./settings/excluded-domains.component";
 import { ExportComponent } from "./settings/export.component";
 import { FolderAddEditComponent } from "./settings/folder-add-edit.component";
@@ -186,6 +187,12 @@ const routes: Routes = [
     component: ExportComponent,
     canActivate: [AuthGuard],
     data: { state: "export" },
+  },
+  {
+    path: "autofill",
+    component: AutofillComponent,
+    canActivate: [AuthGuard],
+    data: { state: "autofill" },
   },
   {
     path: "folders",

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -110,6 +110,7 @@ import { SendGroupingsComponent } from "./send/send-groupings.component";
 import { SendTypeComponent } from "./send/send-type.component";
 import { ServicesModule } from "./services/services.module";
 import { AboutComponent } from "./settings/about.component";
+import { AutofillComponent } from './settings/autofill.component';
 import { ExcludedDomainsComponent } from "./settings/excluded-domains.component";
 import { ExportComponent } from "./settings/export.component";
 import { FolderAddEditComponent } from "./settings/folder-add-edit.component";
@@ -249,6 +250,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     RemovePasswordComponent,
     VaultSelectComponent,
     AboutComponent,
+    AutofillComponent
   ],
   providers: [CurrencyPipe, DatePipe],
   bootstrap: [AppComponent],

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -110,7 +110,7 @@ import { SendGroupingsComponent } from "./send/send-groupings.component";
 import { SendTypeComponent } from "./send/send-type.component";
 import { ServicesModule } from "./services/services.module";
 import { AboutComponent } from "./settings/about.component";
-import { AutofillComponent } from './settings/autofill.component';
+import { AutofillComponent } from "./settings/autofill.component";
 import { ExcludedDomainsComponent } from "./settings/excluded-domains.component";
 import { ExportComponent } from "./settings/export.component";
 import { FolderAddEditComponent } from "./settings/folder-add-edit.component";
@@ -250,7 +250,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     RemovePasswordComponent,
     VaultSelectComponent,
     AboutComponent,
-    AutofillComponent
+    AutofillComponent,
   ],
   providers: [CurrencyPipe, DatePipe],
   bootstrap: [AppComponent],

--- a/apps/browser/src/popup/settings/autofill.component.html
+++ b/apps/browser/src/popup/settings/autofill.component.html
@@ -1,0 +1,74 @@
+<header>
+    <div class="left">
+      <button type="button" routerLink="/tabs/settings">
+        <span class="header-icon"><i class="bwi bwi-angle-left" aria-hidden="true"></i></span>
+        <span>{{ "back" | i18n }}</span>
+      </button>
+    </div>
+    <h1 class="center">
+      <span class="title">{{ "autofill" | i18n }}</span>
+    </h1>
+    <div class="right"></div>
+</header>
+<main tabindex="-1">
+    <div class="box">
+        <div class="box-content">
+        <div class="box-content-row box-content-row-checkbox" appBoxRow>
+            <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
+            <input
+            id="autofill"
+            type="checkbox"
+            aria-describedby="autofillHelp"
+            (change)="updateAutoFillOnPageLoad()"
+            [(ngModel)]="enableAutoFillOnPageLoad"
+            />
+        </div>
+        </div>
+        <div id="autofillHelp" class="box-footer">
+        {{ "enableAutoFillOnPageLoadDesc" | i18n }}
+        <b>{{ "warning" | i18n }}</b
+        >: {{ "experimentalFeature" | i18n }}
+        </div>
+    </div>
+    <div class="box">
+        <div class="box-content">
+        <div class="box-content-row" appBoxRow>
+            <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
+            <select
+            id="defaultAutofill"
+            name="DefaultAutofill"
+            aria-describedby="defaultAutofillHelp"
+            [(ngModel)]="autoFillOnPageLoadDefault"
+            (change)="updateAutoFillOnPageLoadDefault()"
+            [disabled]="!enableAutoFillOnPageLoad"
+            >
+            <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
+                {{ o.name }}
+            </option>
+            </select>
+        </div>
+        </div>
+        <div id="defaultAutofillHelp" class="box-footer">
+        {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
+        </div>
+    </div>
+    <div class="box">
+        <div class="box-content">
+            <div class="box-content-row" appBoxRow>
+            <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
+            <select
+                id="defaultUriMatch"
+                name="DefaultUriMatch"
+                aria-describedby="defaultUriMatchHelp"
+                [(ngModel)]="defaultUriMatch"
+                (change)="saveDefaultUriMatch()"
+            >
+                <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
+            </select>
+            </div>
+        </div>
+        <div id="defaultUriMatchHelp" class="box-footer">
+            {{ "defaultUriMatchDetectionDesc" | i18n }}
+        </div>
+        </div>
+</main>

--- a/apps/browser/src/popup/settings/autofill.component.html
+++ b/apps/browser/src/popup/settings/autofill.component.html
@@ -1,74 +1,74 @@
 <header>
-    <div class="left">
-      <button type="button" routerLink="/tabs/settings">
-        <span class="header-icon"><i class="bwi bwi-angle-left" aria-hidden="true"></i></span>
-        <span>{{ "back" | i18n }}</span>
-      </button>
-    </div>
-    <h1 class="center">
-      <span class="title">{{ "autofill" | i18n }}</span>
-    </h1>
-    <div class="right"></div>
+  <div class="left">
+    <button type="button" routerLink="/tabs/settings">
+      <span class="header-icon"><i class="bwi bwi-angle-left" aria-hidden="true"></i></span>
+      <span>{{ "back" | i18n }}</span>
+    </button>
+  </div>
+  <h1 class="center">
+    <span class="title">{{ "autofill" | i18n }}</span>
+  </h1>
+  <div class="right"></div>
 </header>
 <main tabindex="-1">
-    <div class="box">
-        <div class="box-content">
-        <div class="box-content-row box-content-row-checkbox" appBoxRow>
-            <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
-            <input
-            id="autofill"
-            type="checkbox"
-            aria-describedby="autofillHelp"
-            (change)="updateAutoFillOnPageLoad()"
-            [(ngModel)]="enableAutoFillOnPageLoad"
-            />
-        </div>
-        </div>
-        <div id="autofillHelp" class="box-footer">
-        {{ "enableAutoFillOnPageLoadDesc" | i18n }}
-        <b>{{ "warning" | i18n }}</b
-        >: {{ "experimentalFeature" | i18n }}
-        </div>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
+        <input
+          id="autofill"
+          type="checkbox"
+          aria-describedby="autofillHelp"
+          (change)="updateAutoFillOnPageLoad()"
+          [(ngModel)]="enableAutoFillOnPageLoad"
+        />
+      </div>
     </div>
-    <div class="box">
-        <div class="box-content">
-        <div class="box-content-row" appBoxRow>
-            <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
-            <select
-            id="defaultAutofill"
-            name="DefaultAutofill"
-            aria-describedby="defaultAutofillHelp"
-            [(ngModel)]="autoFillOnPageLoadDefault"
-            (change)="updateAutoFillOnPageLoadDefault()"
-            [disabled]="!enableAutoFillOnPageLoad"
-            >
-            <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
-                {{ o.name }}
-            </option>
-            </select>
-        </div>
-        </div>
-        <div id="defaultAutofillHelp" class="box-footer">
-        {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
-        </div>
+    <div id="autofillHelp" class="box-footer">
+      {{ "enableAutoFillOnPageLoadDesc" | i18n }}
+      <b>{{ "warning" | i18n }}</b
+      >: {{ "experimentalFeature" | i18n }}
     </div>
-    <div class="box">
-        <div class="box-content">
-            <div class="box-content-row" appBoxRow>
-            <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
-            <select
-                id="defaultUriMatch"
-                name="DefaultUriMatch"
-                aria-describedby="defaultUriMatchHelp"
-                [(ngModel)]="defaultUriMatch"
-                (change)="saveDefaultUriMatch()"
-            >
-                <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
-            </select>
-            </div>
-        </div>
-        <div id="defaultUriMatchHelp" class="box-footer">
-            {{ "defaultUriMatchDetectionDesc" | i18n }}
-        </div>
-        </div>
+  </div>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
+        <select
+          id="defaultAutofill"
+          name="DefaultAutofill"
+          aria-describedby="defaultAutofillHelp"
+          [(ngModel)]="autoFillOnPageLoadDefault"
+          (change)="updateAutoFillOnPageLoadDefault()"
+          [disabled]="!enableAutoFillOnPageLoad"
+        >
+          <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
+            {{ o.name }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div id="defaultAutofillHelp" class="box-footer">
+      {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
+        <select
+          id="defaultUriMatch"
+          name="DefaultUriMatch"
+          aria-describedby="defaultUriMatchHelp"
+          [(ngModel)]="defaultUriMatch"
+          (change)="saveDefaultUriMatch()"
+        >
+          <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
+        </select>
+      </div>
+    </div>
+    <div id="defaultUriMatchHelp" class="box-footer">
+      {{ "defaultUriMatchDetectionDesc" | i18n }}
+    </div>
+  </div>
 </main>

--- a/apps/browser/src/popup/settings/autofill.component.ts
+++ b/apps/browser/src/popup/settings/autofill.component.ts
@@ -11,26 +11,23 @@ import { UriMatchType } from "@bitwarden/common/enums/uriMatchType";
 export class AutofillComponent implements OnInit {
   enableAutoFillOnPageLoad = false;
   autoFillOnPageLoadDefault = false;
-  autoFillOnPageLoadOptions: any[]; 
+  autoFillOnPageLoadOptions: any[];
   defaultUriMatch = UriMatchType.Domain;
   uriMatchOptions: any[];
 
-  constructor(
-    private stateService: StateService,
-    i18nService: I18nService
-  ) {
+  constructor(private stateService: StateService, i18nService: I18nService) {
     this.autoFillOnPageLoadOptions = [
       { name: i18nService.t("autoFillOnPageLoadYes"), value: true },
       { name: i18nService.t("autoFillOnPageLoadNo"), value: false },
     ];
     this.uriMatchOptions = [
-        { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
-        { name: i18nService.t("host"), value: UriMatchType.Host },
-        { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
-        { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
-        { name: i18nService.t("exact"), value: UriMatchType.Exact },
-        { name: i18nService.t("never"), value: UriMatchType.Never },
-      ];
+      { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
+      { name: i18nService.t("host"), value: UriMatchType.Host },
+      { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
+      { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
+      { name: i18nService.t("exact"), value: UriMatchType.Exact },
+      { name: i18nService.t("never"), value: UriMatchType.Never },
+    ];
   }
 
   async ngOnInit() {
@@ -38,7 +35,7 @@ export class AutofillComponent implements OnInit {
 
     this.autoFillOnPageLoadDefault =
       (await this.stateService.getAutoFillOnPageLoadDefault()) ?? true;
-      
+
     const defaultUriMatch = await this.stateService.getDefaultUriMatch();
     this.defaultUriMatch = defaultUriMatch == null ? UriMatchType.Domain : defaultUriMatch;
   }

--- a/apps/browser/src/popup/settings/autofill.component.ts
+++ b/apps/browser/src/popup/settings/autofill.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit } from "@angular/core";
+
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { StateService } from "@bitwarden/common/abstractions/state.service";
+import { UriMatchType } from "@bitwarden/common/enums/uriMatchType";
+
+@Component({
+  selector: "app-autofill",
+  templateUrl: "autofill.component.html",
+})
+export class AutofillComponent implements OnInit {
+  enableAutoFillOnPageLoad = false;
+  autoFillOnPageLoadDefault = false;
+  autoFillOnPageLoadOptions: any[]; 
+  defaultUriMatch = UriMatchType.Domain;
+  uriMatchOptions: any[];
+
+  constructor(
+    private stateService: StateService,
+    i18nService: I18nService
+  ) {
+    this.autoFillOnPageLoadOptions = [
+      { name: i18nService.t("autoFillOnPageLoadYes"), value: true },
+      { name: i18nService.t("autoFillOnPageLoadNo"), value: false },
+    ];
+    this.uriMatchOptions = [
+        { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
+        { name: i18nService.t("host"), value: UriMatchType.Host },
+        { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
+        { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
+        { name: i18nService.t("exact"), value: UriMatchType.Exact },
+        { name: i18nService.t("never"), value: UriMatchType.Never },
+      ];
+  }
+
+  async ngOnInit() {
+    this.enableAutoFillOnPageLoad = await this.stateService.getEnableAutoFillOnPageLoad();
+
+    this.autoFillOnPageLoadDefault =
+      (await this.stateService.getAutoFillOnPageLoadDefault()) ?? true;
+      
+    const defaultUriMatch = await this.stateService.getDefaultUriMatch();
+    this.defaultUriMatch = defaultUriMatch == null ? UriMatchType.Domain : defaultUriMatch;
+  }
+
+  async updateAutoFillOnPageLoad() {
+    await this.stateService.setEnableAutoFillOnPageLoad(this.enableAutoFillOnPageLoad);
+  }
+
+  async updateAutoFillOnPageLoadDefault() {
+    await this.stateService.setAutoFillOnPageLoadDefault(this.autoFillOnPageLoadDefault);
+  }
+
+  async saveDefaultUriMatch() {
+    await this.stateService.setDefaultUriMatch(this.defaultUriMatch);
+  }
+}

--- a/apps/browser/src/popup/settings/options.component.html
+++ b/apps/browser/src/popup/settings/options.component.html
@@ -26,25 +26,6 @@
     </h2>
   </div>
   <ng-container *ngIf="showGeneral">
-    <div class="box">
-      <div class="box-content">
-        <div class="box-content-row" appBoxRow>
-          <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
-          <select
-            id="defaultUriMatch"
-            name="DefaultUriMatch"
-            aria-describedby="defaultUriMatchHelp"
-            [(ngModel)]="defaultUriMatch"
-            (change)="saveDefaultUriMatch()"
-          >
-            <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
-          </select>
-        </div>
-      </div>
-      <div id="defaultUriMatchHelp" class="box-footer">
-        {{ "defaultUriMatchDetectionDesc" | i18n }}
-      </div>
-    </div>
     <div class="box" *ngIf="showClearClipboard">
       <div class="box-content">
         <div class="box-content-row" appBoxRow>
@@ -226,63 +207,6 @@
         </div>
       </div>
       <div id="themeHelp" class="box-footer">{{ "themeDesc" | i18n }}</div>
-    </div>
-  </ng-container>
-  <div class="box box-section-divider">
-    <h2>
-      <button
-        type="button"
-        class="box-header-expandable"
-        (click)="showAutofill = !showAutofill"
-        [attr.aria-expanded]="showAutofill"
-      >
-        <i *ngIf="!showAutofill" class="bwi bwi-angle-right bwi-sm icon" aria-hidden="true"></i>
-        <i *ngIf="showAutofill" class="bwi bwi-angle-down bwi-sm icon" aria-hidden="true"></i>
-        Autofill
-      </button>
-    </h2>
-  </div>
-  <ng-container *ngIf="showAutofill">
-    <div class="box">
-      <div class="box-content">
-        <div class="box-content-row box-content-row-checkbox" appBoxRow>
-          <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
-          <input
-            id="autofill"
-            type="checkbox"
-            aria-describedby="autofillHelp"
-            (change)="updateAutoFillOnPageLoad()"
-            [(ngModel)]="enableAutoFillOnPageLoad"
-          />
-        </div>
-      </div>
-      <div id="autofillHelp" class="box-footer">
-        {{ "enableAutoFillOnPageLoadDesc" | i18n }}
-        <b>{{ "warning" | i18n }}</b
-        >: {{ "experimentalFeature" | i18n }}
-      </div>
-    </div>
-    <div class="box">
-      <div class="box-content">
-        <div class="box-content-row" appBoxRow>
-          <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
-          <select
-            id="defaultAutofill"
-            name="DefaultAutofill"
-            aria-describedby="defaultAutofillHelp"
-            [(ngModel)]="autoFillOnPageLoadDefault"
-            (change)="updateAutoFillOnPageLoadDefault()"
-            [disabled]="!enableAutoFillOnPageLoad"
-          >
-            <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
-              {{ o.name }}
-            </option>
-          </select>
-        </div>
-      </div>
-      <div id="defaultAutofillHelp" class="box-footer">
-        {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
-      </div>
     </div>
   </ng-container>
 </main>

--- a/apps/browser/src/popup/settings/settings.component.html
+++ b/apps/browser/src/popup/settings/settings.component.html
@@ -12,6 +12,14 @@
     <h2 class="box-header">{{ "manage" | i18n }}</h2>
     <div class="box-content single-line">
       <button
+      type="button"
+      class="box-content-row box-content-row-flex text-default"
+      routerLink="/autofill"
+    >
+      <div class="row-main">{{ "autofill" | i18n }}</div>
+      <i class="bwi bwi-angle-right bwi-lg row-sub-icon" aria-hidden="true"></i>
+    </button>
+      <button
         type="button"
         class="box-content-row box-content-row-flex text-default"
         routerLink="/folders"

--- a/apps/browser/src/popup/settings/settings.component.html
+++ b/apps/browser/src/popup/settings/settings.component.html
@@ -12,13 +12,13 @@
     <h2 class="box-header">{{ "manage" | i18n }}</h2>
     <div class="box-content single-line">
       <button
-      type="button"
-      class="box-content-row box-content-row-flex text-default"
-      routerLink="/autofill"
-    >
-      <div class="row-main">{{ "autofill" | i18n }}</div>
-      <i class="bwi bwi-angle-right bwi-lg row-sub-icon" aria-hidden="true"></i>
-    </button>
+        type="button"
+        class="box-content-row box-content-row-flex text-default"
+        routerLink="/autofill"
+      >
+        <div class="row-main">{{ "autofill" | i18n }}</div>
+        <i class="bwi bwi-angle-right bwi-lg row-sub-icon" aria-hidden="true"></i>
+      </button>
       <button
         type="button"
         class="box-content-row box-content-row-flex text-default"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add “Auto-fill” option under “Manage”
When clicked, slide up a new page title “Auto-fill” where the following settings are moved from the “Options” page:
Auto-fill on page load
Default auto-fill setting for login items
Default URL match detection
Remove above items from the “Options” page
## Code changes
Added new Autofill component for the navigation in Settings
Moved code from Options to Autofill
Declared component and route

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4648522/216314055-695d235c-259c-4621-b07d-c28a1da936b6.png">
<img width="373" alt="image" src="https://user-images.githubusercontent.com/4648522/216314111-3d574260-f1e1-49ea-bf86-9aa15db64edd.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
