### PR TITLE
[PM-2846][PM-2860] Properly pass region from global to account state

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -287,7 +287,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     this.selectedRegion = region;
     await this.stateService.setRegion(region);
     if (region === Region.SelfHosted) {
-      // if user saves with empty fields, default to US
+      // If user saves a self-hosted region with empty fields, default to US
       if (this.isEmpty()) {
         await this.setRegion(Region.US);
       }

--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -286,19 +286,19 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
   async setRegion(region: Region) {
     this.selectedRegion = region;
     await this.stateService.setRegion(region);
-    switch (region) {
-      case Region.EU:
+    if (region === Region.SelfHosted) {
+      // if user saves with empty fields, default to US
+      if (this.isEmpty()) {
+        await this.setRegion(Region.US);
+      }
+    } else {
+      // If we are setting the region to EU or US, clear the self-hosted URLs
+      this.stateService.setEnvironmentUrls(new EnvironmentUrls());
+      if (region === Region.EU) {
         this.setUrlsInternal(this.euUrls);
-        break;
-      case Region.US:
+      } else if (region === Region.US) {
         this.setUrlsInternal(this.usUrls);
-        break;
-      case Region.SelfHosted:
-        // if user saves with empty fields, default to US
-        if (this.isEmpty()) {
-          await this.setRegion(Region.US);
-        }
-        break;
+      }
     }
   }
 

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -179,7 +179,7 @@ export class StateService<
   }
 
   async addAccount(account: TAccount) {
-    account = await this.setAccountEnvironmentUrls(account);
+    account = await this.setAccountEnvironment(account);
     await this.updateState(async (state) => {
       state.authenticatedAccounts.push(account.profile.userId);
       await this.storageService.save(keys.authenticatedAccounts, state.authenticatedAccounts);
@@ -2608,6 +2608,7 @@ export class StateService<
     );
     // EnvironmentUrls are set before authenticating and should override whatever is stored from any previous session
     const environmentUrls = account.settings.environmentUrls;
+    const region = account.settings.region;
     if (storedAccount?.settings != null) {
       account.settings = storedAccount.settings;
     } else if (await this.storageService.has(keys.tempAccountSettings)) {
@@ -2615,6 +2616,8 @@ export class StateService<
       await this.storageService.remove(keys.tempAccountSettings);
     }
     account.settings.environmentUrls = environmentUrls;
+    account.settings.region = region;
+
     if (
       account.settings.vaultTimeoutAction === VaultTimeoutAction.LogOut &&
       account.settings.vaultTimeout != null
@@ -2642,6 +2645,7 @@ export class StateService<
     );
     if (storedAccount?.settings != null) {
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
+      storedAccount.settings.region = account.settings.region;
       account.settings = storedAccount.settings;
     }
     await this.storageService.save(
@@ -2664,6 +2668,7 @@ export class StateService<
     );
     if (storedAccount?.settings != null) {
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
+      storedAccount.settings.region = account.settings.region;
       account.settings = storedAccount.settings;
     }
     await this.storageService.save(
@@ -2812,14 +2817,21 @@ export class StateService<
     return Object.assign(this.createAccount(), persistentAccountInformation);
   }
 
-  protected async setAccountEnvironmentUrls(account: TAccount): Promise<TAccount> {
+  // The environment urls and region are selected before login and are transferred here to an authenticated account
+  protected async setAccountEnvironment(account: TAccount): Promise<TAccount> {
     account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
+    account.settings.region = await this.getGlobalRegion();
     return account;
   }
 
   protected async getGlobalEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
     options = this.reconcileOptions(options, await this.defaultOnDiskOptions());
     return (await this.getGlobals(options)).environmentUrls ?? new EnvironmentUrls();
+  }
+
+  protected async getGlobalRegion(options?: StorageOptions): Promise<string> {
+    options = this.reconcileOptions(options, await this.defaultOnDiskOptions());
+    return (await this.getGlobals(options)).region ?? null;
   }
 
   protected async clearDecryptedDataForActiveUser(): Promise<void> {

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -30,6 +30,7 @@ import { LocalData } from "../../vault/models/data/local.data";
 import { CipherView } from "../../vault/models/view/cipher.view";
 import { CollectionView } from "../../vault/models/view/collection.view";
 import { AddEditCipherInfo } from "../../vault/types/add-edit-cipher-info";
+import { Region } from "../abstractions/environment.service";
 import { LogService } from "../abstractions/log.service";
 import { StateMigrationService } from "../abstractions/state-migration.service";
 import { StateService as StateServiceAbstraction } from "../abstractions/state.service";
@@ -2818,9 +2819,13 @@ export class StateService<
   }
 
   // The environment urls and region are selected before login and are transferred here to an authenticated account
+  // If a non-self-hosted region is selected, we don't want to persist the environment URLs, as those are defined in the EnvironmentService
   protected async setAccountEnvironment(account: TAccount): Promise<TAccount> {
-    account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
     account.settings.region = await this.getGlobalRegion();
+    if (account.settings.region == Region.SelfHosted) {
+      account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
+    }
+
     return account;
   }
 

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -2606,7 +2606,7 @@ export class StateService<
         await this.defaultOnDiskLocalOptions()
       )
     );
-    // EnvironmentUrls are set before authenticating and should override whatever is stored from any previous session
+    // EnvironmentUrls and region are set before authenticating and should override whatever is stored from any previous session
     const environmentUrls = account.settings.environmentUrls;
     const region = account.settings.region;
     if (storedAccount?.settings != null) {

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -30,7 +30,6 @@ import { LocalData } from "../../vault/models/data/local.data";
 import { CipherView } from "../../vault/models/view/cipher.view";
 import { CollectionView } from "../../vault/models/view/collection.view";
 import { AddEditCipherInfo } from "../../vault/types/add-edit-cipher-info";
-import { Region } from "../abstractions/environment.service";
 import { LogService } from "../abstractions/log.service";
 import { StateMigrationService } from "../abstractions/state-migration.service";
 import { StateService as StateServiceAbstraction } from "../abstractions/state.service";
@@ -2819,13 +2818,9 @@ export class StateService<
   }
 
   // The environment urls and region are selected before login and are transferred here to an authenticated account
-  // If a non-self-hosted region is selected, we don't want to persist the environment URLs, as those are defined in the EnvironmentService
   protected async setAccountEnvironment(account: TAccount): Promise<TAccount> {
     account.settings.region = await this.getGlobalRegion();
-    if (account.settings.region == Region.SelfHosted) {
-      account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
-    }
-
+    account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
     return account;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Properly pass the user's selected region from the global (pre-authenticated) state into the user's account state when they are logged in.  The current implementation does not allow different regions to be selected between accounts on clients that support multiple accounts.

## Code changes

- **state.service.ts:** Added logic to pull region from global state and pass in to the account state.
- **environment.service.ts:** Modified `setRegion()` to clear the environment URLs when a non-self-hosted region is selected.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
