### PR TITLE
Modified needs-qa labeler to only fire when PR is opened or edited

### DIFF
--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -5,7 +5,7 @@ name: Label Issue Pull Request
 
 on:
   pull_request:
-    types: [opened, synchronize, edited] # Check when PR is opened, new pushes are made, or target branch is edited
+    types: [opened, edited] # Check when PR is opened or target branch is edited
     paths-ignore:
       - .github/workflows/** # We don't need QA on workflow changes
     branches:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix inadvertent runs of the `Label Issue Pull Request` action.

## Code changes

I did not account for scenarios where `needs-qa` has been removed (as it has been tested) but we need to pull `master` into the branch.  That push would trigger the action to run again, applying the tag that was removed.  I modified the action to be a bit more selective on when it will trigger.  Now it will only trigger when a PR is opened and when edited, which is to catch when the target branch changes.

- **[.github/workflows/label-issue-pull-request.yml](https://github.com/bitwarden/clients/compare/fix-issue-label-action?expand=1#diff-d6bbcb02c652bcaa86a2da3c08ca015be30a974bc462339fffde8dc1acd334d6):** Removed `synchronize` from trigger list.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
