### PR TITLE
[PM-2908] [Defect] Missing account creation toast when onboarding to tde org

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2249,7 +2249,7 @@
     "message": "Request admin approval"
   },
   "approveWithMasterPassword": {
-    "message": "Approve with master password" 
+    "message": "Approve with master password"
   },
   "eu": {
     "message": "EU",
@@ -2267,5 +2267,8 @@
   },
   "display": {
     "message": "Display"
+  },
+  "accountSuccessfullyCreated": {
+    "message": "Account successfully created!"
   }
 }

--- a/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
@@ -13,6 +13,7 @@ import { TokenService } from "@bitwarden/common/auth/abstractions/token.service"
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 
@@ -36,7 +37,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
     protected apiService: ApiService,
     protected i18nService: I18nService,
     protected validationService: ValidationService,
-    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    protected platformUtilsService: PlatformUtilsService
   ) {
     super(
       formBuilder,
@@ -53,7 +55,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
       apiService,
       i18nService,
       validationService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      platformUtilsService
     );
   }
 }

--- a/apps/desktop/src/auth/login/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/desktop/src/auth/login/login-decryption-options/login-decryption-options.component.ts
@@ -13,6 +13,7 @@ import { TokenService } from "@bitwarden/common/auth/abstractions/token.service"
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 
@@ -36,7 +37,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
     protected apiService: ApiService,
     protected i18nService: I18nService,
     protected validationService: ValidationService,
-    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    protected platformUtilsService: PlatformUtilsService
   ) {
     super(
       formBuilder,
@@ -53,7 +55,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
       apiService,
       i18nService,
       validationService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      platformUtilsService
     );
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2268,7 +2268,7 @@
     "message": "Request admin approval"
   },
   "approveWithMasterPassword": {
-    "message": "Approve with master password" 
+    "message": "Approve with master password"
   },
   "region": {
     "message": "Region"
@@ -2286,6 +2286,8 @@
   },
   "accessDenied": {
     "message": "Access denied. You do not have permission to view this page."
+  },
+  "accountSuccessfullyCreated": {
+    "message": "Account successfully created!"
   }
-  
 }

--- a/apps/web/src/app/auth/login/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/web/src/app/auth/login/login-decryption-options/login-decryption-options.component.ts
@@ -13,6 +13,7 @@ import { TokenService } from "@bitwarden/common/auth/abstractions/token.service"
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 @Component({
@@ -35,7 +36,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
     protected apiService: ApiService,
     protected i18nService: I18nService,
     protected validationService: ValidationService,
-    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    protected platformUtilsService: PlatformUtilsService
   ) {
     super(
       formBuilder,
@@ -52,7 +54,8 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
       apiService,
       i18nService,
       validationService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      platformUtilsService
     );
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6993,5 +6993,8 @@
   },
   "selectedRegionFlag": {
     "message": "Selected region flag"
+  },
+  "accountSuccessfullyCreated": {
+    "message": "Account successfully created!"
   }
 }

--- a/libs/angular/src/auth/components/base-login-decryption-options.component.ts
+++ b/libs/angular/src/auth/components/base-login-decryption-options.component.ts
@@ -31,6 +31,7 @@ import { KeysRequest } from "@bitwarden/common/models/request/keys.request";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -92,7 +93,8 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
     protected apiService: ApiService,
     protected i18nService: I18nService,
     protected validationService: ValidationService,
-    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    protected deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    protected platformUtilsService: PlatformUtilsService
   ) {}
 
   async ngOnInit() {
@@ -112,6 +114,11 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
         // We are dealing with a new account if:
         //  - User does not have admin approval (i.e. has not enrolled into admin reset)
         //  - AND does not have a master password
+        this.platformUtilsService.showToast(
+          "success",
+          null,
+          this.i18nService.t("accountSuccessfullyCreated")
+        );
         this.loadNewUserData();
       } else {
         this.loadUntrustedDeviceData(accountDecryptionOptions);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add account created toast

## Screenshots

![image](https://github.com/bitwarden/clients/assets/2285588/c64d95f6-0c7d-44e1-a2ea-3c407a6e5c94)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
