### PR TITLE
[AC-1595]  Update SSO identifier copy to inform admins about Domain Verification

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3926,8 +3926,9 @@
   "ssoIdentifier": {
     "message": "SSO identifier"
   },
-  "ssoIdentifierHint": {
-    "message": "Provide this ID to your members to login with SSO."
+  "ssoIdentifierHintDesc": {
+    "message": "Provide this ID to your members to login with SSO. To bypass this step, set up <0>Domain verification</0>",
+    "description": "The contents of <0></0> will be used to create a link to the 'Domain verification' page."
   },
   "unlinkSso": {
     "message": "Unlink SSO"

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso.component.html
@@ -30,7 +30,9 @@
     <bit-form-field>
       <bit-label>{{ "ssoIdentifier" | i18n }}</bit-label>
       <input bitInput type="text" formControlName="ssoIdentifier" />
-      <bit-hint>{{ "ssoIdentifierHint" | i18n }}</bit-hint>
+      <bit-hint bit-i18n key="ssoIdentifierHintDesc">
+        <a *bit-i18n-tag="let text" routerLink="../domain-verification">{{ text }}</a>
+      </bit-hint>
     </bit-form-field>
 
     <hr />


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Currently, admins can bypass the SSO identifier step to reduce the number of login steps for their organization members by claiming a domain. This update modifies the SSO identifier's helper text to include a link to the domain verification settings page to make the feature more discoverable.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **sso.component.html:** Use the new key and `bit-i18n` component
- **messages.json:** Update the message key to include`<0></0>` template tags to allow translators to specify the link location in the translated string. 
  - See https://github.com/bitwarden/clients/pull/6302 for more details.

## Screenshots

![image](https://github.com/bitwarden/clients/assets/8764515/3dfb9a4f-d42e-4162-a7cd-715e9f6962a3)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
