### PR TITLE
Fix feature flags not working properly

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -139,6 +139,8 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     this.eventsUrl = envUrls.events = urls.events;
     this.keyConnectorUrl = urls.keyConnector;
     // scimUrl is not saved to storage
+
+    this.urlsSubject.next(urls);
   }
 
   async setUrls(urls: Urls): Promise<Urls> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Due to race conditions the api url is not set during the first fetch och server config. This causes the config to be fetched from `api.bitwarden.com`. The config is then supposed to be re-fetched when the api url is set by the environment service, but due to a missing line this is not done when the urls are set from storage. This causes the browser extension to incorrectly load feature flags from production.

## Code changes

- `environment.service.ts` Emit url changes when loading urls from storage

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
