### PR TITLE
[PM-2522] Simplelogin: Fix display of api-error messages

### DIFF
--- a/libs/common/src/tools/generator/username/email-forwarders/simple-login-forwarder.ts
+++ b/libs/common/src/tools/generator/username/email-forwarders/simple-login-forwarder.ts
@@ -35,13 +35,9 @@ export class SimpleLoginForwarder implements Forwarder {
     if (response.status === 401) {
       throw "Invalid SimpleLogin API key.";
     }
-    try {
-      const json = await response.json();
-      if (json?.error != null) {
-        throw "SimpleLogin error:" + json.error;
-      }
-    } catch {
-      // Do nothing...
+    const json = await response.json();
+    if (json?.error != null) {
+      throw "SimpleLogin error:" + json.error;
     }
     throw "Unknown SimpleLogin error occurred.";
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
While working on https://github.com/bitwarden/clients/pull/4809 I had some issues seeing proper api error messages as the details weren’t showing up in the error toasts. It turned out that the returning errors were thrown inside a try-catch. Those would then be caught by the catch and then a generic error message would be thrown.

This pattern was also discovered in the SimpleLogin username generator.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/tools/generator/username/email-forwarders/simple-login-forwarder.ts** `Remove try-catch to display proper api-errors

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
