### PR TITLE
[AC-1084] Don't copy hidden spaces when selecting password

### DIFF
--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -11,7 +11,7 @@ enum CharacterType {
 
 @Component({
   selector: "bit-color-password",
-  template: `<div
+  template: `<span
     *ngFor="let character of passwordArray; index as i"
     [class]="getCharacterClass(character)"
   >
@@ -19,7 +19,7 @@ enum CharacterType {
     <span *ngIf="showCount" class="tw-whitespace-nowrap tw-text-xs tw-leading-5 tw-text-main">{{
       i + 1
     }}</span>
-  </div>`,
+  </span>`,
 })
 export class ColorPasswordComponent {
   @Input() private password: string = null;
@@ -44,10 +44,11 @@ export class ColorPasswordComponent {
 
   getCharacterClass(character: string) {
     const charType = this.getCharacterType(character);
-    const charClass = this.characterStyles[charType].concat("tw-inline-flex");
+    const charClass = this.characterStyles[charType];
 
     if (this.showCount) {
       return charClass.concat([
+        "tw-inline-flex",
         "tw-flex-col",
         "tw-items-center",
         "tw-w-7",

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -20,6 +20,7 @@ enum CharacterType {
       i + 1
     }}</span>
   </span>`,
+  preserveWhitespaces: false,
 })
 export class ColorPasswordComponent {
   @Input() private password: string = null;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bug: When selecting and copying a password displayed using the `ColorPasswordComponent`, the copied selection included hidden whitespace.

Thanks to @coroiu for this fix, I'm just doing the Jira/Github admin.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* use `span` elements instead of `div`, to avoid invisible whitespace
* move `tw-inline-flex` to the "count" display only, it's not required for the normal display and interferes with Chrome

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
