### PR TITLE
[PM-2597] Do not show the notification banner on the configured bitwarden vault domain

### DIFF
--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -26,10 +26,64 @@ interface HTMLElementWithFormOpId extends HTMLElement {
  * and async scripts to finish loading.
  * https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
  */
-document.addEventListener("DOMContentLoaded", (event) => {
-  // Do not show the notification bar on the Bitwarden vault
-  // because they can add logins and change passwords there
-  if (window.location.hostname.startsWith("vault.bitwarden")) {
+document.addEventListener("DOMContentLoaded", async (event) => {
+  // These are preferences for whether to show the notification bar based on the user's settings
+  // and they are set in the Settings > Options page in the browser extension.
+  let disabledAddLoginNotification = false;
+  let disabledChangedPasswordNotification = false;
+  let showNotificationBar = true;
+
+  // Look up the active user id from storage
+  const activeUserIdKey = "activeUserId";
+  let activeUserId: string;
+  await chrome.storage.local.get(activeUserIdKey, (obj: any) => {
+    if (obj == null || obj[activeUserIdKey] == null) {
+      return;
+    }
+    activeUserId = obj[activeUserIdKey];
+  });
+
+  // Look up the user's settings from storage
+  await chrome.storage.local.get(activeUserId, (obj: any) => {
+    if (obj?.[activeUserId] == null) {
+      return;
+    }
+
+    const userSettings = obj[activeUserId].settings;
+
+    // Do not show the notification bar on the Bitwarden vault
+    // because they can add logins and change passwords there
+    if (window.location.origin === userSettings.serverConfig.environment.vault) {
+      showNotificationBar = false;
+
+      return;
+    }
+
+    // NeverDomains is a dictionary of domains that the user has chosen to never
+    // show the notification bar on (for login detail collection or password change).
+    // It is managed in the Settings > Excluded Domains page in the browser extension.
+    // Example: '{"bitwarden.com":null}'
+    const excludedDomainsDict = userSettings.neverDomains;
+
+    if (
+      excludedDomainsDict != null &&
+      // eslint-disable-next-line
+      excludedDomainsDict.hasOwnProperty(window.location.hostname)
+    ) {
+      return;
+    }
+
+    // Set local disabled preferences
+    disabledAddLoginNotification = userSettings.disableAddLoginNotification;
+    disabledChangedPasswordNotification = userSettings.disableChangedPasswordNotification;
+
+    if (!disabledAddLoginNotification || !disabledChangedPasswordNotification) {
+      // If the user has not disabled both notifications, then handle the initial page change (null -> actual page)
+      handlePageChange();
+    }
+  });
+
+  if (!showNotificationBar) {
     return;
   }
 
@@ -76,53 +130,6 @@ document.addEventListener("DOMContentLoaded", (event) => {
     "save",
   ]);
   const changePasswordButtonContainsNames = new Set(["pass", "change", "contras", "senha"]);
-
-  // These are preferences for whether to show the notification bar based on the user's settings
-  // and they are set in the Settings > Options page in the browser extension.
-  let disabledAddLoginNotification = false;
-  let disabledChangedPasswordNotification = false;
-
-  // Look up the active user id from storage
-  const activeUserIdKey = "activeUserId";
-  let activeUserId: string;
-  chrome.storage.local.get(activeUserIdKey, (obj: any) => {
-    if (obj == null || obj[activeUserIdKey] == null) {
-      return;
-    }
-    activeUserId = obj[activeUserIdKey];
-  });
-
-  // Look up the user's settings from storage
-  chrome.storage.local.get(activeUserId, (obj: any) => {
-    if (obj?.[activeUserId] == null) {
-      return;
-    }
-
-    const userSettings = obj[activeUserId].settings;
-
-    // NeverDomains is a dictionary of domains that the user has chosen to never
-    // show the notification bar on (for login detail collection or password change).
-    // It is managed in the Settings > Excluded Domains page in the browser extension.
-    // Example: '{"bitwarden.com":null}'
-    const excludedDomainsDict = userSettings.neverDomains;
-
-    if (
-      excludedDomainsDict != null &&
-      // eslint-disable-next-line
-      excludedDomainsDict.hasOwnProperty(window.location.hostname)
-    ) {
-      return;
-    }
-
-    // Set local disabled preferences
-    disabledAddLoginNotification = userSettings.disableAddLoginNotification;
-    disabledChangedPasswordNotification = userSettings.disableChangedPasswordNotification;
-
-    if (!disabledAddLoginNotification || !disabledChangedPasswordNotification) {
-      // If the user has not disabled both notifications, then handle the initial page change (null -> actual page)
-      handlePageChange();
-    }
-  });
 
   // Message Processing
 

--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -29,7 +29,7 @@ interface HTMLElementWithFormOpId extends HTMLElement {
 document.addEventListener("DOMContentLoaded", (event) => {
   // Do not show the notification bar on the Bitwarden vault
   // because they can add logins and change passwords there
-  if (window.location.hostname.endsWith("vault.bitwarden.com")) {
+  if (window.location.hostname.startsWith("vault.bitwarden")) {
     return;
   }
 

--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -3,6 +3,7 @@ import ChangePasswordRuntimeMessage from "../../background/models/changePassword
 import AutofillField from "../models/autofill-field";
 import { WatchedForm } from "../models/watched-form";
 import { FormData } from "../services/abstractions/autofill.service";
+import { UserSettings } from "../types";
 
 interface HTMLElementWithFormOpId extends HTMLElement {
   formOpId: string;
@@ -49,7 +50,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
       return;
     }
 
-    const userSettings = obj[activeUserId].settings;
+    const userSettings: UserSettings = obj[activeUserId].settings;
 
     // Do not show the notification bar on the Bitwarden vault
     // because they can add logins and change passwords there

--- a/apps/browser/src/autofill/types/index.ts
+++ b/apps/browser/src/autofill/types/index.ts
@@ -1,0 +1,41 @@
+import { Region } from "@bitwarden/common/platform/abstractions/environment.service";
+import { VaultTimeoutAction } from "@bitwarden/common/src/enums/vault-timeout-action.enum";
+
+export type UserSettings = {
+  avatarColor: string | null;
+  environmentUrls: {
+    api: string | null;
+    base: string | null;
+    events: string | null;
+    icons: string | null;
+    identity: string | null;
+    keyConnector: string | null;
+    notifications: string | null;
+    webVault: string | null;
+  };
+  pinProtected: { [key: string]: any };
+  region: Region;
+  serverConfig: {
+    environment: {
+      api: string | null;
+      cloudRegion: string | null;
+      identity: string | null;
+      notifications: string | null;
+      sso: string | null;
+      vault: string | null;
+    };
+    featureStates: { [key: string]: any };
+    gitHash: string;
+    server: { [key: string]: any };
+    utcDate: string;
+    version: string;
+  };
+  settings: {
+    equivalentDomains: string[][];
+  };
+  neverDomains?: { [key: string]: any };
+  disableAddLoginNotification?: boolean;
+  disableChangedPasswordNotification?: boolean;
+  vaultTimeout: number;
+  vaultTimeoutAction: VaultTimeoutAction;
+};


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [x] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Do not display the bitwarden banner on web vault domains (e.g. `vault.bitwarden.eu`)

## Assumptions

- Users will not want to see the Bitwarden banner to add their vault login credentials to the same vault they've just logged into, since it serves no practical purpose. Removing the banner in these cases serves as a Quality of Life improvement.
- There is some small risk that the banner enables a haphazard workflow whereby a user could potentially lock themselves out of their vault by, in haste, misunderstanding a banner action.

## Code changes

~The code early return (that would otherwise display the banner) no longer matches the end of the location hostname against `vault.bitwarden.com` but now matches the start of the location hostname against `vault.bitwarden` (ignores TLD)~

User settings are loaded earlier and the check to determine if the banner should display now does a direct comparison of the window location origin against the configured vault domain in the extension.