### PR TITLE
[PM-1890] Lock active account first

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -180,13 +180,17 @@ export class AppComponent implements OnInit, OnDestroy {
           case "lockVault":
             await this.vaultTimeoutService.lock(message.userId);
             break;
-          case "lockAllVaults":
-            for (const userId in await firstValueFrom(this.stateService.accounts$)) {
-              if (userId != null) {
-                await this.vaultTimeoutService.lock(userId);
-              }
-            }
+          case "lockAllVaults": {
+            const currentUser = await this.stateService.getUserId();
+            const accounts = await firstValueFrom(this.stateService.accounts$);
+            await this.vaultTimeoutService.lock(currentUser);
+            Promise.all(
+              Object.keys(accounts)
+                .filter((u) => u !== currentUser)
+                .map((u) => this.vaultTimeoutService.lock(u))
+            );
             break;
+          }
           case "locked":
             this.modalService.closeAll();
             if (


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Locking all non-active accounts prior to active lead to process reload issues. This was ultimately due to auth guard being triggered and loading lock with the prompt biometrics parameter.

I'm not sure why auth guard routing depended on locking order, but if the active account is logged out first this doesn't occur, blocking this issue 🤷 

## Code changes

- **app.component.ts**: instead of locking in order, lock the active account first, then lock all others.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
