### PR TITLE
[SM-477] remove new org button from org-switcher

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.html
@@ -2,7 +2,7 @@
   <bit-icon [icon]="logo" class="tw-w-full tw-text-alt2"></bit-icon>
 </a>
 
-<org-switcher [filter]="orgFilter"></org-switcher>
+<org-switcher [filter]="orgFilter" [hideNewButton]="true"></org-switcher>
 <bit-nav-item icon="bwi-collection" [text]="'projects' | i18n" route="projects"></bit-nav-item>
 <bit-nav-item icon="bwi-key" [text]="'secrets' | i18n" route="secrets"></bit-nav-item>
 <bit-nav-item

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
@@ -28,6 +28,7 @@
     </bit-nav-item>
   </ng-container>
   <bit-nav-item
+    *ngIf="!hideNewButton"
     icon="bwi-plus"
     [text]="'newOrganization' | i18n"
     route="/create-organization"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
@@ -38,6 +38,7 @@ export class OrgSwitcherComponent {
 
   /**
    * Visibility of the New Organization button
+   * (Temporary; will be removed when ability to create organizations is added to SM.)
    */
   @Input()
   hideNewButton = false;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts
@@ -36,6 +36,12 @@ export class OrgSwitcherComponent {
   @Output()
   openChange = new EventEmitter<boolean>();
 
+  /**
+   * Visibility of the New Organization button
+   */
+  @Input()
+  hideNewButton = false;
+
   constructor(private route: ActivatedRoute, private organizationService: OrganizationService) {}
 
   protected toggle(event?: MouseEvent) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The New Organization button should not be shown in the SM org-switcher. This PR adds an input that toggles its visibility. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **`bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.ts`** add new boolean input `hideNewButton`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
