### PR TITLE
[PM-3588] Close duplicate single-action windows

### DIFF
--- a/apps/browser/src/platform/popup/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/browser-popout-window.service.ts
@@ -12,7 +12,6 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
   };
 
   async openUnlockPrompt(senderWindowId: number) {
-    await this.closeUnlockPrompt();
     await this.openSingleActionPopout(
       senderWindowId,
       "popup/index.html?uilocation=popout",
@@ -36,8 +35,6 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
       action: string;
     }
   ) {
-    await this.closePasswordRepromptPrompt();
-
     const promptWindowPath =
       "popup/index.html#/view-cipher" +
       "?uilocation=popout" +
@@ -73,18 +70,14 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
 
     const popupWindow = await BrowserApi.createWindow(windowOptions);
 
-    if (!singleActionPopoutKey) {
-      return;
-    }
+    await this.closeSingleActionPopout(singleActionPopoutKey);
     this.singleActionPopoutTabIds[singleActionPopoutKey] = popupWindow?.tabs[0].id;
   }
 
   private async closeSingleActionPopout(popoutKey: string) {
     const tabId = this.singleActionPopoutTabIds[popoutKey];
-    if (!tabId) {
-      return;
-    }
-    await BrowserApi.removeTab(tabId);
+
+    tabId && (await BrowserApi.removeTab(tabId));
     this.singleActionPopoutTabIds[popoutKey] = null;
   }
 }

--- a/apps/browser/src/platform/popup/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/browser-popout-window.service.ts
@@ -77,7 +77,9 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
   private async closeSingleActionPopout(popoutKey: string) {
     const tabId = this.singleActionPopoutTabIds[popoutKey];
 
-    tabId && (await BrowserApi.removeTab(tabId));
+    if (tabId) {
+      await BrowserApi.removeTab(tabId);
+    }
     this.singleActionPopoutTabIds[popoutKey] = null;
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

This ensures that if multiple single-action windows are opened (e.g. reprompt keyboard shortcut bug), the extra windows will be dismissed right away

## Code changes

Important note: This does _not_ address _preventing_ multiple/excess window generation. This PR is for handling those scenarios within the browser popout service by closing excess windows. Additional upstream work around this (addressing other cases and root causes) will be addressed in followup tasks.

See notes in the comments