### PR TITLE
[PM-3978] Refactor CipherService to always generate a new cipher key on encryption

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -283,6 +283,10 @@ describe("Cipher Service", () => {
     });
 
     describe("encryptWithCipherKey", () => {
+      beforeEach(() => {
+        jest.spyOn<any, string>(cipherService, "encryptCipherWithCipherKey");
+      });
+
       it("is not called when enableCipherKeyEncryption is false", async () => {
         process.env.FLAGS = JSON.stringify({
           enableCipherKeyEncryption: false,

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -283,10 +283,6 @@ describe("Cipher Service", () => {
     });
 
     describe("encryptWithCipherKey", () => {
-      beforeEach(() => {
-        jest.spyOn<any, string>(cipherService, "encryptCipherWithCipherKey");
-      });
-
       it("is not called when enableCipherKeyEncryption is false", async () => {
         process.env.FLAGS = JSON.stringify({
           enableCipherKeyEncryption: false,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `encrypt()` on `CipherService` was previously not handling moving a cipher to an organization, because:

- In the `shareWithServer()` method, we assign an `organizationId` to the cipher. 
- In the `encrypt()` method, we used `getKeyForCipherKeyDecryption()` to determine the key to use to decrypt the cipher key.  However, at that point the `organizationId` was filled in on the cipher, so the `orgKey` was returned.  This key was used to try to decrypt the cipher key.
- This decryption failed, because the cipher key was encrypted with the user's key (before it was shared with an org).

Rather than trying to infer whether it was valid to use the same key for decryption of the key as encryption, I opted to just re-generate the cipher key on every encryption event, and then encrypt the cipher with this key.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
