### PR TITLE
TDE - DeviceTrustCryptoService - Don't trust a device if TDE was turned off

### DIFF
--- a/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
@@ -46,6 +46,14 @@ export class DeviceTrustCryptoService implements DeviceTrustCryptoServiceAbstrac
   }
 
   async trustDeviceIfRequired(): Promise<void> {
+    // This handles the case in which a user has selected to trust a device
+    // however, their org has turned off TDE after they've made their choice
+    // They should not see device trusted toast
+    const supportsDeviceTrust = await this.supportsDeviceTrust();
+    if (!supportsDeviceTrust) {
+      return;
+    }
+
     const shouldTrustDevice = await this.getShouldTrustDevice();
     if (shouldTrustDevice) {
       await this.trustDevice();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Prevent device trust logic from executing if TDE has been turned off after the user has chosen to trust a device. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/auth/services/device-trust-crypto.service.implementation.ts:** Short circuit `trustDeviceIfRequired` if TDE has been disabled. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
