### PR TITLE
SM-637: Add SM Trash Auto-delete Callout

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/trash/trash.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/trash/trash.component.html
@@ -1,6 +1,9 @@
 <sm-header>
   <sm-new-menu></sm-new-menu>
 </sm-header>
+<bit-callout type="warning" [title]="'warning' | i18n">{{
+  "trashCleanupWarning" | i18n
+}}</bit-callout>
 <sm-secrets-list
   (deleteSecretsEvent)="openDeleteSecret($event)"
   (restoreSecretsEvent)="openRestoreSecret($event)"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Add callout to SM Trash page about secret auto-deletion after 30 days.

The auto delete is not implemented yet but once it is and is turned on, any secrets older than 30 days will be automatically deleted.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

<img width="1231" alt="empty" src="https://user-images.githubusercontent.com/5691612/224115938-3bf5a2ec-9285-4e31-8c74-927b53b82f74.png">

<img width="1234" alt="not-empty" src="https://user-images.githubusercontent.com/5691612/224115931-a9b5149d-b391-4e8f-a7c2-fcdceb77bcb7.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
