### PR TITLE
Fix Chrome Async Messages Issues

### DIFF
--- a/apps/browser/src/services/browser-state.service.ts
+++ b/apps/browser/src/services/browser-state.service.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject } from "rxjs";
 
 import { GlobalState } from "@bitwarden/common/models/domain/global-state";
 import { StorageOptions } from "@bitwarden/common/models/domain/storage-options";
+import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
 import { StateService as BaseStateService } from "@bitwarden/common/services/state.service";
 
 import { Account } from "../models/account";
@@ -130,6 +131,30 @@ export class BrowserStateService
       account,
       this.reconcileOptions(options, await this.defaultInMemoryOptions())
     );
+  }
+
+  override async getCryptoMasterKey(options?: StorageOptions): Promise<SymmetricCryptoKey> {
+    const key = await super.getCryptoMasterKey(options);
+    if (key == null) {
+      return null;
+    }
+
+    // Chrome will only send back { keyB64: string }
+    // so we need to make sure it has the prototype
+    return SymmetricCryptoKey.fromJSON(key);
+  }
+
+  override async getDecryptedCryptoSymmetricKey(
+    options?: StorageOptions
+  ): Promise<SymmetricCryptoKey> {
+    const key = await super.getDecryptedCryptoSymmetricKey(options);
+    if (key == null) {
+      return null;
+    }
+
+    // Chrome will only send back { keyB64: string }
+    // so we need to make sure it has the prototype
+    return SymmetricCryptoKey.fromJSON(key);
   }
 
   override async setLastActive(value: number, options?: StorageOptions): Promise<void> {

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -325,9 +325,10 @@ export class CipherService implements CipherServiceAbstraction {
 
   @sequentialize(() => "getAllDecrypted")
   async getAllDecrypted(): Promise<CipherView[]> {
-    if ((await this.getDecryptedCipherCache()) != null) {
+    const decryptedCiphersCache = await this.getDecryptedCipherCache();
+    if (decryptedCiphersCache != null) {
       await this.reindexCiphers();
-      return await this.getDecryptedCipherCache();
+      return decryptedCiphersCache;
     }
 
     const hasKey = await this.cryptoService.hasKey();
@@ -356,7 +357,10 @@ export class CipherService implements CipherServiceAbstraction {
       .flat()
       .sort(this.getLocaleSortingFunction());
 
-    await this.setDecryptedCipherCache(decCiphers);
+    // Don't bother caching if there are no ciphers
+    if (decCiphers.length !== 0) {
+      await this.setDecryptedCipherCache(decCiphers);
+    }
     return decCiphers;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix issues related to how chrome and firefox browser extensions differ.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/browser/browserApi.ts:** Made the `receiveMessage` able to give values back in chrome browser extensions.
- **apps/browser/src/services/browser-state.service.ts:** Forced a few datatypes back into the class form
- **libs/common/src/vault/services/cipher.service.ts:** Decryption would sometimes take a bit longer and we would cache the empty ciphers list making it not try again under normal operation.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
