### PR TITLE
[PM-3520] [BEEEP] Clean-up report constructors

### DIFF
--- a/apps/web/src/app/admin-console/organizations/tools/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/exposed-passwords-report.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from "@angular/router";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -25,12 +24,11 @@ export class ExposedPasswordsReportComponent extends BaseExposedPasswordsReportC
     cipherService: CipherService,
     auditService: AuditService,
     modalService: ModalService,
-    messagingService: MessagingService,
     private organizationService: OrganizationService,
     private route: ActivatedRoute,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(cipherService, auditService, modalService, messagingService, passwordRepromptService);
+    super(cipherService, auditService, modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/inactive-two-factor-report.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from "@angular/router";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -21,13 +20,12 @@ export class InactiveTwoFactorReportComponent extends BaseInactiveTwoFactorRepor
   constructor(
     cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     private route: ActivatedRoute,
     logService: LogService,
     passwordRepromptService: PasswordRepromptService,
     private organizationService: OrganizationService
   ) {
-    super(cipherService, modalService, messagingService, logService, passwordRepromptService);
+    super(cipherService, modalService, logService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/admin-console/organizations/tools/reused-passwords-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/reused-passwords-report.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from "@angular/router";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -23,12 +22,11 @@ export class ReusedPasswordsReportComponent extends BaseReusedPasswordsReportCom
   constructor(
     cipherService: CipherService,
     modalService: ModalService,
-    stateService: StateService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(cipherService, modalService, stateService, passwordRepromptService);
+    super(cipherService, modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/admin-console/organizations/tools/reused-passwords-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/reused-passwords-report.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from "@angular/router";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
@@ -24,13 +23,12 @@ export class ReusedPasswordsReportComponent extends BaseReusedPasswordsReportCom
   constructor(
     cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     stateService: StateService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(cipherService, modalService, messagingService, stateService, passwordRepromptService);
+    super(cipherService, modalService, stateService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/admin-console/organizations/tools/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/unsecured-websites-report.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from "@angular/router";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -20,12 +19,11 @@ export class UnsecuredWebsitesReportComponent extends BaseUnsecuredWebsitesRepor
   constructor(
     cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(cipherService, modalService, messagingService, passwordRepromptService);
+    super(cipherService, modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/admin-console/organizations/tools/weak-passwords-report.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/weak-passwords-report.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from "@angular/router";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
@@ -25,18 +24,11 @@ export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportCompone
     cipherService: CipherService,
     passwordStrengthService: PasswordStrengthServiceAbstraction,
     modalService: ModalService,
-    messagingService: MessagingService,
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(
-      cipherService,
-      passwordStrengthService,
-      modalService,
-      messagingService,
-      passwordRepromptService
-    );
+    super(cipherService, passwordStrengthService, modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/reports/pages/cipher-report.component.ts
@@ -21,7 +21,6 @@ export class CipherReportComponent {
 
   constructor(
     private modalService: ModalService,
-    public requiresPaid: boolean,
     protected passwordRepromptService: PasswordRepromptService
   ) {}
 

--- a/apps/web/src/app/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/reports/pages/cipher-report.component.ts
@@ -2,7 +2,6 @@ import { Directive, ViewChild, ViewContainerRef } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -22,7 +21,6 @@ export class CipherReportComponent {
 
   constructor(
     private modalService: ModalService,
-    protected messagingService: MessagingService,
     public requiresPaid: boolean,
     protected passwordRepromptService: PasswordRepromptService
   ) {}

--- a/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
@@ -22,7 +22,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     modalService: ModalService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, true, passwordRepromptService);
+    super(modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/exposed-passwords-report.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
@@ -21,10 +20,9 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     protected cipherService: CipherService,
     protected auditService: AuditService,
     modalService: ModalService,
-    messagingService: MessagingService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, passwordRepromptService);
+    super(modalService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -24,7 +24,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     private logService: LogService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, true, passwordRepromptService);
+    super(modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
@@ -22,11 +21,10 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
   constructor(
     protected cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     private logService: LogService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, passwordRepromptService);
+    super(modalService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
@@ -20,11 +19,10 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
   constructor(
     protected cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, passwordRepromptService);
+    super(modalService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
@@ -19,7 +18,6 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
   constructor(
     protected cipherService: CipherService,
     modalService: ModalService,
-    stateService: StateService,
     passwordRepromptService: PasswordRepromptService
   ) {
     super(modalService, true, passwordRepromptService);

--- a/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/reused-passwords-report.component.ts
@@ -20,7 +20,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     modalService: ModalService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, true, passwordRepromptService);
+    super(modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
@@ -17,10 +16,9 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
   constructor(
     protected cipherService: CipherService,
     modalService: ModalService,
-    messagingService: MessagingService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, passwordRepromptService);
+    super(modalService, true, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/reports/pages/unsecured-websites-report.component.ts
@@ -18,7 +18,7 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
     modalService: ModalService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, true, passwordRepromptService);
+    super(modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
@@ -25,7 +25,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     modalService: ModalService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, true, passwordRepromptService);
+    super(modalService, passwordRepromptService);
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/reports/pages/weak-passwords-report.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 
 import { ModalService } from "@bitwarden/angular/services/modal.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PasswordRepromptService } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
@@ -24,10 +23,9 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     protected cipherService: CipherService,
     protected passwordStrengthService: PasswordStrengthServiceAbstraction,
     modalService: ModalService,
-    messagingService: MessagingService,
     passwordRepromptService: PasswordRepromptService
   ) {
-    super(modalService, messagingService, true, passwordRepromptService);
+    super(modalService, true, passwordRepromptService);
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
While reviewing some work done on https://github.com/bitwarden/clients/pull/5998 and team-tools planning to take ownership of individual and organisational reports, I realised some unneeded services/values being passed down into the baseCipherReport.

Seeing that these unused services weren't obvious and only visible when traversing down the components, this is a good candidate for a refactor. 

Looking at how the vault currently opens an item for edit (routerLink/navigate to `vault?itemId=xxx`) we can likely also get rid of the modalService and the passwordRepromptService. ModalService is deprecated anyway and the reprompt should not be a concern of the report.component.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- **Remove unused messagingService -** 4b474d6
- **Remove unused StateService -** ef633ee 
- **Remove requiresPaid from CipherReportComponent -** db498cdfa5ad9eefcc500bb635e1aa83cff93206 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
