### PR TITLE
Add ability to create project during the secret creation flow

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5916,6 +5916,10 @@
     "message": "New project",
     "description": "Title for creating a new project."
   },
+  "addNewProject": {
+    "message": "+ New project",
+    "description": "Title for creating a new project."
+  },
   "softDeleteSecretWarning": {
     "message": "Deleting secrets can affect existing integrations.",
     "description": "Warns that deleting secrets can have consequences on integrations"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -29,10 +29,15 @@
         <bit-label>{{ "project" | i18n }}</bit-label>
         <select bitInput name="project" formControlName="project">
           <option value="">{{ "selectPlaceholder" | i18n }}</option>
-          <option *ngFor="let f of projects" [value]="f.id">
-            {{ f.name }}
+          <option *ngFor="let p of projects; let i = index" [value]="p.id">
+            {{ p.name }}
           </option>
         </select>
+      </bit-form-field>
+
+      <bit-form-field *ngIf="addNewProject == true">
+        <bit-label>{{ "projectName" | i18n }}</bit-label>
+        <input formControlName="newProjectName" maxlength="1000" bitInput />
       </bit-form-field>
     </div>
     <div bitDialogFooter class="tw-flex tw-gap-2">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ x ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

During the secret creation modal, you need to be able to stop the user from creating a secret without  a project attached. This change will allow the user to add a project on the fly from within the secret modal by selecting "Add new Project" from the projects drop down.

## Code changes

apps/web/src/locales/en/messages.json - added the "+ Add New Project" messaging
bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html - Adding input for the project name of the project you are creating, only show this if they selected the add project option from the drop down 
bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts - logic to save the new project if they are adding a project from within the secret. Also logic to set visibility and add/remove validators on the newProjectName formGroup


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
