### PR TITLE
[PM-3822] Only show popout warning on file SendAddEdit

### DIFF
--- a/apps/browser/src/tools/popup/send/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send/send-add-edit.component.html
@@ -27,7 +27,7 @@
       icon="bwi-external-link bwi-rotate-270 bwi-fw"
       [clickable]="true"
       title="{{ 'sendFileCalloutHeader' | i18n }}"
-      *ngIf="showFilePopoutMessage && send.type === sendType.File && !disableSend"
+      *ngIf="showFilePopoutMessage && type === sendType.File && !disableSend"
       (click)="popOutWindow()"
     >
       <div *ngIf="showChromiumFileWarning">{{ "sendLinuxChromiumFileWarning" | i18n }}</div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The popout warning message was showing when the send had the type of file and text selected, it should show only to file.

## Code changes
- **send-add-edit.component.html:** Using the type instead the send.type as validation

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
