### PR TITLE
[AC-1599] Fix Secrets Manager cost subtotal when creating an organization

### DIFF
--- a/apps/web/src/app/billing/settings/organization-plans.component.ts
+++ b/apps/web/src/app/billing/settings/organization-plans.component.ts
@@ -314,16 +314,11 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       return 0;
     }
 
-    let subTotal = plan.basePrice;
-    if (plan.hasAdditionalSeatsOption && formValues.userSeats) {
-      subTotal += this.seatTotal(plan, formValues.userSeats);
-    }
-
-    if (plan.hasAdditionalServiceAccountOption && formValues.additionalServiceAccounts) {
-      subTotal += this.additionalServiceAccountTotal(plan);
-    }
-
-    return subTotal;
+    return (
+      plan.basePrice +
+      this.seatTotal(plan, formValues.userSeats) +
+      this.additionalServiceAccountTotal(plan)
+    );
   }
 
   get freeTrial() {

--- a/apps/web/src/app/billing/settings/organization-plans.component.ts
+++ b/apps/web/src/app/billing/settings/organization-plans.component.ts
@@ -319,8 +319,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       subTotal += this.seatTotal(plan, formValues.userSeats);
     }
 
-    if (plan.hasAdditionalStorageOption && formValues.additionalServiceAccounts) {
-      subTotal += this.additionalServiceAccountTotal(this.selectedPlan);
+    if (plan.hasAdditionalServiceAccountOption && formValues.additionalServiceAccounts) {
+      subTotal += this.additionalServiceAccountTotal(plan);
     }
 
     return subTotal;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The SM subtotal on the create organization page did not include the cost of SM service accounts.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* remove unnecessary `if` statements (the service account one referred to `hasAdditionalStorageOption` which was incorrect, but also this is handled by the getters, so we can simplify this logic and just remove it altogether)
* pass in `plan` (being the SM plan) to `additionalServiceAccountTotal`, not the `selectedPlan` (which is a PM plan without the required cost info)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
