### PR TITLE
Minimizes on copy only after re-prompt password is accepted

### DIFF
--- a/apps/desktop/src/vault/app/vault/view.component.ts
+++ b/apps/desktop/src/vault/app/vault/view.component.ts
@@ -104,7 +104,17 @@ export class ViewComponent extends BaseViewComponent implements OnChanges {
   }
 
   async copy(value: string, typeI18nKey: string, aType: string) {
-    super.copy(value, typeI18nKey, aType);
+    if (value == null) {
+      return;
+    }
+
+    if (
+      this.passwordRepromptService.protectedFields().includes(aType) &&
+      !(await this.promptPassword())
+    ) {
+      return;
+    }
+    await super.copy(value, typeI18nKey, aType);
     this.messagingService.send("minimizeOnCopy");
   }
 

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -316,17 +316,6 @@ export class ViewComponent implements OnDestroy, OnInit {
   }
 
   async copy(value: string, typeI18nKey: string, aType: string) {
-    if (value == null) {
-      return;
-    }
-
-    if (
-      this.passwordRepromptService.protectedFields().includes(aType) &&
-      !(await this.promptPassword())
-    ) {
-      return;
-    }
-
     const copyOptions = this.win != null ? { window: this.win } : null;
     this.platformUtilsService.copyToClipboard(value, copyOptions);
     this.platformUtilsService.showToast(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes https://github.com/bitwarden/clients/issues/4750.

If you have the "Minimize when copying to clipboard" option selected in the settings, and you try to copy a password that needs a re-prompt of the master password, then it will wait till you enter the correct password before minimizing.

## Code changes
Moved the code for displaying and listening to the password re-prompt from the parent of ViewComponent to itself, so that if the password is not accepted, you will not reach the message that causes the window to minimize.

This might not be the best way of doing things. e.g., you could return a boolean value from the parent's copy function and then check for that in the child to see if you should minimize.

**libs/angular/src/vault/components/view.component.ts** is the BaseViewComponent i.e., the parent of ViewComponent and where I moved the code from.

**apps/desktop/src/vault/app/vault/view.component.ts** is the ViewComponent i.e., where I moved the code to.

## Screenshots

![giphy5](https://user-images.githubusercontent.com/73389504/233965813-d3a95079-d4a9-4860-ab4a-886b11af707f.gif)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
