### PR TITLE
[AC-1531] Fix SM subscribe component not showing in free org billing tab

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -62,7 +62,7 @@
     </ng-container>
   </dl>
   <ng-container *ngIf="userOrg.canEditSubscription">
-    <div class="tw-mb-7 tw-flex-col">
+    <div class="tw-flex-col">
       <strong class="tw-block tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300">{{
         "details" | i18n
       }}</strong>
@@ -98,29 +98,33 @@
   </ng-container>
 
   <ng-container *ngIf="userOrg.canEditSubscription">
-    <button
-      bitButton
-      buttonType="secondary"
-      type="button"
-      (click)="changePlan()"
-      *ngIf="showChangePlanButton"
-    >
-      {{ "changeBillingPlan" | i18n }}
-    </button>
-    <app-change-plan
-      [organizationId]="organizationId"
-      (onChanged)="closeChangePlan()"
-      (onCanceled)="closeChangePlan()"
-      *ngIf="showChangePlan"
-    ></app-change-plan>
+    <div class="tw-mt-7">
+      <button
+        bitButton
+        buttonType="secondary"
+        type="button"
+        (click)="changePlan()"
+        *ngIf="showChangePlanButton"
+      >
+        {{ "changeBillingPlan" | i18n }}
+      </button>
+      <app-change-plan
+        [organizationId]="organizationId"
+        (onChanged)="closeChangePlan()"
+        (onCanceled)="closeChangePlan()"
+        *ngIf="showChangePlan"
+      ></app-change-plan>
+    </div>
   </ng-container>
 
   <ng-container *ngIf="showSecretsManagerSubscribe">
-    <sm-subscribe-standalone
-      [plan]="sub.secretsManagerPlan"
-      [organization]="userOrg"
-      (onSubscribe)="subscriptionAdjusted()"
-    ></sm-subscribe-standalone>
+    <div class="tw-mt-7">
+      <sm-subscribe-standalone
+        [plan]="sub.secretsManagerPlan"
+        [organization]="userOrg"
+        (onSubscribe)="subscriptionAdjusted()"
+      ></sm-subscribe-standalone>
+    </div>
   </ng-container>
 
   <ng-container *ngIf="userOrg.canEditSubscription">

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -114,8 +114,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     this.showSecretsManagerSubscribe =
       this.userOrg.canEditSubscription &&
       !this.userOrg.useSecretsManager &&
-      this.subscription != null &&
-      !this.subscription.cancelled &&
+      !this.subscription?.cancelled &&
       !this.subscriptionMarkedForCancel;
 
     this.showAdjustSecretsManager =

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
@@ -30,8 +30,12 @@ export class SecretsManagerSubscribeStandaloneComponent {
 
   submit = async () => {
     const request = new SecretsManagerSubscribeRequest();
-    request.additionalSmSeats = this.formGroup.value.userSeats;
-    request.additionalServiceAccounts = this.formGroup.value.additionalServiceAccounts;
+    request.additionalSmSeats = this.plan.hasAdditionalSeatsOption
+      ? this.formGroup.value.userSeats
+      : 0;
+    request.additionalServiceAccounts = this.plan.hasAdditionalServiceAccountOption
+      ? this.formGroup.value.additionalServiceAccounts
+      : 0;
 
     await this.organizationApiService.subscribeToSecretsManager(this.organization.id, request);
 

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
@@ -44,25 +44,27 @@
       <bit-hint *ngIf="upgradeOrganization">{{ "addSecretsManagerUpgradeDesc" | i18n }}</bit-hint>
     </bit-form-control>
 
-    <div *ngIf="formGroup.value.enabled && selectedPlan.hasAdditionalSeatsOption" class="tw-w-1/2">
-      <bit-form-field>
-        <bit-label>{{ "userSeats" | i18n }}</bit-label>
-        <input bitInput formControlName="userSeats" type="number" />
-        <bit-hint>{{ "userSeatsHowManyDesc" | i18n }}</bit-hint>
-      </bit-form-field>
+    <ng-container *ngIf="formGroup.value.enabled">
+      <div *ngIf="selectedPlan.hasAdditionalSeatsOption" class="tw-w-1/2">
+        <bit-form-field>
+          <bit-label>{{ "userSeats" | i18n }}</bit-label>
+          <input bitInput formControlName="userSeats" type="number" />
+          <bit-hint>{{ "userSeatsHowManyDesc" | i18n }}</bit-hint>
+        </bit-form-field>
 
-      <bit-form-field>
-        <bit-label>{{ "additionalServiceAccounts" | i18n }}</bit-label>
-        <input bitInput formControlName="additionalServiceAccounts" type="number" />
-        <bit-hint>{{
-          "additionalServiceAccountsDesc"
-            | i18n : serviceAccountsIncluded : (monthlyCostPerServiceAccount | currency : "$")
-        }}</bit-hint>
-      </bit-form-field>
+        <bit-form-field>
+          <bit-label>{{ "additionalServiceAccounts" | i18n }}</bit-label>
+          <input bitInput formControlName="additionalServiceAccounts" type="number" />
+          <bit-hint>{{
+            "additionalServiceAccountsDesc"
+              | i18n : serviceAccountsIncluded : (monthlyCostPerServiceAccount | currency : "$")
+          }}</bit-hint>
+        </bit-form-field>
+      </div>
 
       <button *ngIf="showSubmitButton" type="submit" bitButton buttonType="primary" bitFormButton>
         {{ "save" | i18n }}
       </button>
-    </div>
+    </ng-container>
   </div>
 </div>

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
@@ -51,7 +51,8 @@
           <input bitInput formControlName="userSeats" type="number" />
           <bit-hint>{{ "userSeatsHowManyDesc" | i18n }}</bit-hint>
         </bit-form-field>
-
+      </div>
+      <div *ngIf="selectedPlan.hasAdditionalServiceAccountOption" class="tw-w-1/2">
         <bit-form-field>
           <bit-label>{{ "additionalServiceAccounts" | i18n }}</bit-label>
           <input bitInput formControlName="additionalServiceAccounts" type="number" />


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the SM subscribe component not appearing in the billing tab for free orgs.

Requires https://github.com/bitwarden/server/pull/3114.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**organization-subscription-cloud**
* free orgs do not have a `sub.subscription` object, because that comes from Stripe, and free orgs don't have a Stripe record. Remove that null check in the `showSecretsManagerSubscribe` boolean logic.
* fix up spacing between components

**sm-subscribe**
* fix bug where the Save button was not shown for free orgs
* send zero values for free orgs, it was previously sending the default values (i.e. 1 additional seat) and then throwing an error because a free org cannot buy additional seats

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Free org:
<img width="774" alt="Screenshot 2023-07-18 at 9 23 48 am" src="https://github.com/bitwarden/clients/assets/31796059/72a1e5fa-e5e4-450c-a444-b26c680d8a1c">

Paid org (proof of no regression on layout):
<img width="774" alt="Screenshot 2023-07-18 at 9 23 36 am" src="https://github.com/bitwarden/clients/assets/31796059/8bb41719-c615-491c-a5ea-4d059ba09270">



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
