### PR TITLE
Removed PR edit trigger from workflow that adds needs-qa label

### DIFF
--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -5,7 +5,7 @@ name: Label Issue Pull Request
 
 on:
   pull_request:
-    types: [opened, edited] # Check when PR is opened or target branch is edited
+    types: [opened] # Check when PR is opened
     paths-ignore:
       - .github/workflows/** # We don't need QA on workflow changes
     branches:

--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -5,7 +5,8 @@ name: Label Issue Pull Request
 
 on:
   pull_request:
-    types: [opened] # Check when PR is opened
+    types:
+      - opened # Check when PR is opened
     paths-ignore:
       - .github/workflows/** # We don't need QA on workflow changes
     branches:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The workflow to add `needs-qa` was triggered on a PR `open` or `edited` trigger.  The intent there was to capture when the target branch changed, so you couldn't open a PR targeting a non-`master` branch then re-target to `master` and avoid having the label applied.

However, this caused problems when the PR description was changed, as it would re-add the `needs-qa` label.

## Code changes

- **label-issue-pull-request.yml:** Removed `edited` from trigger array

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
