### PR TITLE
[PM-2643] Resolve DUO iframe not being clickable

### DIFF
--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -11,7 +11,7 @@
     <title>Bitwarden</title>
     <base href="" />
   </head>
-  <body class="layout_frontend">
+  <body>
     <app-root>
       <div id="loading"><i class="bwi bwi-spinner bwi-spin bwi-3x" aria-hidden="true"></i></div>
     </app-root>

--- a/apps/desktop/src/scss/environment.scss
+++ b/apps/desktop/src/scss/environment.scss
@@ -1,30 +1,4 @@
 ﻿html.os_macos {
-  body.layout_frontend {
-    -webkit-app-region: drag;
-
-    button,
-    a,
-    i,
-    b,
-    span,
-    input,
-    p,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    img,
-    select,
-    textarea,
-    label,
-    .box,
-    .modal-backdrop {
-      -webkit-app-region: no-drag;
-    }
-  }
-
   .vault .header-search {
     -webkit-app-region: drag;
 

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -207,7 +207,6 @@ export class VaultComponent implements OnInit, OnDestroy {
     if (!this.syncService.syncInProgress) {
       await this.load();
     }
-    document.body.classList.remove("layout_frontend");
 
     this.searchBarService.setEnabled(true);
     this.searchBarService.setPlaceholderText(this.i18nService.t("searchVault"));
@@ -226,7 +225,6 @@ export class VaultComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.searchBarService.setEnabled(false);
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-    document.body.classList.add("layout_frontend");
   }
 
   async load() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The DUO 2fa iframe is not clickable on macOS. This seems to be related to the `-webkit-app-region: drag` that is turned on for the `layout_frontend`. Since we now have a proper drag handle in the top bar we should be able to safely disable this.

Resolves https://github.com/bitwarden/clients/issues/5680

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/scss/environment.scss:** Remove `webkit-app-region: drag` for `layout_frontend`.
- **apps/desktop/src/vault/app/vault/vault.component.ts**: Remove `layout_frontend` since it's no longer used.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
