### PR TITLE
Defect/PM-2403 - Attempt 2 at fixing Safari - SSO + 2FA login flow not properly closing the tab 

### DIFF
--- a/apps/browser/src/auth/popup/two-factor-options.component.html
+++ b/apps/browser/src/auth/popup/two-factor-options.component.html
@@ -1,6 +1,6 @@
 <header>
   <div class="left">
-    <button type="button" routerLink="/2fa">{{ "close" | i18n }}</button>
+    <button type="button" (click)="close()">{{ "close" | i18n }}</button>
   </div>
   <h1 class="center">
     <span class="title">{{ "twoStepOptions" | i18n }}</span>

--- a/apps/browser/src/auth/popup/two-factor-options.component.ts
+++ b/apps/browser/src/auth/popup/two-factor-options.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 
 import { TwoFactorOptionsComponent as BaseTwoFactorOptionsComponent } from "@bitwarden/angular/auth/components/two-factor-options.component";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
@@ -15,14 +15,33 @@ export class TwoFactorOptionsComponent extends BaseTwoFactorOptionsComponent {
     twoFactorService: TwoFactorService,
     router: Router,
     i18nService: I18nService,
-    platformUtilsService: PlatformUtilsService
+    platformUtilsService: PlatformUtilsService,
+    private activatedRoute: ActivatedRoute
   ) {
     super(twoFactorService, router, i18nService, platformUtilsService, window);
+  }
+
+  close() {
+    this.navigateTo2FA();
   }
 
   choose(p: any) {
     super.choose(p);
     this.twoFactorService.setSelectedProvider(p.type);
-    this.router.navigate(["2fa"]);
+
+    this.navigateTo2FA();
+  }
+
+  navigateTo2FA() {
+    const sso = this.activatedRoute.snapshot.queryParamMap.get("sso") === "true";
+
+    if (sso) {
+      // Persist SSO flag back to the 2FA comp if it exists
+      // in order for successful login logic to work properly for
+      // SSO + 2FA in browser extension
+      this.router.navigate(["2fa"], { queryParams: { sso: true } });
+    } else {
+      this.router.navigate(["2fa"]);
+    }
   }
 }

--- a/apps/browser/src/auth/popup/two-factor.component.ts
+++ b/apps/browser/src/auth/popup/two-factor.component.ts
@@ -147,7 +147,15 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
   }
 
   anotherMethod() {
-    this.router.navigate(["2fa-options"]);
+    const sso = this.route.snapshot.queryParamMap.get("sso") === "true";
+
+    if (sso) {
+      // We must persist this so when the user returns to the 2FA comp, the
+      // proper onSuccessfulLogin logic is executed.
+      this.router.navigate(["2fa-options"], { queryParams: { sso: true } });
+    } else {
+      this.router.navigate(["2fa-options"]);
+    }
   }
 
   async isLinux() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[Jira: PM-2403](https://bitwarden.atlassian.net/browse/PM-2403)

Persist SSO flag between 2FA component and 2FA Options component and back so that the correct onSuccessful login logic can run which closes the tab extension and sidesteps Safari master password invalid issues due to null KDF config / iterations again. Tested on Chrome, Firefox + sidebar, Edge, Opera + sidebar, and Safari

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/two-factor-options.component.html, apps/browser/src/auth/popup/two-factor-options.component.ts, apps/browser/src/auth/popup/two-factor.component.ts:** Persist sso query param flag between all 2FA routes. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
