### PR TITLE
[SM-533] update onboarding CLI link

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding-task.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding-task.component.html
@@ -15,7 +15,11 @@
   <button type="button" bitLink *ngIf="!route">
     <ng-container *ngTemplateOutlet="content"></ng-container>
   </button>
-  <div class="tw-ml-8 tw-mt-1 tw-text-sm" [ngClass]="{ 'tw-opacity-50': completed }">
+  <div
+    class="tw-ml-8 tw-mt-1 tw-text-sm"
+    [ngClass]="{ 'tw-opacity-50': completed }"
+    (click)="handleClick($event)"
+  >
     <ng-content></ng-content>
   </div>
 </li>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding-task.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding-task.component.ts
@@ -19,4 +19,11 @@ export class OnboardingTaskComponent {
 
   @Input()
   route: string | any[];
+
+  handleClick(ev: MouseEvent) {
+    /**
+     * If the main `ng-content` is clicked, we don't want to trigger the task's click handler.
+     */
+    ev.stopPropagation();
+  }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.html
@@ -11,7 +11,13 @@
       [completed]="view.tasks.createServiceAccount"
     >
       <span class="tw-pl-1">
-        {{ "downloadThe" | i18n }} <a bitLink routerLink="">{{ "smCLI" | i18n }}</a>
+        {{ "downloadThe" | i18n }}
+        <a
+          bitLink
+          href="https://bitwarden.com/help/secrets-manager/developer-quick-start/"
+          target="_blank"
+          >{{ "smCLI" | i18n }}</a
+        >
       </span>
     </sm-onboarding-task>
     <sm-onboarding-task


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
- Updates the SM onboarding to use the CLI marketing link and open in a new tab.
- Fixes a bug where clicking the link would trigger the task's click handler (clicking "Download the SM CLI" would also open the new service account dialog).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/overview/onboarding-task.component.ts:** Stop event propogation when `onboarding-task` is clicked outside of the main task item

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
