### PR TITLE
[PM-3878] Setting send password to null if it is empty

### DIFF
--- a/apps/desktop/src/app/tools/send/add-edit.component.ts
+++ b/apps/desktop/src/app/tools/send/add-edit.component.ts
@@ -50,7 +50,6 @@ export class AddEditComponent extends BaseAddEditComponent {
   }
 
   async refresh() {
-    this.password = null;
     const send = await this.loadSend();
     this.send = await send.decrypt();
     this.updateFormValues();

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -11,6 +11,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
 import { Send } from "@bitwarden/common/tools/send/models/domain/send";
@@ -251,7 +252,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
     this.send.disabled = this.formGroup.controls.disabled.value;
     this.send.type = this.type;
 
-    if (this.send.name == null || this.send.name === "") {
+    if (Utils.isNullOrWhitespace(this.send.name)) {
       this.platformUtilsService.showToast(
         "error",
         this.i18nService.t("errorOccurred"),
@@ -285,7 +286,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (this.send.password != null && this.send.password.trim() === "") {
+    if (Utils.isNullOrWhitespace(this.send.password)) {
       this.send.password = null;
     }
 

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -67,7 +67,6 @@ export class AddEditComponent implements OnInit, OnDestroy {
   disableHideEmail = false;
   send: SendView;
   hasPassword: boolean;
-  password: string;
   showPassword = false;
   formPromise: Promise<any>;
   deletePromise: Promise<any>;
@@ -286,11 +285,8 @@ export class AddEditComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (
-      this.formGroup.controls.password.value != null &&
-      this.formGroup.controls.password.value.trim() === ""
-    ) {
-      this.password = null;
+    if (this.send.password != null && this.send.password.trim() === "") {
+      this.send.password = null;
     }
 
     this.formPromise = this.encryptSend(file).then(async (encSend) => {
@@ -379,12 +375,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   protected async encryptSend(file: File): Promise<[Send, EncArrayBuffer]> {
-    const sendData = await this.sendService.encrypt(
-      this.send,
-      file,
-      this.formGroup.controls.password.value,
-      null
-    );
+    const sendData = await this.sendService.encrypt(this.send, file, this.send.password, null);
 
     // Parse dates
     try {
@@ -420,7 +411,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
       hideEmail: this.send?.hideEmail ?? false,
       disabled: this.send?.disabled ?? false,
       type: this.send.type ?? this.type,
-      password: "",
+      password: null,
 
       selectedDeletionDatePreset: this.editMode ? DatePreset.Custom : DatePreset.SevenDays,
       selectedExpirationDatePreset: this.editMode ? DatePreset.Custom : DatePreset.Never,


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The password was being set on edit, this was caused because if we send "" the password will be set to an empty string so we are sending it null to avoid it being set

## Code changes

- **send/add-edit.component.ts:** Clearing the password on the send object if it is empty and using that property in all cases


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
