### PR TITLE
[PM-1345] Bugfix - Items with "Re-prompt Masterpassword" fail silently

### DIFF
--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
@@ -96,7 +96,7 @@ describe("CipherContextMenuHandler", () => {
 
       expect(cipherService.getAllDecryptedForUrl).toHaveBeenCalledWith("https://test.com");
 
-      expect(mainContextMenuHandler.loadOptions).toHaveBeenCalledTimes(1);
+      expect(mainContextMenuHandler.loadOptions).toHaveBeenCalledTimes(2);
 
       expect(mainContextMenuHandler.loadOptions).toHaveBeenCalledWith(
         "Test Cipher (Test Username)",

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -4,7 +4,6 @@ import { StateFactory } from "@bitwarden/common/platform/factories/state-factory
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
@@ -171,11 +170,7 @@ export class CipherContextMenuHandler {
   }
 
   private async updateForCipher(url: string, cipher: CipherView) {
-    if (
-      cipher == null ||
-      cipher.type !== CipherType.Login ||
-      cipher.reprompt !== CipherRepromptType.None
-    ) {
+    if (cipher == null || cipher.type !== CipherType.Login) {
       return;
     }
 

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -203,17 +203,45 @@ export class ContextMenuClickedHandler {
         if (tab == null) {
           return;
         }
-        await this.autofillAction(tab, cipher);
+
+        if (cipher.reprompt !== CipherRepromptType.None) {
+          await BrowserApi.tabSendMessageData(tab, "passwordReprompt", {
+            cipherId: cipher.id,
+            action: AUTOFILL_ID,
+          });
+        } else {
+          await this.autofillAction(tab, cipher);
+        }
+
         break;
       case COPY_USERNAME_ID:
         this.copyToClipboard({ text: cipher.login.username, tab: tab });
         break;
       case COPY_PASSWORD_ID:
-        this.copyToClipboard({ text: cipher.login.password, tab: tab });
-        this.eventCollectionService.collect(EventType.Cipher_ClientCopiedPassword, cipher.id);
+        if (cipher.reprompt !== CipherRepromptType.None) {
+          await BrowserApi.tabSendMessageData(tab, "passwordReprompt", {
+            cipherId: cipher.id,
+            action: COPY_PASSWORD_ID,
+          });
+        } else {
+          this.copyToClipboard({ text: cipher.login.password, tab: tab });
+          this.eventCollectionService.collect(EventType.Cipher_ClientCopiedPassword, cipher.id);
+        }
+
         break;
       case COPY_VERIFICATIONCODE_ID:
-        this.copyToClipboard({ text: await this.totpService.getCode(cipher.login.totp), tab: tab });
+        if (cipher.reprompt !== CipherRepromptType.None) {
+          await BrowserApi.tabSendMessageData(tab, "passwordReprompt", {
+            cipherId: cipher.id,
+            action: COPY_VERIFICATIONCODE_ID,
+          });
+        } else {
+          this.copyToClipboard({
+            text: await this.totpService.getCode(cipher.login.totp),
+            tab: tab,
+          });
+        }
+
         break;
     }
   }

--- a/apps/browser/src/autofill/content/message_handler.ts
+++ b/apps/browser/src/autofill/content/message_handler.ts
@@ -28,6 +28,7 @@ window.addEventListener(
 
 const forwardCommands = [
   "promptForLogin",
+  "passwordReprompt",
   "addToLockedVaultPendingNotifications",
   "unlockCompleted",
   "addedCipher",

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -239,7 +239,11 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     if (cipher.reprompt !== CipherRepromptType.None) {
-      await BrowserApi.tabSendMessageData(tab, "passwordReprompt", { cipherId: cipher.id });
+      await BrowserApi.tabSendMessageData(tab, "passwordReprompt", {
+        cipherId: cipher.id,
+        action: "autofill",
+      });
+
       return null;
     }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -234,7 +234,12 @@ export default class AutofillService implements AutofillServiceInterface {
       }
     }
 
-    if (cipher == null || cipher.reprompt !== CipherRepromptType.None) {
+    if (cipher == null) {
+      return null;
+    }
+
+    if (cipher.reprompt !== CipherRepromptType.None) {
+      await BrowserApi.tabSendMessageData(tab, "passwordReprompt", { cipherId: cipher.id });
       return null;
     }
 

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -61,6 +61,8 @@ export default class RuntimeBackground {
   }
 
   async processMessage(msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) {
+    const cipherId = msg.data?.cipherId;
+
     switch (msg.command) {
       case "loggedIn":
       case "unlocked": {
@@ -110,11 +112,19 @@ export default class RuntimeBackground {
       case "bgReopenPromptForLogin":
         await this.browserPopoutWindowService.openLoginPrompt(sender.tab?.windowId);
         break;
+      case "passwordReprompt":
+        if (cipherId) {
+          BrowserApi.openBitwardenExtensionTab(
+            `popup/index.html#/view-cipher?cipherId=${cipherId}&senderTabId=${sender.tab.id}`,
+            true
+          );
+        }
+        break;
       case "openAddEditCipher": {
         const addEditCipherUrl =
-          msg.data?.cipherId == null
+          cipherId == null
             ? "popup/index.html#/edit-cipher"
-            : "popup/index.html#/edit-cipher?cipherId=" + msg.data.cipherId;
+            : "popup/index.html#/edit-cipher?cipherId=" + cipherId;
 
         BrowserApi.openBitwardenExtensionTab(addEditCipherUrl, true);
         break;

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -115,7 +115,7 @@ export default class RuntimeBackground {
       case "passwordReprompt":
         if (cipherId) {
           BrowserApi.openBitwardenExtensionTab(
-            `popup/index.html#/view-cipher?cipherId=${cipherId}&senderTabId=${sender.tab.id}`,
+            `popup/index.html#/view-cipher?cipherId=${cipherId}&senderTabId=${sender.tab.id}&action=${msg.data?.action}`,
             true
           );
         }

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -70,7 +70,7 @@ export default class RuntimeBackground {
 
         if (this.lockedVaultPendingNotifications?.length > 0) {
           item = this.lockedVaultPendingNotifications.pop();
-          await this.browserPopoutWindowService.closeLoginPrompt();
+          await BrowserApi.closeBitwardenPromptWindow();
         }
 
         await this.main.refreshBadge();
@@ -110,14 +110,18 @@ export default class RuntimeBackground {
         break;
       case "promptForLogin":
       case "bgReopenPromptForLogin":
-        await this.browserPopoutWindowService.openLoginPrompt(sender.tab?.windowId);
+        BrowserApi.openBitwardenPromptWindow(sender.tab?.windowId);
         break;
       case "passwordReprompt":
         if (cipherId) {
-          BrowserApi.openBitwardenExtensionTab(
-            `popup/index.html#/view-cipher?cipherId=${cipherId}&senderTabId=${sender.tab.id}&action=${msg.data?.action}`,
-            true
-          );
+          const promptWindowPath =
+            `popup/index.html#/view-cipher` +
+            `?uilocation=popout` +
+            `&cipherId=${cipherId}` +
+            `&senderTabId=${sender.tab.id}` +
+            `&action=${msg.data?.action}`;
+
+          BrowserApi.openBitwardenPromptWindow(sender.tab?.windowId, promptWindowPath);
         }
         break;
       case "openAddEditCipher": {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -70,7 +70,7 @@ export default class RuntimeBackground {
 
         if (this.lockedVaultPendingNotifications?.length > 0) {
           item = this.lockedVaultPendingNotifications.pop();
-          await BrowserApi.closeBitwardenPromptWindow();
+          await this.browserPopoutWindowService.closeUnlockPrompt();
         }
 
         await this.main.refreshBadge();
@@ -110,18 +110,15 @@ export default class RuntimeBackground {
         break;
       case "promptForLogin":
       case "bgReopenPromptForLogin":
-        BrowserApi.openBitwardenPromptWindow(sender.tab?.windowId);
+        await this.browserPopoutWindowService.openUnlockPrompt(sender.tab?.windowId);
         break;
       case "passwordReprompt":
         if (cipherId) {
-          const promptWindowPath =
-            `popup/index.html#/view-cipher` +
-            `?uilocation=popout` +
-            `&cipherId=${cipherId}` +
-            `&senderTabId=${sender.tab.id}` +
-            `&action=${msg.data?.action}`;
-
-          BrowserApi.openBitwardenPromptWindow(sender.tab?.windowId, promptWindowPath);
+          await this.browserPopoutWindowService.openPasswordRepromptPrompt(sender.tab?.windowId, {
+            cipherId: cipherId,
+            senderTabId: sender.tab.id,
+            action: msg.data?.action,
+          });
         }
         break;
       case "openAddEditCipher": {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -42,11 +42,20 @@ export class BrowserApi {
     });
   }
 
-  static async getTab(tabId: number) {
-    if (tabId == null) {
+  static async getTab(tabId: number): Promise<chrome.tabs.Tab> | null {
+    if (!tabId) {
       return null;
     }
-    return await chrome.tabs.get(tabId);
+
+    if (BrowserApi.manifestVersion === 3) {
+      return await chrome.tabs.get(tabId);
+    }
+
+    return new Promise((resolve) =>
+      chrome.tabs.get(tabId, (tab) => {
+        resolve(tab);
+      })
+    );
   }
 
   static async getTabFromCurrentWindow(): Promise<chrome.tabs.Tab> | null {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -201,38 +201,6 @@ export class BrowserApi {
 
   private static registeredMessageListeners: any[] = [];
 
-  static async openBitwardenPromptWindow(senderWindowId?: number, promptWindowURL?: string) {
-    const senderWindow = senderWindowId && (await BrowserApi.getWindow(senderWindowId));
-    await BrowserApi.closeBitwardenPromptWindow();
-
-    const url = chrome.extension.getURL(promptWindowURL || "popup/index.html?uilocation=popout");
-
-    const defaultWindowOptions: chrome.windows.CreateData = {
-      url,
-      type: "normal",
-      focused: true,
-      width: 500,
-      height: 800,
-    };
-    const windowOptions = senderWindow
-      ? {
-          ...defaultWindowOptions,
-          left: senderWindow.left + senderWindow.width - defaultWindowOptions.width - 15,
-          top: senderWindow.top + 90,
-        }
-      : defaultWindowOptions;
-    await chrome.windows.create(windowOptions);
-  }
-
-  static async closeBitwardenPromptWindow(promptWindowURL?: string) {
-    const url = chrome.extension.getURL(promptWindowURL || "popup/index.html?uilocation=popout");
-    const tabs = await BrowserApi.tabsQuery({
-      url,
-      windowType: "popup",
-    });
-    tabs.forEach((tab) => chrome.tabs.remove(tab.id));
-  }
-
   static messageListener(
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => void

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -192,6 +192,38 @@ export class BrowserApi {
 
   private static registeredMessageListeners: any[] = [];
 
+  static async openBitwardenPromptWindow(senderWindowId?: number, promptWindowURL?: string) {
+    const senderWindow = senderWindowId && (await BrowserApi.getWindow(senderWindowId));
+    await BrowserApi.closeBitwardenPromptWindow();
+
+    const url = chrome.extension.getURL(promptWindowURL || "popup/index.html?uilocation=popout");
+
+    const defaultWindowOptions: chrome.windows.CreateData = {
+      url,
+      type: "normal",
+      focused: true,
+      width: 500,
+      height: 800,
+    };
+    const windowOptions = senderWindow
+      ? {
+          ...defaultWindowOptions,
+          left: senderWindow.left + senderWindow.width - defaultWindowOptions.width - 15,
+          top: senderWindow.top + 90,
+        }
+      : defaultWindowOptions;
+    await chrome.windows.create(windowOptions);
+  }
+
+  static async closeBitwardenPromptWindow(promptWindowURL?: string) {
+    const url = chrome.extension.getURL(promptWindowURL || "popup/index.html?uilocation=popout");
+    const tabs = await BrowserApi.tabsQuery({
+      url,
+      windowType: "popup",
+    });
+    tabs.forEach((tab) => chrome.tabs.remove(tab.id));
+  }
+
   static messageListener(
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => void

--- a/apps/browser/src/platform/popup/abstractions/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/abstractions/browser-popout-window.service.ts
@@ -4,9 +4,9 @@ interface BrowserPopoutWindowService {
   openPasswordRepromptPrompt(
     senderWindowId: number,
     promptData: {
+      action: string;
       cipherId: string;
       senderTabId: number;
-      action: string;
     }
   ): Promise<void>;
   closePasswordRepromptPrompt(): Promise<void>;

--- a/apps/browser/src/platform/popup/abstractions/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/abstractions/browser-popout-window.service.ts
@@ -1,6 +1,15 @@
 interface BrowserPopoutWindowService {
-  openLoginPrompt(senderWindowId: number): Promise<void>;
-  closeLoginPrompt(): Promise<void>;
+  openUnlockPrompt(senderWindowId: number): Promise<void>;
+  closeUnlockPrompt(): Promise<void>;
+  openPasswordRepromptPrompt(
+    senderWindowId: number,
+    promptData: {
+      cipherId: string;
+      senderTabId: number;
+      action: string;
+    }
+  ): Promise<void>;
+  closePasswordRepromptPrompt(): Promise<void>;
 }
 
 export { BrowserPopoutWindowService };

--- a/apps/browser/src/platform/popup/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/browser-popout-window.service.ts
@@ -39,8 +39,8 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
     await this.closePasswordRepromptPrompt();
 
     const promptWindowPath =
-      `popup/index.html#/view-cipher` +
-      `?uilocation=popout` +
+      "popup/index.html#/view-cipher" +
+      "?uilocation=popout" +
       `&cipherId=${cipherId}` +
       `&senderTabId=${senderTabId}` +
       `&action=${action}`;

--- a/apps/browser/src/platform/popup/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/browser-popout-window.service.ts
@@ -11,20 +11,48 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
     height: 800,
   };
 
-  async openLoginPrompt(senderWindowId: number) {
-    await this.closeLoginPrompt();
-    await this.openPopoutWindow(
+  async openUnlockPrompt(senderWindowId: number) {
+    await this.closeUnlockPrompt();
+    await this.openSingleActionPopout(
       senderWindowId,
       "popup/index.html?uilocation=popout",
-      "loginPrompt"
+      "unlockPrompt"
     );
   }
 
-  async closeLoginPrompt() {
-    await this.closeSingleActionPopout("loginPrompt");
+  async closeUnlockPrompt() {
+    await this.closeSingleActionPopout("unlockPrompt");
   }
 
-  private async openPopoutWindow(
+  async openPasswordRepromptPrompt(
+    senderWindowId: number,
+    {
+      cipherId,
+      senderTabId,
+      action,
+    }: {
+      cipherId: string;
+      senderTabId: number;
+      action: string;
+    }
+  ) {
+    await this.closePasswordRepromptPrompt();
+
+    const promptWindowPath =
+      `popup/index.html#/view-cipher` +
+      `?uilocation=popout` +
+      `&cipherId=${cipherId}` +
+      `&senderTabId=${senderTabId}` +
+      `&action=${action}`;
+
+    await this.openSingleActionPopout(senderWindowId, promptWindowPath, "passwordReprompt");
+  }
+
+  async closePasswordRepromptPrompt() {
+    await this.closeSingleActionPopout("passwordReprompt");
+  }
+
+  private async openSingleActionPopout(
     senderWindowId: number,
     popupWindowURL: string,
     singleActionPopoutKey: string

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -555,7 +555,7 @@
         class="box-content-row"
         appStopClick
         (click)="fillCipher()"
-        *ngIf="cipher.type !== cipherType.SecureNote && !cipher.isDeleted && !inPopout"
+        *ngIf="cipher.type !== cipherType.SecureNote && !cipher.isDeleted"
       >
         <div class="row-main text-primary">
           <div class="icon text-primary" aria-hidden="true">

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -555,7 +555,11 @@
         class="box-content-row"
         appStopClick
         (click)="fillCipher()"
-        *ngIf="cipher.type !== cipherType.SecureNote && !cipher.isDeleted"
+        *ngIf="
+          cipher.type !== cipherType.SecureNote &&
+          !cipher.isDeleted &&
+          (!this.inPopout || this.loadAction)
+        "
       >
         <div class="row-main text-primary">
           <div class="icon text-primary" aria-hidden="true">

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -158,7 +158,7 @@ export class ViewComponent extends BaseViewComponent {
     switch (this.loadAction) {
       case AUTOFILL_ID:
         this.fillCipher();
-        break;
+        return;
       case COPY_USERNAME_ID:
         await this.copy(this.cipher.login.username, "username", "Username");
         break;
@@ -172,10 +172,7 @@ export class ViewComponent extends BaseViewComponent {
         break;
     }
 
-    if (
-      this.inPopout &&
-      [COPY_USERNAME_ID, COPY_PASSWORD_ID, COPY_VERIFICATIONCODE_ID].includes(this.loadAction)
-    ) {
+    if (this.inPopout) {
       this.close();
     }
   }

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -313,13 +313,10 @@ export class ViewComponent extends BaseViewComponent {
     this.tab = await BrowserApi.getTabFromCurrentWindow();
 
     if (this.senderTabId) {
-      // @TODO `BrowserApi.getTab(this.senderTabId)`?
-      this.tab = (await BrowserApi.tabsQuery({ currentWindow: false }))?.find(({ id }) => {
-        return id === this.senderTabId;
-      });
+      this.tab = await BrowserApi.getTab(this.senderTabId);
     }
 
-    if (this.tab == null) {
+    if (!this.tab) {
       return;
     }
 

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -36,6 +36,12 @@ export const COPY_USERNAME_ID = "copy-username";
 export const COPY_PASSWORD_ID = "copy-password";
 export const COPY_VERIFICATIONCODE_ID = "copy-totp";
 
+type LoadAction =
+  | typeof AUTOFILL_ID
+  | typeof COPY_USERNAME_ID
+  | typeof COPY_PASSWORD_ID
+  | typeof COPY_VERIFICATIONCODE_ID;
+
 @Component({
   selector: "app-vault-view",
   templateUrl: "view.component.html",
@@ -45,7 +51,7 @@ export class ViewComponent extends BaseViewComponent {
   pageDetails: any[] = [];
   tab: any;
   senderTabId?: number;
-  loadAction?: "autofill" | "copy-username" | "copy-password" | "copy-totp";
+  loadAction?: LoadAction;
   uilocation?: "popout" | "popup" | "sidebar" | "tab";
   loadPageDetailsTimeout: number;
   inPopout = false;

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -31,6 +31,11 @@ import { PopupUtilsService } from "../../../../popup/services/popup-utils.servic
 
 const BroadcasterSubscriptionId = "ChildViewComponent";
 
+export const AUTOFILL_ID = "autofill";
+export const COPY_USERNAME_ID = "copy-username";
+export const COPY_PASSWORD_ID = "copy-password";
+export const COPY_VERIFICATIONCODE_ID = "copy-totp";
+
 @Component({
   selector: "app-vault-view",
   templateUrl: "view.component.html",
@@ -40,6 +45,7 @@ export class ViewComponent extends BaseViewComponent {
   pageDetails: any[] = [];
   tab: any;
   senderTabId: number;
+  loadAction: string;
   loadPageDetailsTimeout: number;
   inPopout = false;
   cipherType = CipherType;
@@ -96,6 +102,7 @@ export class ViewComponent extends BaseViewComponent {
   ngOnInit() {
     this.senderTabId =
       parseInt((this.route.queryParams as any).value?.senderTabId, 10) || undefined;
+    this.loadAction = (this.route.queryParams as any).value?.action || undefined;
     this.inPopout = this.popupUtilsService.inPopout(window);
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
     this.route.queryParams.pipe(first()).subscribe(async (params) => {
@@ -145,8 +152,21 @@ export class ViewComponent extends BaseViewComponent {
     await super.load();
     await this.loadPageDetails();
 
-    if (this.senderTabId) {
-      this.fillCipher();
+    switch (this.loadAction) {
+      case AUTOFILL_ID:
+        this.fillCipher();
+        break;
+      case COPY_USERNAME_ID:
+        this.copy(this.cipher.login.username, "username", "Username");
+        break;
+      case COPY_PASSWORD_ID:
+        this.copy(this.cipher.login.password, "password", "Password");
+        break;
+      case COPY_VERIFICATIONCODE_ID:
+        this.copy(this.cipher.login.totp, "verificationCodeTotp", "TOTP");
+        break;
+      default:
+        break;
     }
   }
 

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -161,24 +161,22 @@ export class ViewComponent extends BaseViewComponent {
         break;
       case COPY_USERNAME_ID:
         await this.copy(this.cipher.login.username, "username", "Username");
-        if (this.inPopout) {
-          this.close();
-        }
         break;
       case COPY_PASSWORD_ID:
         await this.copy(this.cipher.login.password, "password", "Password");
-        if (this.inPopout) {
-          this.close();
-        }
         break;
       case COPY_VERIFICATIONCODE_ID:
         await this.copy(this.cipher.login.totp, "verificationCodeTotp", "TOTP");
-        if (this.inPopout) {
-          this.close();
-        }
         break;
       default:
         break;
+    }
+
+    if (
+      this.inPopout &&
+      [COPY_USERNAME_ID, COPY_PASSWORD_ID, COPY_VERIFICATIONCODE_ID].includes(this.loadAction)
+    ) {
+      this.close();
     }
   }
 
@@ -304,9 +302,10 @@ export class ViewComponent extends BaseViewComponent {
 
     if (this.inPopout) {
       window.close();
-    } else {
-      this.location.back();
+      return;
     }
+
+    this.location.back();
   }
 
   private async loadPageDetails() {

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -185,7 +185,7 @@ export class ViewComponent extends BaseViewComponent {
         break;
     }
 
-    if (this.inPopout) {
+    if (this.inPopout && this.loadAction) {
       this.close();
     }
   }

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -44,8 +44,9 @@ export class ViewComponent extends BaseViewComponent {
   showAttachments = true;
   pageDetails: any[] = [];
   tab: any;
-  senderTabId: number;
-  loadAction: string;
+  senderTabId?: number;
+  loadAction?: "autofill" | "copy-username" | "copy-password" | "copy-totp";
+  uilocation?: "popout" | "popup" | "sidebar" | "tab";
   loadPageDetailsTimeout: number;
   inPopout = false;
   cipherType = CipherType;
@@ -102,8 +103,10 @@ export class ViewComponent extends BaseViewComponent {
   ngOnInit() {
     this.senderTabId =
       parseInt((this.route.queryParams as any).value?.senderTabId, 10) || undefined;
-    this.loadAction = (this.route.queryParams as any).value?.action || undefined;
-    this.inPopout = this.popupUtilsService.inPopout(window);
+    this.loadAction = (this.route.queryParams as any).value?.action;
+    this.uilocation = (this.route.queryParams as any).value?.uilocation;
+    this.inPopout = this.uilocation === "popout" || this.popupUtilsService.inPopout(window);
+
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
     this.route.queryParams.pipe(first()).subscribe(async (params) => {
       if (params.cipherId) {
@@ -157,13 +160,22 @@ export class ViewComponent extends BaseViewComponent {
         this.fillCipher();
         break;
       case COPY_USERNAME_ID:
-        this.copy(this.cipher.login.username, "username", "Username");
+        await this.copy(this.cipher.login.username, "username", "Username");
+        if (this.inPopout) {
+          this.close();
+        }
         break;
       case COPY_PASSWORD_ID:
-        this.copy(this.cipher.login.password, "password", "Password");
+        await this.copy(this.cipher.login.password, "password", "Password");
+        if (this.inPopout) {
+          this.close();
+        }
         break;
       case COPY_VERIFICATIONCODE_ID:
-        this.copy(this.cipher.login.totp, "verificationCodeTotp", "TOTP");
+        await this.copy(this.cipher.login.totp, "verificationCodeTotp", "TOTP");
+        if (this.inPopout) {
+          this.close();
+        }
         break;
       default:
         break;
@@ -219,7 +231,7 @@ export class ViewComponent extends BaseViewComponent {
     if (didAutofill) {
       this.platformUtilsService.showToast("success", null, this.i18nService.t("autoFillSuccess"));
 
-      if (this.senderTabId) {
+      if (this.inPopout) {
         this.close();
       }
     }
@@ -287,7 +299,10 @@ export class ViewComponent extends BaseViewComponent {
 
   close() {
     if (this.senderTabId) {
-      BrowserApi.focusTab(this.tab.id);
+      BrowserApi.focusTab(this.senderTabId);
+    }
+
+    if (this.inPopout) {
       window.close();
     } else {
       this.location.back();
@@ -300,7 +315,7 @@ export class ViewComponent extends BaseViewComponent {
 
     if (this.senderTabId) {
       // @TODO `BrowserApi.getTab(this.senderTabId)`?
-      this.tab = (await BrowserApi.tabsQuery({ currentWindow: true }))?.find(({ id }) => {
+      this.tab = (await BrowserApi.tabsQuery({ currentWindow: false }))?.find(({ id }) => {
         return id === this.senderTabId;
       });
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Password reprompt is not triggering when using hotkey combos or the right-click context menu to autofill, copy the page password, or copy the page TOTP. This PR updates those cases to trigger a new window for password reprompt, a la #5384 

## Code changes

See notes in changes.

## Screenshots

https://github.com/bitwarden/clients/assets/1556494/2595cfa3-a45d-4466-8c31-2f49cee14707

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
