### PR TITLE
[PM-3215] Create MasterKey from Password If Needed

### DIFF
--- a/apps/web/src/app/auth/settings/change-password.component.ts
+++ b/apps/web/src/app/auth/settings/change-password.component.ts
@@ -190,10 +190,24 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
     newMasterKey: MasterKey,
     newUserKey: [UserKey, EncString]
   ) {
+    // This is a recreation of what is done in user-verification.service since
+    // TDE accounts might have a master password but they could have logged in
+    // through a trusted device so we have never set a master key for them
+    // into state.
+    let masterKey = await this.cryptoService.getMasterKey();
+    if (!masterKey) {
+      masterKey = await this.cryptoService.makeMasterKey(
+        this.currentMasterPassword,
+        await this.stateService.getEmail(),
+        await this.stateService.getKdfType(),
+        await this.stateService.getKdfConfig()
+      );
+    }
+
     const request = new PasswordRequest();
     request.masterPasswordHash = await this.cryptoService.hashMasterKey(
       this.currentMasterPassword,
-      null
+      masterKey
     );
     request.masterPasswordHint = this.masterPasswordHint;
     request.newMasterPasswordHash = newMasterPasswordHash;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
After you have trusted your device with your master password the next time you log out and log back in you will have never set a `MasterKey`. But since you do have a master password available we show you the change password component. This changes it so that we match the logic down in user-verification.service that we look in state for it first and then create it from the password if we didn't. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/auth/settings/change-password.component.ts:** Search state for `MasterKey` first and if it's not there recreate it from the current password we have.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
