### PR TITLE
[PM-2197] Fix memory leaks in Safari

### DIFF
--- a/apps/browser/src/browser/browserApi.ts
+++ b/apps/browser/src/browser/browserApi.ts
@@ -182,7 +182,9 @@ export class BrowserApi {
     if (BrowserApi.isSafariApi && !BrowserApi.isBackgroundPage(window)) {
       BrowserApi.registeredMessageListeners.push(callback);
 
-      window.onunload = () => {
+      // The MDN recommend using 'visibilitychange' but that event is fired any time the popup window is obscured as well
+      // 'pagehide' works just like 'unload' but is compatible with the back/forward cache, so we prefer using that one
+      window.onpagehide = () => {
         for (const callback of BrowserApi.registeredMessageListeners) {
           chrome.runtime.onMessage.removeListener(callback);
         }

--- a/libs/angular/src/services/theming/theming.service.ts
+++ b/libs/angular/src/services/theming/theming.service.ts
@@ -63,7 +63,7 @@ export class ThemingService implements AbstractThemingService {
 
   protected monitorSystemThemeChanges(): void {
     fromEvent<MediaQueryListEvent>(
-      this.window.matchMedia("(prefers-color-scheme: dark)"),
+      window.matchMedia("(prefers-color-scheme: dark)"),
       "change"
     ).subscribe((event) => {
       this.updateSystemTheme(event.matches ? ThemeType.Dark : ThemeType.Light);


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix the memory leaks that appear only in Safari.

## Code changes
- **browserApi.ts:** Deregister all messageListeners on a popup unload event in Safari
- **theming.service.ts:** Remove a reference cycle between window and ThemingService caused by subscribing to the matchMedia event. Note that in Safari we are using the background page window here and it doesn't handle dynamic theme changes, so we could just as well disable the `monitorSystemThemeChanges` in Safari.
https://github.com/bitwarden/clients/blob/89ae1017e3dfec0e10f2fd189970d7321611298d/apps/browser/src/popup/services/services.module.ts#L481-L482

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
