### PR TITLE
[PM-3982] Improved validation on send hide email policy subscriber

### DIFF
--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -154,8 +154,13 @@ export class AddEditComponent implements OnInit, OnDestroy {
       .policyAppliesToActiveUser$(PolicyType.SendOptions, (p) => p.data.disableHideEmail)
       .pipe(takeUntil(this.destroy$))
       .subscribe((policyAppliesToActiveUser) => {
-        if ((this.disableHideEmail = policyAppliesToActiveUser)) {
+        if (
+          (this.disableHideEmail = policyAppliesToActiveUser) &&
+          !this.formGroup.controls.hideEmail.value
+        ) {
           this.formGroup.controls.hideEmail.disable();
+        } else {
+          this.formGroup.controls.hideEmail.enable();
         }
       });
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

On desktop when syncing the vault, after a change on the Sends Option policies, it doesn't properly enables or disables the send currently open.

## Code changes
- **send/Add-Edit.component.ts:** Added check to only disable if the hideEmail is unchecked and enabling on all the other cases.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
