### PR TITLE
[PM-3314] Fixed missing MP prompt on lock component

### DIFF
--- a/apps/browser/src/auth/popup/lock.component.html
+++ b/apps/browser/src/auth/popup/lock.component.html
@@ -5,13 +5,19 @@
       <span class="title">{{ "verifyIdentity" | i18n }}</span>
     </h1>
     <div class="right">
-      <button type="submit" *ngIf="!hideInput">{{ "unlock" | i18n }}</button>
+      <button type="submit" *ngIf="pinEnabled || masterPasswordEnabled">
+        {{ "unlock" | i18n }}
+      </button>
     </div>
   </header>
   <main tabindex="-1">
     <div class="box">
       <div class="box-content">
-        <div class="box-content-row box-content-row-flex" appBoxRow *ngIf="!hideInput">
+        <div
+          class="box-content-row box-content-row-flex"
+          appBoxRow
+          *ngIf="pinEnabled || masterPasswordEnabled"
+        >
           <div class="row-main" *ngIf="pinEnabled">
             <label for="pin">{{ "pin" | i18n }}</label>
             <input
@@ -24,7 +30,7 @@
               appInputVerbatim
             />
           </div>
-          <div class="row-main" *ngIf="!pinEnabled">
+          <div class="row-main" *ngIf="masterPasswordEnabled && !pinEnabled">
             <label for="masterPassword">{{ "masterPass" | i18n }}</label>
             <input
               id="masterPassword"

--- a/apps/browser/src/auth/popup/lock.component.ts
+++ b/apps/browser/src/auth/popup/lock.component.ts
@@ -10,6 +10,7 @@ import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abs
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -50,7 +51,8 @@ export class LockComponent extends BaseLockComponent {
     passwordStrengthService: PasswordStrengthServiceAbstraction,
     private authService: AuthService,
     dialogService: DialogServiceAbstraction,
-    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    userVerificationService: UserVerificationService
   ) {
     super(
       router,
@@ -69,7 +71,8 @@ export class LockComponent extends BaseLockComponent {
       policyService,
       passwordStrengthService,
       dialogService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      userVerificationService
     );
     this.successRoute = "/tabs/current";
     this.isInitialLockScreen = (window as any).previousPopupUrl == null;

--- a/apps/desktop/src/auth/lock.component.html
+++ b/apps/desktop/src/auth/lock.component.html
@@ -4,7 +4,11 @@
     <p>{{ "yourVaultIsLocked" | i18n }}</p>
     <div class="box last">
       <div class="box-content">
-        <div class="box-content-row box-content-row-flex" appBoxRow *ngIf="!hideInput">
+        <div
+          class="box-content-row box-content-row-flex"
+          appBoxRow
+          *ngIf="pinEnabled || masterPasswordEnabled"
+        >
           <div class="row-main" *ngIf="pinEnabled">
             <label for="pin">{{ "pin" | i18n }}</label>
             <input
@@ -17,7 +21,7 @@
               appInputVerbatim
             />
           </div>
-          <div class="row-main" *ngIf="!pinEnabled">
+          <div class="row-main" *ngIf="masterPasswordEnabled && !pinEnabled">
             <label for="masterPassword">{{ "masterPass" | i18n }}</label>
             <input
               id="masterPassword"
@@ -57,14 +61,14 @@
         <button
           type="button"
           class="btn block"
-          [ngClass]="{ 'primary font-weight-bold': hideInput }"
+          [ngClass]="{ 'primary font-weight-bold': !pinEnabled && !masterPasswordEnabled }"
           (click)="unlockBiometric()"
         >
           {{ biometricText | i18n }}
         </button>
       </div>
       <div class="buttons-row">
-        <button type="submit" class="btn primary block" *ngIf="!hideInput">
+        <button type="submit" class="btn primary block" *ngIf="pinEnabled || masterPasswordEnabled">
           <i class="bwi bwi-unlock" aria-hidden="true"></i> <b>{{ "unlock" | i18n }}</b>
         </button>
         <button type="button" class="btn block" (click)="logOut()">

--- a/apps/desktop/src/auth/lock.component.ts
+++ b/apps/desktop/src/auth/lock.component.ts
@@ -10,6 +10,7 @@ import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeou
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { DeviceType, KeySuffixOptions } from "@bitwarden/common/enums";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
@@ -52,7 +53,8 @@ export class LockComponent extends BaseLockComponent {
     passwordStrengthService: PasswordStrengthServiceAbstraction,
     logService: LogService,
     dialogService: DialogServiceAbstraction,
-    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    userVerificationService: UserVerificationService
   ) {
     super(
       router,
@@ -71,7 +73,8 @@ export class LockComponent extends BaseLockComponent {
       policyService,
       passwordStrengthService,
       dialogService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      userVerificationService
     );
   }
 

--- a/apps/web/src/app/auth/lock.component.ts
+++ b/apps/web/src/app/auth/lock.component.ts
@@ -9,6 +9,7 @@ import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeou
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -43,7 +44,8 @@ export class LockComponent extends BaseLockComponent {
     policyService: InternalPolicyService,
     passwordStrengthService: PasswordStrengthServiceAbstraction,
     dialogService: DialogServiceAbstraction,
-    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction
+    deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction,
+    userVerificationService: UserVerificationService
   ) {
     super(
       router,
@@ -62,7 +64,8 @@ export class LockComponent extends BaseLockComponent {
       policyService,
       passwordStrengthService,
       dialogService,
-      deviceTrustCryptoService
+      deviceTrustCryptoService,
+      userVerificationService
     );
   }
 

--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -345,6 +345,19 @@ export class LockComponent implements OnInit, OnDestroy {
   private async load() {
     this.pinStatus = await this.vaultTimeoutSettingsService.isPinLockSet();
 
+    // The loading of the lock component works as follows:
+    //   1. First, is locking a valid timeout action?  If not, we will log the user out.
+    //   2. If locking IS a valid timeout action, we proceed to show the user the lock screen.
+    //      The user will be able to unlock as follows:
+    //        - If they have a PIN set, they will be presented with the PIN input
+    //        - If they have a master password and no PIN, they will be presented with the master password input
+    //        - If they have biometrics enabled, they will be presented with the biometric prompt
+    //   Note: The following scenario is currently NOT handled:
+    //     - The user has a master password and no PIN
+    //     - The user has logged in with Trusted Device Encryption
+    //     - The user is offline
+    //     - The user locks their vault
+    //   This will result in the user not being able to unlock their vault and having to log out.
     let ephemeralPinSet = await this.stateService.getUserKeyPinEphemeral();
     ephemeralPinSet ||= await this.stateService.getDecryptedPinProtected();
     this.pinEnabled =


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/5894, we added a check that hid the master password input AND the PIN input if PIN was not enabled.

I decided to take the opportunity to remove the confusing `hideInput` property (what input was it hiding and why?) and instead introduce `masterPasswordEnabled` to align with the existing `pinEnabled` property.  The intent of `hideInput` was to hide the UI for master password and PIN entry in the case where users don't have either input.  Previously, that was only with Key Connector, but now we have TDE as well.

Now, we hide that UI if we don't have `pinEnabled` and don't have `masterPasswordEnabled`.

## Code changes

- **lock.component.html:** Replaced `hideInput` with references to `pinEnabled` and `masterPasswordEnabled` (all clients)
- **lock.component.ts:** Added lookup for `hasMasterPassword()` to set `masterPasswordEnabled`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
