### PR TITLE
[PM-2596] Bitwarden logo on notification bar should point to vault domain for the user's region

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -5,6 +5,7 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { ThemeType } from "@bitwarden/common/enums";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
@@ -30,7 +31,8 @@ export default class NotificationBackground {
     private authService: AuthService,
     private policyService: PolicyService,
     private folderService: FolderService,
-    private stateService: BrowserStateService
+    private stateService: BrowserStateService,
+    private environmentService: EnvironmentService
   ) {}
 
   async init() {
@@ -167,6 +169,7 @@ export default class NotificationBackground {
             isVaultLocked: this.notificationQueue[i].wasVaultLocked,
             theme: await this.getCurrentTheme(),
             removeIndividualVault: await this.removeIndividualVault(),
+            webVaultURL: await this.environmentService.getWebVaultUrl(),
           },
         });
       } else if (this.notificationQueue[i].type === NotificationQueueMessageType.ChangePassword) {
@@ -175,6 +178,7 @@ export default class NotificationBackground {
           typeData: {
             isVaultLocked: this.notificationQueue[i].wasVaultLocked,
             theme: await this.getCurrentTheme(),
+            webVaultURL: await this.environmentService.getWebVaultUrl(),
           },
         });
       }

--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -834,6 +834,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
       isVaultLocked: typeData.isVaultLocked,
       theme: typeData.theme,
       removeIndividualVault: typeData.removeIndividualVault,
+      webVaultURL: typeData.webVaultURL,
     };
     const barQueryString = new URLSearchParams(barQueryParams).toString();
     const barPage = "notification/bar.html?" + barQueryString;

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -30,7 +30,16 @@ function load() {
     notificationChangeDesc: chrome.i18n.getMessage("notificationChangeDesc"),
   };
 
-  document.getElementById("logo-link").title = i18n.appName;
+  const logoLink = document.getElementById("logo-link") as HTMLAnchorElement;
+  logoLink.title = i18n.appName;
+
+  // Update logo link to user's regional domain
+  const webVaultURL = getQueryVariable("webVaultURL");
+  const newVaultURL = webVaultURL && decodeURIComponent(webVaultURL);
+
+  if (newVaultURL && newVaultURL !== logoLink.href) {
+    logoLink.href = newVaultURL;
+  }
 
   // i18n for "Add" template
   const addTemplate = document.getElementById("template-add") as HTMLTemplateElement;

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -570,7 +570,8 @@ export default class MainBackground {
       this.authService,
       this.policyService,
       this.folderService,
-      this.stateService
+      this.stateService,
+      this.environmentService
     );
 
     this.tabsBackground = new TabsBackground(this, this.notificationBackground);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [x] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

The link for the Bitwarden logo on the browser extension notification bar always points to `vault.bitwarden.com`. EU users need it to point to the EU domain (`vault.bitwarden.eu`).

## Code changes

The user's `region` setting is now passed to the nav bar's iframe url query string, where it is retrieved and used to conditionally update the icon anchor `href` as needed.