### PR TITLE
PM-1195 - Copy send link fix on browser

### DIFF
--- a/libs/common/src/models/view/send.view.ts
+++ b/libs/common/src/models/view/send.view.ts
@@ -68,9 +68,12 @@ export class SendView implements View {
   }
 
   toJSON() {
-    return Utils.merge(this, {
-      key: Utils.fromBufferToB64(this.key),
-    });
+    return Utils.merge(
+      { ...this },
+      {
+        key: Utils.fromBufferToB64(this.key),
+      }
+    );
   }
 
   static fromJSON(json: DeepJsonify<SendView>) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Copy send link was broken on browser extension. The `key` part of url wasn't being sent.

## Code changes

- **send.view.ts:** `ToJson` was affecting current `this` object and changing the `key` property into a Base64 string, so all the subsequent calls to  `Utils.fromBufferTo` on `ToJson` or `get urlB64Key()` were returning and empty string as they were expecting `key` to be an `ArrayBuffer`. So now a copy of `this` is made and changed by `ToJson`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
