### PR TITLE
[PM-1644] Resolve active tab using the wrong background color

### DIFF
--- a/libs/components/src/tabs/shared/tab-list-item.directive.ts
+++ b/libs/components/src/tabs/shared/tab-list-item.directive.ts
@@ -81,7 +81,7 @@ export class TabListItemDirective implements FocusableOption {
       "tw-border-t-primary-500",
       "tw-border-b",
       "tw-border-b-background",
-      "tw-bg-background",
+      "!tw-bg-background",
       "hover:tw-border-t-primary-700",
       "focus-visible:tw-border-t-primary-700",
       "focus-visible:!tw-text-primary-700",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The acitve tab uses the wrong background color. Seems the transparent background gets priority over the correct background. This should work better once we've removed the base bootstrap styling.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:

![image](https://user-images.githubusercontent.com/137855/228344308-dd48ffaa-8ff1-4258-b8a6-00d7a75039e6.png)

After:

![image](https://user-images.githubusercontent.com/137855/228344199-dc718462-3cab-47ce-a0f1-1ad7480d30d5.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
