### PR TITLE
[EC-1074] Defect - When Deleted 500 Vault items from a large vault, `Select All` feature sometimes automatically deselects

### DIFF
--- a/apps/web/src/vault/individual-vault/vault-items.component.html
+++ b/apps/web/src/vault/individual-vault/vault-items.component.html
@@ -16,6 +16,7 @@
             type="checkbox"
             bitCheckbox
             id="checkAll"
+            [disabled]="isProcessingAction"
             (change)="checkAll($any($event.target).checked)"
             [(ngModel)]="isAllChecked"
           />
@@ -33,6 +34,7 @@
         <th bitCell class="tw-min-w-fit tw-text-right">
           <button
             [bitMenuTriggerFor]="headerMenu"
+            [disabled]="isProcessingAction"
             bitIconButton="bwi-ellipsis-v"
             size="small"
             type="button"
@@ -77,8 +79,8 @@
       <tr
         bitRow
         *ngFor="let col of filteredCollections"
-        (click)="navigateCollection(col)"
-        class="tw-cursor-pointer"
+        [class.tw-cursor-pointer]="!isProcessingAction"
+        (click)="!isProcessingAction && navigateCollection(col)"
         alignContent="middle"
       >
         <td bitCell (click)="checkRow(col)" appStopProp>
@@ -87,6 +89,7 @@
             class="tw-cursor-pointer"
             type="checkbox"
             bitCheckbox
+            [disabled]="isProcessingAction"
             [(ngModel)]="$any(col).checked"
             appStopProp
           />
@@ -102,6 +105,7 @@
             class="tw-text-start"
             linkType="secondary"
             (click)="navigateCollection(col)"
+            [disabled]="isProcessingAction"
           >
             {{ col.node.name }}
           </button>
@@ -128,6 +132,7 @@
           <button
             *ngIf="canEditCollection(col.node) || canDeleteCollection(col.node)"
             [bitMenuTriggerFor]="collectionOptions"
+            [disabled]="isProcessingAction"
             size="small"
             bitIconButton="bwi-ellipsis-v"
             type="button"
@@ -167,12 +172,18 @@
       <tr
         bitRow
         *ngFor="let c of filteredCiphers"
-        class="tw-cursor-pointer"
-        (click)="selectCipher(c)"
+        [class.tw-cursor-pointer]="!isProcessingAction"
+        (click)="!isProcessingAction && selectCipher(c)"
         alignContent="middle"
       >
         <td bitCell (click)="checkRow(c)" appStopProp>
-          <input type="checkbox" bitCheckbox [(ngModel)]="$any(c).checked" appStopProp />
+          <input
+            type="checkbox"
+            bitCheckbox
+            [disabled]="isProcessingAction"
+            [(ngModel)]="$any(c).checked"
+            appStopProp
+          />
         </td>
         <td bitCell>
           <app-vault-icon [cipher]="c"></app-vault-icon>
@@ -185,6 +196,7 @@
             [queryParams]="{ itemId: c.id }"
             queryParamsHandling="merge"
             title="{{ 'editItem' | i18n }}"
+            [disabled]="isProcessingAction"
           >
             {{ c.name }}
           </button>
@@ -230,6 +242,7 @@
         <td bitCell class="tw-text-right">
           <button
             [bitMenuTriggerFor]="cipherOptions"
+            [disabled]="isProcessingAction"
             size="small"
             bitIconButton="bwi-ellipsis-v"
             type="button"

--- a/apps/web/src/vault/individual-vault/vault-items.component.ts
+++ b/apps/web/src/vault/individual-vault/vault-items.component.ts
@@ -530,6 +530,13 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     return false; // Always return false for non org vault
   }
 
+  /**
+   * @deprecated Block interaction using long running modal dialog instead
+   */
+  protected get isProcessingAction() {
+    return this.actionPromise != null;
+  }
+
   protected updateSearchedCollections(collections: TreeNode<CollectionFilter>[]) {
     if (this.searchService.isSearchable(this.searchText)) {
       this.searchedCollections = this.searchPipe.transform(

--- a/apps/web/src/vault/org-vault/vault-items.component.ts
+++ b/apps/web/src/vault/org-vault/vault-items.component.ts
@@ -310,6 +310,13 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     }
   }
 
+  /**
+   * @deprecated Block interaction using long running modal dialog instead
+   */
+  protected get isProcessingAction() {
+    return this.actionPromise != null;
+  }
+
   protected deleteCipherWithServer(id: string, permanent: boolean) {
     if (!this.organization?.canEditAnyCollection) {
       return super.deleteCipherWithServer(id, this.deleted);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The user is able to interact with vault-items while actions like delete are happening. This PR is a temporary fix to disable all interaction surfaces during those async actions.

## Code changes

Disable all clickable buttons and links while `actionPromise` is not `null`.

## Screenshots

### Individual vault
![image](https://user-images.githubusercontent.com/2285588/218455278-3e444ec3-0ebe-4616-a2b5-8e9bf01035ef.png)

### Org vault
![image](https://user-images.githubusercontent.com/2285588/218455167-b72bec15-01c4-44ad-9874-bba82036fd9b.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
