### PR TITLE
[AC-244] Consider a user's email as verified when they accept an organization invitation via the email link

### DIFF
--- a/apps/web/src/app/auth/accept-organization.component.ts
+++ b/apps/web/src/app/auth/accept-organization.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationUserService } from "@bitwarden/common/abstractions/organization-user/organization-user.service";
 import {
   OrganizationUserAcceptInitRequest,
@@ -43,7 +44,8 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     private logService: LogService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private organizationUserService: OrganizationUserService,
-    private messagingService: MessagingService
+    private messagingService: MessagingService,
+    private apiService: ApiService
   ) {
     super(router, platformUtilsService, i18nService, route, stateService);
   }
@@ -67,6 +69,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     }
 
     await this.actionPromise;
+    await this.apiService.refreshIdentityToken();
     await this.stateService.setOrganizationInvitation(null);
     this.platformUtilService.showToast(
       "success",


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

If a user is invited to an organization and accepts the email invite, the member record should be considered automatically verified.

Refreshing identity token after accepting org invite is necessary to get updated email verified status so that the ‘verify email’ modal disappears.

## Code changes

This PR is tied to the changes in [this server PR](https://github.com/bitwarden/server/pull/3199).

- **apps/web/src/app/auth/accept-organization.component.ts:** Refreshing the identity token after accepting the Org invite.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
