### PR TITLE
[PM-2814] Add ConfigService to CipherService

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -413,6 +413,14 @@ export default class MainBackground {
 
     this.configApiService = new ConfigApiService(this.apiService, this.authService);
 
+    this.configService = new BrowserConfigService(
+      this.stateService,
+      this.configApiService,
+      this.authService,
+      this.environmentService,
+      true
+    );
+
     this.cipherService = new CipherService(
       this.cryptoService,
       this.settingsService,
@@ -422,7 +430,7 @@ export default class MainBackground {
       this.stateService,
       this.encryptService,
       this.cipherFileUploadService,
-      this.configApiService
+      this.configService
     );
     this.folderService = new BrowserFolderService(
       this.cryptoService,
@@ -538,15 +546,6 @@ export default class MainBackground {
       this.messagingService
     );
 
-    this.configApiService = new ConfigApiService(this.apiService, this.authService);
-
-    this.configService = new BrowserConfigService(
-      this.stateService,
-      this.configApiService,
-      this.authService,
-      this.environmentService,
-      true
-    );
     this.browserPopoutWindowService = new BrowserPopoutWindowService();
 
     const systemUtilsServiceReloadCallback = () => {

--- a/apps/browser/src/platform/background/service-factories/config-service.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/config-service.factory.ts
@@ -1,0 +1,42 @@
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
+import { ConfigService } from "@bitwarden/common/platform/services/config/config.service";
+
+import {
+  authServiceFactory,
+  AuthServiceInitOptions,
+} from "../../../auth/background/service-factories/auth-service.factory";
+
+import { configApiServiceFactory, ConfigApiServiceInitOptions } from "./config-api.service.factory";
+import {
+  environmentServiceFactory,
+  EnvironmentServiceInitOptions,
+} from "./environment-service.factory";
+import { FactoryOptions, CachedServices, factory } from "./factory-options";
+import { stateServiceFactory, StateServiceInitOptions } from "./state-service.factory";
+
+type ConfigServiceFactoryOptions = FactoryOptions;
+
+export type ConfigServiceInitOptions = ConfigServiceFactoryOptions &
+  StateServiceInitOptions &
+  ConfigApiServiceInitOptions &
+  AuthServiceInitOptions &
+  EnvironmentServiceInitOptions;
+
+export function configServiceFactory(
+  cache: { configService?: ConfigServiceAbstraction } & CachedServices,
+  opts: ConfigServiceInitOptions
+): Promise<ConfigServiceAbstraction> {
+  return factory(
+    cache,
+    "configService",
+    opts,
+    async () =>
+      new ConfigService(
+        await stateServiceFactory(cache, opts),
+        await configApiServiceFactory(cache, opts),
+        await authServiceFactory(cache, opts),
+        await environmentServiceFactory(cache, opts),
+        true
+      )
+  );
+}

--- a/apps/browser/src/platform/background/service-factories/config-service.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/config-service.factory.ts
@@ -14,7 +14,11 @@ import {
 import { FactoryOptions, CachedServices, factory } from "./factory-options";
 import { stateServiceFactory, StateServiceInitOptions } from "./state-service.factory";
 
-type ConfigServiceFactoryOptions = FactoryOptions;
+type ConfigServiceFactoryOptions = FactoryOptions & {
+  configServiceOptions?: {
+    subscribe?: boolean;
+  };
+};
 
 export type ConfigServiceInitOptions = ConfigServiceFactoryOptions &
   StateServiceInitOptions &
@@ -36,7 +40,7 @@ export function configServiceFactory(
         await configApiServiceFactory(cache, opts),
         await authServiceFactory(cache, opts),
         await environmentServiceFactory(cache, opts),
-        true
+        opts.configServiceOptions?.subscribe ?? true
       )
   );
 }

--- a/apps/browser/src/vault/background/service_factories/cipher-service.factory.ts
+++ b/apps/browser/src/vault/background/service_factories/cipher-service.factory.ts
@@ -18,9 +18,9 @@ import {
   ApiServiceInitOptions,
 } from "../../../platform/background/service-factories/api-service.factory";
 import {
-  configApiServiceFactory,
-  ConfigApiServiceInitOptions,
-} from "../../../platform/background/service-factories/config-api.service.factory";
+  configServiceFactory,
+  ConfigServiceInitOptions,
+} from "../../../platform/background/service-factories/config-service.factory";
 import {
   cryptoServiceFactory,
   CryptoServiceInitOptions,
@@ -54,7 +54,7 @@ export type CipherServiceInitOptions = CipherServiceFactoryOptions &
   SearchServiceInitOptions &
   StateServiceInitOptions &
   EncryptServiceInitOptions &
-  ConfigApiServiceInitOptions;
+  ConfigServiceInitOptions;
 
 export function cipherServiceFactory(
   cache: { cipherService?: AbstractCipherService } & CachedServices,
@@ -74,7 +74,7 @@ export function cipherServiceFactory(
         await stateServiceFactory(cache, opts),
         await encryptServiceFactory(cache, opts),
         await cipherFileUploadServiceFactory(cache, opts),
-        await configApiServiceFactory(cache, opts)
+        await configServiceFactory(cache, opts)
       )
   );
 }

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -26,12 +26,14 @@ import { UserVerificationApiService } from "@bitwarden/common/auth/services/user
 import { UserVerificationService } from "@bitwarden/common/auth/services/user-verification/user-verification.service";
 import { ClientType, KeySuffixOptions, LogLevelType } from "@bitwarden/common/enums";
 import { ConfigApiServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config-api.service.abstraction";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { Account } from "@bitwarden/common/platform/models/domain/account";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
 import { AppIdService } from "@bitwarden/common/platform/services/app-id.service";
 import { BroadcasterService } from "@bitwarden/common/platform/services/broadcaster.service";
 import { ConfigApiService } from "@bitwarden/common/platform/services/config/config-api.service";
+import { ConfigService } from "@bitwarden/common/platform/services/config/config.service";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { CryptoService } from "@bitwarden/common/platform/services/crypto.service";
 import { EncryptServiceImplementation } from "@bitwarden/common/platform/services/cryptography/encrypt.service.implementation";
@@ -150,6 +152,7 @@ export class Main {
   deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction;
   authRequestCryptoService: AuthRequestCryptoServiceAbstraction;
   configApiService: ConfigApiServiceAbstraction;
+  configService: ConfigServiceAbstraction;
 
   constructor() {
     let p = null;
@@ -334,6 +337,14 @@ export class Main {
 
     this.configApiService = new ConfigApiService(this.apiService, this.authService);
 
+    this.configService = new ConfigService(
+      this.stateService,
+      this.configApiService,
+      this.authService,
+      this.environmentService,
+      true
+    );
+
     this.cipherService = new CipherService(
       this.cryptoService,
       this.settingsService,
@@ -343,7 +354,7 @@ export class Main {
       this.stateService,
       this.encryptService,
       this.cipherFileUploadService,
-      this.configApiService
+      this.configService
     );
 
     this.folderService = new FolderService(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -272,7 +272,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         stateService: StateServiceAbstraction,
         encryptService: EncryptService,
         fileUploadService: CipherFileUploadServiceAbstraction,
-        configApiService: ConfigApiServiceAbstraction
+        configService: ConfigServiceAbstraction
       ) =>
         new CipherService(
           cryptoService,
@@ -283,7 +283,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
           stateService,
           encryptService,
           fileUploadService,
-          configApiService
+          configService
         ),
       deps: [
         CryptoServiceAbstraction,
@@ -294,7 +294,7 @@ import { AbstractThemingService } from "./theming/theming.service.abstraction";
         StateServiceAbstraction,
         EncryptService,
         CipherFileUploadServiceAbstraction,
-        ConfigApiServiceAbstraction,
+        ConfigServiceAbstraction,
       ],
     },
     {

--- a/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
@@ -1,4 +1,5 @@
 import { Observable } from "rxjs";
+import { SemVer } from "semver";
 
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { Region } from "../environment.service";
@@ -16,6 +17,7 @@ export abstract class ConfigServiceAbstraction {
     key: FeatureFlag,
     defaultValue?: T
   ) => Promise<T>;
+  checkServerMeetsVersionRequirement: (minServerVersion: SemVer) => Promise<boolean>;
 
   /**
    * Force ConfigService to fetch an updated config from the server and emit it from serverConfig$

--- a/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
@@ -17,7 +17,7 @@ export abstract class ConfigServiceAbstraction {
     key: FeatureFlag,
     defaultValue?: T
   ) => Promise<T>;
-  checkServerMeetsVersionRequirement: (minServerVersion: SemVer) => Promise<boolean>;
+  checkServerMeetsVersionRequirement: (minimumRequiredServerVersion: SemVer) => Promise<boolean>;
 
   /**
    * Force ConfigService to fetch an updated config from the server and emit it from serverConfig$

--- a/libs/common/src/platform/services/config/config.service.ts
+++ b/libs/common/src/platform/services/config/config.service.ts
@@ -10,6 +10,7 @@ import {
   merge,
   timer,
 } from "rxjs";
+import { SemVer } from "semver";
 
 import { AuthService } from "../../../auth/abstractions/auth.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
@@ -102,5 +103,24 @@ export class ConfigService implements ConfigServiceAbstraction {
 
     await this.stateService.setServerConfig(data);
     this.environmentService.setCloudWebVaultUrl(data.environment?.cloudRegion);
+  }
+
+  /**
+   * Verifies whether the server version meets the minimum required version
+   * @param minimumRequiredServerVersion The minimum version required
+   * @returns True if the server version is greater than or equal to the minimum required version
+   */
+  async checkServerMeetsVersionRequirement(minimumRequiredServerVersion: SemVer): Promise<boolean> {
+    return firstValueFrom(
+      this.serverConfig$.pipe(
+        map((serverConfig) => {
+          if (serverConfig == null) {
+            return false;
+          }
+          const serverVersion = new SemVer(serverConfig.version);
+          return serverVersion.compare(minimumRequiredServerVersion) >= 0;
+        })
+      )
+    );
   }
 }

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -5,7 +5,7 @@ import { ApiService } from "../../abstractions/api.service";
 import { SearchService } from "../../abstractions/search.service";
 import { SettingsService } from "../../abstractions/settings.service";
 import { UriMatchType, FieldType } from "../../enums";
-import { ConfigApiServiceAbstraction } from "../../platform/abstractions/config/config-api.service.abstraction";
+import { ConfigServiceAbstraction } from "../../platform/abstractions/config/config.service.abstraction";
 import { CryptoService } from "../../platform/abstractions/crypto.service";
 import { EncryptService } from "../../platform/abstractions/encrypt.service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
@@ -17,7 +17,6 @@ import {
   OrgKey,
   SymmetricCryptoKey,
 } from "../../platform/models/domain/symmetric-crypto-key";
-import { ServerConfigResponse } from "../../platform/models/response/server-config.response";
 import { ContainerService } from "../../platform/services/container.service";
 import { CipherFileUploadService } from "../abstractions/file-upload/cipher-file-upload.service";
 import { CipherRepromptType } from "../enums/cipher-reprompt-type";
@@ -33,8 +32,6 @@ import { CipherService } from "./cipher.service";
 
 const ENCRYPTED_TEXT = "This data has been encrypted";
 const ENCRYPTED_BYTES = mock<EncArrayBuffer>();
-const DATE_NOW = new Date();
-const UNSUPPORTED_VERSION = "2023.2.0";
 
 const cipherData: CipherData = {
   id: "id",
@@ -104,7 +101,7 @@ describe("Cipher Service", () => {
   const i18nService = mock<I18nService>();
   const searchService = mock<SearchService>();
   const encryptService = mock<EncryptService>();
-  const configApiService = mock<ConfigApiServiceAbstraction>();
+  const configService = mock<ConfigServiceAbstraction>();
 
   let cipherService: CipherService;
   let cipherObj: Cipher;
@@ -118,7 +115,7 @@ describe("Cipher Service", () => {
     mockReset(i18nService);
     mockReset(searchService);
     mockReset(encryptService);
-    mockReset(configApiService);
+    mockReset(configService);
 
     encryptService.encryptToBytes.mockReturnValue(Promise.resolve(ENCRYPTED_BYTES));
     encryptService.encrypt.mockReturnValue(Promise.resolve(new EncString(ENCRYPTED_TEXT)));
@@ -134,7 +131,7 @@ describe("Cipher Service", () => {
       stateService,
       encryptService,
       cipherFileUploadService,
-      configApiService
+      configService
     );
 
     cipherObj = new Cipher(cipherData);
@@ -150,9 +147,7 @@ describe("Cipher Service", () => {
         Promise.resolve<any>(new SymmetricCryptoKey(new Uint8Array(32)))
       );
 
-      configApiService.get.mockReturnValue(
-        Promise.resolve(new ServerConfigResponse({ version: UNSUPPORTED_VERSION }))
-      );
+      configService.checkServerMeetsVersionRequirement.mockReturnValue(Promise.resolve(false));
       process.env.FLAGS = JSON.stringify({
         enableCipherKeyEncryption: false,
       });
@@ -257,9 +252,7 @@ describe("Cipher Service", () => {
       cipherView.type = CipherType.Login;
 
       encryptService.decryptToBytes.mockReturnValue(Promise.resolve(makeStaticByteArray(64)));
-      configApiService.get.mockReturnValue(
-        Promise.resolve(new ServerConfigResponse({ version: getVersion() }))
-      );
+      configService.checkServerMeetsVersionRequirement.mockReturnValue(Promise.resolve(true));
       cryptoService.makeCipherKey.mockReturnValue(
         Promise.resolve(new SymmetricCryptoKey(makeStaticByteArray(64)) as CipherKey)
       );
@@ -312,26 +305,6 @@ describe("Cipher Service", () => {
 
         expect(cipherService["encryptWithCipherKey"]).toHaveBeenCalled();
       });
-
-      it("is called when server version has hotfix suffix", async () => {
-        mockReset(configApiService);
-
-        process.env.FLAGS = JSON.stringify({
-          enableCipherKeyEncryption: true,
-        });
-
-        configApiService.get.mockReturnValue(
-          Promise.resolve(new ServerConfigResponse({ version: getVersion() }))
-        );
-        await cipherService.encrypt(cipherView);
-
-        expect(cipherService["encryptWithCipherKey"]).toHaveBeenCalled();
-      });
     });
   });
-
-  function getVersion(): string {
-    const year = DATE_NOW.getFullYear() + 1;
-    return year + "." + DATE_NOW.getMonth() + ".0";
-  }
 });

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -6,7 +6,7 @@ import { SettingsService } from "../../abstractions/settings.service";
 import { FieldType, UriMatchType } from "../../enums";
 import { ErrorResponse } from "../../models/response/error.response";
 import { View } from "../../models/view/view";
-import { ConfigApiServiceAbstraction } from "../../platform/abstractions/config/config-api.service.abstraction";
+import { ConfigServiceAbstraction } from "../../platform/abstractions/config/config.service.abstraction";
 import { CryptoService } from "../../platform/abstractions/crypto.service";
 import { EncryptService } from "../../platform/abstractions/encrypt.service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
@@ -67,7 +67,7 @@ export class CipherService implements CipherServiceAbstraction {
     private stateService: StateService,
     private encryptService: EncryptService,
     private cipherFileUploadService: CipherFileUploadService,
-    private configApiService: ConfigApiServiceAbstraction
+    private configService: ConfigServiceAbstraction
   ) {}
 
   async getDecryptedCipherCache(): Promise<CipherView[]> {
@@ -1258,8 +1258,11 @@ export class CipherService implements CipherServiceAbstraction {
   }
 
   async getCipherKeyEncryptionEnabled(): Promise<boolean> {
-    const minVersion = new SemVer(CIPHER_KEY_ENC_MIN_SERVER_VER);
-    const serverVersion = new SemVer((await this.configApiService.get()).version);
-    return flagEnabled("enableCipherKeyEncryption") && serverVersion.compare(minVersion) > 0;
+    return (
+      flagEnabled("enableCipherKeyEncryption") &&
+      (await this.configService.checkServerMeetsVersionRequirement(
+        new SemVer(CIPHER_KEY_ENC_MIN_SERVER_VER)
+      ))
+    );
   }
 }


### PR DESCRIPTION
Updated version check.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `CipherService` had a dependency on `ConfigApiService` instead of `ConfigService`.  What that meant is that every encryption operation made a call to the server to retrieve the server version.

This change updates to depend on the `ConfigService` instead, with a new method on the `ConfigService` to do the server version comparison instead of relying on the consuming service to do so.

## Code changes

- **config.service.ts:** Added new method for consumers to check server version compatibility for a desired feature.
- **config.service.abstraction.ts:** New method definition.
- **cipher.service.ts:** Updated to reference the new method on `ConfigService`.  Also updated to short-circuit the need to call `ConfigService` at all to only occur if the feature flag is on.
- Other files - configured DI dependencies for `CipherService` on all clients.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
