### PR TITLE
[PS-2455] Catch and log contextmenu errors

### DIFF
--- a/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
@@ -1,6 +1,7 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -12,6 +13,7 @@ import { MainContextMenuHandler } from "./main-context-menu-handler";
 describe("context-menu", () => {
   let stateService: MockProxy<BrowserStateService>;
   let i18nService: MockProxy<I18nService>;
+  let logService: MockProxy<LogService>;
 
   let removeAllSpy: jest.SpyInstance<void, [callback?: () => void]>;
   let createSpy: jest.SpyInstance<
@@ -24,6 +26,7 @@ describe("context-menu", () => {
   beforeEach(() => {
     stateService = mock();
     i18nService = mock();
+    logService = mock();
 
     removeAllSpy = jest
       .spyOn(chrome.contextMenus, "removeAll")
@@ -36,7 +39,7 @@ describe("context-menu", () => {
       return props.id;
     });
 
-    sut = new MainContextMenuHandler(stateService, i18nService);
+    sut = new MainContextMenuHandler(stateService, i18nService, logService);
   });
 
   afterEach(() => jest.resetAllMocks());

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -1,4 +1,5 @@
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
 import { Utils } from "@bitwarden/common/misc/utils";
 import { GlobalState } from "@bitwarden/common/models/domain/global-state";
@@ -10,6 +11,10 @@ import {
   i18nServiceFactory,
   I18nServiceInitOptions,
 } from "../../background/service_factories/i18n-service.factory";
+import {
+  logServiceFactory,
+  LogServiceInitOptions,
+} from "../../background/service_factories/log-service.factory";
 import {
   stateServiceFactory,
   StateServiceInitOptions,
@@ -36,7 +41,11 @@ export class MainContextMenuHandler {
 
   create: (options: chrome.contextMenus.CreateProperties) => Promise<void>;
 
-  constructor(private stateService: BrowserStateService, private i18nService: I18nService) {
+  constructor(
+    private stateService: BrowserStateService,
+    private i18nService: I18nService,
+    private logService: LogService
+  ) {
     if (chrome.contextMenus) {
       this.create = (options) => {
         return new Promise<void>((resolve, reject) => {
@@ -56,30 +65,32 @@ export class MainContextMenuHandler {
 
   static async mv3Create(cachedServices: CachedServices) {
     const stateFactory = new StateFactory(GlobalState, Account);
-    const serviceOptions: StateServiceInitOptions & I18nServiceInitOptions = {
-      cryptoFunctionServiceOptions: {
-        win: self,
-      },
-      encryptServiceOptions: {
-        logMacFailures: false,
-      },
-      i18nServiceOptions: {
-        systemLanguage: chrome.i18n.getUILanguage(),
-      },
-      logServiceOptions: {
-        isDev: false,
-      },
-      stateMigrationServiceOptions: {
-        stateFactory: stateFactory,
-      },
-      stateServiceOptions: {
-        stateFactory: stateFactory,
-      },
-    };
+    const serviceOptions: StateServiceInitOptions & I18nServiceInitOptions & LogServiceInitOptions =
+      {
+        cryptoFunctionServiceOptions: {
+          win: self,
+        },
+        encryptServiceOptions: {
+          logMacFailures: false,
+        },
+        i18nServiceOptions: {
+          systemLanguage: chrome.i18n.getUILanguage(),
+        },
+        logServiceOptions: {
+          isDev: false,
+        },
+        stateMigrationServiceOptions: {
+          stateFactory: stateFactory,
+        },
+        stateServiceOptions: {
+          stateFactory: stateFactory,
+        },
+      };
 
     return new MainContextMenuHandler(
       await stateServiceFactory(cachedServices, serviceOptions),
-      await i18nServiceFactory(cachedServices, serviceOptions)
+      await i18nServiceFactory(cachedServices, serviceOptions),
+      await logServiceFactory(cachedServices, serviceOptions)
     );
   }
 
@@ -100,11 +111,6 @@ export class MainContextMenuHandler {
     this.initRunning = true;
 
     try {
-      if (menuDisabled) {
-        await MainContextMenuHandler.removeAll();
-        return false;
-      }
-
       const create = async (options: Omit<chrome.contextMenus.CreateProperties, "contexts">) => {
         await this.create({ ...options, contexts: ["all"] });
       };
@@ -157,11 +163,12 @@ export class MainContextMenuHandler {
         parentId: ROOT_ID,
         title: this.i18nService.t("copyElementIdentifier"),
       });
-
-      return true;
+    } catch (error) {
+      this.logService.warning(error.message);
     } finally {
       this.initRunning = false;
     }
+    return true;
   }
 
   static async removeAll() {
@@ -195,33 +202,37 @@ export class MainContextMenuHandler {
       return;
     }
 
-    const sanitizedTitle = MainContextMenuHandler.sanitizeContextMenuTitle(title);
+    try {
+      const sanitizedTitle = MainContextMenuHandler.sanitizeContextMenuTitle(title);
 
-    const createChildItem = async (parent: string) => {
-      const menuItemId = `${parent}_${id}`;
-      return await this.create({
-        type: "normal",
-        id: menuItemId,
-        parentId: parent,
-        title: sanitizedTitle,
-        contexts: ["all"],
-      });
-    };
+      const createChildItem = async (parent: string) => {
+        const menuItemId = `${parent}_${id}`;
+        return await this.create({
+          type: "normal",
+          id: menuItemId,
+          parentId: parent,
+          title: sanitizedTitle,
+          contexts: ["all"],
+        });
+      };
 
-    if (cipher == null || !Utils.isNullOrEmpty(cipher.login.password)) {
-      await createChildItem(AUTOFILL_ID);
-      if (cipher?.viewPassword ?? true) {
-        await createChildItem(COPY_PASSWORD_ID);
+      if (cipher == null || !Utils.isNullOrEmpty(cipher.login.password)) {
+        await createChildItem(AUTOFILL_ID);
+        if (cipher?.viewPassword ?? true) {
+          await createChildItem(COPY_PASSWORD_ID);
+        }
       }
-    }
 
-    if (cipher == null || !Utils.isNullOrEmpty(cipher.login.username)) {
-      await createChildItem(COPY_USERNAME_ID);
-    }
+      if (cipher == null || !Utils.isNullOrEmpty(cipher.login.username)) {
+        await createChildItem(COPY_USERNAME_ID);
+      }
 
-    const canAccessPremium = await this.stateService.getCanAccessPremium();
-    if (canAccessPremium && (cipher == null || !Utils.isNullOrEmpty(cipher.login.totp))) {
-      await createChildItem(COPY_VERIFICATIONCODE_ID);
+      const canAccessPremium = await this.stateService.getCanAccessPremium();
+      if (canAccessPremium && (cipher == null || !Utils.isNullOrEmpty(cipher.login.totp))) {
+        await createChildItem(COPY_VERIFICATIONCODE_ID);
+      }
+    } catch (error) {
+      this.logService.warning(error.message);
     }
   }
 

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -89,10 +89,15 @@ export class MainContextMenuHandler {
    */
   async init(): Promise<boolean> {
     const menuDisabled = await this.stateService.getDisableContextMenuItem();
+    if (menuDisabled) {
+      await MainContextMenuHandler.removeAll();
+      return false;
+    }
 
     if (this.initRunning) {
-      return menuDisabled;
+      return true;
     }
+    this.initRunning = true;
 
     try {
       if (menuDisabled) {

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -573,7 +573,11 @@ export default class MainBackground {
     this.avatarUpdateService = new AvatarUpdateService(this.apiService, this.stateService);
 
     if (!this.popupOnlyContext) {
-      this.mainContextMenuHandler = new MainContextMenuHandler(this.stateService, this.i18nService);
+      this.mainContextMenuHandler = new MainContextMenuHandler(
+        this.stateService,
+        this.i18nService,
+        this.logService
+      );
 
       this.cipherContextMenuHandler = new CipherContextMenuHandler(
         this.mainContextMenuHandler,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
With the recent rebuild of the contextmenu to support MV2 and MV3, there have been some issues with async operations and creating/modifying the contextmenu. Most of the errors are irrelevant for the program flow, but the throw causes other side-effects. By catching and logging them, we are able to cancel out any side-effects and keep track of any issues occurring. This is a bandaid which we hopefully can remove the need for in the future.

If only Chrome offered to query which contextMenu items are present, then we could remove specific child items instead of constantly rebuilding it.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/autofill/browser/main-context-menu-handler.ts:** Add try-catch and logging to `init()` and `loadOptions`
- **apps/browser/src/background/main.background.ts:** Fix constructor for MainContextMenuHandler
- **apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts:** Fix constructor in tests


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
