### PR TITLE
Updated checkServerMeetsVersionRequirement to use observable

### DIFF
--- a/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.abstraction.ts
@@ -17,7 +17,9 @@ export abstract class ConfigServiceAbstraction {
     key: FeatureFlag,
     defaultValue?: T
   ) => Promise<T>;
-  checkServerMeetsVersionRequirement: (minimumRequiredServerVersion: SemVer) => Promise<boolean>;
+  checkServerMeetsVersionRequirement$: (
+    minimumRequiredServerVersion: SemVer
+  ) => Observable<boolean>;
 
   /**
    * Force ConfigService to fetch an updated config from the server and emit it from serverConfig$

--- a/libs/common/src/platform/services/config/config.service.ts
+++ b/libs/common/src/platform/services/config/config.service.ts
@@ -110,17 +110,15 @@ export class ConfigService implements ConfigServiceAbstraction {
    * @param minimumRequiredServerVersion The minimum version required
    * @returns True if the server version is greater than or equal to the minimum required version
    */
-  async checkServerMeetsVersionRequirement(minimumRequiredServerVersion: SemVer): Promise<boolean> {
-    return firstValueFrom(
-      this.serverConfig$.pipe(
-        map((serverConfig) => {
-          if (serverConfig == null) {
-            return false;
-          }
-          const serverVersion = new SemVer(serverConfig.version);
-          return serverVersion.compare(minimumRequiredServerVersion) >= 0;
-        })
-      )
+  checkServerMeetsVersionRequirement$(minimumRequiredServerVersion: SemVer) {
+    return this.serverConfig$.pipe(
+      map((serverConfig) => {
+        if (serverConfig == null) {
+          return false;
+        }
+        const serverVersion = new SemVer(serverConfig.version);
+        return serverVersion.compare(minimumRequiredServerVersion) >= 0;
+      })
     );
   }
 }

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -1,4 +1,5 @@
 import { mock, mockReset } from "jest-mock-extended";
+import { of } from "rxjs";
 
 import { makeStaticByteArray } from "../../../spec/utils";
 import { ApiService } from "../../abstractions/api.service";
@@ -147,7 +148,7 @@ describe("Cipher Service", () => {
         Promise.resolve<any>(new SymmetricCryptoKey(new Uint8Array(32)))
       );
 
-      configService.checkServerMeetsVersionRequirement.mockReturnValue(Promise.resolve(false));
+      configService.checkServerMeetsVersionRequirement$.mockReturnValue(of(false));
       process.env.FLAGS = JSON.stringify({
         enableCipherKeyEncryption: false,
       });
@@ -252,7 +253,7 @@ describe("Cipher Service", () => {
       cipherView.type = CipherType.Login;
 
       encryptService.decryptToBytes.mockReturnValue(Promise.resolve(makeStaticByteArray(64)));
-      configService.checkServerMeetsVersionRequirement.mockReturnValue(Promise.resolve(true));
+      configService.checkServerMeetsVersionRequirement$.mockReturnValue(of(true));
       cryptoService.makeCipherKey.mockReturnValue(
         Promise.resolve(new SymmetricCryptoKey(makeStaticByteArray(64)) as CipherKey)
       );

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1,3 +1,4 @@
+import { firstValueFrom } from "rxjs";
 import { SemVer } from "semver";
 
 import { ApiService } from "../../abstractions/api.service";
@@ -1260,8 +1261,10 @@ export class CipherService implements CipherServiceAbstraction {
   async getCipherKeyEncryptionEnabled(): Promise<boolean> {
     return (
       flagEnabled("enableCipherKeyEncryption") &&
-      (await this.configService.checkServerMeetsVersionRequirement(
-        new SemVer(CIPHER_KEY_ENC_MIN_SERVER_VER)
+      (await firstValueFrom(
+        this.configService.checkServerMeetsVersionRequirement$(
+          new SemVer(CIPHER_KEY_ENC_MIN_SERVER_VER)
+        )
       ))
     );
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Refactored the new `checkServerMeetsVersionRequirement` to return an observable instead of a promise, as recommended by @eliykat here: https://github.com/bitwarden/clients/pull/6241#discussion_r1320973020.

## Code changes

- **config.service.ts:** Refactored to return an observable.
- **cipher.service.ts:** Refactored to use `firstValueFrom()`.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
