### PR TITLE
[PM-1884] Address vault ui long name overflow and vertical letter cutoff

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -19,7 +19,7 @@
   <div class="tw-inline-flex tw-w-full">
     <button
       bitLink
-      class="tw-overflow-hidden tw-text-ellipsis tw-text-start"
+      class="tw-overflow-hidden tw-text-ellipsis tw-text-start tw-leading-snug"
       [disabled]="disabled"
       [routerLink]="[]"
       [queryParams]="{ itemId: cipher.id }"

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -31,7 +31,7 @@
     </button>
     <ng-container *ngIf="cipher.hasAttachments">
       <i
-        class="bwi bwi-paperclip tw-ml-2"
+        class="bwi bwi-paperclip tw-ml-2 tw-leading-normal"
         appStopProp
         title="{{ 'attachments' | i18n }}"
         aria-hidden="true"
@@ -39,7 +39,7 @@
       <span class="sr-only">{{ "attachments" | i18n }}</span>
       <ng-container *ngIf="showFixOldAttachments">
         <i
-          class="bwi bwi-exclamation-triangle tw-ml-2 tw-text-warning"
+          class="bwi bwi-exclamation-triangle tw-ml-2 tw-leading-normal tw-text-warning"
           appStopProp
           title="{{ 'attachmentsNeedFix' | i18n }}"
           aria-hidden="true"

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -19,7 +19,7 @@
     bitLink
     [disabled]="disabled"
     type="button"
-    class="tw-w-full tw-overflow-hidden tw-text-ellipsis tw-text-start"
+    class="tw-w-full tw-truncate tw-text-start tw-leading-snug"
     linkType="secondary"
     [routerLink]="[]"
     [queryParams]="{ collectionId: collection.id }"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Resolve UI issues in the vault:
- insufficient line-height causes vertical character cutoff of collection names in the vault tab view 
- long names in the vault views cause text to wrap and not truncate properly

## Code changes

see: https://github.com/bitwarden/clients/pull/5345#discussion_r1183840081


## Screenshots

| Before | After |
| --- | --- |
| ![all-before](https://user-images.githubusercontent.com/1556494/235962007-dde92504-840f-453a-9a70-658b5aa47d9c.png) | ![all-after](https://user-images.githubusercontent.com/1556494/235962006-d5269883-3b4d-46a8-b9ac-45df753ee9b4.png) |
| ![vault-before](https://user-images.githubusercontent.com/1556494/235962012-07f6fa89-b520-424e-84fb-9000751f6a45.png) | ![vault-after](https://user-images.githubusercontent.com/1556494/235962009-f3c47e4d-e8cd-42bc-8148-d8bc1d387ba6.png) |
