### PR TITLE
Ask to save changes on exit

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as url from "url";
 
-import { app, BrowserWindow, screen } from "electron";
+import { app, BrowserWindow, screen, ipcMain } from "electron";
 
 import { LogService } from "@bitwarden/common/abstractions/log.service";
 import { StateService } from "@bitwarden/common/abstractions/state.service";
@@ -98,6 +98,9 @@ export class WindowMain {
         // throw e;
         reject(e);
       }
+      ipcMain.on("request-app-quit", () => {
+        app.quit();
+      });
     });
   }
 

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -635,9 +635,9 @@ export class VaultComponent implements OnInit, OnDestroy {
       }
     });
 
-    this.addEditComponent.submit();
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil
     this.modal.onClosed.subscribe(() => {
+      this.addEditComponent.submit();
       this.modal = null;
     });
   }

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectorRef,
   Component,
+  HostListener,
   NgZone,
   OnDestroy,
   OnInit,
@@ -8,6 +9,7 @@ import {
   ViewContainerRef,
 } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
+import { ipcRenderer } from "electron";
 import { first } from "rxjs/operators";
 
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
@@ -83,6 +85,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   activeFilter: VaultFilter = new VaultFilter();
 
   private modal: ModalRef = null;
+  private triedQuit = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -632,6 +635,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       }
     });
 
+    this.addEditComponent.submit();
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil
     this.modal.onClosed.subscribe(() => {
       this.modal = null;
@@ -770,6 +774,32 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     return true;
+  }
+
+  private async saveChangesOrCancel() {
+    const result = await ipcRenderer.invoke("showMessageBox", {
+      type: "warning",
+      title: "Unsaved Changes",
+      message: "Do you want to save your pending changes?",
+      buttons: ["Yes", "No", "Cancel"],
+    });
+    return result;
+  }
+
+  @HostListener("window:beforeunload", ["$event"])
+  private async onBeforeUnload(event: BeforeUnloadEvent) {
+    if (!this.triedQuit && this.dirtyInput() && this.action == "edit") {
+      event.returnValue = false;
+      let response = await this.saveChangesOrCancel();
+      response = response.response;
+      if (response === 0 || response === 1) {
+        if (response === 0) {
+          await this.addEditComponent.submit();
+        }
+        this.triedQuit = true;
+        ipcRenderer.send("request-app-quit");
+      }
+    }
   }
 
   private async passwordReprompt(cipher: CipherView) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes https://github.com/bitwarden/clients/issues/4729. It displays a message box when you try to quit with unsaved changes, asking if you want to save the changes. You can also cancel the exit.

Also, if you accept the overwrite password confirmation box and then generate a new password, the new password will be instantly saved. This applies to generating a new username as well.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **window.main.ts:** Added the ipcMain.on('request-app-quit') listener to detect when the message box indicates to exit
- **vault.component.ts** Added this.addEditComponent.submit() in openGenerator to save generated  password / username. SaveChangesOrCancel displays a message box with "Yes", "No" and "Cancel" buttons. Added a listener for beforeunload event, which is handled by onBeforeUnload.

onBeforeUnload works by displaying a message if the item's properties have changed. If the user presses "Yes" then the app exits by requesting the app to quit and setting triedQuit to false, so when it enters onBeforeUnload again, it will not edit event.returnValue, so the app exits and saves any changes. "No" does the same thing but without saving any changes. "Cancel" changes the event.returnValue to prevent the app from exiting.



## Screenshots
### Generating Password
![giphy (3)](https://user-images.githubusercontent.com/73389504/233361680-a23b2a95-5a3e-47ec-a876-60fa9880af81.gif)
### Confirm Changes
![giphy (1)](https://user-images.githubusercontent.com/73389504/233361163-f59495d5-aca8-4a4f-a5c7-3e06fe4eb969.gif)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
