### PR TITLE
[SM-464] remove org switcher item options

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
@@ -17,14 +17,6 @@
       (mainContentClicked)="toggle()"
       [hideActiveStyles]="true"
     >
-      <button
-        slot-end
-        bitIconButton="bwi-ellipsis-v"
-        [bitMenuTriggerFor]="orgSwitchMenu"
-        size="small"
-        [title]="'options' | i18n"
-        [attr.aria-label]="['organization' | i18n, org.name, 'options' | i18n].join(' ')"
-      ></button>
     </bit-nav-item>
   </ng-container>
   <bit-nav-item
@@ -34,18 +26,3 @@
   ></bit-nav-item>
   <bit-nav-divider></bit-nav-divider>
 </bit-nav-group>
-
-<bit-menu #orgSwitchMenu>
-  <button type="button" bitMenuItem>
-    <i class="bwi bwi-fw bwi-key tw-text-xl" aria-hidden="true"></i>
-    <span>{{ "enrollPasswordReset" | i18n }}</span>
-  </button>
-  <button type="button" bitMenuItem>
-    <i class="bwi bwi-fw bwi-link tw-text-xl" aria-hidden="true"></i>
-    <span>{{ "linkSso" | i18n }}</span>
-  </button>
-  <button type="button" bitMenuItem>
-    <i class="bwi bwi-fw bwi-sign-out tw-text-xl tw-text-danger" aria-hidden="true"></i>
-    <span class="tw-text-danger">{{ "leaveOrganization" | i18n }}</span>
-  </button>
-</bit-menu>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
@@ -1,5 +1,3 @@
-<!-- Please remove this disable statement when editing this file! -->
-<!-- eslint-disable @angular-eslint/template/button-has-type -->
 <bit-nav-group
   *ngIf="activeOrganization$ | async as activeOrganization"
   [text]="activeOrganization.name"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The options on a org-switcher item don't do anything at the moment. This PR removes the fake options.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **`bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html`:** Removed `bit-menu` and trigger button


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
