### PR TITLE
Avoid line breaks in header controls

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -222,6 +222,7 @@ header {
     justify-content: center;
     align-items: center;
     height: 100%;
+    white-space: pre;
 
     @include themify($themes) {
       color: themed("headerColor");


### PR DESCRIPTION
## Type of change

Avoid line break inside header controls.

Closes #4920

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

For certain languages (in the example provided in #4920, traditional chinese/taiwanes `zh_TW`) the "Back" button (when going to the vault, and then into a folder) can break over multiple lines - looking awkward and wrong. This PR sets explicit `white-space: pre` to suppress lines breaking.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **base.scss:** add `white-space:pre` to the styles for buttons/controls inside the header

## Screenshots

Before:

![current back button, with the two traditional chinese characters on separate lines](https://user-images.githubusercontent.com/895831/222969912-e0735792-56bf-4b05-b183-5eb0eacfdf42.png)

After:

![with the fix applied, both chinese characters remain on the same line and don't break](https://user-images.githubusercontent.com/895831/222969940-39872585-bf9e-4d96-84e6-bf28262c8050.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
