### PR TITLE
[PM-2861] Added QA and DevTest URLs to Self-Hosted Exclusion

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -320,12 +320,18 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
 
   isSelfHosted(): boolean {
     return ![
-      "http://vault.bitwarden.com",
+      "http://vault.bitwarden.com", // Prod US
       "https://vault.bitwarden.com",
-      "http://vault.bitwarden.eu",
+      "http://vault.bitwarden.eu", // Prod EU
       "https://vault.bitwarden.eu",
-      "http://vault.qa.bitwarden.pw",
+      "http://vault.qa.bitwarden.pw", // QA US
       "https://vault.qa.bitwarden.pw",
+      "http://vault.euqa.bitwarden.pw", // QA EU
+      "https://vault.euqa.bitwarden.pw",
+      "http://vault.usdevtest.bitwarden.pw", // Dev US
+      "https://vault.usdevtest.bitwarden.pw",
+      "http://vault.eudevtest.bitwarden.pw", // Dev EU
+      "https://vault.eudevtest.bitwarden.pw",
     ].includes(this.getWebVaultUrl());
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We need to exclude the EU QA environment and the US and EU DevTest environments from being treated as self-hosted int the `isSelfHosted()` check in the `EnvironmentService`.

Note that this hard-coding of individual URLs is in the scope of the `EnvironmentService` refactoring described in https://bitwarden.atlassian.net/browse/PM-2637.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **environment.service.ts:** Added additional web app URLs

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
