### PR TITLE
Updated message keys for CrowdIn to pick them up

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2152,7 +2152,7 @@
   "notificationSentDevice": {
     "message": "A notification has been sent to your device."
   },
-  "logInInitiated": {
+  "loginInitiated": {
     "message": "Login initiated"
   },
   "exposedMasterPassword": {

--- a/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.html
+++ b/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.html
@@ -1,7 +1,7 @@
 <div id="login-initiated">
   <header>
     <h1 class="margin-auto">
-      <span class="title">{{ "logInInitiated" | i18n }}</span>
+      <span class="title">{{ "loginInitiated" | i18n }}</span>
     </h1>
   </header>
 
@@ -13,7 +13,7 @@
     <ng-container *ngIf="!loading">
       <ng-container *ngIf="data.state == State.ExistingUserUntrustedDevice">
         <div class="standard-x-margin">
-          <p class="lead">{{ "logInInitiated" | i18n }}</p>
+          <p class="lead">{{ "loginInitiated" | i18n }}</p>
           <h6 class="mb-20px">{{ "deviceApprovalRequired" | i18n }}</h6>
         </div>
 
@@ -66,7 +66,7 @@
 
       <ng-container *ngIf="data.state == State.NewUser">
         <div class="standard-x-margin">
-          <p class="lead">{{ "logInInitiated" | i18n }}</p>
+          <p class="lead">{{ "loginInitiated" | i18n }}</p>
         </div>
 
         <form

--- a/apps/browser/src/auth/popup/login-with-device.component.html
+++ b/apps/browser/src/auth/popup/login-with-device.component.html
@@ -7,7 +7,7 @@
   <div class="content login-page">
     <ng-container *ngIf="state == StateEnum.StandardAuthRequest">
       <div>
-        <p class="lead">{{ "logInInitiated" | i18n }}</p>
+        <p class="lead">{{ "loginInitiated" | i18n }}</p>
 
         <div>
           <p>{{ "notificationSentDevice" | i18n }}</p>

--- a/apps/desktop/src/auth/login/login-decryption-options/login-decryption-options.component.html
+++ b/apps/desktop/src/auth/login/login-decryption-options/login-decryption-options.component.html
@@ -7,7 +7,7 @@
     </div>
 
     <ng-container *ngIf="!loading">
-      <h1 id="heading">{{ "logInInitiated" | i18n }}</h1>
+      <h1 id="heading">{{ "loginInitiated" | i18n }}</h1>
       <h6
         *ngIf="data.state == State.ExistingUserUntrustedDevice"
         id="subHeading"

--- a/apps/desktop/src/auth/login/login-with-device.component.html
+++ b/apps/desktop/src/auth/login/login-with-device.component.html
@@ -3,7 +3,7 @@
     <img class="logo-image" alt="Bitwarden" />
 
     <ng-container *ngIf="state == StateEnum.StandardAuthRequest">
-      <p class="lead text-center">{{ "logInInitiated" | i18n }}</p>
+      <p class="lead text-center">{{ "loginInitiated" | i18n }}</p>
 
       <div class="box last">
         <div class="box-content">

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2109,7 +2109,7 @@
   "logInWithAnotherDevice": {
     "message": "Log in with another device"
   },
-  "logInInitiated": {
+  "loginInitiated": {
     "message": "Login initiated"
   },
   "notificationSentDevice": {

--- a/apps/web/src/app/auth/login/login-with-device.component.html
+++ b/apps/web/src/app/auth/login/login-with-device.component.html
@@ -14,7 +14,7 @@
       <div
         class="tw-mt-3 tw-rounded-md tw-border tw-border-solid tw-border-secondary-300 tw-bg-background tw-p-6"
       >
-        <h2 class="tw-mb-6 tw-text-xl tw-font-semibold">{{ "logInInitiated" | i18n }}</h2>
+        <h2 class="tw-mb-6 tw-text-xl tw-font-semibold">{{ "loginInitiated" | i18n }}</h2>
 
         <div class="tw-text-light">
           <p class="tw-mb-6">{{ "notificationSentDevice" | i18n }}</p>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6865,31 +6865,31 @@
   "trustedDevices": {
     "message": "Trusted devices"
   },
-  "memberDecryptionTdeDescriptionPartOne": {
+  "memberDecryptionOptionTdeDescriptionPartOne": {
     "message": "Once authenticated, members will decrypt vault data using a key stored on their device. The",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO Required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionLinkOne": {
+  "memberDecryptionOptionTdeDescriptionLinkOne": {
     "message": "single organization",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionPartTwo": {
+  "memberDecryptionOptionTdeDescriptionPartTwo": {
     "message": "policy,",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionLinkTwo": {
+  "memberDecryptionOptionTdeDescriptionLinkTwo": {
     "message": "SSO required",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionPartThree": {
+  "memberDecryptionOptionTdeDescriptionPartThree": {
     "message": "policy, and",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionLinkThree": {
+  "memberDecryptionOptionTdeDescriptionLinkThree": {
     "message": "account recovery administration",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },
-  "memberDecryptionTdeDescriptionPartFour": {
+  "memberDecryptionOptionTdeDescriptionPartFour": {
     "message": "policy with automatic enrollment will turn on when this option is used.",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Once authenticated, members will decrypt vault data using a key stored on their device. The single organization policy, SSO required policy, and account recovery administration policy with automatic enrollment will turn on when this option is used.'"
   },

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
@@ -81,13 +81,15 @@
           {{ "trustedDevices" | i18n }}
         </bit-label>
         <bit-hint>
-          {{ "memberDecryptionTdeDescriptionPartOne" | i18n }}
-          <a routerLink="../policies">{{ "memberDecryptionTdeDescriptionLinkOne" | i18n }}</a>
-          {{ "memberDecryptionTdeDescriptionPartTwo" | i18n }}
-          <a routerLink="../policies">{{ "memberDecryptionTdeDescriptionLinkTwo" | i18n }}</a>
-          {{ "memberDecryptionTdeDescriptionPartThree" | i18n }}
-          <a routerLink="../policies">{{ "memberDecryptionTdeDescriptionLinkThree" | i18n }}</a>
-          {{ "memberDecryptionTdeDescriptionPartFour" | i18n }}
+          {{ "memberDecryptionOptionTdeDescriptionPartOne" | i18n }}
+          <a routerLink="../policies">{{ "memberDecryptionOptionTdeDescriptionLinkOne" | i18n }}</a>
+          {{ "memberDecryptionOptionTdeDescriptionPartTwo" | i18n }}
+          <a routerLink="../policies">{{ "memberDecryptionOptionTdeDescriptionLinkTwo" | i18n }}</a>
+          {{ "memberDecryptionOptionTdeDescriptionPartThree" | i18n }}
+          <a routerLink="../policies">{{
+            "memberDecryptionOptionTdeDescriptionLinkThree" | i18n
+          }}</a>
+          {{ "memberDecryptionOptionTdeDescriptionPartFour" | i18n }}
         </bit-hint>
       </bit-radio-button>
     </bit-radio-group>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In order for CrowdIn translators to pick up the changes, the message `key` must change.  I've updated the keys for the messages that changed for TDE.

## Code changes

- **messages.json:** Updated the message `key` for `loginInitiated` on desktop and browser (it was already updated on web) and the TDE description message on web
- All other files - Updated the usages of this message to reflect the change.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
