### PR TITLE
[AC-1567] Fix max additional service account cost estimate

### DIFF
--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
@@ -5,7 +5,7 @@
     <bit-hint>
       <strong>{{ "total" | i18n }}:</strong>
       {{ formGroup.value.seatCount || 0 }} &times; {{ options.seatPrice | currency : "$" }} =
-      {{ seatTotal | currency : "$" }} / {{ options.interval | i18n }}
+      {{ seatTotalCost | currency : "$" }} / {{ options.interval | i18n }}
     </bit-hint>
   </bit-form-field>
   <bit-form-control>
@@ -28,7 +28,7 @@
     <bit-hint>
       <strong>{{ "maxSeatCost" | i18n }}:</strong>
       {{ formGroup.value.maxAutoscaleSeats || 0 }} &times;
-      {{ options.seatPrice | currency : "$" }} = {{ maxSeatTotal | currency : "$" }} /
+      {{ options.seatPrice | currency : "$" }} = {{ maxSeatTotalCost | currency : "$" }} /
       {{ options.interval | i18n }}
     </bit-hint>
   </bit-form-field>
@@ -44,16 +44,16 @@
     />
     <bit-hint>
       <div>
+        {{ "includedServiceAccounts" | i18n : options.baseServiceAccountCount }}
         {{
-          "additionalServiceAccountsDesc"
-            | i18n : options.baseServiceAccountCount : (monthlyServiceAccountPrice | currency : "$")
+          "addAdditionalServiceAccountDesc" | i18n : (monthlyServiceAccountPrice | currency : "$")
         }}
       </div>
       <div>
         <strong>{{ "total" | i18n }}:</strong>
         {{ formGroup.value.additionalServiceAccounts || 0 }} &times;
         {{ options.additionalServiceAccountPrice | currency : "$" }} =
-        {{ serviceAccountTotal | currency : "$" }} / {{ options.interval | i18n }}
+        {{ serviceAccountTotalCost | currency : "$" }} / {{ options.interval | i18n }}
       </div>
     </bit-hint>
   </bit-form-field>
@@ -80,10 +80,13 @@
       [min]="formGroup.value.additionalServiceAccounts"
     />
     <bit-hint>
+      <div>
+        {{ "includedServiceAccounts" | i18n : options.baseServiceAccountCount }}
+      </div>
       <strong>{{ "maxServiceAccountCost" | i18n }}:</strong>
-      {{ formGroup.value.maxAutoscaleServiceAccounts || 0 }} &times;
+      {{ maxAdditionalServiceAccounts }} &times;
       {{ options.additionalServiceAccountPrice | currency : "$" }} =
-      {{ maxServiceAccountTotal | currency : "$" }} / {{ options.interval | i18n }}
+      {{ maxServiceAccountTotalCost | currency : "$" }} / {{ options.interval | i18n }}
     </bit-hint>
   </bit-form-field>
   <button type="submit" bitButton buttonType="primary" bitFormButton>

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.html
@@ -45,9 +45,7 @@
     <bit-hint>
       <div>
         {{ "includedServiceAccounts" | i18n : options.baseServiceAccountCount }}
-        {{
-          "addAdditionalServiceAccountDesc" | i18n : (monthlyServiceAccountPrice | currency : "$")
-        }}
+        {{ "addAdditionalServiceAccounts" | i18n : (monthlyServiceAccountPrice | currency : "$") }}
       </div>
       <div>
         <strong>{{ "total" | i18n }}:</strong>

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.ts
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-adjust-subscription.component.ts
@@ -72,24 +72,26 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
       : this.options.additionalServiceAccountPrice / 12;
   }
 
-  get serviceAccountTotal(): number {
+  get serviceAccountTotalCost(): number {
     return Math.abs(
       this.formGroup.value.additionalServiceAccounts * this.options.additionalServiceAccountPrice
     );
   }
 
-  get seatTotal(): number {
+  get seatTotalCost(): number {
     return Math.abs(this.formGroup.value.seatCount * this.options.seatPrice);
   }
 
-  get maxServiceAccountTotal(): number {
-    return Math.abs(
-      (this.formGroup.value.maxAutoscaleServiceAccounts ?? 0) *
-        this.options.additionalServiceAccountPrice
-    );
+  get maxAdditionalServiceAccounts(): number {
+    const maxTotalServiceAccounts = this.formGroup.value.maxAutoscaleServiceAccounts ?? 0;
+    return Math.max(0, maxTotalServiceAccounts - this.options.baseServiceAccountCount);
   }
 
-  get maxSeatTotal(): number {
+  get maxServiceAccountTotalCost(): number {
+    return this.maxAdditionalServiceAccounts * this.options.additionalServiceAccountPrice;
+  }
+
+  get maxSeatTotalCost(): number {
     return Math.abs((this.formGroup.value.maxAutoscaleSeats ?? 0) * this.options.seatPrice);
   }
 

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
@@ -56,10 +56,13 @@
         <bit-form-field>
           <bit-label>{{ "additionalServiceAccounts" | i18n }}</bit-label>
           <input bitInput formControlName="additionalServiceAccounts" type="number" />
-          <bit-hint>{{
-            "additionalServiceAccountsDesc"
-              | i18n : serviceAccountsIncluded : (monthlyCostPerServiceAccount | currency : "$")
-          }}</bit-hint>
+          <bit-hint>
+            {{ "includedServiceAccounts" | i18n : serviceAccountsIncluded }}
+            {{
+              "addAdditionalServiceAccountDesc"
+                | i18n : (monthlyCostPerServiceAccount | currency : "$")
+            }}
+          </bit-hint>
         </bit-form-field>
       </div>
 

--- a/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
+++ b/apps/web/src/app/billing/organizations/secrets-manager/sm-subscribe.component.html
@@ -59,7 +59,7 @@
           <bit-hint>
             {{ "includedServiceAccounts" | i18n : serviceAccountsIncluded }}
             {{
-              "addAdditionalServiceAccountDesc"
+              "addAdditionalServiceAccounts"
                 | i18n : (monthlyCostPerServiceAccount | currency : "$")
             }}
           </bit-hint>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7016,15 +7016,20 @@
   "additionalServiceAccounts": {
     "message": "Additional service accounts"
   },
-  "additionalServiceAccountsDesc": {
-    "message": "Your plan comes with $COUNT$ service accounts. You can add additional service accounts for $COST$ per month.",
+  "includedServiceAccounts": {
+    "message": "Your plan comes with $COUNT$ service accounts.",
     "placeholders": {
       "count": {
         "content": "$1",
         "example": "50"
-      },
+      }
+    }
+  },
+  "addAdditionalServiceAccountDesc": {
+    "message": "You can add additional service accounts for $COST$ per month.",
+    "placeholders": {
       "cost": {
-        "content": "$2",
+        "content": "$1",
         "example": "$0.50"
       }
     }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7025,7 +7025,7 @@
       }
     }
   },
-  "addAdditionalServiceAccountDesc": {
+  "addAdditionalServiceAccounts": {
     "message": "You can add additional service accounts for $COST$ per month.",
     "placeholders": {
       "cost": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix a bug where the max service account cost estimate included the free service accounts included in the plan.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- rename current getters to include the word `Cost`, to make it clear they're calculating money and not seats/service accounts themselves
- fix the calculation for potential max service account cost
- I also noticed that the "Your plan comes with X service accounts." should be repeated below this input (per the Figma). Split the current string for `additionalServiceAccountsDesc` so that we can reuse the first sentence. Update current places it's used to use the 2 new strings instead of the 1 old one.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Adjust subscription component, showing the additional hint text and correct calculation:
![Screenshot 2023-07-31 at 9 04 01 am](https://github.com/bitwarden/clients/assets/31796059/f978c89f-553b-4d3d-9cb7-32ebe3767f03)

Subscribe component, showing no regression on the hint text:
![Screenshot 2023-07-31 at 9 20 12 am](https://github.com/bitwarden/clients/assets/31796059/76162c0e-594a-4ac3-8145-da728c4cc4ad)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
