### PR TITLE
[PM-3210] "View all login options" incorrectly navigates to /login

### DIFF
--- a/apps/browser/src/auth/popup/login-with-device.component.html
+++ b/apps/browser/src/auth/popup/login-with-device.component.html
@@ -30,7 +30,7 @@
 
         <div class="footer">
           {{ "loginWithDeviceEnabledInfo" | i18n }}
-          <a routerLink="/login">{{ "viewAllLoginOptions" | i18n }}</a>
+          <a href="#" (click)="back()">{{ "viewAllLoginOptions" | i18n }}</a>
         </div>
       </div>
     </ng-container>

--- a/apps/browser/src/auth/popup/login-with-device.component.ts
+++ b/apps/browser/src/auth/popup/login-with-device.component.ts
@@ -1,3 +1,4 @@
+import { Location } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 
@@ -46,7 +47,8 @@ export class LoginWithDeviceComponent
     loginService: LoginService,
     syncService: SyncService,
     deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
-    authReqCryptoService: AuthRequestCryptoServiceAbstraction
+    authReqCryptoService: AuthRequestCryptoServiceAbstraction,
+    private location: Location
   ) {
     super(
       router,
@@ -70,5 +72,9 @@ export class LoginWithDeviceComponent
     super.onSuccessfulLogin = async () => {
       await syncService.fullSync(true);
     };
+  }
+
+  protected back() {
+    this.location.back();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`LoginWithDeviceComponent` is used for both TDE and non-TDE device login, which means that we cannot have a hardcoded route. This fix uses location.back for a very simple fix :)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
