### PR TITLE
[SM-616] use correct file extension in SM export

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.html
@@ -9,8 +9,8 @@
 
   <bit-form-field class="tw-max-w-sm">
     <bit-label>{{ "fileFormat" | i18n }}</bit-label>
-    <select bitInput formControlName="format">
-      <option *ngFor="let format of exportFormats" [ngValue]="format">{{ format }}</option>
+    <select bitInput formControlName="formatKey" [disabled]="true">
+      <option *ngFor="let format of exportFormatKeys" [ngValue]="format">{{ format }}</option>
     </select>
   </bit-form-field>
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.html
@@ -9,7 +9,7 @@
 
   <bit-form-field class="tw-max-w-sm">
     <bit-label>{{ "fileFormat" | i18n }}</bit-label>
-    <select bitInput formControlName="formatKey" [disabled]="true">
+    <select bitInput formControlName="formatKey">
       <option *ngFor="let format of exportFormatKeys" [ngValue]="format">{{ format }}</option>
     </select>
   </bit-form-field>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes the format selector in SM Export to properly select the correct file extension.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.ts:** The format select was previous passing the format _name_ as the file extension to be used. Now, the name is checked against a dict to get its corresponding file extension.
## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
