### PR TITLE
[AC-1562] Added region custom field to PayPal add credits

### DIFF
--- a/apps/web/src/app/billing/settings/add-credit.component.ts
+++ b/apps/web/src/app/billing/settings/add-credit.component.ts
@@ -43,6 +43,7 @@ export class AddCreditComponent implements OnInit {
   private userId: string;
   private name: string;
   private email: string;
+  private region: string;
 
   constructor(
     private stateService: StateService,
@@ -76,7 +77,9 @@ export class AddCreditComponent implements OnInit {
       this.email = this.subject;
       this.ppButtonCustomField = "user_id:" + this.userId;
     }
+    this.region = await this.stateService.getRegion();
     this.ppButtonCustomField += ",account_credit:1";
+    this.ppButtonCustomField += `,region:${this.region}`;
     this.returnUrl = window.location.href;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Recent work was finished for the mothership where we added the custom field `region` to PayPal objects so that the mothership could route traffic to the appropriate PayPal IPN endpoint. Everything worked as expected, with the exception of adding credits under the payment method page. When adding credits, we found that the server-side logic was bypassed entirely, and instead, the user was redirected to PayPal where they could add their credits, then they would be redirected back to Bitwarden. This pull request resolved this issue where the `region` custom field isn't being set by the server by getting the user's region setting on the client side, and adding that as a custom field to Paypal.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **add-credit.component.ts:** Adding the user's region as an additional custom field when adding account credits

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
