### PR TITLE
[PM-4036] Fixed iso string issue where the date wasn't converted back to Date

### DIFF
--- a/libs/common/src/vault/models/view/fido2-key.view.ts
+++ b/libs/common/src/vault/models/view/fido2-key.view.ts
@@ -29,6 +29,9 @@ export class Fido2KeyView extends ItemView {
   }
 
   static fromJSON(obj: Partial<Jsonify<Fido2KeyView>>): Fido2KeyView {
-    return Object.assign(new Fido2KeyView(), obj);
+    const creationDate = obj.creationDate != null ? new Date(obj.creationDate) : null;
+    return Object.assign(new Fido2KeyView(), obj, {
+      creationDate,
+    });
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Converting from `Date` to IsoString was throwing an error because I missed a spot where conversion to Date should happened.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
