### PR TITLE
[PM-2565] Add restriction to only encrypt fails on CLI

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -27,6 +27,7 @@ import { GlobalState } from "@bitwarden/common/models/domain/global-state";
 import { AppIdService } from "@bitwarden/common/services/appId.service";
 import { AuditService } from "@bitwarden/common/services/audit.service";
 import { BroadcasterService } from "@bitwarden/common/services/broadcaster.service";
+import { ConfigApiService } from "@bitwarden/common/services/config/config-api.service";
 import { ContainerService } from "@bitwarden/common/services/container.service";
 import { CryptoService } from "@bitwarden/common/services/crypto.service";
 import { EncryptServiceImplementation } from "@bitwarden/common/services/cryptography/encrypt.service.implementation";
@@ -248,6 +249,8 @@ export class Main {
     );
 
     this.searchService = new SearchService(this.logService, this.i18nService);
+
+    this.configApiService = new ConfigApiService(this.apiService);
 
     this.cipherService = new CipherService(
       this.cryptoService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The [PR](https://github.com/bitwarden/clients/pull/5538) for adding validations to ensure new encryption isn't called when the server doesn't support it fails on the CLI.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

The initial failure was due to the CipherService attempting to access the configApiService before it had been instantiated.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
