### PR TITLE
[PM-1405] Remove auto-fill on page load verbiage

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2127,7 +2127,7 @@
     "message": "How to auto-fill"
   },
   "autofillSelectInfo": {
-    "message": "Select an item from this page or use the shortcut: $COMMAND$.",
+    "message": "Select an item from this page or use the shortcut: $COMMAND$",
     "placeholders": {
       "command": {
         "content": "$1",

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2126,7 +2126,7 @@
   "howToAutofill": {
     "message": "How to auto-fill"
   },
-  "autofillSelectInfo": {
+  "autofillSelectInfoWithCommand": {
     "message": "Select an item from this page or use the shortcut: $COMMAND$",
     "placeholders": {
       "command": {
@@ -2135,7 +2135,7 @@
       }
     }
   },
-  "autofillSelectInfoNoCommand": {
+  "autofillSelectInfoWithoutCommand": {
     "message": "Select an item from this page or set a shortcut in settings."
   },
   "gotIt": {

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2127,7 +2127,7 @@
     "message": "How to auto-fill"
   },
   "autofillSelectInfo": {
-    "message": "Select an item from this page or use the shortcut: $COMMAND$. You can also try auto-fill on page load.",
+    "message": "Select an item from this page or use the shortcut: $COMMAND$.",
     "placeholders": {
       "command": {
         "content": "$1",
@@ -2136,7 +2136,7 @@
     }
   },
   "autofillSelectInfoNoCommand": {
-    "message": "Select an item from this page or set a shortcut in settings. You can also try auto-fill on page load."
+    "message": "Select an item from this page or set a shortcut in settings."
   },
   "gotIt": {
     "message": "Got it"

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -305,9 +305,9 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
 
   private setAutofillCalloutText(command: string) {
     if (command) {
-      this.autofillCalloutText = this.i18nService.t("autofillSelectInfo", command);
+      this.autofillCalloutText = this.i18nService.t("autofillSelectInfoWithCommand", command);
     } else {
-      this.autofillCalloutText = this.i18nService.t("autofillSelectInfoNoCommand");
+      this.autofillCalloutText = this.i18nService.t("autofillSelectInfoWithoutCommand");
     }
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove "You can also try auto-fill on page load" from browser extension callout.
## Code changes

- **apps/browser/src/_locales/en/messages.json:** Remove extra sentence.

## Screenshots

![Screenshot 2023-03-15 at 8 52 34 AM](https://user-images.githubusercontent.com/8926729/225314610-dc6c4b76-71ca-466a-bd99-f6c78ceae0f1.png)


![Screenshot 2023-03-15 at 8 40 11 AM](https://user-images.githubusercontent.com/8926729/225312634-3a988fc1-a44a-4960-a7c9-8935bd633ea4.png)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
