### PR TITLE
[SM-589][SM-592] Remove router reuse hack

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6605,5 +6605,8 @@
         "example": "14"
       }
     }
+  },
+  "dismiss": {
+    "message": "Dismiss"
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding.component.html
@@ -1,10 +1,4 @@
-<details
-  *ngIf="visible"
-  #details
-  class="tw-rounded-sm tw-bg-background-alt tw-text-main"
-  (toggle)="toggle()"
-  open
->
+<details #details class="tw-rounded-sm tw-bg-background-alt tw-text-main" (toggle)="toggle()" open>
   <summary class="tw-list-none tw-p-2 tw-px-4">
     <div class="tw-flex tw-select-none tw-items-center tw-gap-4">
       <i class="bwi bwi-dashboard tw-text-3xl tw-text-primary-500" aria-hidden="true"></i>
@@ -29,9 +23,9 @@
       type="button"
       class="tw-ml-auto tw-block"
       [ngClass]="{ 'tw-invisible': !isComplete }"
-      (click)="dismiss()"
+      (click)="dismiss.emit()"
     >
-      Dismiss
+      {{ "dismiss" | i18n }}
     </button>
   </div>
 </details>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, ContentChildren, Input, QueryList } from "@angular/core";
+import { Component, ContentChildren, EventEmitter, Input, Output, QueryList } from "@angular/core";
 
 import { OnboardingTaskComponent } from "./onboarding-task.component";
 
@@ -6,16 +6,14 @@ import { OnboardingTaskComponent } from "./onboarding-task.component";
   selector: "sm-onboarding",
   templateUrl: "./onboarding.component.html",
 })
-export class OnboardingComponent implements AfterContentInit {
+export class OnboardingComponent {
   @ContentChildren(OnboardingTaskComponent) tasks: QueryList<OnboardingTaskComponent>;
   @Input() title: string;
 
+  @Output() dismiss = new EventEmitter<void>();
+
   protected open = true;
   protected visible = false;
-
-  ngAfterContentInit() {
-    this.visible = !this.isComplete;
-  }
 
   protected get amountCompleted(): number {
     return this.tasks.filter((task) => task.completed).length;
@@ -31,9 +29,5 @@ export class OnboardingComponent implements AfterContentInit {
 
   protected toggle() {
     this.open = !this.open;
-  }
-
-  protected dismiss() {
-    this.visible = false;
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
@@ -3,7 +3,7 @@
 </sm-header>
 
 <div *ngIf="view$ | async as view; else spinner">
-  <sm-onboarding [title]="'getStarted' | i18n">
+  <sm-onboarding [title]="'getStarted' | i18n" *ngIf="showOnboarding" (dismiss)="hideOnboarding()">
     <sm-onboarding-task
       [title]="'createServiceAccount' | i18n"
       (click)="openServiceAccountDialog()"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -80,14 +80,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     private organizationService: OrganizationService,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService
-  ) {
-    /**
-     * We want to remount the `sm-onboarding` component on route change.
-     * The component only toggles its visibility on init and on user dismissal.
-     */
-    this.prevShouldReuseRoute = this.router.routeReuseStrategy.shouldReuseRoute;
-    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-  }
+  ) {}
 
   ngOnInit() {
     const orgId$ = this.route.params.pipe(
@@ -139,7 +132,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.router.routeReuseStrategy.shouldReuseRoute = this.prevShouldReuseRoute;
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -8,7 +8,7 @@ import {
   takeUntil,
   combineLatest,
   startWith,
-  distinct,
+  distinctUntilChanged,
 } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
@@ -85,7 +85,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     const orgId$ = this.route.params.pipe(
       map((p) => p.organizationId),
-      distinct()
+      distinctUntilChanged()
     );
 
     orgId$

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import {
   map,
   Observable,
@@ -9,6 +9,7 @@ import {
   combineLatest,
   startWith,
   distinctUntilChanged,
+  take,
 } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
@@ -56,11 +57,11 @@ type Tasks = {
 })
 export class OverviewComponent implements OnInit, OnDestroy {
   private destroy$: Subject<void> = new Subject<void>();
-  private prevShouldReuseRoute: any;
   private tableSize = 10;
   private organizationId: string;
   protected organizationName: string;
   protected userIsAdmin: boolean;
+  protected showOnboarding = false;
 
   protected view$: Observable<{
     allProjects: ProjectListView[];
@@ -72,7 +73,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router,
     private projectService: ProjectService,
     private secretService: SecretService,
     private serviceAccountService: ServiceAccountService,
@@ -129,6 +129,16 @@ export class OverviewComponent implements OnInit, OnDestroy {
         };
       })
     );
+
+    // Refresh onboarding status when orgId changes by fetching the first value from view$.
+    orgId$
+      .pipe(
+        switchMap(() => this.view$.pipe(take(1))),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((view) => {
+        this.showOnboarding = Object.values(view.tasks).includes(false);
+      });
   }
 
   ngOnDestroy(): void {
@@ -236,5 +246,9 @@ export class OverviewComponent implements OnInit, OnDestroy {
       null,
       this.i18nService.t("valueCopied", this.i18nService.t("value"))
     );
+  }
+
+  protected hideOnboarding() {
+    this.showOnboarding = false;
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
+import { AuthGuard } from "@bitwarden/angular/auth/guards/auth.guard";
 import { Organization } from "@bitwarden/common/models/domain/organization";
 import { OrganizationPermissionsGuard } from "@bitwarden/web-vault/app/organizations/guards/org-permissions.guard";
 import { buildFlaggedRoute } from "@bitwarden/web-vault/app/oss-routing.module";
@@ -19,7 +20,7 @@ const routes: Routes = [
   buildFlaggedRoute("secretsManager", {
     path: ":organizationId",
     component: LayoutComponent,
-    canActivate: [OrganizationPermissionsGuard, SMGuard],
+    canActivate: [AuthGuard, OrganizationPermissionsGuard, SMGuard],
     data: {
       organizationPermissions: (org: Organization) => org.canAccessSecretsManager,
     },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

It seems the router reuse hack causes a unintended side effect of tricking the application into believing the `/login` route should be stored, which results in a redirect loop from `/login` to `/login` which is handled by not redirecting anywhere.

Also added `AuthGuard` to the secrets manager routes, which ensures that the previous url is properly stored when redirecting to the login page.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
