### PR TITLE
[PM-4014] Bugfix - Do not prevent deferred autofill if tab location is an equivalent domain

### DIFF
--- a/apps/browser/src/autofill/content/autofill.js
+++ b/apps/browser/src/autofill/content/autofill.js
@@ -993,15 +993,8 @@
       function fillTheElement(el, op) {
           var shouldCheck;
           if (el && null !== op && void 0 !== op && !(el.disabled || el.a || el.readOnly)) {
-              let tabURLChanged = !fillScript.savedUrls?.some(url => url.startsWith(window.location.origin));
-
-              // If the page origin doesn't match a savedURL, check the page location against equivalent domains
-              if (tabURLChanged) {
-                tabURLChanged = !fillScript.equivalentDomains.some(url => window.location.host.endsWith(url));
-              }
-
               // Check to make sure the page location didn't change
-              if (tabURLChanged) {
+              if (!fillScript.pageIsQualifiedURL(window.location.href)) {
                 return;
               }
 

--- a/apps/browser/src/autofill/content/autofill.js
+++ b/apps/browser/src/autofill/content/autofill.js
@@ -993,11 +993,18 @@
       function fillTheElement(el, op) {
           var shouldCheck;
           if (el && null !== op && void 0 !== op && !(el.disabled || el.a || el.readOnly)) {
-              const tabURLChanged = !fillScript.savedUrls?.some(url => url.startsWith(window.location.origin))
+              let tabURLChanged = !fillScript.savedUrls?.some(url => url.startsWith(window.location.origin));
+
+              // If the page origin doesn't match a savedURL, check the page location against equivalent domains
+              if (tabURLChanged) {
+                tabURLChanged = !fillScript.equivalentDomains.some(url => window.location.host.endsWith(url));
+              }
+
               // Check to make sure the page location didn't change
               if (tabURLChanged) {
                 return;
               }
+
               switch (markTheFilling && el.form && !el.form.opfilled && (el.form.opfilled = true),
               el.type ? el.type.toLowerCase() : null) {
                   case 'checkbox':

--- a/apps/browser/src/autofill/jest/autofill-mocks.ts
+++ b/apps/browser/src/autofill/jest/autofill-mocks.ts
@@ -115,6 +115,7 @@ function createAutofillScriptMock(
       delay_between_operations: 20,
     },
     savedUrls: [],
+    equivalentDomains: [],
     script,
     itemType: "",
     untrustedIframe: false,

--- a/apps/browser/src/autofill/jest/autofill-mocks.ts
+++ b/apps/browser/src/autofill/jest/autofill-mocks.ts
@@ -115,10 +115,10 @@ function createAutofillScriptMock(
       delay_between_operations: 20,
     },
     savedUrls: [],
-    equivalentDomains: [],
     script,
     itemType: "",
     untrustedIframe: false,
+    pageIsQualifiedURL: (url: string) => true,
     ...customFields,
   };
 }

--- a/apps/browser/src/autofill/models/autofill-script.ts
+++ b/apps/browser/src/autofill/models/autofill-script.ts
@@ -21,4 +21,5 @@ export default class AutofillScript {
   savedUrls: string[];
   untrustedIframe: boolean;
   itemType: string; // Appears to be unused, read but not written
+  equivalentDomains: string[];
 }

--- a/apps/browser/src/autofill/models/autofill-script.ts
+++ b/apps/browser/src/autofill/models/autofill-script.ts
@@ -21,5 +21,5 @@ export default class AutofillScript {
   savedUrls: string[];
   untrustedIframe: boolean;
   itemType: string; // Appears to be unused, read but not written
-  equivalentDomains: string[];
+  pageIsQualifiedURL: (url: string) => boolean;
 }

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -386,7 +386,6 @@ describe("AutofillService", () => {
               delay_between_operations: 20,
             },
             savedUrls: [],
-            equivalentDomains: [],
             script: [
               ["click_on_opid", "username-field"],
               ["focus_by_opid", "username-field"],
@@ -397,6 +396,7 @@ describe("AutofillService", () => {
               ["focus_by_opid", "password-field"],
             ],
             untrustedIframe: false,
+            pageIsQualifiedURL: () => true,
           },
           url: currentAutofillPageDetails.tab.url,
         },
@@ -1245,13 +1245,6 @@ describe("AutofillService", () => {
     });
 
     describe("given a list of login uri views", () => {
-      beforeEach(() => {
-        const equivalentDomains = new Set([]);
-        jest
-          .spyOn(settingsService as any, "getEquivalentDomains")
-          .mockReturnValue(equivalentDomains);
-      });
-
       it("returns an empty array of saved login uri views if the login cipher has no login uri views", async () => {
         options.cipher.login.uris = [];
 
@@ -1397,12 +1390,8 @@ describe("AutofillService", () => {
           usernameField.readonly = true;
           totpField.viewable = false;
           totpField.readonly = true;
-          const equivalentDomains = new Set(["example.com"]);
           jest.spyOn(autofillService as any, "findUsernameField");
           jest.spyOn(autofillService as any, "findTotpField");
-          jest
-            .spyOn(settingsService as any, "getEquivalentDomains")
-            .mockReturnValue(equivalentDomains);
         });
 
         it("will attempt to find a username field from hidden fields if no visible username fields are found", async () => {
@@ -1893,7 +1882,6 @@ describe("AutofillService", () => {
         );
         expect(value).toStrictEqual({
           autosubmit: null,
-          equivalentDomains: ["example.com"],
           metadata: {},
           properties: { delay_between_operations: 20 },
           savedUrls: ["https://www.example.com"],
@@ -1982,10 +1970,10 @@ describe("AutofillService", () => {
         metadata: {},
         properties: { delay_between_operations: 20 },
         savedUrls: [],
-        equivalentDomains: [],
         script: [],
         itemType: "",
         untrustedIframe: false,
+        pageIsQualifiedURL: () => true,
       };
 
       it("returns an unmodified fill script when the field is a `span` field", () => {
@@ -2174,7 +2162,6 @@ describe("AutofillService", () => {
         expect(autofillService["makeScriptActionWithValue"]).toHaveBeenCalledTimes(4);
         expect(value).toStrictEqual({
           autosubmit: null,
-          equivalentDomains: [],
           itemType: "",
           metadata: {},
           properties: {

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -386,6 +386,7 @@ describe("AutofillService", () => {
               delay_between_operations: 20,
             },
             savedUrls: [],
+            equivalentDomains: [],
             script: [
               ["click_on_opid", "username-field"],
               ["focus_by_opid", "username-field"],
@@ -1244,6 +1245,13 @@ describe("AutofillService", () => {
     });
 
     describe("given a list of login uri views", () => {
+      beforeEach(() => {
+        const equivalentDomains = new Set([]);
+        jest
+          .spyOn(settingsService as any, "getEquivalentDomains")
+          .mockReturnValue(equivalentDomains);
+      });
+
       it("returns an empty array of saved login uri views if the login cipher has no login uri views", async () => {
         options.cipher.login.uris = [];
 
@@ -1389,8 +1397,12 @@ describe("AutofillService", () => {
           usernameField.readonly = true;
           totpField.viewable = false;
           totpField.readonly = true;
+          const equivalentDomains = new Set(["example.com"]);
           jest.spyOn(autofillService as any, "findUsernameField");
           jest.spyOn(autofillService as any, "findTotpField");
+          jest
+            .spyOn(settingsService as any, "getEquivalentDomains")
+            .mockReturnValue(equivalentDomains);
         });
 
         it("will attempt to find a username field from hidden fields if no visible username fields are found", async () => {
@@ -1881,6 +1893,7 @@ describe("AutofillService", () => {
         );
         expect(value).toStrictEqual({
           autosubmit: null,
+          equivalentDomains: ["example.com"],
           metadata: {},
           properties: { delay_between_operations: 20 },
           savedUrls: ["https://www.example.com"],
@@ -1969,6 +1982,7 @@ describe("AutofillService", () => {
         metadata: {},
         properties: { delay_between_operations: 20 },
         savedUrls: [],
+        equivalentDomains: [],
         script: [],
         itemType: "",
         untrustedIframe: false,
@@ -2160,6 +2174,7 @@ describe("AutofillService", () => {
         expect(autofillService["makeScriptActionWithValue"]).toHaveBeenCalledTimes(4);
         expect(value).toStrictEqual({
           autosubmit: null,
+          equivalentDomains: [],
           itemType: "",
           metadata: {},
           properties: {

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -450,13 +450,7 @@ export default class AutofillService implements AutofillServiceInterface {
       login?.uris?.filter((u) => u.match != UriMatchType.Never).map((u) => u.uri) ?? [];
 
     fillScript.untrustedIframe = this.inUntrustedIframe(pageDetails.url, options);
-    fillScript.equivalentDomains = fillScript.savedUrls.reduce((equivalentCipherDomains, url) => {
-      const additionalEquivalentDomains = Array.from(
-        this.settingsService.getEquivalentDomains(url)
-      );
-
-      return [...equivalentCipherDomains, ...additionalEquivalentDomains];
-    }, [] as string[]);
+    fillScript.pageIsQualifiedURL = (pageUrl: string) => this.isQualifiedURL(pageUrl, options);
 
     let passwordFields = AutofillService.loadPasswordFields(
       pageDetails,
@@ -955,13 +949,18 @@ export default class AutofillService implements AutofillServiceInterface {
     // Check the pageUrl against cipher URIs using the configured match detection.
     // Remember: if we are in this function, the tabUrl already matches a saved URI for the login.
     // We need to verify the pageUrl also matches.
+    return !this.isQualifiedURL(pageUrl, options);
+  }
+
+  isQualifiedURL(pageUrl: string, options: GenerateFillScriptOptions): boolean {
     const equivalentDomains = this.settingsService.getEquivalentDomains(pageUrl);
     const matchesUri = options.cipher.login.matchesUri(
       pageUrl,
       equivalentDomains,
       options.defaultUriMatch
     );
-    return !matchesUri;
+
+    return matchesUri;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -450,6 +450,13 @@ export default class AutofillService implements AutofillServiceInterface {
       login?.uris?.filter((u) => u.match != UriMatchType.Never).map((u) => u.uri) ?? [];
 
     fillScript.untrustedIframe = this.inUntrustedIframe(pageDetails.url, options);
+    fillScript.equivalentDomains = fillScript.savedUrls.reduce((equivalentCipherDomains, url) => {
+      const additionalEquivalentDomains = Array.from(
+        this.settingsService.getEquivalentDomains(url)
+      );
+
+      return [...equivalentCipherDomains, ...additionalEquivalentDomains];
+    }, [] as string[]);
 
     let passwordFields = AutofillService.loadPasswordFields(
       pageDetails,

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -90,9 +90,9 @@ describe("InsertAutofillContentService", () => {
       metadata: {},
       autosubmit: null,
       savedUrls: ["https://bitwarden.com"],
-      equivalentDomains: [],
       untrustedIframe: false,
       itemType: "login",
+      pageIsQualifiedURL: () => true,
     };
   });
 
@@ -109,7 +109,6 @@ describe("InsertAutofillContentService", () => {
       jest.spyOn(insertAutofillContentService as any, "fillingWithinSandboxedIframe");
       jest.spyOn(insertAutofillContentService as any, "userCancelledInsecureUrlAutofill");
       jest.spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill");
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged");
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -121,7 +120,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).not.toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).not.toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).not.toHaveBeenCalled();
     });
 
@@ -131,7 +129,6 @@ describe("InsertAutofillContentService", () => {
         .mockReturnValue(true);
       jest.spyOn(insertAutofillContentService as any, "userCancelledInsecureUrlAutofill");
       jest.spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill");
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged");
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -143,7 +140,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).not.toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).not.toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).not.toHaveBeenCalled();
     });
 
@@ -155,7 +151,6 @@ describe("InsertAutofillContentService", () => {
         .spyOn(insertAutofillContentService as any, "userCancelledInsecureUrlAutofill")
         .mockReturnValue(true);
       jest.spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill");
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged");
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -165,7 +160,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).not.toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).not.toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).not.toHaveBeenCalled();
     });
 
@@ -179,7 +173,6 @@ describe("InsertAutofillContentService", () => {
       jest
         .spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill")
         .mockReturnValue(true);
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged").mockReturnValue(false);
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -189,7 +182,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).not.toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).not.toHaveBeenCalled();
     });
 
@@ -203,7 +195,6 @@ describe("InsertAutofillContentService", () => {
       jest
         .spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill")
         .mockReturnValue(false);
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged").mockReturnValue(true);
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -213,7 +204,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).not.toHaveBeenCalled();
     });
 
@@ -227,7 +217,6 @@ describe("InsertAutofillContentService", () => {
       jest
         .spyOn(insertAutofillContentService as any, "userCancelledUntrustedIframeAutofill")
         .mockReturnValue(false);
-      jest.spyOn(insertAutofillContentService as any, "tabURLChanged").mockReturnValue(false);
       jest.spyOn(insertAutofillContentService as any, "runFillScriptAction");
 
       insertAutofillContentService.fillForm(fillScript);
@@ -237,7 +226,6 @@ describe("InsertAutofillContentService", () => {
       expect(
         insertAutofillContentService["userCancelledUntrustedIframeAutofill"]
       ).toHaveBeenCalled();
-      expect(insertAutofillContentService["tabURLChanged"]).toHaveBeenCalled();
       expect(insertAutofillContentService["runFillScriptAction"]).toHaveBeenCalledTimes(3);
       expect(insertAutofillContentService["runFillScriptAction"]).toHaveBeenNthCalledWith(
         1,

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -90,6 +90,7 @@ describe("InsertAutofillContentService", () => {
       metadata: {},
       autosubmit: null,
       savedUrls: ["https://bitwarden.com"],
+      equivalentDomains: [],
       untrustedIframe: false,
       itemType: "login",
     };

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -39,7 +39,7 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
       this.fillingWithinSandboxedIframe() ||
       this.userCancelledInsecureUrlAutofill(fillScript.savedUrls) ||
       this.userCancelledUntrustedIframeAutofill(fillScript) ||
-      this.tabURLChanged(fillScript.savedUrls)
+      this.tabURLChanged(fillScript.savedUrls, fillScript.equivalentDomains)
     ) {
       return;
     }
@@ -48,13 +48,24 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
   }
 
   /**
-   * Determines if the page URL no longer matches one of the cipher's savedURL domains
-   * @param {string[] | null} savedUrls
+   * Determines if the page URL no longer matches one of the cipher's savedUrls or equivalentDomains
+   * @param {string[]} savedUrls
+   * @param {string[]} equivalentDomains
    * @returns {boolean}
    * @private
    */
-  private tabURLChanged(savedUrls?: AutofillScript["savedUrls"]): boolean {
-    return savedUrls && !savedUrls.some((url) => url.startsWith(window.location.origin));
+  private tabURLChanged(
+    savedUrls: AutofillScript["savedUrls"] = [],
+    equivalentDomains: AutofillScript["equivalentDomains"] = []
+  ): boolean {
+    let tabURLChanged = !savedUrls.some((url) => url.startsWith(window.location.origin));
+
+    // If the page origin doesn't match a savedURL, check the page location against equivalent domains
+    if (tabURLChanged) {
+      tabURLChanged = !equivalentDomains.some((url) => window.location.host.endsWith(url));
+    }
+
+    return tabURLChanged;
   }
 
   /**

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -39,33 +39,13 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
       this.fillingWithinSandboxedIframe() ||
       this.userCancelledInsecureUrlAutofill(fillScript.savedUrls) ||
       this.userCancelledUntrustedIframeAutofill(fillScript) ||
-      this.tabURLChanged(fillScript.savedUrls, fillScript.equivalentDomains)
+      // Does the page URL still match (didn't change) one of the cipher's qualified URLs?
+      !fillScript.pageIsQualifiedURL(window.location.href)
     ) {
       return;
     }
 
     fillScript.script.forEach(this.runFillScriptAction);
-  }
-
-  /**
-   * Determines if the page URL no longer matches one of the cipher's savedUrls or equivalentDomains
-   * @param {string[]} savedUrls
-   * @param {string[]} equivalentDomains
-   * @returns {boolean}
-   * @private
-   */
-  private tabURLChanged(
-    savedUrls: AutofillScript["savedUrls"] = [],
-    equivalentDomains: AutofillScript["equivalentDomains"] = []
-  ): boolean {
-    let tabURLChanged = !savedUrls.some((url) => url.startsWith(window.location.origin));
-
-    // If the page origin doesn't match a savedURL, check the page location against equivalent domains
-    if (tabURLChanged) {
-      tabURLChanged = !equivalentDomains.some((url) => window.location.host.endsWith(url));
-    }
-
-    return tabURLChanged;
   }
 
   /**


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When trying to autofill using keyboard shortcut or clicking in the extension, it will not auto-fill on [equivalent domains](https://bitwarden.com/help/uri-match-detection/#equivalent-domains) (e.g. `https://accounts.google.com` when the cipher is set up for `https://youtube.com`. This behaviour was introduced in https://github.com/bitwarden/clients/pull/6280. 

## Code changes

This PR updates the relevant changes to include equivalent domains in the tab location change check.
