### PR TITLE
[PM-3277] 1password1pux importer can also import json

### DIFF
--- a/apps/cli/src/tools/import.command.ts
+++ b/apps/cli/src/tools/import.command.ts
@@ -66,7 +66,7 @@ export class ImportCommand {
 
     try {
       let contents;
-      if (format === "1password1pux") {
+      if (format === "1password1pux" && filepath.endsWith(".1pux")) {
         contents = await CliUtils.extractZipContent(filepath, "export.data");
       } else if (format === "protonpass" && filepath.endsWith(".zip")) {
         contents = await CliUtils.extractZipContent(filepath, "Proton Pass/data.json");

--- a/apps/web/src/app/tools/import-export/import.component.ts
+++ b/apps/web/src/app/tools/import-export/import.component.ts
@@ -325,7 +325,7 @@ export class ImportComponent implements OnInit, OnDestroy {
   }
 
   private getFileContents(file: File): Promise<string> {
-    if (this.format === "1password1pux") {
+    if (this.format === "1password1pux" && file.name.endsWith(".1pux")) {
       return this.extractZipContent(file, "export.data");
     }
     if (

--- a/libs/importer/src/models/import-options.ts
+++ b/libs/importer/src/models/import-options.ts
@@ -12,7 +12,7 @@ export const featuredImportOptions = [
   { id: "keepass2xml", name: "KeePass 2 (xml)" },
   { id: "lastpasscsv", name: "LastPass (csv)" },
   { id: "safaricsv", name: "Safari and macOS (csv)" },
-  { id: "1password1pux", name: "1Password (1pux)" },
+  { id: "1password1pux", name: "1Password (1pux/json)" },
 ] as const;
 
 export const regularImportOptions = [


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The .1pux-format is technically just a zip-file that contains a file named `export.data`which is a json file. These changes add support to upload either a 1pux or the export.data file directly. The thought to change this came through the [recent addtion of the ProtonPass importer](https://github.com/bitwarden/clients/pull/5766).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/cli/src/tools/import.command.ts:** Ensure that files ending with `.1pux` are treated as zip files and extract the export.data. 
- **apps/web/src/app/tools/import-export/import.component.ts:** Ensure that files ending with `.1pux` are treated as zip files and extract the export.data. 
- **libs/importer/src/models/import-options.ts:** Display that the 1password 1pux importer support 1pux but also the upload of the unzipped `export.data (json)`
## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
