### PR TITLE
Updated config to turn on vault-item encryption for QA testing.

### DIFF
--- a/apps/browser/config/base.json
+++ b/apps/browser/config/base.json
@@ -1,6 +1,7 @@
 {
   "dev_flags": {},
   "flags": {
-    "showPasswordless": true
+    "showPasswordless": true,
+    "enableCipherKeyEncryption": false
   }
 }

--- a/apps/browser/config/production.json
+++ b/apps/browser/config/production.json
@@ -1,3 +1,5 @@
 {
-  "flags": {}
+  "flags": {
+    "enableCipherKeyEncryption": true
+  }
 }

--- a/apps/cli/config/production.json
+++ b/apps/cli/config/production.json
@@ -1,3 +1,5 @@
 {
-  "flags": {}
+  "flags": {
+    "enableCipherKeyEncryption": true
+  }
 }

--- a/apps/desktop/config/production.json
+++ b/apps/desktop/config/production.json
@@ -1,5 +1,6 @@
 {
   "flags": {
-    "showDDGSetting": true
+    "showDDGSetting": true,
+    "enableCipherKeyEncryption": true
   }
 }

--- a/apps/web/config/selfhosted.json
+++ b/apps/web/config/selfhosted.json
@@ -9,6 +9,6 @@
   "flags": {
     "secretsManager": false,
     "showPasswordless": false,
-    "enableCipherKeyEncryption": false
+    "enableCipherKeyEncryption": true
   }
 }

--- a/apps/web/config/selfhosted.json
+++ b/apps/web/config/selfhosted.json
@@ -8,6 +8,7 @@
   },
   "flags": {
     "secretsManager": false,
-    "showPasswordless": false
+    "showPasswordless": false,
+    "enableCipherKeyEncryption": false
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Enable client-side flags for QA to test vault item encryption.  This PR turns on the new encryption in the following environments:
- Desktop
- Browser
- CLI
- Web Vault
  - Self-hosted environment

## Code changes

- **base.json:** Added base default of `false` for Browser config.
- **production.json:** For CLI, Desktop, and Browser, set `enableCipherKeyEncryption` to `true`
- **selfhosted.json:** For web vault, set `enableCipherKeyEncryption` to `true` for self-hosted, so QA can test on their self-hosted instances

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
