### PR TITLE
Added missing localization for trial initiation.

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6959,6 +6959,9 @@
   "selectedRegionFlag": {
     "message": "Selected region flag"
   },
+  "inviteUsers": {
+    "message": "Invite Users"
+  },
   "secretsManagerForPlan": {
     "message": "Secrets Manager for $PLAN$",
     "placeholders": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/5546, we added the environment selector for trial initiation.  During this, we added i18n for the "Invite Users" button but forgot to add the "inviteUsers" phrase to the `messages.json`.

## Code changes


- **message.json:** Added missing phrase.

## Screenshots

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
