### PR TITLE
[PM-2997] Disable electron devtools in release builds

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -127,6 +127,7 @@ export class WindowMain {
         nodeIntegration: true,
         backgroundThrottling: false,
         contextIsolation: false,
+        devTools: !app.isPackaged,
       },
     });
 


### PR DESCRIPTION
## Type of change

Disable electron devtools in release builds

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

In the current release desktop client, you can open the devtools by hitting F12 or ctrl+shift+I. This can be a security issue / break security guarantees the user might expect. For example, when the vault is unlocked, the export function still requires you to enter the master password in order to be able to export.

This security feature can be circumvented by entering:
`bitwardenContainerService.cryptoService.compareAndUpdateKeyHash = function(a,b) {return true}`
into the console of the dev tools. Then, the vaults contents can be exported without access to the master password.

Furthermore, encryption keys can be extracted:
`bitwardenContainerService.cryptoService.getEncKey().then(e => console.log(e))`

Disabling this "feature" makes it at least a little harder to extract secrets / make unencrypted copies of the vault. This PR disables devtools for packaged builds (release) but leaves them on in dev mode.

## Code changes

- window.main.ts: Disable dev tools, when the app is packaged.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
