### PR TITLE
[PM-3589] Context Menu No Longer Shows Autofill Ciphers

### DIFF
--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -183,7 +183,7 @@ export class CipherContextMenuHandler {
     if (
       cipher == null ||
       cipher.type !== CipherType.Login ||
-      (await this.userVerificationService.hasMasterPasswordAndMasterKeyHash())
+      !(await this.userVerificationService.hasMasterPasswordAndMasterKeyHash())
     ) {
       return;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Context menu ciphers are not appearing due to a logic error when verifying that a user has a master password and key hash. Modifying the boolean check for logged in status allows autofill ciphers to be populated.

## Code changes

- **apps/browser/src/autofill/browser/cipher-context-menu-handler.ts:** Modifying the early exit conditional for `updateForCipher` to ensure users are logged in before continuing, rather than exiting early if users are logged in.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
