### PR TITLE
[PM-3353] Fix enabling biometrics

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -5,6 +5,7 @@ import {
   BehaviorSubject,
   combineLatest,
   concatMap,
+  distinctUntilChanged,
   filter,
   firstValueFrom,
   map,
@@ -190,6 +191,7 @@ export class SettingsComponent implements OnInit {
 
     this.form.controls.biometric.valueChanges
       .pipe(
+        distinctUntilChanged(),
         concatMap(async (enabled) => {
           await this.updateBiometric(enabled);
           if (enabled) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix a bug where a user could not enable biometrics. This was caused by valueChanges for the biometrics checkbox firing multiple times, interrupting the flow and causing errors.

## Code changes

- **apps/browser/src/popup/settings/settings.component.ts:** Use `distinctUntilChanged` to only get the first emitted value of the form control.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
