### PR TITLE
[PM-264] When a free user is upgrading their org plan, the Cancel button is misaligned

### DIFF
--- a/apps/web/src/app/billing/settings/organization-plans.component.html
+++ b/apps/web/src/app/billing/settings/organization-plans.component.html
@@ -329,7 +329,7 @@
     >
       {{ "submit" | i18n }}
     </button>
-    <button type="button" class="btn btn-outline-secondary" (click)="cancel()" *ngIf="showCancel">
+    <button type="button" buttonType="secondary" bitButton (click)="cancel()" *ngIf="showCancel">
       {{ "cancel" | i18n }}
     </button>
   </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR is purposed to fix the issue where the Cancel button was misaligned when a free user is upgrading their org plan. In the Billing > Subscription section of the Settings on the Org page, the Cancel button was appearing below the Submit button instead of aligning with it in OrganizationPlansComponent. This issue has been fixed in this PR.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organization-plans.component.html:** Updated the cancel button to use the `bitButton` component to match the styling of the submit button

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:
![image](https://github.com/bitwarden/clients/assets/133619638/0ff2b3ad-3642-470c-8824-bc0d1821b752)

After:
![image](https://github.com/bitwarden/clients/assets/133619638/4e83ed52-bc16-4b22-b5c7-0fc4578e6d8f)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
