### PR TITLE
[PM-3928] HideEmail enable validation moved to UpdateFormValues

### DIFF
--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -207,9 +207,6 @@ export class AddEditComponent implements OnInit, OnDestroy {
         this.send = await send.decrypt();
         this.type = this.send.type;
         this.updateFormValues();
-        if (this.send.hideEmail) {
-          this.formGroup.controls.hideEmail.enable();
-        }
       } else {
         this.send = new SendView();
         this.send.type = this.type;
@@ -425,6 +422,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
         "yyyy-MM-ddTHH:mm"
       ),
     });
+
+    if (this.send.hideEmail) {
+      this.formGroup.controls.hideEmail.enable();
+    }
   }
 
   private async handleCopyLinkToClipboard() {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

On desktop the HideEmail checkbox is showing as inactive on some cases when it is selected and has the do not HideEmail policy. When selected should always be clickable, this fixes it.

## Code changes

Moved the verification to validate if the HideEmail box is active to the `UpdateFormValues` method so that it is called on Send change at desktop

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
