### PR TITLE
[CL-119] rename slots in nav-item

### DIFF
--- a/libs/components/src/navigation/nav-group.component.html
+++ b/libs/components/src/navigation/nav-group.component.html
@@ -29,10 +29,10 @@
   </ng-template>
 
   <!-- Show toggle to the left for trees otherwise to the right -->
-  <ng-container slot-start *ngIf="variant === 'tree'">
+  <ng-container slot="start" *ngIf="variant === 'tree'">
     <ng-container *ngTemplateOutlet="button"></ng-container>
   </ng-container>
-  <ng-container slot-end *ngIf="variant !== 'tree'">
+  <ng-container slot="end" *ngIf="variant !== 'tree'">
     <ng-container *ngTemplateOutlet="button"></ng-container>
   </ng-container>
 </bit-nav-item>

--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -16,7 +16,7 @@
       #slotStart
       class="[&>*:focus-visible::before]:!tw-ring-text-alt2 [&>*:hover]:!tw-border-text-alt2 [&>*]:!tw-text-alt2"
     >
-      <ng-content select="[slot-start]"></ng-content>
+      <ng-content select="[slot=start]"></ng-content>
     </div>
     <!-- Default content for #slotStart (for consistent sizing) -->
     <div
@@ -75,7 +75,7 @@
     <div
       class="tw-flex tw-gap-1 [&>*:focus-visible::before]:!tw-ring-text-alt2 [&>*:hover]:!tw-border-text-alt2 [&>*]:!tw-text-alt2"
     >
-      <ng-content select="[slot-end]"></ng-content>
+      <ng-content select="[slot=end]"></ng-content>
     </div>
   </div>
 </div>

--- a/libs/components/src/navigation/nav-item.stories.ts
+++ b/libs/components/src/navigation/nav-item.stories.ts
@@ -61,7 +61,7 @@ export const WithChildButtons: Story = {
     template: `
       <bit-nav-item text="Hello World" [route]="['']" icon="bwi-collection">
         <button
-          slot-start
+          slot="start"
           class="tw-ml-auto"
           [bitIconButton]="'bwi-clone'"
           [buttonType]="'contrast'"
@@ -69,7 +69,7 @@ export const WithChildButtons: Story = {
           aria-label="option 1"
         ></button>
         <button
-          slot-end
+          slot="end"
           class="tw-ml-auto"
           [bitIconButton]="'bwi-pencil-square'"
           [buttonType]="'contrast'"
@@ -77,7 +77,7 @@ export const WithChildButtons: Story = {
           aria-label="option 2"
         ></button>
         <button
-          slot-end
+          slot="end"
           class="tw-ml-auto"
           [bitIconButton]="'bwi-check'"
           [buttonType]="'contrast'"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`bit-nav-item` uses `slot-start` and `slot-end` for its content projection selectors. 

To be consistent with the pattern we are starting to use in the CL, these were renamed to target `slot="start"` and `slot="end"`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
