### PR TITLE
[PM-3061] Fix Upgrade CLI Not Finding `UserKey`

### DIFF
--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -183,9 +183,17 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     if (!userKey) {
-      const userKeyMasterKey = await this.stateService.getUserKeyMasterKey({
+      let userKeyMasterKey = await this.stateService.getUserKeyMasterKey({
         userId: userId,
       });
+
+      // Try one more way to get the user key if it still wasn't found.
+      if (userKeyMasterKey == null) {
+        userKeyMasterKey = await this.stateService.getEncryptedCryptoSymmetricKey({
+          userId: userId,
+        });
+      }
+
       if (userKeyMasterKey == null) {
         throw new Error("No encrypted user key found.");
       }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
A CLI that is trying to unlock after upgrade to `tde-key-model-migration` will not have a `UserKey` yet but will have an encrypted crypto symmetric key which is just it's legacy location/name. I made it so that all calls to this method that don't already supply an encrypted user key will be able to fallback to trying to get it from there if the new location does not have it.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/platform/services/crypto.service.ts:** Checks the legacy location for it it has what is now called the `UserKey` that has been encrypted with the `MasterKey`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
