### PR TITLE
PM-3355 - TDE - Browser JIT Account Creation Infinite Loop Fix

### DIFF
--- a/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
@@ -2,8 +2,6 @@ import { Component } from "@angular/core";
 
 import { BaseLoginDecryptionOptionsComponent } from "@bitwarden/angular/auth/components/base-login-decryption-options.component";
 
-import { BrowserApi } from "../../../platform/browser/browser-api";
-
 @Component({
   selector: "browser-login-decryption-options",
   templateUrl: "login-decryption-options.component.html",
@@ -12,7 +10,7 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
   override async createUser(): Promise<void> {
     try {
       await super.createUser();
-      BrowserApi.closeBitwardenExtensionTab();
+      await this.router.navigate(["/tabs/vault"]);
     } catch (error) {
       this.validationService.showError(error);
     }


### PR DESCRIPTION
PM-3355 - TDE - Browser JIT Account Creation - Create user logic still had old logic for simply closing the extension tab but, as we no longer open the login decryption options in a tab, we needed replace that with direct navigation to the vault. 

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts:** Replace now deprecated logic w/ simple vault navigation on successful account creation

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
This was probably an issue across all browser extensions:
Chrome:

https://github.com/bitwarden/clients/assets/116684653/eb59beb3-712e-4562-b7c2-8616c0427d70



Firefox:

https://github.com/bitwarden/clients/assets/116684653/9bcd091a-5cf9-4f47-b9dd-ca478b770d93



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
