### PR TITLE
[SM-479] fix sm-no-items in service accounts

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.html
@@ -5,9 +5,9 @@
 </div>
 
 <sm-no-items *ngIf="serviceAccounts?.length == 0">
-  <ng-container title>{{ "serviceAccountsNoItemsTitle" | i18n }}</ng-container>
-  <ng-container description>{{ "serviceAccountsNoItemsMessage" | i18n }}</ng-container>
-  <button bitButton buttonType="secondary" (click)="newServiceAccountEvent.emit()">
+  <ng-container slot="title">{{ "serviceAccountsNoItemsTitle" | i18n }}</ng-container>
+  <ng-container slot="description">{{ "serviceAccountsNoItemsMessage" | i18n }}</ng-container>
+  <button slot="button" bitButton buttonType="secondary" (click)="newServiceAccountEvent.emit()">
     <i class="bwi bwi-plus" aria-hidden="true"></i>
     {{ "newServiceAccount" | i18n }}
   </button>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `sm-no-items` component wasn't displaying correctly in the service accounts page. This renames the children of the component to make content projection work properly.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
