### PR TITLE
[PM-2928] [PM-2929] [PM-2930] Fixes for: [PM-1203] Replace MP confirmation with verification code

### DIFF
--- a/apps/web/src/app/auth/settings/two-factor-verify.component.html
+++ b/apps/web/src/app/auth/settings/two-factor-verify.component.html
@@ -1,6 +1,5 @@
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate>
   <div class="modal-body">
-    <p>{{ "twoStepLoginAuthDesc" | i18n }}</p>
     <app-user-verification [(ngModel)]="secret" ngDefaultControl name="secret">
     </app-user-verification>
   </div>

--- a/apps/web/src/app/settings/account.component.ts
+++ b/apps/web/src/app/settings/account.component.ts
@@ -1,9 +1,7 @@
 import { Component, ViewChild, ViewContainerRef } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { KeyConnectorService } from "@bitwarden/common/auth/abstractions/key-connector.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 
 import { DeauthorizeSessionsComponent } from "../auth/settings/deauthorize-sessions.component";
 
@@ -26,13 +24,11 @@ export class AccountComponent {
 
   constructor(
     private modalService: ModalService,
-    private apiService: ApiService,
-    private keyConnectorService: KeyConnectorService,
-    private stateService: StateService
+    private userVerificationService: UserVerificationService
   ) {}
 
   async ngOnInit() {
-    this.showChangeEmail = !(await this.keyConnectorService.getUsesKeyConnector());
+    this.showChangeEmail = await this.userVerificationService.hasMasterPassword();
   }
 
   async deauthorizeSessions() {

--- a/apps/web/src/app/settings/security-keys.component.ts
+++ b/apps/web/src/app/settings/security-keys.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild, ViewContainerRef } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { KeyConnectorService } from "@bitwarden/common/auth/abstractions/key-connector.service";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 
 import { ApiKeyComponent } from "./api-key.component";
@@ -20,14 +20,14 @@ export class SecurityKeysComponent implements OnInit {
   showChangeKdf = true;
 
   constructor(
-    private keyConnectorService: KeyConnectorService,
+    private userVerificationService: UserVerificationService,
     private stateService: StateService,
     private modalService: ModalService,
     private apiService: ApiService
   ) {}
 
   async ngOnInit() {
-    this.showChangeKdf = !(await this.keyConnectorService.getUsesKeyConnector());
+    this.showChangeKdf = await this.userVerificationService.hasMasterPassword();
   }
 
   async viewUserApiKey() {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes for defects found by QA:

- [PM-2928 [Defect] Users without Master Passwords still see `Change Email` in the UI and are prompted for an MP](https://bitwarden.atlassian.net/browse/PM-2928)
- [PM-2929 [Defect/Missed Requirement] Change Encryption Key settings visible for users without Master Password](https://bitwarden.atlassian.net/browse/PM-2929)
- [PM-2930 [Defect] Recovery Code and 2FA related modals contain copy that references a Master Password](https://bitwarden.atlassian.net/browse/PM-2930)

## Screenshots

![image](https://github.com/bitwarden/clients/assets/2285588/659b1ad0-9b5c-47fc-8b29-cd6d0634955f)

![image](https://github.com/bitwarden/clients/assets/2285588/cb27134c-b6bc-4381-b994-e81fae8b6be9)

![image](https://github.com/bitwarden/clients/assets/2285588/5c2843dc-aa8d-49d4-b557-426079dc88f6)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
