### PR TITLE
[AC-1612] Disabled access to the Organization Vault tab if the user only has access to assigned collections

### DIFF
--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -6,7 +6,7 @@ import { OrganizationData } from "../../models/data/organization.data";
 import { Organization } from "../../models/domain/organization";
 
 export function canAccessVaultTab(org: Organization): boolean {
-  return org.canViewAssignedCollections || org.canViewAllCollections;
+  return org.canViewAllCollections;
 }
 
 export function canAccessSettingsTab(org: Organization): boolean {

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -6,7 +6,7 @@ import { OrganizationData } from "../../models/data/organization.data";
 import { Organization } from "../../models/domain/organization";
 
 export function canAccessVaultTab(org: Organization): boolean {
-  return org.canViewAllCollections;
+  return org.canViewAssignedCollections || org.canViewAllCollections;
 }
 
 export function canAccessSettingsTab(org: Organization): boolean {

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -174,7 +174,7 @@ export class Organization {
   }
 
   get canViewAllCollections() {
-    return this.canCreateNewCollections || this.canEditAnyCollection || this.canDeleteAnyCollection;
+    return this.canEditAnyCollection || this.canDeleteAnyCollection;
   }
 
   get canEditAssignedCollections() {


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

As part of work for https://github.com/bitwarden/server/pull/3233 it was identified the need to block access to the Organization tab if the user's only active permission is to view assigned collections.

## Code changes

- **libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts:** Updated access to the vault tab permission to only check if the user can view all collections
- **libs/common/src/admin-console/models/domain/organization.ts:** Updated the permission check to view all collections in an organization to not consider if the user can create new collections

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
