### PR TITLE
[PM-3253] Add shortcut to autofill selected field with a generated password

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -91,6 +91,9 @@
   "autoFill": {
     "message": "Auto-fill"
   },
+  "commandAutofillGeneratePasswordDesc": {
+    "message": "Generate a new password and auto-fill the current field"
+  },
   "generatePasswordCopied": {
     "message": "Generate password (copied)"
   },

--- a/apps/browser/src/autofill/background/service_factories/autofill-service.factory.ts
+++ b/apps/browser/src/autofill/background/service_factories/autofill-service.factory.ts
@@ -11,6 +11,10 @@ import {
   eventCollectionServiceFactory,
 } from "../../../background/service-factories/event-collection-service.factory";
 import {
+  passwordGenerationServiceFactory,
+  PasswordGenerationServiceInitOptions,
+} from "../../../background/service-factories/password-generation-service.factory";
+import {
   settingsServiceFactory,
   SettingsServiceInitOptions,
 } from "../../../background/service-factories/settings-service.factory";
@@ -43,7 +47,8 @@ export type AutoFillServiceInitOptions = AutoFillServiceOptions &
   EventCollectionServiceInitOptions &
   LogServiceInitOptions &
   SettingsServiceInitOptions &
-  UserVerificationServiceInitOptions;
+  UserVerificationServiceInitOptions &
+  PasswordGenerationServiceInitOptions;
 
 export function autofillServiceFactory(
   cache: { autofillService?: AbstractAutoFillService } & CachedServices,
@@ -61,7 +66,8 @@ export function autofillServiceFactory(
         await eventCollectionServiceFactory(cache, opts),
         await logServiceFactory(cache, opts),
         await settingsServiceFactory(cache, opts),
-        await userVerificationServiceFactory(cache, opts)
+        await userVerificationServiceFactory(cache, opts),
+        await passwordGenerationServiceFactory(cache, opts)
       )
   );
 }

--- a/apps/browser/src/autofill/commands/autofill-tab-command.ts
+++ b/apps/browser/src/autofill/commands/autofill-tab-command.ts
@@ -50,6 +50,21 @@ export class AutofillTabCommand {
     });
   }
 
+  async doAutoFillGeneratePassword(tab: chrome.tabs.Tab) {
+    if (!tab.id) {
+      throw new Error("Tab does not have an id, cannot complete autofill.");
+    }
+
+    const details = await this.collectPageDetails(tab.id);
+    await this.autofillService.doAutoFillGeneratePassword([
+      {
+        frameId: 0,
+        tab: tab,
+        details: details,
+      },
+    ]);
+  }
+
   private async collectPageDetails(tabId: number): Promise<AutofillPageDetails> {
     return new Promise((resolve, reject) => {
       chrome.tabs.sendMessage(

--- a/apps/browser/src/autofill/content/autofill.js
+++ b/apps/browser/src/autofill/content/autofill.js
@@ -323,6 +323,7 @@
               // START MODIFICATION
               var elTagName = el.tagName.toLowerCase();
               addProp(field, 'tagName', elTagName);
+              addProp(field, 'inFocus', el === theView.document.activeElement);
 
               if (elTagName === 'span') {
                   return field;

--- a/apps/browser/src/autofill/content/autofillv2.ts
+++ b/apps/browser/src/autofill/content/autofillv2.ts
@@ -365,6 +365,7 @@ function collect(document: Document) {
         // START MODIFICATION
         var elTagName = el.tagName.toLowerCase();
         addProp(field, "tagName", elTagName);
+        addProp(field, "inFocus", el === theView.document.activeElement);
 
         if (elTagName === "span") {
           return field;

--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -40,4 +40,5 @@ export abstract class AutofillService {
     fromCommand: boolean
   ) => Promise<string>;
   doAutoFillActiveTab: (pageDetails: PageDetail[], fromCommand: boolean) => Promise<string>;
+  doAutoFillGeneratePassword: (pageDetails: PageDetail[]) => void;
 }

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -309,6 +309,7 @@ export default class AutofillService implements AutofillServiceInterface {
       },
       { frameId: activeTabPageDetail.frameId }
     );
+    this.passwordGenerationService.addHistory(password);
   }
 
   /**

--- a/apps/browser/src/background/commands.background.ts
+++ b/apps/browser/src/background/commands.background.ts
@@ -52,6 +52,9 @@ export default class CommandsBackground {
       case "autofill_login":
         await this.autoFillLogin(sender ? sender.tab : null);
         break;
+      case "autofill_generate_password":
+        await this.autoFillGeneratePassword(sender ? sender.tab : null);
+        break;
       case "open_popup":
         await this.openPopup();
         break;
@@ -98,6 +101,18 @@ export default class CommandsBackground {
     }
 
     await this.main.collectPageDetailsForContentScript(tab, "autofill_cmd");
+  }
+
+  private async autoFillGeneratePassword(tab?: chrome.tabs.Tab) {
+    if (!tab) {
+      tab = await BrowserApi.getTabFromCurrentWindowId();
+    }
+
+    if (tab == null) {
+      return;
+    }
+
+    await this.main.collectPageDetailsForContentScript(tab, "autofill_generate_password_cmd");
   }
 
   private async openPopup() {

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -518,7 +518,8 @@ export default class MainBackground {
       this.eventCollectionService,
       this.logService,
       this.settingsService,
-      this.userVerificationService
+      this.userVerificationService,
+      this.passwordGenerationService
     );
     this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
     this.exportService = new VaultExportService(

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -176,6 +176,15 @@ export default class RuntimeBackground {
             });
             this.autofillTimeout = setTimeout(async () => await this.autofillPage(msg.tab), 300);
             break;
+          case "autofill_generate_password_cmd":
+            await this.autofillService.doAutoFillGeneratePassword([
+              {
+                frameId: sender.frameId,
+                tab: msg.tab,
+                details: msg.details,
+              },
+            ]);
+            break;
           default:
             break;
         }

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -93,6 +93,9 @@
       },
       "description": "__MSG_commandGeneratePasswordDesc__"
     },
+    "autofill_generate_password": {
+      "description": "__MSG_commandAutofillGeneratePasswordDesc__"
+    },
     "lock_vault": {
       "description": "__MSG_commandLockVaultDesc__"
     }

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -100,6 +100,9 @@
       },
       "description": "__MSG_commandGeneratePasswordDesc__"
     },
+    "autofill_generate_password": {
+      "description": "__MSG_commandAutofillGeneratePasswordDesc__"
+    },
     "lock_vault": {
       "description": "__MSG_commandLockVaultDesc__"
     }

--- a/apps/browser/src/platform/listeners/on-command-listener.ts
+++ b/apps/browser/src/platform/listeners/on-command-listener.ts
@@ -24,6 +24,8 @@ export const onCommandListener = async (command: string, tab: chrome.tabs.Tab) =
     case "generate_password":
       await doGeneratePasswordToClipboard(tab);
       break;
+    case "autofill_generate_password":
+      await doAutoFillGeneratePassword(tab);
   }
 };
 
@@ -107,4 +109,43 @@ const doGeneratePasswordToClipboard = async (tab: chrome.tabs.Tab): Promise<void
     await stateServiceFactory(cache, options)
   );
   command.generatePasswordToClipboard(tab);
+};
+
+const doAutoFillGeneratePassword = async (tab: chrome.tabs.Tab): Promise<void> => {
+  const cachedServices: CachedServices = {};
+  const opts = {
+    cryptoFunctionServiceOptions: {
+      win: self,
+    },
+    encryptServiceOptions: {
+      logMacFailures: true,
+    },
+    logServiceOptions: {
+      isDev: false,
+    },
+    platformUtilsServiceOptions: {
+      clipboardWriteCallback: () => Promise.resolve(),
+      biometricCallback: () => Promise.resolve(false),
+      win: self,
+    },
+    stateServiceOptions: {
+      stateFactory: new StateFactory(GlobalState, Account),
+    },
+    stateMigrationServiceOptions: {
+      stateFactory: new StateFactory(GlobalState, Account),
+    },
+    apiServiceOptions: {
+      logoutCallback: () => Promise.resolve(),
+    },
+    keyConnectorServiceOptions: {
+      logoutCallback: () => Promise.resolve(),
+    },
+    i18nServiceOptions: {
+      systemLanguage: BrowserApi.getUILanguage(self),
+    },
+  };
+  const autofillService = await autofillServiceFactory(cachedServices, opts);
+
+  const command = new AutofillTabCommand(autofillService);
+  await command.doAutoFillGeneratePassword(tab);
 };


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add a shortcut to autofill selected field with a generated password
So now a user can select any field in the website and use the given shortcut to fill the field with a random generated password

## Code changes

- **apps/browser/src/autofill/background/service_factories/autofill-service.factory.ts**: Add passwordGenerationServiceFactory to autofill service factory
- **apps/browser/src/autofill/content/autofill.js**: Add `inFocus` property to fields to page details for getting the focused field
- **apps/browser/src/autofill/services/autofill.service.ts**: Add the new method for autofilling the focused field with a generated password
- **apps/browser/src/background/commands.background.ts**: Add a new command `autofill_generate_password` to autofill the focused field with a generated password
- **apps/browser/src/manifest.json**: Add shortcut for autofilling the focused field with a generated password

## Video Description
https://github.com/bitwarden/clients/assets/35865870/74cdd883-9e06-4c35-b680-06f74e088ef4

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
