### PR TITLE
[PM-2368] Add fullSync on successful import

### DIFF
--- a/apps/cli/src/tools/import.command.ts
+++ b/apps/cli/src/tools/import.command.ts
@@ -2,6 +2,7 @@ import * as program from "commander";
 import * as inquirer from "inquirer";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { ImportServiceAbstraction, ImportType } from "@bitwarden/importer";
 
 import { Response } from "../models/response";
@@ -11,7 +12,8 @@ import { CliUtils } from "../utils";
 export class ImportCommand {
   constructor(
     private importService: ImportServiceAbstraction,
-    private organizationService: OrganizationService
+    private organizationService: OrganizationService,
+    private syncService: SyncService
   ) {}
 
   async run(
@@ -76,6 +78,7 @@ export class ImportCommand {
 
       const response = await this.importService.import(importer, contents, organizationId);
       if (response.success) {
+        this.syncService.fullSync(true);
         return Response.success(new MessageResponse("Imported " + filepath, null));
       }
     } catch (err) {

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -442,7 +442,11 @@ export class VaultProgram extends Program {
       })
       .action(async (format, filepath, options) => {
         await this.exitIfLocked();
-        const command = new ImportCommand(this.main.importService, this.main.organizationService);
+        const command = new ImportCommand(
+          this.main.importService,
+          this.main.organizationService,
+          this.main.syncService
+        );
         const response = await command.run(format, filepath, options);
         this.processResponse(response);
       });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Analog to https://github.com/bitwarden/clients/pull/4380 we also need to add a full sync to the `import.command`, so that when a user calls `bw list items` those are populated.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/cli/src/vault.program.ts:** Pass in the syncService into the importCommand
- **apps/cli/src/tools/import.command.ts:** Require syncService and call fullSync after a successful import.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
