### PR TITLE
[PM-2762] Update Logic on HTTP Warning

### DIFF
--- a/apps/browser/src/autofill/content/autofill.js
+++ b/apps/browser/src/autofill/content/autofill.js
@@ -752,7 +752,7 @@
 
           if (
               // At least one of the `savedURLs` uses SSL
-              savedURLs.some(url => url.startsWith('https://')) &&
+              savedURLs.some(url => url.startsWith(`https://${window.location.hostname}`)) &&
               // The current page is not using SSL
               document.location.protocol === 'http:' &&
               // There are password inputs on the page


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This code change allows users to autofill insecure hosts using a vault item that has URI references to domains with both secure (`https`) and insecure (`http`) protocols. We are now ensuring that the warning for autofilling on an insecure website ONLY shows if the URI used for matching is `https`.

This means if a user has two URIs saved for a single item

`http://abc.com`
`https://xyz.com`

The user will see the warning if they try to fill on `http://xyz.com` but not if they try to fill on `http://abc.com`

## Code changes

- **apps/browser/src/autofill/content/autofill.js:** Modified the initial conditional check within `urlNotSecure` to validate if any of the vault item's saved urls contain a reference to the current page's hostname with a secure `https` protocol. This effectively facilitates the requested behavior within the ticket. 

## Screenshots

https://github.com/bitwarden/clients/assets/16629865/b6705fd8-e366-49e4-81ab-a0f5c673db27

