### PR TITLE
[PM-3881] Fix ENV=cloud npm run build:oss:watch

### DIFF
--- a/apps/web/config/cloud.json
+++ b/apps/web/config/cloud.json
@@ -13,7 +13,8 @@
   "dev": {
     "proxyApi": "https://api.bitwarden.com",
     "proxyIdentity": "https://identity.bitwarden.com",
-    "proxyEvents": "https://events.bitwarden.com"
+    "proxyEvents": "https://events.bitwarden.com",
+    "proxyNotifications": "https://notifications.bitwarden.com"
   },
   "flags": {
     "secretsManager": true,

--- a/apps/web/config/qa.json
+++ b/apps/web/config/qa.json
@@ -7,7 +7,8 @@
   "dev": {
     "proxyApi": "https://api.qa.bitwarden.pw",
     "proxyIdentity": "https://identity.qa.bitwarden.pw",
-    "proxyEvents": "https://events.qa.bitwarden.pw"
+    "proxyEvents": "https://events.qa.bitwarden.pw",
+    "proxyNotifications": "https://notifications.qa.bitwarden.pw"
   },
   "flags": {
     "secretsManager": true,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

I was testing https://github.com/bitwarden/clients/pull/6261 and I realized that `ENV=cloud npm run build:oss:watch` does not work. It fails with:

```
[webpack-cli] TypeError: Cannot read properties of undefined (reading 'upgrade')
```

This fixes the problem.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
