### PR TITLE
[PM-1722] gracefully fail if site prompts user for passkey on load

### DIFF
--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -95,6 +95,11 @@ navigator.credentials.get = async (
   abortController?: AbortController
 ): Promise<Credential> => {
   const fallbackSupported = browserNativeWebauthnSupport;
+
+  if (options?.mediation && options.mediation !== "optional") {
+    throw new Error("Webauthn Conditional UI not supported in this browser.");
+  }
+
   try {
     const response = await messenger.request(
       {

--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -1,3 +1,5 @@
+import { FallbackRequestedError } from "@bitwarden/common/vault/abstractions/fido2/fido2-client.service.abstraction";
+
 import { WebauthnUtils } from "../../../browser/webauthn-utils";
 
 import { MessageType } from "./messaging/message";
@@ -96,11 +98,11 @@ navigator.credentials.get = async (
 ): Promise<Credential> => {
   const fallbackSupported = browserNativeWebauthnSupport;
 
-  if (options?.mediation && options.mediation !== "optional") {
-    throw new Error("Webauthn Conditional UI not supported in this browser.");
-  }
-
   try {
+    if (options?.mediation && options.mediation !== "optional") {
+      throw new FallbackRequestedError();
+    }
+
     const response = await messenger.request(
       {
         type: MessageType.CredentialGetRequest,


### PR DESCRIPTION
```
- [ ] Bug fix
- [ X ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Some sites will prompt you to use your passkey the moment you navigate to their sign-in page. Our objective is to gracefully fail that request, and the user will have to take some form of action (clicking use passkey, typing in username, etc) to use their passkey. 

## Code changes

page-script has been updated to look for an `mediation` key in the `options` argument for `navigate credentials get`. It will throw an error if the mediation value is `optional`

## Testing Locally

I found two sites that will prompt for using an existing passkey on load. With the new `mediation optional` logic the users will have to take action to use their passkeys. Those sites are [Kayak](https://www.kayak.com/) and [BestBuy](https://www.bestbuy.com/)

## Screenshots

Kayak after the user submits their email

![kayak_passkey](https://github.com/bitwarden/clients/assets/8302660/9208f97f-800d-4dc6-9874-c573256ec53c)


BestBuy after the user clicks "sign in with passkey"

![bestbuy_passkey](https://github.com/bitwarden/clients/assets/8302660/f3fd6aac-d640-4ce2-8d2c-00fceb9fbfc7)

