### PR TITLE
Corrected syntax for job to label branches with needs-qa

### DIFF
--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -5,8 +5,7 @@ name: Label Issue Pull Request
 
 on:
   pull_request:
-    types:
-      - [opened, synchronize, edited] # Check when PR is opened, new pushes are made, or target branch is edited
+    types: [opened, synchronize, edited] # Check when PR is opened, new pushes are made, or target branch is edited
     paths-ignore:
       - .github/workflows/** # We don't need QA on workflow changes
     branches:


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In #4727, I added a new Github workflow to add a `needs-qa` label.  Upon merge into `master`, I discovered that I had the incorrect syntax for the `types` field in YAML.  

## Code changes

- **label-issue-pull-request.yml:** Modified the syntax for the triggering types.  Putting the `-` in front of the field was interpreted as a list of lists of types, which is not the intent.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
