### PR TITLE
Remove password options from `serve` unlock

### DIFF
--- a/apps/cli/src/commands/serve.command.ts
+++ b/apps/cli/src/commands/serve.command.ts
@@ -245,6 +245,10 @@ export class ServeCommand {
     });
 
     router.post("/unlock", async (ctx, next) => {
+      // Do not allow guessing password location through serve command
+      delete ctx.request.query.passwordFile;
+      delete ctx.request.query.passwordEnv;
+
       const response = await this.unlockCommand.run(
         ctx.request.body.password == null ? null : (ctx.request.body.password as string),
         ctx.request.query


### PR DESCRIPTION
These options are no longer considered safe as the file location or environment variable could be guessed by an attacker.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove `passwordFile` and `passwordEnv` from `bw serve` query options going to the `unlock` endpoint.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
