### PR TITLE
[PM-2114] Tweak error onBlur/touched/untouched behavior

### DIFF
--- a/libs/components/src/input/input.directive.ts
+++ b/libs/components/src/input/input.directive.ts
@@ -78,15 +78,9 @@ export class BitInputDirective implements BitFormFieldControl {
     return this.id;
   }
 
-  private isActive = true;
-  @HostListener("blur")
-  onBlur() {
-    this.isActive = true;
-  }
-
   @HostListener("input")
   onInput() {
-    this.isActive = false;
+    this.ngControl?.control?.markAsUntouched();
   }
 
   get hasError() {
@@ -97,7 +91,7 @@ export class BitInputDirective implements BitFormFieldControl {
         this.ngControl?.errors != null
       );
     } else {
-      return this.ngControl?.status === "INVALID" && this.ngControl?.touched && this.isActive;
+      return this.ngControl?.status === "INVALID" && this.ngControl?.touched;
     }
   }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

https://github.com/bitwarden/clients/pull/4375 introduced a behavior where errors would disappear when the user started typing on an invalid field but introduced an issue where errors would never appear if the user tried to submit the form by using `enter` while focused on the invalid field. See videos below

## Screenshots

### Issue
https://user-images.githubusercontent.com/2285588/234590217-0f39965a-a4c9-49f3-8fad-ace4d8a9e760.mov

### Proposed fix
https://user-images.githubusercontent.com/2285588/234590312-a0a4ab6b-2ba1-4042-a7cc-83af022030a1.mov

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
