### PR TITLE
[PM-1700] Put KDF warning behind a LaunchDarkly Feature Flag

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -31,6 +31,7 @@ import {
 import { SearchPipe } from "@bitwarden/angular/pipes/search.pipe";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { BroadcasterService } from "@bitwarden/common/abstractions/broadcaster.service";
+import { ConfigServiceAbstraction } from "@bitwarden/common/abstractions/config/config.service.abstraction";
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
@@ -46,6 +47,7 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { CollectionView } from "@bitwarden/common/admin-console/models/view/collection.view";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { KdfType, DEFAULT_PBKDF2_ITERATIONS, EventType } from "@bitwarden/common/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ServiceUtils } from "@bitwarden/common/misc/serviceUtils";
 import { Utils } from "@bitwarden/common/misc/utils";
 import { TreeNode } from "@bitwarden/common/models/domain/tree-node";
@@ -170,13 +172,12 @@ export class VaultComponent implements OnInit, OnDestroy {
     private totpService: TotpService,
     private eventCollectionService: EventCollectionService,
     private searchService: SearchService,
-    private searchPipe: SearchPipe
+    private searchPipe: SearchPipe,
+    private configService: ConfigServiceAbstraction
   ) {}
 
   async ngOnInit() {
     this.showBrowserOutdated = window.navigator.userAgent.indexOf("MSIE") !== -1;
-    // disable warning for March release -> add await this.isLowKdfIteration(); when ready
-    this.showLowKdf = false;
     this.trashCleanupWarning = this.i18nService.t(
       this.platformUtilsService.isSelfHost()
         ? "trashCleanupWarningSelfHosted"
@@ -187,8 +188,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       first(),
       switchMap(async (params: Params) => {
         this.showVerifyEmail = !(await this.tokenService.getEmailVerified());
-        // disable warning for March release -> add await this.isLowKdfIteration(); when ready
-        this.showLowKdf = false;
+        this.showLowKdf = await this.isLowKdfIteration();
         await this.syncService.fullSync(false);
 
         const canAccessPremium = await this.stateService.getCanAccessPremium();
@@ -856,9 +856,17 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async isLowKdfIteration() {
-    const kdfType = await this.stateService.getKdfType();
-    const kdfOptions = await this.stateService.getKdfConfig();
-    return kdfType === KdfType.PBKDF2_SHA256 && kdfOptions.iterations < DEFAULT_PBKDF2_ITERATIONS;
+    const showLowKdfEnabled = await this.configService.getFeatureFlagBool(
+      FeatureFlag.DisplayLowKdfFlag
+    );
+
+    if (showLowKdfEnabled) {
+      const kdfType = await this.stateService.getKdfType();
+      const kdfOptions = await this.stateService.getKdfConfig();
+      return kdfType === KdfType.PBKDF2_SHA256 && kdfOptions.iterations < DEFAULT_PBKDF2_ITERATIONS;
+    }
+
+    return showLowKdfEnabled;
   }
 
   protected async repromptCipher(ciphers: CipherView[]) {

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -857,7 +857,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
   async isLowKdfIteration() {
     const showLowKdfEnabled = await this.configService.getFeatureFlagBool(
-      FeatureFlag.DisplayLowKdfFlag
+      FeatureFlag.DisplayLowKdfIterationWarningFlag
     );
 
     if (showLowKdfEnabled) {

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -1,3 +1,4 @@
 export enum FeatureFlag {
   DisplayEuEnvironmentFlag = "display-eu-environment",
+  DisplayLowKdfFlag = "display-low-kdf",
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -1,4 +1,4 @@
 export enum FeatureFlag {
   DisplayEuEnvironmentFlag = "display-eu-environment",
-  DisplayLowKdfFlag = "display-low-kdf",
+  DisplayLowKdfIterationWarningFlag = "display-kdf-iteration-warning",
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Refactor the `isLowKdfIteration()` method to check if the `display-kdf-iteration-warning` feature flag is enabled before evaluating the low KDF iteration warning condition. This will allow for better control over when the low KDF iteration warning is displayed to users.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/enums/feature-flag.enum.ts:** Created a new flag `DisplayLowKdfIterationWarningFlag`
- **apps/web/src/app/vault/individual-vault/vault.component.ts** Updated the `isLowKdfIteration()` method to include a call to retrieve the feature flag value for `display-kdf-iteration-warning`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
