### PR TITLE
PM-2010: Update Request Headers for AnonAddy API request.

### DIFF
--- a/libs/common/src/tools/generator/username/email-forwarders/anon-addy-forwarder.ts
+++ b/libs/common/src/tools/generator/username/email-forwarders/anon-addy-forwarder.ts
@@ -18,6 +18,7 @@ export class AnonAddyForwarder implements Forwarder {
       headers: new Headers({
         Authorization: "Bearer " + options.apiKey,
         "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
       }),
     };
     const url = "https://app.anonaddy.com/api/v1/aliases";


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Currently an incorrect or malformed API request to AnonAddy sends back a `HTTP 302` response instead of the proper error code making troubleshooting AnonAddy integration difficult. When our clients currently receive this response, it throws an "Unknown AnonAddy error". 

### Example response when API key was incorrectly entered and `X-Requested-With` header is missing

```http
HTTP/2 302 Found
server: nginx
content-type: text/html; charset=UTF-8
location: https://app.anonaddy.com/login
cache-control: no-cache, private
date: Mon, 05 Jun 2023 14:47:45 GMT
access-control-allow-origin: *
access-control-expose-headers: Cache-Control, Content-Language, Content-Type, Expires, Last-Modified, Pragma
x-frame-options: SAMEORIGIN
x-xss-protection: 0
x-content-type-options: nosniff
strict-transport-security: max-age=63072000; includeSubDomains; preload
content-security-policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com/; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://js.stripe.com/; object-src 'none'
referrer-policy: origin-when-cross-origin
X-Firefox-Spdy: h2
```

By sending the correct request headers as demonstrated in the examples in AnonAddy's own documentation [here](https://app.anonaddy.com/docs/#aliases-POSTapi-v1-aliases) and the user has an error in their API key or other error occurs, their servers will properly respond to it and our clients will in turn provide an accurate error response to the user.

### Example POST request for creating aliases with AnonAddy API:

```javascript
const headers = {
    "Content-Type": "application/json",
    "X-Requested-With": "XMLHttpRequest",
    "Authorization": "Bearer {token}",
    "Accept": "application/json",
};
```

### Note

If the API request has the correct `"Authorization": "Bearer {token}"` header set and there are no other errors with the request, the API request works as expected. This fix only accounts for the fact that our integration  is not properly reporting the error taking place.


## Code changes

- **libs/common/src/tools/generator/username/email-forwarders/anon-addy-forwarder.ts**: 
  - Added the request header, `X-Requested-With` with a value of `XMLHttpRequest`.