### PR TITLE
[PM-2744] cli import is failing

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -255,30 +255,7 @@ export class Main {
 
     this.searchService = new SearchService(this.logService, this.i18nService);
 
-    this.configApiService = new ConfigApiService(this.apiService, this.authService);
-
-    this.cipherService = new CipherService(
-      this.cryptoService,
-      this.settingsService,
-      this.apiService,
-      this.i18nService,
-      this.searchService,
-      this.stateService,
-      this.encryptService,
-      this.cipherFileUploadService,
-      this.configApiService
-    );
-
     this.broadcasterService = new BroadcasterService();
-
-    this.folderService = new FolderService(
-      this.cryptoService,
-      this.i18nService,
-      this.cipherService,
-      this.stateService
-    );
-
-    this.folderApiService = new FolderApiService(this.folderService, this.apiService);
 
     this.collectionService = new CollectionService(
       this.cryptoService,
@@ -338,6 +315,29 @@ export class Main {
       this.passwordStrengthService,
       this.policyService
     );
+
+    this.configApiService = new ConfigApiService(this.apiService, this.authService);
+
+    this.cipherService = new CipherService(
+      this.cryptoService,
+      this.settingsService,
+      this.apiService,
+      this.i18nService,
+      this.searchService,
+      this.stateService,
+      this.encryptService,
+      this.cipherFileUploadService,
+      this.configApiService
+    );
+
+    this.folderService = new FolderService(
+      this.cryptoService,
+      this.i18nService,
+      this.cipherService,
+      this.stateService
+    );
+
+    this.folderApiService = new FolderApiService(this.folderService, this.apiService);
 
     const lockedCallback = async () =>
       await this.cryptoService.clearStoredKey(KeySuffixOptions.Auto);


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

CLI's import was throwing the following exception `Cannot read properties of undefined (reading 'getAuthStatus')`. Changing the service creation order so that `AuthService` is defined when called on import

## Code changes
- **bw.ts:** Changed the order of service creation so that when creating the `ConfigApiService` instance the `AuthService` is already defined

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
