### PR TITLE
[PM-4011] Remove Autofill Injection in All Frames

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -75,7 +75,7 @@ describe("AutofillService", () => {
     const autofillV1Script = "autofill.js";
     const autofillV2Script = "autofill-init.js";
     const defaultAutofillScripts = ["autofiller.js", "notificationBar.js", "contextMenuHandler.js"];
-    const defaultExecuteScriptOptions = { allFrames: true, runAt: "document_start" };
+    const defaultExecuteScriptOptions = { runAt: "document_start" };
     let tabMock: chrome.tabs.Tab;
     let sender: chrome.runtime.MessageSender;
 
@@ -91,11 +91,13 @@ describe("AutofillService", () => {
       [autofillV1Script, ...defaultAutofillScripts].forEach((scriptName) => {
         expect(BrowserApi.executeScriptInTab).toHaveBeenCalledWith(tabMock.id, {
           file: `content/${scriptName}`,
+          frameId: sender.frameId,
           ...defaultExecuteScriptOptions,
         });
       });
       expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalledWith(tabMock.id, {
         file: `content/${autofillV2Script}`,
+        frameId: sender.frameId,
         ...defaultExecuteScriptOptions,
       });
     });

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -62,7 +62,7 @@ export default class AutofillService implements AutofillServiceInterface {
     for (const injectedScript of injectedScripts) {
       await BrowserApi.executeScriptInTab(sender.tab.id, {
         file: `content/${injectedScript}`,
-        allFrames: true,
+        frameId: sender.frameId,
         runAt: "document_start",
       });
     }


### PR DESCRIPTION
## Type of change


```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove injection of autofill scripts from `allFrames` into the specific `frameId` that is associated with the sender tab.

Validated that this resolved issues present within https://www.seznam.cz/ when scrolling ajax content.

Resolves https://github.com/bitwarden/clients/pull/6348

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/autofill/services/autofill.service.ts:** Adjusting script injection to take into account the specific frameId for a given tab sender. Remove `allFrames` declaration that facilitated injection in all frame contexts.