### PR TITLE
[DEVOPS-1185] Split out the windows os from the new cli matrix build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Version Test
         run: |
           unzip "./dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
-          testVersion=$(bw -v)
+          testVersion=$(./test/bw -v)
           echo "version: $_PACKAGE_VERSION"
           echo "testVersion: $testVersion"
           if [[ $testVersion != $_PACKAGE_VERSION ]]; then

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -66,10 +66,10 @@ jobs:
 
 
   cli:
-    name: Build CLI
+    name: Build CLI ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, macos-11]
     runs-on: ${{ matrix.os }}
     needs:
       - setup
@@ -82,14 +82,81 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
 
       - name: Setup Unix Vars
-        if: runner.os != 'Windows'
         run: |
           echo "LOWER_RUNNER_OS=$(echo $RUNNER_OS | awk '{print tolower($0)}')" >> $GITHUB_ENV
           echo "SHORT_RUNNER_OS=$(echo $RUNNER_OS | awk '{print substr($0, 1, 3)}' | \
             awk '{print tolower($0)}')" >> $GITHUB_ENV
 
+      - name: Set up Node
+        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048  # v3.2.0
+        with:
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+          node-version: '16'
+
+      - name: Install node-gyp
+        run: |
+          npm install -g node-gyp
+          node-gyp install $(node -v)
+
+      - name: Install
+        run: npm ci
+        working-directory: ./
+
+      - name: Build & Package Unix
+        run: npm run dist:${{ env.SHORT_RUNNER_OS }} --quiet
+
+      - name: Zip Unix
+        run: |
+          cd ./dist/${{ env.LOWER_RUNNER_OS }}
+          zip ../bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip ./bw
+
+      - name: Version Test
+        run: |
+          cd ./dist/
+          unzip "./dist/bw-windows-${env:_PACKAGE_VERSION}.zip" -d "./test"
+          testVersion=$(bw -v)
+          echo "version: $_PACKAGE_VERSION"
+          echo "testVersion: $testVersion"
+          if [[ $testVersion != $_PACKAGE_VERSION ]]; then
+            echo "Version test failed."
+            exit 1
+          fi
+
+      - name: Create checksums Unix
+        run: |
+          cd ./dist
+          sha256sum bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip \
+            | awk '{split($0, a); print a[1]}' > bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
+
+      - name: Upload unix zip asset
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+        with:
+          name: bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
+          path: apps/cli/dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
+          if-no-files-found: error
+
+      - name: Upload unix checksum asset
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+        with:
+          name: bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
+          path: apps/cli/dist/bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
+          if-no-files-found: error
+
+  cli-windows:
+    name: Build CLI Windows
+    runs-on: windows-2019
+    needs:
+      - setup
+    env:
+      _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
+      _WIN_PKG_FETCH_VERSION: 16.16.0
+      _WIN_PKG_VERSION: 3.4
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
+
       - name: Setup Windows builder
-        if: runner.os == 'Windows'
         run: |
           choco install checksum --no-progress
           choco install reshack --no-progress
@@ -109,7 +176,6 @@ jobs:
 
       - name: Get pkg-fetch
         shell: pwsh
-        if: runner.os == 'Windows'
         run: |
           cd $HOME
           $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v$env:_WIN_PKG_VERSION/node-v$env:_WIN_PKG_FETCH_VERSION-win-x64"
@@ -120,7 +186,6 @@ jobs:
 
       - name: Setup Version Info
         shell: pwsh
-        if: runner.os == 'Windows'
         run: |
           $major,$minor,$patch = $env:_PACKAGE_VERSION.split('.')
           $versionInfo = @"
@@ -155,7 +220,6 @@ jobs:
 
       - name: Resource Hacker
         shell: cmd
-        if: runner.os == 'Windows'
         run: |
           set PATH=%PATH%;C:\Program Files (x86)\Resource Hacker
           set WIN_PKG=C:\Users\runneradmin\.pkg-cache\v%_WIN_PKG_VERSION%\fetched-v%_WIN_PKG_FETCH_VERSION%-win-x64
@@ -170,7 +234,6 @@ jobs:
         working-directory: ./
 
       - name: Build & Package Windows
-        if: runner.os == 'Windows'
         run: npm run dist:win --quiet
 
       - name: Build & Package Unix
@@ -179,7 +242,6 @@ jobs:
 
       - name: Package Chocolatey
         shell: pwsh
-        if: runner.os == 'Windows'
         run: |
           Copy-Item -Path stores/chocolatey -Destination dist/chocolatey -Recurse
           Copy-Item dist/windows/bw.exe -Destination dist/chocolatey/tools
@@ -188,17 +250,9 @@ jobs:
 
       - name: Zip Windows
         shell: cmd
-        if: runner.os == 'Windows'
         run: 7z a ./dist/bw-windows-%_PACKAGE_VERSION%.zip ./dist/windows/bw.exe
 
-      - name: Zip Unix
-        if: runner.os != 'Windows'
-        run: |
-          cd ./dist/${{ env.LOWER_RUNNER_OS }}
-          zip ../bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip ./bw
-
       - name: Version Test
-        if: runner.os == 'Windows'
         run: |
           dir ./dist/
           Expand-Archive -Path "./dist/bw-windows-${env:_PACKAGE_VERSION}.zip" -DestinationPath "./test/windows"
@@ -210,20 +264,11 @@ jobs:
           }
 
       - name: Create checksums Windows
-        if: runner.os == 'Windows'
         run: |
           checksum -f="./dist/bw-windows-${env:_PACKAGE_VERSION}.zip" `
             -t sha256 | Out-File -Encoding ASCII ./dist/bw-windows-sha256-${env:_PACKAGE_VERSION}.txt
 
-      - name: Create checksums Unix
-        if: runner.os != 'Windows'
-        run: |
-          cd ./dist
-          sha256sum bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip \
-            | awk '{split($0, a); print a[1]}' > bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
-
       - name: Upload windows zip asset
-        if: runner.os == 'Windows'
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: bw-windows-${{ env._PACKAGE_VERSION }}.zip
@@ -231,31 +276,13 @@ jobs:
           if-no-files-found: error
 
       - name: Upload windows checksum asset
-        if: runner.os == 'Windows'
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: bw-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           path: apps/cli/dist/bw-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           if-no-files-found: error
 
-      - name: Upload unix zip asset
-        if: runner.os != 'Windows'
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
-        with:
-          name: bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
-          path: apps/cli/dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
-          if-no-files-found: error
-
-      - name: Upload unix checksum asset
-        if: runner.os != 'Windows'
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
-        with:
-          name: bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
-          path: apps/cli/dist/bw-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
-          if-no-files-found: error
-
       - name: Upload Chocolatey asset
-        if: runner.os == 'Windows'
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
@@ -263,7 +290,6 @@ jobs:
           if-no-files-found: error
 
       - name: Upload NPM Build Directory asset
-        if: runner.os == 'Windows'
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
@@ -352,6 +378,7 @@ jobs:
       - cloc
       - setup
       - cli
+      - cli-windows
       - snap
     steps:
       - name: Check if any job failed

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Version Test
         run: |
           cd ./dist/
+          ls -lRf
           unzip "./dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
           testVersion=$(bw -v)
           echo "version: $_PACKAGE_VERSION"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -235,9 +235,6 @@ jobs:
       - name: Build & Package Windows
         run: npm run dist:win --quiet
 
-      - name: Build & Package Unix
-        run: npm run dist:${{ env.SHORT_RUNNER_OS }} --quiet
-
       - name: Package Chocolatey
         shell: pwsh
         run: |

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -236,7 +236,6 @@ jobs:
         run: npm run dist:win --quiet
 
       - name: Build & Package Unix
-        if: runner.os != 'Windows'
         run: npm run dist:${{ env.SHORT_RUNNER_OS }} --quiet
 
       - name: Package Chocolatey

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Version Test
         run: |
           cd ./dist/
-          unzip "./dist/bw-windows-${env:_PACKAGE_VERSION}.zip" -d "./test"
+          unzip "./dist/bw-bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
           testVersion=$(bw -v)
           echo "version: $_PACKAGE_VERSION"
           echo "testVersion: $testVersion"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Version Test
         run: |
           cd ./dist/
-          unzip "./dist/bw-bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
+          unzip "./dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
           testVersion=$(bw -v)
           echo "version: $_PACKAGE_VERSION"
           echo "testVersion: $testVersion"

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -113,8 +113,6 @@ jobs:
 
       - name: Version Test
         run: |
-          cd ./dist/
-          ls -lRf
           unzip "./dist/bw-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip" -d "./test"
           testVersion=$(bw -v)
           echo "version: $_PACKAGE_VERSION"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Split *nix and windows cli builds.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build-cli.yml:** Add new job outside of os matrix for building Windows CLI artifacts. Removed Windows-only steps from CLI build for macOS and linux.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
