### PR TITLE
[SM-673] redirect from SM root to overview page

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets-manager.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets-manager.module.ts
@@ -5,10 +5,8 @@ import { SharedModule } from "@bitwarden/web-vault/app/shared";
 import { LayoutModule } from "./layout/layout.module";
 import { SecretsManagerSharedModule } from "./shared/sm-shared.module";
 import { SecretsManagerRoutingModule } from "./sm-routing.module";
-import { SMGuard } from "./sm.guard";
 
 @NgModule({
   imports: [SharedModule, SecretsManagerSharedModule, SecretsManagerRoutingModule, LayoutModule],
-  providers: [SMGuard],
 })
 export class SecretsManagerModule {}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm-routing.module.ts
@@ -13,59 +13,70 @@ import { ProjectsModule } from "./projects/projects.module";
 import { SecretsModule } from "./secrets/secrets.module";
 import { ServiceAccountsModule } from "./service-accounts/service-accounts.module";
 import { SettingsModule } from "./settings/settings.module";
-import { SMGuard } from "./sm.guard";
+import { canActivateSM } from "./sm.guard";
 import { TrashModule } from "./trash/trash.module";
 
 const routes: Routes = [
   buildFlaggedRoute("secretsManager", {
-    path: ":organizationId",
-    component: LayoutComponent,
-    canActivate: [AuthGuard, OrganizationPermissionsGuard, SMGuard],
-    data: {
-      organizationPermissions: (org: Organization) => org.canAccessSecretsManager,
-    },
+    path: "",
     children: [
       {
         path: "",
-        component: NavigationComponent,
-        outlet: "sidebar",
-      },
-      {
-        path: "secrets",
-        loadChildren: () => SecretsModule,
-        data: {
-          titleId: "secrets",
-        },
-      },
-      {
-        path: "projects",
-        loadChildren: () => ProjectsModule,
-        data: {
-          titleId: "projects",
-        },
-      },
-      {
-        path: "service-accounts",
-        loadChildren: () => ServiceAccountsModule,
-        data: {
-          titleId: "serviceAccounts",
-        },
-      },
-      {
-        path: "trash",
-        loadChildren: () => TrashModule,
-        data: {
-          titleId: "trash",
-        },
-      },
-      {
-        path: "settings",
-        loadChildren: () => SettingsModule,
-      },
-      {
-        path: "",
-        loadChildren: () => OverviewModule,
+        canActivate: [canActivateSM],
         pathMatch: "full",
+        children: [],
+      },
+      {
+        path: ":organizationId",
+        component: LayoutComponent,
+        canActivate: [AuthGuard, OrganizationPermissionsGuard],
+        data: {
+          organizationPermissions: (org: Organization) => org.canAccessSecretsManager,
+        },
+        children: [
+          {
+            path: "",
+            component: NavigationComponent,
+            outlet: "sidebar",
+          },
+          {
+            path: "secrets",
+            loadChildren: () => SecretsModule,
+            data: {
+              titleId: "secrets",
+            },
+          },
+          {
+            path: "projects",
+            loadChildren: () => ProjectsModule,
+            data: {
+              titleId: "projects",
+            },
+          },
+          {
+            path: "service-accounts",
+            loadChildren: () => ServiceAccountsModule,
+            data: {
+              titleId: "serviceAccounts",
+            },
+          },
+          {
+            path: "trash",
+            loadChildren: () => TrashModule,
+            data: {
+              titleId: "trash",
+            },
+          },
+          {
+            path: "settings",
+            loadChildren: () => SettingsModule,
+          },
+          {
+            path: "",
+            loadChildren: () => OverviewModule,
+            pathMatch: "full",
+          },
+        ],
       },
     ],
   }),

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
@@ -6,16 +6,27 @@ import {
   RouterStateSnapshot,
 } from "@angular/router";
 
+import { AuthGuard } from "@bitwarden/angular/auth/guards/auth.guard";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 
 /**
  * Redirects from root `/sm` to first organization with access to SM
  */
 export const canActivateSM: CanActivateFn = async (
   route: ActivatedRouteSnapshot,
-  _state: RouterStateSnapshot
+  state: RouterStateSnapshot
 ) => {
-  const orgs = await inject(OrganizationService).getAll();
+  const authService = inject(AuthService);
+  const orgService = inject(OrganizationService);
+  const authGuard = inject(AuthGuard);
+
+  if ((await authService.getAuthStatus()) !== AuthenticationStatus.Unlocked) {
+    return authGuard.canActivate(route, state);
+  }
+
+  const orgs = await orgService.getAll();
   const smOrg = orgs.find((o) => o.canAccessSecretsManager);
   if (smOrg) {
     return createUrlTreeFromSnapshot(route, ["/sm", smOrg.id]);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
@@ -1,10 +1,24 @@
-import { Injectable } from "@angular/core";
-import { ActivatedRouteSnapshot, CanActivate } from "@angular/router";
+import { inject } from "@angular/core";
+import {
+  ActivatedRouteSnapshot,
+  CanActivateFn,
+  createUrlTreeFromSnapshot,
+  RouterStateSnapshot,
+} from "@angular/router";
 
-@Injectable()
-export class SMGuard implements CanActivate {
-  async canActivate(route: ActivatedRouteSnapshot) {
-    // TODO: Verify org
-    return true;
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+
+/**
+ * Redirects from root `/sm` to first organization with access to SM
+ */
+export const canActivateSM: CanActivateFn = async (
+  route: ActivatedRouteSnapshot,
+  _state: RouterStateSnapshot
+) => {
+  const orgs = await inject(OrganizationService).getAll();
+  const smOrg = orgs.find((o) => o.canAccessSecretsManager);
+  if (smOrg) {
+    return createUrlTreeFromSnapshot(route, ["sm", smOrg.id]);
   }
-}
+  return createUrlTreeFromSnapshot(route, ["/vault"]);
+};

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
@@ -18,7 +18,7 @@ export const canActivateSM: CanActivateFn = async (
   const orgs = await inject(OrganizationService).getAll();
   const smOrg = orgs.find((o) => o.canAccessSecretsManager);
   if (smOrg) {
-    return createUrlTreeFromSnapshot(route, ["sm", smOrg.id]);
+    return createUrlTreeFromSnapshot(route, ["/sm", smOrg.id]);
   }
   return createUrlTreeFromSnapshot(route, ["/vault"]);
 };

--- a/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts
@@ -10,6 +10,7 @@ import { AuthGuard } from "@bitwarden/angular/auth/guards/auth.guard";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 
 /**
  * Redirects from root `/sm` to first organization with access to SM
@@ -18,9 +19,15 @@ export const canActivateSM: CanActivateFn = async (
   route: ActivatedRouteSnapshot,
   state: RouterStateSnapshot
 ) => {
+  const syncService = inject(SyncService);
   const authService = inject(AuthService);
   const orgService = inject(OrganizationService);
   const authGuard = inject(AuthGuard);
+
+  /** Workaround to avoid service initialization race condition. */
+  if ((await syncService.getLastSync()) == null) {
+    await syncService.fullSync(false);
+  }
 
   if ((await authService.getAuthStatus()) !== AuthenticationStatus.Unlocked) {
     return authGuard.canActivate(route, state);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When users land on `/sm` they are now redirected to their first available organization with access to SM. If the user does not have access to SM, they are redirected to the vault. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/sm.guard.ts:** Updated guard to redirect based on available orgs. Rewrote the guard to no longer use the deprecated `CanActivate` interface and to use the new `CanActivateFn` pattern.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
