### PR TITLE
[PM-3820] Window Messaging Fix;

### DIFF
--- a/apps/browser/src/vault/fido2/content/messaging/messenger.ts
+++ b/apps/browser/src/vault/fido2/content/messaging/messenger.ts
@@ -24,10 +24,16 @@ type Handler = (
 
 export class Messenger {
   static forDOMCommunication(window: Window) {
+    const windowOrigin = window.location.origin;
+
     return new Messenger({
-      postMessage: window.postMessage.bind(window),
+      postMessage: (message) => window.postMessage(message, windowOrigin),
       messages$: new Observable((subscriber) => {
         const eventListener = (event: MessageEvent<MessageWithMetadata>) => {
+          if (event.origin !== windowOrigin) {
+            return;
+          }
+
           subscriber.next(event.data);
         };
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add a window origin check on the `postMessage` implementation.

## Code changes

- **messenger.ts:** Modified listener to only `next()` the message if the origin matches the window origin.  This is an approach to resolve the security concerns documented [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns).

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
