### PR TITLE
[SM-590] show email as fallback name in SM header

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/header.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/header.component.html
@@ -49,7 +49,7 @@
                 <div class="tw-ml-2 tw-block tw-overflow-hidden tw-whitespace-nowrap">
                   <span>{{ "loggedInAs" | i18n }}</span>
                   <small class="tw-block tw-overflow-hidden tw-whitespace-nowrap tw-text-muted">
-                    {{ account.name }}
+                    {{ account.name || account.email }}
                   </small>
                 </div>
               </div>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/header.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/header.component.html
@@ -33,7 +33,7 @@
             [bitMenuTriggerFor]="accountMenu"
             class="tw-border-0 tw-bg-transparent tw-p-0"
           >
-            <bit-avatar [id]="account.userId" [text]="account.name || account.email"></bit-avatar>
+            <bit-avatar [id]="account.userId" [text]="account | userName"></bit-avatar>
           </button>
 
           <bit-menu #accountMenu>
@@ -42,14 +42,11 @@
                 class="tw-flex tw-items-center tw-py-1 tw-px-4 tw-leading-tight tw-text-info"
                 appStopProp
               >
-                <bit-avatar
-                  [text]="account.name || account.email"
-                  [id]="account.userId"
-                ></bit-avatar>
+                <bit-avatar [text]="account | userName" [id]="account.userId"></bit-avatar>
                 <div class="tw-ml-2 tw-block tw-overflow-hidden tw-whitespace-nowrap">
                   <span>{{ "loggedInAs" | i18n }}</span>
                   <small class="tw-block tw-overflow-hidden tw-whitespace-nowrap tw-text-muted">
-                    {{ account.name || account.email }}
+                    {{ account | userName }}
                   </small>
                 </div>
               </div>

--- a/libs/angular/src/pipes/user-name.pipe.ts
+++ b/libs/angular/src/pipes/user-name.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from "@angular/core";
 
 interface User {
   name?: string;
-  email: string;
+  email?: string;
 }
 
 @Pipe({
@@ -11,6 +11,10 @@ interface User {
 export class UserNamePipe implements PipeTransform {
   transform(user?: User): string {
     if (user == null) {
+      return null;
+    }
+
+    if (user.name == null && user.email == null) {
       return null;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

If the user doesn't have a name, the SM header account dropdown should fallback to showing the user's email.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
