### PR TITLE
[PM-3978] Handle sharing with org with cipher key encryption

### DIFF
--- a/apps/web/src/app/vault/org-vault/add-edit.component.ts
+++ b/apps/web/src/app/vault/org-vault/add-edit.component.ts
@@ -110,7 +110,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     if (!this.organization.canEditAnyCollection) {
       return super.encryptCipher();
     }
-    return this.cipherService.encrypt(this.cipher, null, this.originalCipher);
+    return this.cipherService.encrypt(this.cipher, null, null, this.originalCipher);
   }
 
   protected async deleteCipher() {

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -11,7 +11,8 @@ export abstract class CipherService {
   clearCache: (userId?: string) => Promise<void>;
   encrypt: (
     model: CipherView,
-    key?: SymmetricCryptoKey,
+    keyForEncryption?: SymmetricCryptoKey,
+    keyForCipherKeyDecryption?: SymmetricCryptoKey,
     originalCipher?: Cipher
   ) => Promise<Cipher>;
   encryptFields: (fieldsModel: FieldView[], key: SymmetricCryptoKey) => Promise<Field[]>;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When sharing a cipher with an org, the key we need to use to decrypt the cipher key is different than the key we need to use to re-encrypt it.  We need to decrypt the key using the individual user's key and encrypt it using the org key.

In order to make that intent explicit, I've added a new parameter to `encrypt()` to pass in the key we want to use to decrypt the cipher key.  Previously we had a `key` parameter, and it represented (and still does represent) the key used to encrypt either the cipher or the cipher key (depending on if cipher key encryption is enabled).  The new parameter represents the key used to decrypt the cipher key.  Currently, the only use case is for sharing with an org.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
