### PR TITLE
[PM-2582] Add Attachment on new client with encryption off to an item with encryption key results in corrupt attachment

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -628,7 +628,7 @@ export class CipherService implements CipherServiceAbstraction {
     const key = await this.getKeyForCipherKeyDecryption(cipher);
 
     const cipherEncKey =
-      (await this.getCipherKeyEncryptionEnabled()) && cipher.key != null
+      (await this.getCipherKeyEncryptionEnabled()) || cipher.key != null
         ? new SymmetricCryptoKey(await this.encryptService.decryptToBytes(cipher.key, key))
         : key;
     const encFileName = await this.cryptoService.encrypt(filename, cipherEncKey);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If you have an item that has an individual item encryption key, and then you add an attachment to it with a client that has the new encryption/decryption logic on it but has encryption turned off, the attachment is corrupted and can’t be downloaded.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/vault/services/cipher.service.ts:** The attachment was getting corrupted because it was always using the cipher key to decrypt the attachment, which was not the key used for encryption. I decided to use the `cipher key` used for encrypting the cipher when adding attachments on an older client. I changed the condition for determining the attachment encryption to use the `cipher key` when not null.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
