### PR TITLE
Notify subscribers when URLs are set from storage

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -139,6 +139,8 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     this.eventsUrl = envUrls.events = urls.events;
     this.keyConnectorUrl = urls.keyConnector;
     // scimUrl is not saved to storage
+
+    this.urlsSubject.next(envUrls);
   }
 
   async setUrls(urls: Urls): Promise<Urls> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `ConfigService` needs to reload configuration when the environment URLs change.  It does this by subscribing to the `urls` Observable.  

Currently, that observable only notifies subscribers when the `setUrls()` method is called on `EnvironmentService`.  It does not do so when the `setUrlsFromStorage()` method is called.  This leaves subscribers unaware that the URLs have changed.

## Code changes

- **environment.service.ts:** Notified `urls` subscribers when the URLs are set from storage.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
