### PR TITLE
[PM-3427] chore: avoid switching to the next tab when unlocked and reduce freezing

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -71,11 +71,6 @@ export default class RuntimeBackground {
           await this.browserPopoutWindowService.closeLoginPrompt();
         }
 
-        await this.main.refreshBadge();
-        await this.main.refreshMenu(false);
-        this.notificationsService.updateConnection(msg.command === "unlocked");
-        this.systemService.cancelProcessReload();
-
         if (item) {
           await BrowserApi.focusWindow(item.commandToRetry.sender.tab.windowId);
           await BrowserApi.focusTab(item.commandToRetry.sender.tab.id);
@@ -85,6 +80,12 @@ export default class RuntimeBackground {
             item
           );
         }
+
+        await this.main.refreshBadge();
+        await this.main.refreshMenu(false);
+        this.notificationsService.updateConnection(msg.command === "unlocked");
+        this.systemService.cancelProcessReload();
+
         break;
       }
       case "addToLockedVaultPendingNotifications":
@@ -179,9 +180,9 @@ export default class RuntimeBackground {
         try {
           BrowserApi.createNewTab(
             "popup/index.html?uilocation=popout#/sso?code=" +
-              encodeURIComponent(msg.code) +
-              "&state=" +
-              encodeURIComponent(msg.state)
+            encodeURIComponent(msg.code) +
+            "&state=" +
+            encodeURIComponent(msg.state)
           );
         } catch {
           this.logService.error("Unable to open sso popout tab");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When unlocking the vault from a tab, the next tab was loaded instead of the original, with a period of freezing. This caused poor user experience.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->



- **browser/src/background/runtime.background.ts:** Move the code for the tab focusing step ahead of the time-consuming vault refreshing step.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
