### PR TITLE
[PM-3031] Remove provider orgs from org dropdown in the collection dialog

### DIFF
--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -110,7 +110,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
       this.organizations$ = this.organizationService.organizations$.pipe(
         map((orgs) =>
           orgs
-            .filter((o) => o.canCreateNewCollections)
+            .filter((o) => o.canCreateNewCollections && !o.isProviderUser)
             .sort(Utils.getSortFunction(this.i18nService, "name"))
         )
       );

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -385,7 +385,9 @@ export class VaultComponent implements OnInit, OnDestroy {
           this.collections = collections;
           this.selectedCollection = selectedCollection;
 
-          this.canCreateCollections = allOrganizations?.some((o) => o.canCreateNewCollections);
+          this.canCreateCollections = allOrganizations?.some(
+            (o) => o.canCreateNewCollections && !o.isProviderUser
+          );
 
           this.showBulkMove =
             filter.type !== "trash" &&


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix issue where members of provider orgs have the option to create collections from individual vault.

## Code changes

- **apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts:** Filter out provider orgs from the org dropdown
- **apps/web/src/app/vault/individual-vault/vault.component.ts:** Don't show the New Collection option in the individual vault if a user only belongs to a provider org.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
