### PR TITLE
[PM-3046] [PM-3047] Defects for discoverable and non-discoverable passkeys on desktop and web

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -134,7 +134,7 @@
           </div>
 
           <!--Passkey-->
-          <div class="box" *ngIf="cipher.login.fido2Key">
+          <div class="box" *ngIf="cipher.login.fido2Key && !cloneMode">
             <div class="box-content">
               <div class="box-content-row text-muted">
                 <span class="row-label">{{ "typePasskey" | i18n }}</span>

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectorRef, Component, NgZone } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { first } from "rxjs/operators";
 
-import { DialogServiceAbstraction, SimpleDialogType } from "@bitwarden/angular/services/dialog";
+import { DialogServiceAbstraction } from "@bitwarden/angular/services/dialog";
 import { ViewComponent as BaseViewComponent } from "@bitwarden/angular/vault/components/view.component";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
@@ -154,16 +154,6 @@ export class ViewComponent extends BaseViewComponent {
   }
 
   async clone() {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "passkeyNotCopied" },
-      content: { key: "passkeyNotCopiedAlert" },
-      type: SimpleDialogType.INFO,
-    });
-
-    if (!confirmed) {
-      return false;
-    }
-
     if (this.cipher.isDeleted) {
       return false;
     }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2283,5 +2283,11 @@
   },
   "passkeyTwoStepLogin": {
     "message": "Available for two-step login"
+  },
+  "passkeyNotCopied": {
+    "message": "Passkey will not be copied"
+  },
+  "passkeyNotCopiedAlert": {
+    "message": "The passkey will not be copied to the cloned item. Do you want to continue cloning this item?"
   }
 }

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -114,6 +114,12 @@
                 </button>
               </div>
             </div>
+            <!--Passkey-->
+            <div class="box-content-row text-muted" *ngIf="cipher.login.fido2Key" appBoxRow>
+              <span class="row-label">{{ "typePasskey" | i18n }}</span>
+              {{ "passkeyTwoStepLogin" | i18n }}
+            </div>
+
             <div class="box-content-row" appBoxRow>
               <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>
               <input

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -115,7 +115,11 @@
               </div>
             </div>
             <!--Passkey-->
-            <div class="box-content-row text-muted" *ngIf="cipher.login.fido2Key" appBoxRow>
+            <div
+              class="box-content-row text-muted"
+              *ngIf="cipher.login.fido2Key && !cloneMode"
+              appBoxRow
+            >
               <span class="row-label">{{ "typePasskey" | i18n }}</span>
               {{ "passkeyTwoStepLogin" | i18n }}
             </div>

--- a/apps/desktop/src/vault/app/vault/view.component.html
+++ b/apps/desktop/src/vault/app/vault/view.component.html
@@ -119,11 +119,9 @@
             </div>
           </div>
           <!--Passkey-->
-          <div class="box-content" *ngIf="cipher.login.fido2Key">
-            <div class="box-content-row text-muted">
-              <span class="row-label">{{ "typePasskey" | i18n }}</span>
-              {{ "passkeyTwoStepLogin" | i18n }}
-            </div>
+          <div class="box-content-row text-muted" *ngIf="cipher.login.fido2Key">
+            <span class="row-label">{{ "typePasskey" | i18n }}</span>
+            {{ "passkeyTwoStepLogin" | i18n }}
           </div>
           <div
             class="box-content-row box-content-row-flex totp"
@@ -607,7 +605,7 @@
   <button
     type="button"
     class="primary"
-    *ngIf="!cipher?.organizationId && !cipher.isDeleted"
+    *ngIf="!cipher?.organizationId && !cipher.isDeleted && !cipher.fido2Key?.rpId"
     (click)="clone()"
     appA11yTitle="{{ 'clone' | i18n }}"
   >

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -168,7 +168,7 @@ export class VaultItemsComponent {
     return (
       ((vaultItem.cipher.organizationId && this.cloneableOrganizationCiphers) ||
         vaultItem.cipher.organizationId == null) &&
-      vaultItem.cipher.fido2Key == null
+      !vaultItem.cipher.fido2Key?.rpId
     );
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -641,14 +641,16 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async cloneCipher(cipher: CipherView) {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "passkeyNotCopied" },
-      content: { key: "passkeyNotCopiedAlert" },
-      type: SimpleDialogType.INFO,
-    });
+    if (cipher.login?.fido2Key) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "passkeyNotCopied" },
+        content: { key: "passkeyNotCopiedAlert" },
+        type: SimpleDialogType.INFO,
+      });
 
-    if (!confirmed) {
-      return false;
+      if (!confirmed) {
+        return false;
+      }
     }
 
     const component = await this.editCipher(cipher);

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -641,6 +641,16 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async cloneCipher(cipher: CipherView) {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "passkeyNotCopied" },
+      content: { key: "passkeyNotCopiedAlert" },
+      type: SimpleDialogType.INFO,
+    });
+
+    if (!confirmed) {
+      return false;
+    }
+
     const component = await this.editCipher(cipher);
     component.cloneMode = true;
   }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6859,5 +6859,11 @@
   },
   "passkeyTwoStepLogin": {
     "message": "Available for two-step login"
+  },
+  "passkeyNotCopied": {
+    "message": "Passkey will not be copied"
+  },
+  "passkeyNotCopiedAlert": {
+    "message": "The passkey will not be copied to the cloned item. Do you want to continue cloning this item?"
   }
 }

--- a/libs/angular/src/components/share.component.ts
+++ b/libs/angular/src/components/share.component.ts
@@ -144,7 +144,8 @@ export class ShareComponent implements OnInit, OnDestroy {
       //Determine if Fido2Key object is disvoverable or non discoverable
       const newFido2Key = cipher.login?.fido2Key || cipher.fido2Key;
 
-      const exisitingOrgCiphers = await this.cipherService.getAllFromApiForOrganization(orgId);
+      const ciphers = await this.cipherService.getAllDecrypted();
+      const exisitingOrgCiphers = ciphers.filter((c) => c.organizationId === orgId);
 
       return exisitingOrgCiphers.some((c) => {
         const existingFido2key = c.login?.fido2Key || c.fido2Key;
@@ -152,8 +153,7 @@ export class ShareComponent implements OnInit, OnDestroy {
         return (
           !c.isDeleted &&
           existingFido2key.rpId === newFido2Key.rpId &&
-          existingFido2key.userHandle === newFido2Key.userHandle &&
-          existingFido2key.nonDiscoverableId === newFido2Key.nonDiscoverableId
+          existingFido2key.userHandle === newFido2Key.userHandle
         );
       });
     }

--- a/libs/angular/src/vault/components/icon.component.ts
+++ b/libs/angular/src/vault/components/icon.component.ts
@@ -70,33 +70,34 @@ export class IconComponent implements OnInit {
 
         switch (cipher.type) {
           case CipherType.Login:
-            icon = "bwi-globe";
+          case CipherType.Fido2Key: {
+            icon = cipher.type === CipherType.Login ? "bwi-globe" : "bwi-passkey";
 
-            if (cipher.login.uri) {
-              let hostnameUri = cipher.login.uri;
-              let isWebsite = false;
+            let uri =
+              cipher.type === CipherType.Login ? cipher.login.uri : cipher.fido2Key.launchUri;
+            let isWebsite = false;
 
-              if (hostnameUri.indexOf("androidapp://") === 0) {
+            if (uri) {
+              if (uri.indexOf("androidapp://") === 0) {
                 icon = "bwi-android";
                 image = null;
-              } else if (hostnameUri.indexOf("iosapp://") === 0) {
+              } else if (uri.indexOf("iosapp://") === 0) {
                 icon = "bwi-apple";
                 image = null;
-              } else if (
-                imageEnabled &&
-                hostnameUri.indexOf("://") === -1 &&
-                hostnameUri.indexOf(".") > -1
-              ) {
-                hostnameUri = "http://" + hostnameUri;
+              } else if (imageEnabled && uri.indexOf("://") === -1 && uri.indexOf(".") > -1) {
+                uri = "http://" + uri;
                 isWebsite = true;
               } else if (imageEnabled) {
-                isWebsite = hostnameUri.indexOf("http") === 0 && hostnameUri.indexOf(".") > -1;
+                isWebsite = uri.indexOf("http") === 0 && uri.indexOf(".") > -1;
               }
 
               if (imageEnabled && isWebsite) {
                 try {
-                  image = iconsUrl + "/" + Utils.getHostname(hostnameUri) + "/icon.png";
-                  fallbackImage = "images/bwi-globe.png";
+                  image = iconsUrl + "/" + Utils.getHostname(uri) + "/icon.png";
+                  fallbackImage =
+                    cipher.type === CipherType.Login
+                      ? "images/bwi-globe.png"
+                      : "images/bwi-passkey";
                 } catch (e) {
                   // Ignore error since the fallback icon will be shown if image is null.
                 }
@@ -105,6 +106,7 @@ export class IconComponent implements OnInit {
               image = null;
             }
             break;
+          }
           case CipherType.SecureNote:
             icon = "bwi-sticky-note";
             break;
@@ -116,9 +118,6 @@ export class IconComponent implements OnInit {
             break;
           case CipherType.Identity:
             icon = "bwi-id-card";
-            break;
-          case CipherType.Fido2Key:
-            icon = "bwi-passkey";
             break;
           default:
             break;

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -156,14 +156,16 @@ export class ViewComponent implements OnDestroy, OnInit {
   }
 
   async clone() {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "passkeyNotCopied" },
-      content: { key: "passkeyNotCopiedAlert" },
-      type: SimpleDialogType.INFO,
-    });
+    if (this.cipher.login?.fido2Key) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "passkeyNotCopied" },
+        content: { key: "passkeyNotCopiedAlert" },
+        type: SimpleDialogType.INFO,
+      });
 
-    if (!confirmed) {
-      return false;
+      if (!confirmed) {
+        return false;
+      }
     }
 
     if (await this.promptPassword()) {

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -156,6 +156,16 @@ export class ViewComponent implements OnDestroy, OnInit {
   }
 
   async clone() {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "passkeyNotCopied" },
+      content: { key: "passkeyNotCopiedAlert" },
+      type: SimpleDialogType.INFO,
+    });
+
+    if (!confirmed) {
+      return false;
+    }
+
     if (await this.promptPassword()) {
       this.onCloneCipher.emit(this.cipher);
       return true;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

**For Non-discoverable passkey:** 

- The passkey field is missing when editing an item.
- There's no dialog warning when cloning a non-discoverable passkey (web and desktop).

**For Discoverable passkey:** 

- The clone button should not be an option on the footer of the vault item view (desktop).

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/vault/popup/components/vault/view.component.tst:** Moved dialog to the base class to be shared by browser and desktop.
- **apps/desktop/src/vault/app/vault/add-edit.component.html:** Added passkey view to during edit for non-discoverable passkey.

Also, I added a check to prevent dialog popups on ciphers without non-discoverable passkey.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
<img width="958" alt="Screenshot 2023-07-17 at 3 16 37 PM" src="https://github.com/bitwarden/clients/assets/13024008/fa8b6fea-49b2-4ea0-a990-0203de5a033a">
<img width="963" alt="Screenshot 2023-07-17 at 3 17 25 PM" src="https://github.com/bitwarden/clients/assets/13024008/14ebc533-d788-4393-a572-22e63d02c1c8">
<img width="668" alt="Screenshot 2023-07-17 at 3 32 08 PM" src="https://github.com/bitwarden/clients/assets/13024008/86a0c680-54e6-44b4-9aae-b465f3e1a358">
<img width="452" alt="Screenshot 2023-07-17 at 3 32 24 PM" src="https://github.com/bitwarden/clients/assets/13024008/1a228335-27bd-4741-a820-3579f0e6a9c5">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
