### PR TITLE
[AC-1046] activate autofill on page load policy 

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2111,6 +2111,9 @@
       }
     }
   },
+  "autofillPageLoadPolicyActivated": {
+    "message": "Your organization policies have turned on auto-fill on page load."
+  },
   "tryAutofillPageLoad": {
     "message": "Try auto-fill on page load?"
   },

--- a/apps/browser/src/services/browser-policy.service.ts
+++ b/apps/browser/src/services/browser-policy.service.ts
@@ -1,6 +1,9 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, filter, map, switchMap, tap } from "rxjs";
 import { Jsonify } from "type-fest";
 
+import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+import { StateService } from "@bitwarden/common/abstractions/state.service";
+import { PolicyType } from "@bitwarden/common/enums/policyType";
 import { Policy } from "@bitwarden/common/models/domain/policy";
 import { PolicyService } from "@bitwarden/common/services/policy/policy.service";
 
@@ -13,4 +16,31 @@ export class BrowserPolicyService extends PolicyService {
     initializeAs: "array",
   })
   protected _policies: BehaviorSubject<Policy[]>;
+
+  constructor(stateService: StateService, organizationService: OrganizationService) {
+    super(stateService, organizationService);
+
+    this._policies
+      .pipe(
+        map((policies) => policies.find((p) => p.type == PolicyType.ActivateAutofill && p.enabled)),
+        filter((p) => p != null),
+        switchMap(async (p) => await this.stateService.getActivatedAutofillPolicy()),
+        tap((activated) => {
+          if (activated === undefined) {
+            this.stateService.setActivatedAutofillPolicy(false);
+          }
+        })
+      )
+      .subscribe();
+
+    this.updateAutofillPolicy();
+  }
+
+  async updateAutofillPolicy(): Promise<void> {
+    const activated = await this.stateService.getActivatedAutofillPolicy();
+    if (activated === false) {
+      this.stateService.setEnableAutoFillOnPageLoad(true);
+      this.stateService.setActivatedAutofillPolicy(true);
+    }
+  }
 }

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -119,6 +119,17 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
       this.loginCiphers.length > 0 &&
       !(await this.stateService.getEnableAutoFillOnPageLoad()) &&
       !(await this.stateService.getDismissedAutofillCallout());
+
+    // activate autofill on page load if policy is set
+    if (await this.stateService.getActivateAutoFillOnPageLoadFromPolicy()) {
+      await this.stateService.setEnableAutoFillOnPageLoad(true);
+      await this.stateService.setActivateAutoFillOnPageLoadFromPolicy(false);
+      this.platformUtilsService.showToast(
+        "info",
+        null,
+        this.i18nService.t("autofillPageLoadPolicyActivated")
+      );
+    }
   }
 
   ngOnDestroy() {

--- a/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
@@ -139,17 +139,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         window.setTimeout(() => this.popupUtils.setContentScrollY(window, this.state?.scrollY), 0);
       }
     });
-
-    // activate autofill on page load if policy is set
-    if (await this.browserStateService.getActivateAutoFillOnPageLoadFromPolicy()) {
-      await this.browserStateService.setEnableAutoFillOnPageLoad(true);
-      await this.browserStateService.setActivateAutoFillOnPageLoadFromPolicy(false);
-      this.platformUtilsService.showToast(
-        "info",
-        null,
-        this.i18nService.t("autofillPageLoadPolicyActivated")
-      );
-    }
   }
 
   ngOnDestroy() {

--- a/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
@@ -6,6 +6,7 @@ import { first } from "rxjs/operators";
 
 import { VaultFilter } from "@bitwarden/angular/vault/vault-filter/models/vault-filter.model";
 import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.service";
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { TreeNode } from "@bitwarden/common/models/domain/tree-node";
@@ -72,6 +73,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   private allCiphers: CipherView[] = null;
 
   constructor(
+    private i18nService: I18nService,
     private cipherService: CipherService,
     private router: Router,
     private ngZone: NgZone,
@@ -137,6 +139,17 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         window.setTimeout(() => this.popupUtils.setContentScrollY(window, this.state?.scrollY), 0);
       }
     });
+
+    // activate autofill on page load if policy is set
+    if (await this.browserStateService.getActivateAutoFillOnPageLoadFromPolicy()) {
+      await this.browserStateService.setEnableAutoFillOnPageLoad(true);
+      await this.browserStateService.setActivateAutoFillOnPageLoadFromPolicy(false);
+      this.platformUtilsService.showToast(
+        "info",
+        null,
+        this.i18nService.t("autofillPageLoadPolicyActivated")
+      );
+    }
   }
 
   ngOnDestroy() {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4856,6 +4856,12 @@
   "personalVaultExportPolicyInEffect": {
     "message": "One or more organization policies prevents you from exporting your individual vault."
   },
+  "activateAutofill": {
+    "message": "Activate autofill"
+  },
+  "activateAutofillDesc": {
+    "message": "Activate the autofill with page load settings on the browser extension for all existing and new members."
+  },
   "selectType": {
     "message": "Select SSO type"
   },

--- a/bitwarden_license/bit-web/src/app/app.component.ts
+++ b/bitwarden_license/bit-web/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 
 import { AppComponent as BaseAppComponent } from "@bitwarden/web-vault/app/app.component";
 
+import { ActivateAutofillPolicy } from "./policies/activate-autofill.component";
 import { DisablePersonalVaultExportPolicy } from "./policies/disable-personal-vault-export.component";
 import { MaximumVaultTimeoutPolicy } from "./policies/maximum-vault-timeout.component";
 
@@ -16,6 +17,7 @@ export class AppComponent extends BaseAppComponent {
     this.policyListService.addPolicies([
       new MaximumVaultTimeoutPolicy(),
       new DisablePersonalVaultExportPolicy(),
+      new ActivateAutofillPolicy(),
     ]);
   }
 }

--- a/bitwarden_license/bit-web/src/app/app.module.ts
+++ b/bitwarden_license/bit-web/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { WildcardRoutingModule } from "@bitwarden/web-vault/app/wildcard-routing
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 import { OrganizationsModule } from "./organizations/organizations.module";
+import { ActivateAutofillPolicyComponent } from "./policies/activate-autofill.component";
 import { DisablePersonalVaultExportPolicyComponent } from "./policies/disable-personal-vault-export.component";
 import { MaximumVaultTimeoutPolicyComponent } from "./policies/maximum-vault-timeout.component";
 
@@ -39,6 +40,7 @@ import { MaximumVaultTimeoutPolicyComponent } from "./policies/maximum-vault-tim
     AppComponent,
     DisablePersonalVaultExportPolicyComponent,
     MaximumVaultTimeoutPolicyComponent,
+    ActivateAutofillPolicyComponent,
   ],
   bootstrap: [AppComponent],
 })

--- a/bitwarden_license/bit-web/src/app/policies/activate-autofill.component.html
+++ b/bitwarden_license/bit-web/src/app/policies/activate-autofill.component.html
@@ -1,0 +1,12 @@
+<div class="form-group">
+  <div class="form-check">
+    <input
+      class="form-check-input"
+      type="checkbox"
+      id="enabled"
+      [formControl]="enabled"
+      name="Enabled"
+    />
+    <label class="form-check-label" for="enabled">{{ "turnOn" | i18n }}</label>
+  </div>
+</div>

--- a/bitwarden_license/bit-web/src/app/policies/activate-autofill.component.ts
+++ b/bitwarden_license/bit-web/src/app/policies/activate-autofill.component.ts
@@ -1,0 +1,20 @@
+import { Component } from "@angular/core";
+
+import { PolicyType } from "@bitwarden/common/enums/policyType";
+import {
+  BasePolicy,
+  BasePolicyComponent,
+} from "@bitwarden/web-vault/app/organizations/policies/base-policy.component";
+
+export class ActivateAutofillPolicy extends BasePolicy {
+  name = "activateAutofill";
+  description = "activateAutofillDesc";
+  type = PolicyType.ActivateAutofill;
+  component = ActivateAutofillPolicyComponent;
+}
+
+@Component({
+  selector: "policy-activate-autofill",
+  templateUrl: "activate-autofill.component.html",
+})
+export class ActivateAutofillPolicyComponent extends BasePolicyComponent {}

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -357,4 +357,6 @@ export abstract class StateService<T extends Account = Account> {
 
   getAvatarColor: (options?: StorageOptions) => Promise<string | null | undefined>;
   setAvatarColor: (value: string, options?: StorageOptions) => Promise<void>;
+  getActivatedAutofillPolicy: (options?: StorageOptions) => Promise<boolean | undefined>;
+  setActivatedAutofillPolicy: (value: boolean, options?: StorageOptions) => Promise<void>;
 }

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -357,6 +357,11 @@ export abstract class StateService<T extends Account = Account> {
 
   getAvatarColor: (options?: StorageOptions) => Promise<string | null | undefined>;
   setAvatarColor: (value: string, options?: StorageOptions) => Promise<void>;
-  getActivatedAutofillPolicy: (options?: StorageOptions) => Promise<boolean | undefined>;
-  setActivatedAutofillPolicy: (value: boolean, options?: StorageOptions) => Promise<void>;
+  getActivateAutoFillOnPageLoadFromPolicy: (
+    options?: StorageOptions
+  ) => Promise<boolean | undefined>;
+  setActivateAutoFillOnPageLoadFromPolicy: (
+    value: boolean,
+    options?: StorageOptions
+  ) => Promise<void>;
 }

--- a/libs/common/src/enums/policyType.ts
+++ b/libs/common/src/enums/policyType.ts
@@ -10,4 +10,5 @@ export enum PolicyType {
   ResetPassword = 8, // Allows orgs to use reset password : also can enable auto-enrollment during invite flow
   MaximumVaultTimeout = 9, // Sets the maximum allowed vault timeout
   DisablePersonalVaultExport = 10, // Disable personal vault export
+  ActivateAutofill = 11, // Activates autofill with page load on the browser extension
 }

--- a/libs/common/src/models/domain/account.ts
+++ b/libs/common/src/models/domain/account.ts
@@ -238,6 +238,7 @@ export class AccountSettings {
   serverConfig?: ServerConfigData;
   approveLoginRequests?: boolean;
   avatarColor?: string;
+  activatedAutofillPolicy?: boolean;
 
   static fromJSON(obj: Jsonify<AccountSettings>): AccountSettings {
     if (obj == null) {

--- a/libs/common/src/models/domain/account.ts
+++ b/libs/common/src/models/domain/account.ts
@@ -238,7 +238,7 @@ export class AccountSettings {
   serverConfig?: ServerConfigData;
   approveLoginRequests?: boolean;
   avatarColor?: string;
-  activatedAutofillPolicy?: boolean;
+  activateAutoFillOnPageLoadFromPolicy?: boolean;
 
   static fromJSON(obj: Jsonify<AccountSettings>): AccountSettings {
     if (obj == null) {

--- a/libs/common/src/services/policy/policy.service.ts
+++ b/libs/common/src/services/policy/policy.service.ts
@@ -21,7 +21,7 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
   policies$ = this._policies.asObservable();
 
   constructor(
-    private stateService: StateService,
+    protected stateService: StateService,
     private organizationService: OrganizationService
   ) {
     this.stateService.activeAccountUnlocked$

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2364,6 +2364,23 @@ export class StateService<
     );
   }
 
+  async getActivatedAutofillPolicy(options?: StorageOptions): Promise<boolean> {
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.settings?.activatedAutofillPolicy;
+  }
+
+  async setActivatedAutofillPolicy(value: boolean, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+    account.settings.activatedAutofillPolicy = value;
+    return await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+  }
+
   protected async getGlobals(options: StorageOptions): Promise<TGlobalState> {
     let globals: TGlobalState;
     if (this.useMemory(options.storageLocation)) {

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2364,17 +2364,20 @@ export class StateService<
     );
   }
 
-  async getActivatedAutofillPolicy(options?: StorageOptions): Promise<boolean> {
+  async getActivateAutoFillOnPageLoadFromPolicy(options?: StorageOptions): Promise<boolean> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.settings?.activatedAutofillPolicy;
+    )?.settings?.activateAutoFillOnPageLoadFromPolicy;
   }
 
-  async setActivatedAutofillPolicy(value: boolean, options?: StorageOptions): Promise<void> {
+  async setActivateAutoFillOnPageLoadFromPolicy(
+    value: boolean,
+    options?: StorageOptions
+  ): Promise<void> {
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
-    account.settings.activatedAutofillPolicy = value;
+    account.settings.activateAutoFillOnPageLoadFromPolicy = value;
     return await this.saveAccount(
       account,
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds a new policy that will automatically activate auto-fill on page load for all users in the organization when the policy is enabled.

From the end-user perspective, a one-time notification will show to indicate that the organization turned on the setting. The policy will not restrict the user from modifying the setting after activation. This means that the user can:
- Turn off auto-fill
- Modify the “default autofill setting for login items”
- Modify URI match detection on the item level


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Some of the messaging on browser has been lost recently, specifically "loggedIn", "unlocked", and "syncCompleted" messages don't get caught by the `bitwardenPopupMainMessageListener`. This means that we can't detect when the user completes any of these actions to activate the setting and show the popup. As an alternative, I have attached the flag detection on the `current-tab.component` so when the user navigates to that page it activates from the policy.


- **bitwarden_license/bit-web/src/app/policies/activate-autofill.component.html,ts:** New component for the ActivateAutofill policy
- **apps/browser/src/services/browser-policy.service.ts:** Whenever the policies are updated, we check for the `ActivateAutofill` policy and set a flag for later when we know the popup is open.
- **libs/common/src/enums/policyType.ts:** add flag to state service
- **apps/browser/src/vault/popup/components/vault/vault-filter.component.ts:** Checks for previous flag and enables autofill on page load if true.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
