### PR TITLE
[PS-2422] Keeper CSV import: Fix subfolders not being created

### DIFF
--- a/libs/common/spec/importers/keeper-csv-importer.spec.ts
+++ b/libs/common/spec/importers/keeper-csv-importer.spec.ts
@@ -1,4 +1,5 @@
 import { KeeperCsvImporter as Importer } from "@bitwarden/common/importers/keeper/keeper-csv-importer";
+import { Utils } from "@bitwarden/common/misc/utils";
 
 import { testData as TestData } from "./test-data/keeper-csv/testdata.csv";
 
@@ -73,5 +74,50 @@ describe("Keeper CSV Importer", () => {
     const cipher3 = result.ciphers.shift();
     expect(cipher3.fields[0].name).toEqual("Account ID");
     expect(cipher3.fields[0].value).toEqual("23456");
+  });
+
+  it("should create folders, with subfolders and relationships", async () => {
+    const result = await importer.parse(TestData);
+    expect(result != null).toBe(true);
+
+    const folders = result.folders;
+    expect(folders).not.toBeNull();
+    expect(folders.length).toBe(2);
+
+    const folder1 = folders.shift();
+    expect(folder1.name).toBe("Foo");
+
+    //With subfolders
+    const folder2 = folders.shift();
+    expect(folder2.name).toBe("Foo/Baz");
+
+    // [Cipher, Folder]
+    expect(result.folderRelationships.length).toBe(3);
+    expect(result.folderRelationships[0]).toEqual([0, 0]);
+    expect(result.folderRelationships[1]).toEqual([1, 0]);
+    expect(result.folderRelationships[2]).toEqual([2, 1]);
+  });
+
+  it("should create collections, with subcollections and relationships", async () => {
+    importer.organizationId = Utils.newGuid();
+    const result = await importer.parse(TestData);
+    expect(result != null).toBe(true);
+
+    const collections = result.collections;
+    expect(collections).not.toBeNull();
+    expect(collections.length).toBe(2);
+
+    const collections1 = collections.shift();
+    expect(collections1.name).toBe("Foo");
+
+    //With subCollection
+    const collections2 = collections.shift();
+    expect(collections2.name).toBe("Foo/Baz");
+
+    // [Cipher, Folder]
+    expect(result.collectionRelationships.length).toBe(3);
+    expect(result.collectionRelationships[0]).toEqual([0, 0]);
+    expect(result.collectionRelationships[1]).toEqual([1, 0]);
+    expect(result.collectionRelationships[2]).toEqual([2, 1]);
   });
 });

--- a/libs/common/src/importers/base-importer.ts
+++ b/libs/common/src/importers/base-importer.ts
@@ -418,6 +418,8 @@ export abstract class BaseImporter {
   protected processFolder(result: ImportResult, folderName: string) {
     let folderIndex = result.folders.length;
     const hasFolder = !this.isNullOrWhitespace(folderName);
+    // Replace backslashes with forward slashes, ensuring we create sub-folders
+    folderName = folderName.replace("\\", "/");
     let addFolder = hasFolder;
 
     if (hasFolder) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In Bitwarden, subfolders are separated/indicated using forward-slashes The Keeper CSV export separates folders uses backslashes 

The import completes successfully, but subfolders are not shown as subfolders in the UI. They behaved like normal root-folders.

## Code changes
- **libs/common/src/importers/base-importer.ts:** Replace backslashes with forwardslashes in baseImporter, as this ensures all importers using this method benefit from this fix.
- **libs/common/spec/importers/keeper-csv-importer.spec.ts:** Added tests to verfiy folder/collection creation

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
