### PR TITLE
[PS-2456] Revert to MV2 Autofill Logic

### DIFF
--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.spec.ts
@@ -9,13 +9,12 @@ import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
-import { AutofillTabCommand } from "../commands/autofill-tab-command";
-
 import {
   CopyToClipboardAction,
   ContextMenuClickedHandler,
   CopyToClipboardOptions,
   GeneratePasswordToClipboardAction,
+  AutofillAction,
 } from "./context-menu-clicked-handler";
 import {
   AUTOFILL_ID,
@@ -59,9 +58,9 @@ describe("ContextMenuClickedHandler", () => {
 
   let copyToClipboard: CopyToClipboardAction;
   let generatePasswordToClipboard: GeneratePasswordToClipboardAction;
+  let autofill: AutofillAction;
   let authService: MockProxy<AuthService>;
   let cipherService: MockProxy<CipherService>;
-  let autofillTabCommand: MockProxy<AutofillTabCommand>;
   let totpService: MockProxy<TotpService>;
   let eventCollectionService: MockProxy<EventCollectionService>;
 
@@ -70,18 +69,18 @@ describe("ContextMenuClickedHandler", () => {
   beforeEach(() => {
     copyToClipboard = jest.fn<void, [CopyToClipboardOptions]>();
     generatePasswordToClipboard = jest.fn<Promise<void>, [tab: chrome.tabs.Tab]>();
+    autofill = jest.fn<Promise<void>, [tab: chrome.tabs.Tab, cipher: CipherView]>();
     authService = mock();
     cipherService = mock();
-    autofillTabCommand = mock();
     totpService = mock();
     eventCollectionService = mock();
 
     sut = new ContextMenuClickedHandler(
       copyToClipboard,
       generatePasswordToClipboard,
+      autofill,
       authService,
       cipherService,
-      autofillTabCommand,
       totpService,
       eventCollectionService
     );
@@ -106,9 +105,9 @@ describe("ContextMenuClickedHandler", () => {
 
       await sut.run(createData("T_1", AUTOFILL_ID), { id: 5 } as any);
 
-      expect(autofillTabCommand.doAutofillTabWithCipherCommand).toBeCalledTimes(1);
+      expect(autofill).toBeCalledTimes(1);
 
-      expect(autofillTabCommand.doAutofillTabWithCipherCommand).toBeCalledWith({ id: 5 }, cipher);
+      expect(autofill).toBeCalledWith({ id: 5 }, cipher);
     });
 
     it("copies username to clipboard", async () => {

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -43,6 +43,7 @@ import {
 
 export type CopyToClipboardOptions = { text: string; tab: chrome.tabs.Tab };
 export type CopyToClipboardAction = (options: CopyToClipboardOptions) => void;
+export type AutofillAction = (tab: chrome.tabs.Tab, cipher: CipherView) => Promise<void>;
 
 export type GeneratePasswordToClipboardAction = (tab: chrome.tabs.Tab) => Promise<void>;
 
@@ -53,9 +54,9 @@ export class ContextMenuClickedHandler {
   constructor(
     private copyToClipboard: CopyToClipboardAction,
     private generatePasswordToClipboard: GeneratePasswordToClipboardAction,
+    private autofillAction: AutofillAction,
     private authService: AuthService,
     private cipherService: CipherService,
-    private autofillTabCommand: AutofillTabCommand,
     private totpService: TotpService,
     private eventCollectionService: EventCollectionService
   ) {}
@@ -104,12 +105,16 @@ export class ContextMenuClickedHandler {
       await stateServiceFactory(cachedServices, serviceOptions)
     );
 
+    const autofillCommand = new AutofillTabCommand(
+      await autofillServiceFactory(cachedServices, serviceOptions)
+    );
+
     return new ContextMenuClickedHandler(
       (options) => copyToClipboard(options.tab, options.text),
       (tab) => generatePasswordToClipboardCommand.generatePasswordToClipboard(tab),
+      (tab, cipher) => autofillCommand.doAutofillTabWithCipherCommand(tab, cipher),
       await authServiceFactory(cachedServices, serviceOptions),
       await cipherServiceFactory(cachedServices, serviceOptions),
-      new AutofillTabCommand(await autofillServiceFactory(cachedServices, serviceOptions)),
       await totpServiceFactory(cachedServices, serviceOptions),
       await eventCollectionServiceFactory(cachedServices, serviceOptions)
     );
@@ -205,7 +210,7 @@ export class ContextMenuClickedHandler {
         if (tab == null) {
           return;
         }
-        await this.autofillTabCommand.doAutofillTabWithCipherCommand(tab, cipher);
+        await this.autofillAction(tab, cipher);
         break;
       case COPY_USERNAME_ID:
         this.copyToClipboard({ text: cipher.login.username, tab: tab });

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -89,7 +89,6 @@ import TabsBackground from "../autofill/background/tabs.background";
 import { CipherContextMenuHandler } from "../autofill/browser/cipher-context-menu-handler";
 import { ContextMenuClickedHandler } from "../autofill/browser/context-menu-clicked-handler";
 import { MainContextMenuHandler } from "../autofill/browser/main-context-menu-handler";
-import { AutofillTabCommand } from "../autofill/commands/autofill-tab-command";
 import { AutofillService as AutofillServiceAbstraction } from "../autofill/services/abstractions/autofill.service";
 import AutofillService from "../autofill/services/autofill.service";
 import { BrowserApi } from "../browser/browserApi";
@@ -543,9 +542,20 @@ export default class MainBackground {
           this.platformUtilsService.copyToClipboard(password, { window: window });
           this.passwordGenerationService.addHistory(password);
         },
+        async (tab, cipher) => {
+          this.loginToAutoFill = cipher;
+          if (tab == null) {
+            return;
+          }
+
+          BrowserApi.tabSendMessage(tab, {
+            command: "collectPageDetails",
+            tab: tab,
+            sender: "contextMenu",
+          });
+        },
         this.authService,
         this.cipherService,
-        new AutofillTabCommand(this.autofillService),
         this.totpService,
         this.eventCollectionService
       );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Revert to logic that was used for MV2 as shown [here](https://github.com/bitwarden/clients/blob/e941f06bac63a2de6fae35d21c74cfde313014fa/apps/browser/src/background/contextMenus.background.ts#L134-L145). This is so that the unlock on autofill retries the autofill request. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/autofill/browser/context-menu-clicked-handler.ts:** Change it so that it accepts an autofill callback so that MV3 and MV2 can have different implementations.
- **apps/browser/src/background/main.background.ts:** Send a custom MV2 callback that is based on the logic that was in place before context menu changes. 
- **apps/browser/src/autofill/browser/context-menu-clicked-handler.spec.ts:** Update tests to use the callback.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
