### PR TITLE
[PS-2176] Open WebAuthn Prompt in New Tab for all browser extensions

### DIFF
--- a/apps/browser/src/auth/popup/two-factor.component.ts
+++ b/apps/browser/src/auth/popup/two-factor.component.ts
@@ -68,8 +68,8 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
       return syncService.fullSync(true);
     };
     super.successRoute = "/tabs/vault";
-    this.webAuthnNewTab =
-      this.platformUtilsService.isFirefox() || this.platformUtilsService.isSafari();
+    // FIXME: Chromium 110 has broken WebAuthn support in extensions via an iframe
+    this.webAuthnNewTab = true;
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix for WebAuthn being broken in any chromium 110, this makes it so that the WebAuthn prompt opens up in a new tab just like we do for Firefox and Safari. 

I am not totally sure if this will be fixed or is now the intended behavior, I will be filing an issue with chromium to find out that information, but in the meantime we should get this feature back to working for users. 

Additional context to reviewers:
- WebAuthn Support was added [here](https://github.com/bitwarden/clients/pull/1379)
- A mention of firefox NOT supporting webauthn in the iframe of browser extension [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1460986)
- A mention of an enterprise policy introduced in chrome 110 that can disable the check [here](https://support.google.com/chrome/a/answer/7679408#webAth110)

Fixes #4691 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/two-factor.component.ts:** Always set new tab option to true since the only browsers this did work on were chromium based ones.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
