### PR TITLE
[PM-3284] Fix argon2 simd loading for desktop clients

### DIFF
--- a/apps/desktop/webpack.renderer.js
+++ b/apps/desktop/webpack.renderer.js
@@ -40,11 +40,6 @@ const common = {
         },
         type: "asset/resource",
       },
-      {
-        test: /\.wasm$/,
-        loader: "base64-loader",
-        type: "javascript/auto",
-      },
     ],
   },
   plugins: [],

--- a/patches/argon2-browser+1.18.0.patch
+++ b/patches/argon2-browser+1.18.0.patch
@@ -1,8 +1,18 @@
 diff --git a/node_modules/argon2-browser/lib/argon2.js b/node_modules/argon2-browser/lib/argon2.js
-index ffa77a5..98b2f13 100644
+index ffa77a5..36b914d 100644
 --- a/node_modules/argon2-browser/lib/argon2.js
 +++ b/node_modules/argon2-browser/lib/argon2.js
-@@ -78,16 +78,27 @@
+@@ -29,7 +29,8 @@
+         if (
+             global.process &&
+             global.process.versions &&
+-            global.process.versions.node
++            global.process.versions.node &&
++            !process.versions['electron']
+         ) {
+             promise = loadWasmModule().then(
+                 (Module) =>
+@@ -78,16 +79,27 @@
          if (global.loadArgon2WasmBinary) {
              return global.loadArgon2WasmBinary();
          }
@@ -36,7 +46,7 @@ index ffa77a5..98b2f13 100644
          return fetch(wasmPath)
              .then((response) => response.arrayBuffer())
              .then((ab) => new Uint8Array(ab));
-@@ -351,7 +362,28 @@
+@@ -351,7 +363,28 @@
              loadModule._module.unloadRuntime();
              delete loadModule._promise;
              delete loadModule._module;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
https://github.com/bitwarden/clients/pull/4921 added SIMD support for Argon2 by slightly modifying the loading code of the argon2-browser library. Unfortunately the (rather complex) loading logic argon2-browser's js wrapper has a code-path for node environments, that is also triggered in the Window process of the electron desktop client. This code-path has the argon2 non-SIMD binary hard-coded in a minified javascript file.

This PR fixes this by detecting the electron environment, and applying the same loading logic as on web/browser.

I tested in dev mode on linux, and built as an AppImage.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- argon2-browser+1.18.0.patch: Detect electron and skip the node-specific loading logic
- webpack.renderer.js: Fix base64 loader being applied twice


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
