### PR TITLE
[PM-1914] Migrate all dialogs to use the new bitDialogFooter default styling

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -65,7 +65,7 @@
         </bit-tab>
       </bit-tab-group>
     </div>
-    <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+    <ng-container bitDialogFooter>
       <button bitButton buttonType="primary" bitFormButton type="submit">
         {{ "save" | i18n }}
       </button>
@@ -87,6 +87,6 @@
         [bitAction]="delete"
         [appA11yTitle]="'delete' | i18n"
       ></button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -325,7 +325,7 @@
         ></bit-tab>
       </bit-tab-group>
     </div>
-    <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
         {{ "save" | i18n }}
       </button>
@@ -373,6 +373,6 @@
           [disabled]="loading"
         ></button>
       </div>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -149,7 +149,7 @@ const DialogAccessSelectorTemplate: Story<AccessSelectorComponent> = (
           [showMemberRoles]="showMemberRoles"
         ></bit-access-selector>
       </span>
-      <div bitDialogFooter class="tw-flex tw-items-center tw-flex-row tw-gap-2">
+      <ng-container bitDialogFooter>
         <button bitButton buttonType="primary">Save</button>
         <button bitButton buttonType="secondary">Cancel</button>
         <button
@@ -159,7 +159,7 @@ const DialogAccessSelectorTemplate: Story<AccessSelectorComponent> = (
           size="default"
           title="Delete"
           aria-label="Delete"></button>
-      </div>
+      </ng-container>
     </bit-dialog>
 `,
 });

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
@@ -73,7 +73,7 @@
         </bit-tab>
       </bit-tab-group>
     </div>
-    <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
         {{ "save" | i18n }}
       </button>
@@ -98,6 +98,6 @@
         [bitAction]="delete"
         [disabled]="loading"
       ></button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/apps/web/src/app/settings/change-kdf/change-kdf-confirmation.component.html
+++ b/apps/web/src/app/settings/change-kdf/change-kdf-confirmation.component.html
@@ -39,12 +39,12 @@
       </div>
     </form>
   </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button bitButton buttonType="primary" type="submit" [loading]="loading" form="form">
       <span>{{ "changeKdf" | i18n }}</span>
     </button>
     <button bitButton buttonType="secondary" type="button" data-dismiss="modal">
       {{ "cancel" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/apps/web/src/app/tools/import-export/dialog/import-success-dialog.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/import-success-dialog.component.html
@@ -24,9 +24,9 @@
     </bit-table>
   </div>
 
-  <div bitDialogFooter>
+  <ng-container bitDialogFooter>
     <button bitButton bitDialogClose buttonType="primary" type="button">
       {{ "ok" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
@@ -16,10 +16,10 @@
       {{ "permanentlyDeleteSelectedItemsDesc" | i18n : cipherIds.length }}
     </ng-container>
   </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button bitButton type="submit" buttonType="danger" [bitAction]="submit">
       {{ (permanent ? "permanentlyDelete" : "delete") | i18n }}
     </button>
     <button bitButton type="button" (click)="cancel()">{{ "cancel" | i18n }}</button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.html
@@ -12,13 +12,13 @@
         </select>
       </bit-form-field>
     </span>
-    <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+    <ng-container bitDialogFooter>
       <button bitButton bitFormButton type="submit" buttonType="primary">
         {{ "save" | i18n }}
       </button>
       <button bitButton bitFormButton type="button" buttonType="secondary" (click)="cancel()">
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-restore-dialog/bulk-restore-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-restore-dialog/bulk-restore-dialog.component.html
@@ -5,10 +5,10 @@
   <span bitDialogContent>
     {{ "restoreSelectedItemsDesc" | i18n : cipherIds.length }}
   </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button bitButton type="submit" buttonType="primary" [bitAction]="submit">
       {{ "restore" | i18n }}
     </button>
     <button bitButton type="button" (click)="cancel()">{{ "cancel" | i18n }}</button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-share-dialog/bulk-share-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-share-dialog/bulk-share-dialog.component.html
@@ -62,12 +62,12 @@
       </tbody>
     </table>
   </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button bitButton type="submit" buttonType="primary" [bitAction]="submit">
       {{ "save" | i18n }}
     </button>
     <button bitButton type="button" buttonType="secondary" (click)="cancel()">
       {{ "cancel" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
@@ -49,7 +49,7 @@
         {{ "automaticDomainVerificationProcess" | i18n }}
       </bit-callout>
     </div>
-    <div bitDialogFooter class="tw-flex tw-flex-row tw-items-center tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton bitFormButton buttonType="primary">
         <span *ngIf="!data?.orgDomain?.verifiedDate">{{ "verifyDomain" | i18n }}</span>
         <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reverifyDomain" | i18n }}</span>
@@ -70,6 +70,6 @@
         type="submit"
         bitFormButton
       ></button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
@@ -23,13 +23,13 @@
       </bit-form-field>
     </div>
 
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton buttonType="danger" bitFormButton>
         {{ title | i18n }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
@@ -10,13 +10,13 @@
         <input formControlName="name" maxlength="1000" bitInput />
       </bit-form-field>
     </span>
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton buttonType="primary" bitFormButton>
         {{ "save" | i18n }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.html
@@ -6,12 +6,12 @@
     </div>
     {{ "deleteItemConfirmation" | i18n }}
   </span>
-  <div bitDialogFooter class="tw-flex tw-gap-2">
+  <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="primary" [bitAction]="delete">
       {{ submitButtonText | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>
       {{ "close" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -35,7 +35,7 @@
         </select>
       </bit-form-field>
     </div>
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton buttonType="primary" bitFormButton>
         {{ "save" | i18n }}
       </button>
@@ -58,6 +58,6 @@
         bitFormButton
         (click)="openDeleteSecretDialog()"
       ></button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
@@ -32,13 +32,13 @@
       ></sm-expiration-options>
     </div>
 
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
         {{ "newAccessToken" | i18n }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -23,10 +23,10 @@
     {{ data.expirationDate === null ? ("never" | i18n) : (data.expirationDate | date : "medium") }}
   </div>
 
-  <div bitDialogFooter class="tw-flex tw-gap-2">
+  <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="primary" (click)="copyAccessToken()">
       <i class="bwi bwi-clone" aria-hidden="true"></i>
       {{ "copyToken" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
@@ -23,13 +23,13 @@
       </bit-form-field>
     </div>
 
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton buttonType="danger" bitFormButton>
         {{ title }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
@@ -12,13 +12,13 @@
         </bit-form-field>
       </div>
     </div>
-    <div bitDialogFooter class="tw-flex tw-gap-2">
+    <ng-container bitDialogFooter>
       <button type="submit" bitButton buttonType="primary" bitFormButton>
         {{ "save" | i18n }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </bit-dialog>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/dialog/sm-import-error-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/dialog/sm-import-error-dialog.component.html
@@ -19,9 +19,9 @@
       </ng-template>
     </bit-table>
   </span>
-  <div bitDialogFooter>
+  <ng-container bitDialogFooter>
     <button bitButton bitDialogClose buttonType="primary" type="button">
       {{ "ok" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/dialogs/access-removal-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/dialogs/access-removal-dialog.component.html
@@ -3,12 +3,12 @@
   <span bitDialogContent>
     {{ data.message | i18n }}
   </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="danger" [bitAction]="removeAccess">
       {{ "removeAccess" | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" [bitAction]="cancel">
       {{ "cancel" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-status-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-status-dialog.component.html
@@ -25,9 +25,9 @@
     </bit-table>
   </div>
 
-  <div bitDialogFooter class="tw-flex tw-gap-2">
+  <ng-container bitDialogFooter>
     <button bitButton buttonType="primary" bitDialogClose type="button">
       {{ "close" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-hard-delete.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-hard-delete.component.html
@@ -7,12 +7,12 @@
         : ("hardDeleteSecretsConfirmation" | i18n)
     }}
   </span>
-  <div bitDialogFooter class="tw-flex tw-gap-2">
+  <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="primary" [bitAction]="delete">
       {{ submitButtonText | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>
       {{ "close" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-restore.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-restore.component.html
@@ -5,12 +5,12 @@
       data.secretIds.length === 1 ? ("restoreSecretPrompt" | i18n) : ("restoreSecretsPrompt" | i18n)
     }}
   </span>
-  <div bitDialogFooter class="tw-flex tw-gap-2">
+  <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="primary" [bitAction]="restore">
       {{ title | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>
       {{ "close" | i18n }}
     </button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -44,10 +44,10 @@ class StoryDialogComponent {
         <br />
         Animal: {{ animal }}
       </span>
-      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+      <ng-container bitDialogFooter>
         <button bitButton buttonType="primary" (click)="dialogRef.close()">Save</button>
         <button bitButton buttonType="secondary" bitDialogClose>Cancel</button>
-      </div>
+      </ng-container>
     </bit-dialog>
   `,
 })

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -25,7 +25,7 @@
   </div>
 
   <div
-    class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-p-4"
+    class="tw-flex tw-flex-row tw-items-center tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-p-4"
   >
     <ng-content select="[bitDialogFooter]"></ng-content>
   </div>

--- a/libs/components/src/dialog/dialog/dialog.stories.ts
+++ b/libs/components/src/dialog/dialog/dialog.stories.ts
@@ -55,7 +55,7 @@ const Template: Story<DialogComponent> = (args: DialogComponent) => ({
   <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
     <span bitDialogTitle>{{title}}</span>
     <span bitDialogContent>Dialog body text goes here.</span>
-    <div bitDialogFooter class="tw-flex tw-items-center tw-flex-row tw-gap-2">
+    <ng-container bitDialogFooter>
       <button bitButton buttonType="primary">Save</button>
       <button bitButton buttonType="secondary">Cancel</button>
       <button
@@ -65,7 +65,7 @@ const Template: Story<DialogComponent> = (args: DialogComponent) => ({
         size="default"
         title="Delete"
         aria-label="Delete"></button>
-    </div>
+    </ng-container>
   </bit-dialog>
   `,
 });
@@ -98,18 +98,18 @@ const TemplateScrolling: Story<DialogComponent> = (args: DialogComponent) => ({
   props: args,
   template: `
   <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
-  <span bitDialogTitle>Scrolling Example</span>
-  <span bitDialogContent>
-    Dialog body text goes here.<br>
-    <ng-container *ngFor="let _ of [].constructor(100)">
-      repeating lines of characters <br>
+    <span bitDialogTitle>Scrolling Example</span>
+    <span bitDialogContent>
+      Dialog body text goes here.<br>
+      <ng-container *ngFor="let _ of [].constructor(100)">
+        repeating lines of characters <br>
+      </ng-container>
+      end of sequence!
+    </span>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary">Save</button>
+      <button bitButton buttonType="secondary">Cancel</button>
     </ng-container>
-    end of sequence!
-  </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
-    <button bitButton buttonType="primary">Save</button>
-    <button bitButton buttonType="secondary">Cancel</button>
-  </div>
   </bit-dialog>
   `,
 });
@@ -123,18 +123,18 @@ const TemplateTabbed: Story<DialogComponent> = (args: DialogComponent) => ({
   props: args,
   template: `
   <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
-  <span bitDialogTitle>Tab Content Example</span>
-  <span bitDialogContent>
-    <bit-tab-group>
-        <bit-tab label="First Tab">First Tab Content</bit-tab>
-        <bit-tab label="Second Tab">Second Tab Content</bit-tab>
-        <bit-tab label="Third Tab">Third Tab Content</bit-tab>
-    </bit-tab-group>
-  </span>
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
-    <button bitButton buttonType="primary">Save</button>
-    <button bitButton buttonType="secondary">Cancel</button>
-  </div>
+    <span bitDialogTitle>Tab Content Example</span>
+    <span bitDialogContent>
+      <bit-tab-group>
+          <bit-tab label="First Tab">First Tab Content</bit-tab>
+          <bit-tab label="Second Tab">Second Tab Content</bit-tab>
+          <bit-tab label="Third Tab">Third Tab Content</bit-tab>
+      </bit-tab-group>
+    </span>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary">Save</button>
+      <button bitButton buttonType="secondary">Cancel</button>
+    </ng-container>
   </bit-dialog>
   `,
 });

--- a/libs/components/src/dialog/simple-configurable-dialog/simple-configurable-dialog.component.html
+++ b/libs/components/src/dialog/simple-configurable-dialog/simple-configurable-dialog.component.html
@@ -5,7 +5,7 @@
 
   <div bitDialogContent>{{ content }}</div>
 
-  <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+  <ng-container bitDialogFooter>
     <button
       type="button"
       bitButton
@@ -24,5 +24,5 @@
     >
       {{ cancelButtonText }}
     </button>
-  </div>
+  </ng-container>
 </bit-simple-dialog>

--- a/libs/components/src/dialog/simple-dialog.service.stories.ts
+++ b/libs/components/src/dialog/simple-dialog.service.stories.ts
@@ -44,10 +44,10 @@ class StoryDialogComponent {
         <br />
         Animal: {{ animal }}
       </span>
-      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
+      <ng-container bitDialogFooter>
         <button bitButton buttonType="primary" (click)="dialogRef.close()">Save</button>
         <button bitButton buttonType="secondary" bitDialogClose>Cancel</button>
-      </div>
+      </ng-container>
     </bit-simple-dialog>
   `,
 })

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -16,7 +16,9 @@
   <div class="tw-overflow-y-auto tw-px-4 tw-pt-2 tw-pb-4 tw-text-center tw-text-base">
     <ng-content select="[bitDialogContent]"></ng-content>
   </div>
-  <div class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-p-4">
+  <div
+    class="tw-flex tw-flex-row tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-p-4"
+  >
     <ng-content select="[bitDialogFooter]"></ng-content>
   </div>
 </div>

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
@@ -26,12 +26,12 @@ const Template: Story<SimpleDialogComponent> = (args: SimpleDialogComponent) => 
   props: args,
   template: `
   <bit-simple-dialog>
-      <span bitDialogTitle>Alert Dialog</span>
-      <span bitDialogContent>Message Content</span>
-      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
-        <button bitButton buttonType="primary">Yes</button>
-        <button bitButton buttonType="secondary">No</button>
-      </div>
+    <span bitDialogTitle>Alert Dialog</span>
+    <span bitDialogContent>Message Content</span>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary">Yes</button>
+      <button bitButton buttonType="secondary">No</button>
+    </ng-container>
   </bit-simple-dialog>
   `,
 });
@@ -42,13 +42,13 @@ const TemplateWithIcon: Story<SimpleDialogComponent> = (args: SimpleDialogCompon
   props: args,
   template: `
   <bit-simple-dialog>
-      <i bitDialogIcon class="bwi bwi-star tw-text-3xl tw-text-success" aria-hidden="true"></i>
-      <span bitDialogTitle>Premium Subscription Available</span>
-      <span bitDialogContent> Message Content</span>
-      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
-        <button bitButton buttonType="primary">Yes</button>
-        <button bitButton buttonType="secondary">No</button>
-      </div>
+    <i bitDialogIcon class="bwi bwi-star tw-text-3xl tw-text-success" aria-hidden="true"></i>
+    <span bitDialogTitle>Premium Subscription Available</span>
+    <span bitDialogContent> Message Content</span>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary">Yes</button>
+      <button bitButton buttonType="secondary">No</button>
+    </ng-container>
   </bit-simple-dialog>
   `,
 });
@@ -59,19 +59,19 @@ const TemplateScroll: Story<SimpleDialogComponent> = (args: SimpleDialogComponen
   props: args,
   template: `
   <bit-simple-dialog>
-      <span bitDialogTitle>Alert Dialog</span>
-      <span bitDialogContent>
-        Message Content
-        Message text goes here.<br>
-        <ng-container *ngFor="let _ of [].constructor(100)">
-          repeating lines of characters <br>
-        </ng-container>
-        end of sequence!
-      </span>
-      <div bitDialogFooter class="tw-flex tw-flex-row tw-gap-2">
-        <button bitButton buttonType="primary">Yes</button>
-        <button bitButton buttonType="secondary">No</button>
-      </div>
+    <span bitDialogTitle>Alert Dialog</span>
+    <span bitDialogContent>
+      Message Content
+      Message text goes here.<br>
+      <ng-container *ngFor="let _ of [].constructor(100)">
+        repeating lines of characters <br>
+      </ng-container>
+      end of sequence!
+    </span>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary">Yes</button>
+      <button bitButton buttonType="secondary">No</button>
+    </ng-container>
   </bit-simple-dialog>
   `,
 });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Follow up to #5254, which migrates all the dialogs to follow the new style.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
