### PR TITLE
Defect / PM-1354 - Fix master password not auto focused on web login flow

### DIFF
--- a/apps/web/src/auth/login/login.component.html
+++ b/apps/web/src/auth/login/login.component.html
@@ -68,8 +68,8 @@
                 id="login_input_master-password"
                 type="password"
                 bitInput
+                #masterPasswordInput
                 formControlName="masterPassword"
-                appAutofocus
               />
               <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
             </bit-form-field>

--- a/libs/angular/src/auth/components/login.component.ts
+++ b/libs/angular/src/auth/components/login.component.ts
@@ -1,4 +1,4 @@
-import { Directive, NgZone, OnInit } from "@angular/core";
+import { Directive, ElementRef, NgZone, OnInit, ViewChild } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { take } from "rxjs/operators";
@@ -26,6 +26,8 @@ import { CaptchaProtectedComponent } from "./captcha-protected.component";
 
 @Directive()
 export class LoginComponent extends CaptchaProtectedComponent implements OnInit {
+  @ViewChild("masterPasswordInput", { static: true }) masterPasswordInput: ElementRef;
+
   showPassword = false;
   formPromise: Promise<AuthResult>;
   onSuccessfulLogin: () => Promise<any>;
@@ -238,10 +240,16 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
 
   toggleValidateEmail(value: boolean) {
     this.validatedEmail = value;
-    if (!value) {
-      // Reset master password only when going from validated to not validated (not you btn press)
+    if (!this.validatedEmail) {
+      // Reset master password only when going from validated to not validated
       // so that autofill can work properly
       this.formGroup.controls.masterPassword.reset();
+    } else {
+      // When email is validated, focus on master password after
+      // waiting for input to be rendered
+      this.ngZone.onStable
+        .pipe(take(1))
+        .subscribe(() => this.masterPasswordInput?.nativeElement?.focus());
     }
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the web client login master password flow not autofocusing the master password field after a valid email has been entered. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/auth/login/login.component.html:** Remove `appAutoFocus` directive as it doesn't work anymore since we refactored the login.component to work with [autofill & two step login](https://github.com/bitwarden/clients/pull/4844) (Note: at least I think that's when it was broken). Add template reference variable so web login component can focus the input. 

- **libs/angular/src/auth/components/login.component.ts:** On email validation, autofocus the master password input. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://user-images.githubusercontent.com/116684653/229230208-06873574-bda7-4318-9830-4ff7db900b91.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
