### PR TITLE
Switch logo color based on color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bitwarden/brand/master/screenshots/apps-combo-logo.png" alt="Bitwarden" />
+  <img src="https://raw.githubusercontent.com/bitwarden/brand/master/screenshots/apps-combo.png" alt="Bitwarden" />
+  <picture>
+      <source srcset="https://github.com/bitwarden/brand/raw/master/logos/logo-horizontal.svg" media="(prefers-color-scheme: light),(prefers-color-scheme: dark)" class="source-dark">
+      <img src="https://github.com/bitwarden/brand/raw/master/logos/logo-horizontal-white.svg" width="77%" alt="Bitwarden" style="visibility:visible;max-width:100%;">
+  </picture>
 </p>
 <p align="center">
   <a href="https://github.com/bitwarden/clients/actions/workflows/build-browser.yml?query=branch:master" target="_blank">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ X] Other
```

## Objective

Make the README.md look much better in dark mode in a browser.

## Code changes

I have adjusted the content of the README file to pick a logo based on the active color preference of the browser session.

For this pull request to work, a pull request in the brands repository needs to be merged first.
https://github.com/bitwarden/brand/pull/31

- **README.md:** Adjusted the image content used at the top of the page.

## Screenshots

It fixes this look:
![image](https://user-images.githubusercontent.com/39677/219902390-d1d3f197-1aa2-42ba-8415-3ea335dedd97.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
