### PR TITLE
[PS-2175] Rename Billing Sync Key in View Billing Sync Token modal

### DIFF
--- a/apps/web/src/app/organizations/billing/billing-sync-api-key.component.html
+++ b/apps/web/src/app/organizations/billing/billing-sync-api-key.component.html
@@ -37,7 +37,7 @@
 
         <div *ngIf="clientSecret && !showRotateScreen">
           <p>{{ "copyPasteBillingSync" | i18n }}</p>
-          <label for="clientSecret">Billing Sync Key</label>
+          <label for="clientSecret">Billing sync token</label>
           <div class="input-group">
             <input
               id="clientSecret"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Resolving an inconsistency on the Billing Sync Token modal on Cloud. 
On Cloud, this modal has the header “View Billing Sync Token,” and the button “Rotate Token.” However, the label for the field itself reads “Billing Sync Key”

On Self-Hosted, we refer to the value in this field as the “Billing sync token” in the modal. In addition, [our documentation](https://bitwarden.com/help/families-for-enterprise-self-hosted/#step-3-setup-billing-sync) refers to this value as the “Billing Sync Token”

Renaming this string to "Billing sync token" will match the Design decision to move to sentence casing for non-branded strings as outlined in `PS-1528` and make this modal consistent across environments. (cc: @bitwarden/dept-design)

## Code changes

apps/web/src/app/organizations/billing/billing-sync-api-key.component.html
@atjbramley and I found the "Billing Sync Key" string on line 40 of this file, it's not present in `messages.json` so I don't believe it's a string that gets translated by CrowdIn

## Screenshots
Previously:
![1f57b1ef-200f-4588-9012-3e992fb1c943](https://user-images.githubusercontent.com/17710965/225147596-5a2e7479-4075-48b0-beb5-c45e3c036026.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
