### PR TITLE
[PM-3168] Fix trial initiation "Invite Users" link

### DIFF
--- a/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
+++ b/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
@@ -51,7 +51,7 @@ describe("TrialInitiationComponent", () => {
             component: BlankComponent,
           },
           {
-            path: `organizations/${testOrgId}/manage/members`,
+            path: `organizations/${testOrgId}/members`,
             component: BlankComponent,
           },
         ]),
@@ -301,7 +301,7 @@ describe("TrialInitiationComponent", () => {
     describe("navigateToOrgVault", () => {
       it("should call verticalStepper.previous()", fakeAsync(() => {
         component.navigateToOrgInvite();
-        expect(routerSpy).toHaveBeenCalledWith(["organizations", testOrgId, "manage", "members"]);
+        expect(routerSpy).toHaveBeenCalledWith(["organizations", testOrgId, "members"]);
       }));
     });
   });

--- a/apps/web/src/app/auth/trial-initiation/trial-initiation.component.ts
+++ b/apps/web/src/app/auth/trial-initiation/trial-initiation.component.ts
@@ -227,7 +227,7 @@ export class TrialInitiationComponent implements OnInit, OnDestroy {
   }
 
   navigateToOrgInvite() {
-    this.router.navigate(["organizations", this.orgId, "manage", "members"]);
+    this.router.navigate(["organizations", this.orgId, "members"]);
   }
 
   previousStep() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The path for an organization member maintenance is `/organizations/{id}/members`.  It was previously `/organizations/{id}/manage/members`.  When this URL changed, it broke the trial initiation component that navigated to that link when the user clicks "Invite Users.

## Code changes

- **trial-initiation.component.ts:** Changed routing.
- **trial-intiation.component.spec.ts:** Adjusted test to reflect changed route.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
