### PR TITLE
[AC-1542] Update manage password reset label

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -246,7 +246,7 @@
                       (change)="handleDependentPermissions()"
                     />
                     <label class="!tw-font-normal" for="manageResetPassword">
-                      {{ "manageResetPassword" | i18n }}
+                      {{ "manageAccountRecovery" | i18n }}
                     </label>
                   </div>
                 </div>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4375,8 +4375,8 @@
   "manageUsers": {
     "message": "Manage users"
   },
-  "manageResetPassword": {
-    "message": "Manage password reset"
+  "manageAccountRecovery": {
+    "message": "Manage account recovery"
   },
   "disableRequiredError": {
     "message": "You must manually turn the $POLICYNAME$ policy before this policy can be turned off.",


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Leftover from previous verbiage changes, update remaining `password reset` to `account recovery` within the custom permission list

## Code changes
- **messages.json:** Removed old message and replaced with `manageAccountRecovery`
- **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html**: Updated reference to new message

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
