### PR TITLE
[PM-3326] [CLI] Add minNumber, minSpecial and ambiguous password generation options

### DIFF
--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -299,6 +299,7 @@ export class Program {
       .option("-p, --passphrase", "Generate a passphrase.")
       .option("--length <length>", "Length of the password.")
       .option("--words <words>", "Number of words.")
+      .option("--minNumber <count>", "Minimum number of numeric characters.")
       .option("--separator <separator>", "Word separator.")
       .option("-c, --capitalize", "Title case passphrase.")
       .option("--includeNumber", "Passphrase includes number.")

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -300,6 +300,7 @@ export class Program {
       .option("--length <length>", "Length of the password.")
       .option("--words <words>", "Number of words.")
       .option("--minNumber <count>", "Minimum number of numeric characters.")
+      .option("--minSpecial <count>", "Minimum number of special characters.")
       .option("--separator <separator>", "Word separator.")
       .option("-c, --capitalize", "Title case passphrase.")
       .option("--includeNumber", "Passphrase includes number.")

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -304,6 +304,7 @@ export class Program {
       .option("--separator <separator>", "Word separator.")
       .option("-c, --capitalize", "Title case passphrase.")
       .option("--includeNumber", "Passphrase includes number.")
+      .option("--ambiguous", "Avoid ambiguous characters.")
       .on("--help", () => {
         writeLn("\n  Notes:");
         writeLn("");

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -62,13 +62,12 @@ class Options {
     this.capitalize = CliUtils.convertBooleanOption(passedOptions?.capitalize);
     this.includeNumber = CliUtils.convertBooleanOption(passedOptions?.includeNumber);
     this.ambiguous = CliUtils.convertBooleanOption(passedOptions?.ambiguous);
-    this.length = passedOptions?.length != null ? parseInt(passedOptions?.length, null) : 14;
+    this.length = CliUtils.convertNumberOption(passedOptions?.length, 14);
     this.type = passedOptions?.passphrase ? "passphrase" : "password";
-    this.separator = passedOptions?.separator == null ? "-" : passedOptions.separator + "";
-    this.words = passedOptions?.words != null ? parseInt(passedOptions.words, null) : 3;
-    this.minNumber = passedOptions?.minNumber != null ? parseInt(passedOptions.minNumber, null) : 1;
-    this.minSpecial =
-      passedOptions?.minSpecial != null ? parseInt(passedOptions.minSpecial, null) : 1;
+    this.separator = CliUtils.convertStringOption(passedOptions?.separator, "-");
+    this.words = CliUtils.convertNumberOption(passedOptions?.words, 3);
+    this.minNumber = CliUtils.convertNumberOption(passedOptions?.minNumber, 1);
+    this.minSpecial = CliUtils.convertNumberOption(passedOptions?.minSpecial, 1);
 
     if (!this.uppercase && !this.lowercase && !this.special && !this.number) {
       this.lowercase = true;

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -25,6 +25,7 @@ export class GenerateCommand {
       capitalize: normalizedOptions.capitalize,
       includeNumber: normalizedOptions.includeNumber,
       minNumber: normalizedOptions.minNumber,
+      minSpecial: normalizedOptions.minSpecial,
     };
 
     const enforcedOptions = (await this.stateService.getIsAuthenticated())
@@ -49,6 +50,7 @@ class Options {
   capitalize: boolean;
   includeNumber: boolean;
   minNumber: number;
+  minSpecial: number;
 
   constructor(passedOptions: Record<string, any>) {
     this.uppercase = CliUtils.convertBooleanOption(passedOptions?.uppercase);
@@ -62,6 +64,7 @@ class Options {
     this.separator = passedOptions?.separator == null ? "-" : passedOptions.separator + "";
     this.words = passedOptions?.words != null ? parseInt(passedOptions.words, null) : 3;
     this.minNumber = passedOptions?.minNumber != null ? parseInt(passedOptions.minNumber, null) : 1;
+    this.minSpecial = passedOptions?.minSpecial != null ? parseInt(passedOptions.minSpecial, null) : 1;
 
     if (!this.uppercase && !this.lowercase && !this.special && !this.number) {
       this.lowercase = true;

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -26,6 +26,7 @@ export class GenerateCommand {
       includeNumber: normalizedOptions.includeNumber,
       minNumber: normalizedOptions.minNumber,
       minSpecial: normalizedOptions.minSpecial,
+      ambiguous: normalizedOptions.ambiguous,
     };
 
     const enforcedOptions = (await this.stateService.getIsAuthenticated())
@@ -51,6 +52,7 @@ class Options {
   includeNumber: boolean;
   minNumber: number;
   minSpecial: number;
+  ambiguous: boolean;
 
   constructor(passedOptions: Record<string, any>) {
     this.uppercase = CliUtils.convertBooleanOption(passedOptions?.uppercase);
@@ -59,12 +61,14 @@ class Options {
     this.special = CliUtils.convertBooleanOption(passedOptions?.special);
     this.capitalize = CliUtils.convertBooleanOption(passedOptions?.capitalize);
     this.includeNumber = CliUtils.convertBooleanOption(passedOptions?.includeNumber);
+    this.ambiguous = CliUtils.convertBooleanOption(passedOptions?.ambiguous);
     this.length = passedOptions?.length != null ? parseInt(passedOptions?.length, null) : 14;
     this.type = passedOptions?.passphrase ? "passphrase" : "password";
     this.separator = passedOptions?.separator == null ? "-" : passedOptions.separator + "";
     this.words = passedOptions?.words != null ? parseInt(passedOptions.words, null) : 3;
     this.minNumber = passedOptions?.minNumber != null ? parseInt(passedOptions.minNumber, null) : 1;
-    this.minSpecial = passedOptions?.minSpecial != null ? parseInt(passedOptions.minSpecial, null) : 1;
+    this.minSpecial =
+      passedOptions?.minSpecial != null ? parseInt(passedOptions.minSpecial, null) : 1;
 
     if (!this.uppercase && !this.lowercase && !this.special && !this.number) {
       this.lowercase = true;

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -24,6 +24,7 @@ export class GenerateCommand {
       numWords: normalizedOptions.words,
       capitalize: normalizedOptions.capitalize,
       includeNumber: normalizedOptions.includeNumber,
+      minNumber: normalizedOptions.minNumber,
     };
 
     const enforcedOptions = (await this.stateService.getIsAuthenticated())
@@ -47,6 +48,7 @@ class Options {
   words: number;
   capitalize: boolean;
   includeNumber: boolean;
+  minNumber: number;
 
   constructor(passedOptions: Record<string, any>) {
     this.uppercase = CliUtils.convertBooleanOption(passedOptions?.uppercase);
@@ -59,6 +61,7 @@ class Options {
     this.type = passedOptions?.passphrase ? "passphrase" : "password";
     this.separator = passedOptions?.separator == null ? "-" : passedOptions.separator + "";
     this.words = passedOptions?.words != null ? parseInt(passedOptions.words, null) : 3;
+    this.minNumber = passedOptions?.minNumber != null ? parseInt(passedOptions.minNumber, null) : 1;
 
     if (!this.uppercase && !this.lowercase && !this.special && !this.number) {
       this.lowercase = true;

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -1,5 +1,6 @@
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
+import { PasswordGeneratorOptions } from "@bitwarden/common/tools/generator/password/password-generator-options";
 
 import { Response } from "../models/response";
 import { StringResponse } from "../models/response/string.response";
@@ -13,7 +14,7 @@ export class GenerateCommand {
 
   async run(cmdOptions: Record<string, any>): Promise<Response> {
     const normalizedOptions = new Options(cmdOptions);
-    const options = {
+    const options: PasswordGeneratorOptions = {
       uppercase: normalizedOptions.uppercase,
       lowercase: normalizedOptions.lowercase,
       number: normalizedOptions.number,

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -253,11 +253,11 @@ export class CliUtils {
     return optionValue || optionValue === "" ? true : false;
   }
 
-  static convertNumberOption(optionValue: any, defaultValue: any) {
+  static convertNumberOption(optionValue: any, defaultValue: number) {
     return optionValue != null ? parseInt(optionValue, null) : defaultValue;
   }
 
-  static convertStringOption(optionValue: any, defaultValue: any) {
+  static convertStringOption(optionValue: any, defaultValue: string) {
     return optionValue != null ? String(optionValue) : defaultValue;
   }
 }

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -254,7 +254,15 @@ export class CliUtils {
   }
 
   static convertNumberOption(optionValue: any, defaultValue: number) {
-    return optionValue != null ? parseInt(optionValue, null) : defaultValue;
+    try {
+      if (optionValue != null) {
+        const numVal = parseInt(optionValue);
+        return !Number.isNaN(numVal) ? numVal : defaultValue;
+      }
+      return defaultValue;
+    } catch {
+      return defaultValue;
+    }
   }
 
   static convertStringOption(optionValue: any, defaultValue: string) {

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -252,4 +252,12 @@ export class CliUtils {
   static convertBooleanOption(optionValue: any) {
     return optionValue || optionValue === "" ? true : false;
   }
+
+  static convertNumberOption(optionValue: any, defaultValue: any) {
+    return optionValue != null ? parseInt(optionValue, null) : defaultValue;
+  }
+
+  static convertStringOption(optionValue: any, defaultValue: any) {
+    return optionValue != null ? String(optionValue) : defaultValue;
+  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR aims to add missing password generation options to the CLI. Options like **Minimum numbers**, **Minimum special**, and **Avoid ambiguous characters** are present in clients like `desktop` and `browser`, but not in the `cli`.

## Code changes

Since the options are already accepted by the `password-generation` service, the only changes made were in the following files:

- `program.ts` - Accept the `minNumber`, `minSpecial`, and `ambiguous` options in the CLI
- `generate.command.ts` - Accept and validate the options passed to the program and forward them to the `generatePassword` function from the `password-generation` service.
- `utils.ts` - Also took the chance to extract two new utils - `convertNumberOption` and `convertStringOption` to use when parsing the input options.

## Screenshots

![Screenshot 2023-08-06 at 21 46 41](https://github.com/bitwarden/clients/assets/7235666/a31b1ed1-ccaa-4297-9626-406e29bb66b5)

![Screenshot 2023-08-06 at 22 26 06](https://github.com/bitwarden/clients/assets/7235666/01e9f529-3e92-439b-bb3e-83be5c2f8f57)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
