### PR TITLE
SM-646-SidebarRendering

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
@@ -1,6 +1,6 @@
 <div class="tw-flex tw-w-full">
   <nav
-    class="tw-fixed tw-left-0 tw-top-0 tw-max-h-screen tw-min-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
+    class="tw-fixed tw-inset-y-0 tw-left-0 tw-max-h-screen tw-min-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
   >
     <router-outlet name="sidebar"></router-outlet>
   </nav>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html
@@ -1,6 +1,6 @@
 <div class="tw-flex tw-w-full">
   <nav
-    class="tw-fixed tw-max-h-screen tw-min-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
+    class="tw-fixed tw-left-0 tw-top-0 tw-max-h-screen tw-min-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
   >
     <router-outlet name="sidebar"></router-outlet>
   </nav>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.stories.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.stories.ts
@@ -1,6 +1,12 @@
 import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { Meta, Story, applicationConfig, moduleMetadata } from "@storybook/angular";
+import {
+  Meta,
+  Story,
+  applicationConfig,
+  componentWrapperDecorator,
+  moduleMetadata,
+} from "@storybook/angular";
 import { BehaviorSubject } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -27,6 +33,13 @@ export default {
   title: "Web/Layout",
   component: LayoutComponent,
   decorators: [
+    componentWrapperDecorator(
+      /**
+       * Applying a CSS transform prevents a `position: fixed` element from overflowing its container
+       * https://github.com/storybookjs/storybook/issues/8011#issue-490251969
+       */
+      (story) => `<div class="tw-scale-100">${story}</div>`
+    ),
     moduleMetadata({
       imports: [RouterModule, LayoutModule, IconModule],
       declarations: [StoryContentComponent],

--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.stories.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.stories.ts
@@ -35,7 +35,7 @@ export default {
   decorators: [
     componentWrapperDecorator(
       /**
-       * Applying a CSS transform prevents a `position: fixed` element from overflowing its container
+       * Applying a CSS transform makes a `position: fixed` element act like it is `position: relative`
        * https://github.com/storybookjs/storybook/issues/8011#issue-490251969
        */
       (story) => `<div class="tw-scale-100">${story}</div>`


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ x ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When opening a list item after scrolling down on the page the sidebar doesn't render full height. We wanted to fix this.
## Code changes

**bitwarden_license/bit-web/src/app/secrets-manager/layout/layout.component.html:** Added tw-top-0 and tw-left-0, these should have been set originally in order to tell it where to position the sidebar properly.

- **file.ext:** Description of what was changed and why

## Screenshots

![image](https://github.com/bitwarden/clients/assets/106776772/e1840a32-5b78-4169-ab0b-f73ead9e3ad1)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
