### PR TITLE
[CL-130] fix select styles on desktop & browser

### DIFF
--- a/apps/browser/src/popup/scss/popup.scss
+++ b/apps/browser/src/popup/scss/popup.scss
@@ -12,3 +12,4 @@
 @import "environment.scss";
 @import "pages.scss";
 @import "@angular/cdk/overlay-prebuilt.css";
+@import "../../../../../libs/components/src/multi-select/scss/bw.theme";

--- a/apps/desktop/src/scss/styles.scss
+++ b/apps/desktop/src/scss/styles.scss
@@ -17,3 +17,4 @@
 @import "left-nav.scss";
 @import "loading.scss";
 @import "../../../../libs/angular/src/scss/icons.scss";
+@import "../../../../libs/components/src/multi-select/scss/bw.theme";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Desktop and browser don't render `bit-select` or `bit-multi-select` properly. This is caused by the `ng-select` styles not being imported on those clients.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots



https://github.com/bitwarden/clients/assets/17113462/abb4da4b-65fd-4395-b4e5-0d20c3e4c907


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
