### PR TITLE
added previous-url to global-state

### DIFF
--- a/apps/web/src/app/auth/lock.component.ts
+++ b/apps/web/src/app/auth/lock.component.ts
@@ -69,7 +69,7 @@ export class LockComponent extends BaseLockComponent {
   async ngOnInit() {
     await super.ngOnInit();
     this.onSuccessfulSubmit = async () => {
-      const previousUrl = this.routerService.getPreviousUrl();
+      const previousUrl = await this.routerService.getPreviousUrl();
       if (previousUrl && previousUrl !== "/" && previousUrl.indexOf("lock") === -1) {
         this.successRoute = previousUrl;
       }

--- a/apps/web/src/app/auth/login/login.component.ts
+++ b/apps/web/src/app/auth/login/login.component.ts
@@ -177,7 +177,7 @@ export class LoginComponent extends BaseLoginComponent implements OnInit, OnDest
       }
     }
 
-    const previousUrl = this.routerService.getPreviousUrl();
+    const previousUrl = await this.routerService.getPreviousUrl();
     if (previousUrl) {
       this.router.navigateByUrl(previousUrl);
     } else {

--- a/apps/web/src/app/auth/two-factor.component.ts
+++ b/apps/web/src/app/auth/two-factor.component.ts
@@ -83,7 +83,7 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
 
   async goAfterLogIn() {
     this.loginService.clearValues();
-    const previousUrl = this.routerService.getPreviousUrl();
+    const previousUrl = await this.routerService.getPreviousUrl();
     if (previousUrl) {
       this.router.navigateByUrl(previousUrl);
     } else {

--- a/apps/web/src/app/core/router.service.ts
+++ b/apps/web/src/app/core/router.service.ts
@@ -5,15 +5,17 @@ import { filter } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
+import { StateService } from "./state";
+
 @Injectable()
 export class RouterService {
-  private previousUrl: string = undefined;
   private currentUrl: string = undefined;
 
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private titleService: Title,
+    private stateService: StateService,
     i18nService: I18nService
   ) {
     this.currentUrl = this.router.url;
@@ -46,11 +48,11 @@ export class RouterService {
       });
   }
 
-  getPreviousUrl() {
-    return this.previousUrl;
+  async getPreviousUrl() {
+    return await this.stateService.getPreviousUrl();
   }
 
   setPreviousUrl(url: string) {
-    this.previousUrl = url;
+    this.stateService.setPreviousUrl(url);
   }
 }

--- a/apps/web/src/app/core/state/state.service.ts
+++ b/apps/web/src/app/core/state/state.service.ts
@@ -114,4 +114,14 @@ export class StateService extends BaseStateService<GlobalState, Account> {
     options = this.reconcileOptions(options, await this.defaultInMemoryOptions());
     return await super.setLastSync(value, options);
   }
+
+  async getPreviousUrl(options?: StorageOptions): Promise<string> {
+    options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
+    return await super.getPreviousUrl(options);
+  }
+
+  async setPreviousUrl(url: string, options?: StorageOptions): Promise<void> {
+    options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
+    return await super.setPreviousUrl(url, options);
+  }
 }

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -395,4 +395,6 @@ export abstract class StateService<T extends Account = Account> {
     value: Record<string, Record<string, boolean>>,
     options?: StorageOptions
   ) => Promise<void>;
+  getPreviousUrl: (options?: StorageOptions) => Promise<string>;
+  setPreviousUrl: (url: string, options?: StorageOptions) => Promise<void>;
 }

--- a/libs/common/src/platform/models/domain/global-state.ts
+++ b/libs/common/src/platform/models/domain/global-state.ts
@@ -37,4 +37,5 @@ export class GlobalState {
   enableBrowserIntegrationFingerprint?: boolean;
   enableDuckDuckGoBrowserIntegration?: boolean;
   region?: string;
+  previousUrl: string;
 }

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -2447,6 +2447,23 @@ export class StateService<
     );
   }
 
+  async getPreviousUrl(options?: StorageOptions): Promise<string> {
+    return (
+      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.previousUrl;
+  }
+
+  async setPreviousUrl(url: string, options?: StorageOptions): Promise<void> {
+    const globals = await this.getGlobals(
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+    globals.previousUrl = url;
+    await this.saveGlobals(
+      globals,
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+  }
+
   protected async getGlobals(options: StorageOptions): Promise<TGlobalState> {
     let globals: TGlobalState;
     if (this.useMemory(options.storageLocation)) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
PR addresses issue when user tries to deep link into web-vault using SSO login flow. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/platform/models/domain/global-state.ts :** added `previousUrl: string` to track deep link URL. Adding it to `global-state` means allows `state.service.ts` to store the `global-state` in local storage in the browser.
- **state.service.ts :** 
  - **Abstraction :** added `(get/set)PreviousUrl` methods
  - **Lib common Implementation :** implemented get/set
  - **Web Implementation :** called get/set from _Lib Common_ implementation
- **apps/web/src/app/core/router.service.ts :** Added state service and modified get/set methods to fetch from state.
- All other files were minor updates to account for `async` when calling the `getPreviousUrl` method.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
