### PR TITLE
[AC-1137] Fix Groups columns appear for families

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-items.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-items.component.html
@@ -25,7 +25,7 @@
           }}</label>
         </th>
         <th bitCell class="tw-w-1/2">{{ "name" | i18n }}</th>
-        <th bitCell class="tw-w-max">
+        <th bitCell class="tw-w-max" *ngIf="showOwnershipColumn">
           <ng-container *ngIf="!organization">{{ "owner" | i18n }}</ng-container>
           <ng-container *ngIf="organization">
             {{ (activeFilter.selectedCollectionNode ? "groups" : "collections") | i18n }}
@@ -110,7 +110,7 @@
             {{ col.node.name }}
           </button>
         </td>
-        <td bitCell>
+        <td bitCell *ngIf="showOwnershipColumn">
           <ng-container *ngIf="!organization">
             <app-org-badge
               organizationName="{{ col.node.organizationId | orgNameFromId: organizations }}"
@@ -221,7 +221,7 @@
           <br />
           <span class="tw-text-sm tw-text-muted" appStopProp>{{ c.subTitle }}</span>
         </td>
-        <td bitCell>
+        <td bitCell *ngIf="showOwnershipColumn">
           <ng-container *ngIf="!organization">
             <app-org-badge
               organizationName="{{ c.organizationId | orgNameFromId: organizations }}"

--- a/apps/web/src/app/vault/individual-vault/vault-items.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-items.component.html
@@ -24,7 +24,9 @@
             "all" | i18n
           }}</label>
         </th>
-        <th bitCell class="tw-w-1/2">{{ "name" | i18n }}</th>
+        <th bitCell [ngClass]="showOwnershipColumn ? 'tw-w-1/2' : 'tw-w-full'">
+          {{ "name" | i18n }}
+        </th>
         <th bitCell class="tw-w-max" *ngIf="showOwnershipColumn">
           <ng-container *ngIf="!organization">{{ "owner" | i18n }}</ng-container>
           <ng-container *ngIf="organization">

--- a/apps/web/src/app/vault/individual-vault/vault-items.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-items.component.ts
@@ -113,6 +113,17 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnDe
     return this.isPaging() ? this.pagedCiphers : this.ciphers;
   }
 
+  /**
+   * Flag to determine if the 3rd "ownership" column (Owner, Collections, or Groups) should be shown.
+   */
+  protected get showOwnershipColumn() {
+    return (
+      !this.organization || // "Owner" is always shown for personal vault
+      !this.activeFilter.selectedCollectionNode || // "Collections" when filtering by all items
+      this.organization.useGroups // "Groups" when filtering by collections
+    );
+  }
+
   constructor(
     searchService: SearchService,
     protected i18nService: I18nService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix the "Groups" column from incorrectly appearing for non-enterprise organizations that do not have groups.

## Code changes

- **apps/web/src/app/vault/individual-vault/vault-items.component.ts:** Add flag for determining if the "Ownership" column should be shown in the vault. 
- **apps/web/src/app/vault/individual-vault/vault-items.component.html:** Use the new flag to conditionally render the 3rd column and adjust the width of the "Name" column

## Screenshots

### Free Org filtering by "All items" 
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/8764515/226490101-7e6f4239-9391-4a1e-a37e-7375171ff54e.png">

### Free Org filtering by "Collections"
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/8764515/226490130-d63dac2f-552b-4255-b93a-d0dae066769e.png">

### Enterprise Org filtering by "Collections"
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/8764515/226490227-f29e01a8-9065-4906-ade9-8b8eda76c7f8.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
