### PR TITLE
[PM-119] Re-encrypt the Cipher Key on all Ciphers when a user rotates their symmetric key

### DIFF
--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -150,6 +150,7 @@ export class CipherView implements View, InitializerMetadata {
     const attachments = obj.attachments?.map((a: any) => AttachmentView.fromJSON(a));
     const fields = obj.fields?.map((f: any) => FieldView.fromJSON(f));
     const passwordHistory = obj.passwordHistory?.map((ph: any) => PasswordHistoryView.fromJSON(ph));
+    const key = obj.key == null ? null : SymmetricCryptoKey.fromJSON(obj.key);
 
     Object.assign(view, obj, {
       revisionDate: revisionDate,
@@ -157,6 +158,7 @@ export class CipherView implements View, InitializerMetadata {
       attachments: attachments,
       fields: fields,
       passwordHistory: passwordHistory,
+      key: key,
     });
 
     switch (obj.type) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When a user [rotates their encryption key](https://bitwarden.com/help/account-encryption-key/#how-to-rotate-your-encryption-key), their cipher keys should be re-encrypted with the user’s new symmetric key.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
No major change was needed. All I had to do was to copy the key retrieved from the server back to the `CipherView` and ensure the newly encrypted `cipher key` is updated on the server.   

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
