### PR TITLE
[PM-1829] Allow Safari popup to be full height in Safari >= 16.1

### DIFF
--- a/apps/browser/src/popup/main.ts
+++ b/apps/browser/src/popup/main.ts
@@ -1,9 +1,17 @@
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 
+import BrowserPlatformUtilsService from "../services/browserPlatformUtils.service";
+
 require("./scss/popup.scss");
 
 import { AppModule } from "./app.module";
+
+// We put this first to minimize the delay in window changing.
+// Should be removed once we deprecate support for Safari 16.0 and older.
+if (BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)) {
+  document.documentElement.classList.add("browser_safari_height");
+}
 
 if (process.env.ENV === "production") {
   enableProdMode();

--- a/apps/browser/src/popup/main.ts
+++ b/apps/browser/src/popup/main.ts
@@ -10,7 +10,7 @@ import { AppModule } from "./app.module";
 // We put this first to minimize the delay in window changing.
 // Should be removed once we deprecate support for Safari 16.0 and older.
 if (BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)) {
-  document.documentElement.classList.add("browser_safari_height");
+  document.documentElement.classList.add("safari_height_fix");
 }
 
 if (process.env.ENV === "production") {

--- a/apps/browser/src/popup/scss/environment.scss
+++ b/apps/browser/src/popup/scss/environment.scss
@@ -1,6 +1,6 @@
 @import "variables.scss";
 
-html.browser_safari {
+html.browser_safari.safari_height_fix {
   body {
     height: 360px !important;
 

--- a/apps/browser/src/services/browserPlatformUtils.service.spec.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.spec.ts
@@ -22,6 +22,7 @@ describe("Browser Utils Service", () => {
     afterEach(() => {
       window.matchMedia = undefined;
       (window as any).chrome = undefined;
+      (BrowserPlatformUtilsService as any).deviceCache = null;
     });
 
     it("should detect chrome", () => {
@@ -95,6 +96,10 @@ describe("Safari Height Fix", () => {
     Object.defineProperty(navigator, "userAgent", {
       value: originalUserAgent,
     });
+  });
+
+  afterEach(() => {
+    (BrowserPlatformUtilsService as any).deviceCache = null;
   });
 
   it("should apply fix for safari 15.6", () => {

--- a/apps/browser/src/services/browserPlatformUtils.service.spec.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.spec.ts
@@ -86,3 +86,94 @@ describe("Browser Utils Service", () => {
     });
   });
 });
+
+describe("Safari Height Fix", () => {
+  const originalUserAgent = navigator.userAgent;
+
+  // Reset the userAgent.
+  afterAll(() => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: originalUserAgent,
+    });
+  });
+
+  it("should apply fix for safari 15.6", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.1 Safari/605.1.15",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(true);
+  });
+
+  it("should apply fix for safari 16.1", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(true);
+  });
+
+  it("should not apply fix for safari 16.1", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for safari 16.4", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for safari 17.0 (future releases)", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for chrome", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for firefox", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for opera", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3175.3 Safari/537.36 OPR/49.0.2695.0 (Edition developer)",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+
+  it("should not apply fix for edge", () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43",
+    });
+    expect(BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)).toBe(false);
+  });
+});

--- a/apps/browser/src/services/browserPlatformUtils.service.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.ts
@@ -105,7 +105,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     );
   }
 
-  static safariVersion(win: Window & typeof globalThis): string {
+  static safariVersion(): string {
     return navigator.userAgent.match("Version/([0-9.]*)")?.[1];
   }
 
@@ -118,9 +118,9 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
       return false;
     }
 
-    const version = BrowserPlatformUtilsService.safariVersion(window);
-    const parts = version.split(".").map((v) => Number(v));
-    return parts?.[0] < 18 || (parts?.[0] == 16 && parts?.[1] == 0);
+    const version = BrowserPlatformUtilsService.safariVersion();
+    const parts = version?.split(".")?.map((v) => Number(v));
+    return parts?.[0] < 16 || (parts?.[0] === 16 && parts?.[1] === 0);
   }
 
   isSafari(): boolean {

--- a/apps/browser/src/services/browserPlatformUtils.service.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.ts
@@ -105,6 +105,24 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     );
   }
 
+  static safariVersion(win: Window & typeof globalThis): string {
+    return navigator.userAgent.match("Version/([0-9.]*)")?.[1];
+  }
+
+  /**
+   * Safari previous to version 16.1 had a bug which caused artifacts on hover in large extension popups.
+   * https://bugs.webkit.org/show_bug.cgi?id=218704
+   */
+  static shouldApplySafariHeightFix(win: Window & typeof globalThis): boolean {
+    if (!BrowserPlatformUtilsService.isSafari(win)) {
+      return false;
+    }
+
+    const version = BrowserPlatformUtilsService.safariVersion(window);
+    const parts = version.split(".").map((v) => Number(v));
+    return parts?.[0] < 18 || (parts?.[0] == 16 && parts?.[1] == 0);
+  }
+
   isSafari(): boolean {
     return this.getDevice() === DeviceType.SafariExtension;
   }

--- a/apps/browser/src/services/browserPlatformUtils.service.ts
+++ b/apps/browser/src/services/browserPlatformUtils.service.ts
@@ -13,7 +13,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     number,
     { tryResolve: (canceled: boolean, password: string) => Promise<boolean>; date: Date }
   >();
-  private deviceCache: DeviceType = null;
+  private static deviceCache: DeviceType = null;
 
   constructor(
     private messagingService: MessagingService,
@@ -22,26 +22,30 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     private win: Window & typeof globalThis
   ) {}
 
-  getDevice(): DeviceType {
+  static getDevice(win: Window & typeof globalThis): DeviceType {
     if (this.deviceCache) {
       return this.deviceCache;
     }
 
     if (BrowserPlatformUtilsService.isFirefox()) {
       this.deviceCache = DeviceType.FirefoxExtension;
-    } else if (BrowserPlatformUtilsService.isOpera(this.win)) {
+    } else if (BrowserPlatformUtilsService.isOpera(win)) {
       this.deviceCache = DeviceType.OperaExtension;
     } else if (BrowserPlatformUtilsService.isEdge()) {
       this.deviceCache = DeviceType.EdgeExtension;
     } else if (BrowserPlatformUtilsService.isVivaldi()) {
       this.deviceCache = DeviceType.VivaldiExtension;
-    } else if (BrowserPlatformUtilsService.isChrome(this.win)) {
+    } else if (BrowserPlatformUtilsService.isChrome(win)) {
       this.deviceCache = DeviceType.ChromeExtension;
-    } else if (BrowserPlatformUtilsService.isSafari(this.win)) {
+    } else if (BrowserPlatformUtilsService.isSafari(win)) {
       this.deviceCache = DeviceType.SafariExtension;
     }
 
     return this.deviceCache;
+  }
+
+  getDevice(): DeviceType {
+    return BrowserPlatformUtilsService.getDevice(this.win);
   }
 
   getDeviceString(): string {
@@ -53,6 +57,9 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return ClientType.Browser;
   }
 
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
   static isFirefox(): boolean {
     return (
       navigator.userAgent.indexOf(" Firefox/") !== -1 ||
@@ -64,7 +71,10 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return this.getDevice() === DeviceType.FirefoxExtension;
   }
 
-  static isChrome(win: Window & typeof globalThis): boolean {
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
+  private static isChrome(win: Window & typeof globalThis): boolean {
     return win.chrome && navigator.userAgent.indexOf(" Chrome/") !== -1;
   }
 
@@ -72,7 +82,10 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return this.getDevice() === DeviceType.ChromeExtension;
   }
 
-  static isEdge(): boolean {
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
+  private static isEdge(): boolean {
     return navigator.userAgent.indexOf(" Edg/") !== -1;
   }
 
@@ -80,7 +93,10 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return this.getDevice() === DeviceType.EdgeExtension;
   }
 
-  static isOpera(win: Window & typeof globalThis): boolean {
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
+  private static isOpera(win: Window & typeof globalThis): boolean {
     return (
       (!!win.opr && !!win.opr.addons) || !!win.opera || navigator.userAgent.indexOf(" OPR/") >= 0
     );
@@ -90,7 +106,10 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return this.getDevice() === DeviceType.OperaExtension;
   }
 
-  static isVivaldi(): boolean {
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
+  private static isVivaldi(): boolean {
     return navigator.userAgent.indexOf(" Vivaldi/") !== -1;
   }
 
@@ -98,6 +117,9 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     return this.getDevice() === DeviceType.VivaldiExtension;
   }
 
+  /**
+   * @deprecated Do not call this directly, use getDevice() instead
+   */
   static isSafari(win: Window & typeof globalThis): boolean {
     // Opera masquerades as Safari, so make sure we're not there first
     return (
@@ -105,7 +127,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     );
   }
 
-  static safariVersion(): string {
+  private static safariVersion(): string {
     return navigator.userAgent.match("Version/([0-9.]*)")?.[1];
   }
 
@@ -114,7 +136,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
    * https://bugs.webkit.org/show_bug.cgi?id=218704
    */
   static shouldApplySafariHeightFix(win: Window & typeof globalThis): boolean {
-    if (!BrowserPlatformUtilsService.isSafari(win)) {
+    if (BrowserPlatformUtilsService.getDevice(win) !== DeviceType.SafariExtension) {
       return false;
     }
 


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

To workaround a Safari bug that caused issues for extensions with windows of certain height, we previously limited the window size. This bug is solved in Safari 16.1 and newer, so using the user agent, we apply the workaround only to the unpatched versions.

GitHub issue here #1692.

I've also noticed that the user agent sniffing in the browser extension wasn't entirely correct, at least the static `isSafari` function would also match Chrome on Mac (with user agent `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36`). Following @Hinton's recommendations I've deprecated the static `isBrowser` functions to keep them from being used and made `getDevice` static, which is does return the correct result. In another PR we can either remove them or replace them by `getDevice` calls.

## Code changes

- **main.ts:** Apply the fix as early as possible in the startup
- **environment.scss**: Change the CSS rule that limits the height to only apply when the browser is safari AND when the safari version is less than 16.1.
- **browserPlatformUtils.service.spec.ts**: Added tests to make sure that the user agent sniffing is correct.
- **browserPlatformUtils.service.ts**: Implement the fix detection logic and deprecate isBrowser functions

## Screenshots

Before this change             |  After this change
:-------------------------:|:-------------------------:
![Screenshot 2023-04-17 at 11 35 05](https://user-images.githubusercontent.com/725423/232446028-67911774-414b-42a1-8076-a1f82dc15a3d.png)  |  ![Screenshot 2023-04-17 at 11 30 45](https://user-images.githubusercontent.com/725423/232446044-10dc6885-0b7a-48b5-82ea-bb08acb49093.png)
