### PR TITLE
[PM-3315] Changed settings menu to be enabled whenever the account is not locked

### DIFF
--- a/apps/desktop/src/main/menu/menu.first.ts
+++ b/apps/desktop/src/main/menu/menu.first.ts
@@ -48,7 +48,7 @@ export class FirstMenu {
       label: this.localize(process.platform === "darwin" ? "preferences" : "settings"),
       click: () => this.sendMessage("openSettings"),
       accelerator: "CmdOrCtrl+,",
-      enabled: this._isLockable,
+      enabled: !this._isLocked,
     };
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/5894, we added a check that disabled the Settings menu on desktop if the account was not "lockable".  This meant that an account without a master password couldn't access the Settings menu at all.  This is not the desired behavior.

This change reverts this behavior back to the previous check - if the account is locked or there is no active account, the Settings menu is disabled.  If there is an active account and the account is not locked, the Settings menu is enabled.

## Code changes

- **menu.first.ts:** Reverted `enabled` property to be based on whether the account is locked, not whether it is lockable.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
