### PR TITLE
Adding missing await to properly set region on web client

### DIFF
--- a/apps/web/src/app/core/init.service.ts
+++ b/apps/web/src/app/core/init.service.ts
@@ -45,7 +45,7 @@ export class InitService {
 
       const urls = process.env.URLS as Urls;
       urls.base ??= this.win.location.origin;
-      this.environmentService.setUrls(urls);
+      await this.environmentService.setUrls(urls);
       this.environmentService.initialized = true;
 
       setTimeout(() => this.notificationsService.init(), 3000);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/5764, we changed logic to clear environment URLs when the US or EU region is selected.  Doing so exposed another bug in the initialization of the web client.

## Code changes

- **init.ts:** Properly await the `setUrls` call

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
