### PR TITLE
[PM-1909] Apply search input contrast fix to all pages

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -302,6 +302,19 @@ header {
           color: themed("headerInputPlaceholderColor");
         }
       }
+      /** make the cancel button visible in both dark/light themes **/
+      &[type="search"]::-webkit-search-cancel-button {
+        -webkit-appearance: none;
+        appearance: none;
+        height: 15px;
+        width: 15px;
+        background-repeat: no-repeat;
+        mask-image: url("../images/close-button-white.svg");
+        -webkit-mask-image: url("../images/close-button-white.svg");
+        @include themify($themes) {
+          background-color: themed("headerInputColor");
+        }
+      }
     }
   }
 
@@ -448,19 +461,6 @@ main {
 .tab-page {
   main {
     bottom: 55px;
-  }
-
-  [type="search"]::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    appearance: none;
-    height: 15px;
-    width: 15px;
-    background-repeat: no-repeat;
-    mask-image: url("../images/close-button-white.svg");
-    -webkit-mask-image: url("../images/close-button-white.svg");
-    @include themify($themes) {
-      background-color: themed("headerInputColor");
-    }
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ x ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

I just made the previous commit https://github.com/bitwarden/clients/pull/3929 complete by applying the change to all affected search inputs, not just ones inside of `.tab-page`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

"clients/apps/browser/src/popup/scss/base.scss" : I modified the previous fix that made for better contrast on the search input apply to all pages.

## Screenshots

The correct behaviour exists in the "outer" routes, seen here.
<img width="414" alt="Pasted image 20230420164913" src="https://user-images.githubusercontent.com/9141395/233490314-c8ec0fa6-8e3a-4071-b4a4-a1a51ab89545.png">

However, in the Vault submenu items like Login, Card, Identity, Secure Note, Folders, and Collections, the dismiss icon for both light and dark themes is not legible.


<img width="414" alt="Pasted image 20230420165236" src="https://user-images.githubusercontent.com/9141395/233490588-6196d82c-2c4d-4db9-95ba-7a8e27624363.png">
<img width="414" alt="Pasted image 20230420165258" src="https://user-images.githubusercontent.com/9141395/233490594-ffb4291c-ae5c-429d-9495-71659e987088.png">

So I moved the previous fix to apply to all inputs of type search, and now the above pages look like this

<img width="414" alt="image" src="https://user-images.githubusercontent.com/9141395/233490840-88407c32-f43f-42de-ae49-a641bdef4441.png">

<img width="414" alt="image" src="https://user-images.githubusercontent.com/9141395/233491540-be66206c-56f3-4c37-90cd-de51e27546e8.png">




## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
