### PR TITLE
[CL-104] fix overlay + virtual scroll view recycling bug

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -58,7 +58,7 @@
       </tr>
     </ng-container>
     <ng-template body let-rows$>
-      <ng-container *cdkVirtualFor="let item of rows$">
+      <ng-container *cdkVirtualFor="let item of rows$; templateCacheSize: 0">
         <tr
           *ngIf="item.collection"
           bitRow

--- a/libs/angular/src/directives/fallback-src.directive.ts
+++ b/libs/angular/src/directives/fallback-src.directive.ts
@@ -6,9 +6,15 @@ import { Directive, ElementRef, HostListener, Input } from "@angular/core";
 export class FallbackSrcDirective {
   @Input("appFallbackSrc") appFallbackSrc: string;
 
+  /** Only try setting the fallback once. This prevents an infinite loop if the fallback itself is missing. */
+  private tryFallback = true;
+
   constructor(private el: ElementRef) {}
 
   @HostListener("error") onError() {
-    this.el.nativeElement.src = this.appFallbackSrc;
+    if (this.tryFallback) {
+      this.el.nativeElement.src = this.appFallbackSrc;
+      this.tryFallback = false;
+    }
   }
 }

--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -31,7 +31,13 @@ export class MenuTriggerForDirective implements OnDestroy {
     panelClass: "bit-menu-panel",
     hasBackdrop: true,
     backdropClass: "cdk-overlay-transparent-backdrop",
-    scrollStrategy: this.overlay.scrollStrategies.reposition(),
+    scrollStrategy: this.overlay.scrollStrategies.reposition({
+      /**
+       * Autoclosing is required to properly track position in virtual scroll viewports.
+       * @see https://bitwarden.atlassian.net/browse/CL-104
+       */
+      autoClose: true,
+    }),
     positionStrategy: this.overlay
       .position()
       .flexibleConnectedTo(this.elementRef)

--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -31,13 +31,11 @@ export class MenuTriggerForDirective implements OnDestroy {
     panelClass: "bit-menu-panel",
     hasBackdrop: true,
     backdropClass: "cdk-overlay-transparent-backdrop",
-    scrollStrategy: this.overlay.scrollStrategies.reposition({
-      /**
-       * Autoclosing is required to properly track position in virtual scroll viewports.
-       * @see https://bitwarden.atlassian.net/browse/CL-104
-       */
-      autoClose: true,
-    }),
+    /**
+     * `scrollStrategies.resposition` is not supported in virtual scroll viewports.
+     * @see https://bitwarden.atlassian.net/browse/CL-104
+     */
+    scrollStrategy: this.overlay.scrollStrategies.block(),
     positionStrategy: this.overlay
       .position()
       .flexibleConnectedTo(this.elementRef)

--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -31,11 +31,7 @@ export class MenuTriggerForDirective implements OnDestroy {
     panelClass: "bit-menu-panel",
     hasBackdrop: true,
     backdropClass: "cdk-overlay-transparent-backdrop",
-    /**
-     * `scrollStrategies.resposition` is not supported in virtual scroll viewports.
-     * @see https://bitwarden.atlassian.net/browse/CL-104
-     */
-    scrollStrategy: this.overlay.scrollStrategies.block(),
+    scrollStrategy: this.overlay.scrollStrategies.reposition(),
     positionStrategy: this.overlay
       .position()
       .flexibleConnectedTo(this.elementRef)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR disables view recycling in `vault-items`. This prevents a bug where the overlay menu would reattach onto new elements after scrolling in a virtual scroll viewport.

While testing this change on the `vault-items` story in Storybook, a bug was also found with the `fallback-src` directive. If the fallback itself is missing, the directive will request the resource in an infinite loop. This was fixed by only trying to set the fallback image once.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
