### PR TITLE
[PM-3840] Utilizes base64 instead of base32 for Steam Guard TOTP

### DIFF
--- a/libs/common/src/services/totp.service.ts
+++ b/libs/common/src/services/totp.service.ts
@@ -64,7 +64,7 @@ export class TotpService implements TotpServiceAbstraction {
     const timeHex = this.leftPad(this.decToHex(Math.floor(epoch / period)), 16, "0");
     const timeBytes = Utils.fromHexToArray(timeHex);
     let keyBytes: Uint8Array;
-    if (isSteamAuth) {
+    if (isSteamAuth && !this.isValidB32(keyB32) /* backwards compatibility */) {
       keyBytes = this.b64ToBytes(keyB32);
     } else {
       keyBytes = this.b32ToBytes(keyB32);
@@ -172,6 +172,15 @@ export class TotpService implements TotpServiceAbstraction {
     }
 
     return arr;
+  }
+
+  private isValidB32(str: string): boolean {
+    for (let i = 0; i < str.length; i++) {
+      if (!B32Chars.includes(str[i])) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private async sign(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The Steam Guard TOTP uses a base64 shared secret key instead of base32. This feature allows Steam Guard TOTP to be used directly without the need to convert the shared secret key to base32.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/services/totp.service.ts:** Utilizes base64 instead of base32 for Steam Guard TOTP
