### PR TITLE
[PM-3894] fix popover size when dialog is open and Chrome is zoomed

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -6,6 +6,26 @@
   margin: 0;
 }
 
+html {
+  width: 375px !important;
+  height: 600px !important;
+
+  ::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+  }
+
+  .cdk-global-scrollblock {
+    position: unset;
+  }
+
+  .cdk-global-scrollblock body {
+    position: fixed;
+    width: 100%;
+    overflow-y: scroll;
+  }
+}
+
 html,
 body {
   font-family: $font-family-sans-serif;
@@ -15,8 +35,9 @@ body {
 }
 
 body {
-  width: 375px !important;
-  height: 600px !important;
+  position: fixed;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
   color: $text-color;
   background-color: $background-color;

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -14,9 +14,6 @@ html {
 
 html,
 body {
-  width: 375px !important;
-  height: 600px !important;
-  overflow: hidden;
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   line-height: $line-height-base;
@@ -24,6 +21,9 @@ body {
 }
 
 body {
+  width: 375px !important;
+  height: 600px !important;
+  overflow: hidden;
   color: $text-color;
   background-color: $background-color;
 

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -7,27 +7,16 @@
 }
 
 html {
-  width: 375px !important;
-  height: 600px !important;
-
-  ::-webkit-scrollbar {
-    width: 0px;
-    background: transparent;
-  }
-
-  .cdk-global-scrollblock {
+  &.cdk-global-scrollblock {
     position: unset;
-  }
-
-  .cdk-global-scrollblock body {
-    position: fixed;
-    width: 100%;
-    overflow-y: scroll;
   }
 }
 
 html,
 body {
+  width: 375px !important;
+  height: 600px !important;
+  overflow: hidden;
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   line-height: $line-height-base;
@@ -35,10 +24,6 @@ body {
 }
 
 body {
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
   color: $text-color;
   background-color: $background-color;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR fixes a Chrome bug that shrinks the popover window width to 25px when both of the following are true:

- `position: fixed` is on the root element
  - (This style is applied by `.cdk-global-scrollblock` when a dialog is opened with the `DialogService`)
- Zoom is higher that 100% in the browser appearance settings


## Code changes

- `.cdk-global-scrollblock` was overridden to not apply `position: fixed` on `html`. This means that users on the Chrome extension _who have zoom set to above 100%_ will be able to scroll when dialogs are open (since there is overflow on the `html` element after zooming).

## Screenshots

Bug:

https://github.com/bitwarden/clients/assets/17113462/63e37586-34a3-4e8a-89dc-16fe4212e2a7


Fixed:



https://github.com/bitwarden/clients/assets/17113462/a9b60e33-c41e-4eef-ab82-942764cb9c80





## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
