### PR TITLE
Add type check to npm scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,7 @@ jobs:
       # Tests in apps/ are typechecked when their app is built, so we just do it here for libs/
       # See https://bitwarden.atlassian.net/browse/EC-497
       - name: Run typechecking
-        run: |
-          for p in libs/**/tsconfig.spec.json; do
-            echo "Typechecking $p"
-            npx tsc --noEmit --project $p
-          done
+        run: npm run test:types
 
       - name: Run tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "jest",
     "test:watch": "jest --clearCache && jest --watch",
     "test:watch:all": "jest --watchAll",
+    "test:types": "for p in libs/**/tsconfig.spec.json; do  echo \"Typechecking $p\"; tsc --noEmit --project $p; done",
     "docs:json": "compodoc -p ./tsconfig.json -e json -d .",
     "storybook": "npm run docs:json && start-storybook -p 6006",
     "build-storybook": "npm run docs:json && build-storybook",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Adds a convenience script to typecheck as we do as part of our build pipeline ([added here](https://github.com/bitwarden/clients/pull/3421)).

⚠️ Here I only add the script, but I'm of the opinion this should be added to the `test` script directly
```json
"test": "concurrently -n Types,Jest -c yellow,cyan \"npm run test:types\" \"jest\"",
```

Opinions on that?

I also see much less value in adding these to watch commands, but open to investigating that as well.