### PR TITLE
[AC-1173] Fix state bugs in auto-save edit flow

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -397,9 +397,12 @@ export default class NotificationBackground {
   private async editItem(cipherView: CipherView, senderTab: chrome.tabs.Tab) {
     await this.stateService.setAddEditCipherInfo({
       cipher: cipherView,
+      collectionIds: cipherView.collectionIds,
     });
 
-    await BrowserApi.tabSendMessageData(senderTab, "openAddEditCipher");
+    await BrowserApi.tabSendMessageData(senderTab, "openAddEditCipher", {
+      cipherId: cipherView.id,
+    });
   }
 
   private async folderExists(folderId: string) {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -102,9 +102,15 @@ export default class RuntimeBackground {
       case "promptForLogin":
         BrowserApi.openBitwardenExtensionTab("popup/index.html", true, sender.tab);
         break;
-      case "openAddEditCipher":
-        BrowserApi.openBitwardenExtensionTab("popup/index.html#/edit-cipher", true, sender.tab);
+      case "openAddEditCipher": {
+        const addEditCipherUrl =
+          msg.data?.cipherId == null
+            ? "popup/index.html#/edit-cipher"
+            : "popup/index.html#/edit-cipher?cipherId=" + msg.data.cipherId;
+
+        BrowserApi.openBitwardenExtensionTab(addEditCipherUrl, true, sender.tab);
         break;
+      }
       case "closeTab":
         setTimeout(() => {
           BrowserApi.closeBitwardenExtensionTab();

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -626,8 +626,8 @@ export class AddEditComponent implements OnInit, OnDestroy {
       this.cipher = addEditCipherInfo.cipher;
       this.collectionIds = addEditCipherInfo.collectionIds;
 
-      if (!this.allowPersonal && this.cipher.organizationId == null) {
-        // Personal ownership isn't allowed, so 'null' must mean it hasn't been set yet
+      if (!this.editMode && !this.allowPersonal && this.cipher.organizationId == null) {
+        // This is a new cipher and personal ownership isn't allowed, so we need to set the default owner
         this.cipher.organizationId = this.defaultOwnerId;
       }
     }

--- a/libs/common/src/vault/types/add-edit-cipher-info.ts
+++ b/libs/common/src/vault/types/add-edit-cipher-info.ts
@@ -1,5 +1,11 @@
 import { CipherView } from "../models/view/cipher.view";
 
+/**
+ * Used to temporarily save the state of the AddEditComponent, e.g. when the user navigates away to the Generator page.
+ * @property cipher The unsaved item being added or edited
+ * @property collectionIds The collections that are selected for the item (currently these are not mapped back to
+ * cipher.collectionIds until the item is saved)
+ */
 export type AddEditCipherInfo = {
   cipher: CipherView;
   collectionIds?: string[];


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following bugs in the new auto-save edit flow:
* when updating an existing item, the state of the "collections" checkboxes were not being restored according to `cipher.collectionIds`
* if you have the Remove Personal Vault policy activated, but still have some personal items (from before the policy was turned on), the edit flow changes the Owner from individual to organization. This is not how the popup works and is not able to be saved (we have the "Move to Organization" flow to do this properly).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- save `collectionIds` in the `AddEditCipherInfo` object. This is used because `AddEditComponent` doesn't use reactive forms and doesn't map the selected collection checkboxes to the `Cipher` object until the item is saved, so it's not expecting `cipher.collectionIds` to be accurate
- pass the cipher Id in the `openAddEditCipher` message and include it in the queryparams when opening the tab. This ensures that `AddEditComponent` is in `editMode` for existing ciphers
- don't overwrite ownership options for existing ciphers when restoring state
- add comments on `AddEditCipherInfo`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
