### PR TITLE
[PM-1801] 'appendOnly' virtual list to stop repeat icon GETs

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-filter.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-filter.component.html
@@ -200,6 +200,7 @@
       <p>{{ "noItemsInList" | i18n }}</p>
     </div>
     <cdk-virtual-scroll-viewport
+      appendOnly
       itemSize="55"
       minBufferPx="400"
       maxBufferPx="600"

--- a/apps/browser/src/vault/popup/components/vault/vault-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-items.component.html
@@ -93,6 +93,7 @@
       </div>
     </div>
     <cdk-virtual-scroll-viewport
+      appendOnly
       itemSize="55"
       minBufferPx="400"
       maxBufferPx="600"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As I was doing a cleanup/spring clean of my various vault items on the extension, I noticed that the performance for visiting already seen list items was a bit slow and also upon a closer look, kept hammering an icon endpoint `https://icons.bitwarden.net/whateversite/icon.png`

Here is a [video](https://drive.google.com/file/d/11HEmuJHr8tAtgt2sjSNopM9d3jUoJtKJ/view?usp=sharing) of it (I didn't show the list items for privacy).

The [documentation](https://material.angular.io/cdk/scrolling/overview#append-only-mode) for the cdk virtual scroll mentions a clean fix, which is to use `appendOnly`:

> Virtual scroll viewports that render nontrivial items may find it more performant to simply append to the list as the user scrolls without removing rendered views

I would consider the icons to be non-trivial, as a bit of house cleaning or backtracking shouldn't trigger _any_ GET as it should be soft cached. It looks like [this](https://drive.google.com/file/d/1hOszFmYt4ByEb_a1g_-XN73QMmxECcm2/view?usp=sharing) afterwards. Notice how if something wasn't caught in the first pass, it could very well trigger a request, but it only is ever done _once_ when you're in this view, not an infinite amount of times like before.

## Code changes

Like I said, I added the `appendOnly` flag to the 2 files where we are using virtual lists.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
