### PR TITLE
[PM-1889] Debounce value changes

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 import { Router } from "@angular/router";
-import { concatMap, filter, map, Observable, Subject, takeUntil, tap } from "rxjs";
+import { concatMap, debounceTime, filter, map, Observable, Subject, takeUntil, tap } from "rxjs";
 import Swal from "sweetalert2";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
@@ -155,6 +155,7 @@ export class SettingsComponent implements OnInit {
 
     this.form.controls.vaultTimeout.valueChanges
       .pipe(
+        debounceTime(250),
         concatMap(async (value) => {
           await this.saveVaultTimeout(value);
         }),


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

observable value change is triggering twice, debounce to display warning only once on choosing never lock. Other observables in file either are not triggering multiple times, or, in the case of biometrics, quickly turning off in the event of failed native messaging is desirable.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
