### PR TITLE
Add `wasm-unsafe-eval` to browser CSP

### DIFF
--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -65,7 +65,7 @@
     "webRequestBlocking"
   ],
   "optional_permissions": ["nativeMessaging"],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; object-src 'self'",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-2387

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Apparently the browser extension manifest v2 file also needs a CSP for loading WASM support. It works on my machine with ot without it, but QA is reporting problems in their testing that seems to suggest it is needed here too.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **manifest.json:** Add wasm support to CSP.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
