### PR TITLE
[PM-1334] Add option to match URI by Origin

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1281,6 +1281,10 @@
     "message": "Host",
     "description": "A URL's host value. For example, the host of https://sub.domain.com:443 is 'sub.domain.com:443'."
   },
+  "origin": {
+    "message": "Origin",
+    "description": "A URL's origin value. For example, the origin of https://sub.domain.com:443 is 'https://sub.domain.com:443'."
+  },
   "exact": {
     "message": "Exact"
   },

--- a/apps/browser/src/popup/settings/autofill.component.ts
+++ b/apps/browser/src/popup/settings/autofill.component.ts
@@ -31,6 +31,7 @@ export class AutofillComponent implements OnInit {
     this.uriMatchOptions = [
       { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
       { name: i18nService.t("host"), value: UriMatchType.Host },
+      { name: i18nService.t("origin"), value: UriMatchType.Origin },
       { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
       { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
       { name: i18nService.t("exact"), value: UriMatchType.Exact },

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -52,6 +52,7 @@ export class OptionsComponent implements OnInit {
     this.uriMatchOptions = [
       { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
       { name: i18nService.t("host"), value: UriMatchType.Host },
+      { name: i18nService.t("origin"), value: UriMatchType.Origin },
       { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
       { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
       { name: i18nService.t("exact"), value: UriMatchType.Exact },

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -148,6 +148,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
       { name: i18nService.t("defaultMatchDetection"), value: null },
       { name: i18nService.t("baseDomain"), value: UriMatchType.Domain },
       { name: i18nService.t("host"), value: UriMatchType.Host },
+      { name: i18nService.t("origin"), value: UriMatchType.Origin },
       { name: i18nService.t("startsWith"), value: UriMatchType.StartsWith },
       { name: i18nService.t("regEx"), value: UriMatchType.RegularExpression },
       { name: i18nService.t("exact"), value: UriMatchType.Exact },

--- a/libs/common/src/enums/uriMatchType.ts
+++ b/libs/common/src/enums/uriMatchType.ts
@@ -5,4 +5,5 @@ export enum UriMatchType {
   Exact = 3,
   RegularExpression = 4,
   Never = 5,
+  Origin = 6,
 }

--- a/libs/common/src/misc/utils.ts
+++ b/libs/common/src/misc/utils.ts
@@ -268,6 +268,15 @@ export class Utils {
     }
   }
 
+  static getOrigin(uriString: string): string {
+    const url = Utils.getUrl(uriString);
+    try {
+      return url != null && url.origin !== "" ? url.origin : null;
+    } catch {
+      return null;
+    }
+  }
+
   static getDomain(uriString: string): string {
     if (Utils.isNullOrWhitespace(uriString)) {
       return null;

--- a/libs/common/src/vault/models/view/login-uri-view.spec.ts
+++ b/libs/common/src/vault/models/view/login-uri-view.spec.ts
@@ -9,6 +9,11 @@ const testData = [
     expected: "http://example.com/login",
   },
   {
+    match: UriMatchType.Origin,
+    uri: "https://example.com/path",
+    expected: "https://example.com/path",
+  },
+  {
     match: UriMatchType.Host,
     uri: "bitwarden.com",
     expected: "http://bitwarden.com",
@@ -62,5 +67,17 @@ describe("LoginUriView", () => {
     const uri = new LoginUriView();
     Object.assign(uri, { match: UriMatchType.Host, uri: "someprotocol://bitwarden.com" });
     expect(uri.canLaunch).toBe(false);
+  });
+
+  it(`canLaunch() should return false when origin does not match`, async () => {
+    const uri = new LoginUriView();
+    Object.assign(uri, { match: UriMatchType.Origin, uri: "someprotocol://bitwarden.com" });
+    expect(uri.canLaunch).toBe(false);
+  });
+
+  it(`canLaunch() should return true when origin does match`, async () => {
+    const uri = new LoginUriView();
+    Object.assign(uri, { match: UriMatchType.Origin, uri: "http://bitwarden.com" });
+    expect(uri.canLaunch).toBe(true);
   });
 });

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -473,6 +473,13 @@ export class CipherService implements CipherServiceAbstraction {
               }
               break;
             }
+            case UriMatchType.Origin: {
+              const urlOrigin = Utils.getOrigin(url);
+              if (urlOrigin != null && urlOrigin === Utils.getOrigin(u.uri)) {
+                return true;
+              }
+              break;
+            }
             case UriMatchType.Exact:
               if (url === u.uri) {
                 return true;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The fundamental boundary of web security is the [Same Origin Policy (SOP)](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy), of which many additional security standards of the web platform are built on top of. For users familiar with SOP, being able to match vault URIs by origins makes it easier for them to reason about the security of a page they are attempting to autofill using vault login. However, users currently cannot restrict autofilling vault logins by matching the origin of the site they want to autofill a login with the origin of the URI saved to vault login they intend to autofill. 

The current match detection options have security or usability flaws for achieving the same functionality as match by [Origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin):
- `Base domain` match detection will exclude checking if the scheme and SLD of URIs match, which opens up the opportunity to fall for autofilling a login into a subdomain taken over by an attacker. 
- `Host` match detection excludes the scheme of a URI, which may result in (1) the unlikely chance of falling for an HTTPS downgrade attack and autofilling, or (2) matching to any scheme in `CanLaunchWhitelist`
- `Exact` match detection will match the path of a URI. When saving a new vault login, Bitwarden takes the current URL on the page, strips the query parameters and saves that as the URI for the vault item. To replicate the functionality of match detection by origin, the user will often need to manually delete the path of URIs autosaved when creating a new vault login.
- `Starts with` suffers from the same problem as `Exact`, because of what Bitwarden does when saving a new vault item, except it's slightly more permissive as URIs with additional paths appended will autofill.
- `Regex` would allow for users to achieve the same functionality as match by origin, but it would (1) require writing a regex without making any mistakes, (2) would make matching by origin inaccessible for people not familiar with regex, and (3) require the user to copy over the regex pattern to each of their existing clients or new clients they use.

Additionally, this change may help mitigate some concerns from [cure53's recent audit (e.g. BWN-04-005 WP4)](https://bitwarden.com/_gatsby/file/587f36548f06fac33536c4808b79802f/2022%20Bitwarden%20Security%20Assessment%20Report.pdf?eu=db8f01b2e1cafb820f3ba0d16b266761e26a53adfd506082686ce0fc4ea19a8777f44b0420c072e42e605fde85b244b96e932b601aed81dbc9bb4cf5e967f80e57870ebd66e77054042892ade1f7554d69951359a5d6c15aa43c7285b0e0bf701a561b2cab29ecd4edab3c65b0d77a60eab1af7f63c7a120a4561e17c1076ead27f8c59a7000bd8ae64eaca5bbed4ad3c2b269184799ad66642d4d4950b06abcbab6510c6458415d5f84a625b612f2ce4349297f161703e8673f8656ae3836c6b7fba50bde2e7db4a8c1377481caac87e44ea42825e0cc24b6803b780c62de4ae9fb2ab586315861e27fa9d00eeb474c5a31c15fdc6763846d01c868e6b407cc6ab870666267).

## Test Plan
The following is a list of tests conducted with steps to reproduce:
- Ran `npm run test:watch` and checked that `libs/common/src/vault/models/view/login-uri-view.spec.ts` passed
- Built browser extension and loaded it, then did the following:
   1. Settings -> Auto-fill -> Set Default URI match detection to Origin
![image](https://user-images.githubusercontent.com/14011954/223045280-04c43f54-e59e-4498-8ac5-d7b26b769ccb.png)

   3. Go to https://sandbox.0xedward.io/autofill, fill in some random value for username and password and save the form data to Bitwarden when prompted
   4. Select the login vault item corresponding to https://sandbox.0xedward.io/autofill -> Edit -> Check under URI that Origin appears on the dropdown list of match detection options -> Edit URI from `https://sandbox.0xedward.io/autofill` to `http://sandbox.0xedward.io/autofill` -> Notice Bitwarden no longer shows that vault item as an autofill option for the page
![image](https://user-images.githubusercontent.com/14011954/223045207-aedc9d75-0d8f-4007-b5e0-7b69b5373e62.png)
- Built the web vault -> logged into to my vault -> Edit the `sandbox.0xedward.io` vault item -> Check Origin appears in the dropdown list of match detection options
![image](https://user-images.githubusercontent.com/14011954/223047775-4c7479ac-28c1-498a-8e92-fbac194be427.png)


## Additional info
- This change will require an update to https://bitwarden.com/help/uri-match-detection/#match-detection-options and cut a new release for the web vault and the browser extension
- [Mobile implementation of this change](https://github.com/bitwarden/mobile/pull/2402)
