### PR TITLE
[SM-611] Fix edit dialog & overview secrets refresh

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -116,7 +116,11 @@ export class OverviewComponent implements OnInit, OnDestroy {
       share()
     );
 
-    const secrets$ = combineLatest([orgId$, this.secretService.secret$.pipe(startWith(null))]).pipe(
+    const secrets$ = combineLatest([
+      orgId$,
+      this.secretService.secret$.pipe(startWith(null)),
+      this.projectService.project$.pipe(startWith(null)),
+    ]).pipe(
       switchMap(([orgId]) => this.secretService.getSecrets(orgId)),
       share()
     );

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
@@ -46,7 +46,7 @@ export class SecretDeleteDialogComponent {
 
     if (bulkResponses.find((response) => response.errorMessage)) {
       this.openBulkStatusDialog(bulkResponses.filter((response) => response.errorMessage));
-      this.dialogRef.close();
+      this.dialogRef.close(true);
       return;
     }
 
@@ -54,7 +54,7 @@ export class SecretDeleteDialogComponent {
       this.data.secrets.length === 1 ? "softDeleteSuccessToast" : "softDeletesSuccessToast";
     this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
 
-    this.dialogRef.close();
+    this.dialogRef.close(true);
   };
 
   openBulkStatusDialog(bulkStatusResults: BulkOperationStatus[]) {
@@ -62,7 +62,7 @@ export class SecretDeleteDialogComponent {
       data: {
         title: "deleteSecrets",
         subTitle: "secrets",
-        columnTitle: "secretName",
+        columnTitle: "name",
         message: "bulkDeleteSecretsErrorMessage",
         details: bulkStatusResults,
       },

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -26,7 +26,7 @@
         <bit-form-field class="tw-mt-3 tw-mb-0">
           <bit-label>{{ "project" | i18n }}</bit-label>
           <select bitInput name="project" formControlName="project">
-            <option value="selectPlaceholder">{{ "selectPlaceholder" | i18n }}</option>
+            <option value="">{{ "selectPlaceholder" | i18n }}</option>
             <option *ngFor="let f of projects" [value]="f.id">
               {{ f.name }}
             </option>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -26,7 +26,7 @@
         <bit-form-field class="tw-mt-3 tw-mb-0">
           <bit-label>{{ "project" | i18n }}</bit-label>
           <select bitInput name="project" formControlName="project">
-            <option value="">{{ "selectPlaceholder" | i18n }}</option>
+            <option value="selectPlaceholder">{{ "selectPlaceholder" | i18n }}</option>
             <option *ngFor="let f of projects" [value]="f.id">
               {{ f.name }}
             </option>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -154,12 +154,18 @@ export class SecretDialogComponent implements OnInit {
   private getSecretListView() {
     const secretListViews: SecretListView[] = [];
     const emptyProjects: SecretProjectView[] = [];
-    const selectedProject = [this.projects.find((p) => p.id == this.formGroup.value.project)];
 
     const secretListView = new SecretListView();
+
+    if (this.formGroup.value.project) {
+      secretListView.projects = [this.projects.find((p) => p.id == this.formGroup.value.project)];
+    } else {
+      secretListView.projects = emptyProjects;
+    }
+
     secretListView.organizationId = this.data.organizationId;
+    secretListView.id = this.data.secretId;
     secretListView.name = this.formGroup.value.name;
-    secretListView.projects = selectedProject ? selectedProject : emptyProjects;
     secretListViews.push(secretListView);
     return secretListViews;
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -78,7 +78,7 @@ export class SecretDialogComponent implements OnInit {
       name: secret.name,
       value: secret.value,
       notes: secret.note,
-      project: secret.projects[0]?.id,
+      project: secret.projects[0]?.id != null ? secret.projects[0]?.id : "selectPlaceholder",
     });
     this.loading = false;
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -78,7 +78,7 @@ export class SecretDialogComponent implements OnInit {
       name: secret.name,
       value: secret.value,
       notes: secret.note,
-      project: secret.projects[0]?.id != null ? secret.projects[0]?.id : "selectPlaceholder",
+      project: secret.projects[0]?.id ?? "",
     });
     this.loading = false;
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to fix the edit secret dialog that doesn't launch when the secret is not assigned to a project.

The PR also has the secrets list refresh when a project deletion occurs on the overview page.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
- bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts

Load default value if not projects exist.

- bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts

Have secrets list refresh when a project deletion occurs on the overview page.

## Screenshots

![image](https://user-images.githubusercontent.com/43214426/223558179-5f88c8b4-c01a-4ea9-9a4b-20a6f5329843.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
