### PR TITLE
[PM-1624] Fix typo "subcription" > "subscription"

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1994,7 +1994,7 @@
   "ssoKeyConnectorError": {
     "message": "Key connector error: make sure key connector is available and working correctly."
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "organizationIsDisabled": {

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -198,7 +198,7 @@
             <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>
             <span class="row-label">
               <a routerLink="/premium">
-                {{ "premiumSubcriptionRequired" | i18n }}
+                {{ "premiumSubscriptionRequired" | i18n }}
               </a>
             </span>
           </div>
@@ -224,10 +224,10 @@
               >{{ "number" | i18n }}</span
             >
             <span [hidden]="showCardNumber" class="monospaced">{{
-              cipher.card.maskedNumber | creditCardNumber : cipher.card.brand
+              cipher.card.maskedNumber | creditCardNumber: cipher.card.brand
             }}</span>
             <span [hidden]="!showCardNumber" class="monospaced">{{
-              cipher.card.number | creditCardNumber : cipher.card.brand
+              cipher.card.number | creditCardNumber: cipher.card.brand
             }}</span>
           </div>
           <div class="action-buttons">
@@ -642,15 +642,15 @@
     <div class="box-footer">
       <div>
         <b class="font-weight-semibold">{{ "dateUpdated" | i18n }}:</b>
-        {{ cipher.revisionDate | date : "medium" }}
+        {{ cipher.revisionDate | date: "medium" }}
       </div>
       <div *ngIf="cipher.creationDate">
         <b class="font-weight-semibold">{{ "dateCreated" | i18n }}:</b>
-        {{ cipher.creationDate | date : "medium" }}
+        {{ cipher.creationDate | date: "medium" }}
       </div>
       <div *ngIf="cipher.passwordRevisionDisplayDate">
         <b class="font-weight-semibold">{{ "datePasswordUpdated" | i18n }}:</b>
-        {{ cipher.passwordRevisionDisplayDate | date : "medium" }}
+        {{ cipher.passwordRevisionDisplayDate | date: "medium" }}
       </div>
       <div *ngIf="cipher.hasPasswordHistory">
         <b class="font-weight-semibold">{{ "passwordHistory" | i18n }}:</b>

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2023,7 +2023,7 @@
   "apiKey": {
     "message": "API key"
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "organizationIsDisabled": {

--- a/apps/desktop/src/vault/app/vault/view.component.html
+++ b/apps/desktop/src/vault/app/vault/view.component.html
@@ -173,7 +173,7 @@
               <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>
               <span class="row-label">
                 <a [routerLink]="" (click)="showGetPremium()"
-                  >{{ "premiumSubcriptionRequired" | i18n }}
+                  >{{ "premiumSubscriptionRequired" | i18n }}
                 </a>
               </span>
             </div>
@@ -199,10 +199,10 @@
                 >{{ "number" | i18n }}</span
               >
               <span *ngIf="!showCardNumber" class="monospaced">{{
-                cipher.card.maskedNumber | creditCardNumber : cipher.card.brand
+                cipher.card.maskedNumber | creditCardNumber: cipher.card.brand
               }}</span>
               <span *ngIf="showCardNumber" class="monospaced">{{
-                cipher.card.number | creditCardNumber : cipher.card.brand
+                cipher.card.number | creditCardNumber: cipher.card.brand
               }}</span>
             </div>
             <div class="action-buttons">
@@ -505,15 +505,15 @@
       <div class="box-footer">
         <div>
           <b class="font-weight-semibold">{{ "dateUpdated" | i18n }}:</b>
-          {{ cipher.revisionDate | date : "medium" }}
+          {{ cipher.revisionDate | date: "medium" }}
         </div>
         <div *ngIf="cipher.creationDate">
           <b class="font-weight-semibold">{{ "dateCreated" | i18n }}:</b>
-          {{ cipher.creationDate | date : "medium" }}
+          {{ cipher.creationDate | date: "medium" }}
         </div>
         <div *ngIf="cipher.passwordRevisionDisplayDate">
           <b class="font-weight-semibold">{{ "datePasswordUpdated" | i18n }}:</b>
-          {{ cipher.passwordRevisionDisplayDate | date : "medium" }}
+          {{ cipher.passwordRevisionDisplayDate | date: "medium" }}
         </div>
         <div *ngIf="cipher.hasPasswordHistory">
           <b class="font-weight-semibold">{{ "passwordHistory" | i18n }}:</b>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5519,7 +5519,7 @@
       }
     }
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "scim": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Correct a small yet annoying typo in one of the localisation strings: `subcription` > `subscription`

(unless there's now no way to correct the typo in messages.json because of all the translations, in which case feel free to close this PR)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/_locales/en/messages.json**, **apps/desktop/src/locales/en/messages.json**, **apps/web/src/locales/en/messages.json**: Correct the typo in the localisation string name
- **apps/browser/src/vault/popup/components/vault/view.component.html**, **apps/desktop/src/vault/app/vault/view.component.html**: Use the corrected localisation string (it seems it's not used on the web vault?)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
