### PR TITLE
[SM-470] fix SM edit secret spinner

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -1,38 +1,39 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
     <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
-    <div bitDialogContent>
-      <div *ngIf="loading" class="tw-text-center">
+    <div bitDialogContent class="tw-relative">
+      <div
+        *ngIf="showSpinner"
+        class="tw-absolute tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-bg-background-alt"
+      >
         <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
       </div>
-      <ng-container *ngIf="!loading">
-        <div class="tw-flex tw-gap-4 tw-pt-4">
-          <bit-form-field class="tw-w-1/3">
-            <bit-label for="secret-name">{{ "name" | i18n }}</bit-label>
-            <input formControlName="name" bitInput />
-          </bit-form-field>
-          <bit-form-field class="tw-w-full">
-            <bit-label>{{ "value" | i18n }}</bit-label>
-            <textarea bitInput rows="4" formControlName="value"></textarea>
-          </bit-form-field>
-        </div>
-        <bit-form-field>
-          <bit-label>{{ "notes" | i18n }}</bit-label>
-          <textarea bitInput rows="4" formControlName="notes"></textarea>
+      <div class="tw-flex tw-gap-4 tw-pt-4">
+        <bit-form-field class="tw-w-1/3">
+          <bit-label for="secret-name">{{ "name" | i18n }}</bit-label>
+          <input formControlName="name" bitInput />
         </bit-form-field>
-
-        <hr />
-
-        <bit-form-field class="tw-mt-3 tw-mb-0">
-          <bit-label>{{ "project" | i18n }}</bit-label>
-          <select bitInput name="project" formControlName="project">
-            <option value="">{{ "selectPlaceholder" | i18n }}</option>
-            <option *ngFor="let f of projects" [value]="f.id">
-              {{ f.name }}
-            </option>
-          </select>
+        <bit-form-field class="tw-w-full">
+          <bit-label>{{ "value" | i18n }}</bit-label>
+          <textarea bitInput rows="4" formControlName="value"></textarea>
         </bit-form-field>
-      </ng-container>
+      </div>
+      <bit-form-field>
+        <bit-label>{{ "notes" | i18n }}</bit-label>
+        <textarea bitInput rows="4" formControlName="notes"></textarea>
+      </bit-form-field>
+
+      <hr />
+
+      <bit-form-field class="tw-mt-3 tw-mb-0">
+        <bit-label>{{ "project" | i18n }}</bit-label>
+        <select bitInput name="project" formControlName="project">
+          <option value="">{{ "selectPlaceholder" | i18n }}</option>
+          <option *ngFor="let f of projects" [value]="f.id">
+            {{ f.name }}
+          </option>
+        </select>
+      </bit-form-field>
     </div>
     <div bitDialogFooter class="tw-flex tw-gap-2">
       <button type="submit" bitButton buttonType="primary" bitFormButton>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Currently, when user edits a secret, the loading spinner appears twice. 

The goal of this PR is to...
- Keep the spinner from flickering off and on.
- Only show the spinner with the edit modal. Don't show it with the add modal.
- Update the spinner size to keep the modal from changing size when it is finished loading.


## Code changes

- The spinner is now absolutely position over the main content, to ensure no size changes. 
- The form is disabled while loading.

## Screenshots
### Before

https://user-images.githubusercontent.com/17113462/223830234-e4117910-c14b-4801-8042-9bb7ed76abe8.mov

### After
https://user-images.githubusercontent.com/17113462/223801734-da66a847-1f4e-4f1c-977a-220e7e623501.mov



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
