### PR TITLE
[SM-624] add text-align unset to bitLink

### DIFF
--- a/apps/web/src/scss/tailwind.css
+++ b/apps/web/src/scss/tailwind.css
@@ -20,3 +20,11 @@ summary.tw-list-none::marker,
 summary.tw-list-none::-webkit-details-marker {
   display: none;
 }
+
+/** 
+ * Arbitrary values can't be used with `text-align`:
+ * https://github.com/tailwindlabs/tailwindcss/issues/802#issuecomment-849013311
+ */
+.tw-text-unset {
+  text-align: unset;
+}

--- a/libs/components/src/link/link.directive.ts
+++ b/libs/components/src/link/link.directive.ts
@@ -24,6 +24,7 @@ const linkStyles: Record<LinkType, string[]> = {
 };
 
 const commonStyles = [
+  "tw-text-unset",
   "tw-leading-none",
   "tw-p-0",
   "tw-font-semibold",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

HTML button's have a default center text align. We don't correct for this in `bitLink`, resulting in `a[bitLink]` and `button[bitLink]` having different styles, when they _should_ be visually indistinct. This PR updates `bitLink` to have a text align of `unset`. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/scss/tailwind.css:** Adds a new global class `tw-text-unset`. This was needed because Tailwind is inconsistent with where arbitrary values are allowed--we can't simply do `tw-text-[unset]` like we can with other Tailwind classes.
- **libs/components/src/link/link.directive.ts:** Updates the `bitLink` directive to use `tw-text-unset`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
