### PR TITLE
[PM-3356] Fallback to OTP When MasterPassword Hasn't Been Used

### DIFF
--- a/libs/angular/src/auth/components/user-verification.component.ts
+++ b/libs/angular/src/auth/components/user-verification.component.ts
@@ -69,7 +69,7 @@ export class UserVerificationComponent implements ControlValueAccessor, OnInit, 
   ) {}
 
   async ngOnInit() {
-    this.hasMasterPassword = await this.userVerificationService.hasMasterPasswordHash();
+    this.hasMasterPassword = await this.userVerificationService.hasMasterPasswordAndMasterKeyHash();
     this.processChanges(this.secret.value);
 
     this.secret.valueChanges

--- a/libs/angular/src/auth/components/user-verification.component.ts
+++ b/libs/angular/src/auth/components/user-verification.component.ts
@@ -69,7 +69,7 @@ export class UserVerificationComponent implements ControlValueAccessor, OnInit, 
   ) {}
 
   async ngOnInit() {
-    this.hasMasterPassword = await this.userVerificationService.hasMasterPassword();
+    this.hasMasterPassword = await this.userVerificationService.hasMasterPasswordHash();
     this.processChanges(this.secret.value);
 
     this.secret.valueChanges

--- a/libs/angular/src/vault/services/password-reprompt.service.spec.ts
+++ b/libs/angular/src/vault/services/password-reprompt.service.spec.ts
@@ -21,12 +21,12 @@ describe("PasswordRepromptService", () => {
 
   describe("enabled()", () => {
     it("returns false if a user does not have a master password", async () => {
-      userVerificationService.hasMasterPassword.mockResolvedValue(false);
+      userVerificationService.hasMasterPasswordAndMasterKeyHash.mockResolvedValue(false);
 
       expect(await passwordRepromptService.enabled()).toBe(false);
     });
     it("returns true if the user has a master password", async () => {
-      userVerificationService.hasMasterPassword.mockResolvedValue(true);
+      userVerificationService.hasMasterPasswordAndMasterKeyHash.mockResolvedValue(true);
 
       expect(await passwordRepromptService.enabled()).toBe(true);
     });

--- a/libs/angular/src/vault/services/password-reprompt.service.ts
+++ b/libs/angular/src/vault/services/password-reprompt.service.ts
@@ -39,6 +39,6 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
   }
 
   async enabled() {
-    return await this.userVerificationService.hasMasterPasswordHash();
+    return await this.userVerificationService.hasMasterPasswordAndMasterKeyHash();
   }
 }

--- a/libs/angular/src/vault/services/password-reprompt.service.ts
+++ b/libs/angular/src/vault/services/password-reprompt.service.ts
@@ -39,6 +39,6 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
   }
 
   async enabled() {
-    return await this.userVerificationService.hasMasterPassword();
+    return await this.userVerificationService.hasMasterPasswordHash();
   }
 }

--- a/libs/common/src/auth/abstractions/user-verification/user-verification.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/user-verification/user-verification.service.abstraction.ts
@@ -20,5 +20,5 @@ export abstract class UserVerificationService {
    * @param userId The user id to check. If not provided, the current user id used
    * @returns True if the user has a master password and has used it in the current session
    */
-  hasMasterPasswordHash: (userId?: string) => Promise<boolean>;
+  hasMasterPasswordAndMasterKeyHash: (userId?: string) => Promise<boolean>;
 }

--- a/libs/common/src/auth/abstractions/user-verification/user-verification.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/user-verification/user-verification.service.abstraction.ts
@@ -15,4 +15,10 @@ export abstract class UserVerificationService {
    * @returns True if the user has a master password
    */
   hasMasterPassword: (userId?: string) => Promise<boolean>;
+  /**
+   * Check if the user has a master password and has used it during their current session
+   * @param userId The user id to check. If not provided, the current user id used
+   * @returns True if the user has a master password and has used it in the current session
+   */
+  hasMasterPasswordHash: (userId?: string) => Promise<boolean>;
 }

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -113,7 +113,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
     return !(await this.stateService.getUsesKeyConnector({ userId }));
   }
 
-  async hasMasterPasswordHash(userId?: string): Promise<boolean> {
+  async hasMasterPasswordAndMasterKeyHash(userId?: string): Promise<boolean> {
     return (
       (await this.hasMasterPassword(userId)) &&
       (await this.cryptoService.getMasterKeyHash()) != null

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -113,6 +113,13 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
     return !(await this.stateService.getUsesKeyConnector({ userId }));
   }
 
+  async hasMasterPasswordHash(userId?: string): Promise<boolean> {
+    return (
+      (await this.hasMasterPassword(userId)) &&
+      (await this.cryptoService.getMasterKeyHash()) != null
+    );
+  }
+
   private validateInput(verification: Verification) {
     if (verification?.secret == null || verification.secret === "") {
       if (verification.type === VerificationType.OTP) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Server PR: https://github.com/bitwarden/server/pull/3184

Similar Tickets:
https://bitwarden.atlassian.net/browse/PM-3373
https://bitwarden.atlassian.net/browse/PM-3375

Use OTP as our form of verification for sessions in which the user has never entered a password. This is done by making the user verification `hasMasterPassword` check more strict by also seeing if the master key hash is in state.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/auth/services/user-verification/user-verification.service.ts:** Add method that builds on the `hasMasterPassword` method by also checking for hash.
- **libs/angular/src/vault/services/password-reprompt.service.ts:** Skip reprompt if they have never entered their MP in this session
- **libs/angular/src/auth/components/user-verification.component.ts:** Switch user verification to using this method as well.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
