### PR TITLE
PM-3456 - TDE Admin Auth Req Flow - FF dead object issue 

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -24,7 +24,9 @@ import {
 } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
 import { PolicyApiService } from "@bitwarden/common/admin-console/services/policy/policy-api.service";
+import { AuthRequestCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/auth-request-crypto.service.abstraction";
 import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/auth/abstractions/auth.service";
+import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
 import { KeyConnectorService } from "@bitwarden/common/auth/abstractions/key-connector.service";
 import { LoginService as LoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/login.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
@@ -249,6 +251,20 @@ function getBgService<T>(service: keyof MainBackground) {
         return cryptoService;
       },
       deps: [EncryptService],
+    },
+    {
+      provide: AuthRequestCryptoServiceAbstraction,
+      useFactory: () => {
+        return getBgService<AuthRequestCryptoServiceAbstraction>("authRequestCryptoService")();
+      },
+      deps: [],
+    },
+    {
+      provide: DeviceTrustCryptoServiceAbstraction,
+      useFactory: () => {
+        return getBgService<DeviceTrustCryptoServiceAbstraction>("deviceTrustCryptoService")();
+      },
+      deps: [],
     },
     {
       provide: EventUploadService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[PM-3456](https://bitwarden.atlassian.net/browse/PM-3456)
Resolve Firefox Browser Extension issue with TDE Admin Auth Request flow 
- The foreground popup must retrieve the long lived background services for the new TDE services

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/services/services.module.ts:** 
    - Add logic to retrieve `AuthRequestCryptoService` from background
    - Add logic to retrieve `DeviceTrustCryptoService` from background

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
