### PR TITLE
[PM-3453] Update Autofill service to use new method to check for MP hash

### DIFF
--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
@@ -118,8 +118,8 @@ describe("CipherContextMenuHandler", () => {
     it("adds ciphers with master password reprompt if the user does not have a master password", async () => {
       authService.getAuthStatus.mockResolvedValue(AuthenticationStatus.Unlocked);
 
-      // User does not have a master password (key connector user or TDE user)
-      userVerificationService.hasMasterPassword.mockResolvedValue(false);
+      // User does not have a master password, or has one but hasn't logged in with it (key connector user or TDE user)
+      userVerificationService.hasMasterPasswordAndMasterKeyHash.mockResolvedValue(false);
 
       mainContextMenuHandler.init.mockResolvedValue(true);
 

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -185,7 +185,7 @@ export class CipherContextMenuHandler {
       cipher == null ||
       cipher.type !== CipherType.Login ||
       (cipher.reprompt !== CipherRepromptType.None &&
-        (await this.userVerificationService.hasMasterPassword()))
+        (await this.userVerificationService.hasMasterPasswordAndMasterKeyHash()))
     ) {
       return;
     }

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -239,7 +239,7 @@ export default class AutofillService implements AutofillServiceInterface {
     if (
       cipher == null ||
       (cipher.reprompt !== CipherRepromptType.None &&
-        (await this.userVerificationService.hasMasterPassword()))
+        (await this.userVerificationService.hasMasterPasswordAndMasterKeyHash()))
     ) {
       return null;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We introduced a new method on the `userVerificationService` that checks that a user has a master password **and** they have logged in with it (i.e. it is in state).  That is the only way that we can have the MP hash in state to do the reprompt comparison.  

This changes the code from https://github.com/bitwarden/clients/pull/5885 to use this new method.

## Code changes

- **cipher-context-menu-handler.spec.ts:** Changed test to use new method.
- **cipher-context-menu-handler.ts:** Changed to use new method.
- **autofill.service.ts:** Changed to use new method.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
