### PR TITLE
[PM-2814] Handle key rotation missing key

### DIFF
--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -82,5 +82,4 @@ export abstract class CipherService {
     asAdmin?: boolean
   ) => Promise<void>;
   getKeyForCipherKeyDecryption: (cipher: Cipher) => Promise<any>;
-  getCipherKeyEncryptionEnabled: () => Promise<boolean>;
 }

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -267,7 +267,7 @@ describe("Cipher Service", () => {
 
         const cipher = await cipherService.encrypt(cipherView);
 
-        expect(cipher.key).toBeUndefined();
+        expect(cipher.key).toBeNull();
       });
 
       it("is defined when enableCipherKeyEncryption flag is true", async () => {

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -283,7 +283,7 @@ describe("Cipher Service", () => {
 
     describe("encryptWithCipherKey", () => {
       beforeEach(() => {
-        jest.spyOn<any, string>(cipherService, "encryptWithCipherKey");
+        jest.spyOn<any, string>(cipherService, "encryptCipherWithCipherKey");
       });
 
       it("is not called when enableCipherKeyEncryption is false", async () => {
@@ -293,7 +293,7 @@ describe("Cipher Service", () => {
 
         await cipherService.encrypt(cipherView);
 
-        expect(cipherService["encryptWithCipherKey"]).not.toHaveBeenCalled();
+        expect(cipherService["encryptCipherWithCipherKey"]).not.toHaveBeenCalled();
       });
 
       it("is called when enableCipherKeyEncryption is true", async () => {
@@ -303,7 +303,7 @@ describe("Cipher Service", () => {
 
         await cipherService.encrypt(cipherView);
 
-        expect(cipherService["encryptWithCipherKey"]).toHaveBeenCalled();
+        expect(cipherService["encryptCipherWithCipherKey"]).toHaveBeenCalled();
       });
     });
   });

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -95,62 +95,14 @@ export class CipherService implements CipherServiceAbstraction {
     key?: SymmetricCryptoKey,
     originalCipher: Cipher = null
   ): Promise<Cipher> {
-    // Adjust password history
     if (model.id != null) {
       if (originalCipher == null) {
         originalCipher = await this.get(model.id);
       }
       if (originalCipher != null) {
-        const existingCipher = await originalCipher.decrypt(
-          await this.getKeyForCipherKeyDecryption(originalCipher)
-        );
-        model.passwordHistory = existingCipher.passwordHistory || [];
-        if (model.type === CipherType.Login && existingCipher.type === CipherType.Login) {
-          if (
-            existingCipher.login.password != null &&
-            existingCipher.login.password !== "" &&
-            existingCipher.login.password !== model.login.password
-          ) {
-            const ph = new PasswordHistoryView();
-            ph.password = existingCipher.login.password;
-            ph.lastUsedDate = model.login.passwordRevisionDate = new Date();
-            model.passwordHistory.splice(0, 0, ph);
-          } else {
-            model.login.passwordRevisionDate = existingCipher.login.passwordRevisionDate;
-          }
-        }
-        if (existingCipher.hasFields) {
-          const existingHiddenFields = existingCipher.fields.filter(
-            (f) =>
-              f.type === FieldType.Hidden &&
-              f.name != null &&
-              f.name !== "" &&
-              f.value != null &&
-              f.value !== ""
-          );
-          const hiddenFields =
-            model.fields == null
-              ? []
-              : model.fields.filter(
-                  (f) => f.type === FieldType.Hidden && f.name != null && f.name !== ""
-                );
-          existingHiddenFields.forEach((ef) => {
-            const matchedField = hiddenFields.find((f) => f.name === ef.name);
-            if (matchedField == null || matchedField.value !== ef.value) {
-              const ph = new PasswordHistoryView();
-              ph.password = ef.name + ": " + ef.value;
-              ph.lastUsedDate = new Date();
-              model.passwordHistory.splice(0, 0, ph);
-            }
-          });
-        }
+        await this.updateExistingCipherFromModel(model, originalCipher);
       }
-      if (model.passwordHistory != null && model.passwordHistory.length === 0) {
-        model.passwordHistory = null;
-      } else if (model.passwordHistory != null && model.passwordHistory.length > 5) {
-        // only save last 5 history
-        model.passwordHistory = model.passwordHistory.slice(0, 5);
-      }
+      this.adjustPasswordHistoryLength(model);
     }
 
     const cipher = new Cipher();
@@ -174,29 +126,33 @@ export class CipherService implements CipherServiceAbstraction {
     if (await this.getCipherKeyEncryptionEnabled()) {
       cipher.key = originalCipher?.key ?? null;
 
-      // Get the decrypted cipher key used for cipher key encryption
-      const keyForCipherKeyDecryption = await this.getKeyForCipherKeyDecryption(cipher);
-      const decryptedCipherKey = await this.getDecryptedCipherKey(
-        cipher,
-        keyForCipherKeyDecryption
-      );
-
-      // If the cipher key is null, or a different encryption key is passed in, we need to encrypt
-      // the cipher key.
-      if (cipher.key == null || key != null) {
-        // Get the key to use for encrypting the cipher key. If the key is passed in, use that.
-        // A different key will be passed in when rotating. Otherwise use the same key used for decryption.
-        const keyForCipherKeyEncryption = key ?? (await this.getKeyForCipherKeyDecryption(cipher));
-        cipher.key = await this.encryptService.encrypt(
-          decryptedCipherKey.key,
-          keyForCipherKeyEncryption
+      // First, we get the key for cipher key encryption, in its decrypted form
+      let decryptedCipherKey: SymmetricCryptoKey;
+      if (cipher.key == null) {
+        decryptedCipherKey = await this.cryptoService.makeCipherKey();
+      } else {
+        const keyForCipherKeyDecryption = await this.getKeyForCipherKeyDecryption(cipher);
+        decryptedCipherKey = new SymmetricCryptoKey(
+          await this.encryptService.decryptToBytes(cipher.key, keyForCipherKeyDecryption)
         );
       }
 
-      return this.encryptCipher(model, cipher, decryptedCipherKey);
-    }
+      // Then, we have to encrypt the cipher key itself with the proper key
+      // If a key is provided as a parameter, we use it, otherwise we use the user key from state.
+      // The key is provided as a parameter during operations in which the key is changing (e.g. rotation)
+      const keyForCipherKeyEncryption = key ?? (await this.getKeyForCipherKeyDecryption(cipher));
+      cipher.key = await this.encryptService.encrypt(
+        decryptedCipherKey.key,
+        keyForCipherKeyEncryption
+      );
 
-    return this.encryptCipher(model, cipher, key);
+      return this.encryptCipher(model, cipher, decryptedCipherKey);
+    } else {
+      // We want to ensure that the cipher key is null if cipher key encryption is disabled
+      // so that decryption uses the proper key.
+      cipher.key = null;
+      return this.encryptCipher(model, cipher, key);
+    }
   }
 
   async encryptAttachments(
@@ -998,6 +954,64 @@ export class CipherService implements CipherServiceAbstraction {
 
   // Helpers
 
+  private async updateExistingCipherFromModel(
+    model: CipherView,
+    originalCipher: Cipher
+  ): Promise<void> {
+    const existingCipher = await originalCipher.decrypt(
+      await this.getKeyForCipherKeyDecryption(originalCipher)
+    );
+    model.passwordHistory = existingCipher.passwordHistory || [];
+    if (model.type === CipherType.Login && existingCipher.type === CipherType.Login) {
+      if (
+        existingCipher.login.password != null &&
+        existingCipher.login.password !== "" &&
+        existingCipher.login.password !== model.login.password
+      ) {
+        const ph = new PasswordHistoryView();
+        ph.password = existingCipher.login.password;
+        ph.lastUsedDate = model.login.passwordRevisionDate = new Date();
+        model.passwordHistory.splice(0, 0, ph);
+      } else {
+        model.login.passwordRevisionDate = existingCipher.login.passwordRevisionDate;
+      }
+    }
+    if (existingCipher.hasFields) {
+      const existingHiddenFields = existingCipher.fields.filter(
+        (f) =>
+          f.type === FieldType.Hidden &&
+          f.name != null &&
+          f.name !== "" &&
+          f.value != null &&
+          f.value !== ""
+      );
+      const hiddenFields =
+        model.fields == null
+          ? []
+          : model.fields.filter(
+              (f) => f.type === FieldType.Hidden && f.name != null && f.name !== ""
+            );
+      existingHiddenFields.forEach((ef) => {
+        const matchedField = hiddenFields.find((f) => f.name === ef.name);
+        if (matchedField == null || matchedField.value !== ef.value) {
+          const ph = new PasswordHistoryView();
+          ph.password = ef.name + ": " + ef.value;
+          ph.lastUsedDate = new Date();
+          model.passwordHistory.splice(0, 0, ph);
+        }
+      });
+    }
+  }
+
+  private adjustPasswordHistoryLength(model: CipherView) {
+    if (model.passwordHistory != null && model.passwordHistory.length === 0) {
+      model.passwordHistory = null;
+    } else if (model.passwordHistory != null && model.passwordHistory.length > 5) {
+      // only save last 5 history
+      model.passwordHistory = model.passwordHistory.slice(0, 5);
+    }
+  }
+
   private async shareAttachmentWithServer(
     attachmentView: AttachmentView,
     cipherId: string,
@@ -1225,27 +1239,6 @@ export class CipherService implements CipherServiceAbstraction {
 
   private clearSortedCiphers() {
     this.sortedCiphersCache.clear();
-  }
-
-  /**
-   * Get the encryption key for a cipher. If `cipher` does not have a `key`, a new key will be generated.
-   * @param cipher The cipher whose encryption key is to be determined
-   * @param keyForCipherKeyDecryption The encryption key to be used to decrypt the cipher key
-   * @returns The encryption key for the cipher
-   */
-  private async getDecryptedCipherKey(
-    cipher: Cipher,
-    keyForCipherKeyDecryption: SymmetricCryptoKey
-  ): Promise<SymmetricCryptoKey> {
-    let enckey: SymmetricCryptoKey;
-    if (cipher.key == null) {
-      enckey = await this.cryptoService.makeCipherKey();
-    } else {
-      enckey = new SymmetricCryptoKey(
-        await this.encryptService.decryptToBytes(cipher.key, keyForCipherKeyDecryption)
-      );
-    }
-    return enckey;
   }
 
   private async encryptCipher(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We removed the `key` property from the `CipherView` in https://github.com/bitwarden/clients/pull/6241/commits/242570cf3bd55052cf250f5ec3850137ac927e37.  Doing this broke key rotation, as the assumption was that the encryption key for the cipher key would always be the user's encryption key.  This isn't valid on key rotation, when it's the new encryption key that should be used.

Note: I've created https://bitwarden.atlassian.net/browse/PM-3899 to capture the work to make it such that we don't need to re-encrypt the entire cipher on key rotation any more, once we have removed the cipher key encryption feature flag and are confident that all clients are using the new method.

## Code changes

- **cipher.service.ts:**
  - Moved the cipher model update and password history update to their own methods to reduce complexity in `encrypt()` (no changes to the code here).
  - Updated `encryptCipherWithCipherKey()` method to separate out the logic for determining the key for _cipher_ encryption from the logic for determining _cipher key_ encryption.
    - 🤔 The current implementation re-encrypts the cipher `key` on every call instead of only when the key has changed.  Is it worth adding that check based on encryption performance?
  - Added an explicit set of the `cipher.key` to `null` if we are not using cipher key encryption, to address the concern noted by @eliykat [here](https://github.com/bitwarden/clients/pull/6241#discussion_r1321043475).
 - **cipher.service.spec.ts:** Test adjustments for new method names

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
