### PR TITLE
Remove tapable as dependency as we don't use it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,7 +165,6 @@
         "storybook-addon-designs": "6.3.1",
         "style-loader": "3.3.2",
         "tailwindcss": "3.3.2",
-        "tapable": "1.1.3",
         "ts-jest": "28.0.8",
         "ts-loader": "9.4.2",
         "tsconfig-paths-webpack-plugin": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "storybook-addon-designs": "6.3.1",
     "style-loader": "3.3.2",
     "tailwindcss": "3.3.2",
-    "tapable": "1.1.3",
     "ts-jest": "28.0.8",
     "ts-loader": "9.4.2",
     "tsconfig-paths-webpack-plugin": "3.5.2",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Remove [tapable](https://github.com/webpack/tapable) as dependency as we don't use it

tapable is a package which is used by other packages we depend on, but we don't actually use it anywhere.

## Code changes

- **package.json and package-lock.json:** Changes after running `npm uninstall tapable`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
