### PR TITLE
Match with Renovate package names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,17 +29,17 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      "packageNames": ["typescript"],
+      "matchPackageNames": ["typescript"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {
-      "packageNames": ["typescript"],
+      "matchPackageNames": ["typescript"],
       "matchUpdateTypes": "patch"
     },
     {
       "groupName": "jest",
-      "packageNames": ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
+      "matchPackageNames": ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
       "matchUpdateTypes": "major"
     }
   ],


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Moves Renovate to use `matchPackageNames`. Per documentation this seems to be the expected parameter.

## Code changes

- **.github/renovate.json:** Configuration adjustment.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
