### PR TITLE
Conditionally display new copy under subscriptions table [AC-1657]

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -81,7 +81,7 @@
                 {{ i.quantity * i.amount | currency : "$" }} /{{ i.interval | i18n }}
               </td>
             </tr>
-            <tr bitRow>
+            <tr bitRow *ngIf="discount && discount.active">
               <td bitCell colspan="2">
                 <small>
                   {{ "accurateInvoicing" | i18n }}

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -81,6 +81,17 @@
                 {{ i.quantity * i.amount | currency : "$" }} /{{ i.interval | i18n }}
               </td>
             </tr>
+            <tr bitRow>
+              <td bitCell colspan="2">
+                <small>
+                  {{ "accurateInvoicing" | i18n }}
+                  <a routerLink="/settings/subscription/billing-history">
+                    {{ "billingHistory" | i18n }}
+                  </a>
+                  {{ "page" | i18n }}
+                </small>
+              </td>
+            </tr>
           </ng-container>
           <ng-container *ngIf="userOrg.isFreeOrg">
             <tr bitRow *ngIf="userOrg.usePasswordManager">

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -84,11 +84,11 @@
             <tr bitRow *ngIf="discount && discount.active">
               <td bitCell colspan="2">
                 <small>
-                  {{ "accurateInvoicing" | i18n }}
+                  {{ "customBillingStart" | i18n }}
                   <a routerLink="/settings/subscription/billing-history">
                     {{ "billingHistory" | i18n }}
                   </a>
-                  {{ "page" | i18n }}
+                  {{ "customBillingEnd" | i18n }}
                 </small>
               </td>
             </tr>

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -140,6 +140,10 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     return this.sub != null ? this.sub.upcomingInvoice : null;
   }
 
+  get discount() {
+    return this.sub != null ? this.sub.discount : null;
+  }
+
   get isExpired() {
     const nextInvoice = this.nextInvoice;
 

--- a/apps/web/src/app/billing/settings/user-subscription.component.html
+++ b/apps/web/src/app/billing/settings/user-subscription.component.html
@@ -90,6 +90,17 @@
             </td>
             <td>{{ i.quantity * i.amount | currency : "$" }} /{{ i.interval | i18n }}</td>
           </tr>
+          <tr>
+            <td colspan="2">
+              <small>
+                {{ "accurateInvoicing" | i18n }}
+                <a routerLink="/settings/subscription/billing-history">
+                  {{ "billingHistory" | i18n }}
+                </a>
+                {{ "page" | i18n }}
+              </small>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/apps/web/src/app/billing/settings/user-subscription.component.html
+++ b/apps/web/src/app/billing/settings/user-subscription.component.html
@@ -90,7 +90,7 @@
             </td>
             <td>{{ i.quantity * i.amount | currency : "$" }} /{{ i.interval | i18n }}</td>
           </tr>
-          <tr>
+          <tr *ngIf="discount != null && discount.active">
             <td colspan="2">
               <small>
                 {{ "accurateInvoicing" | i18n }}

--- a/apps/web/src/app/billing/settings/user-subscription.component.html
+++ b/apps/web/src/app/billing/settings/user-subscription.component.html
@@ -93,11 +93,11 @@
           <tr *ngIf="discount != null && discount.active">
             <td colspan="2">
               <small>
-                {{ "accurateInvoicing" | i18n }}
+                {{ "customBillingStart" | i18n }}
                 <a routerLink="/settings/subscription/billing-history">
                   {{ "billingHistory" | i18n }}
                 </a>
-                {{ "page" | i18n }}
+                {{ "customBillingEnd" | i18n }}
               </small>
             </td>
           </tr>

--- a/apps/web/src/app/billing/settings/user-subscription.component.ts
+++ b/apps/web/src/app/billing/settings/user-subscription.component.ts
@@ -206,6 +206,10 @@ export class UserSubscriptionComponent implements OnInit {
     return this.sub != null ? this.sub.upcomingInvoice : null;
   }
 
+  get discount() {
+    return this.sub != null ? this.sub.discount : null;
+  }
+
   get storagePercentage() {
     return this.sub != null && this.sub.maxStorageGb
       ? +(100 * (this.sub.storageGb / this.sub.maxStorageGb)).toFixed(2)

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7178,10 +7178,10 @@
   "alreadyHaveAccount": {
     "message": "Already have an account?"
   },
-  "accurateInvoicing": {
-    "message": "For more accurate invoicing, visit the "
+  "customBillingStart": {
+    "message": "Custom billing is not reflected. Visit the "
   },
-  "page": {
-    "message": "page."
+  "customBillingEnd": {
+    "message": " page for latest invoicing."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7177,5 +7177,11 @@
   },
   "alreadyHaveAccount": {
     "message": "Already have an account?"
+  },
+  "accurateInvoicing": {
+    "message": "For more accurate invoicing, visit the "
+  },
+  "page": {
+    "message": "page."
   }
 }

--- a/libs/common/src/billing/models/response/organization-subscription.response.ts
+++ b/libs/common/src/billing/models/response/organization-subscription.response.ts
@@ -3,6 +3,7 @@ import { OrganizationResponse } from "../../../admin-console/models/response/org
 import {
   BillingSubscriptionResponse,
   BillingSubscriptionUpcomingInvoiceResponse,
+  BillingCustomerDiscount,
 } from "./subscription.response";
 
 export class OrganizationSubscriptionResponse extends OrganizationResponse {
@@ -10,6 +11,7 @@ export class OrganizationSubscriptionResponse extends OrganizationResponse {
   storageGb: number;
   subscription: BillingSubscriptionResponse;
   upcomingInvoice: BillingSubscriptionUpcomingInvoiceResponse;
+  discount: BillingCustomerDiscount;
   expiration: string;
   expirationWithoutGracePeriod: string;
   secretsManagerBeta: boolean;
@@ -25,6 +27,8 @@ export class OrganizationSubscriptionResponse extends OrganizationResponse {
       upcomingInvoice == null
         ? null
         : new BillingSubscriptionUpcomingInvoiceResponse(upcomingInvoice);
+    const discount = this.getResponseProperty("Discount");
+    this.discount = discount == null ? null : new BillingCustomerDiscount(discount);
     this.expiration = this.getResponseProperty("Expiration");
     this.expirationWithoutGracePeriod = this.getResponseProperty("ExpirationWithoutGracePeriod");
     this.secretsManagerBeta = this.getResponseProperty("SecretsManagerBeta");

--- a/libs/common/src/billing/models/response/subscription.response.ts
+++ b/libs/common/src/billing/models/response/subscription.response.ts
@@ -7,6 +7,7 @@ export class SubscriptionResponse extends BaseResponse {
   maxStorageGb: number;
   subscription: BillingSubscriptionResponse;
   upcomingInvoice: BillingSubscriptionUpcomingInvoiceResponse;
+  discount: BillingCustomerDiscount;
   license: any;
   expiration: string;
   usingInAppPurchase: boolean;
@@ -21,11 +22,13 @@ export class SubscriptionResponse extends BaseResponse {
     this.usingInAppPurchase = this.getResponseProperty("UsingInAppPurchase");
     const subscription = this.getResponseProperty("Subscription");
     const upcomingInvoice = this.getResponseProperty("UpcomingInvoice");
+    const discount = this.getResponseProperty("Discount");
     this.subscription = subscription == null ? null : new BillingSubscriptionResponse(subscription);
     this.upcomingInvoice =
       upcomingInvoice == null
         ? null
         : new BillingSubscriptionUpcomingInvoiceResponse(upcomingInvoice);
+    this.discount = discount == null ? null : new BillingCustomerDiscount(discount);
   }
 }
 
@@ -86,5 +89,16 @@ export class BillingSubscriptionUpcomingInvoiceResponse extends BaseResponse {
     super(response);
     this.date = this.getResponseProperty("Date");
     this.amount = this.getResponseProperty("Amount");
+  }
+}
+
+export class BillingCustomerDiscount extends BaseResponse {
+  id: string;
+  active: boolean;
+
+  constructor(response: any) {
+    super(response);
+    this.id = this.getResponseProperty("Id");
+    this.active = this.getResponseProperty("Active");
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[JIRA Ticket](https://bitwarden.atlassian.net/browse/AC-1657)
The purpose of this PR is to consume newly added discount information from the Subscription API endpoints and use the existence of discounts to conditionally display new copy under the Subscriptions tables.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **messages.json:** Add new translation entries used to build up the copy being added under the Subscriptions tables.

- **subscription.response.ts:** Add a new `BillingCustomerDiscount` class. Add it as a field to the `SubscriptionResponse`. Populate the discount using the `Discount` response property.

- **organization-subscription.response.ts:** Add the `BillingCustomerDiscount` as a field to the `OrganizationSubscriptionResponse` class. Populate the discount using the `Discount` response property.

- **user-subscription.component.ts:** Add a `discount` getter to retrieve the applied discount.

- **user-subscription.component.html:** Use the `discount` getter to check for the existence of a discount. If one exists, add another table row to the subscriptions table with the new copy.

- **organization-subscription-cloud.component.ts:** Add a `discount` getter to retrieve the applied discount.

- **organization-subscription-cloud.component.html:** Use the `discount` getter to check for the existence of a discount. If one exists, add another table row to the subscriptions table with the new copy.

Discounts being used are added to the API response as part of this PR: https://github.com/bitwarden/server/pull/3278

## Screenshots

Premium User:
![image](https://github.com/bitwarden/clients/assets/144709477/234b4c3a-f92a-42d1-9e39-434569bd2670)

Organization User:
![image](https://github.com/bitwarden/clients/assets/144709477/1a21813c-54d6-4c70-98ce-ae76dd93ecf2)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
