### PR TITLE
Fix callout still present after clicking 'Got it'

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -277,6 +277,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
 
   async dismissCallout() {
     await this.stateService.setDismissedAutofillCallout(true);
+    this.showHowToAutofill = false;
   }
 
   private async setCallout() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix callout not dismissing when clicking 'Got it'
## Code changes

- **apps/browser/src/vault/popup/components/vault/current-tab.component.ts:** Set `showHotToAutofill` variable to false when the user clicks 'Got it'


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
