### PR TITLE
[PM-3805] Extension PopOut Window Closes When Navigating Away From Vault Item View

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -302,11 +302,8 @@ export class ViewComponent extends BaseViewComponent {
   }
 
   close() {
-    if (this.senderTabId) {
+    if (this.inPopout && this.senderTabId) {
       BrowserApi.focusTab(this.senderTabId);
-    }
-
-    if (this.inPopout) {
       window.close();
       return;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

A regression was identified where the vault item view component, within the browser extension, was closing anytime a user attempted to navigate away from an individual vault item. This should not be the case, and the user should be returned to the list of vault items if they are within a popout of the vault.

## Code changes

- **apps/browser/src/vault/popup/components/vault/view.component.ts:** Modified the conditional used to close a user's popout window in the context of a single use popout. If we do not have a sender ID, our expectation should be that this is a manually opened popout window, not a single use popout window. As a result, we should navigate back instead of closing the window when a senderId query param is not passed to the view.

## Screenshots

https://github.com/bitwarden/clients/assets/16629865/160e4a9e-ff76-410b-8dcd-b6189e04dbc9

