### PR TITLE
[SM-571] reenable route reuse on destroy

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -54,6 +54,7 @@ type Tasks = {
 })
 export class OverviewComponent implements OnInit, OnDestroy {
   private destroy$: Subject<void> = new Subject<void>();
+  private prevShouldReuseRoute: any;
   private tableSize = 10;
   private organizationId: string;
   protected organizationName: string;
@@ -80,6 +81,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
      * We want to remount the `sm-onboarding` component on route change.
      * The component only toggles its visibility on init and on user dismissal.
      */
+    this.prevShouldReuseRoute = this.router.routeReuseStrategy.shouldReuseRoute;
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
   }
 
@@ -133,6 +135,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.router.routeReuseStrategy.shouldReuseRoute = this.prevShouldReuseRoute;
     this.destroy$.next();
     this.destroy$.complete();
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR fixes an issue where routes were never being reused.

Background:

The `OverviewComponent` sets `this.router.routeReuseStrategy.shouldReuseRoute = () => false;`

This is done to remount the page and trigger the loading spinner when switching organizations, which is needed to prevent a potential vertical layout shift from the onboarding component appearing.

This PR sets `this.router.routeReuseStrategy.shouldReuseRoute` back to its initial value when navigating away from the overview page.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
