### PR TITLE
[PM-1826] [PM-2168] [Tech debt] Migrate file-password-prompt to dialog

### DIFF
--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -20,7 +20,7 @@
   </div>
 
   <ng-container bitDialogFooter>
-    <button bitButton buttonType="primary" type="submit">
+    <button bitButton buttonType="primary" type="submit" (click)="submit()">
       <span>{{ "importData" | i18n }}</span>
     </button>
     <button bitButton bitDialogClose buttonType="secondary" type="button">

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -5,7 +5,7 @@
 
   <div bitDialogContent>
     {{ "confirmVaultImportDesc" | i18n }}
-    <bit-form-field class="tw-m-6">
+    <bit-form-field class="tw-mt-6">
       <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
       <input
         bitInput

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -5,7 +5,7 @@
 
   <div bitDialogContent>
     {{ "confirmVaultImportDesc" | i18n }}
-    <bit-form-field>
+    <bit-form-field class="tw-m-6">
       <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
       <input
         bitInput

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -23,7 +23,7 @@
     <button bitButton buttonType="primary" type="submit">
       <span>{{ "importData" | i18n }}</span>
     </button>
-    <button bitButton bitDialogClose buttonType="secondary" type="button" (click)="cancel()">
+    <button bitButton bitDialogClose buttonType="secondary" type="button">
       <span>{{ "cancel" | i18n }}</span>
     </button>
   </ng-container>

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -1,30 +1,32 @@
-<bit-dialog>
-  <span bitDialogTitle>
-    {{ "confirmVaultImport" | i18n }}
-  </span>
+<form (submit)="submit()">
+  <bit-dialog>
+    <span bitDialogTitle>
+      {{ "confirmVaultImport" | i18n }}
+    </span>
 
-  <div bitDialogContent>
-    {{ "confirmVaultImportDesc" | i18n }}
-    <bit-form-field class="tw-mt-6">
-      <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
-      <input
-        bitInput
-        type="password"
-        name="filePassword"
-        [formControl]="filePassword"
-        appAutofocus
-        appInputVerbatim
-      />
-      <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
-    </bit-form-field>
-  </div>
+    <div bitDialogContent>
+      {{ "confirmVaultImportDesc" | i18n }}
+      <bit-form-field class="tw-mt-6">
+        <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="password"
+          name="filePassword"
+          [formControl]="filePassword"
+          appAutofocus
+          appInputVerbatim
+        />
+        <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+      </bit-form-field>
+    </div>
 
-  <ng-container bitDialogFooter>
-    <button bitButton buttonType="primary" type="submit" (click)="submit()">
-      <span>{{ "importData" | i18n }}</span>
-    </button>
-    <button bitButton bitDialogClose buttonType="secondary" type="button">
-      <span>{{ "cancel" | i18n }}</span>
-    </button>
-  </ng-container>
-</bit-dialog>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary" type="submit">
+        <span>{{ "importData" | i18n }}</span>
+      </button>
+      <button bitButton bitDialogClose buttonType="secondary" type="button">
+        <span>{{ "cancel" | i18n }}</span>
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html
@@ -1,45 +1,30 @@
-<!-- Please remove this disable statement when editing this file! -->
-<!-- eslint-disable tailwindcss/no-custom-classname -->
-<div
-  class="modal fade"
-  role="dialog"
-  aria-modal="true"
-  [attr.aria-labelledby]="'confirmVaultImport' | i18n"
->
-  <div class="modal-dialog modal-dialog-scrollable" role="document">
-    <form #form (ngSubmit)="submit()">
-      <div class="form-group modal-content">
-        <h2 class="tw-my-6 tw-ml-3.5 tw-font-semibold" id="confirmVaultImport">
-          {{ "confirmVaultImport" | i18n | uppercase }}
-        </h2>
-        <div
-          class="tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-px-3.5 tw-pt-3.5"
-        >
-          {{ "confirmVaultImportDesc" | i18n }}
-          <bit-form-field class="tw-pt-3.5">
-            <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
-            <input
-              bitInput
-              type="password"
-              name="filePassword"
-              [formControl]="filePassword"
-              appAutofocus
-              appInputVerbatim
-            />
-            <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
-          </bit-form-field>
-        </div>
-        <div
-          class="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-px-3.5 tw-pb-3.5 tw-pt-4"
-        >
-          <button bitButton buttonType="primary" class="tw-mr-2" type="submit" appBlurClick>
-            <span>{{ "importData" | i18n }}</span>
-          </button>
-          <button bitButton buttonType="secondary" type="button" (click)="cancel()">
-            <span>{{ "cancel" | i18n }}</span>
-          </button>
-        </div>
-      </div>
-    </form>
+<bit-dialog>
+  <span bitDialogTitle>
+    {{ "confirmVaultImport" | i18n }}
+  </span>
+
+  <div bitDialogContent>
+    {{ "confirmVaultImportDesc" | i18n }}
+    <bit-form-field>
+      <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
+      <input
+        bitInput
+        type="password"
+        name="filePassword"
+        [formControl]="filePassword"
+        appAutofocus
+        appInputVerbatim
+      />
+      <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+    </bit-form-field>
   </div>
-</div>
+
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" type="submit">
+      <span>{{ "importData" | i18n }}</span>
+    </button>
+    <button bitButton bitDialogClose buttonType="secondary" type="button" (click)="cancel()">
+      <span>{{ "cancel" | i18n }}</span>
+    </button>
+  </ng-container>
+</bit-dialog>

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.ts
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.ts
@@ -1,7 +1,6 @@
+import { DialogRef } from "@angular/cdk/dialog";
 import { Component } from "@angular/core";
 import { FormControl, Validators } from "@angular/forms";
-
-import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 
 @Component({
   templateUrl: "file-password-prompt.component.html",
@@ -9,18 +8,17 @@ import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 export class FilePasswordPromptComponent {
   filePassword = new FormControl("", Validators.required);
 
-  constructor(private modalRef: ModalRef) {}
+  constructor(public dialogRef: DialogRef) {}
 
   submit() {
     this.filePassword.markAsTouched();
     if (!this.filePassword.valid) {
       return;
     }
-
-    this.modalRef.close(this.filePassword.value);
+    this.dialogRef.close(this.filePassword.value);
   }
 
   cancel() {
-    this.modalRef.close(null);
+    this.dialogRef.close(null);
   }
 }

--- a/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.ts
+++ b/apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.ts
@@ -17,8 +17,4 @@ export class FilePasswordPromptComponent {
     }
     this.dialogRef.close(this.filePassword.value);
   }
-
-  cancel() {
-    this.dialogRef.close(null);
-  }
 }

--- a/apps/web/src/app/tools/import-export/import.component.ts
+++ b/apps/web/src/app/tools/import-export/import.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 import * as JSZip from "jszip";
-import { Subject } from "rxjs";
+import { Subject, lastValueFrom } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import Swal, { SweetAlertIcon } from "sweetalert2";
 
@@ -270,15 +270,11 @@ export class ImportComponent implements OnInit, OnDestroy {
   }
 
   async getFilePassword(): Promise<string> {
-    const ref = this.modalService.open(FilePasswordPromptComponent, {
-      allowMultipleModals: true,
+    const dialog = this.dialogService.open<string>(FilePasswordPromptComponent, {
+      ariaModal: true,
     });
 
-    if (ref == null) {
-      return null;
-    }
-
-    return await ref.onClosedPromise();
+    return await lastValueFrom(dialog.closed);
   }
 
   ngOnDestroy(): void {

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -62,6 +62,10 @@ export class BitwardenPasswordProtectedImporter extends BitwardenJsonImporter im
     jdoc: BitwardenPasswordProtectedFileFormat,
     password: string
   ): Promise<boolean> {
+    if (this.isNullOrWhitespace(password)) {
+      return false;
+    }
+
     this.key = await this.cryptoService.makePinKey(
       password,
       jdoc.salt,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Migrate file-password-prompt to dialog which also cleaned up any custom tailwind class usage

## Code changes
- **apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html:** Replace to use bitDialog
- **apps/web/src/app/tools/import-export/dialog/file-password-prompt.component.html:** Replace usage of ModalRef to DialogRef
- **apps/web/src/app/tools/import-export/import.component.ts:** Get result from new dialog
- **libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts:** Fix issue with cancel/empty password returned

## Screenshots
**BEFORE:**
![image](https://github.com/bitwarden/clients/assets/2670567/15f3442f-e0f9-4718-ac3d-94a4a20826c9)

**AFTER:**
![image](https://github.com/bitwarden/clients/assets/2670567/c510d9d7-6ad9-41ec-b11b-1d9309aabeab)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
