### PR TITLE
[PM-3644] [BEEEP] Experiment with reactive syncing

### DIFF
--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -24,7 +24,6 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
-import { InternalFolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 
@@ -41,6 +40,7 @@ import {
   TwoFactorAuthenticationPolicy,
 } from "./admin-console/organizations/policies";
 import { RouterService } from "./core";
+import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 
 const BroadcasterSubscriptionId = "AppComponent";
 const IdleTimeout = 60000 * 10; // 10 minutes
@@ -58,7 +58,7 @@ export class AppComponent implements OnDestroy, OnInit {
   constructor(
     @Inject(DOCUMENT) private document: Document,
     private broadcasterService: BroadcasterService,
-    private folderService: InternalFolderService,
+    private folderService: FolderService,
     private settingsService: SettingsService,
     private syncService: SyncService,
     private passwordGenerationService: PasswordGenerationServiceAbstraction,

--- a/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
@@ -51,7 +51,7 @@ export class FolderAddEditComponent extends BaseFolderAddEditComponent {
     }
 
     try {
-      this.deletePromise = this.folderApiService.delete(this.folder.id);
+      this.deletePromise = this.folderService.delete(this.folder.id);
       await this.deletePromise;
       this.platformUtilsService.showToast("success", null, this.i18nService.t("deletedFolder"));
       this.onDeletedFolder.emit(this.folder);
@@ -71,7 +71,7 @@ export class FolderAddEditComponent extends BaseFolderAddEditComponent {
 
     try {
       const folder = await this.folderService.encrypt(this.folder);
-      this.formPromise = this.folderApiService.save(folder);
+      this.formPromise = this.folderService.save(folder);
       await this.formPromise;
       this.platformUtilsService.showToast(
         "success",

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -304,6 +304,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         I18nServiceAbstraction,
         CipherServiceAbstraction,
         StateServiceAbstraction,
+        SyncServiceAbstraction,
       ],
     },
     {
@@ -416,7 +417,6 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
       deps: [
         ApiServiceAbstraction,
         SettingsServiceAbstraction,
-        FolderServiceAbstraction,
         CipherServiceAbstraction,
         CryptoServiceAbstraction,
         CollectionServiceAbstraction,
@@ -427,7 +427,6 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         KeyConnectorServiceAbstraction,
         StateServiceAbstraction,
         ProviderServiceAbstraction,
-        FolderApiServiceAbstraction,
         OrganizationServiceAbstraction,
         SendApiServiceAbstraction,
         LOGOUT_CALLBACK,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -303,6 +303,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         CryptoServiceAbstraction,
         I18nServiceAbstraction,
         CipherServiceAbstraction,
+        FolderApiServiceAbstraction,
         StateServiceAbstraction,
         SyncServiceAbstraction,
       ],
@@ -314,7 +315,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
     {
       provide: FolderApiServiceAbstraction,
       useClass: FolderApiService,
-      deps: [FolderServiceAbstraction, ApiServiceAbstraction],
+      deps: [ApiServiceAbstraction],
     },
     {
       provide: AccountApiServiceAbstraction,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -134,10 +134,7 @@ import { CipherService as CipherServiceAbstraction } from "@bitwarden/common/vau
 import { CollectionService as CollectionServiceAbstraction } from "@bitwarden/common/vault/abstractions/collection.service";
 import { CipherFileUploadService as CipherFileUploadServiceAbstraction } from "@bitwarden/common/vault/abstractions/file-upload/cipher-file-upload.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
-import {
-  FolderService as FolderServiceAbstraction,
-  InternalFolderService,
-} from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { FolderService as FolderServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "@bitwarden/common/vault/abstractions/password-reprompt.service";
 import { SyncNotifierService as SyncNotifierServiceAbstraction } from "@bitwarden/common/vault/abstractions/sync/sync-notifier.service.abstraction";
 import { SyncService as SyncServiceAbstraction } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -308,10 +305,6 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         SyncServiceAbstraction,
         NotificationsServiceAbstraction,
       ],
-    },
-    {
-      provide: InternalFolderService,
-      useExisting: FolderServiceAbstraction,
     },
     {
       provide: FolderApiServiceAbstraction,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -306,6 +306,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         FolderApiServiceAbstraction,
         StateServiceAbstraction,
         SyncServiceAbstraction,
+        NotificationsServiceAbstraction,
       ],
     },
     {

--- a/libs/common/src/abstractions/notifications.service.ts
+++ b/libs/common/src/abstractions/notifications.service.ts
@@ -1,4 +1,9 @@
+import { Observable } from "rxjs";
+import { NotificationResponse } from "../models/response/notification.response";
+
 export abstract class NotificationsService {
+  readonly notifications$: Observable<NotificationResponse>;
+
   init: () => Promise<void>;
   updateConnection: (sync?: boolean) => Promise<void>;
   reconnectFromActivity: () => Promise<void>;

--- a/libs/common/src/services/notifications.service.ts
+++ b/libs/common/src/services/notifications.service.ts
@@ -1,5 +1,6 @@
 import * as signalR from "@microsoft/signalr";
 import * as signalRMsgPack from "@microsoft/signalr-protocol-msgpack";
+import { Subject } from "rxjs";
 
 import { ApiService } from "../abstractions/api.service";
 import { NotificationsService as NotificationsServiceAbstraction } from "../abstractions/notifications.service";
@@ -26,6 +27,9 @@ export class NotificationsService implements NotificationsServiceAbstraction {
   private inited = false;
   private inactive = false;
   private reconnectTimer: any = null;
+  private _notifications$ = new Subject<NotificationResponse>();
+
+  readonly notifications$ = this._notifications$.asObservable();
 
   constructor(
     private syncService: SyncService,
@@ -146,16 +150,6 @@ export class NotificationsService implements NotificationsServiceAbstraction {
       case NotificationType.SyncLoginDelete:
         await this.syncService.syncDeleteCipher(notification.payload as SyncCipherNotification);
         break;
-      case NotificationType.SyncFolderCreate:
-      // case NotificationType.SyncFolderUpdate:
-      //   await this.syncService.syncUpsertFolder(
-      //     notification.payload as SyncFolderNotification,
-      //     notification.type === NotificationType.SyncFolderUpdate
-      //   );
-      //   break;
-      // case NotificationType.SyncFolderDelete:
-      //   await this.syncService.syncDeleteFolder(notification.payload as SyncFolderNotification);
-      //   break;
       case NotificationType.SyncVault:
       case NotificationType.SyncCiphers:
       case NotificationType.SyncSettings:

--- a/libs/common/src/services/notifications.service.ts
+++ b/libs/common/src/services/notifications.service.ts
@@ -147,15 +147,15 @@ export class NotificationsService implements NotificationsServiceAbstraction {
         await this.syncService.syncDeleteCipher(notification.payload as SyncCipherNotification);
         break;
       case NotificationType.SyncFolderCreate:
-      case NotificationType.SyncFolderUpdate:
-        await this.syncService.syncUpsertFolder(
-          notification.payload as SyncFolderNotification,
-          notification.type === NotificationType.SyncFolderUpdate
-        );
-        break;
-      case NotificationType.SyncFolderDelete:
-        await this.syncService.syncDeleteFolder(notification.payload as SyncFolderNotification);
-        break;
+      // case NotificationType.SyncFolderUpdate:
+      //   await this.syncService.syncUpsertFolder(
+      //     notification.payload as SyncFolderNotification,
+      //     notification.type === NotificationType.SyncFolderUpdate
+      //   );
+      //   break;
+      // case NotificationType.SyncFolderDelete:
+      //   await this.syncService.syncDeleteFolder(notification.payload as SyncFolderNotification);
+      //   break;
       case NotificationType.SyncVault:
       case NotificationType.SyncCiphers:
       case NotificationType.SyncSettings:

--- a/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
@@ -1,8 +1,9 @@
+import { FolderData } from "../../models/data/folder.data";
 import { Folder } from "../../models/domain/folder";
 import { FolderResponse } from "../../models/response/folder.response";
 
 export class FolderApiServiceAbstraction {
-  save: (folder: Folder) => Promise<any>;
+  save: (folder: Folder) => Promise<FolderData>;
   delete: (id: string) => Promise<any>;
   get: (id: string) => Promise<FolderResponse>;
 }

--- a/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
@@ -21,11 +21,12 @@ export abstract class FolderService {
    * @deprecated Only use in CLI!
    */
   getAllDecryptedFromState: () => Promise<FolderView[]>;
+  save: (folder: Folder) => Promise<unknown>;
+  delete: (id: string | string[]) => Promise<any>;
 }
 
 export abstract class InternalFolderService extends FolderService {
   upsert: (folder: FolderData | FolderData[]) => Promise<void>;
   // replace: (folders: { [id: string]: FolderData }) => Promise<void>;
   clear: (userId: string) => Promise<any>;
-  delete: (id: string | string[]) => Promise<any>;
 }

--- a/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
@@ -25,7 +25,7 @@ export abstract class FolderService {
 
 export abstract class InternalFolderService extends FolderService {
   upsert: (folder: FolderData | FolderData[]) => Promise<void>;
-  replace: (folders: { [id: string]: FolderData }) => Promise<void>;
+  // replace: (folders: { [id: string]: FolderData }) => Promise<void>;
   clear: (userId: string) => Promise<any>;
   delete: (id: string | string[]) => Promise<any>;
 }

--- a/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
@@ -23,10 +23,5 @@ export abstract class FolderService {
   getAllDecryptedFromState: () => Promise<FolderView[]>;
   save: (folder: Folder) => Promise<unknown>;
   delete: (id: string | string[]) => Promise<any>;
-}
-
-export abstract class InternalFolderService extends FolderService {
-  upsert: (folder: FolderData | FolderData[]) => Promise<void>;
-  // replace: (folders: { [id: string]: FolderData }) => Promise<void>;
   clear: (userId: string) => Promise<any>;
 }

--- a/libs/common/src/vault/abstractions/sync/sync.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/sync/sync.service.abstraction.ts
@@ -1,17 +1,20 @@
+import { Observable } from "rxjs";
 import {
   SyncCipherNotification,
   SyncFolderNotification,
   SyncSendNotification,
 } from "../../../models/response/notification.response";
+import { SyncResponse } from "../../models/response/sync.response";
 
 export abstract class SyncService {
   syncInProgress: boolean;
+  sync$: Observable<SyncResponse>;
 
   getLastSync: () => Promise<Date>;
   setLastSync: (date: Date, userId?: string) => Promise<any>;
   fullSync: (forceSync: boolean, allowThrowOnError?: boolean) => Promise<boolean>;
-  syncUpsertFolder: (notification: SyncFolderNotification, isEdit: boolean) => Promise<boolean>;
-  syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;
+  // syncUpsertFolder: (notification: SyncFolderNotification, isEdit: boolean) => Promise<boolean>;
+  // syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;
   syncUpsertCipher: (notification: SyncCipherNotification, isEdit: boolean) => Promise<boolean>;
   syncDeleteCipher: (notification: SyncFolderNotification) => Promise<boolean>;
   syncUpsertSend: (notification: SyncSendNotification, isEdit: boolean) => Promise<boolean>;

--- a/libs/common/src/vault/services/folder/folder-api.service.ts
+++ b/libs/common/src/vault/services/folder/folder-api.service.ts
@@ -7,9 +7,9 @@ import { FolderRequest } from "../../../vault/models/request/folder.request";
 import { FolderResponse } from "../../../vault/models/response/folder.response";
 
 export class FolderApiService implements FolderApiServiceAbstraction {
-  constructor(private folderService: InternalFolderService, private apiService: ApiService) {}
+  constructor(private apiService: ApiService) {}
 
-  async save(folder: Folder): Promise<any> {
+  async save(folder: Folder): Promise<FolderData> {
     const request = new FolderRequest(folder);
 
     let response: FolderResponse;
@@ -20,13 +20,11 @@ export class FolderApiService implements FolderApiServiceAbstraction {
       response = await this.putFolder(folder.id, request);
     }
 
-    const data = new FolderData(response);
-    await this.folderService.upsert(data);
+    return new FolderData(response);
   }
 
   async delete(id: string): Promise<any> {
     await this.deleteFolder(id);
-    await this.folderService.delete(id);
   }
 
   async get(id: string): Promise<FolderResponse> {

--- a/libs/common/src/vault/services/folder/folder-api.service.ts
+++ b/libs/common/src/vault/services/folder/folder-api.service.ts
@@ -1,6 +1,5 @@
 import { ApiService } from "../../../abstractions/api.service";
 import { FolderApiServiceAbstraction } from "../../../vault/abstractions/folder/folder-api.service.abstraction";
-import { InternalFolderService } from "../../../vault/abstractions/folder/folder.service.abstraction";
 import { FolderData } from "../../../vault/models/data/folder.data";
 import { Folder } from "../../../vault/models/domain/folder";
 import { FolderRequest } from "../../../vault/models/request/folder.request";

--- a/libs/common/src/vault/services/folder/folder.service.ts
+++ b/libs/common/src/vault/services/folder/folder.service.ts
@@ -9,7 +9,7 @@ import { StateService } from "../../../platform/abstractions/state.service";
 import { Utils } from "../../../platform/misc/utils";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
-import { InternalFolderService as InternalFolderServiceAbstraction } from "../../../vault/abstractions/folder/folder.service.abstraction";
+import { FolderService as FolderServiceAbstraction } from "../../../vault/abstractions/folder/folder.service.abstraction";
 import { CipherData } from "../../../vault/models/data/cipher.data";
 import { FolderData } from "../../../vault/models/data/folder.data";
 import { Folder } from "../../../vault/models/domain/folder";
@@ -17,7 +17,7 @@ import { FolderView } from "../../../vault/models/view/folder.view";
 import { FolderApiServiceAbstraction } from "../../abstractions/folder/folder-api.service.abstraction";
 import { SyncService } from "../../abstractions/sync/sync.service.abstraction";
 
-export class FolderService implements InternalFolderServiceAbstraction {
+export class FolderService implements FolderServiceAbstraction {
   protected _folders: BehaviorSubject<Folder[]> = new BehaviorSubject([]);
   protected _folderViews: BehaviorSubject<FolderView[]> = new BehaviorSubject([]);
 

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -129,40 +129,6 @@ export class SyncService implements SyncServiceAbstraction {
     }
   }
 
-  // async syncUpsertFolder(notification: SyncFolderNotification, isEdit: boolean): Promise<boolean> {
-  //   this.syncStarted();
-  //   if (await this.stateService.getIsAuthenticated()) {
-  //     try {
-  //       const localFolder = await this.folderService.get(notification.id);
-  //       if (
-  //         (!isEdit && localFolder == null) ||
-  //         (isEdit && localFolder != null && localFolder.revisionDate < notification.revisionDate)
-  //       ) {
-  //         const remoteFolder = await this.folderApiService.get(notification.id);
-  //         if (remoteFolder != null) {
-  //           await this.folderService.upsert(new FolderData(remoteFolder));
-  //           this.messagingService.send("syncedUpsertedFolder", { folderId: notification.id });
-  //           return this.syncCompleted(true);
-  //         }
-  //       }
-  //     } catch (e) {
-  //       this.logService.error(e);
-  //     }
-  //   }
-  //   return this.syncCompleted(false);
-  // }
-
-  // async syncDeleteFolder(notification: SyncFolderNotification): Promise<boolean> {
-  //   this.syncStarted();
-  //   if (await this.stateService.getIsAuthenticated()) {
-  //     await this.folderService.delete(notification.id);
-  //     this.messagingService.send("syncedDeletedFolder", { folderId: notification.id });
-  //     this.syncCompleted(true);
-  //     return true;
-  //   }
-  //   return this.syncCompleted(false);
-  // }
-
   async syncUpsertCipher(notification: SyncCipherNotification, isEdit: boolean): Promise<boolean> {
     this.syncStarted();
     if (await this.stateService.getIsAuthenticated()) {

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -1,3 +1,4 @@
+import { Subject } from "rxjs";
 import { ApiService } from "../../../abstractions/api.service";
 import { SettingsService } from "../../../abstractions/settings.service";
 import { InternalOrganizationServiceAbstraction } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
@@ -36,14 +37,18 @@ import { FolderResponse } from "../../../vault/models/response/folder.response";
 import { CollectionService } from "../../abstractions/collection.service";
 import { CollectionData } from "../../models/data/collection.data";
 import { CollectionDetailsResponse } from "../../models/response/collection.response";
+import { SyncResponse } from "../../models/response/sync.response";
 
 export class SyncService implements SyncServiceAbstraction {
+  private _sync$ = new Subject<SyncResponse>();
+
   syncInProgress = false;
+
+  readonly sync$ = this._sync$.asObservable();
 
   constructor(
     private apiService: ApiService,
     private settingsService: SettingsService,
-    private folderService: InternalFolderService,
     private cipherService: CipherService,
     private cryptoService: CryptoService,
     private collectionService: CollectionService,
@@ -54,7 +59,6 @@ export class SyncService implements SyncServiceAbstraction {
     private keyConnectorService: KeyConnectorService,
     private stateService: StateService,
     private providerService: ProviderService,
-    private folderApiService: FolderApiServiceAbstraction,
     private organizationService: InternalOrganizationServiceAbstraction,
     private sendApiService: SendApiService,
     private logoutCallback: (expired: boolean) => Promise<void>
@@ -105,12 +109,14 @@ export class SyncService implements SyncServiceAbstraction {
       const response = await this.apiService.getSync();
 
       await this.syncProfile(response.profile);
-      await this.syncFolders(response.folders);
+      // await this.syncFolders(response.folders);
       await this.syncCollections(response.collections);
       await this.syncCiphers(response.ciphers);
       await this.syncSends(response.sends);
       await this.syncSettings(response.domains);
       await this.syncPolicies(response.policies);
+
+      this._sync$.next(response);
 
       await this.setLastSync(now);
       return this.syncCompleted(true);
@@ -123,39 +129,39 @@ export class SyncService implements SyncServiceAbstraction {
     }
   }
 
-  async syncUpsertFolder(notification: SyncFolderNotification, isEdit: boolean): Promise<boolean> {
-    this.syncStarted();
-    if (await this.stateService.getIsAuthenticated()) {
-      try {
-        const localFolder = await this.folderService.get(notification.id);
-        if (
-          (!isEdit && localFolder == null) ||
-          (isEdit && localFolder != null && localFolder.revisionDate < notification.revisionDate)
-        ) {
-          const remoteFolder = await this.folderApiService.get(notification.id);
-          if (remoteFolder != null) {
-            await this.folderService.upsert(new FolderData(remoteFolder));
-            this.messagingService.send("syncedUpsertedFolder", { folderId: notification.id });
-            return this.syncCompleted(true);
-          }
-        }
-      } catch (e) {
-        this.logService.error(e);
-      }
-    }
-    return this.syncCompleted(false);
-  }
+  // async syncUpsertFolder(notification: SyncFolderNotification, isEdit: boolean): Promise<boolean> {
+  //   this.syncStarted();
+  //   if (await this.stateService.getIsAuthenticated()) {
+  //     try {
+  //       const localFolder = await this.folderService.get(notification.id);
+  //       if (
+  //         (!isEdit && localFolder == null) ||
+  //         (isEdit && localFolder != null && localFolder.revisionDate < notification.revisionDate)
+  //       ) {
+  //         const remoteFolder = await this.folderApiService.get(notification.id);
+  //         if (remoteFolder != null) {
+  //           await this.folderService.upsert(new FolderData(remoteFolder));
+  //           this.messagingService.send("syncedUpsertedFolder", { folderId: notification.id });
+  //           return this.syncCompleted(true);
+  //         }
+  //       }
+  //     } catch (e) {
+  //       this.logService.error(e);
+  //     }
+  //   }
+  //   return this.syncCompleted(false);
+  // }
 
-  async syncDeleteFolder(notification: SyncFolderNotification): Promise<boolean> {
-    this.syncStarted();
-    if (await this.stateService.getIsAuthenticated()) {
-      await this.folderService.delete(notification.id);
-      this.messagingService.send("syncedDeletedFolder", { folderId: notification.id });
-      this.syncCompleted(true);
-      return true;
-    }
-    return this.syncCompleted(false);
-  }
+  // async syncDeleteFolder(notification: SyncFolderNotification): Promise<boolean> {
+  //   this.syncStarted();
+  //   if (await this.stateService.getIsAuthenticated()) {
+  //     await this.folderService.delete(notification.id);
+  //     this.messagingService.send("syncedDeletedFolder", { folderId: notification.id });
+  //     this.syncCompleted(true);
+  //     return true;
+  //   }
+  //   return this.syncCompleted(false);
+  // }
 
   async syncUpsertCipher(notification: SyncCipherNotification, isEdit: boolean): Promise<boolean> {
     this.syncStarted();
@@ -361,13 +367,13 @@ export class SyncService implements SyncServiceAbstraction {
     await this.organizationService.replace(organizations);
   }
 
-  private async syncFolders(response: FolderResponse[]) {
-    const folders: { [id: string]: FolderData } = {};
-    response.forEach((f) => {
-      folders[f.id] = new FolderData(f);
-    });
-    return await this.folderService.replace(folders);
-  }
+  // private async syncFolders(response: FolderResponse[]) {
+  //   const folders: { [id: string]: FolderData } = {};
+  //   response.forEach((f) => {
+  //     folders[f.id] = new FolderData(f);
+  //   });
+  //   return await this.folderService.replace(folders);
+  // }
 
   private async syncCollections(response: CollectionDetailsResponse[]) {
     const collections: { [id: string]: CollectionData } = {};

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -27,13 +27,9 @@ import { SendResponse } from "../../../tools/send/models/response/send.response"
 import { SendApiService } from "../../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../../tools/send/services/send.service.abstraction";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
-import { FolderApiServiceAbstraction } from "../../../vault/abstractions/folder/folder-api.service.abstraction";
-import { InternalFolderService } from "../../../vault/abstractions/folder/folder.service.abstraction";
 import { SyncService as SyncServiceAbstraction } from "../../../vault/abstractions/sync/sync.service.abstraction";
 import { CipherData } from "../../../vault/models/data/cipher.data";
-import { FolderData } from "../../../vault/models/data/folder.data";
 import { CipherResponse } from "../../../vault/models/response/cipher.response";
-import { FolderResponse } from "../../../vault/models/response/folder.response";
 import { CollectionService } from "../../abstractions/collection.service";
 import { CollectionData } from "../../models/data/collection.data";
 import { CollectionDetailsResponse } from "../../models/response/collection.response";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- Simplify `SyncService`
- Simplify `NotificationService`
- Simplify `ApiService` and move all domain operations into `DomainService`
  - This way components will no longer need access to `ApiService` (which will align us with the SDK)
- Get rid of `InternalDomainService` and encapsulate all that logic inside the service
  - E.g: Make operations such as `upsert` private to the `DomainService`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
