### PR TITLE
Bump Firefox Min Version

### DIFF
--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -105,7 +105,7 @@
   "applications": {
     "gecko": {
       "id": "{446900e4-71c2-419f-a6a7-df9c091e268b}",
-      "strict_min_version": "42.0"
+      "strict_min_version": "91.0"
     }
   },
   "sidebar_action": {

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -113,7 +113,7 @@
   "applications": {
     "gecko": {
       "id": "{446900e4-71c2-419f-a6a7-df9c091e268b}",
-      "strict_min_version": "42.0"
+      "strict_min_version": "91.0"
     }
   },
   "sidebar_action": {

--- a/apps/browser/src/platform/services/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/browser-platform-utils.service.ts
@@ -314,10 +314,6 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
       return false;
     }
 
-    if (this.isFirefox()) {
-      return parseInt((await browser.runtime.getBrowserInfo()).version.split(".")[0], 10) >= 87;
-    }
-
     return true;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves #3829 

Bumping the min version of our next version of Firefox from `42` -> `91`. `91` was chosen because it is the second most recent version of Firefox ESR. This may stop some users from updating to the next version of our browser extension `2023.9.X`. Older versions of the clients are not guaranteed to be supported on newer version of our server. We recommend anyone on an unsupported version of Firefox to update to a supported version.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/manifest{.v3}.json:** Update `strict_min_version`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
