### PR TITLE
[PM-1689] Add restriction to only encrypt fails on browser

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -51,6 +51,7 @@ import { AvatarUpdateService } from "@bitwarden/common/services/account/avatar-u
 import { ApiService } from "@bitwarden/common/services/api.service";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
 import { AuditService } from "@bitwarden/common/services/audit.service";
+import { ConfigApiService } from "@bitwarden/common/services/config/config-api.service";
 import { ConfigService } from "@bitwarden/common/services/config/config.service";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
 import { ContainerService } from "@bitwarden/common/services/container.service";
@@ -311,6 +312,8 @@ export default class MainBackground {
       this.fileUploadService
     );
     this.searchService = new SearchService(this.logService, this.i18nService);
+
+    this.configApiService = new ConfigApiService(this.apiService);
 
     this.cipherService = new CipherService(
       this.cryptoService,

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -58,6 +58,7 @@ import { AuthService } from "@bitwarden/common/auth/services/auth.service";
 import { LoginService } from "@bitwarden/common/auth/services/login.service";
 import { StateFactory } from "@bitwarden/common/factories/stateFactory";
 import { GlobalState } from "@bitwarden/common/models/domain/global-state";
+import { ConfigApiService } from "@bitwarden/common/services/config/config-api.service";
 import { ConsoleLogService } from "@bitwarden/common/services/consoleLog.service";
 import { ContainerService } from "@bitwarden/common/services/container.service";
 import { SearchService } from "@bitwarden/common/services/search.service";
@@ -490,6 +491,11 @@ function getBgService<T>(service: keyof MainBackground) {
       provide: ConfigServiceAbstraction,
       useClass: BrowserConfigService,
       deps: [StateServiceAbstraction, ConfigApiServiceAbstraction],
+    },
+    {
+      provide: ConfigApiServiceAbstraction,
+      useClass: ConfigApiService,
+      deps: [ApiService],
     },
     {
       provide: DialogServiceAbstraction,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The [PR](https://github.com/bitwarden/clients/pull/5538) for adding validations to ensure new encryption isn't called when the server doesn't support it works on all clients except the browser.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
The initial failure was due to the `CipherService` attempting to access the configApiService before it had been instantiated. To resolve this issue, I ensured the `ConfigApiService` was initialized within the `main.background.ts` file on the browser client side.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
