### PR TITLE
PM-3369 - TDE - Persist user's choice to trust device to state when user ma…

### DIFF
--- a/libs/angular/src/auth/components/base-login-decryption-options.component.ts
+++ b/libs/angular/src/auth/components/base-login-decryption-options.component.ts
@@ -143,10 +143,7 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
   private async setRememberDeviceDefaultValue() {
     const rememberDeviceFromState = await this.deviceTrustCryptoService.getShouldTrustDevice();
 
-    let rememberDevice = true;
-    if (rememberDeviceFromState !== null) {
-      rememberDevice = rememberDeviceFromState;
-    }
+    const rememberDevice = rememberDeviceFromState ?? true;
 
     this.rememberDevice.setValue(rememberDevice);
   }

--- a/libs/angular/src/auth/components/base-login-decryption-options.component.ts
+++ b/libs/angular/src/auth/components/base-login-decryption-options.component.ts
@@ -145,6 +145,9 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
     const rememberDeviceFromState = await this.deviceTrustCryptoService.getShouldTrustDevice();
     if (rememberDeviceFromState !== null) {
       this.rememberDevice.setValue(rememberDeviceFromState);
+    } else {
+      // Assume true if not set
+      this.deviceTrustCryptoService.setShouldTrustDevice(true);
     }
   }
 

--- a/libs/angular/src/auth/components/base-login-decryption-options.component.ts
+++ b/libs/angular/src/auth/components/base-login-decryption-options.component.ts
@@ -12,7 +12,6 @@ import {
   takeUntil,
   defer,
   throwError,
-  distinctUntilChanged,
 } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -94,10 +93,10 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.loading = true;
 
-    // Persist user choice from state if it exists
-    await this.setRememberDeviceFromStateIfExists();
-
     this.setupRememberDeviceValueChanges();
+
+    // Persist user choice from state if it exists
+    await this.setRememberDeviceDefaultValue();
 
     try {
       const accountDecryptionOptions: AccountDecryptionOptions =
@@ -141,20 +140,20 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async setRememberDeviceFromStateIfExists() {
+  private async setRememberDeviceDefaultValue() {
     const rememberDeviceFromState = await this.deviceTrustCryptoService.getShouldTrustDevice();
+
+    let rememberDevice = true;
     if (rememberDeviceFromState !== null) {
-      this.rememberDevice.setValue(rememberDeviceFromState);
-    } else {
-      // Assume true if not set
-      this.deviceTrustCryptoService.setShouldTrustDevice(true);
+      rememberDevice = rememberDeviceFromState;
     }
+
+    this.rememberDevice.setValue(rememberDevice);
   }
 
   private setupRememberDeviceValueChanges() {
     this.rememberDevice.valueChanges
       .pipe(
-        distinctUntilChanged(),
         switchMap((value) =>
           defer(() => this.deviceTrustCryptoService.setShouldTrustDevice(value))
         ),

--- a/libs/common/src/auth/abstractions/device-trust-crypto.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/device-trust-crypto.service.abstraction.ts
@@ -7,7 +7,7 @@ export abstract class DeviceTrustCryptoServiceAbstraction {
    * @description Retrieves the users choice to trust the device which can only happen after decryption
    * Note: this value should only be used once and then reset
    */
-  getShouldTrustDevice: () => Promise<boolean>;
+  getShouldTrustDevice: () => Promise<boolean | null>;
   setShouldTrustDevice: (value: boolean) => Promise<void>;
 
   trustDeviceIfRequired: () => Promise<void>;

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1367,7 +1367,7 @@ export class StateService<
     await this.saveAccount(account, options);
   }
 
-  async getShouldTrustDevice(options?: StorageOptions): Promise<boolean> {
+  async getShouldTrustDevice(options?: StorageOptions): Promise<boolean | null> {
     options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
 
     if (options?.userId == null) {
@@ -1376,7 +1376,7 @@ export class StateService<
 
     const account = await this.getAccount(options);
 
-    return account?.settings?.trustDeviceChoiceForDecryption ?? false;
+    return account?.settings?.trustDeviceChoiceForDecryption ?? null;
   }
 
   async setShouldTrustDevice(value: boolean, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
…kes choice + load previous choices out of state

[PM-3369](https://bitwarden.atlassian.net/browse/PM-3369)

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/angular/src/auth/components/base-login-decryption-options.component.ts:** Set `userShouldTrustDevice` on user choice and on load if not found in state
- **libs/common/src/auth/abstractions/device-trust-crypto.service.abstraction.ts:** Support null return for `userShouldTrustDevice`
- **libs/common/src/platform/services/state.service.ts:** Support null return for `userShouldTrustDevice`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/116684653/7e60f426-aece-46db-abd0-ea9bceca82f8


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-3369]: https://bitwarden.atlassian.net/browse/PM-3369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ