### PR TITLE
[PM-3600] Try to get key in master password reprompt check

### DIFF
--- a/libs/angular/src/vault/components/password-reprompt.component.ts
+++ b/libs/angular/src/vault/components/password-reprompt.component.ts
@@ -27,7 +27,8 @@ export class PasswordRepromptComponent {
   }
 
   async submit() {
-    if (!(await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, null))) {
+    const storedMasterKey = await this.cryptoService.getOrDeriveMasterKey(this.masterPassword);
+    if (!(await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, storedMasterKey))) {
       this.platformUtilsService.showToast(
         "error",
         this.i18nService.t("errorOccurred"),

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -117,7 +117,8 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
   async hasMasterPasswordAndMasterKeyHash(userId?: string): Promise<boolean> {
     return (
       (await this.hasMasterPassword(userId)) &&
-      (await this.cryptoService.getMasterKeyHash()) != null
+      (await this.cryptoService.getMasterKeyHash()) != null &&
+      (await this.stateService.getMasterKey()) != null // if a user unlocks with biometrics, no master key is stored
     );
   }
 

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -117,8 +117,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
   async hasMasterPasswordAndMasterKeyHash(userId?: string): Promise<boolean> {
     return (
       (await this.hasMasterPassword(userId)) &&
-      (await this.cryptoService.getMasterKeyHash()) != null &&
-      (await this.stateService.getMasterKey()) != null // if a user unlocks with biometrics, no master key is stored
+      (await this.cryptoService.getMasterKeyHash()) != null
     );
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix Master Password reprompt erroring when a user has logged in with biometrics by getting or deriving the key when the reprompt is submitted.

## Code changes

- **libs/angular/src/vault/components/password-reprompt.component.ts:** Get or derive the key before comparing the master password hashes. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
