### PR TITLE
[PS-2495] Make CLI login failure output consistent

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -293,7 +293,7 @@ export class LoginCommand {
 
       return await this.handleSuccessResponse();
     } catch (e) {
-      return Response.error(e);
+      return Response.error("Login failed.");
     }
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Current Behavior

When using a Personal API Key (via `--apikey`) to login via CLI and if the attempt is unsuccessful due to an invalid client secret or id, the error generated is currently an unfriendly one. This is inconsistent with how other error situations are handled by other CLI commands/workflows including logging in with conventional emails/passwords. It also results in some extra stringfieid JSON in JSON if simultaneously using the `--response` parameter.

## Why

The reason this is occurring is is because the code `--apikey` logins hit lacks a provision for a user friendly error message unlike other paths.

## Result

The result is the user is either:

- a) is displayed a raw error response rather than a simple error (which would be consistent with username/password based login failures). This is the case even when *not* invoked with `--response` which is particularly unfriendly
- b) or, when invoked with `--response`, the user is provided with a stringified JSON in JSON rehash of the same raw error response.

## Fix Provided

This simple fix sets a default login command failure error message. This change impacts both the default and `--response` error outputs when logging in via `--apikey` - making them both not only cleaner but consistent with other similar situations in the CLI app. e.g. the output generated by invalid username/password based logins as well as all other unsuccessful invocations of CLI commands I compared against.

The user side of this fix was alluded to as a possible contributing factor in https://github.com/bitwarden/clients/issues/4521#issuecomment-1428934576 (by myself admittedly lol) so it has some relevance to #4521. Besides being annoying whenever I've encountered this in interactive mode, it also cleans up the output when used non-interactively and makes its content more deterministic for automation.

Bonus: This also enables `--pretty` to work with `--response` during `--apikey` credential failures which is a use case where I find it never works even though error states from other command flows work just fine with it.

## Alternatives

While it might be worth considering explicitly handling api id/secret failures rather than relying on the current fallback exception for a such a well traveled path, that's a larger change and outside the scope of this PR.

## Backwards compatibility warning

If anyone is relying on parsing the previously stringified embedded JSON in JSON to detect login errors rather than relying on the always (i.e. before and after this change) provided `success` field than this change will break their stuff. While I suspect the current behavior was always inadvertent - since it's inconsistent with other situations/CLI app commands - it's unavoidable that someone may have come to rely on it. I don't think that's a good reason to keep incorrect behavior in place.

##  Documentation

This change in behavior - even if a correction of undesirable prior behavior - should be documented in release notes or something. AFAIK the current schema and behavior of CLI failure responses isn't documented anywhere I've been able to find so, yeah... but feel free to correct me if I'm wrong (or maybe it's just not publicly posted?).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **cli/src/auth/commands/login.command.ts:** Adds a friendly default error message to the fallback Response.error call and replaces the previous unfriendly stringified error output (by way of `e`) that was only ever triggered in a couple of situations as far as I can tell. This change seems the least intrusive, though it was tempting to add explicit handling for Personal API Key login failures earlier in the login command code path. Arguably something to follow up on another day, but that would be a deeper change than this PR advocates. It was also tempting to append a `JSON.stringify(e)` to the end of the new error message string, but I chose not to because it would be inconsistent with the output provided when a login failure occurs due to a bad username/password. Also, I think a better way to handle providing any additional data to the user about the error would be to provide it as as an additional data object in the response output and/or hidden behind a `--verbose/--debug` command if ever deemed desirable. The primary path I'm aware of that gets to this catch is a credential problem as a result of an `--apikey` option provided by the user, but there could certainly be other paths here. Even so this fix maintains a generic error message so it shouldn't matter if something else ends up here. I haven't seen any particularly actionable additional info in the stringified output currently provided, but if a need should arise I suggest a later PR could add the raw error response to a data object akin to what's done for successful responses (at least when `--response` is specified on the command line) and/or behind --debug/--verbose as previously noted.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Current output:

```
~$ ./bw logout && BW_CLIENTID=user.[a bogus id] BW_CLIENTSECRET=[an invalid secret] ./bw login --apikey --pretty
{"response":{"error":"invalid_client"},"captchaRequired":false,"statusCode":400}
```
New output:
```
Login failed.
```

The new output matches how things look when logging in with an email+password.

In addition output changes when invoking the CLI with `--response`. 

Current output:
```
~$ ./bw logout && BW_CLIENTID=user.[a bogus id] BW_CLIENTSECRET=[an invalid secret] ./bw login --apikey --response --pretty
{
  "success": false,
  "message": "{\"response\":{\"error\":\"invalid_client\"},\"captchaRequired\":false,\"statusCode\":400}"
}
```
New output:
```
{
  "success": false,
  "message": "Login failed."
}
```

This new output, similarly, also matches how things look when logging in with an email+password with the `--response` option.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
