### PR TITLE
[SM-539] hide HTML Details marker on Safari

### DIFF
--- a/apps/web/src/scss/tailwind.css
+++ b/apps/web/src/scss/tailwind.css
@@ -11,3 +11,12 @@
 td.tw-break-words {
   overflow-wrap: anywhere;
 }
+
+/** 
+ * tw-list-none hides summary arrow in Firefox & Chrome but not Safari:
+ * https://github.com/tailwindlabs/tailwindcss/issues/924#issuecomment-915509785
+ */
+summary.tw-list-none::marker,
+summary.tw-list-none::-webkit-details-marker {
+  display: none;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Hide the browser's default marker for the HTML `<details>` element when `tw-list-none` is present

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **`apps/web/src/scss/tailwind.css`:** Add patch to Tailwind for consistent `<details>` styling across browsers: https://github.com/tailwindlabs/tailwindcss/issues/924#issuecomment-915509785

## Screenshots

![image](https://user-images.githubusercontent.com/17113462/220732599-87771ffb-7eb6-4d37-b58e-44826999f8bc.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
