### PR TITLE
[AC-1214] External-id-field-unmodifiable-for-users-and-groups-after-org-vault-refresh

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
@@ -92,7 +92,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
   groupForm = this.formBuilder.group({
     accessAll: [false],
     name: ["", [Validators.required, Validators.maxLength(100)]],
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
+    externalId: ["", [Validators.maxLength(300)]],
     members: [[] as AccessItemValue[]],
     collections: [[] as AccessItemValue[]],
   });

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -79,7 +79,7 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
   protected formGroup = this.formBuilder.group({
     emails: ["", [Validators.required, commaSeparatedEmails]],
     type: OrganizationUserType.User,
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
+    externalId: ["", [Validators.maxLength(300)]],
     accessAllCollections: false,
     accessSecretsManager: false,
     access: [[] as AccessItemValue[]],


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The ExternalId fields should be editable within the Web Portal as they are editable through the API.
This PR aims to revert back the change made on the Organization and User ExternalId fields that made them disabled.

## Code changes

- **apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts:** Changed the ExternalId field to be editable
- **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts:** Changed the ExternalId field to be editable

## Screenshots

<img width="810" alt="image" src="https://user-images.githubusercontent.com/108268980/229157613-1eb640fa-b601-40ce-ab93-71211a2bd21a.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/108268980/229157698-103e0887-9bd6-4dfa-84d9-a79749fecdba.png">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
