### PR TITLE
Select specific characters from password via CLI

### DIFF
--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -151,6 +151,7 @@ export class VaultProgram extends Program {
       .option("--itemid <itemid>", "Attachment's item id.")
       .option("--output <output>", "Output directory or filename for attachment.")
       .option("--organizationid <organizationid>", "Organization id for an organization object.")
+      .option("--characters <characters>", "selected characters to return from the item")
       .on("--help", () => {
         writeLn("\n  If raw output is specified and no output filename or directory is given for");
         writeLn("  an attachment query, the attachment content is written to stdout.");


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add ability to select specific characters from the password by their indices via the cli.
E.g. when prompted by pages to select the 3rd 15th and 17th character of the password you can do:
```sh
bw get password --characters "3,15,17" myBank
# 3: p
# 15: w
# 17: d
``` 

## Code changes


- **apps/cli/src/vault.program.ts** Update command line options to get on CLI to accept `characters` which is a list of comma-selected indices of characters to print from the password.
- **apps/cli/src/commands/get.command.ts** if characters supplied in above command then used to filter specific characters from the password before returning