### PR TITLE
[PM-1961] Minimize on copy now always works when using right click to copy

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -731,9 +731,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         null,
         this.i18nService.t("valueCopied", this.i18nService.t(labelI18nKey))
       );
-      if (this.action === "view") {
-        this.messagingService.send("minimizeOnCopy");
-      }
+      this.messagingService.send("minimizeOnCopy");
     });
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes https://github.com/bitwarden/clients/issues/4184. 

If you enabled the minimize on copy option, it would only work on copying with right-click if you were viewing an element. If you were not viewing an element, it would still copy, but not minimze

## Code changes

**vault.component.ts** Removed the condition "this.action == 'view'" for the "MinimizeOnCopy" message to be sent, as this means you would have to be viewing an entity to be for it to minimize on copying with right-click.


## Screenshots

![giphy (1)](https://user-images.githubusercontent.com/73389504/234268041-05228f1a-a57c-42ee-8d7c-520ef1d70b58.gif)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
