### PR TITLE
[SM-607] fix BitIcon innerHTML rerender removing click handler

### DIFF
--- a/libs/components/src/icon/icon.component.ts
+++ b/libs/components/src/icon/icon.component.ts
@@ -1,23 +1,23 @@
-import { Component, HostBinding, Input } from "@angular/core";
-import { DomSanitizer } from "@angular/platform-browser";
+import { Component, Input } from "@angular/core";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 
 import { Icon, isIcon } from "./icon";
 
 @Component({
   selector: "bit-icon",
-  template: ``,
+  template: `<div *ngIf="html" [outerHTML]="html"></div>`,
 })
 export class BitIconComponent {
-  @Input() icon: Icon;
+  protected html: SafeHtml;
 
-  @HostBinding()
-  protected get innerHtml() {
-    if (!isIcon(this.icon)) {
-      return "";
+  @Input() set icon(icon: Icon) {
+    if (!isIcon(icon)) {
+      this.html = "";
+      return;
     }
 
-    const svg = this.icon.svg;
-    return this.domSanitizer.bypassSecurityTrustHtml(svg);
+    const svg = icon.svg;
+    this.html = this.domSanitizer.bypassSecurityTrustHtml(svg);
   }
 
   constructor(private domSanitizer: DomSanitizer) {}

--- a/libs/components/src/icon/icon.component.ts
+++ b/libs/components/src/icon/icon.component.ts
@@ -1,24 +1,24 @@
-import { Component, Input } from "@angular/core";
+import { Component, HostBinding, Input } from "@angular/core";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 
 import { Icon, isIcon } from "./icon";
 
 @Component({
   selector: "bit-icon",
-  template: `<div *ngIf="html" [outerHTML]="html"></div>`,
+  template: ``,
 })
 export class BitIconComponent {
-  protected html: SafeHtml;
-
   @Input() set icon(icon: Icon) {
     if (!isIcon(icon)) {
-      this.html = "";
+      this.innerHtml = "";
       return;
     }
 
     const svg = icon.svg;
-    this.html = this.domSanitizer.bypassSecurityTrustHtml(svg);
+    this.innerHtml = this.domSanitizer.bypassSecurityTrustHtml(svg);
   }
+
+  @HostBinding() innerHtml: SafeHtml;
 
   constructor(private domSanitizer: DomSanitizer) {}
 }

--- a/libs/components/src/icon/icon.components.spec.ts
+++ b/libs/components/src/icon/icon.components.spec.ts
@@ -3,6 +3,14 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { Icon, svgIcon } from "./icon";
 import { BitIconComponent } from "./icon.component";
 
+/**
+ * Remove comments from HTML string.
+ * Necessary to prevent Angular bindings comments from failing tests.
+ **/
+const stripComments = (html: string) => {
+  return html.replace(/<!--(?:.|\n)*?-->/gm, "");
+};
+
 describe("IconComponent", () => {
   let component: BitIconComponent;
   let fixture: ComponentFixture<BitIconComponent>;
@@ -24,7 +32,7 @@ describe("IconComponent", () => {
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.innerHTML).toBe("");
+    expect(stripComments(el.innerHTML)).toBe("");
   });
 
   it("should contain icon when input is a safe Icon", () => {
@@ -34,6 +42,6 @@ describe("IconComponent", () => {
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
-    expect(el.innerHTML).toBe(`<svg><text x="0" y="15">safe icon</text></svg>`);
+    expect(stripComments(el.innerHTML)).toBe(`<svg><text x="0" y="15">safe icon</text></svg>`);
   });
 });

--- a/libs/components/src/icon/icon.components.spec.ts
+++ b/libs/components/src/icon/icon.components.spec.ts
@@ -3,14 +3,6 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { Icon, svgIcon } from "./icon";
 import { BitIconComponent } from "./icon.component";
 
-/**
- * Remove comments from HTML string.
- * Necessary to prevent Angular bindings comments from failing tests.
- **/
-const stripComments = (html: string) => {
-  return html.replace(/<!--(?:.|\n)*?-->/gm, "");
-};
-
 describe("IconComponent", () => {
   let component: BitIconComponent;
   let fixture: ComponentFixture<BitIconComponent>;
@@ -32,7 +24,7 @@ describe("IconComponent", () => {
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
-    expect(stripComments(el.innerHTML)).toBe("");
+    expect(el.innerHTML).toBe("");
   });
 
   it("should contain icon when input is a safe Icon", () => {
@@ -42,6 +34,6 @@ describe("IconComponent", () => {
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
-    expect(stripComments(el.innerHTML)).toBe(`<svg><text x="0" y="15">safe icon</text></svg>`);
+    expect(el.innerHTML).toBe(`<svg><text x="0" y="15">safe icon</text></svg>`);
   });
 });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The SM logo was not consistently registering click events. This was caused by `BitIcon` repeatedly updating its `innerHTML`. This PR fixes `BitIcon` to only update when the icon source is changed. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/icon/icon.component.ts:** Remove `innerHTML` getter. 
- **libs/components/src/icon/icon.components.spec.ts:** Update tests to not fail from Angular's `<!-- bindings... -->` comments.
## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
