### PR TITLE
[PM-2582] Fix adding attachments 

### DIFF
--- a/libs/angular/src/vault/components/attachments.component.ts
+++ b/libs/angular/src/vault/components/attachments.component.ts
@@ -295,7 +295,21 @@ export class AttachmentsComponent implements OnInit {
     return this.cipherService.get(this.cipherId);
   }
 
-  protected saveCipherAttachment(file: File) {
+  protected async saveCipherAttachment(file: File) {
+    //if cipher key encryption is disabled but the item has an individual key,
+    //then we rollback to using the user key as the main key of encryption of the item
+    //in order to keep item and it's attachments with the same encryption level
+    if (
+      this.cipherDomain.key != null &&
+      !(await this.cipherService.getCipherKeyEncryptionEnabled())
+    ) {
+      const model = await this.cipherDomain.decrypt(
+        await this.cipherService.getKeyForCipherKeyDecryption(this.cipherDomain)
+      );
+      this.cipherDomain = await this.cipherService.encrypt(model);
+      await this.cipherService.updateWithServer(this.cipherDomain);
+    }
+
     return this.cipherService.saveAttachmentWithServer(this.cipherDomain, file);
   }
 

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -78,4 +78,5 @@ export abstract class CipherService {
   restoreWithServer: (id: string, asAdmin?: boolean) => Promise<any>;
   restoreManyWithServer: (ids: string[]) => Promise<any>;
   getKeyForCipherKeyDecryption: (cipher: Cipher) => Promise<SymmetricCryptoKey>;
+  getCipherKeyEncryptionEnabled: () => Promise<boolean>;
 }

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1204,7 +1204,7 @@ export class CipherService implements CipherServiceAbstraction {
     return cipher;
   }
 
-  private async getCipherKeyEncryptionEnabled(): Promise<boolean> {
+  async getCipherKeyEncryptionEnabled(): Promise<boolean> {
     const minVersion = new SemVer(CIPHER_KEY_ENC_MIN_SERVER_VER);
     const serverVersion = new SemVer((await this.configApiService.get()).version);
     return flagEnabled("enableCipherKeyEncryption") && serverVersion.compare(minVersion) > 0;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
To fix the problem of adding an attachment to an item with cipher key level encryption in a client with user key level encryption.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **attachments.component.ts:** Identify the encryption level of the item to which we pretend to add an attachment. If it's level is cipher key encryption and the client has this level disabled, we revert it's encryption level in order to have the item and the attachment in the same level of encryption.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
