### PR TITLE
[AC-1454] Migrate 2fa.directory call 

### DIFF
--- a/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
@@ -5,11 +5,11 @@ import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+// eslint-disable-next-line no-restricted-imports
+import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-
-import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
 
 // eslint-disable-next-line no-restricted-imports
 import { InactiveTwoFactorReportComponent as BaseInactiveTwoFactorReportComponent } from "../../../reports/pages/inactive-two-factor-report.component";

--- a/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
@@ -9,6 +9,8 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
+
 // eslint-disable-next-line no-restricted-imports
 import { InactiveTwoFactorReportComponent as BaseInactiveTwoFactorReportComponent } from "../../../reports/pages/inactive-two-factor-report.component";
 
@@ -25,9 +27,17 @@ export class InactiveTwoFactorReportComponent extends BaseInactiveTwoFactorRepor
     private route: ActivatedRoute,
     logService: LogService,
     passwordRepromptService: PasswordRepromptService,
-    private organizationService: OrganizationService
+    private organizationService: OrganizationService,
+    reportsApiService: ReportsApiServiceAbstraction
   ) {
-    super(cipherService, modalService, messagingService, logService, passwordRepromptService);
+    super(
+      cipherService,
+      modalService,
+      messagingService,
+      logService,
+      passwordRepromptService,
+      reportsApiService
+    );
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -4,13 +4,14 @@ import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-// eslint-disable-next-line no-restricted-imports
-import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
 
+// eslint-disable-next-line no-restricted-imports
 import { CipherReportComponent } from "./cipher-report.component";
 
 @Component({

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -120,6 +120,8 @@ import {
   PasswordStrengthService,
   PasswordStrengthServiceAbstraction,
 } from "@bitwarden/common/tools/password-strength";
+import { ReportsApiService } from "@bitwarden/common/tools/reports/reports-api.service";
+import { ReportsApiServiceAbstraction } from "@bitwarden/common/tools/reports/reports-api.service.abstraction";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service";
 import { SendApiService as SendApiServiceAbstraction } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service";
@@ -687,6 +689,11 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         AppIdServiceAbstraction,
         DevicesApiServiceAbstraction,
       ],
+    },
+    {
+      provide: ReportsApiServiceAbstraction,
+      useClass: ReportsApiService,
+      deps: [ApiServiceAbstraction],
     },
   ],
 })

--- a/libs/common/src/tools/reports/models/response/inactive-two-factor.response.ts
+++ b/libs/common/src/tools/reports/models/response/inactive-two-factor.response.ts
@@ -1,0 +1,15 @@
+import { BaseResponse } from "../../../../models/response/base.response";
+
+interface ReadonlyStringDictionaryObject {
+  readonly [key: string]: string;
+}
+
+export class InactiveTwoFactorReponse extends BaseResponse {
+  services: Map<string, string>;
+
+  constructor(response: any) {
+    super(response);
+    const servicesData: ReadonlyStringDictionaryObject = this.getResponseProperty("Services");
+    this.services = new Map(Object.entries(servicesData));
+  }
+}

--- a/libs/common/src/tools/reports/reports-api.service.abstraction.ts
+++ b/libs/common/src/tools/reports/reports-api.service.abstraction.ts
@@ -1,0 +1,5 @@
+import { InactiveTwoFactorReponse } from "./models/response/inactive-two-factor.response";
+
+export class ReportsApiServiceAbstraction {
+  getInactiveTwoFactor: () => Promise<InactiveTwoFactorReponse>;
+}

--- a/libs/common/src/tools/reports/reports-api.service.ts
+++ b/libs/common/src/tools/reports/reports-api.service.ts
@@ -1,0 +1,13 @@
+import { ApiService } from "../../abstractions/api.service";
+
+import { InactiveTwoFactorReponse } from "./models/response/inactive-two-factor.response";
+import { ReportsApiServiceAbstraction } from "./reports-api.service.abstraction";
+
+export class ReportsApiService implements ReportsApiServiceAbstraction {
+  constructor(private apiService: ApiService) {}
+
+  async getInactiveTwoFactor(): Promise<InactiveTwoFactorReponse> {
+    const r = await this.apiService.send("GET", "/reports/inactive-two-factor", null, true, true);
+    return new InactiveTwoFactorReponse(r);
+  }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> We currently call the 2fa.directory API every time a user generates the Inactive Two Factor report which isn't a very friendly approach. This PR now calls our backend instead.

## Code changes
- **.../organizations/tools/inactive-two-factor-report.component.ts**: Updated ctor to match parent class
- **inactive-two-factor-report.component.ts**: Removed old call directly to 2fa.directory API and replaced it with a call to our backend
- **jslib-services.module.ts**: Added `ReportsApiService` for service injection
- **inactive-two-factor.response.ts**: Created response object to handle `Dictionary<string,string>` object from the server. Interface enables the `Dictionary` to be directly mapped into our corresponding `Map` object.
- **reports-api.service.ts**: Created api service/abstraction in order to call our API 

## Discussion
- I created the `../reports/*` structure within `libs/common` to conform to our new standards. However, this clashes with an existing `no-restricted-imports` rule with in the `web` project.  Suggestions on best path forward?

## Before you submit
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
