### PR TITLE
[PM-2089] Fix Collections not nesting properly in the Org Vault

### DIFF
--- a/apps/web/src/app/vault/utils/collection-utils.spec.ts
+++ b/apps/web/src/app/vault/utils/collection-utils.spec.ts
@@ -1,0 +1,28 @@
+import { CollectionView } from "@bitwarden/common/admin-console/models/view/collection.view";
+
+import { getNestedCollectionTree } from "./collection-utils";
+
+describe("CollectionUtils Service", () => {
+  describe("getNestedCollectionTree", () => {
+    it("should return collections properly sorted if provided out of order", () => {
+      // Arrange
+      const collections: CollectionView[] = [];
+
+      const parentCollection = new CollectionView();
+      parentCollection.name = "Parent";
+
+      const childCollection = new CollectionView();
+      childCollection.name = "Parent/Child";
+
+      collections.push(childCollection);
+      collections.push(parentCollection);
+
+      // Act
+      const result = getNestedCollectionTree(collections);
+
+      // Assert
+      expect(result[0].node.name).toBe("Parent");
+      expect(result[0].children[0].node.name).toBe("Child");
+    });
+  });
+});

--- a/apps/web/src/app/vault/utils/collection-utils.ts
+++ b/apps/web/src/app/vault/utils/collection-utils.ts
@@ -17,7 +17,9 @@ export function getNestedCollectionTree(
   // Collections need to be cloned because ServiceUtils.nestedTraverse actively
   // modifies the names of collections.
   // These changes risk affecting collections store in StateService.
-  const clonedCollections = collections.map(cloneCollection);
+  const clonedCollections = collections
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(cloneCollection);
 
   const nodes: TreeNode<CollectionView | CollectionAdminView>[] = [];
   clonedCollections.forEach((collection) => {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

It was discovered that in some cases, Organizations are not displaying correctly in the Org Vault. After some research, I determined the CollectionAdminService is not returning collections sorted in the same sort order that CollectionService is. CollectionService is used by the Individual Vault and that is why they behave differently.

## Code changes
- **apps/web/src/app/vault/utils/collection-utils.ts:** Sort collections by name here so we can properly create the TreeNodes.
- **apps/web/src/app/vault/utils/collection-utils.spec.ts:** Add a unit test for this case 😎 

## Screenshots

Before:
![Screenshot 2023-05-04 at 12 39 41 PM](https://user-images.githubusercontent.com/8926729/236269545-c84f8dad-dd83-4a41-80c8-2f2cf7ba775d.png)

After:
![Screenshot 2023-05-04 at 12 39 25 PM](https://user-images.githubusercontent.com/8926729/236269590-c8f3a034-af2b-410f-91e7-aaf860246ab0.png)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
