### PR TITLE
[PS-2414] Fix missing kdf parameters in key connector code

### DIFF
--- a/libs/common/src/models/request/account/set-key-connector-key.request.ts
+++ b/libs/common/src/models/request/account/set-key-connector-key.request.ts
@@ -1,4 +1,5 @@
 import { KdfType } from "../../../enums/kdfType";
+import { KdfConfig } from "../../domain/kdf-config";
 import { KeysRequest } from "../keys.request";
 
 export class SetKeyConnectorKeyRequest {
@@ -6,18 +7,22 @@ export class SetKeyConnectorKeyRequest {
   keys: KeysRequest;
   kdf: KdfType;
   kdfIterations: number;
+  kdfMemory?: number;
+  kdfParallelism?: number;
   orgIdentifier: string;
 
   constructor(
     key: string,
     kdf: KdfType,
-    kdfIterations: number,
+    kdfConfig: KdfConfig,
     orgIdentifier: string,
     keys: KeysRequest
   ) {
     this.key = key;
     this.kdf = kdf;
-    this.kdfIterations = kdfIterations;
+    this.kdfIterations = kdfConfig.iterations;
+    this.kdfMemory = kdfConfig.memory;
+    this.kdfParallelism = kdfConfig.parallelism;
     this.orgIdentifier = orgIdentifier;
     this.keys = keys;
   }

--- a/libs/common/src/services/keyConnector.service.ts
+++ b/libs/common/src/services/keyConnector.service.ts
@@ -85,12 +85,13 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   async convertNewSsoUserToKeyConnector(tokenResponse: IdentityTokenResponse, orgId: string) {
     const { kdf, kdfIterations, kdfMemory, kdfParallelism, keyConnectorUrl } = tokenResponse;
     const password = await this.cryptoFunctionService.randomBytes(64);
+    const kdfConfig = new KdfConfig(kdfIterations, kdfMemory, kdfParallelism);
 
     const k = await this.cryptoService.makeKey(
       Utils.fromBufferToB64(password),
       await this.tokenService.getEmail(),
       kdf,
-      new KdfConfig(kdfIterations, kdfMemory, kdfParallelism)
+      kdfConfig
     );
     const keyConnectorRequest = new KeyConnectorUserKeyRequest(k.encKeyB64);
     await this.cryptoService.setKey(k);
@@ -110,7 +111,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     const setPasswordRequest = new SetKeyConnectorKeyRequest(
       encKey[1].encryptedString,
       kdf,
-      kdfIterations,
+      kdfConfig,
       orgId,
       keys
     );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Due to https://github.com/bitwarden/mobile/pull/2339 I had another look at the changes, and saw that in the key connector code, adding memory / parallelism seems to have been forgotten. The server side does expect the parameters: https://github.com/bitwarden/server/blob/cb1ba50ce26ce33b2a5acf30536a2075e4fadebd/src/Api/Models/Request/Accounts/SetKeyConnectorKeyRequestModel.cs#L17-L21

## Code changes

The changes are: 
- set-key-connector-key.request.ts: Replace kdfiterations by kdfconfig in parameters and add memory and parallelism
- keyConnector.service.ts: replace kdfIterations by kdfConfig as the parameter for the key connector request