### PR TITLE
[PM-2560] Fix Firefox default passkeys handling

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -186,10 +186,17 @@ export class BrowserApi {
   ) {
     chrome.runtime.onMessage.addListener(
       (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
-        // The callback needs to return a truthy value here so that we can return a response using sendResponse
-        // This can sometimes return non-boolean values which are considered truthy,
-        // so we need to explicitly check for true
-        return callback(msg, sender, sendResponse) === true;
+        if (
+          msg.command === "fido2RegisterCredentialRequest" ||
+          msg.command === "fido2GetCredentialRequest"
+        ) {
+          // The callback needs to return a truthy value here for fido2 requests so that we can return a response
+          // using sendResponse. This can sometimes return non-boolean values which are considered truthy,
+          // so we need to explicitly check for true
+          return callback(msg, sender, sendResponse) === true;
+        } else {
+          callback(msg, sender, sendResponse);
+        }
       }
     );
 

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -184,7 +184,11 @@ export class BrowserApi {
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => unknown
   ) {
-    chrome.runtime.onMessage.addListener(callback);
+    chrome.runtime.onMessage.addListener(
+      (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
+        return callback(msg, sender, sendResponse) === true;
+      }
+    );
 
     // Keep track of all the events registered in a Safari popup so we can remove
     // them when the popup gets unloaded, otherwise we cause a memory leak

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -186,6 +186,9 @@ export class BrowserApi {
   ) {
     chrome.runtime.onMessage.addListener(
       (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
+        // The callback needs to return a truthy value here so that we can return a response using sendResponse
+        // This can sometimes return non-boolean values which are considered truthy,
+        // so we need to explicitly check for true
         return callback(msg, sender, sendResponse) === true;
       }
     );

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -184,18 +184,18 @@ export class BrowserApi {
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => unknown
   ) {
-  chrome.runtime.onMessage.addListener(
-    (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
-      const messageResponse = callback(msg, sender, sendResponse);
+    chrome.runtime.onMessage.addListener(
+      (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
+        const messageResponse = callback(msg, sender, sendResponse);
 
-      if (!messageResponse) {
-        return false;
+        if (!messageResponse) {
+          return false;
+        }
+
+        Promise.resolve(messageResponse);
+        return true;
       }
-
-      Promise.resolve(messageResponse);
-      return true;
-    }
-  );
+    );
 
     // Keep track of all the events registered in a Safari popup so we can remove
     // them when the popup gets unloaded, otherwise we cause a memory leak

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -184,21 +184,18 @@ export class BrowserApi {
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => unknown
   ) {
-    chrome.runtime.onMessage.addListener(
-      (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
-        if (
-          msg.command === "fido2RegisterCredentialRequest" ||
-          msg.command === "fido2GetCredentialRequest"
-        ) {
-          // The callback needs to return a truthy value here for fido2 requests so that we can return a response
-          // using sendResponse. This can sometimes return non-boolean values which are considered truthy,
-          // so we need to explicitly check for true
-          return callback(msg, sender, sendResponse) === true;
-        } else {
-          callback(msg, sender, sendResponse);
-        }
+  chrome.runtime.onMessage.addListener(
+    (msg: any, sender: chrome.runtime.MessageSender, sendResponse: any) => {
+      const messageResponse = callback(msg, sender, sendResponse);
+
+      if (!messageResponse) {
+        return false;
       }
-    );
+
+      Promise.resolve(messageResponse);
+      return true;
+    }
+  );
 
     // Keep track of all the events registered in a Safari popup so we can remove
     // them when the popup gets unloaded, otherwise we cause a memory leak


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix an issue where Firefox's default passkey handler was not being invoked. This was caused by `sendResponse()` in `runtime.background.ts` not getting a response back from the callback being sent in `browser-api.ts`.

## Code changes

- **apps/browser/src/platform/browser/browser-api.ts:** Return the callback in call to `chrome.runtime.onMessage.addListener()` and check that is a boolean value of true.

## Screenshots

Demo that it works with the passkey feature flag off:

https://github.com/bitwarden/clients/assets/8926729/1cfb0e73-fcb3-49b6-8ec4-634e440ccf98


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
