### PR TITLE
[PM-267] Display importFormatError when failed to parse input

### DIFF
--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -108,7 +108,16 @@ export class ImportService implements ImportServiceAbstraction {
     fileContents: string,
     organizationId: string = null
   ): Promise<ImportResult> {
-    const importResult = await importer.parse(fileContents);
+    let importResult: ImportResult;
+    try {
+      importResult = await importer.parse(fileContents);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(this.i18nService.t("importFormatError"));
+      }
+      throw error;
+    }
+
     if (!importResult.success) {
       if (!Utils.isNullOrWhitespace(importResult.errorMessage)) {
         throw new Error(importResult.errorMessage);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On providing an invalid format (csv, xml, json) the importer should throw an error and display "Data is not formatted correctly. Please check your import file and try again."

## Code changes
- **libs/importer/src/services/import.service.ts:** Added a try-catch and on SyntaxError, throw ImportFormatError

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
