### PR TITLE
[PM-3807] Store all passkeys as login cipher type

### DIFF
--- a/libs/common/src/vault/abstractions/fido2/fido2-authenticator.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/fido2/fido2-authenticator.service.abstraction.ts
@@ -81,7 +81,7 @@ export interface Fido2AuthenticatorMakeCredentialsParams {
   };
   /** A Boolean value that indicates that individually-identifying attestation MAY be returned by the authenticator. */
   enterpriseAttestationPossible?: boolean; // Ignored by bitwarden at the moment
-  /** The effective resident key requirement for credential creation, a Boolean value determined by the client. */
+  /** The effective resident key requirement for credential creation, a Boolean value determined by the client. Resident is synonymous with discoverable. */
   requireResidentKey: boolean;
   requireUserVerification: boolean;
   /** Forwarded to user interface */

--- a/libs/common/src/vault/api/fido2-key.api.ts
+++ b/libs/common/src/vault/api/fido2-key.api.ts
@@ -11,6 +11,7 @@ export class Fido2KeyApi extends BaseResponse {
   counter: string;
   rpName: string;
   userDisplayName: string;
+  discoverable: string;
 
   constructor(data: any = null) {
     super(data);
@@ -28,5 +29,6 @@ export class Fido2KeyApi extends BaseResponse {
     this.counter = this.getResponseProperty("Counter");
     this.rpName = this.getResponseProperty("RpName");
     this.userDisplayName = this.getResponseProperty("UserDisplayName");
+    this.discoverable = this.getResponseProperty("discoverable");
   }
 }

--- a/libs/common/src/vault/api/fido2-key.api.ts
+++ b/libs/common/src/vault/api/fido2-key.api.ts
@@ -29,6 +29,6 @@ export class Fido2KeyApi extends BaseResponse {
     this.counter = this.getResponseProperty("Counter");
     this.rpName = this.getResponseProperty("RpName");
     this.userDisplayName = this.getResponseProperty("UserDisplayName");
-    this.discoverable = this.getResponseProperty("discoverable");
+    this.discoverable = this.getResponseProperty("Discoverable");
   }
 }

--- a/libs/common/src/vault/models/data/cipher.data.ts
+++ b/libs/common/src/vault/models/data/cipher.data.ts
@@ -4,7 +4,6 @@ import { CipherResponse } from "../response/cipher.response";
 
 import { AttachmentData } from "./attachment.data";
 import { CardData } from "./card.data";
-import { Fido2KeyData } from "./fido2-key.data";
 import { FieldData } from "./field.data";
 import { IdentityData } from "./identity.data";
 import { LoginData } from "./login.data";
@@ -27,7 +26,6 @@ export class CipherData {
   secureNote?: SecureNoteData;
   card?: CardData;
   identity?: IdentityData;
-  fido2Key?: Fido2KeyData;
   fields?: FieldData[];
   attachments?: AttachmentData[];
   passwordHistory?: PasswordHistoryData[];
@@ -60,8 +58,6 @@ export class CipherData {
     switch (this.type) {
       case CipherType.Login:
         this.login = new LoginData(response.login);
-        this.fido2Key =
-          response.fido2Key != undefined ? new Fido2KeyData(response.fido2Key) : undefined;
         break;
       case CipherType.SecureNote:
         this.secureNote = new SecureNoteData(response.secureNote);
@@ -71,9 +67,6 @@ export class CipherData {
         break;
       case CipherType.Identity:
         this.identity = new IdentityData(response.identity);
-        break;
-      case CipherType.Fido2Key:
-        this.fido2Key = new Fido2KeyData(response.fido2Key);
         break;
       default:
         break;

--- a/libs/common/src/vault/models/data/fido2-key.data.ts
+++ b/libs/common/src/vault/models/data/fido2-key.data.ts
@@ -11,6 +11,7 @@ export class Fido2KeyData {
   counter: string;
   rpName: string;
   userDisplayName: string;
+  discoverable: string;
 
   constructor(data?: Fido2KeyApi) {
     if (data == null) {
@@ -27,5 +28,6 @@ export class Fido2KeyData {
     this.counter = data.counter;
     this.rpName = data.rpName;
     this.userDisplayName = data.userDisplayName;
+    this.discoverable = data.discoverable;
   }
 }

--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -13,7 +13,6 @@ import { CipherView } from "../view/cipher.view";
 
 import { Attachment } from "./attachment";
 import { Card } from "./card";
-import { Fido2Key } from "./fido2-key";
 import { Field } from "./field";
 import { Identity } from "./identity";
 import { Login } from "./login";
@@ -39,7 +38,6 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
   identity: Identity;
   card: Card;
   secureNote: SecureNote;
-  fido2Key: Fido2Key;
   attachments: Attachment[];
   fields: Field[];
   passwordHistory: Password[];
@@ -96,9 +94,6 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
       case CipherType.Identity:
         this.identity = new Identity(obj.identity);
         break;
-      case CipherType.Fido2Key:
-        this.fido2Key = new Fido2Key(obj.fido2Key);
-        break;
       default:
         break;
     }
@@ -147,9 +142,6 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
         break;
       case CipherType.Identity:
         model.identity = await this.identity.decrypt(this.organizationId, encKey);
-        break;
-      case CipherType.Fido2Key:
-        model.fido2Key = await this.fido2Key.decrypt(this.organizationId, encKey);
         break;
       default:
         break;
@@ -236,9 +228,6 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
       case CipherType.Identity:
         c.identity = this.identity.toIdentityData();
         break;
-      case CipherType.Fido2Key:
-        c.fido2Key = this.fido2Key.toFido2KeyData();
-        break;
       default:
         break;
     }
@@ -291,9 +280,6 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
         break;
       case CipherType.SecureNote:
         domain.secureNote = SecureNote.fromJSON(obj.secureNote);
-        break;
-      case CipherType.Fido2Key:
-        domain.fido2Key = Fido2Key.fromJSON(obj.fido2Key);
         break;
       default:
         break;

--- a/libs/common/src/vault/models/domain/fido2-key.spec.ts
+++ b/libs/common/src/vault/models/domain/fido2-key.spec.ts
@@ -22,6 +22,7 @@ describe("Fido2Key", () => {
         rpName: null,
         userDisplayName: null,
         counter: null,
+        discoverable: null,
       });
     });
 
@@ -37,6 +38,7 @@ describe("Fido2Key", () => {
         counter: "counter",
         rpName: "rpName",
         userDisplayName: "userDisplayName",
+        discoverable: "discoverable",
       };
       const fido2Key = new Fido2Key(data);
 
@@ -51,6 +53,7 @@ describe("Fido2Key", () => {
         counter: { encryptedString: "counter", encryptionType: 0 },
         rpName: { encryptedString: "rpName", encryptionType: 0 },
         userDisplayName: { encryptedString: "userDisplayName", encryptionType: 0 },
+        discoverable: { encryptedString: "discoverable", encryptionType: 0 },
       });
     });
 
@@ -76,6 +79,7 @@ describe("Fido2Key", () => {
       fido2Key.counter = mockEnc("2");
       fido2Key.rpName = mockEnc("rpName");
       fido2Key.userDisplayName = mockEnc("userDisplayName");
+      fido2Key.discoverable = mockEnc("true");
 
       const fido2KeyView = await fido2Key.decrypt(null);
 
@@ -90,6 +94,7 @@ describe("Fido2Key", () => {
         rpName: "rpName",
         userDisplayName: "userDisplayName",
         counter: 2,
+        discoverable: true,
       });
     });
   });
@@ -104,9 +109,10 @@ describe("Fido2Key", () => {
         keyValue: "keyValue",
         rpId: "rpId",
         userHandle: "userHandle",
-        counter: "counter",
+        counter: "2",
         rpName: "rpName",
         userDisplayName: "userDisplayName",
+        discoverable: "true",
       };
 
       const fido2Key = new Fido2Key(data);
@@ -129,6 +135,7 @@ describe("Fido2Key", () => {
       fido2Key.counter = createEncryptedEncString("2");
       fido2Key.rpName = createEncryptedEncString("rpName");
       fido2Key.userDisplayName = createEncryptedEncString("userDisplayName");
+      fido2Key.discoverable = createEncryptedEncString("discoverable");
 
       const json = JSON.stringify(fido2Key);
       const result = Fido2Key.fromJSON(JSON.parse(json));

--- a/libs/common/src/vault/models/domain/fido2-key.ts
+++ b/libs/common/src/vault/models/domain/fido2-key.ts
@@ -17,6 +17,7 @@ export class Fido2Key extends Domain {
   counter: EncString;
   rpName: EncString;
   userDisplayName: EncString;
+  discoverable: EncString;
 
   constructor(obj?: Fido2KeyData) {
     super();
@@ -38,6 +39,7 @@ export class Fido2Key extends Domain {
         counter: null,
         rpName: null,
         userDisplayName: null,
+        discoverable: null,
       },
       []
     );
@@ -56,6 +58,7 @@ export class Fido2Key extends Domain {
         userHandle: null,
         rpName: null,
         userDisplayName: null,
+        discoverable: null,
       },
       orgId,
       encKey
@@ -71,6 +74,16 @@ export class Fido2Key extends Domain {
     );
     // Counter will end up as NaN if this fails
     view.counter = parseInt(counter);
+
+    const { discoverable } = await this.decryptObj(
+      { discoverable: "" },
+      {
+        discoverable: null,
+      },
+      orgId,
+      encKey
+    );
+    view.discoverable = discoverable === "true";
 
     return view;
   }
@@ -88,6 +101,7 @@ export class Fido2Key extends Domain {
       counter: null,
       rpName: null,
       userDisplayName: null,
+      discoverable: null,
     });
     return i;
   }
@@ -107,6 +121,7 @@ export class Fido2Key extends Domain {
     const counter = EncString.fromJSON(obj.counter);
     const rpName = EncString.fromJSON(obj.rpName);
     const userDisplayName = EncString.fromJSON(obj.userDisplayName);
+    const discoverable = EncString.fromJSON(obj.discoverable);
 
     return Object.assign(new Fido2Key(), obj, {
       credentialId,
@@ -119,6 +134,7 @@ export class Fido2Key extends Domain {
       counter,
       rpName,
       userDisplayName,
+      discoverable,
     });
   }
 }

--- a/libs/common/src/vault/models/domain/login.spec.ts
+++ b/libs/common/src/vault/models/domain/login.spec.ts
@@ -123,6 +123,7 @@ describe("Login DTO", () => {
           counter: "counter" as EncryptedString,
           rpName: "rpName" as EncryptedString,
           userDisplayName: "userDisplayName" as EncryptedString,
+          discoverable: "discoverable" as EncryptedString,
         },
       });
 
@@ -143,6 +144,7 @@ describe("Login DTO", () => {
           counter: "counter_fromJSON",
           rpName: "rpName_fromJSON",
           userDisplayName: "userDisplayName_fromJSON",
+          discoverable: "discoverable_fromJSON",
         },
       });
       expect(actual).toBeInstanceOf(Login);

--- a/libs/common/src/vault/models/request/cipher.request.ts
+++ b/libs/common/src/vault/models/request/cipher.request.ts
@@ -104,6 +104,10 @@ export class CipherRequest {
             cipher.login.fido2Key.userDisplayName != null
               ? cipher.login.fido2Key.userDisplayName.encryptedString
               : null;
+          this.login.fido2Key.discoverable =
+            cipher.login.fido2Key.discoverable != null
+              ? cipher.login.fido2Key.discoverable.encryptedString
+              : null;
         }
         break;
       case CipherType.SecureNote:
@@ -196,6 +200,10 @@ export class CipherRequest {
         this.fido2Key.userDisplayName =
           cipher.fido2Key.userDisplayName != null
             ? cipher.fido2Key.userDisplayName.encryptedString
+            : null;
+        this.fido2Key.discoverable =
+          cipher.fido2Key.discoverable != null
+            ? cipher.fido2Key.discoverable.encryptedString
             : null;
         break;
       default:

--- a/libs/common/src/vault/models/request/cipher.request.ts
+++ b/libs/common/src/vault/models/request/cipher.request.ts
@@ -23,7 +23,6 @@ export class CipherRequest {
   secureNote: SecureNoteApi;
   card: CardApi;
   identity: IdentityApi;
-  fido2Key: Fido2KeyApi;
   fields: FieldApi[];
   passwordHistory: PasswordHistoryRequest[];
   // Deprecated, remove at some point and rename attachments2 to attachments
@@ -167,43 +166,6 @@ export class CipherRequest {
         this.identity.licenseNumber =
           cipher.identity.licenseNumber != null
             ? cipher.identity.licenseNumber.encryptedString
-            : null;
-        break;
-      case CipherType.Fido2Key:
-        this.fido2Key = new Fido2KeyApi();
-        this.fido2Key.credentialId =
-          cipher.fido2Key.credentialId != null
-            ? cipher.fido2Key.credentialId.encryptedString
-            : null;
-        this.fido2Key.keyType =
-          cipher.fido2Key.keyType != null
-            ? (cipher.fido2Key.keyType.encryptedString as "public-key")
-            : null;
-        this.fido2Key.keyAlgorithm =
-          cipher.fido2Key.keyAlgorithm != null
-            ? (cipher.fido2Key.keyAlgorithm.encryptedString as "ECDSA")
-            : null;
-        this.fido2Key.keyCurve =
-          cipher.fido2Key.keyCurve != null
-            ? (cipher.fido2Key.keyCurve.encryptedString as "P-256")
-            : null;
-        this.fido2Key.keyValue =
-          cipher.fido2Key.keyValue != null ? cipher.fido2Key.keyValue.encryptedString : null;
-        this.fido2Key.rpId =
-          cipher.fido2Key.rpId != null ? cipher.fido2Key.rpId.encryptedString : null;
-        this.fido2Key.rpName =
-          cipher.fido2Key.rpName != null ? cipher.fido2Key.rpName.encryptedString : null;
-        this.fido2Key.counter =
-          cipher.fido2Key.counter != null ? cipher.fido2Key.counter.encryptedString : null;
-        this.fido2Key.userHandle =
-          cipher.fido2Key.userHandle != null ? cipher.fido2Key.userHandle.encryptedString : null;
-        this.fido2Key.userDisplayName =
-          cipher.fido2Key.userDisplayName != null
-            ? cipher.fido2Key.userDisplayName.encryptedString
-            : null;
-        this.fido2Key.discoverable =
-          cipher.fido2Key.discoverable != null
-            ? cipher.fido2Key.discoverable.encryptedString
             : null;
         break;
       default:

--- a/libs/common/src/vault/models/response/cipher.response.ts
+++ b/libs/common/src/vault/models/response/cipher.response.ts
@@ -4,7 +4,6 @@ import { IdentityApi } from "../../../models/api/identity.api";
 import { LoginApi } from "../../../models/api/login.api";
 import { SecureNoteApi } from "../../../models/api/secure-note.api";
 import { BaseResponse } from "../../../models/response/base.response";
-import { Fido2KeyApi } from "../../api/fido2-key.api";
 import { CipherRepromptType } from "../../enums/cipher-reprompt-type";
 
 import { AttachmentResponse } from "./attachment.response";
@@ -22,7 +21,6 @@ export class CipherResponse extends BaseResponse {
   card: CardApi;
   identity: IdentityApi;
   secureNote: SecureNoteApi;
-  fido2Key: Fido2KeyApi;
   favorite: boolean;
   edit: boolean;
   viewPassword: boolean;
@@ -74,11 +72,6 @@ export class CipherResponse extends BaseResponse {
     const secureNote = this.getResponseProperty("SecureNote");
     if (secureNote != null) {
       this.secureNote = new SecureNoteApi(secureNote);
-    }
-
-    const fido2Key = this.getResponseProperty("Fido2Key");
-    if (fido2Key != null) {
-      this.fido2Key = new Fido2KeyApi(fido2Key);
     }
 
     const fields = this.getResponseProperty("Fields");

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -78,8 +78,6 @@ export class CipherView implements View, InitializerMetadata {
         return this.card;
       case CipherType.Identity:
         return this.identity;
-      case CipherType.Fido2Key:
-        return this.fido2Key;
       default:
         break;
     }
@@ -173,9 +171,6 @@ export class CipherView implements View, InitializerMetadata {
         break;
       case CipherType.SecureNote:
         view.secureNote = SecureNoteView.fromJSON(obj.secureNote);
-        break;
-      case CipherType.Fido2Key:
-        view.fido2Key = Fido2KeyView.fromJSON(obj.fido2Key);
         break;
       default:
         break;

--- a/libs/common/src/vault/models/view/fido2-key.view.ts
+++ b/libs/common/src/vault/models/view/fido2-key.view.ts
@@ -13,6 +13,7 @@ export class Fido2KeyView extends ItemView {
   counter: number;
   rpName: string;
   userDisplayName: string;
+  discoverable: boolean;
 
   get subTitle(): string {
     return this.userDisplayName;

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1166,34 +1166,6 @@ export class CipherService implements CipherServiceAbstraction {
           key
         );
         return;
-      case CipherType.Fido2Key:
-        cipher.fido2Key = new Fido2Key();
-        await this.encryptObjProperty(
-          model.fido2Key,
-          cipher.fido2Key,
-          {
-            credentialId: null,
-            keyType: null,
-            keyAlgorithm: null,
-            keyCurve: null,
-            keyValue: null,
-            rpId: null,
-            rpName: null,
-            userHandle: null,
-            userDisplayName: null,
-            origin: null,
-          },
-          key
-        );
-        cipher.fido2Key.counter = await this.cryptoService.encrypt(
-          String(model.fido2Key.counter),
-          key
-        );
-        cipher.fido2Key.discoverable = await this.cryptoService.encrypt(
-          String(model.fido2Key.discoverable),
-          key
-        );
-        break;
       default:
         throw new Error("Unknown cipher type.");
     }

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1112,6 +1112,10 @@ export class CipherService implements CipherServiceAbstraction {
             String(model.login.fido2Key.counter),
             key
           );
+          cipher.login.fido2Key.discoverable = await this.cryptoService.encrypt(
+            String(model.login.fido2Key.discoverable),
+            key
+          );
         }
         return;
       case CipherType.SecureNote:
@@ -1183,6 +1187,10 @@ export class CipherService implements CipherServiceAbstraction {
         );
         cipher.fido2Key.counter = await this.cryptoService.encrypt(
           String(model.fido2Key.counter),
+          key
+        );
+        cipher.fido2Key.discoverable = await this.cryptoService.encrypt(
+          String(model.fido2Key.discoverable),
           key
         );
         break;

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -422,7 +422,7 @@ describe("FidoAuthenticatorService", () => {
        * Spec: If requireUserVerification is true and the authenticator cannot perform user verification, return an error code equivalent to "ConstraintError" and terminate the operation.
        * Deviation: User verification is checked before checking for excluded credentials
        **/
-      /** TODO: This test should only be activated if we disable support for user verification */
+      /** NOTE: This test should only be activated if we disable support for user verification */
       it.skip("should throw error if requireUserVerification is set to true", async () => {
         const params = await createParams({ requireUserVerification: true });
 
@@ -741,7 +741,7 @@ function createCipherView(
 ): CipherView {
   const cipher = new CipherView();
   cipher.id = data.id ?? Utils.newGuid();
-  cipher.type = data.type ?? CipherType.Fido2Key;
+  cipher.type = CipherType.Login;
   cipher.localData = {};
 
   const fido2KeyView = new Fido2KeyView();

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -262,7 +262,7 @@ describe("FidoAuthenticatorService", () => {
 
       beforeEach(async () => {
         existingCipher = createCipherView({ type: CipherType.Login });
-        params = await createParams();
+        params = await createParams({ requireResidentKey: false });
         cipherService.get.mockImplementation(async (id) =>
           id === existingCipher.id ? ({ decrypt: () => existingCipher } as any) : undefined
         );
@@ -321,6 +321,7 @@ describe("FidoAuthenticatorService", () => {
                 userHandle: Fido2Utils.bufferToString(params.userEntity.id),
                 counter: 0,
                 userDisplayName: params.userEntity.displayName,
+                discoverable: false,
               }),
             }),
           })
@@ -797,6 +798,7 @@ function createCipherView(
   fido2KeyView.userHandle = fido2Key.userHandle ?? Fido2Utils.bufferToString(randomBytes(16));
   fido2KeyView.keyAlgorithm = fido2Key.keyAlgorithm ?? "ECDSA";
   fido2KeyView.keyCurve = fido2Key.keyCurve ?? "P-256";
+  fido2KeyView.discoverable = true;
   fido2KeyView.keyValue =
     fido2KeyView.keyValue ??
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgTC-7XDZipXbaVBlnkjlBgO16ZmqBZWejK2iYo6lV0dehRANCAASOcM2WduNq1DriRYN7ZekvZz-bRhA-qNT4v0fbp5suUFJyWmgOQ0bybZcLXHaerK5Ep1JiSrQcewtQNgLtry7f";

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -101,7 +101,7 @@ describe("FidoAuthenticatorService", () => {
 
     describe.skip("when extensions parameter is present", () => undefined);
 
-    describe("vault contains excluded non-discoverable credential", () => {
+    describe("vault contains excluded credential", () => {
       let excludedCipher: CipherView;
       let params: Fido2AuthenticatorMakeCredentialsParams;
 
@@ -152,83 +152,6 @@ describe("FidoAuthenticatorService", () => {
       it("should not inform user of duplication when the excluded credential belongs to an organization", async () => {
         userInterfaceSession.informExcludedCredential.mockResolvedValue();
         excludedCipher.organizationId = "someOrganizationId";
-
-        try {
-          await authenticator.makeCredential(params);
-          // eslint-disable-next-line no-empty
-        } catch {}
-
-        expect(userInterfaceSession.informExcludedCredential).not.toHaveBeenCalled();
-      });
-
-      it("should not inform user of duplication when input data does not pass checks", async () => {
-        userInterfaceSession.informExcludedCredential.mockResolvedValue();
-        const invalidParams = await createInvalidParams();
-
-        for (const p of Object.values(invalidParams)) {
-          try {
-            await authenticator.makeCredential(p);
-            // eslint-disable-next-line no-empty
-          } catch {}
-        }
-        expect(userInterfaceSession.informExcludedCredential).not.toHaveBeenCalled();
-      });
-
-      it.todo(
-        "should not throw error if the excluded credential has been marked as deleted in the vault"
-      );
-    });
-
-    describe("vault contains excluded discoverable credential", () => {
-      let excludedCipherView: CipherView;
-      let params: Fido2AuthenticatorMakeCredentialsParams;
-
-      beforeEach(async () => {
-        excludedCipherView = createCipherView();
-        params = await createParams({
-          excludeCredentialDescriptorList: [
-            {
-              id: guidToRawFormat(excludedCipherView.fido2Key.credentialId),
-              type: "public-key",
-            },
-          ],
-        });
-        cipherService.get.mockImplementation(async (id) =>
-          id === excludedCipherView.id
-            ? ({ decrypt: async () => excludedCipherView } as any)
-            : undefined
-        );
-        cipherService.getAllDecrypted.mockResolvedValue([excludedCipherView]);
-      });
-
-      /**
-       * Spec: collect an authorization gesture confirming user consent for creating a new credential.
-       * Deviation: Consent is not asked and the user is simply informed of the situation.
-       **/
-      it("should inform user", async () => {
-        userInterfaceSession.informExcludedCredential.mockResolvedValue();
-
-        try {
-          await authenticator.makeCredential(params);
-          // eslint-disable-next-line no-empty
-        } catch {}
-
-        expect(userInterfaceSession.informExcludedCredential).toHaveBeenCalled();
-      });
-
-      /** Spec: return an error code equivalent to "NotAllowedError" and terminate the operation. */
-      it("should throw error", async () => {
-        userInterfaceSession.informExcludedCredential.mockResolvedValue();
-
-        const result = async () => await authenticator.makeCredential(params);
-
-        await expect(result).rejects.toThrowError(Fido2AutenticatorErrorCode.NotAllowed);
-      });
-
-      /** Devation: Organization ciphers are not checked against excluded credentials, even if the user has access to them. */
-      it("should not inform user of duplication when the excluded credential belongs to an organization", async () => {
-        userInterfaceSession.informExcludedCredential.mockResolvedValue();
-        excludedCipherView.organizationId = "someOrganizationId";
 
         try {
           await authenticator.makeCredential(params);

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -188,8 +188,6 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
       }
 
       let cipherOptions: CipherView[];
-
-      // eslint-disable-next-line no-empty
       if (params.allowCredentialDescriptorList?.length > 0) {
         cipherOptions = await this.findCredentialsById(
           params.allowCredentialDescriptorList,
@@ -344,7 +342,8 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
         !cipher.isDeleted &&
         cipher.type === CipherType.Login &&
         cipher.login.fido2Key != undefined &&
-        cipher.login.fido2Key.rpId === rpId
+        cipher.login.fido2Key.rpId === rpId &&
+        cipher.login.fido2Key.discoverable
     );
   }
 }

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -380,6 +380,7 @@ async function createKeyView(
   fido2Key.counter = 0;
   fido2Key.rpName = params.rpEntity.name;
   fido2Key.userDisplayName = params.userEntity.displayName;
+  fido2Key.discoverable = params.requireResidentKey;
 
   return fido2Key;
 }

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -299,10 +299,9 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
         (cipher) =>
           !cipher.isDeleted &&
           cipher.organizationId == undefined &&
-          ((cipher.type === CipherType.Fido2Key && ids.includes(cipher.fido2Key.credentialId)) ||
-            (cipher.type === CipherType.Login &&
-              cipher.login.fido2Key != undefined &&
-              ids.includes(cipher.login.fido2Key.credentialId)))
+          cipher.type === CipherType.Login &&
+          cipher.login.fido2Key != undefined &&
+          ids.includes(cipher.login.fido2Key.credentialId)
       )
       .map((cipher) => cipher.id);
   }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

Server PR here: https://github.com/bitwarden/server/pull/3261

## Objective
- Add `discoverable` property to Fido2Key
- Remove handling of standalone `Fido2Key` cipher type

**Note:** This PR does not remove the actual `CipherType.Fido2Key` type, since UI views and components still rely on it. The removal will be part of [PM-3810 Storage v2 - Unify the UI when viewing an item that has a passkey (clients)](https://bitwarden.atlassian.net/browse/PM-3810)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
