### PR TITLE
[PM-3148] Passkey Field Always Shows on Login Items

### DIFF
--- a/apps/web/src/app/vault/individual-vault/add-edit.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.html
@@ -191,24 +191,25 @@
               </button>
             </div>
           </div>
-          <ng-container *ngIf="cipher.login.fido2Key"></ng-container>
-          <div class="row">
-            <div class="col-6 form-group">
-              <label for="loginFido2key">{{ "typePasskey" | i18n }}</label>
-              <div class="input-group">
-                <input
-                  id="loginFido2key"
-                  class="form-control"
-                  type="text"
-                  name="Login.Fido2key"
-                  [value]="'passkeyTwoStepLogin' | i18n"
-                  appInputVerbatim
-                  disabled
-                  readonly
-                />
+          <ng-container *ngIf="cipher.login.fido2Key">
+            <div class="row">
+              <div class="col-6 form-group">
+                <label for="loginFido2key">{{ "typePasskey" | i18n }}</label>
+                <div class="input-group">
+                  <input
+                    id="loginFido2key"
+                    class="form-control"
+                    type="text"
+                    name="Login.Fido2key"
+                    [value]="'passkeyTwoStepLogin' | i18n"
+                    appInputVerbatim
+                    disabled
+                    readonly
+                  />
+                </div>
               </div>
             </div>
-          </div>
+          </ng-container>
           <div class="tw-flex tw-flex-row">
             <div class="tw-mb-4 tw-w-1/2">
               <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Login items on Web are always showing the Passkey field even when the item does not have a non-discoverable passkey on it.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes
The bug might have appeared during merge. The two-step passkey view was outside the `ngIf` conditional.
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
