### PR TITLE
[AC-1458] Update local organization data after subscribing to Secrets Manager

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -9,7 +9,7 @@ import { SettingsService as SettingsServiceAbstraction } from "@bitwarden/common
 import { TotpService as TotpServiceAbstraction } from "@bitwarden/common/abstractions/totp.service";
 import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "@bitwarden/common/abstractions/vaultTimeout/vaultTimeout.service";
 import { VaultTimeoutSettingsService as VaultTimeoutSettingsServiceAbstraction } from "@bitwarden/common/abstractions/vaultTimeout/vaultTimeoutSettings.service";
-import { InternalOrganizationService as InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { InternalPolicyService as InternalPolicyServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService as ProviderServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider.service";

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
-import { InternalOrganizationService as InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { OrganizationData } from "@bitwarden/common/admin-console/models/data/organization.data";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { SecretsManagerSubscribeRequest } from "@bitwarden/common/billing/models/request/sm-subscribe.request";
@@ -40,14 +40,12 @@ export class SecretsManagerSubscribeStandaloneComponent {
       this.organization.id,
       request
     );
+    const organizationData = new OrganizationData(profileOrganization, {
+      isMember: this.organization.isMember,
+      isProviderUser: this.organization.isProviderUser,
+    });
+    await this.organizationService.upsert(organizationData);
 
-    if (profileOrganization != null) {
-      const organizationData = new OrganizationData(profileOrganization, {
-        isMember: this.organization.isMember,
-        isProviderUser: this.organization.isProviderUser,
-      });
-      await this.organizationService.upsert(organizationData);
-    }
     this.platformUtilsService.showToast("success", null, this.i18nService.t("subscriptionUpdated"));
 
     this.onSubscribe.emit();

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe-standalone.component.ts
@@ -2,6 +2,8 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
+import { InternalOrganizationService as InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationData } from "@bitwarden/common/admin-console/models/data/organization.data";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { SecretsManagerSubscribeRequest } from "@bitwarden/common/billing/models/request/sm-subscribe.request";
 import { PlanResponse } from "@bitwarden/common/billing/models/response/plan.response";
@@ -25,7 +27,8 @@ export class SecretsManagerSubscribeStandaloneComponent {
     private formBuilder: FormBuilder,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
-    private organizationApiService: OrganizationApiServiceAbstraction
+    private organizationApiService: OrganizationApiServiceAbstraction,
+    private organizationService: InternalOrganizationServiceAbstraction
   ) {}
 
   submit = async () => {
@@ -33,8 +36,18 @@ export class SecretsManagerSubscribeStandaloneComponent {
     request.additionalSmSeats = this.formGroup.value.userSeats;
     request.additionalServiceAccounts = this.formGroup.value.additionalServiceAccounts;
 
-    await this.organizationApiService.subscribeToSecretsManager(this.organization.id, request);
+    const profileOrganization = await this.organizationApiService.subscribeToSecretsManager(
+      this.organization.id,
+      request
+    );
 
+    if (profileOrganization != null) {
+      const organizationData = new OrganizationData(profileOrganization, {
+        isMember: this.organization.isMember,
+        isProviderUser: this.organization.isProviderUser,
+      });
+      await this.organizationService.upsert(organizationData);
+    }
     this.platformUtilsService.showToast("success", null, this.i18nService.t("subscriptionUpdated"));
 
     this.onSubscribe.emit();

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -22,7 +22,7 @@ import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "@bitwarde
 import { VaultTimeoutSettingsService as VaultTimeoutSettingsServiceAbstraction } from "@bitwarden/common/abstractions/vaultTimeout/vaultTimeoutSettings.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import {
-  InternalOrganizationService,
+  InternalOrganizationServiceAbstraction,
   OrganizationService as OrganizationServiceAbstraction,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
@@ -583,7 +583,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
       deps: [StateServiceAbstraction],
     },
     {
-      provide: InternalOrganizationService,
+      provide: InternalOrganizationServiceAbstraction,
       useExisting: OrganizationServiceAbstraction,
     },
     {

--- a/libs/common/src/admin-console/abstractions/organization/organization-api.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization-api.service.abstraction.ts
@@ -26,6 +26,7 @@ import { OrganizationApiKeyInformationResponse } from "../../models/response/org
 import { OrganizationAutoEnrollStatusResponse } from "../../models/response/organization-auto-enroll-status.response";
 import { OrganizationKeysResponse } from "../../models/response/organization-keys.response";
 import { OrganizationResponse } from "../../models/response/organization.response";
+import { ProfileOrganizationResponse } from "../../models/response/profile-organization.response";
 
 export class OrganizationApiServiceAbstraction {
   get: (id: string) => Promise<OrganizationResponse>;
@@ -68,5 +69,8 @@ export class OrganizationApiServiceAbstraction {
   getSso: (id: string) => Promise<OrganizationSsoResponse>;
   updateSso: (id: string, request: OrganizationSsoRequest) => Promise<OrganizationSsoResponse>;
   selfHostedSyncLicense: (id: string) => Promise<void>;
-  subscribeToSecretsManager: (id: string, request: SecretsManagerSubscribeRequest) => Promise<void>;
+  subscribeToSecretsManager: (
+    id: string,
+    request: SecretsManagerSubscribeRequest
+  ) => Promise<ProfileOrganizationResponse>;
 }

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -87,4 +87,5 @@ export abstract class OrganizationService {
 
 export abstract class InternalOrganizationService extends OrganizationService {
   replace: (organizations: { [id: string]: OrganizationData }) => Promise<void>;
+  upsert: (OrganizationData: OrganizationData | OrganizationData[]) => Promise<void>;
 }

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -85,7 +85,7 @@ export abstract class OrganizationService {
   hasOrganizations: () => boolean;
 }
 
-export abstract class InternalOrganizationService extends OrganizationService {
+export abstract class InternalOrganizationServiceAbstraction extends OrganizationService {
   replace: (organizations: { [id: string]: OrganizationData }) => Promise<void>;
   upsert: (OrganizationData: OrganizationData | OrganizationData[]) => Promise<void>;
 }

--- a/libs/common/src/admin-console/services/organization/organization-api.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization-api.service.ts
@@ -29,6 +29,7 @@ import { OrganizationApiKeyInformationResponse } from "../../models/response/org
 import { OrganizationAutoEnrollStatusResponse } from "../../models/response/organization-auto-enroll-status.response";
 import { OrganizationKeysResponse } from "../../models/response/organization-keys.response";
 import { OrganizationResponse } from "../../models/response/organization.response";
+import { ProfileOrganizationResponse } from "../../models/response/profile-organization.response";
 
 export class OrganizationApiService implements OrganizationApiServiceAbstraction {
   constructor(private apiService: ApiService, private syncService: SyncService) {}
@@ -311,13 +312,14 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
   async subscribeToSecretsManager(
     id: string,
     request: SecretsManagerSubscribeRequest
-  ): Promise<void> {
-    return await this.apiService.send(
+  ): Promise<ProfileOrganizationResponse> {
+    const r = await this.apiService.send(
       "POST",
       "/organizations/" + id + "/subscribe-secrets-manager",
       request,
       true,
-      false
+      true
     );
+    return new ProfileOrganizationResponse(r);
   }
 }

--- a/libs/common/src/admin-console/services/organization/organization.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization.service.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject, concatMap, map, Observable } from "rxjs";
 
 import { StateService } from "../../../platform/abstractions/state.service";
 import {
-  InternalOrganizationService as InternalOrganizationServiceAbstraction,
+  InternalOrganizationServiceAbstraction,
   isMember,
 } from "../../abstractions/organization/organization.service.abstraction";
 import { OrganizationData } from "../../models/data/organization.data";

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -1,6 +1,6 @@
 import { ApiService } from "../../../abstractions/api.service";
 import { SettingsService } from "../../../abstractions/settings.service";
-import { InternalOrganizationService } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
+import { InternalOrganizationServiceAbstraction } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
 import { InternalPolicyService } from "../../../admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "../../../admin-console/abstractions/provider.service";
 import { OrganizationData } from "../../../admin-console/models/data/organization.data";
@@ -55,7 +55,7 @@ export class SyncService implements SyncServiceAbstraction {
     private stateService: StateService,
     private providerService: ProviderService,
     private folderApiService: FolderApiServiceAbstraction,
-    private organizationService: InternalOrganizationService,
+    private organizationService: InternalOrganizationServiceAbstraction,
     private sendApiService: SendApiService,
     private logoutCallback: (expired: boolean) => Promise<void>
   ) {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Updating the organization in clients using the `ProfileOrganizationResponseModel` return from Server `subscribe-secrets-manager`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **secrets-manager/sm-subscribe-standalone.component.ts:** Return the response from Server `subscribe-secrets-manager` and call upsert in organizationService
- **abstractions/organization/organization-api.service.abstraction.ts:** Modify the interface to return `ProfileOrganizationResponseModel` for `subscribeToSecretsManager` method
- **admin-console/services/organization/organization-api.service.ts:** Modify the implementation to return `ProfileOrganizationResponseModel` for `subscribeToSecretsManager` method
## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
