### PR TITLE
[PM-3383] Hide Change Password menu option for user with no MP

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -495,7 +495,6 @@ export class AppComponent implements OnInit, OnDestroy {
       updateRequest = {
         accounts: null,
         activeUserId: null,
-        hideChangeMasterPassword: true,
       };
     } else {
       const accounts: { [userId: string]: MenuAccount } = {};
@@ -515,13 +514,13 @@ export class AppComponent implements OnInit, OnDestroy {
             isLockable: availableTimeoutActions.includes(VaultTimeoutAction.Lock),
             email: stateAccounts[i].profile.email,
             userId: stateAccounts[i].profile.userId,
+            hasMasterPassword: await this.userVerificationService.hasMasterPassword(userId),
           };
         }
       }
       updateRequest = {
         accounts: accounts,
         activeUserId: await this.stateService.getUserId(),
-        hideChangeMasterPassword: !(await this.userVerificationService.hasMasterPassword()),
       };
     }
 

--- a/apps/desktop/src/main/menu/menu.account.ts
+++ b/apps/desktop/src/main/menu/menu.account.ts
@@ -15,14 +15,15 @@ export class AccountMenu implements IMenubarMenu {
   }
 
   get items(): MenuItemConstructorOptions[] {
-    return [
-      this.premiumMembership,
-      this.changeMasterPassword,
-      this.twoStepLogin,
-      this.fingerprintPhrase,
-      this.separator,
-      this.deleteAccount,
-    ];
+    const items = [this.premiumMembership];
+    if (!this._hideMasterPassword) {
+      items.push(this.changeMasterPassword);
+    }
+    items.push(this.twoStepLogin);
+    items.push(this.fingerprintPhrase);
+    items.push(this.separator);
+    items.push(this.deleteAccount);
+    return items;
   }
 
   private readonly _i18nService: I18nService;
@@ -30,19 +31,22 @@ export class AccountMenu implements IMenubarMenu {
   private readonly _webVaultUrl: string;
   private readonly _window: BrowserWindow;
   private readonly _isLocked: boolean;
+  private readonly _hideMasterPassword: boolean;
 
   constructor(
     i18nService: I18nService,
     messagingService: MessagingService,
     webVaultUrl: string,
     window: BrowserWindow,
-    isLocked: boolean
+    isLocked: boolean,
+    hideMasterPassword: boolean
   ) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
     this._webVaultUrl = webVaultUrl;
     this._window = window;
     this._isLocked = isLocked;
+    this._hideMasterPassword = hideMasterPassword;
   }
 
   private get premiumMembership(): MenuItemConstructorOptions {

--- a/apps/desktop/src/main/menu/menu.account.ts
+++ b/apps/desktop/src/main/menu/menu.account.ts
@@ -16,7 +16,7 @@ export class AccountMenu implements IMenubarMenu {
 
   get items(): MenuItemConstructorOptions[] {
     const items = [this.premiumMembership];
-    if (!this._hideMasterPassword) {
+    if (this._hasMasterPassword) {
       items.push(this.changeMasterPassword);
     }
     items.push(this.twoStepLogin);
@@ -31,7 +31,7 @@ export class AccountMenu implements IMenubarMenu {
   private readonly _webVaultUrl: string;
   private readonly _window: BrowserWindow;
   private readonly _isLocked: boolean;
-  private readonly _hideMasterPassword: boolean;
+  private readonly _hasMasterPassword: boolean;
 
   constructor(
     i18nService: I18nService,
@@ -39,14 +39,14 @@ export class AccountMenu implements IMenubarMenu {
     webVaultUrl: string,
     window: BrowserWindow,
     isLocked: boolean,
-    hideMasterPassword: boolean
+    hasMasterPassword: boolean
   ) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
     this._webVaultUrl = webVaultUrl;
     this._window = window;
     this._isLocked = isLocked;
-    this._hideMasterPassword = hideMasterPassword;
+    this._hasMasterPassword = hasMasterPassword;
   }
 
   private get premiumMembership(): MenuItemConstructorOptions {

--- a/apps/desktop/src/main/menu/menu.updater.ts
+++ b/apps/desktop/src/main/menu/menu.updater.ts
@@ -1,5 +1,4 @@
 export class MenuUpdateRequest {
-  hideChangeMasterPassword: boolean;
   activeUserId: string;
   accounts: { [userId: string]: MenuAccount };
 }
@@ -10,4 +9,5 @@ export class MenuAccount {
   isLockable: boolean;
   userId: string;
   email: string;
+  hasMasterPassword: boolean;
 }

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -64,6 +64,8 @@ export class Menubar {
 
     const isLockable = !isLocked && updateRequest?.accounts[updateRequest.activeUserId]?.isLockable;
 
+    const hideUpdateMasterPassword = updateRequest?.hideChangeMasterPassword ?? false;
+
     this.items = [
       new FileMenu(
         i18nService,
@@ -76,7 +78,14 @@ export class Menubar {
       ),
       new EditMenu(i18nService, messagingService, isLocked),
       new ViewMenu(i18nService, messagingService, isLocked),
-      new AccountMenu(i18nService, messagingService, webVaultUrl, windowMain.win, isLocked),
+      new AccountMenu(
+        i18nService,
+        messagingService,
+        webVaultUrl,
+        windowMain.win,
+        isLocked,
+        hideUpdateMasterPassword
+      ),
       new WindowMenu(i18nService, messagingService, windowMain),
       new HelpMenu(
         i18nService,

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -63,8 +63,7 @@ export class Menubar {
     }
 
     const isLockable = !isLocked && updateRequest?.accounts[updateRequest.activeUserId]?.isLockable;
-
-    const hideUpdateMasterPassword = updateRequest?.hideChangeMasterPassword ?? false;
+    const hideChangeMasterPassword = updateRequest?.hideChangeMasterPassword ?? false;
 
     this.items = [
       new FileMenu(
@@ -84,7 +83,7 @@ export class Menubar {
         webVaultUrl,
         windowMain.win,
         isLocked,
-        hideUpdateMasterPassword
+        hideChangeMasterPassword
       ),
       new WindowMenu(i18nService, messagingService, windowMain),
       new HelpMenu(

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -63,7 +63,8 @@ export class Menubar {
     }
 
     const isLockable = !isLocked && updateRequest?.accounts[updateRequest.activeUserId]?.isLockable;
-    const hideChangeMasterPassword = updateRequest?.hideChangeMasterPassword ?? false;
+    const hasMasterPassword =
+      updateRequest?.accounts[updateRequest.activeUserId]?.hasMasterPassword ?? false;
 
     this.items = [
       new FileMenu(
@@ -83,7 +84,7 @@ export class Menubar {
         webVaultUrl,
         windowMain.win,
         isLocked,
-        hideChangeMasterPassword
+        hasMasterPassword
       ),
       new WindowMenu(i18nService, messagingService, windowMain),
       new HelpMenu(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Hide the Change Master Password menu option on the desktop when a user has no Master Password.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **app.component.ts:** Moved the `hasMasterPassword` to the `MenuAccount`, since it is dependent upon the active account just like `isLockable` and the other properties on the account.  I also changed from negative ("hide...") to positive "has..." to avoid negation in the conditionals.
- **menu.updater.ts:** Moved the master password property to the `MenuAccount` class.
- **menu.account.ts:** Changed `items()` to dynamically build the item array and only show the `changeMasterPassword` item if the active account has a master password.  This follows the pattern of other menu options with dynamic item lists.
- **menubar.ts:** Use the `hasMasterPassword` property on the active account to tell the `AccountMenu` whether to show the Change Master Password option. 

## Screenshots

![image](https://github.com/bitwarden/clients/assets/106564991/5d20965e-e863-4797-b546-bfc678bf4dea)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
