### PR TITLE
[PM-287] Add aria-label to account button

### DIFF
--- a/apps/web/src/app/layouts/navbar.component.html
+++ b/apps/web/src/app/layouts/navbar.component.html
@@ -46,6 +46,7 @@
         <button
           [bitMenuTriggerFor]="accountMenu"
           class="tw-border-0 tw-bg-transparent tw-text-alt2 tw-opacity-70 hover:tw-opacity-90"
+          attr.aria-label="{{ 'accountLoggedInAsName' | i18n : name }}"
         >
           <dynamic-avatar
             [text]="name"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5429,6 +5429,15 @@
     "message": "Current organization",
     "description": "This is used by screen readers to indicate the organization that is currently being shown to the user."
   },
+  "accountLoggedInAsName": {
+    "message": "Account: Logged in as $NAME$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "accountSettings": {
     "message": "Account settings"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add aria-label to the account dropdown button so that voiceover tools read out the text:
"Account: Logged in as [account name]"

## Code changes

Added aria-label to button and corresponding i18n translation catalog entry

## Screencaps

https://user-images.githubusercontent.com/1556494/235766036-e6b80a36-c5f4-4647-ad4f-79a8f33a8434.mp4

https://user-images.githubusercontent.com/1556494/235766075-bee6657f-370a-450b-b7e3-fef835d1d225.mp4

