### PR TITLE
[PM-3783] Add zone.js support for `chrome.runtime.onMessage`

### DIFF
--- a/apps/browser/src/platform/polyfills/zone-patch-chrome-runtime.ts
+++ b/apps/browser/src/platform/polyfills/zone-patch-chrome-runtime.ts
@@ -1,0 +1,36 @@
+/**
+ * Monkey patch `chrome.runtime.onMessage` event listeners to run in the Angular zone.
+ */
+Zone.__load_patch("ChromeRuntimeOnMessage", (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const onMessage = global.chrome.runtime.onMessage;
+  if (typeof global?.chrome?.runtime?.onMessage === "undefined") {
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  api.patchMethod(onMessage, "addListener", (delegate: Function) => (self: any, args: any[]) => {
+    const callback = args.length > 0 ? args[0] : null;
+    if (typeof callback === "function") {
+      const wrapperedCallback = Zone.current.wrap(callback, "ChromeRuntimeOnMessage");
+      callback[api.symbol("chromeRuntimeOnMessageCallback")] = wrapperedCallback;
+      return delegate.call(self, wrapperedCallback);
+    } else {
+      return delegate.apply(self, args);
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  api.patchMethod(onMessage, "removeListener", (delegate: Function) => (self: any, args: any[]) => {
+    const callback = args.length > 0 ? args[0] : null;
+    if (typeof callback === "function") {
+      const wrapperedCallback = callback[api.symbol("chromeRuntimeOnMessageCallback")];
+      if (wrapperedCallback) {
+        return delegate.call(self, wrapperedCallback);
+      } else {
+        return delegate.apply(self, args);
+      }
+    } else {
+      return delegate.apply(self, args);
+    }
+  });
+});

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -86,31 +86,25 @@ export class AppComponent implements OnInit, OnDestroy {
       sendResponse: any
     ) => {
       if (msg.command === "doneLoggingOut") {
-        this.ngZone.run(async () => {
-          this.authService.logOut(async () => {
-            if (msg.expired) {
-              this.showToast({
-                type: "warning",
-                title: this.i18nService.t("loggedOut"),
-                text: this.i18nService.t("loginExpired"),
-              });
-            }
+        this.authService.logOut(async () => {
+          if (msg.expired) {
+            this.showToast({
+              type: "warning",
+              title: this.i18nService.t("loggedOut"),
+              text: this.i18nService.t("loginExpired"),
+            });
+          }
 
-            if (this.activeUserId === null) {
-              this.router.navigate(["home"]);
-            }
-          });
-          this.changeDetectorRef.detectChanges();
+          if (this.activeUserId === null) {
+            this.router.navigate(["home"]);
+          }
         });
+        this.changeDetectorRef.detectChanges();
       } else if (msg.command === "authBlocked") {
-        this.ngZone.run(() => {
-          this.router.navigate(["home"]);
-        });
+        this.router.navigate(["home"]);
       } else if (msg.command === "locked") {
         if (msg.userId == null || msg.userId === (await this.stateService.getUserId())) {
-          this.ngZone.run(() => {
-            this.router.navigate(["lock"]);
-          });
+          this.router.navigate(["lock"]);
         }
       } else if (msg.command === "showDialog") {
         await this.showDialog(msg);
@@ -118,9 +112,7 @@ export class AppComponent implements OnInit, OnDestroy {
         // TODO: Should be refactored to live in another service.
         await this.showNativeMessagingFingerprintDialog(msg);
       } else if (msg.command === "showToast") {
-        this.ngZone.run(() => {
-          this.showToast(msg);
-        });
+        this.showToast(msg);
       } else if (msg.command === "reloadProcess") {
         const forceWindowReload =
           this.platformUtilsService.isSafari() ||
@@ -132,13 +124,9 @@ export class AppComponent implements OnInit, OnDestroy {
           2000
         );
       } else if (msg.command === "reloadPopup") {
-        this.ngZone.run(() => {
-          this.router.navigate(["/"]);
-        });
+        this.router.navigate(["/"]);
       } else if (msg.command === "convertAccountToKeyConnector") {
-        this.ngZone.run(async () => {
-          this.router.navigate(["/remove-password"]);
-        });
+        this.router.navigate(["/remove-password"]);
       } else {
         msg.webExtSender = sender;
         this.broadcasterService.send(msg);

--- a/apps/browser/src/popup/polyfills.ts
+++ b/apps/browser/src/popup/polyfills.ts
@@ -1,3 +1,5 @@
 import "core-js/stable";
 import "date-input-polyfill";
 import "zone.js";
+
+import "../platform/polyfills/zone-patch-chrome-runtime";


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This simplifies the browser by removing the need to call `ngZone.run(() => {...});` when using  `BrowserApi.messageListener` 

Based on the following PR-review discussion https://github.com/bitwarden/clients/pull/5989#discussion_r1310129598

## Code changes

- **zone-patch-chrome-runtime.ts:** Zone.js patch functions. Inspired by [zone.js media query patch](https://github.com/angular/angular/blob/690c8325cdb94735dff8b7494a27bf9ea6f4b80a/packages/zone.js/lib/browser/webapis-media-query.ts)
- **polyfills.ts:** Make sure to import the patches so they run before angular zone is created
- **app.component.ts:** Remove calls to `ngZone` which are no longer needed

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
