### PR TITLE
[PM-1254] Desktop help menu adjustments

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -770,6 +770,9 @@
   "contactUs": {
     "message": "Contact us"
   },
+  "helpAndFeedback": {
+    "message": "Help and feedback"
+  },
   "getHelp": {
     "message": "Get help"
   },

--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -16,8 +16,7 @@ export class HelpMenu implements IMenubarMenu {
 
   get items(): MenuItemConstructorOptions[] {
     const items = [
-      this.getHelp,
-      this.contactUs,
+      this.helpAndFeedback,
       this.fileBugReport,
       this.legal,
       this.separator,
@@ -45,18 +44,10 @@ export class HelpMenu implements IMenubarMenu {
     this._aboutMenu = aboutMenu;
   }
 
-  private get contactUs(): MenuItemConstructorOptions {
+  private get helpAndFeedback(): MenuItemConstructorOptions {
     return {
-      id: "contactUs",
-      label: this.localize("contactUs"),
-      click: () => shell.openExternal("https://bitwarden.com/contact"),
-    };
-  }
-
-  private get getHelp(): MenuItemConstructorOptions {
-    return {
-      id: "getHelp",
-      label: this.localize("getHelp"),
+      id: "helpAndFeedback",
+      label: this.localize("helpAndFeedback"),
       click: () => shell.openExternal("https://bitwarden.com/help"),
     };
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- Change naming for “Get help” link to “Help and feedback”
- Remove “Contact us” option from help menu
- 
## Code changes

- **apps/desktop/src/main/menu/menu.help.ts:** Remove 'Contact us' option. Rename 'Get help' to 'Help and Feedback'.

## Screenshots
Before:
![Screenshot 2023-03-27 at 2 38 19 PM](https://user-images.githubusercontent.com/8926729/228035700-8a97e778-058f-4bd4-948c-8ba53859d9ef.png)

After:
![Screenshot 2023-03-27 at 2 42 19 PM](https://user-images.githubusercontent.com/8926729/228036533-6d5647f1-39df-4d53-832f-da7527e0286a.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
