### PR TITLE
[PM-1205] Use page header for 2FA setup comp on org settings page to match othe…

### DIFF
--- a/apps/web/src/app/organizations/settings/two-factor-setup.component.ts
+++ b/apps/web/src/app/organizations/settings/two-factor-setup.component.ts
@@ -17,6 +17,7 @@ import { TwoFactorSetupComponent as BaseTwoFactorSetupComponent } from "../../..
 })
 // eslint-disable-next-line rxjs-angular/prefer-takeuntil
 export class TwoFactorSetupComponent extends BaseTwoFactorSetupComponent {
+  tabbedHeader = false;
   constructor(
     apiService: ApiService,
     modalService: ModalService,

--- a/apps/web/src/auth/settings/two-factor-setup.component.html
+++ b/apps/web/src/auth/settings/two-factor-setup.component.html
@@ -1,6 +1,6 @@
 <!-- Please remove this disable statement when editing this file! -->
 <!-- eslint-disable @angular-eslint/template/button-has-type -->
-<div class="page-header">
+<div [ngClass]="tabbedHeader ? 'tabbed-header' : 'page-header'">
   <h1 *ngIf="!organizationId">{{ "twoStepLogin" | i18n }}</h1>
   <h1 *ngIf="organizationId">{{ "twoStepLoginEnforcement" | i18n }}</h1>
 </div>

--- a/apps/web/src/auth/settings/two-factor-setup.component.ts
+++ b/apps/web/src/auth/settings/two-factor-setup.component.ts
@@ -43,6 +43,8 @@ export class TwoFactorSetupComponent implements OnInit, OnDestroy {
   modal: ModalRef;
   formPromise: Promise<any>;
 
+  tabbedHeader = true;
+
   private destroy$ = new Subject<void>();
   private twoFactorAuthPolicyAppliesToActiveUser: boolean;
 


### PR DESCRIPTION
…r org settings pages but use tabbed header class on user account settings > security > Two-step login tab.
[PM-1205](https://bitwarden.atlassian.net/browse/PM-1205)

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolve style issues for the 2FA Setup component that I introduced in #4734. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/organizations/settings/two-factor-setup.component.ts, apps/web/src/auth/settings/two-factor-setup.component.ts:** Add tabbed header variable
- **apps/web/src/auth/settings/two-factor-setup.component.html:** consume tabbed header variable to determine proper header class

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

Unanticipated behavior:
![image](https://user-images.githubusercontent.com/116684653/221941721-d20ea692-8dae-459f-8ab2-eac5bf281303.png)

New behavior:
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/116684653/221941876-312f308d-2f88-4b17-821e-81253ffc9cac.png">
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/116684653/221941900-0eb89252-beda-4f65-a2b7-f1082726fae4.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-1205]: https://bitwarden.atlassian.net/browse/PM-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ