### PR TITLE
PM-3331 - TDE - Firefox - Browser extension - fix access denied error…

### DIFF
--- a/libs/common/src/platform/services/config/config.service.ts
+++ b/libs/common/src/platform/services/config/config.service.ts
@@ -40,7 +40,12 @@ export class ConfigService implements ConfigServiceAbstraction {
         const data = new ServerConfigData(response);
         const serverConfig = new ServerConfig(data);
         this._serverConfig.next(serverConfig);
-        if ((await this.authService.getAuthStatus()) === AuthenticationStatus.LoggedOut) {
+
+        const userAuthStatus = await this.authService.getAuthStatus();
+        if (
+          userAuthStatus === AuthenticationStatus.LoggedOut ||
+          userAuthStatus === AuthenticationStatus.Locked
+        ) {
           return serverConfig;
         }
         await this.stateService.setServerConfig(data);


### PR DESCRIPTION
… on popup load which was caused by the `canAccessFeature` guard failing to look up the TDE feature flag as the `ServerConfig` was returning null even after a successful server call as the `fetchServerConfig()` logic only returned the value if the user was unauthenticated

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[PM-3331](https://bitwarden.atlassian.net/browse/PM-3331)
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/platform/services/config/config.service.ts:** Update `fetchServerConfig()` logic to return the retrieved serverConfig in all scenarios

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/116684653/5c353cc6-b4f2-4236-8795-2d20ac00b73b


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-3331]: https://bitwarden.atlassian.net/browse/PM-3331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ