### PR TITLE
SM-671: Fix Secret Deletion Bug

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.html
@@ -137,7 +137,7 @@
         <button
           type="button"
           bitMenuItem
-          (click)="deleteSecretsEvent.emit([secret.id])"
+          (click)="deleteSecretsEvent.emit([secret])"
           *ngIf="secret.write"
         >
           <i class="bwi bwi-fw bwi-trash tw-text-danger" aria-hidden="true"></i>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix small bug in the `sm/SM-574` branch for this PR: https://github.com/bitwarden/clients/pull/4941. When deleting a secret we should pass the whole secret, not just the `id`. (Note, we emit this type: `SecretListView[]`)

Testing should be covered in https://github.com/bitwarden/clients/pull/4941.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **secret-list.component.html:** Pass entire secret list view object, not just id

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
