### PR TITLE
[CL-89] fix focus-visible outline in bitLink

### DIFF
--- a/libs/components/src/link/link.directive.ts
+++ b/libs/components/src/link/link.directive.ts
@@ -58,7 +58,6 @@ const commonStyles = [
   "before:tw-rounded-md",
   "before:tw-transition",
   "focus-visible:before:tw-ring-2",
-  "focus-visible:before:tw-ring-text-contrast",
   "focus-visible:tw-z-10",
 ];
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a bug where the focus-visible outline wasn't visible on `bitLink`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/link/link.directive.ts:** Remove default ring color of `tw-ring-text-contrast`. This color is the same as the main bg color.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
