### PR TITLE
[AC-1374] Limit collection create/delete

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -37,6 +37,21 @@
     {{ "save" | i18n }}
   </button>
 </form>
+<ng-container *ngIf="canUseApi">
+  <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">{{ "apiKey" | i18n }}</h1>
+  <p>
+    {{ "apiKeyDesc" | i18n }}
+    <a href="https://docs.bitwarden.com" target="_blank" rel="noopener">
+      {{ "learnMore" | i18n }}
+    </a>
+  </p>
+  <button type="button" bitButton buttonType="secondary" (click)="viewApiKey()">
+    {{ "viewApiKey" | i18n }}
+  </button>
+  <button type="button" bitButton buttonType="secondary" (click)="rotateApiKey()">
+    {{ "rotateApiKey" | i18n }}
+  </button>
+</ng-container>
 <form
   *ngIf="org && !loading"
   #collectionManagementForm
@@ -59,21 +74,6 @@
     {{ "save" | i18n }}
   </button>
 </form>
-<ng-container *ngIf="canUseApi">
-  <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">{{ "apiKey" | i18n }}</h1>
-  <p>
-    {{ "apiKeyDesc" | i18n }}
-    <a href="https://docs.bitwarden.com" target="_blank" rel="noopener">
-      {{ "learnMore" | i18n }}
-    </a>
-  </p>
-  <button type="button" bitButton buttonType="secondary" (click)="viewApiKey()">
-    {{ "viewApiKey" | i18n }}
-  </button>
-  <button type="button" bitButton buttonType="secondary" (click)="rotateApiKey()">
-    {{ "rotateApiKey" | i18n }}
-  </button>
-</ng-container>
 <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5 !tw-text-danger">{{ "dangerZone" | i18n }}</h1>
 <div class="tw-rounded tw-border tw-border-solid tw-border-danger-500 tw-bg-background tw-p-5">
   <p>{{ "dangerZoneDesc" | i18n }}</p>

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -7,7 +7,7 @@
   ></i>
   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
 </div>
-<form *ngIf="org && !loading" #form [bitSubmit]="submit" [formGroup]="formGroup">
+<form *ngIf="org && !loading" [bitSubmit]="submit" [formGroup]="formGroup">
   <div class="tw-grid tw-grid-cols-2 tw-gap-5">
     <div>
       <bit-form-field>
@@ -54,7 +54,6 @@
 </ng-container>
 <form
   *ngIf="org && !loading"
-  #collectionManagementForm
   [bitSubmit]="submitCollectionManagement"
   [formGroup]="collectionManagementFormGroup"
 >

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -37,6 +37,28 @@
     {{ "save" | i18n }}
   </button>
 </form>
+<form
+  *ngIf="org && !loading"
+  #collectionManagementForm
+  [bitSubmit]="submitCollectionManagement"
+  [formGroup]="collectionManagementFormGroup"
+>
+  <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">{{ "collectionManagement" | i18n }}</h1>
+  <p>{{ "collectionManagementDesc" | i18n }}</p>
+  <bit-form-control>
+    <bit-label>{{ "limitCollectionCdOwnerAdminDesc" | i18n }}</bit-label>
+    <input type="checkbox" bitCheckbox formControlName="limitCollectionCdOwnerAdmin" />
+  </bit-form-control>
+  <button
+    type="submit"
+    bitButton
+    bitFormButton
+    buttonType="primary"
+    id="collectionManagementSubmitButton"
+  >
+    {{ "save" | i18n }}
+  </button>
+</form>
 <ng-container *ngIf="canUseApi">
   <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">{{ "apiKey" | i18n }}</h1>
   <p>

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -170,14 +170,8 @@ export class AccountComponent {
     const request = new OrganizationCollectionManagementUpdateRequest();
     request.limitCreateDeleteOwnerAdmin =
       this.collectionManagementFormGroup.value.limitCollectionCdOwnerAdmin;
-    // eslint-disable-next-line
-    console.log(
-      "value of checkbox on submit: " +
-        this.collectionManagementFormGroup.value.limitCollectionCdOwnerAdmin
-    );
 
-    // TODO Uncomment when ready for end-to-end testing
-    //await this.organizationApiService.updateCollectionManagement(this.organizationId, request);
+    await this.organizationApiService.updateCollectionManagement(this.organizationId, request);
 
     this.platformUtilsService.showToast(
       "success",

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -7,6 +7,7 @@ import { DialogServiceAbstraction } from "@bitwarden/angular/services/dialog";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationCollectionManagementUpdateRequest } from "@bitwarden/common/admin-console/models/request/organization-collection-management-update.request";
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
 import { OrganizationUpdateRequest } from "@bitwarden/common/admin-console/models/request/organization-update.request";
 import { OrganizationResponse } from "@bitwarden/common/admin-console/models/response/organization.response";
@@ -58,6 +59,10 @@ export class AccountComponent {
       { value: "", disabled: true },
       { validators: [Validators.maxLength(50)] }
     ),
+  });
+
+  protected collectionManagementFormGroup = this.formBuilder.group({
+    limitCollectionCdOwnerAdmin: [false],
   });
 
   protected organizationId: string;
@@ -114,6 +119,9 @@ export class AccountComponent {
           billingEmail: this.org.billingEmail,
           businessName: this.org.businessName,
         });
+        this.collectionManagementFormGroup.patchValue({
+          limitCollectionCdOwnerAdmin: this.org.limitCollectionCdOwnerAdmin,
+        });
 
         // Update disabled states - reactive forms prefers not using disabled attribute
         if (!this.selfHosted) {
@@ -156,6 +164,26 @@ export class AccountComponent {
     this.formPromise = this.organizationApiService.save(this.organizationId, request);
     await this.formPromise;
     this.platformUtilsService.showToast("success", null, this.i18nService.t("organizationUpdated"));
+  };
+
+  submitCollectionManagement = async () => {
+    const request = new OrganizationCollectionManagementUpdateRequest();
+    request.limitCreateDeleteOwnerAdmin =
+      this.collectionManagementFormGroup.value.limitCollectionCdOwnerAdmin;
+    // eslint-disable-next-line
+    console.log(
+      "value of checkbox on submit: " +
+        this.collectionManagementFormGroup.value.limitCollectionCdOwnerAdmin
+    );
+
+    // TODO Uncomment when ready for end-to-end testing
+    //await this.organizationApiService.updateCollectionManagement(this.organizationId, request);
+
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("collectionManagementUpdated")
+    );
   };
 
   async deleteOrganization() {

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -84,7 +84,7 @@ export class AccountComponent {
   async ngOnInit() {
     this.selfHosted = this.platformUtilsService.isSelfHost();
 
-    this.route.parent.parent.params
+    this.route.params
       .pipe(
         switchMap((params) => this.organizationService.get$(params.organizationId)),
         switchMap((organization) => {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7036,6 +7036,18 @@
       }
     }
   },
+  "collectionManagement": {
+    "message": "Collection management"
+  },
+  "collectionManagementDesc": {
+    "message": "Manage the collection behavior for the organization"
+  },
+  "limitCollectionCdOwnerAdminDesc": {
+    "message": "Limit collection creation and deletion to owners and admins"
+  },
+  "collectionManagementUpdated": {
+    "message": "Collection management behavior saved"
+  },
   "passwordManagerPlanPrice": {
     "message": "Password Manager plan price"
   },

--- a/libs/common/src/admin-console/abstractions/organization/organization-api.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization-api.service.abstraction.ts
@@ -18,6 +18,7 @@ import { StorageRequest } from "../../../models/request/storage.request";
 import { VerifyBankRequest } from "../../../models/request/verify-bank.request";
 import { ListResponse } from "../../../models/response/list.response";
 import { OrganizationApiKeyType } from "../../enums";
+import { OrganizationCollectionManagementUpdateRequest } from "../../models/request/organization-collection-management-update.request";
 import { OrganizationCreateRequest } from "../../models/request/organization-create.request";
 import { OrganizationKeysRequest } from "../../models/request/organization-keys.request";
 import { OrganizationUpdateRequest } from "../../models/request/organization-update.request";
@@ -69,4 +70,8 @@ export class OrganizationApiServiceAbstraction {
   updateSso: (id: string, request: OrganizationSsoRequest) => Promise<OrganizationSsoResponse>;
   selfHostedSyncLicense: (id: string) => Promise<void>;
   subscribeToSecretsManager: (id: string, request: SecretsManagerSubscribeRequest) => Promise<void>;
+  updateCollectionManagement: (
+    id: string,
+    request: OrganizationCollectionManagementUpdateRequest
+  ) => Promise<OrganizationResponse>;
 }

--- a/libs/common/src/admin-console/models/data/organization.data.ts
+++ b/libs/common/src/admin-console/models/data/organization.data.ts
@@ -49,6 +49,7 @@ export class OrganizationData {
   familySponsorshipValidUntil?: Date;
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
+  limitCollectionCdOwnerAdmin: boolean;
 
   constructor(
     response: ProfileOrganizationResponse,
@@ -100,6 +101,7 @@ export class OrganizationData {
     this.familySponsorshipValidUntil = response.familySponsorshipValidUntil;
     this.familySponsorshipToDelete = response.familySponsorshipToDelete;
     this.accessSecretsManager = response.accessSecretsManager;
+    this.limitCollectionCdOwnerAdmin = response.limitCollectionCdOwnerAdmin;
 
     this.isMember = options.isMember;
     this.isProviderUser = options.isProviderUser;

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -64,6 +64,7 @@ export class Organization {
   familySponsorshipValidUntil?: Date;
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
+  limitCollectionCdOwnerAdmin: boolean;
 
   constructor(obj?: OrganizationData) {
     if (obj == null) {
@@ -115,6 +116,7 @@ export class Organization {
     this.familySponsorshipValidUntil = obj.familySponsorshipValidUntil;
     this.familySponsorshipToDelete = obj.familySponsorshipToDelete;
     this.accessSecretsManager = obj.accessSecretsManager;
+    this.limitCollectionCdOwnerAdmin = obj.limitCollectionCdOwnerAdmin;
   }
 
   get canAccess() {

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -64,6 +64,9 @@ export class Organization {
   familySponsorshipValidUntil?: Date;
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
+  /**
+   * Refers to the ability for an organization to limit collection creation and deletion to owners and admins only
+   */
   limitCollectionCdOwnerAdmin: boolean;
 
   constructor(obj?: OrganizationData) {

--- a/libs/common/src/admin-console/models/request/organization-collection-management-update.request.ts
+++ b/libs/common/src/admin-console/models/request/organization-collection-management-update.request.ts
@@ -1,0 +1,3 @@
+export class OrganizationCollectionManagementUpdateRequest {
+  limitCreateDeleteOwnerAdmin: boolean;
+}

--- a/libs/common/src/admin-console/models/request/organization-update.request.ts
+++ b/libs/common/src/admin-console/models/request/organization-update.request.ts
@@ -5,5 +5,4 @@ export class OrganizationUpdateRequest {
   businessName: string;
   billingEmail: string;
   keys: OrganizationKeysRequest;
-  limitCollectionCdOwnerAdmin: boolean;
 }

--- a/libs/common/src/admin-console/models/request/organization-update.request.ts
+++ b/libs/common/src/admin-console/models/request/organization-update.request.ts
@@ -5,4 +5,5 @@ export class OrganizationUpdateRequest {
   businessName: string;
   billingEmail: string;
   keys: OrganizationKeysRequest;
+  limitCollectionCdOwnerAdmin: boolean;
 }

--- a/libs/common/src/admin-console/models/response/organization.response.ts
+++ b/libs/common/src/admin-console/models/response/organization.response.ts
@@ -33,6 +33,7 @@ export class OrganizationResponse extends BaseResponse {
   smServiceAccounts?: number;
   maxAutoscaleSmSeats?: number;
   maxAutoscaleSmServiceAccounts?: number;
+  limitCollectionCdOwnerAdmin: boolean;
 
   constructor(response: any) {
     super(response);
@@ -72,5 +73,6 @@ export class OrganizationResponse extends BaseResponse {
     this.smServiceAccounts = this.getResponseProperty("SmServiceAccounts");
     this.maxAutoscaleSmSeats = this.getResponseProperty("MaxAutoscaleSmSeats");
     this.maxAutoscaleSmServiceAccounts = this.getResponseProperty("MaxAutoscaleSmServiceAccounts");
+    this.limitCollectionCdOwnerAdmin = this.getResponseProperty("LimitCollectionCdOwnerAdmin");
   }
 }

--- a/libs/common/src/admin-console/models/response/profile-organization.response.ts
+++ b/libs/common/src/admin-console/models/response/profile-organization.response.ts
@@ -48,6 +48,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
   familySponsorshipValidUntil?: Date;
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
+  limitCollectionCdOwnerAdmin: boolean;
 
   constructor(response: any) {
     super(response);
@@ -105,5 +106,6 @@ export class ProfileOrganizationResponse extends BaseResponse {
     }
     this.familySponsorshipToDelete = this.getResponseProperty("FamilySponsorshipToDelete");
     this.accessSecretsManager = this.getResponseProperty("AccessSecretsManager");
+    this.limitCollectionCdOwnerAdmin = this.getResponseProperty("LimitCollectionCdOwnerAdmin");
   }
 }

--- a/libs/common/src/admin-console/services/organization/organization-api.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization-api.service.ts
@@ -21,6 +21,7 @@ import { ListResponse } from "../../../models/response/list.response";
 import { SyncService } from "../../../vault/abstractions/sync/sync.service.abstraction";
 import { OrganizationApiServiceAbstraction } from "../../abstractions/organization/organization-api.service.abstraction";
 import { OrganizationApiKeyType } from "../../enums";
+import { OrganizationCollectionManagementUpdateRequest } from "../../models/request/organization-collection-management-update.request";
 import { OrganizationCreateRequest } from "../../models/request/organization-create.request";
 import { OrganizationKeysRequest } from "../../models/request/organization-keys.request";
 import { OrganizationUpdateRequest } from "../../models/request/organization-update.request";
@@ -319,5 +320,21 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
       true,
       false
     );
+  }
+
+  async updateCollectionManagement(
+    id: string,
+    request: OrganizationCollectionManagementUpdateRequest
+  ): Promise<OrganizationResponse> {
+    const r = await this.apiService.send(
+      "PUT",
+      "/organizations/" + id + "/collection-management",
+      request,
+      true,
+      true
+    );
+    const data = new OrganizationResponse(r);
+    await this.syncService.fullSync(true);
+    return data;
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Add UI within the organization settings for updating the collection management option of limiting collection creation/deletion to Owners/Admins only.

## Code changes
- **account.component.html**: Added UI for the `Collection Management` section.
- **account.component.ts**: Added form group for the new collection management section. Added submit handler that calls the collection management specific API. Updated observable chain to properly refresh `OrganizationResponse` API calls.
- **messages.json**: Added collection management specific strings
- **organization-api.service/abstraction**: Added `updateCollectionManagement` API 
- **organization/data/domain**: Added `limitCollectionCdOwnerAdmin` property
- **organization-collection-management-update.request.ts**: Added request model for collection management API
- **organization response objects**: Added `limitCollectionCdOwnerAdmin` property

## Screenshots
![Screenshot 2023-08-05 at 5 01 31 PM](https://github.com/bitwarden/clients/assets/26154748/7eb4072f-3428-4c2a-81be-25d1ad953783)

## Before you submit
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
