### PR TITLE
SM-617: Remove secret links when displaying secret in the trash

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -64,9 +64,10 @@
       <td bitCell>
         <div class="tw-flex tw-items-center tw-gap-4 tw-break-all">
           <i class="bwi bwi-key tw-text-muted" aria-hidden="true"></i>
-          <button type="button" bitLink (click)="editSecretEvent.emit(secret.id)">
+          <button type="button" bitLink (click)="editSecretEvent.emit(secret.id)" *ngIf="!trash">
             {{ secret.name }}
           </button>
+          <div *ngIf="trash">{{ secret.name }}</div>
         </div>
       </td>
       <td bitCell>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove clickable links for the secrets when the secrets are displaying in the SM Trash.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Secrets List with Links
<img width="1112" alt="sl" src="https://user-images.githubusercontent.com/5691612/224377081-20120750-774d-4edd-b4d2-290ffd702b51.png">

Trash List without Links
<img width="1112" alt="tl" src="https://user-images.githubusercontent.com/5691612/224377093-5dc4ebcf-ec63-44bd-9b3e-a110197b9966.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
