### PR TITLE
[AC-1340] [Defect] Provider users unable to restore vault items for client organizations

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -674,7 +674,8 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     try {
-      await this.cipherService.restoreWithServer(c.id);
+      const asAdmin = this.organization?.canEditAnyCollection;
+      await this.cipherService.restoreWithServer(c.id, asAdmin);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("restoredItem"));
       this.refresh();
     } catch (e) {

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -610,7 +610,8 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   protected restoreCipher() {
-    return this.cipherService.restoreWithServer(this.cipher.id);
+    const asAdmin = this.organization?.canEditAnyCollection;
+    return this.cipherService.restoreWithServer(this.cipher.id, asAdmin);
   }
 
   get defaultOwnerId(): string | null {

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -75,6 +75,6 @@ export abstract class CipherService {
   restore: (
     cipher: { id: string; revisionDate: string } | { id: string; revisionDate: string }[]
   ) => Promise<any>;
-  restoreWithServer: (id: string) => Promise<any>;
+  restoreWithServer: (id: string, asAdmin?: boolean) => Promise<any>;
   restoreManyWithServer: (ids: string[]) => Promise<any>;
 }

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -914,8 +914,10 @@ export class CipherService implements CipherServiceAbstraction {
     await this.stateService.setEncryptedCiphers(ciphers);
   }
 
-  async restoreWithServer(id: string): Promise<any> {
-    const response = await this.apiService.putRestoreCipher(id);
+  async restoreWithServer(id: string, asAdmin = false): Promise<any> {
+    const response = asAdmin
+      ? await this.apiService.putRestoreCipherAdmin(id)
+      : await this.apiService.putRestoreCipher(id);
     await this.restore({ id: id, revisionDate: response.revisionDate });
   }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
After [refactoring the vault tables](https://github.com/bitwarden/clients/pull/4967) we stopped calling the Cipher Admin restore endpoints which Provider Admin users need since they don't have direct Organization permissions.

## Code changes

- **apps/web/src/app/vault/org-vault/vault.component.ts:** Passing the `organization.canEditAnyCollection` argument to `cipherService`
- **libs/angular/src/vault/components/add-edit.component.ts:** Passing the `organization.canEditAnyCollection` argument to `cipherService`
- **libs/common/src/vault/abstractions/cipher.service.ts:** Added new parameter `orgAdmin: boolean` do determine if the service should call the admin delete cipher endpoint
- **libs/common/src/vault/services/cipher.service.ts:** Calling either `apiService.putRestoreCipherAdmin` or `apiService.putRestoreCipher` depending on the passed `orgAdmin: boolean` argument

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
