### PR TITLE
[CL-128] Support placeholders in i18n mock

### DIFF
--- a/libs/components/src/form-field/error-summary.stories.ts
+++ b/libs/components/src/form-field/error-summary.stories.ts
@@ -24,7 +24,7 @@ export default {
               required: "required",
               inputRequired: "Input is required.",
               inputEmail: "Input is not an email-address.",
-              fieldsNeedAttention: "$COUNT$ field(s) above need your attention.",
+              fieldsNeedAttention: "__$1__ field(s) above need your attention.",
             });
           },
         },
@@ -63,12 +63,12 @@ export const Default: StoryObj<BitFormFieldComponent> = {
           <bit-label>Name</bit-label>
           <input bitInput formControlName="name" />
         </bit-form-field>
-  
+
         <bit-form-field>
           <bit-label>Email</bit-label>
           <input bitInput formControlName="email" />
         </bit-form-field>
-  
+
         <button type="submit" bitButton buttonType="primary">Submit</button>
         <bit-error-summary [formGroup]="formObj"></bit-error-summary>
       </form>

--- a/libs/components/src/utils/i18n-mock.service.ts
+++ b/libs/components/src/utils/i18n-mock.service.ts
@@ -12,8 +12,20 @@ export class I18nMockService implements I18nService {
   constructor(private lookupTable: Record<string, string | ((...args: string[]) => string)>) {}
 
   t(id: string, p1?: string, p2?: string, p3?: string) {
-    const value = this.lookupTable[id];
+    let value = this.lookupTable[id];
     if (typeof value == "string") {
+      if (value !== "") {
+        if (p1 != null) {
+          value = value.split("__$1__").join(p1.toString());
+        }
+        if (p2 != null) {
+          value = value.split("__$2__").join(p2.toString());
+        }
+        if (p3 != null) {
+          value = value.split("__$3__").join(p3.toString());
+        }
+      }
+
       return value;
     }
     return value(p1, p2, p3);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Add support for placeholders in the i18n-mock. Since we don't provide full message objects this works slightly different in that you use the expanded form, i.e. `__$1__`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
