### PR TITLE
SM-615: Add Error Messages for Unselected Bulk Actions in SM

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
@@ -2,6 +2,8 @@ import { SelectionModel } from "@angular/cdk/collections";
 import { Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
 import { Subject, takeUntil } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { TableDataSource } from "@bitwarden/components";
 
 import { ServiceAccountView } from "../models/view/service-account.view";
@@ -38,7 +40,10 @@ export class ServiceAccountsListComponent implements OnDestroy {
 
   selection = new SelectionModel<string>(true, []);
 
-  constructor() {
+  constructor(
+    private i18nService: I18nService,
+    private platformUtilsService: PlatformUtilsService
+  ) {
     this.selection.changed
       .pipe(takeUntil(this.destroy$))
       .subscribe((_) => this.onServiceAccountCheckedEvent.emit(this.selection.selected));
@@ -69,6 +74,12 @@ export class ServiceAccountsListComponent implements OnDestroy {
     if (this.selection.selected.length >= 1) {
       this.deleteServiceAccountsEvent.emit(
         this.serviceAccounts.filter((sa) => this.selection.isSelected(sa.id))
+      );
+    } else {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("nothingSelected")
       );
     }
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
@@ -2,6 +2,8 @@ import { SelectionModel } from "@angular/cdk/collections";
 import { Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
 import { Subject, takeUntil } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 import { TableDataSource } from "@bitwarden/components";
 
 import { ProjectListView } from "../models/view/project-list.view";
@@ -38,7 +40,10 @@ export class ProjectsListComponent implements OnDestroy {
 
   selection = new SelectionModel<string>(true, []);
 
-  constructor() {
+  constructor(
+    private i18nService: I18nService,
+    private platformUtilsService: PlatformUtilsService
+  ) {
     this.selection.changed
       .pipe(takeUntil(this.destroy$))
       .subscribe((_) => this.onProjectCheckedEvent.emit(this.selection.selected));
@@ -66,8 +71,16 @@ export class ProjectsListComponent implements OnDestroy {
   }
 
   bulkDeleteProjects() {
-    this.deleteProjectEvent.emit(
-      this.projects.filter((project) => this.selection.isSelected(project.id))
-    );
+    if (this.selection.selected.length >= 1) {
+      this.deleteProjectEvent.emit(
+        this.projects.filter((project) => this.selection.isSelected(project.id))
+      );
+    } else {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("nothingSelected")
+      );
+    }
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
@@ -46,7 +46,10 @@ export class SecretsListComponent implements OnDestroy {
 
   selection = new SelectionModel<string>(true, []);
 
-  constructor() {
+  constructor(
+    private i18nService: I18nService,
+    private platformUtilsService: PlatformUtilsService
+  ) {
     this.selection.changed
       .pipe(takeUntil(this.destroy$))
       .subscribe((_) => this.onSecretCheckedEvent.emit(this.selection.selected));
@@ -74,12 +77,24 @@ export class SecretsListComponent implements OnDestroy {
       this.deleteSecretsEvent.emit(
         this.secrets.filter((secret) => this.selection.isSelected(secret.id))
       );
+    } else {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("nothingSelected")
+      );
     }
   }
 
   bulkRestoreSecrets() {
     if (this.selection.selected.length >= 1) {
       this.restoreSecretsEvent.emit(this.selection.selected);
+    } else {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("nothingSelected")
+      );
     }
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add error messages when executing bulk actions on secrets or projects but nothing is selected.

Specifically:
- When bulk deleting secrets but nothing is selected, this toast should show & no actions are taken
- When bulk restoring secrets from the trash but nothing is selected, this toast should show & no actions are taken
- When bulk deleting projects but nothing is selected, this toast should show & no actions are taken

## Screenshots

<img width="315" alt="Screenshot 2023-03-15 at 12 38 22 PM" src="https://user-images.githubusercontent.com/5691612/225378836-8deca9fb-b641-421a-b3a0-f78375045d51.png">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
