### PR TITLE
[PM-3093],[PM-3094] Org Members with User Role Cannot Move Item with Passkey to Organization

### DIFF
--- a/libs/angular/src/components/share.component.ts
+++ b/libs/angular/src/components/share.component.ts
@@ -144,7 +144,8 @@ export class ShareComponent implements OnInit, OnDestroy {
       //Determine if Fido2Key object is disvoverable or non discoverable
       const newFido2Key = cipher.login?.fido2Key || cipher.fido2Key;
 
-      const exisitingOrgCiphers = await this.cipherService.getAllFromApiForOrganization(orgId);
+      const ciphers = await this.cipherService.getAllDecrypted();
+      const exisitingOrgCiphers = ciphers.filter((c) => c.organizationId === orgId);
 
       return exisitingOrgCiphers.some((c) => {
         const existingFido2key = c.login?.fido2Key || c.fido2Key;
@@ -152,8 +153,7 @@ export class ShareComponent implements OnInit, OnDestroy {
         return (
           !c.isDeleted &&
           existingFido2key.rpId === newFido2Key.rpId &&
-          existingFido2key.userHandle === newFido2Key.userHandle &&
-          existingFido2key.nonDiscoverableId === newFido2Key.nonDiscoverableId
+          existingFido2key.userHandle === newFido2Key.userHandle
         );
       });
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Org members with user role cannot move Items with a passkey to the organization, and users can move non-Discoverable/Discoverable Passkey to the org if the opposite type exists in the org vault.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/angular/src/components/share.component.ts:** `cipherService.getAllFromApiForOrganization` required the user role to have some rights to get all ciphers from an org, used `cipherService.getAllDecrypted` instead since there is no rights restriction and all that is needed is getting ciphers of an organization. Also, prevented the movement of Discoverable/Discoverable Passkey to org if the opposite type exists in the org vault by removing the extra condition to check if a cipher has a `nonDiscoverableId`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
