### PR TITLE
[Defect] In Chromium-based Browser Extensions, Establishing trust after authentication

### DIFF
--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -26,7 +26,7 @@ import { Utils } from "../../misc/utils";
 import { ServerConfigData } from "../../models/data/server-config.data";
 
 import { EncryptedString, EncString } from "./enc-string";
-import { DeviceKey, MasterKey, SymmetricCryptoKey, UserKey } from "./symmetric-crypto-key";
+import { MasterKey, SymmetricCryptoKey, UserKey } from "./symmetric-crypto-key";
 
 export class EncryptionPair<TEncrypted, TDecrypted> {
   encrypted?: TEncrypted;
@@ -107,7 +107,7 @@ export class AccountKeys {
   userKeyMasterKey?: string;
   userKeyAuto?: string;
   userKeyBiometric?: string;
-  deviceKey?: DeviceKey;
+  deviceKey?: ReturnType<SymmetricCryptoKey["toJSON"]>;
   organizationKeys?: EncryptionPair<
     { [orgId: string]: EncryptedOrganizationKeyData },
     Record<string, SymmetricCryptoKey>
@@ -149,7 +149,7 @@ export class AccountKeys {
     return Object.assign(new AccountKeys(), {
       userKey: SymmetricCryptoKey.fromJSON(obj?.userKey),
       masterKey: SymmetricCryptoKey.fromJSON(obj?.masterKey),
-      deviceKey: SymmetricCryptoKey.fromJSON(obj?.deviceKey),
+      deviceKey: obj?.deviceKey,
       cryptoMasterKey: SymmetricCryptoKey.fromJSON(obj?.cryptoMasterKey),
       cryptoSymmetricKey: EncryptionPair.fromJSON(
         obj?.cryptoSymmetricKey,

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1321,7 +1321,7 @@ export class StateService<
 
     const account = await this.getAccount(options);
 
-    account.keys.deviceKey = value;
+    account.keys.deviceKey = value.toJSON();
 
     await this.saveAccount(account, options);
   }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Trust wasn't being properly established on chrome-based browsers.

## Code changes

- **state.service.ts** Properly serialize key before saving it
- **account.ts** Change type to match the serialized version of the key

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
