### PR TITLE
[PM-3219] Vault locking when setting timeout to never

### DIFF
--- a/libs/common/src/auth/services/auth.service.ts
+++ b/libs/common/src/auth/services/auth.service.ts
@@ -244,7 +244,7 @@ export class AuthService implements AuthServiceAbstraction {
     }
 
     // If we don't have a user key in memory, we're locked
-    if (!this.cryptoService.hasUserKeyInMemory(userId)) {
+    if (!(await this.cryptoService.hasUserKeyInMemory(userId))) {
       // Check if the user has vault timeout set to never and verify that
       // they've never unlocked their vault
       const neverLock =


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix vault locking when quitting the app, even when the vault timeout is set to never

## Code changes

- **libs/common/src/auth/services/auth.service.ts:** Add missing await

## Screenshots


https://github.com/bitwarden/clients/assets/8926729/8706272d-59f8-44ca-ad83-7f7b18bebb85


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
