### PR TITLE
[SM-724] improve table header a11y; fix vertical layout shift

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.html
@@ -33,9 +33,12 @@
       </th>
       <th bitCell bitSortable="name" default>{{ "name" | i18n }}</th>
       <th bitCell bitSortable="revisionDate">{{ "lastEdited" | i18n }}</th>
-      <th bitCell class="tw-w-0">
+      <th
+        bitCell
+        class="tw-w-0"
+        [ngClass]="{ 'tw-invisible': !(hasWriteAccessOnSelected$ | async) }"
+      >
         <button
-          *ngIf="hasWriteAccessOnSelected$ | async"
           type="button"
           bitIconButton="bwi-ellipsis-v"
           buttonType="main"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes Axe a11y issue "Table header text should not be empty" by moving show/hide logic to the `th` instead of the `button`. 

Also fixes the vertical layout shift by using css `visibility` instead of `*ngIf`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.html:** Updates show/hide logic in table header

## Screenshots

Existing behavior:

https://user-images.githubusercontent.com/17113462/235195169-843840fc-afdb-4b2b-b4c2-e75ceffd78bc.mov

New behavior:


https://user-images.githubusercontent.com/17113462/235195302-565c1ce4-196b-4d99-8589-483089ac706b.mov



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
