### PR TITLE
[PM-2932] [Defect] Non-discoverable passkey is missing passkey text field in edit view (Browser)

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -132,6 +132,17 @@
               </button>
             </div>
           </div>
+
+          <!--Passkey-->
+          <div class="box" *ngIf="cipher.login.fido2Key">
+            <div class="box-content">
+              <div class="box-content-row text-muted">
+                <span class="row-label">{{ "typePasskey" | i18n }}</span>
+                {{ "passkeyTwoStepLogin" | i18n }}
+              </div>
+            </div>
+          </div>
+
           <div class="box-content-row" appBoxRow>
             <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>
             <input


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When editing a login item with a non-discoverable passkey, the passkey field does not show.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/vault/popup/components/vault/add-edit.component.html:** Added the read-only field to the add-edit component.

## Screenshots
<img width="377" alt="Screenshot 2023-07-12 at 1 59 46 PM" src="https://github.com/bitwarden/clients/assets/13024008/ecd07b3b-bf1e-4518-9370-e8bb3a4caaf1">

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
