### PR TITLE
[SM-538] truncate project badge

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -74,7 +74,8 @@
           *ngFor="let project of secret.projects"
           bitBadge
           badgeType="secondary"
-          class="tw-ml-1"
+          class="tw-ml-1 !tw-block tw-max-w-[32ch] tw-truncate"
+          [title]="project.name"
         >
           {{ project.name }}
         </span>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -74,10 +74,10 @@
           *ngFor="let project of secret.projects"
           bitBadge
           badgeType="secondary"
-          class="tw-ml-1 !tw-block tw-max-w-[32ch] tw-truncate"
+          class="tw-ml-1"
           [title]="project.name"
         >
-          {{ project.name }}
+          {{ project.name | ellipsis: 32 }}
         </span>
       </td>
       <td bitCell class="tw-whitespace-nowrap">{{ secret.revisionDate | date: "medium" }}</td>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The project badges in the secrets list should be truncated to ~32 characters. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html:** Add `tw-truncate`

## Screenshots

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/17113462/220975247-d6e84044-135c-4d62-bb7f-a968f0ca3225.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
