### PR TITLE
[AC-1078] Provider Admin part of an org with Single Org Policy enabled cannot create new Client Organizations

### DIFF
--- a/apps/web/src/app/settings/organization-plans.component.ts
+++ b/apps/web/src/app/settings/organization-plans.component.ts
@@ -71,7 +71,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
     this.formGroup?.controls?.plan?.setValue(plan);
   }
   private _plan = PlanType.Free;
-  @Input() providerId: string;
+  @Input() providerId?: string;
   @Output() onSuccess = new EventEmitter<OnSuccessArgs>();
   @Output() onCanceled = new EventEmitter<void>();
   @Output() onTrialBillingSuccess = new EventEmitter();
@@ -80,7 +80,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
   selfHosted = false;
   productTypes = ProductType;
   formPromise: Promise<string>;
-  singleOrgPolicyBlock = false;
+  singleOrgPolicyAppliesToActiveUser = false;
   isInTrialFlow = false;
   discount = 0;
 
@@ -146,7 +146,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       .policyAppliesToActiveUser$(PolicyType.SingleOrg)
       .pipe(takeUntil(this.destroy$))
       .subscribe((policyAppliesToActiveUser) => {
-        this.singleOrgPolicyBlock = policyAppliesToActiveUser;
+        this.singleOrgPolicyAppliesToActiveUser = policyAppliesToActiveUser;
       });
 
     this.loading = false;
@@ -155,6 +155,10 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  get singleOrgPolicyBlock() {
+    return this.singleOrgPolicyAppliesToActiveUser && this.providerId == null;
   }
 
   get createOrganization() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [c] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Single org policy should not block provider admins from creating client organizations

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
