### PR TITLE
[PM-1803] Fail on unsupported export format

### DIFF
--- a/apps/cli/src/commands/export.command.ts
+++ b/apps/cli/src/commands/export.command.ts
@@ -4,7 +4,6 @@ import * as inquirer from "inquirer";
 import {
   ExportFormat,
   ExportService,
-  isSupportedExportFormat,
   EXPORT_FORMATS,
 } from "@bitwarden/common/abstractions/export.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
@@ -28,7 +27,7 @@ export class ExportCommand {
     }
 
     const format = options.format ?? "csv";
-    if (!isSupportedExportFormat(format)) {
+    if (!this.isSupportedExportFormat(format)) {
       return Response.badRequest(
         `'${format}' is not a supported export format. Supported formats: ${EXPORT_FORMATS.join(
           ", "
@@ -105,5 +104,9 @@ export class ExportCommand {
       return answer.password as string;
     }
     return null;
+  }
+
+  private isSupportedExportFormat(format: string): format is ExportFormat {
+    return EXPORT_FORMATS.includes(format as ExportFormat);
   }
 }

--- a/libs/common/src/abstractions/export.service.ts
+++ b/libs/common/src/abstractions/export.service.ts
@@ -2,11 +2,6 @@ import { EventView } from "../models/view/event.view";
 
 export const EXPORT_FORMATS = ["csv", "json", "encrypted_json"] as const;
 export type ExportFormat = (typeof EXPORT_FORMATS)[number];
-
-export function isSupportedExportFormat(format: string): format is ExportFormat {
-  return EXPORT_FORMATS.includes(format as ExportFormat);
-}
-
 export abstract class ExportService {
   getExport: (format?: ExportFormat, organizationId?: string) => Promise<string>;
   getPasswordProtectedExport: (password: string, organizationId?: string) => Promise<string>;


### PR DESCRIPTION
Issue #5194: https://github.com/bitwarden/clients/issues/5194

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective


The cli previously would take any value for the export format and default to unencrypted json if it wasn't a supported format. This behavior is a little dangerous because if for instance typed "json_encrypted" instead of "encrypted_json" and naively saved the file you might be surprised to learn the payload was not actually encrypted even though the command completed successfully.

This change adds a guard clause when converting the string value passed in via `--format` into the type `ExportFormat` to ensure that the format provided is one of the supported types.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/cli/src/commands/export.command.ts**: Added guard clause for export format
- **libs/common/src/abstractions/export.service.ts**: Added list of supported export formats and method to validate that a string is a valid export format.
