### PR TITLE
[PM-2846] Added missing await on environment URL reset

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -293,7 +293,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
       }
     } else {
       // If we are setting the region to EU or US, clear the self-hosted URLs
-      this.stateService.setEnvironmentUrls(new EnvironmentUrls());
+      await this.stateService.setEnvironmentUrls(new EnvironmentUrls());
       if (region === Region.EU) {
         this.setUrlsInternal(this.euUrls);
       } else if (region === Region.US) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

There is a race condition introduced by a missing `await` when clearing the environment URLs for a non-self-hosted region.  This is causing the web client to not properly initialize its URLs when they are specified on startup (e.g. local development or self-hosted instance).

## Code changes

- **environment.service.ts:** Added missing `await`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
