### PR TITLE
[AC-1504] Allow SM max autoscale limits to be disabled

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -184,9 +184,9 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   get smOptions(): SecretsManagerSubscriptionOptions {
     return {
       seatCount: this.sub.smSeats,
-      seatLimit: this.sub.maxAutoscaleSmSeats,
+      maxAutoscaleSeats: this.sub.maxAutoscaleSmSeats,
       seatPrice: this.sub.secretsManagerPlan.seatPrice,
-      serviceAccountLimit: this.sub.maxAutoscaleSmServiceAccounts,
+      maxAutoscaleServiceAccounts: this.sub.maxAutoscaleSmServiceAccounts,
       serviceAccountCount: this.sub.smServiceAccounts,
       interval: this.sub.secretsManagerPlan.isAnnual ? "year" : "month",
       additionalServiceAccountPrice: this.sub.secretsManagerPlan.additionalPricePerServiceAccount,

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
@@ -20,15 +20,16 @@
     <input
       bitInput
       id="smSeatLimit"
-      formControlName="seatLimit"
+      formControlName="maxAutoscaleSeats"
       type="number"
       step="1"
       [min]="formGroup.value.seatCount"
     />
     <bit-hint>
       <strong>{{ "maxSeatCost" | i18n }}:</strong>
-      {{ formGroup.value.seatLimit || 0 }} &times; {{ options.seatPrice | currency : "$" }} =
-      {{ maxSeatTotal | currency : "$" }} / {{ options.interval | i18n }}
+      {{ formGroup.value.maxAutoscaleSeats || 0 }} &times;
+      {{ options.seatPrice | currency : "$" }} = {{ maxSeatTotal | currency : "$" }} /
+      {{ options.interval | i18n }}
     </bit-hint>
   </bit-form-field>
   <bit-form-field class="tw-w-2/3">
@@ -73,14 +74,14 @@
     <input
       bitInput
       id="additionalServiceAccountLimit"
-      formControlName="serviceAccountLimit"
+      formControlName="maxAutoscaleServiceAccounts"
       type="number"
       step="1"
       [min]="formGroup.value.serviceAccountCount"
     />
     <bit-hint>
       <strong>{{ "maxServiceAccountCost" | i18n }}:</strong>
-      {{ formGroup.value.serviceAccountLimit || 0 }} &times;
+      {{ formGroup.value.maxAutoscaleServiceAccounts || 0 }} &times;
       {{ options.additionalServiceAccountPrice | currency : "$" }} =
       {{ maxServiceAccountTotal | currency : "$" }} / {{ options.interval | i18n }}
     </bit-hint>

--- a/libs/common/src/billing/models/request/organization-sm-subscription-update.request.ts
+++ b/libs/common/src/billing/models/request/organization-sm-subscription-update.request.ts
@@ -18,23 +18,4 @@ export class OrganizationSmSubscriptionUpdateRequest {
    * The maximum number of additional service accounts that can be auto-scaled for the subscription.
    */
   maxAutoscaleServiceAccounts?: number;
-
-  /**
-   * Build a subscription update request for the Secrets Manager product type.
-   * @param seatAdjustment - The number of seats to add or remove from the subscription.
-   * @param serviceAccountAdjustment - The number of additional service accounts to add or remove from the subscription.
-   * @param maxAutoscaleSeats - The maximum number of seats that can be auto-scaled for the subscription.
-   * @param maxAutoscaleServiceAccounts - The maximum number of additional service accounts that can be auto-scaled for the subscription.
-   */
-  constructor(
-    seatAdjustment: number,
-    serviceAccountAdjustment: number,
-    maxAutoscaleSeats?: number,
-    maxAutoscaleServiceAccounts?: number
-  ) {
-    this.seatAdjustment = seatAdjustment;
-    this.serviceAccountAdjustment = serviceAccountAdjustment;
-    this.maxAutoscaleSeats = maxAutoscaleSeats;
-    this.maxAutoscaleServiceAccounts = maxAutoscaleServiceAccounts;
-  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix: even if max autoscale limits were disabled (using the checkbox), we were still sending the max autoscale values, which meant the form values were not being saved properly.

Goes with https://github.com/bitwarden/server/pull/3085.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* Main change is in constructing the request object - send null if the limit is disabled.
* However, I also updated the form control names to match the request object (which in turn matches the server), for better consistency in naming. Also because `seatLimit` vs. `limitSeats` was confusing.
* I also deleted the constructor for the request object in favour of manually assigning the properties, given that JS/TS does not have named parameters.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
