### PR TITLE
Removed self-hosted restriction from Login with Device

### DIFF
--- a/apps/desktop/src/auth/login/login.component.ts
+++ b/apps/desktop/src/auth/login/login.component.ts
@@ -93,7 +93,7 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
 
   async ngOnInit() {
     await super.ngOnInit();
-    await this.checkSelfHosted();
+    await this.getLoginWithDevice(this.loggedEmail);
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
       this.ngZone.run(() => {
         switch (message.command) {
@@ -140,7 +140,7 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
     childComponent.onSaved.subscribe(async () => {
       modal.close();
-      await this.checkSelfHosted();
+      await this.getLoginWithDevice(this.loggedEmail);
     });
   }
 
@@ -176,11 +176,5 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
   private focusInput() {
     const email = this.loggedEmail;
     document.getElementById(email == null || email === "" ? "email" : "masterPassword").focus();
-  }
-
-  private async checkSelfHosted() {
-    this.selfHosted = this.environmentService.isSelfHosted();
-
-    await this.getLoginWithDevice(this.loggedEmail);
   }
 }

--- a/libs/angular/src/auth/components/login.component.ts
+++ b/libs/angular/src/auth/components/login.component.ts
@@ -35,7 +35,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   onSuccessfulLoginNavigate: () => Promise<any>;
   onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
   onSuccessfulLoginForceResetNavigate: () => Promise<any>;
-  selfHosted = false;
   showLoginWithDevice: boolean;
   validatedEmail = false;
   paramEmailSet = false;
@@ -73,7 +72,6 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     protected loginService: LoginService
   ) {
     super(environmentService, i18nService, platformUtilsService);
-    this.selfHosted = platformUtilsService.isSelfHost();
   }
 
   get selfHostedDomain() {
@@ -295,9 +293,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   async getLoginWithDevice(email: string) {
     try {
       const deviceIdentifier = await this.appIdService.getAppId();
-      const res = await this.apiService.getKnownDevice(email, deviceIdentifier);
-      //ensure the application is not self-hosted
-      this.showLoginWithDevice = res && !this.selfHosted;
+      this.showLoginWithDevice = await this.apiService.getKnownDevice(email, deviceIdentifier);
     } catch (e) {
       this.showLoginWithDevice = false;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We currently do not allow self-hosted customers to use Login with Device.  This is due to our notifications not working on self-hosted.  We have addressed this with https://github.com/bitwarden/server/pull/2934.  This change is to remove the client-side checks that prevented the button from displaying.

## Code changes

- **/desktop/src/auth/login/login.component.ts** Replaced `checkSelfHosted()` checks with an explicit `getLoginWithDevice()` call, as that is the only remaining functionality in the `checkSelfHosted()` method
- **/libs/angular/src/auth/components/login.component.ts** Removed check for self-hosted from `getLoginWithDevice()`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
