### PR TITLE
snap: set lzo compression

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -163,7 +163,8 @@
     "autoStart": true,
     "confinement": "strict",
     "plugs": ["default", "password-manager-service"],
-    "stagePackages": ["default"]
+    "stagePackages": ["default"],
+    "compression": "lzo"
   },
   "protocols": [
     {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

With https://github.com/bitwarden/clients/pull/5038 being now merged, you should built the snap with the compression algorithm that gives the best results for desktop apps; according to Canonical, the use of the LZO compression offers 40-74% cold startup improvements over the XZ compression:
* https://forum.snapcraft.io/t/how-to-switch-your-snap-to-use-lzo-compression/21714
* https://snapcraft.io/blog/snap-speed-improvements-with-new-compression-algorithm
 
## Code changes

I've just added the `compression` option in the top `snap` key, and configured the value to `lzo`

Should fix #2609 
