### PR TITLE
PS-1608 - Changed safari extension save dialog

### DIFF
--- a/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
@@ -54,24 +54,24 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             guard let data = blobData else {
                 return
             }
+            NSApplication.shared.setActivationPolicy(.accessory)
             let panel = NSSavePanel()
-            panel.isFloatingPanel = true
             panel.canCreateDirectories = true
             panel.nameFieldStringValue = dlMsg.fileName
-            panel.begin { response in
-                if response == NSApplication.ModalResponse.OK {
-                    if let url = panel.url {
-                        do {
-                            let fileManager = FileManager.default
-                            if !fileManager.fileExists(atPath: url.absoluteString) {
-                                fileManager.createFile(atPath: url.absoluteString, contents: Data(),
-                                                       attributes: nil)
-                            }
-                            try data.write(to: url)
-                        } catch {
-                            print(error)
-                            NSLog("ERROR in downloadFile, \(error)")
+            let response = panel.runModal();
+           
+            if response == NSApplication.ModalResponse.OK {
+                if let url = panel.url {
+                    do {
+                        let fileManager = FileManager.default
+                        if !fileManager.fileExists(atPath: url.absoluteString) {
+                            fileManager.createFile(atPath: url.absoluteString, contents: Data(),
+                                                   attributes: nil)
                         }
+                        try data.write(to: url)
+                    } catch {
+                        print(error)
+                        NSLog("ERROR in downloadFile, \(error)")
                     }
                 }
             }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Save panel from export wasn't always responsive. Sometimes the user tried to save and the popup just closed

## Code changes

- **SafariWebExtensionHandler.swift:** Changed SetActivationPolicy to Accessory. Set SavePanel to run as a Modal.

Changing the SetActivationPolicy is the most important change. As this change may affect the rest of the app (this is changed on Application level), haven't found any impact on the rest of application

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
