### PR TITLE
Login with Device - Change desktop to not get fingerprint from API

### DIFF
--- a/apps/desktop/src/auth/login/login-approval.component.html
+++ b/apps/desktop/src/auth/login/login-approval.component.html
@@ -11,7 +11,7 @@
 
         <div class="section">
           <h4 class="label">{{ "fingerprintPhraseHeader" | i18n }}</h4>
-          <code>{{ authRequestResponse?.requestFingerprint }}</code>
+          <code>{{ fingerprintPhrase }}</code>
         </div>
 
         <div class="section">

--- a/apps/desktop/src/auth/login/login-approval.component.ts
+++ b/apps/desktop/src/auth/login/login-approval.component.ts
@@ -6,14 +6,13 @@ import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 import { ModalConfig } from "@bitwarden/angular/services/modal.service";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AppIdService } from "@bitwarden/common/abstractions/appId.service";
+import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
 import { Utils } from "@bitwarden/common/misc/utils";
-
-import { CryptoService } from './../../../../../libs/common/src/services/crypto.service';
 
 const RequestTimeOut = 60000 * 15; //15 Minutes
 const RequestTimeUpdate = 60000 * 5; //5 Minutes
@@ -67,8 +66,8 @@ export class LoginApprovalComponent implements OnInit, OnDestroy {
     if (this.notificationId != null) {
       this.authRequestResponse = await this.apiService.getAuthRequest(this.notificationId);
       const publicKey = Utils.fromB64ToArray(this.authRequestResponse.publicKey);
-      this.fingerprintPhrase =  (await this.cryptoService.getFingerprint(await this.stateService.getUserId(), publicKey.buffer)).join('-');
       this.email = await this.stateService.getEmail();
+      this.fingerprintPhrase =  (await this.cryptoService.getFingerprint(this.email, publicKey.buffer)).join('-');
       this.updateTimeText();
 
       this.interval = setInterval(() => {

--- a/libs/common/src/auth/models/response/auth-request.response.ts
+++ b/libs/common/src/auth/models/response/auth-request.response.ts
@@ -12,7 +12,6 @@ export class AuthRequestResponse extends BaseResponse {
   masterPasswordHash: string;
   creationDate: string;
   requestApproved?: boolean;
-  requestFingerprint?: string;
   responseDate?: string;
   isAnswered: boolean;
   isExpired: boolean;
@@ -27,7 +26,6 @@ export class AuthRequestResponse extends BaseResponse {
     this.masterPasswordHash = this.getResponseProperty("MasterPasswordHash");
     this.creationDate = this.getResponseProperty("CreationDate");
     this.requestApproved = this.getResponseProperty("RequestApproved");
-    this.requestFingerprint = this.getResponseProperty("RequestFingerprint");
     this.responseDate = this.getResponseProperty("ResponseDate");
 
     const requestDate = new Date(this.creationDate);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We currently store the fingerprint phrase used for verifying “Login with Device” authentication requests in the database.  This should not be stored in the database.  Rather, it should be re-calculated on the client from the public key that is sent in the request, using the cryptoService.getFingerprint() method.

Sending this data over the API and persisting it in the database would allow it to be modified by the sender to any possible value, independent of the public key.

For compatibility with existing (“old”) clients, we should approach this in phases:

Phase 1
-Modify desktop client to generate the fingerprint phrase themselves, ignoring the one retrieved from the API
-Remove fingerprintPhrase from the AuthRequestResponse

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**libs/common/src/auth/models/response/auth-request.response.ts:** Removed fingerprint phrase property

**apps/desktop/src/auth/login/login-approval.component.ts:** Generate fingerprint phrase from `CryptoService`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
