### PR TITLE
[SM-553] Fix header sometimes taking up to much space

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
@@ -2,7 +2,7 @@
   <nav class="tw-min-h-screen tw-w-60 tw-bg-background-alt3">
     <router-outlet name="sidebar"></router-outlet>
   </nav>
-  <main class="tw-min-h-screen tw-flex-1 tw-p-6">
+  <main class="tw-min-h-screen tw-min-w-0 tw-flex-1 tw-p-6">
     <router-outlet></router-outlet>
   </main>
 </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Flexbox is fun. Needed to add `tw-min-w-0` to layout in order to resolve the header consuming to much space.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:

![image](https://user-images.githubusercontent.com/137855/220956025-ffb19dfa-eca8-4de9-a2d4-76f5011c325e.png)

After:

![image](https://user-images.githubusercontent.com/137855/220955915-568a9b79-7d9a-4de8-b094-70401fd61547.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
