### PR TITLE
[PM-3732] Use subtle to make aes keys

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access.service.ts
@@ -53,7 +53,7 @@ export class AccessService {
     serviceAccountId: string,
     accessTokenView: AccessTokenView
   ): Promise<string> {
-    const keyMaterial = await this.cryptoFunctionService.randomBytes(16);
+    const keyMaterial = await this.cryptoFunctionService.aesGenerateKey(128);
     const key = await this.cryptoFunctionService.hkdf(
       keyMaterial,
       "bitwarden-accesstoken",

--- a/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
@@ -167,7 +167,7 @@ export class DeviceTrustCryptoService implements DeviceTrustCryptoServiceAbstrac
 
   private async makeDeviceKey(): Promise<DeviceKey> {
     // Create 512-bit device key
-    const randomBytes: CsprngArray = await this.cryptoFunctionService.randomBytes(64);
+    const randomBytes: CsprngArray = await this.cryptoFunctionService.aesGenerateKey(512);
     const deviceKey = new SymmetricCryptoKey(randomBytes) as DeviceKey;
 
     return deviceKey;

--- a/libs/common/src/auth/services/device-trust-crypto.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.spec.ts
@@ -168,16 +168,16 @@ describe("deviceTrustCryptoService", () => {
       it("creates a new non-null 64 byte device key, securely stores it, and returns it", async () => {
         const mockRandomBytes = new Uint8Array(deviceKeyBytesLength) as CsprngArray;
 
-        const cryptoFuncSvcRandomBytesSpy = jest
-          .spyOn(cryptoFunctionService, "randomBytes")
+        const cryptoFuncSvcGenerateKeySpy = jest
+          .spyOn(cryptoFunctionService, "aesGenerateKey")
           .mockResolvedValue(mockRandomBytes);
 
         // TypeScript will allow calling private methods if the object is of type 'any'
         // This is a hacky workaround, but it allows for cleaner tests
         const deviceKey = await (deviceTrustCryptoService as any).makeDeviceKey();
 
-        expect(cryptoFuncSvcRandomBytesSpy).toHaveBeenCalledTimes(1);
-        expect(cryptoFuncSvcRandomBytesSpy).toHaveBeenCalledWith(deviceKeyBytesLength);
+        expect(cryptoFuncSvcGenerateKeySpy).toHaveBeenCalledTimes(1);
+        expect(cryptoFuncSvcGenerateKeySpy).toHaveBeenCalledWith(deviceKeyBytesLength * 8);
 
         expect(deviceKey).not.toBeNull();
         expect(deviceKey).toBeInstanceOf(SymmetricCryptoKey);

--- a/libs/common/src/auth/services/key-connector.service.ts
+++ b/libs/common/src/auth/services/key-connector.service.ts
@@ -93,7 +93,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
       keyConnectorUrl: legacyKeyConnectorUrl,
       userDecryptionOptions,
     } = tokenResponse;
-    const password = await this.cryptoFunctionService.randomBytes(64);
+    const password = await this.cryptoFunctionService.aesGenerateKey(512);
     const kdfConfig = new KdfConfig(kdfIterations, kdfMemory, kdfParallelism);
 
     const masterKey = await this.cryptoService.makeMasterKey(

--- a/libs/common/src/platform/abstractions/crypto-function.service.ts
+++ b/libs/common/src/platform/abstractions/crypto-function.service.ts
@@ -66,5 +66,14 @@ export abstract class CryptoFunctionService {
   ) => Promise<Uint8Array>;
   rsaExtractPublicKey: (privateKey: Uint8Array) => Promise<Uint8Array>;
   rsaGenerateKeyPair: (length: 1024 | 2048 | 4096) => Promise<[Uint8Array, Uint8Array]>;
+  /**
+   * Generates a key of the given length suitable for use in AES encryption
+   */
+  aesGenerateKey: (bitLength: 128 | 192 | 256 | 512) => Promise<CsprngArray>;
+  /**
+   * Generates a random array of bytes of the given length. Uses a cryptographically secure random number generator.
+   *
+   * Do not use this for generating encryption keys. Use aesGenerateKey or rsaGenerateKeyPair instead.
+   */
   randomBytes: (length: number) => Promise<CsprngArray>;
 }

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -119,7 +119,7 @@ export class CryptoService implements CryptoServiceAbstraction {
       throw new Error("No Master Key found.");
     }
 
-    const newUserKey = await this.cryptoFunctionService.randomBytes(64);
+    const newUserKey = await this.cryptoFunctionService.aesGenerateKey(512);
     return this.buildProtectedSymmetricKey(masterKey, newUserKey);
   }
 
@@ -367,7 +367,7 @@ export class CryptoService implements CryptoServiceAbstraction {
       throw new Error("No key provided");
     }
 
-    const newSymKey = await this.cryptoFunctionService.randomBytes(64);
+    const newSymKey = await this.cryptoFunctionService.aesGenerateKey(512);
     return this.buildProtectedSymmetricKey(key, newSymKey);
   }
 
@@ -458,7 +458,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   async makeOrgKey<T extends OrgKey | ProviderKey>(): Promise<[EncString, T]> {
-    const shareKey = await this.cryptoFunctionService.randomBytes(64);
+    const shareKey = await this.cryptoFunctionService.aesGenerateKey(512);
     const publicKey = await this.getPublicKey();
     const encShareKey = await this.rsaEncrypt(shareKey, publicKey);
     return [encShareKey, new SymmetricCryptoKey(shareKey) as T];
@@ -731,8 +731,8 @@ export class CryptoService implements CryptoServiceAbstraction {
     publicKey: string;
     privateKey: EncString;
   }> {
-    const randomBytes = await this.cryptoFunctionService.randomBytes(64);
-    const userKey = new SymmetricCryptoKey(randomBytes) as UserKey;
+    const rawKey = await this.cryptoFunctionService.aesGenerateKey(512);
+    const userKey = new SymmetricCryptoKey(rawKey) as UserKey;
     const [publicKey, privateKey] = await this.makeKeyPair(userKey);
     await this.setUserKey(userKey);
     await this.stateService.setEncryptedPrivateKey(privateKey.encryptedString);

--- a/libs/common/src/platform/services/web-crypto-function.service.spec.ts
+++ b/libs/common/src/platform/services/web-crypto-function.service.spec.ts
@@ -354,6 +354,20 @@ describe("WebCrypto Function Service", () => {
       ).toBeTruthy();
     });
   });
+
+  describe("aesGenerateKey", () => {
+    it.each([128, 192, 256, 512])("Should make a key of %s bits long", async (length) => {
+      const cryptoFunctionService = getWebCryptoFunctionService();
+      const key = await cryptoFunctionService.aesGenerateKey(length);
+      expect(key.byteLength * 8).toBe(length);
+    });
+
+    it("should not repeat itself for 512 length special case", async () => {
+      const cryptoFunctionService = getWebCryptoFunctionService();
+      const key = await cryptoFunctionService.aesGenerateKey(512);
+      expect(key.slice(0, 32)).not.toEqual(key.slice(32, 64));
+    });
+  });
 });
 
 function testPbkdf2(

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -70,7 +70,7 @@ export class SendService implements InternalSendServiceAbstraction {
     send.hideEmail = model.hideEmail;
     send.maxAccessCount = model.maxAccessCount;
     if (model.key == null) {
-      model.key = await this.cryptoFunctionService.randomBytes(16);
+      model.key = await this.cryptoFunctionService.aesGenerateKey(128);
       model.cryptoKey = await this.cryptoService.makeSendKey(model.key);
     }
     if (password != null) {

--- a/libs/node/src/services/node-crypto-function.service.spec.ts
+++ b/libs/node/src/services/node-crypto-function.service.spec.ts
@@ -271,6 +271,15 @@ describe("NodeCrypto Function Service", () => {
       ).toBeTruthy();
     });
   });
+
+  describe("aesGenerateKey", () => {
+    it("should delegate to randomBytes", async () => {
+      const nodeCryptoFunctionService = new NodeCryptoFunctionService();
+      const spy = jest.spyOn(nodeCryptoFunctionService, "randomBytes");
+      await nodeCryptoFunctionService.aesGenerateKey(256);
+      expect(spy).toHaveBeenCalledWith(32);
+    });
+  });
 });
 
 function testPbkdf2(

--- a/libs/node/src/services/node-crypto-function.service.ts
+++ b/libs/node/src/services/node-crypto-function.service.ts
@@ -271,6 +271,10 @@ export class NodeCryptoFunctionService implements CryptoFunctionService {
     });
   }
 
+  aesGenerateKey(bitLength: 128 | 192 | 256 | 512): Promise<CsprngArray> {
+    return this.randomBytes(bitLength / 8);
+  }
+
   randomBytes(length: number): Promise<CsprngArray> {
     return new Promise<CsprngArray>((resolve, reject) => {
       crypto.randomBytes(length, (error, bytes) => {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Uses generateKey in subtle crypto get generate material used either directly as keys or used to generate keys for aes.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
