### PR TITLE
[PM 3347] Fix enabling biometrics breaking for user with no mp

### DIFF
--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -149,7 +149,7 @@ export class NativeMessagingService {
             {
               command: "biometricUnlock",
               response: "unlocked",
-              keyB64: masterKey.keyB64,
+              keyB64: masterKey?.keyB64,
               userKeyB64: userKey.keyB64,
             },
             appId


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix enabling biometrics breaking for user with no mp

## Code changes

- **apps/desktop/src/services/native-messaging.service.ts:** Use optional chaining on master key because it will be null for users without a master password.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
