### PR TITLE
[AC-1659] Add canCreateNewCollections to Organization objects

### DIFF
--- a/libs/common/src/admin-console/models/data/organization.data.ts
+++ b/libs/common/src/admin-console/models/data/organization.data.ts
@@ -50,6 +50,7 @@ export class OrganizationData {
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
   limitCollectionCdOwnerAdmin: boolean;
+  canCreateNewCollections: boolean;
 
   constructor(
     response: ProfileOrganizationResponse,
@@ -102,6 +103,7 @@ export class OrganizationData {
     this.familySponsorshipToDelete = response.familySponsorshipToDelete;
     this.accessSecretsManager = response.accessSecretsManager;
     this.limitCollectionCdOwnerAdmin = response.limitCollectionCdOwnerAdmin;
+    this.canCreateNewCollections = response.canCreateNewCollections;
 
     this.isMember = options.isMember;
     this.isProviderUser = options.isProviderUser;

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -68,6 +68,7 @@ export class Organization {
    * Refers to the ability for an organization to limit collection creation and deletion to owners and admins only
    */
   limitCollectionCdOwnerAdmin: boolean;
+  canCreateNewCollections: boolean;
 
   constructor(obj?: OrganizationData) {
     if (obj == null) {
@@ -120,6 +121,7 @@ export class Organization {
     this.familySponsorshipToDelete = obj.familySponsorshipToDelete;
     this.accessSecretsManager = obj.accessSecretsManager;
     this.limitCollectionCdOwnerAdmin = obj.limitCollectionCdOwnerAdmin;
+    this.canCreateNewCollections = obj.canCreateNewCollections;
   }
 
   get canAccess() {
@@ -160,10 +162,6 @@ export class Organization {
 
   get canAccessReports() {
     return this.isAdmin || this.permissions.accessReports;
-  }
-
-  get canCreateNewCollections() {
-    return this.isManager || this.permissions.createNewCollections;
   }
 
   get canEditAnyCollection() {

--- a/libs/common/src/admin-console/models/response/profile-organization.response.ts
+++ b/libs/common/src/admin-console/models/response/profile-organization.response.ts
@@ -49,6 +49,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
   familySponsorshipToDelete?: boolean;
   accessSecretsManager: boolean;
   limitCollectionCdOwnerAdmin: boolean;
+  canCreateNewCollections: boolean;
 
   constructor(response: any) {
     super(response);
@@ -107,5 +108,6 @@ export class ProfileOrganizationResponse extends BaseResponse {
     this.familySponsorshipToDelete = this.getResponseProperty("FamilySponsorshipToDelete");
     this.accessSecretsManager = this.getResponseProperty("AccessSecretsManager");
     this.limitCollectionCdOwnerAdmin = this.getResponseProperty("LimitCollectionCdOwnerAdmin");
+    this.canCreateNewCollections = this.getResponseProperty("CanCreateNewCollections");
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Use the server sync response as the source of truth for determining whether the user can create new collections within the given organization context.

## Code changes
- **libs/common/src/admin-console/models/domain/organization.ts**: Added `canCreateNewCollections` property and removed previous getter.
- **libs/common/src/admin-console/models/response/profile-organization.response.ts**: Added `canCreateNewCollections` property and retrieved from the API response
- **libs/common/src/admin-console/models/data/organization.data.ts**: Added `canCreateNewCollections` property

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
