### PR TITLE
Revert "TDE - DeviceTrustCryptoService - Don't trust a device if TDE was turned off"

### DIFF
--- a/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
@@ -46,14 +46,6 @@ export class DeviceTrustCryptoService implements DeviceTrustCryptoServiceAbstrac
   }
 
   async trustDeviceIfRequired(): Promise<void> {
-    // This handles the case in which a user has selected to trust a device
-    // however, their org has turned off TDE after they've made their choice
-    // They should not see device trusted toast
-    const supportsDeviceTrust = await this.supportsDeviceTrust();
-    if (!supportsDeviceTrust) {
-      return;
-    }
-
     const shouldTrustDevice = await this.getShouldTrustDevice();
     if (shouldTrustDevice) {
       await this.trustDevice();


### PR DESCRIPTION
Reverts bitwarden/clients#6010 b/c the user decryption options doesn't get dynamically updated so this code doesn't do what we thought it would. Also, it broke tests. 