### PR TITLE
Improve session syncer observables

### DIFF
--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.spec.ts
@@ -85,22 +85,33 @@ describe("session syncer", () => {
       replaySubject.next("3");
       sut = new SessionSyncer(replaySubject, storageService, metaData);
       // block observing the subject
-      jest.spyOn(sut as any, "observe").mockImplementation();
+      const observeSpy = jest.spyOn(sut as any, "observe").mockImplementation();
 
       sut.init();
 
-      expect(sut["ignoreNUpdates"]).toBe(3);
+      expect(observeSpy).toHaveBeenCalledWith(3);
     });
 
     it("should ignore BehaviorSubject's initial value", () => {
       const behaviorSubject = new BehaviorSubject<string>("initial");
       sut = new SessionSyncer(behaviorSubject, storageService, metaData);
       // block observing the subject
-      jest.spyOn(sut as any, "observe").mockImplementation();
+      const observeSpy = jest.spyOn(sut as any, "observe").mockImplementation();
 
       sut.init();
 
-      expect(sut["ignoreNUpdates"]).toBe(1);
+      expect(observeSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should not ignore Subject's first value", () => {
+      const behaviorSubject = new Subject<string>();
+      sut = new SessionSyncer(behaviorSubject, storageService, metaData);
+      // block observing the subject
+      const observeSpy = jest.spyOn(sut as any, "observe").mockImplementation();
+
+      sut.init();
+
+      expect(observeSpy).toHaveBeenCalledWith(0);
     });
 
     it("should grab an initial value from storage if it exists", async () => {

--- a/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
+++ b/apps/browser/src/decorators/session-sync-observable/session-syncer.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject, concatMap, ReplaySubject, skip, Subject, Subscription } from "rxjs";
 
 import { AbstractMemoryStorageService } from "@bitwarden/common/abstractions/storage.service";
+import { skipFrom } from "@bitwarden/common/misc/skip-from.operator";
 import { Utils } from "@bitwarden/common/misc/utils";
 
 import { BrowserApi } from "../../browser/browserApi";
@@ -12,7 +13,7 @@ export class SessionSyncer {
   id = Utils.newGuid();
 
   // ignore initial values
-  private ignoreNUpdates = 0;
+  private skip$ = new Subject<number>();
 
   constructor(
     private subject: Subject<any>,
@@ -29,19 +30,20 @@ export class SessionSyncer {
   }
 
   async init() {
+    let initialIgnore = 0;
     switch (this.subject.constructor) {
       case ReplaySubject:
         // ignore all updates currently in the buffer
-        this.ignoreNUpdates = (this.subject as any)._buffer.length;
+        initialIgnore = (this.subject as any)._buffer.length;
         break;
       case BehaviorSubject:
-        this.ignoreNUpdates = 1;
+        initialIgnore = 1;
         break;
       default:
         break;
     }
 
-    await this.observe();
+    await this.observe(initialIgnore);
     // must be synchronous
     const hasInSessionMemory = await this.memoryStorageService.has(this.metaData.sessionKey);
     if (hasInSessionMemory) {
@@ -51,20 +53,16 @@ export class SessionSyncer {
     this.listenForUpdates();
   }
 
-  private async observe() {
-    const stream = this.subject.pipe(skip(this.ignoreNUpdates));
-    this.ignoreNUpdates = 0;
+  private async observe(initialIgnore: number) {
+    const stream = this.subject.pipe(skip(initialIgnore));
 
     // This may be a memory leak.
     // There is no good time to unsubscribe from this observable. Hopefully Manifest V3 clears memory from temporary
     // contexts. If so, this is handled by destruction of the context.
     this.subscription = stream
       .pipe(
+        skipFrom(this.skip$),
         concatMap(async (next) => {
-          if (this.ignoreNUpdates > 0) {
-            this.ignoreNUpdates -= 1;
-            return;
-          }
           await this.updateSession(next);
         })
       )
@@ -91,7 +89,7 @@ export class SessionSyncer {
     const value = await this.memoryStorageService.getBypassCache(this.metaData.sessionKey, {
       deserializer: builder,
     });
-    this.ignoreNUpdates = 1;
+    this.skip$.next(1);
     this.subject.next(value);
   }
 

--- a/libs/common/src/misc/skip-from.operator.spec.ts
+++ b/libs/common/src/misc/skip-from.operator.spec.ts
@@ -1,0 +1,59 @@
+import { TestScheduler } from "rxjs/testing";
+
+import { skipFrom } from "./skip-from.operator";
+
+describe("skipFrom", () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it("should skip the initialization value", () => {
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers;
+      const e1 = cold("                 -a--b--c---|");
+      const skipSource = cold<number>(" -----------|");
+      const expected = "                ----b--c---|";
+
+      expectObservable(e1.pipe(skipFrom(skipSource, 1))).toBe(expected);
+    });
+  });
+
+  it("should unsubscribe from the source", () => {
+    testScheduler.run((helpers) => {
+      const { cold, expectSubscriptions } = helpers;
+      const e1 = cold("                 -a--b--c---|");
+      const skipSource = cold<number>(" -----------|");
+      const e2subs = "                  ^----------!";
+
+      e1.pipe(skipFrom(skipSource, 1)).subscribe().unsubscribe();
+
+      expectSubscriptions(skipSource.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it("should skip values based on the source", () => {
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers;
+      const e1 = cold("                 -a--b--c---|");
+      const skipSource = cold<number>(" --1--------|");
+      const expected = "                -a-----c---|";
+
+      expectObservable(e1.pipe(skipFrom(skipSource, 0))).toBe(expected);
+    });
+  });
+
+  it("should update skip values based on the most recent source", () => {
+    testScheduler.run((helpers) => {
+      const { cold, expectObservable } = helpers;
+      const e1 = cold("                 -a--b--c---|");
+      const skipSource = cold<number>(" --2--0-----|");
+      const expected = "                -a-----c---|";
+
+      expectObservable(e1.pipe(skipFrom(skipSource, 0))).toBe(expected);
+    });
+  });
+});

--- a/libs/common/src/misc/skip-from.operator.ts
+++ b/libs/common/src/misc/skip-from.operator.ts
@@ -1,0 +1,33 @@
+import { MonoTypeOperatorFunction, Observable } from "rxjs";
+
+export function skipFrom<T>(
+  skipSource: Observable<number>,
+  initialSkip = 0
+): MonoTypeOperatorFunction<T> {
+  let skip = initialSkip;
+  const innerSubscription = skipSource.subscribe((value) => {
+    skip = value;
+  });
+
+  return function <T>(source: Observable<T>) {
+    return new Observable<T>((subscriber) => {
+      source.subscribe({
+        next(value) {
+          if (skip > 0) {
+            skip -= 1;
+          } else {
+            subscriber.next(value);
+          }
+        },
+        error(err: unknown) {
+          innerSubscription.unsubscribe();
+          subscriber.error(err);
+        },
+        complete() {
+          innerSubscription.unsubscribe();
+          subscriber.complete();
+        },
+      });
+    });
+  };
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR was born of a discussion with @coroiu over observable best-practices. We realized we could convert the `concatMap` to a `switchMap` and potentially improve message backpressure during frequent update events.

Improvements to message ignore logic with `skipFrom` is an idiomatic change to attempt to split filtering logic from subscription actions.

## Code changes

- **session-syncer**: 
  - Move `updateSession` to returning an `Observable` with well-defined teardown logic. This allows us to swap to a `switchMap` and have our `Promise` handle the case where another even comes in while writing state to disk. Of course, there is still the time between sending a message and handling it that would be nice to close, but this is a good step forward.
  - Use `skipFrom` to handle subject skips. This is an idiomatic change in which we are trying to logically separate the intended action from filtering of potential events.
- **skipFrom**: an Observable-based skip filter. It works by forcing an internal skip counter to the emitted value and skipping the next `n` events (unless a new event is emitted on `skipSource`)
 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
