### PR TITLE
[PM-3533] Support onboarding Key Connector users with existing master passwords

### DIFF
--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -600,8 +600,6 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         LogService,
         OrganizationServiceAbstraction,
         CryptoFunctionServiceAbstraction,
-        SyncNotifierServiceAbstraction,
-        MessagingServiceAbstraction,
         LOGOUT_CALLBACK,
       ],
     },

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -208,7 +208,8 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: LOGOUT_CALLBACK,
       useFactory:
-        (messagingService: MessagingServiceAbstraction) => (expired: boolean, userId?: string) =>
+        (messagingService: MessagingServiceAbstraction) =>
+        async (expired: boolean, userId?: string) =>
           messagingService.send("logout", { expired: expired, userId: userId }),
       deps: [MessagingServiceAbstraction],
     },

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -208,8 +208,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: LOGOUT_CALLBACK,
       useFactory:
-        (messagingService: MessagingServiceAbstraction) =>
-        async (expired: boolean, userId?: string) =>
+        (messagingService: MessagingServiceAbstraction) => (expired: boolean, userId?: string) =>
           messagingService.send("logout", { expired: expired, userId: userId }),
       deps: [MessagingServiceAbstraction],
     },

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
@@ -266,11 +266,11 @@ describe("SsoLogInStrategy", () => {
   describe("Key Connector", () => {
     let tokenResponse: IdentityTokenResponse;
     beforeEach(() => {
-      tokenResponse = identityTokenResponseFactory();
+      tokenResponse = identityTokenResponseFactory(null, { HasMasterPassword: false });
       tokenResponse.keyConnectorUrl = keyConnectorUrl;
     });
 
-    it("gets and sets the master key if Key Connector is enabled", async () => {
+    it("gets and sets the master key if Key Connector is enabled and the user doesn't have a master password", async () => {
       const masterKey = new SymmetricCryptoKey(
         new Uint8Array(64).buffer as CsprngArray
       ) as MasterKey;
@@ -283,7 +283,7 @@ describe("SsoLogInStrategy", () => {
       expect(keyConnectorService.setMasterKeyFromUrl).toHaveBeenCalledWith(keyConnectorUrl);
     });
 
-    it("converts new SSO user to Key Connector on first login", async () => {
+    it("converts new SSO user with no master password to Key Connector on first login", async () => {
       tokenResponse.key = null;
 
       apiService.postIdentityToken.mockResolvedValue(tokenResponse);
@@ -296,7 +296,7 @@ describe("SsoLogInStrategy", () => {
       );
     });
 
-    it("decrypts and sets the user key if Key Connector is enabled", async () => {
+    it("decrypts and sets the user key if Key Connector is enabled and the user doesn't have a master password", async () => {
       const userKey = new SymmetricCryptoKey(new Uint8Array(64).buffer as CsprngArray) as UserKey;
       const masterKey = new SymmetricCryptoKey(
         new Uint8Array(64).buffer as CsprngArray

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.ts
@@ -148,9 +148,8 @@ export class SsoLogInStrategy extends LogInStrategy {
         await this.trySetUserKeyWithDeviceKey(tokenResponse);
       }
     } else if (
-      // TODO: remove tokenResponse.keyConnectorUrl after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
       masterKeyEncryptedUserKey != null &&
-      (tokenResponse.keyConnectorUrl || userDecryptionOptions?.keyConnectorOption?.keyConnectorUrl)
+      this.getKeyConnectorUrl(tokenResponse) != null
     ) {
       // Key connector enabled for user
       await this.trySetUserKeyWithMasterKey();

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.ts
@@ -81,9 +81,15 @@ export class SsoLogInStrategy extends LogInStrategy {
     // eventually we’ll need to support migration of existing TDE users to Key Connector
     const newSsoUser = tokenResponse.key == null;
 
-    if (tokenResponse.keyConnectorUrl != null) {
+    const userDecryptionOptions = tokenResponse?.userDecryptionOptions;
+
+    // TODO: remove tokenResponse.keyConnectorUrl reference after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
+    const keyConnectorUrl =
+      tokenResponse.keyConnectorUrl ?? userDecryptionOptions?.keyConnectorOption?.keyConnectorUrl;
+
+    if (keyConnectorUrl != null) {
       if (!newSsoUser) {
-        await this.keyConnectorService.setMasterKeyFromUrl(tokenResponse.keyConnectorUrl);
+        await this.keyConnectorService.setMasterKeyFromUrl(keyConnectorUrl);
       } else {
         await this.keyConnectorService.convertNewSsoUserToKeyConnector(tokenResponse, this.orgId);
       }
@@ -117,7 +123,7 @@ export class SsoLogInStrategy extends LogInStrategy {
         await this.trySetUserKeyWithDeviceKey(tokenResponse);
       }
     } else if (
-      // TODO: remove tokenResponse.keyConnectorUrl when it's deprecated
+      // TODO: remove tokenResponse.keyConnectorUrl after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
       masterKeyEncryptedUserKey != null &&
       (tokenResponse.keyConnectorUrl || userDecryptionOptions?.keyConnectorOption?.keyConnectorUrl)
     ) {

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.ts
@@ -217,11 +217,10 @@ export class SsoLogInStrategy extends LogInStrategy {
     const masterKey = await this.cryptoService.getMasterKey();
 
     if (!masterKey) {
-      throw new Error("Master key not found");
+      return;
     }
 
     const userKey = await this.cryptoService.decryptUserKeyWithMasterKey(masterKey);
-
     await this.cryptoService.setUserKey(userKey);
   }
 

--- a/libs/common/src/auth/services/key-connector.service.ts
+++ b/libs/common/src/auth/services/key-connector.service.ts
@@ -24,7 +24,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     private logService: LogService,
     private organizationService: OrganizationService,
     private cryptoFunctionService: CryptoFunctionService,
-    private logoutCallback: (expired: boolean, userId?: string) => void
+    private logoutCallback: (expired: boolean, userId?: string) => Promise<void>
   ) {}
 
   setUsesKeyConnector(usesKeyConnector: boolean) {

--- a/libs/common/src/auth/services/key-connector.service.ts
+++ b/libs/common/src/auth/services/key-connector.service.ts
@@ -84,7 +84,15 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   }
 
   async convertNewSsoUserToKeyConnector(tokenResponse: IdentityTokenResponse, orgId: string) {
-    const { kdf, kdfIterations, kdfMemory, kdfParallelism, keyConnectorUrl } = tokenResponse;
+    // TODO: Remove after tokenResponse.keyConnectorUrl is deprecated in 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
+    const {
+      kdf,
+      kdfIterations,
+      kdfMemory,
+      kdfParallelism,
+      keyConnectorUrl: legacyKeyConnectorUrl,
+      userDecryptionOptions,
+    } = tokenResponse;
     const password = await this.cryptoFunctionService.randomBytes(64);
     const kdfConfig = new KdfConfig(kdfIterations, kdfMemory, kdfParallelism);
 
@@ -104,6 +112,8 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     const [pubKey, privKey] = await this.cryptoService.makeKeyPair();
 
     try {
+      const keyConnectorUrl =
+        legacyKeyConnectorUrl ?? userDecryptionOptions?.keyConnectorOption?.keyConnectorUrl;
       await this.apiService.postUserKeyToKeyConnector(keyConnectorUrl, keyConnectorRequest);
     } catch (e) {
       this.handleKeyConnectorError(e);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Addresses several issues with handling Key Connector in connection with TDE.

- `KeyConnectorService` was not being properly instantiated due to 2 additional dependencies defined in `JslibServicesModule`.
- Prior to TDE, the identity token response would not include the `KeyConnectorUrl` if the user has a master password. This meant that we could just check for the presence of that property in order to ascertain whether the user has a blank master password or not.  However, post-TDE, the identity token will _always_ contain a `KeyConnectorUrl` in the `UserDecryptionOptions` property - regardless of whether the user has a master password or not.  This PR adds the check for the user having a master password to the client and only attempts to set the `masterKey` from Key Connector if the user has a `KeyConnectorUrl` **and** does not have a master password.

## Code changes

- **jslib-services.module.ts:** Removed incorrect dependencies for `KeyConnectorService`
- **sso-login.strategy.ts:** Updated the logic in `setMasterKey` to handle the response from post-TDE identity, in which the `KeyConnectorUrl` will be populated, even for users who have a master password.  Previously, it would not be populated, so the check for `KeyConnectorUrl` implied a check for the user having a master password as well.
- **sso-login.strategy.spec.ts:** Updated tests.
- **key-connector.service.ts:** Adjusted to use both the legacy and new location for the KeyConnectorUrl.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
