### PR TITLE
Made the cursor change to I-beam cursor when you hover over the search bar

### DIFF
--- a/apps/desktop/src/app/layout/search/search.component.html
+++ b/apps/desktop/src/app/layout/search/search.component.html
@@ -6,6 +6,7 @@
     autocomplete="off"
     [formControl]="searchText"
     appAutofocus
+    style="cursor: text"
   />
   <i class="bwi bwi-search" aria-hidden="true"></i>
 </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes https://github.com/bitwarden/clients/issues/5189 by making the mouse pointer turn into the I-beam when you hover over the search bar

## Code changes

Added the style property : 'style="cursor: text"' in search.component.html. This is the HTML for search bar, so when you hover over it the I-beam will now appear

## Screenshots
Before
![Alt Text](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzBmZWU1YTM4ZGRiYzdjYmQwYTRkMDFjN2JkNGM5MTVlNmI2ODgzMiZjdD1n/FKDNlMa0l5AndIMMrO/giphy.gif)
After
![Alt Text](https://media.giphy.com/media/WGMe4madp3Idml6vkC/giphy.gif)




## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
