### PR TITLE
[SM-520] add secret copy actions

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
@@ -57,6 +57,8 @@
         (deleteSecretsEvent)="openDeleteSecret($event)"
         (newSecretEvent)="openNewSecretDialog()"
         (editSecretEvent)="openEditSecret($event)"
+        (copySecretNameEvent)="copySecretName($event)"
+        (copySecretValueEvent)="copySecretValue($event)"
         [secrets]="view.latestSecrets"
       ></sm-secrets-list>
       <div *ngIf="view.allSecrets.length > 0" class="tw-ml-auto tw-mt-4 tw-max-w-max">

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -11,7 +11,9 @@ import {
   distinct,
 } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { OrganizationService } from "@bitwarden/common/abstractions/organization/organization.service.abstraction";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { DialogService } from "@bitwarden/components";
 
 import { ProjectListView } from "../models/view/project-list.view";
@@ -75,7 +77,9 @@ export class OverviewComponent implements OnInit, OnDestroy {
     private secretService: SecretService,
     private serviceAccountService: ServiceAccountService,
     private dialogService: DialogService,
-    private organizationService: OrganizationService
+    private organizationService: OrganizationService,
+    private platformUtilsService: PlatformUtilsService,
+    private i18nService: I18nService
   ) {
     /**
      * We want to remount the `sm-onboarding` component on route change.
@@ -221,5 +225,24 @@ export class OverviewComponent implements OnInit, OnDestroy {
         operation: OperationType.Add,
       },
     });
+  }
+
+  copySecretName(name: string) {
+    this.platformUtilsService.copyToClipboard(name);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("name"))
+    );
+  }
+
+  async copySecretValue(id: string) {
+    const secret = await this.secretService.getBySecretId(id);
+    this.platformUtilsService.copyToClipboard(secret.value);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("value"))
+    );
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.html
@@ -9,6 +9,8 @@
     (deleteSecretsEvent)="openDeleteSecret($event)"
     (newSecretEvent)="openNewSecretDialog()"
     (editSecretEvent)="openEditSecret($event)"
+    (copySecretNameEvent)="copySecretName($event)"
+    (copySecretValueEvent)="copySecretValue($event)"
     [secrets]="secrets"
   ></sm-secrets-list>
 </ng-container>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
@@ -2,6 +2,8 @@ import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { combineLatestWith, Observable, startWith, switchMap } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { DialogService } from "@bitwarden/components";
 
 import { SecretListView } from "../../models/view/secret-list.view";
@@ -29,7 +31,9 @@ export class ProjectSecretsComponent {
   constructor(
     private route: ActivatedRoute,
     private secretService: SecretService,
-    private dialogService: DialogService
+    private dialogService: DialogService,
+    private platformUtilsService: PlatformUtilsService,
+    private i18nService: I18nService
   ) {}
 
   ngOnInit() {
@@ -74,5 +78,24 @@ export class ProjectSecretsComponent {
         projectId: this.projectId,
       },
     });
+  }
+
+  copySecretName(name: string) {
+    this.platformUtilsService.copyToClipboard(name);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("name"))
+    );
+  }
+
+  async copySecretValue(id: string) {
+    const secret = await this.secretService.getBySecretId(id);
+    this.platformUtilsService.copyToClipboard(secret.value);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("value"))
+    );
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.html
@@ -6,6 +6,8 @@
   (deleteSecretsEvent)="openDeleteSecret($event)"
   (newSecretEvent)="openNewSecretDialog()"
   (editSecretEvent)="openEditSecret($event)"
+  (copySecretNameEvent)="copySecretName($event)"
+  (copySecretValueEvent)="copySecretValue($event)"
   [secrets]="secrets$ | async"
   [search]="search"
 ></sm-secrets-list>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { combineLatestWith, Observable, startWith, switchMap } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { DialogService } from "@bitwarden/components";
 
 import { SecretListView } from "../models/view/secret-list.view";
@@ -30,7 +32,9 @@ export class SecretsComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private secretService: SecretService,
-    private dialogService: DialogService
+    private dialogService: DialogService,
+    private platformUtilsService: PlatformUtilsService,
+    private i18nService: I18nService
   ) {}
 
   ngOnInit() {
@@ -77,5 +81,24 @@ export class SecretsComponent implements OnInit {
         operation: OperationType.Add,
       },
     });
+  }
+
+  copySecretName(name: string) {
+    this.platformUtilsService.copyToClipboard(name);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("name"))
+    );
+  }
+
+  async copySecretValue(id: string) {
+    const secret = await this.secretService.getBySecretId(id);
+    this.platformUtilsService.copyToClipboard(secret.value);
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("valueCopied", this.i18nService.t("value"))
+    );
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -97,7 +97,7 @@
           <i class="bwi bwi-fw bwi-pencil" aria-hidden="true"></i>
           {{ "editSecret" | i18n }}
         </button>
-        <button type="button" bitMenuItem (click)="copySecretNameEvent.emit(secret.id)">
+        <button type="button" bitMenuItem (click)="copySecretNameEvent.emit(secret.name)">
           <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
           {{ "copySecretName" | i18n }}
         </button>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR adds functionality to the "Copy secret name" and "Copy secret value" buttons in the secrets list.

## Code changes

Bound `PlatformUtilsService.copyToClipboard` to the `(editSecretEvent)` and `(copySecretNameEvent)` outputs in all the places we use the secrets list.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
