### PR TITLE
[EC-1037] [EC-742] Cleanup vault folder filter logic

### DIFF
--- a/apps/web/src/vault/individual-vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/vault/individual-vault/vault-filter/services/vault-filter.service.ts
@@ -224,7 +224,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     const ciphers = await this.cipherService.getAllDecrypted();
     const orgCiphers = ciphers.filter((c) => c.organizationId == org?.id);
     return storedFolders.filter(
-      (f) => orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 || f.id == null
+      (f) => orgCiphers.some((oc) => oc.folderId == f.id) || f.id == null
     );
   }
 

--- a/apps/web/src/vault/individual-vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/vault/individual-vault/vault-filter/services/vault-filter.service.ts
@@ -215,15 +215,16 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     storedFolders: FolderView[],
     org?: Organization
   ): Promise<FolderView[]> {
-    if (org?.id == null) {
+    // If no org or "My Vault" is selected, show all folders
+    if (org?.id == null || org?.id == "MyVault") {
       return storedFolders;
     }
+
+    // Otherwise, show only folders that have ciphers from the selected org and the "no folder" folder
     const ciphers = await this.cipherService.getAllDecrypted();
     const orgCiphers = ciphers.filter((c) => c.organizationId == org?.id);
     return storedFolders.filter(
-      (f) =>
-        orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 ||
-        ciphers.filter((c) => c.folderId == f.id).length < 1
+      (f) => orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 || f.id == null
     );
   }
 

--- a/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
+++ b/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
@@ -64,7 +64,7 @@ export class VaultFilterService implements DeprecatedVaultFilterServiceAbstracti
         const ciphers = await this.cipherService.getAllDecrypted();
         const orgCiphers = ciphers.filter((c) => c.organizationId == organizationId);
         folders = storedFolders.filter(
-          (f) => orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 || f.id == null
+          (f) => orgCiphers.some((oc) => oc.folderId == f.id) || f.id == null
         );
       }
 

--- a/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
+++ b/libs/angular/src/vault/vault-filter/services/vault-filter.service.ts
@@ -55,17 +55,19 @@ export class VaultFilterService implements DeprecatedVaultFilterServiceAbstracti
   buildNestedFolders(organizationId?: string): Observable<DynamicTreeNode<FolderView>> {
     const transformation = async (storedFolders: FolderView[]) => {
       let folders: FolderView[];
-      if (organizationId != null) {
+
+      // If no org or "My Vault" is selected, show all folders
+      if (organizationId == null || organizationId == "MyVault") {
+        folders = storedFolders;
+      } else {
+        // Otherwise, show only folders that have ciphers from the selected org and the "no folder" folder
         const ciphers = await this.cipherService.getAllDecrypted();
         const orgCiphers = ciphers.filter((c) => c.organizationId == organizationId);
         folders = storedFolders.filter(
-          (f) =>
-            orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 ||
-            ciphers.filter((c) => c.folderId == f.id).length < 1
+          (f) => orgCiphers.filter((oc) => oc.folderId == f.id).length > 0 || f.id == null
         );
-      } else {
-        folders = storedFolders;
       }
+
       const nestedFolders = await this.getAllFoldersNested(folders);
       return new DynamicTreeNode<FolderView>({
         fullList: folders,


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix an issue where the "Folders" filter section was being hidden by mistake and certain folders were being shown incorrectly when filtering by an organization. 

Specifically:

- "All vaults" and "My vault" should always show all folders
- Organization vault should only show non-empty folders and the "No folder" folder
- Ensures the "Folders" filter section is always visible

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
