### PR TITLE
[PM-3590] Fix route in redirectGuard for browser login

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -58,7 +58,7 @@ const routes: Routes = [
     path: "",
     pathMatch: "full",
     children: [], // Children lets us have an empty component.
-    canActivate: [redirectGuard({ loggedIn: "/tabs/vault", loggedOut: "/home", locked: "/lock" })],
+    canActivate: [redirectGuard({ loggedIn: "/tabs/tabs", loggedOut: "/home", locked: "/lock" })],
   },
   {
     path: "vault",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The web and desktop client usually direct to the vault-page on login but the browser redirects to the tabs-tab showing the favourites and cards
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/app-routing.module.ts:** Change the redirect-route for browser login from `/tabs/vault` to `/tabs/tabs`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
