### PR TITLE
Update Secrets Manager team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # @bitwarden/team-leads
 
 ## Secrets Manager team files ##
-bitwarden_license/bit-web/src/app/secrets-manager @bitwarden/pod-sm-dev
+bitwarden_license/bit-web/src/app/secrets-manager @bitwarden/team-secrets-manager-dev
 
 ## Auth team files ##
 apps/browser/src/auth @bitwarden/team-auth-dev


### PR DESCRIPTION
Migrated the Secrets Manager CODEOWNERS team. All `pod-*` GitHub teams will be deleted afterwards. 


```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x ] Other
```



