### PR TITLE
[EC-1086] The Remove individual vault Enterprise Policy prevents Service Users and Provider admins from creating new vault items via the Provider Portal.

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -257,6 +257,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     const defaultComponentParameters = (comp: AddEditComponent) => {
       comp.organization = this.organization;
+      comp.organizationId = this.organization.id;
       comp.cipherId = cipherId;
       // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
       comp.onSavedCipher.subscribe(async () => {

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -201,7 +201,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
           this.ownershipOptions.push({ name: o.name, value: o.id });
         }
       });
-    if (!this.allowPersonal) {
+    if (!this.allowPersonal && this.organizationId == undefined) {
       this.organizationId = this.ownershipOptions[0].value;
     }
   }


### PR DESCRIPTION
# PR Closed because the branch name is too long

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When single vault policy was in effect the `organizationId` that the user belonged to was was always set for new ciphers. This was overwriting the client organization's id when a provider was trying to create new items in their clients vault.

## Code changes

Check that the `AddEditComponent` hasn't already been provided with an organization id before fetching `organizationId` from policy settings. Organization ids are only provided inside of the org-vault and the user is only allowed to access org-vaults of organizations they belong to or are otherwise allowed to administrate, as such the organization id must be a valid id if supplied.

## Screenshots

![image](https://user-images.githubusercontent.com/2285588/222407315-ddf760e4-d6bc-425e-b29e-9cceac7afa5a.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
