### PR TITLE
[PM-3758] Handle user decryption options from pre-TDE server response

### DIFF
--- a/libs/common/src/auth/login-strategies/login.strategy.spec.ts
+++ b/libs/common/src/auth/login-strategies/login.strategy.spec.ts
@@ -41,10 +41,7 @@ import { IdentityCaptchaResponse } from "../models/response/identity-captcha.res
 import { IdentityTokenResponse } from "../models/response/identity-token.response";
 import { IdentityTwoFactorResponse } from "../models/response/identity-two-factor.response";
 import { MasterPasswordPolicyResponse } from "../models/response/master-password-policy.response";
-import {
-  IUserDecryptionOptionsServerResponse,
-  UserDecryptionOptionsResponse,
-} from "../models/response/user-decryption-options/user-decryption-options.response";
+import { IUserDecryptionOptionsServerResponse } from "../models/response/user-decryption-options/user-decryption-options.response";
 
 import { PasswordLogInStrategy } from "./password-login.strategy";
 
@@ -65,10 +62,6 @@ const name = "NAME";
 const defaultUserDecryptionOptionsServerResponse: IUserDecryptionOptionsServerResponse = {
   HasMasterPassword: true,
 };
-const userDecryptionOptions = new UserDecryptionOptionsResponse(
-  defaultUserDecryptionOptionsServerResponse
-);
-const acctDecryptionOptions = AccountDecryptionOptions.fromResponse(userDecryptionOptions);
 
 const decodedToken = {
   sub: userId,
@@ -197,7 +190,7 @@ describe("LogInStrategy", () => {
             },
           },
           keys: new AccountKeys(),
-          decryptionOptions: acctDecryptionOptions,
+          decryptionOptions: AccountDecryptionOptions.fromResponse(idTokenResponse),
         })
       );
       expect(messagingService.send).toHaveBeenCalledWith("loggedIn");

--- a/libs/common/src/auth/login-strategies/login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/login.strategy.ts
@@ -143,9 +143,7 @@ export abstract class LogInStrategy {
           },
         },
         keys: accountKeys,
-        decryptionOptions: AccountDecryptionOptions.fromResponse(
-          tokenResponse.userDecryptionOptions
-        ),
+        decryptionOptions: AccountDecryptionOptions.fromResponse(tokenResponse),
         adminAuthRequest: adminAuthRequest?.toJSON(),
       })
     );

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
@@ -320,6 +320,7 @@ describe("SsoLogInStrategy", () => {
     let tokenResponse: IdentityTokenResponse;
     beforeEach(() => {
       tokenResponse = identityTokenResponseFactory();
+      tokenResponse.userDecryptionOptions = null;
       tokenResponse.keyConnectorUrl = keyConnectorUrl;
     });
 

--- a/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
+++ b/libs/common/src/auth/login-strategies/sso-login.strategy.spec.ts
@@ -266,7 +266,60 @@ describe("SsoLogInStrategy", () => {
   describe("Key Connector", () => {
     let tokenResponse: IdentityTokenResponse;
     beforeEach(() => {
-      tokenResponse = identityTokenResponseFactory(null, { HasMasterPassword: false });
+      tokenResponse = identityTokenResponseFactory(null, {
+        HasMasterPassword: false,
+        KeyConnectorOption: { KeyConnectorUrl: keyConnectorUrl },
+      });
+      tokenResponse.keyConnectorUrl = keyConnectorUrl;
+    });
+
+    it("gets and sets the master key if Key Connector is enabled and the user doesn't have a master password", async () => {
+      const masterKey = new SymmetricCryptoKey(
+        new Uint8Array(64).buffer as CsprngArray
+      ) as MasterKey;
+
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
+      cryptoService.getMasterKey.mockResolvedValue(masterKey);
+
+      await ssoLogInStrategy.logIn(credentials);
+
+      expect(keyConnectorService.setMasterKeyFromUrl).toHaveBeenCalledWith(keyConnectorUrl);
+    });
+
+    it("converts new SSO user with no master password to Key Connector on first login", async () => {
+      tokenResponse.key = null;
+
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
+
+      await ssoLogInStrategy.logIn(credentials);
+
+      expect(keyConnectorService.convertNewSsoUserToKeyConnector).toHaveBeenCalledWith(
+        tokenResponse,
+        ssoOrgId
+      );
+    });
+
+    it("decrypts and sets the user key if Key Connector is enabled and the user doesn't have a master password", async () => {
+      const userKey = new SymmetricCryptoKey(new Uint8Array(64).buffer as CsprngArray) as UserKey;
+      const masterKey = new SymmetricCryptoKey(
+        new Uint8Array(64).buffer as CsprngArray
+      ) as MasterKey;
+
+      apiService.postIdentityToken.mockResolvedValue(tokenResponse);
+      cryptoService.getMasterKey.mockResolvedValue(masterKey);
+      cryptoService.decryptUserKeyWithMasterKey.mockResolvedValue(userKey);
+
+      await ssoLogInStrategy.logIn(credentials);
+
+      expect(cryptoService.decryptUserKeyWithMasterKey).toHaveBeenCalledWith(masterKey);
+      expect(cryptoService.setUserKey).toHaveBeenCalledWith(userKey);
+    });
+  });
+
+  describe("Key Connector Pre-TDE", () => {
+    let tokenResponse: IdentityTokenResponse;
+    beforeEach(() => {
+      tokenResponse = identityTokenResponseFactory();
       tokenResponse.keyConnectorUrl = keyConnectorUrl;
     });
 

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -11,7 +11,7 @@ import { EnvironmentUrls } from "../../../auth/models/domain/environment-urls";
 import { ForceResetPasswordReason } from "../../../auth/models/domain/force-reset-password-reason";
 import { KeyConnectorUserDecryptionOption } from "../../../auth/models/domain/user-decryption-options/key-connector-user-decryption-option";
 import { TrustedDeviceUserDecryptionOption } from "../../../auth/models/domain/user-decryption-options/trusted-device-user-decryption-option";
-import { UserDecryptionOptionsResponse } from "../../../auth/models/response/user-decryption-options/user-decryption-options.response";
+import { IdentityTokenResponse } from "../../../auth/models/response/identity-token.response";
 import { KdfType, UriMatchType } from "../../../enums";
 import { EventData } from "../../../models/data/event.data";
 import { GeneratedPasswordHistory } from "../../../tools/generator/password";
@@ -311,28 +311,46 @@ export class AccountDecryptionOptions {
   //   return this.keyConnectorOption !== null && this.keyConnectorOption !== undefined;
   // }
 
-  static fromResponse(response: UserDecryptionOptionsResponse): AccountDecryptionOptions {
+  static fromResponse(response: IdentityTokenResponse): AccountDecryptionOptions {
     if (response == null) {
       return null;
     }
 
     const accountDecryptionOptions = new AccountDecryptionOptions();
-    accountDecryptionOptions.hasMasterPassword = response.hasMasterPassword;
 
-    if (response.trustedDeviceOption) {
-      accountDecryptionOptions.trustedDeviceOption = new TrustedDeviceUserDecryptionOption(
-        response.trustedDeviceOption.hasAdminApproval,
-        response.trustedDeviceOption.hasLoginApprovingDevice,
-        response.trustedDeviceOption.hasManageResetPasswordPermission
-      );
+    if (response.userDecryptionOptions) {
+      // If the response has userDecryptionOptions, this means it's on a post-TDE server version and can interrogate
+      // the new decryption options.
+      const responseOptions = response.userDecryptionOptions;
+      accountDecryptionOptions.hasMasterPassword = responseOptions.hasMasterPassword;
+
+      if (responseOptions.trustedDeviceOption) {
+        accountDecryptionOptions.trustedDeviceOption = new TrustedDeviceUserDecryptionOption(
+          responseOptions.trustedDeviceOption.hasAdminApproval,
+          responseOptions.trustedDeviceOption.hasLoginApprovingDevice,
+          responseOptions.trustedDeviceOption.hasManageResetPasswordPermission
+        );
+      }
+
+      if (responseOptions.keyConnectorOption) {
+        accountDecryptionOptions.keyConnectorOption = new KeyConnectorUserDecryptionOption(
+          responseOptions.keyConnectorOption.keyConnectorUrl
+        );
+      }
+    } else {
+      // If the response does not have userDecryptionOptions, this means it's on a pre-TDE server version and so
+      // we must base our decryption options on the presence of the keyConnectorUrl.
+      // Note that the presence of keyConnectorUrl implies that the user does not have a master password, as in pre-TDE
+      // server versions, a master password short-circuited the addition of the keyConnectorUrl to the response.
+      // TODO: remove compatibility check after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
+      const usingKeyConnector = response.keyConnectorUrl != null;
+      accountDecryptionOptions.hasMasterPassword = !usingKeyConnector;
+      if (usingKeyConnector) {
+        accountDecryptionOptions.keyConnectorOption = new KeyConnectorUserDecryptionOption(
+          response.keyConnectorUrl
+        );
+      }
     }
-
-    if (response.keyConnectorOption) {
-      accountDecryptionOptions.keyConnectorOption = new KeyConnectorUserDecryptionOption(
-        response.keyConnectorOption.keyConnectorUrl
-      );
-    }
-
     return accountDecryptionOptions;
   }
 

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -342,7 +342,7 @@ export class AccountDecryptionOptions {
       // we must base our decryption options on the presence of the keyConnectorUrl.
       // Note that the presence of keyConnectorUrl implies that the user does not have a master password, as in pre-TDE
       // server versions, a master password short-circuited the addition of the keyConnectorUrl to the response.
-      // TODO: remove compatibility check after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
+      // TODO: remove this check after 2023.10 release (https://bitwarden.atlassian.net/browse/PM-3537)
       const usingKeyConnector = response.keyConnectorUrl != null;
       accountDecryptionOptions.hasMasterPassword = !usingKeyConnector;
       if (usingKeyConnector) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Prior to TDE, the user's "decryption options" were implied based on the presence or absence of the `keyConnectorUrl` in the token response.  Post-TDE, we have build an explicit `UserDecryptionOptions` property on the response from the server.  However, clients must be able to handle pre-TDE server versions for our self-hosted customers who do not upgrade. 

This has been done by using the `keyConnectorUrl` to initialize the `hasMasterPassword`.  The key code to look at on the server is [here](https://github.com/bitwarden/server/blob/5f4a303180ea4f6caf9c5ed50c6c3858e678e18b/src/Identity/IdentityServer/CustomTokenRequestValidator.cs#L104), in the pre-TDE server-side code.  If the user has a master password, the `keyConnectorUrl` will **not** be in the response.  This allows us to infer the `hasMasterPassword` property based on the `keyConnectorUrl` being present.

## Code changes

- **account.ts:** Modified the `fromJson` for the `AccountDecryptionOptions` to handle mapping the `hasMasterPassword` and `keyConnectorUrl` from the pre-TDE server response.  This required changing the input to include the entire `IdentityTokenResponse` object.
- **login.strategy.ts:** Modified the `fromJson` to pass in the full `IdentityTokenResponse` object.
- **sso-login.strategy.ts:** Simplified the logic in `shouldSetMasterKeyFromKeyConnector` to be based on the presence of `UserDecryptionOptions` in the response.  This parallels the code flow in `account.ts` and keeps it consistent and easier to remove in the future when we can rip out the old response structure.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
