### PR TITLE
[PM-3867] Don't use rxjs timer in CLI ConfigService

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -32,7 +32,6 @@ import { GlobalState } from "@bitwarden/common/platform/models/domain/global-sta
 import { AppIdService } from "@bitwarden/common/platform/services/app-id.service";
 import { BroadcasterService } from "@bitwarden/common/platform/services/broadcaster.service";
 import { ConfigApiService } from "@bitwarden/common/platform/services/config/config-api.service";
-import { ConfigService } from "@bitwarden/common/platform/services/config/config.service";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { CryptoService } from "@bitwarden/common/platform/services/crypto.service";
 import { EncryptServiceImplementation } from "@bitwarden/common/platform/services/cryptography/encrypt.service.implementation";
@@ -78,6 +77,7 @@ import {
 } from "@bitwarden/importer";
 import { NodeCryptoFunctionService } from "@bitwarden/node/services/node-crypto-function.service";
 
+import { CliConfigService } from "./platform/services/cli-config.service";
 import { CliPlatformUtilsService } from "./platform/services/cli-platform-utils.service";
 import { ConsoleLogService } from "./platform/services/console-log.service";
 import { I18nService } from "./platform/services/i18n.service";
@@ -151,7 +151,7 @@ export class Main {
   deviceTrustCryptoService: DeviceTrustCryptoServiceAbstraction;
   authRequestCryptoService: AuthRequestCryptoServiceAbstraction;
   configApiService: ConfigApiServiceAbstraction;
-  configService: ConfigService;
+  configService: CliConfigService;
 
   constructor() {
     let p = null;
@@ -336,7 +336,7 @@ export class Main {
 
     this.configApiService = new ConfigApiService(this.apiService, this.authService);
 
-    this.configService = new ConfigService(
+    this.configService = new CliConfigService(
       this.stateService,
       this.configApiService,
       this.authService,

--- a/apps/cli/src/platform/services/cli-config.service.ts
+++ b/apps/cli/src/platform/services/cli-config.service.ts
@@ -1,0 +1,9 @@
+import { NEVER } from "rxjs";
+
+import { ConfigService } from "@bitwarden/common/platform/services/config/config.service";
+
+export class CliConfigService extends ConfigService {
+  // The rxjs timer uses setTimeout/setInterval under the hood, which prevents the node process from exiting
+  // when the command is finished. Cli should never be alive long enough to use the timer, so we disable it.
+  protected refreshTimer$ = NEVER;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`ConfigService` uses rxjs `timer` to fetch an updated `ServerConfig` at regular intervals.

`timer` uses setTimeout/setInterval under the hood, which prevents the node process from exiting when the command is finished. Cli should never be alive long enough to use the timer, so I've just overridden it in a subclass with `NEVER` (which is an observable that never emits or completes, basically just a stand-in).

One alternative solution is to use the `takeUntil(this.destroy$)` pattern, however we don't currently have that pattern in CLI and I didn't think it was worth introducing it here; maybe we reconsider that if we start using more timers.

This is targeting feature because we don't use configService in CLI yet in `master`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
