### PR TITLE
[PM-1267] Update cli receive command to use api.bitwarden.com

### DIFF
--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -111,7 +111,7 @@ export class SendReceiveCommand extends DownloadCommand {
   private getApiUrl(url: URL) {
     const urls = this.environmentService.getUrls();
     if (url.origin === "https://send.bitwarden.com") {
-      return "https://vault.bitwarden.com/api";
+      return "https://api.bitwarden.com";
     } else if (url.origin === urls.api) {
       return url.origin;
     } else if (this.platformUtilsService.isDev() && url.origin === urls.webVault) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`receive.command` is still defaulting bitwarden cloud domains to `vault.bitwarden.com/api` this updates to use `api.bitwarden.com`

## Code changes
- **receive.command.ts:** Updated ApiUrl method to return `api.bitwarden.com` instead `vault.bitwarden.com/api`


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
