### PR TITLE
[SM-621] unassigned secret badge

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -79,6 +79,10 @@
         >
           {{ project.name | ellipsis: 32 }}
         </span>
+        <span *ngIf="secret.projects.length === 0" bitBadge badgeType="warning" class="tw-ml-1"
+          ><i class="bwi bwi-fw bwi-exclamation-triangle tw-mr-1" aria-hidden="true"></i
+          >{{ "unassigned" | i18n }}</span
+        >
       </td>
       <td bitCell class="tw-whitespace-nowrap">{{ secret.revisionDate | date: "medium" }}</td>
       <td bitCell>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Items in the secrets list that are not assigned to a project should show an "Unassigned" warning badge.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html:** Check projects length and show badge

## Screenshots

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/17113462/223767417-741da888-0ca6-4e59-a01a-760d22448065.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
