### PR TITLE
PS-2450 EC-1073 Do not decode and normalize query

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1991,7 +1991,9 @@ export class ApiService implements ApiServiceAbstraction {
     apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.environmentService.getApiUrl() : apiUrl;
 
     // Prevent directory traversal from malicious paths
-    const requestUrl = apiUrl + Utils.normalizePath(path);
+    const pathParts = path.split("?");
+    const requestUrl =
+      apiUrl + Utils.normalizePath(pathParts[0]) + (pathParts.length > 1 ? `?${pathParts[1]}` : "");
 
     const headers = new Headers({
       "Device-Type": this.deviceType,


### PR DESCRIPTION
Co-authored-by: Jake Fink <jfink@bitwarden.com>

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#4580 introduced URI decoding to our path traversal tests, but we pass in queries as part of those paths. This causes all previously encoded queries to be decoded and processed as part of a path, which caused some weird unintended consequences, depending on `path` implementation.

This PR splits path parts to maintain traversal safety, while keeping queries properly encoded

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
