### PR TITLE
[PM-3970] Empty list of ciphers when logging in via fido 2 popout

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -329,11 +329,6 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
       return [];
     }
 
-    //ensure full sync has completed before getting the ciphers
-    if ((await this.syncService.getLastSync()) == null) {
-      await this.syncService.fullSync(false);
-    }
-
     const ciphers = await this.cipherService.getAllDecrypted();
     return ciphers.filter(
       (cipher) =>
@@ -346,11 +341,6 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
   }
 
   private async findCredentialsByRp(rpId: string): Promise<CipherView[]> {
-    //ensure full sync has completed before getting the ciphers
-    if ((await this.syncService.getLastSync()) == null) {
-      await this.syncService.fullSync(false);
-    }
-
     const ciphers = await this.cipherService.getAllDecrypted();
     return ciphers.filter(
       (cipher) =>

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -84,6 +84,7 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
       }
 
       await userInterfaceSession.ensureUnlockedVault();
+      await this.syncService.fullSync(false);
 
       const existingCipherIds = await this.findExcludedCredentials(
         params.excludeCredentialDescriptorList
@@ -194,6 +195,8 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
       let cipherOptions: CipherView[];
 
       await userInterfaceSession.ensureUnlockedVault();
+      await this.syncService.fullSync(false);
+
       if (params.allowCredentialDescriptorList?.length > 0) {
         cipherOptions = await this.findCredentialsById(
           params.allowCredentialDescriptorList,
@@ -294,11 +297,6 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
 
     if (ids.length === 0) {
       return [];
-    }
-
-    //ensure full sync has completed before getting the ciphers
-    if ((await this.syncService.getLastSync()) == null) {
-      await this.syncService.fullSync(false);
     }
 
     const ciphers = await this.cipherService.getAllDecrypted();


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Main reason for bug was that sync wasn't being called due to a function returning early due to an if-statement.

I've removed duplicated sync calls and moved them all to a single place inside the main functions.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
