### PR TITLE
Fix additional space and characters copied to clipboard

### DIFF
--- a/apps/browser/src/tools/popup/generator/generator.component.html
+++ b/apps/browser/src/tools/popup/generator/generator.component.html
@@ -19,7 +19,11 @@
     {{ "passwordGeneratorPolicyInEffect" | i18n }}
   </app-callout>
   <div class="generated-block" *ngIf="type === 'password'">
-    <div class="generated-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
+    <div
+      class="generated-wrapper"
+      [innerHTML]="password | colorPassword"
+      [appSelectCopy]="password"
+    ></div>
     <div class="action-buttons">
       <button
         type="button"
@@ -41,7 +45,11 @@
     </div>
   </div>
   <div class="generated-block" *ngIf="type === 'username'">
-    <div class="generated-wrapper" [innerHTML]="username | colorPassword" appSelectCopy></div>
+    <div
+      class="generated-wrapper"
+      [innerHTML]="username | colorPassword"
+      [appSelectCopy]="username"
+    ></div>
     <div class="action-buttons" #form [appApiAction]="usernameGeneratingPromise">
       <button
         type="button"

--- a/apps/browser/src/tools/popup/generator/password-generator-history.component.html
+++ b/apps/browser/src/tools/popup/generator/password-generator-history.component.html
@@ -22,7 +22,7 @@
           <div class="row-main-content">
             <div
               class="monospaced password-wrapper"
-              appSelectCopy
+              [appSelectCopy]="h.password"
               [innerHTML]="h.password | colorPassword"
             ></div>
             <span class="detail">{{ h.date | date : "medium" }}</span>

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -74,7 +74,7 @@
             <div
               *ngIf="showPassword && !showPasswordCount"
               class="monospaced password-wrapper"
-              appSelectCopy
+              [appSelectCopy]="cipher.login.password"
               [innerHTML]="cipher.login.password | colorPassword"
             ></div>
             <div

--- a/apps/desktop/src/app/tools/generator.component.html
+++ b/apps/desktop/src/app/tools/generator.component.html
@@ -12,7 +12,11 @@
           {{ "passwordGeneratorPolicyInEffect" | i18n }}
         </app-callout>
         <div class="generated-block" *ngIf="type === 'password'">
-          <div class="generated-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
+          <div
+            class="generated-wrapper"
+            [innerHTML]="password | colorPassword"
+            [appSelectCopy]="password"
+          ></div>
           <div class="action-buttons">
             <button
               type="button"
@@ -35,7 +39,11 @@
           </div>
         </div>
         <div class="generated-block" *ngIf="type === 'username'">
-          <div class="generated-wrapper" [innerHTML]="username | colorPassword" appSelectCopy></div>
+          <div
+            class="generated-wrapper"
+            [innerHTML]="username | colorPassword"
+            [appSelectCopy]="username"
+          ></div>
           <div class="action-buttons" #form [appApiAction]="usernameGeneratingPromise">
             <button
               type="button"

--- a/apps/desktop/src/app/tools/password-generator-history.component.html
+++ b/apps/desktop/src/app/tools/password-generator-history.component.html
@@ -11,7 +11,7 @@
               <div class="row-main">
                 <div
                   class="password-wrapper monospaced"
-                  appSelectCopy
+                  [appSelectCopy]="h.password"
                   [innerHTML]="h.password | colorPassword"
                 ></div>
                 <span class="detail">{{ h.date | date : "medium" }}</span>

--- a/apps/desktop/src/vault/app/vault/view.component.html
+++ b/apps/desktop/src/vault/app/vault/view.component.html
@@ -54,7 +54,7 @@
               <div
                 *ngIf="showPassword && !showPasswordCount"
                 class="monospaced password-wrapper"
-                appSelectCopy
+                [appSelectCopy]="cipher.login.password"
                 [innerHTML]="cipher.login.password | colorPassword"
               ></div>
               <div

--- a/apps/web/src/app/tools/generator.component.html
+++ b/apps/web/src/app/tools/generator.component.html
@@ -8,7 +8,7 @@
   <div class="card-body">
     <bit-color-password
       [password]="type === 'password' ? password : username"
-      appSelectCopy
+      [appSelectCopy]="type === 'password' ? password : username"
     ></bit-color-password>
   </div>
 </div>

--- a/apps/web/src/app/tools/password-generator-history.component.html
+++ b/apps/web/src/app/tools/password-generator-history.component.html
@@ -21,7 +21,7 @@
               <bit-color-password
                 [password]="h.password"
                 class="tw-block tw-font-mono"
-                appSelectCopy
+                [appSelectCopy]="h.password"
               ></bit-color-password>
               <small class="text-muted">{{ h.date | date : "medium" }}</small>
             </div>

--- a/libs/angular/src/directives/select-copy.directive.ts
+++ b/libs/angular/src/directives/select-copy.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener } from "@angular/core";
+import { Directive, ElementRef, HostListener, Input } from "@angular/core";
 
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
 
@@ -8,30 +8,13 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
 export class SelectCopyDirective {
   constructor(private el: ElementRef, private platformUtilsService: PlatformUtilsService) {}
 
+  @Input("appSelectCopy") copyText: string;
+
   @HostListener("copy") onCopy() {
     if (window == null) {
       return;
     }
-    let copyText = "";
-    const selection = window.getSelection();
-    for (let i = 0; i < selection.rangeCount; i++) {
-      const range = selection.getRangeAt(i);
-      const text = range.toString();
 
-      // The selection should only contain one line of text. In some cases however, the
-      // selection contains newlines and space characters from the indentation of following
-      // sibling nodes. To avoid copying passwords containing trailing newlines and spaces
-      // that aren't part of the password, the selection has to be trimmed.
-      let stringEndPos = text.length;
-      const newLinePos = text.search(/(?:\r\n|\r|\n)/);
-      if (newLinePos > -1) {
-        const otherPart = text.substr(newLinePos).trim();
-        if (otherPart === "") {
-          stringEndPos = newLinePos;
-        }
-      }
-      copyText += text.substring(0, stringEndPos);
-    }
-    this.platformUtilsService.copyToClipboard(copyText, { window: window });
+    this.platformUtilsService.copyToClipboard(this.copyText, { window: window });
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the issue where using the mouse to select and copy certain fields will result in additional space/characters included.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/tools/popup/generator/generator.component.html:**
- **apps/browser/src/tools/popup/generator/password-generator-history.component.html:**
- **apps/browser/src/vault/popup/components/vault/view.component.html:**
- **apps/desktop/src/app/tools/generator.component.html:**
- **apps/desktop/src/app/tools/password-generator-history.component.html:**
- **apps/desktop/src/vault/app/vault/view.component.html:**
- **apps/web/src/app/tools/generator.component.html:**
- **apps/web/src/app/tools/password-generator-history.component.html:**
  - Pass template variable to `appSelectCopy` directive to copy to clipboard
- **libs/angular/src/directives/select-copy.directive.ts:**
  - Update directive to accept an input of what to copy to clipboard
  - Removed old code

