### PR TITLE
[AC-1488] Store Organization.SmServiceAccounts as total not additional

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -184,9 +184,9 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   get smOptions(): SecretsManagerSubscriptionOptions {
     return {
       seatCount: this.sub.smSeats,
-      seatLimit: this.sub.maxAutoscaleSmSeats,
+      maxAutoscaleSeats: this.sub.maxAutoscaleSmSeats,
       seatPrice: this.sub.secretsManagerPlan.seatPrice,
-      serviceAccountLimit: this.sub.maxAutoscaleSmServiceAccounts,
+      maxAutoscaleServiceAccounts: this.sub.maxAutoscaleSmServiceAccounts,
       serviceAccountCount: this.sub.smServiceAccounts,
       interval: this.sub.secretsManagerPlan.isAnnual ? "year" : "month",
       additionalServiceAccountPrice: this.sub.secretsManagerPlan.additionalPricePerServiceAccount,

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -187,7 +187,8 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
       maxAutoscaleSeats: this.sub.maxAutoscaleSmSeats,
       seatPrice: this.sub.secretsManagerPlan.seatPrice,
       maxAutoscaleServiceAccounts: this.sub.maxAutoscaleSmServiceAccounts,
-      serviceAccountCount: this.sub.smServiceAccounts,
+      additionalServiceAccounts:
+        this.sub.smServiceAccounts - this.sub.secretsManagerPlan.baseServiceAccount,
       interval: this.sub.secretsManagerPlan.isAnnual ? "year" : "month",
       additionalServiceAccountPrice: this.sub.secretsManagerPlan.additionalPricePerServiceAccount,
       baseServiceAccountCount: this.sub.secretsManagerPlan.baseServiceAccount,

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
@@ -37,7 +37,7 @@
     <input
       bitInput
       id="additionalServiceAccountCount"
-      formControlName="serviceAccountCount"
+      formControlName="additionalServiceAccounts"
       type="number"
       step="1"
       min="0"
@@ -51,7 +51,7 @@
       </div>
       <div>
         <strong>{{ "total" | i18n }}:</strong>
-        {{ formGroup.value.serviceAccountCount || 0 }} &times;
+        {{ formGroup.value.additionalServiceAccounts || 0 }} &times;
         {{ options.additionalServiceAccountPrice | currency : "$" }} =
         {{ serviceAccountTotal | currency : "$" }} / {{ options.interval | i18n }}
       </div>
@@ -77,7 +77,7 @@
       formControlName="maxAutoscaleServiceAccounts"
       type="number"
       step="1"
-      [min]="formGroup.value.serviceAccountCount"
+      [min]="formGroup.value.additionalServiceAccounts"
     />
     <bit-hint>
       <strong>{{ "maxServiceAccountCost" | i18n }}:</strong>

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
@@ -20,15 +20,16 @@
     <input
       bitInput
       id="smSeatLimit"
-      formControlName="seatLimit"
+      formControlName="maxAutoscaleSeats"
       type="number"
       step="1"
       [min]="formGroup.value.seatCount"
     />
     <bit-hint>
       <strong>{{ "maxSeatCost" | i18n }}:</strong>
-      {{ formGroup.value.seatLimit || 0 }} &times; {{ options.seatPrice | currency : "$" }} =
-      {{ maxSeatTotal | currency : "$" }} / {{ options.interval | i18n }}
+      {{ formGroup.value.maxAutoscaleSeats || 0 }} &times;
+      {{ options.seatPrice | currency : "$" }} = {{ maxSeatTotal | currency : "$" }} /
+      {{ options.interval | i18n }}
     </bit-hint>
   </bit-form-field>
   <bit-form-field class="tw-w-2/3">
@@ -73,14 +74,14 @@
     <input
       bitInput
       id="additionalServiceAccountLimit"
-      formControlName="serviceAccountLimit"
+      formControlName="maxAutoscaleServiceAccounts"
       type="number"
       step="1"
       [min]="formGroup.value.serviceAccountCount"
     />
     <bit-hint>
       <strong>{{ "maxServiceAccountCost" | i18n }}:</strong>
-      {{ formGroup.value.serviceAccountLimit || 0 }} &times;
+      {{ formGroup.value.maxAutoscaleServiceAccounts || 0 }} &times;
       {{ options.additionalServiceAccountPrice | currency : "$" }} =
       {{ maxServiceAccountTotal | currency : "$" }} / {{ options.interval | i18n }}
     </bit-hint>

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.ts
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.ts
@@ -33,7 +33,7 @@ export interface SecretsManagerSubscriptionOptions {
   /**
    * The current number of additional service accounts the organization subscribes to.
    */
-  serviceAccountCount: number;
+  additionalServiceAccounts: number;
 
   /**
    * Optional auto-scaling limit for the number of additional service accounts the organization can subscribe to.
@@ -61,7 +61,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
     seatCount: [0, [Validators.required, Validators.min(1)]],
     limitSeats: [false],
     maxAutoscaleSeats: [null as number | null],
-    serviceAccountCount: [0, [Validators.required, Validators.min(0)]],
+    additionalServiceAccounts: [0, [Validators.required, Validators.min(0)]],
     limitServiceAccounts: [false],
     maxAutoscaleServiceAccounts: [null as number | null],
   });
@@ -74,7 +74,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
 
   get serviceAccountTotal(): number {
     return Math.abs(
-      this.formGroup.value.serviceAccountCount * this.options.additionalServiceAccountPrice
+      this.formGroup.value.additionalServiceAccounts * this.options.additionalServiceAccountPrice
     );
   }
 
@@ -115,7 +115,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
 
       if (value.limitServiceAccounts) {
         maxAutoscaleServiceAccountsControl.setValidators([
-          Validators.min(value.serviceAccountCount),
+          Validators.min(value.additionalServiceAccounts),
         ]);
         maxAutoscaleServiceAccountsControl.enable({ emitEvent: false });
       } else {
@@ -126,7 +126,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
     this.formGroup.patchValue({
       seatCount: this.options.seatCount,
       maxAutoscaleSeats: this.options.maxAutoscaleSeats,
-      serviceAccountCount: this.options.serviceAccountCount,
+      additionalServiceAccounts: this.options.additionalServiceAccounts,
       maxAutoscaleServiceAccounts: this.options.maxAutoscaleServiceAccounts,
       limitSeats: this.options.maxAutoscaleSeats != null,
       limitServiceAccounts: this.options.maxAutoscaleServiceAccounts != null,
@@ -143,7 +143,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
     const request = new OrganizationSmSubscriptionUpdateRequest();
     request.seatAdjustment = this.formGroup.value.seatCount - this.options.seatCount;
     request.serviceAccountAdjustment =
-      this.formGroup.value.serviceAccountCount - this.options.serviceAccountCount;
+      this.formGroup.value.additionalServiceAccounts - this.options.additionalServiceAccounts;
     request.maxAutoscaleSeats = this.formGroup.value.limitSeats
       ? this.formGroup.value.maxAutoscaleSeats
       : null;

--- a/libs/common/src/billing/models/request/organization-sm-subscription-update.request.ts
+++ b/libs/common/src/billing/models/request/organization-sm-subscription-update.request.ts
@@ -18,23 +18,4 @@ export class OrganizationSmSubscriptionUpdateRequest {
    * The maximum number of additional service accounts that can be auto-scaled for the subscription.
    */
   maxAutoscaleServiceAccounts?: number;
-
-  /**
-   * Build a subscription update request for the Secrets Manager product type.
-   * @param seatAdjustment - The number of seats to add or remove from the subscription.
-   * @param serviceAccountAdjustment - The number of additional service accounts to add or remove from the subscription.
-   * @param maxAutoscaleSeats - The maximum number of seats that can be auto-scaled for the subscription.
-   * @param maxAutoscaleServiceAccounts - The maximum number of additional service accounts that can be auto-scaled for the subscription.
-   */
-  constructor(
-    seatAdjustment: number,
-    serviceAccountAdjustment: number,
-    maxAutoscaleSeats?: number,
-    maxAutoscaleServiceAccounts?: number
-  ) {
-    this.seatAdjustment = seatAdjustment;
-    this.serviceAccountAdjustment = serviceAccountAdjustment;
-    this.maxAutoscaleSeats = maxAutoscaleSeats;
-    this.maxAutoscaleServiceAccounts = maxAutoscaleServiceAccounts;
-  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
To be consistent with `Seats`, `MaxStorageGb` and `SmSeats`, `Organization.SmServiceAccounts` will include additional + base plan amount, rather than just the additional (which is how it works today).

On the client side, we just need to subtract the base amount back out of the total we receive from the server, to display the additional to the client.

Pairs with server-side changes in bitwarden/server#3086

This is branched from #5781 so that should be merged first.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
