### PR TITLE
[AC-1537] Update trusted devices radio button label

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6828,8 +6828,8 @@
   "updateKdfSettings": {
     "message": "Update KDF settings"
   },
-  "trustedDeviceEncryption": {
-    "message": "Trusted device encryption"
+  "trustedDevices": {
+    "message": "Trusted devices"
   },
   "memberDecryptionTdeDescriptionPartOne": {
     "message": "Once authenticated, members will decrypt vault data using a key stored on their device. The",

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
@@ -78,7 +78,7 @@
         *ngIf="showTdeOptions"
       >
         <bit-label>
-          {{ "trustedDeviceEncryption" | i18n }}
+          {{ "trustedDevices" | i18n }}
         </bit-label>
         <bit-hint>
           {{ "memberDecryptionTdeDescriptionPartOne" | i18n }}


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Update the radio button label from `Trusted device encryption` to `Trusted devices`

## Code changes
- **messages.json**: Updated string key for Crowdin localization changes and changed message to `Trusted devices`
- **../auth/sso/sso.component.html**: Updated string reference

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
