### PR TITLE
Defect/AC-1267 - Fix Login Master Pass Entry Prematurely Showing Validation Errors

### DIFF
--- a/libs/angular/src/auth/components/login.component.ts
+++ b/libs/angular/src/auth/components/login.component.ts
@@ -246,11 +246,19 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
       // so that autofill can work properly
       this.formGroup.controls.masterPassword.reset();
     } else {
+      // Mark MP as untouched so that, when users enter email and hit enter,
+      // the MP field doesn't load with validation errors
+      this.formGroup.controls.masterPassword.markAsUntouched();
+
       // When email is validated, focus on master password after
       // waiting for input to be rendered
-      this.ngZone.onStable
-        .pipe(take(1))
-        .subscribe(() => this.masterPasswordInput?.nativeElement?.focus());
+      if (this.ngZone.isStable) {
+        this.masterPasswordInput?.nativeElement?.focus();
+      } else {
+        this.ngZone.onStable.pipe(take(1)).subscribe(() => {
+          this.masterPasswordInput?.nativeElement?.focus();
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[AC-1267](https://bitwarden.atlassian.net/browse/AC-1267) - Fix Login Master Pass Entry Prematurely Showing Validation Errors

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/angular/src/auth/components/login.component.ts:** 
    - Mark master pass (MP) field as untouched on any load of MP section of login page post email validation in order to prevent validation errors of "input required" from being shown prematurely before the user has entered anything or lost focus on the input **when the user hits enter** on the login screen after entering an email 
    - Improve the logic around the MP autofocus to match existing code patterns to ensure there are no possible scenarios in which the MP would not be autofocused.

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://user-images.githubusercontent.com/116684653/233497641-99787170-c304-4207-b233-22deb59d6457.mov


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[AC-1267]: https://bitwarden.atlassian.net/browse/AC-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ