### PR TITLE
exit immediately after login command run

### DIFF
--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -155,7 +155,7 @@ export class Program {
             async () => await this.main.logout()
           );
           const response = await command.run(email, password, options);
-          this.processResponse(response);
+          this.processResponse(response, true);
         }
       });
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/AC-1311

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Some error states of the login command will hang and not cleanly exit. The thought is that something is not properly awaited. The cause is unknown still, but this works around the problem until a proper solution can be found. Several other commands appear to be passing this flag, likely for the same reasons. Since the login command is not returning large amounts of data to stdout (such as `bw list`, for example), the risks of exiting immediately should not be a problem.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **program.ts:** Exit immediately flag passed while processing the response for the login command.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
