### PR TITLE
[EC-1063] Fix race condition when adding item from collections list

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -161,6 +161,9 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
+    this.writeableCollections = await this.loadCollections();
+    this.canUseReprompt = await this.passwordRepromptService.enabled();
+
     this.policyService
       .policyAppliesToActiveUser$(PolicyType.PersonalOwnership)
       .pipe(
@@ -201,10 +204,6 @@ export class AddEditComponent implements OnInit, OnDestroy {
     if (!this.allowPersonal) {
       this.organizationId = this.ownershipOptions[0].value;
     }
-
-    this.writeableCollections = await this.loadCollections();
-
-    this.canUseReprompt = await this.passwordRepromptService.enabled();
   }
 
   async load() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix #4276. There is a race condition where `writeableCollections` is being set within a subscription callback in the `AddEditComponent` base class, which happens asynchronously but cannot be `await`ed by the child class. The child class ends up racing ahead and accessing it before it's set by the base class.

This does not actually need to be in the subscription callback, so we can just move the assignment up to `ngOnInit` in the base class. Same with `canUseReprompt` which I've moved while we're here.

However, this generally seems at high regression risk due to the way this subscription is structured (lots of unpredictable side effects) so I will flag with the appropriate team.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
