### PR TITLE
[AC-1649] Remove organizationId from collection-bulk-delete.request

### DIFF
--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -3,7 +3,6 @@ import { Component, Inject } from "@angular/core";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { CollectionBulkDeleteRequest } from "@bitwarden/common/models/request/collection-bulk-delete.request";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -127,8 +126,7 @@ export class BulkDeleteDialogComponent {
       );
       return;
     }
-    const deleteRequest = new CollectionBulkDeleteRequest(this.collectionIds);
-    return await this.apiService.deleteManyCollections(this.organization.id, deleteRequest);
+    return await this.apiService.deleteManyCollections(this.organization.id, this.collectionIds);
   }
 
   private close(result: BulkDeleteDialogResult) {

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -127,8 +127,8 @@ export class BulkDeleteDialogComponent {
       );
       return;
     }
-    const deleteRequest = new CollectionBulkDeleteRequest(this.collectionIds, this.organization.id);
-    return await this.apiService.deleteManyCollections(deleteRequest);
+    const deleteRequest = new CollectionBulkDeleteRequest(this.collectionIds);
+    return await this.apiService.deleteManyCollections(this.organization.id, deleteRequest);
   }
 
   private close(result: BulkDeleteDialogResult) {

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -301,7 +301,10 @@ export abstract class ApiService {
     request: CollectionRequest
   ) => Promise<CollectionResponse>;
   deleteCollection: (organizationId: string, id: string) => Promise<any>;
-  deleteManyCollections: (request: CollectionBulkDeleteRequest) => Promise<any>;
+  deleteManyCollections: (
+    organizationId: string,
+    request: CollectionBulkDeleteRequest
+  ) => Promise<any>;
   deleteCollectionUser: (
     organizationId: string,
     id: string,

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -99,7 +99,6 @@ import { PlanResponse } from "../billing/models/response/plan.response";
 import { SubscriptionResponse } from "../billing/models/response/subscription.response";
 import { TaxInfoResponse } from "../billing/models/response/tax-info.response";
 import { TaxRateResponse } from "../billing/models/response/tax-rate.response";
-import { CollectionBulkDeleteRequest } from "../models/request/collection-bulk-delete.request";
 import { DeleteRecoverRequest } from "../models/request/delete-recover.request";
 import { EventRequest } from "../models/request/event.request";
 import { IapCheckRequest } from "../models/request/iap-check.request";
@@ -301,10 +300,7 @@ export abstract class ApiService {
     request: CollectionRequest
   ) => Promise<CollectionResponse>;
   deleteCollection: (organizationId: string, id: string) => Promise<any>;
-  deleteManyCollections: (
-    organizationId: string,
-    request: CollectionBulkDeleteRequest
-  ) => Promise<any>;
+  deleteManyCollections: (organizationId: string, collectionIds: string[]) => Promise<any>;
   deleteCollectionUser: (
     organizationId: string,
     id: string,

--- a/libs/common/src/models/request/collection-bulk-delete.request.ts
+++ b/libs/common/src/models/request/collection-bulk-delete.request.ts
@@ -1,9 +1,7 @@
 export class CollectionBulkDeleteRequest {
   ids: string[];
-  organizationId: string;
 
-  constructor(ids: string[], organizationId?: string) {
+  constructor(ids: string[]) {
     this.ids = ids == null ? [] : ids;
-    this.organizationId = organizationId;
   }
 }

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -834,10 +834,13 @@ export class ApiService implements ApiServiceAbstraction {
     );
   }
 
-  deleteManyCollections(request: CollectionBulkDeleteRequest): Promise<any> {
+  deleteManyCollections(
+    organizationId: string,
+    request: CollectionBulkDeleteRequest
+  ): Promise<any> {
     return this.send(
       "DELETE",
-      "/organizations/" + request.organizationId + "/collections",
+      "/organizations/" + organizationId + "/collections",
       request,
       true,
       false

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -834,14 +834,11 @@ export class ApiService implements ApiServiceAbstraction {
     );
   }
 
-  deleteManyCollections(
-    organizationId: string,
-    request: CollectionBulkDeleteRequest
-  ): Promise<any> {
+  deleteManyCollections(organizationId: string, collectionIds: string[]): Promise<any> {
     return this.send(
       "DELETE",
       "/organizations/" + organizationId + "/collections",
-      request,
+      new CollectionBulkDeleteRequest(collectionIds),
       true,
       false
     );


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Tech Debt - cleaning up out of scope changes from a previous PR.  Removing the `organizationId` property from the `collection-bulk-delete.request` model as it is no longer necessary for the API controller operations.

## Code changes
- **.../bulk-delete-dialog/bulk-delete-dialog.component.ts**: Updated call to api to match new method signature
- **libs/common/src/abstractions/api.service.ts**: updated interface with new method signature
- **libs/common/src/models/request/collection-bulk-delete.request.ts**: updated request model by removing `organizationId` 
- **libs/common/src/services/api.service.ts**: updated service call with updated method signature and changed organization id source to passed in parameter.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
