### PR TITLE
[SM-632] fix copy secret value in Safari

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -45,6 +45,7 @@ import {
   ServiceAccountOperation,
 } from "../service-accounts/dialog/service-account-dialog.component";
 import { ServiceAccountService } from "../service-accounts/service-account.service";
+import { SecretsListComponent } from "../shared/secrets-list.component";
 
 type Tasks = {
   [organizationId: string]: OrganizationTasks;
@@ -278,35 +279,16 @@ export class OverviewComponent implements OnInit, OnDestroy {
   }
 
   copySecretName(name: string) {
-    this.platformUtilsService.copyToClipboard(name);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("name"))
-    );
+    SecretsListComponent.copySecretName(name, this.platformUtilsService, this.i18nService);
   }
 
   copySecretValue(id: string) {
-    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
-    this.copyToClipboardAsync(value).then(() => {
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("valueCopied", this.i18nService.t("value"))
-      );
-    });
-  }
-
-  copyToClipboardAsync(text: Promise<string>) {
-    if (this.platformUtilsService.isSafari()) {
-      return navigator.clipboard.write([
-        new ClipboardItem({
-          ["text/plain"]: text,
-        }),
-      ]);
-    }
-
-    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
+    SecretsListComponent.copySecretValue(
+      id,
+      this.platformUtilsService,
+      this.i18nService,
+      this.secretService
+    );
   }
 
   protected hideOnboarding() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -286,14 +286,27 @@ export class OverviewComponent implements OnInit, OnDestroy {
     );
   }
 
-  async copySecretValue(id: string) {
-    const secret = await this.secretService.getBySecretId(id);
-    this.platformUtilsService.copyToClipboard(secret.value);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("value"))
-    );
+  copySecretValue(id: string) {
+    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
+    this.copyToClipboardAsync(value).then(() => {
+      this.platformUtilsService.showToast(
+        "success",
+        null,
+        this.i18nService.t("valueCopied", this.i18nService.t("value"))
+      );
+    });
+  }
+
+  copyToClipboardAsync(text: Promise<string>) {
+    if (this.platformUtilsService.isSafari()) {
+      return navigator.clipboard.write([
+        new ClipboardItem({
+          ["text/plain"]: text,
+        }),
+      ]);
+    }
+
+    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
   }
 
   protected hideOnboarding() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
@@ -17,6 +17,7 @@ import {
   SecretOperation,
 } from "../../secrets/dialog/secret-dialog.component";
 import { SecretService } from "../../secrets/secret.service";
+import { SecretsListComponent } from "../../shared/secrets-list.component";
 
 @Component({
   selector: "sm-project-secrets",
@@ -81,34 +82,15 @@ export class ProjectSecretsComponent {
   }
 
   copySecretName(name: string) {
-    this.platformUtilsService.copyToClipboard(name);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("name"))
-    );
+    SecretsListComponent.copySecretName(name, this.platformUtilsService, this.i18nService);
   }
 
   copySecretValue(id: string) {
-    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
-    this.copyToClipboardAsync(value).then(() => {
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("valueCopied", this.i18nService.t("value"))
-      );
-    });
-  }
-
-  copyToClipboardAsync(text: Promise<string>) {
-    if (this.platformUtilsService.isSafari()) {
-      return navigator.clipboard.write([
-        new ClipboardItem({
-          ["text/plain"]: text,
-        }),
-      ]);
-    }
-
-    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
+    SecretsListComponent.copySecretValue(
+      id,
+      this.platformUtilsService,
+      this.i18nService,
+      this.secretService
+    );
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.ts
@@ -89,13 +89,26 @@ export class ProjectSecretsComponent {
     );
   }
 
-  async copySecretValue(id: string) {
-    const secret = await this.secretService.getBySecretId(id);
-    this.platformUtilsService.copyToClipboard(secret.value);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("value"))
-    );
+  copySecretValue(id: string) {
+    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
+    this.copyToClipboardAsync(value).then(() => {
+      this.platformUtilsService.showToast(
+        "success",
+        null,
+        this.i18nService.t("valueCopied", this.i18nService.t("value"))
+      );
+    });
+  }
+
+  copyToClipboardAsync(text: Promise<string>) {
+    if (this.platformUtilsService.isSafari()) {
+      return navigator.clipboard.write([
+        new ClipboardItem({
+          ["text/plain"]: text,
+        }),
+      ]);
+    }
+
+    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
@@ -7,6 +7,7 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
 import { DialogService } from "@bitwarden/components";
 
 import { SecretListView } from "../models/view/secret-list.view";
+import { SecretsListComponent } from "../shared/secrets-list.component";
 
 import {
   SecretDeleteDialogComponent,
@@ -84,34 +85,15 @@ export class SecretsComponent implements OnInit {
   }
 
   copySecretName(name: string) {
-    this.platformUtilsService.copyToClipboard(name);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("name"))
-    );
+    SecretsListComponent.copySecretName(name, this.platformUtilsService, this.i18nService);
   }
 
   copySecretValue(id: string) {
-    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
-    this.copyToClipboardAsync(value).then(() => {
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("valueCopied", this.i18nService.t("value"))
-      );
-    });
-  }
-
-  copyToClipboardAsync(text: Promise<string>) {
-    if (this.platformUtilsService.isSafari()) {
-      return navigator.clipboard.write([
-        new ClipboardItem({
-          ["text/plain"]: text,
-        }),
-      ]);
-    }
-
-    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
+    SecretsListComponent.copySecretValue(
+      id,
+      this.platformUtilsService,
+      this.i18nService,
+      this.secretService
+    );
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secrets.component.ts
@@ -92,13 +92,26 @@ export class SecretsComponent implements OnInit {
     );
   }
 
-  async copySecretValue(id: string) {
-    const secret = await this.secretService.getBySecretId(id);
-    this.platformUtilsService.copyToClipboard(secret.value);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("value"))
-    );
+  copySecretValue(id: string) {
+    const value = this.secretService.getBySecretId(id).then((secret) => secret.value);
+    this.copyToClipboardAsync(value).then(() => {
+      this.platformUtilsService.showToast(
+        "success",
+        null,
+        this.i18nService.t("valueCopied", this.i18nService.t("value"))
+      );
+    });
+  }
+
+  copyToClipboardAsync(text: Promise<string>) {
+    if (this.platformUtilsService.isSafari()) {
+      return navigator.clipboard.write([
+        new ClipboardItem({
+          ["text/plain"]: text,
+        }),
+      ]);
+    }
+
+    return text.then((t) => this.platformUtilsService.copyToClipboard(t));
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes copying a secret's value from the secrets list in SM. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

In Safari, we cannot wait for a promise to resolve _and then_ copy text. Instead, we have to pass the promise itself to a `ClipboardItem` constructor. 

This is a short-term fix just for the secrets list in SM. Bringing this fix into the `PlatformUtilsService` itself would warrant further testing/investigation.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
