### PR TITLE
[PM-3505] Fix org admins being unable to clone a vault item from org vault to individual vault

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -134,12 +134,23 @@ describe("Cipher Service", () => {
   });
 
   describe("createWithServer()", () => {
-    it("should call apiService.postCipherAdmin when orgAdmin param is true", async () => {
+    it("should call apiService.postCipherAdmin when orgAdmin param is true and the cipher orgId != null", async () => {
       const spy = jest
         .spyOn(apiService, "postCipherAdmin")
         .mockImplementation(() => Promise.resolve<any>(cipherObj));
       cipherService.createWithServer(cipherObj, true);
       const expectedObj = new CipherCreateRequest(cipherObj);
+
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(expectedObj);
+    });
+    it("should call apiService.postCipher when orgAdmin param is true and the cipher orgId is null", async () => {
+      cipherObj.organizationId = null;
+      const spy = jest
+        .spyOn(apiService, "postCipher")
+        .mockImplementation(() => Promise.resolve<any>(cipherObj));
+      cipherService.createWithServer(cipherObj, true);
+      const expectedObj = new CipherRequest(cipherObj);
 
       expect(spy).toHaveBeenCalled();
       expect(spy).toHaveBeenCalledWith(expectedObj);

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -525,7 +525,7 @@ export class CipherService implements CipherServiceAbstraction {
 
   async createWithServer(cipher: Cipher, orgAdmin?: boolean): Promise<any> {
     let response: CipherResponse;
-    if (orgAdmin) {
+    if (orgAdmin && cipher.organizationId != null) {
       const request = new CipherCreateRequest(cipher);
       response = await this.apiService.postCipherAdmin(request);
     } else if (cipher.collectionIds != null) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fix org admins being unable to clone a vault item from org vault to individual vault## Code changes

- **libs/common/src/vault/services/cipher.service.ts:** Only call postCipherAdmin if the orgId on a cipher is not null
- **libs/common/src/vault/services/cipher.service.spec.ts:** Add a test to cover new condition

## Screenshots


https://github.com/bitwarden/clients/assets/8926729/c8fe90f0-f4ad-4e55-9f97-a23945c77084


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
