### PR TITLE
[PS-2387] dont remove CSP on browser dist

### DIFF
--- a/apps/browser/gulpfile.js
+++ b/apps/browser/gulpfile.js
@@ -59,7 +59,6 @@ function dist(browserName, manifest) {
 
 function distFirefox() {
   return dist("firefox", (manifest) => {
-    delete manifest.content_security_policy;
     delete manifest.storage;
     return manifest;
   });
@@ -68,7 +67,6 @@ function distFirefox() {
 function distOpera() {
   return dist("opera", (manifest) => {
     delete manifest.applications;
-    delete manifest.content_security_policy;
     return manifest;
   });
 }
@@ -76,7 +74,6 @@ function distOpera() {
 function distChrome() {
   return dist("chrome", (manifest) => {
     delete manifest.applications;
-    delete manifest.content_security_policy;
     delete manifest.sidebar_action;
     delete manifest.commands._execute_sidebar_action;
     return manifest;
@@ -86,7 +83,6 @@ function distChrome() {
 function distEdge() {
   return dist("edge", (manifest) => {
     delete manifest.applications;
-    delete manifest.content_security_policy;
     delete manifest.sidebar_action;
     delete manifest.commands._execute_sidebar_action;
     return manifest;

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -65,7 +65,7 @@
     "webRequestBlocking"
   ],
   "optional_permissions": ["nativeMessaging"],
-  "content_security_policy": "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-2387

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Previously we have been removing the CSP from the manifest.json file on dist builds. With the addition of argon2, we now require the CSP to be defined to allow WASM code to load. This PR removes the step during the dist build that deletes the CSP definition. It also bases our CSP back to the default value, which is `"script-src 'self'; object-src 'self';"`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **manifest.json:** Remove `'unsafe-eval'` since it is not part of the default CSP.
- **gulpfile.js:**: Don't delete the CSP from manifest.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
