### PR TITLE
Implement fido2/webauthn support for desktop client on mac and linux

### DIFF
--- a/apps/desktop/src/auth/two-factor.component.html
+++ b/apps/desktop/src/auth/two-factor.component.html
@@ -64,9 +64,14 @@
       </div>
     </ng-container>
     <ng-container *ngIf="selectedProviderType === providerType.WebAuthn">
-      <div id="web-authn-frame">
-        <iframe id="webauthn_iframe" sandbox="allow-scripts allow-same-origin"></iframe>
-      </div>
+      <ng-container *ngIf="!needsWebauthnConnectorFallback">
+        <div id="web-authn-frame">
+          <iframe id="webauthn_iframe" sandbox="allow-scripts allow-same-origin"></iframe>
+        </div>
+      </ng-container>
+      <ng-container *ngIf="needsWebauthnConnectorFallback">
+        <p>{{ "confirmWebauthnInBrowser" | i18n }}</p>
+      </ng-container>
       <div class="box first">
         <div class="box-content">
           <div class="box-content-row box-content-row-checkbox" appBoxRow>

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -614,6 +614,9 @@
       }
     }
   },
+  "confirmWebauthnInBrowser": {
+    "message": "Confirm your Webauthn Key in your Browser"
+  },
   "rememberMe": {
     "message": "Remember me"
   },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -209,10 +209,17 @@ export class Main {
       .filter((s) => s.indexOf("bitwarden://") === 0)
       .forEach((s) => {
         const url = new URL(s);
-        const code = url.searchParams.get("code");
-        const receivedState = url.searchParams.get("state");
-        if (code != null && receivedState != null) {
-          this.messagingService.send("ssoCallback", { code: code, state: receivedState });
+        if (url.hostname === "webauthn-callback") {
+          const data = url.searchParams.get("data");
+          if (data != null) {
+            this.messagingService.send("webauthnCallback", { data: data });
+          }
+        } else {
+          const code = url.searchParams.get("code");
+          const receivedState = url.searchParams.get("state");
+          if (code != null && receivedState != null) {
+            this.messagingService.send("ssoCallback", { code: code, state: receivedState });
+          }
         }
       });
   }

--- a/apps/desktop/src/platform/services/electron-platform-utils.service.ts
+++ b/apps/desktop/src/platform/services/electron-platform-utils.service.ts
@@ -85,10 +85,8 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
     return (await this.getApplicationVersion()).split(/[+|-]/)[0].trim();
   }
 
-  // Temporarily restricted to only Windows until https://github.com/electron/electron/pull/28349
-  // has been merged and an updated electron build is available.
   supportsWebAuthn(win: Window): boolean {
-    return process.platform === "win32";
+    return true;
   }
 
   supportsDuo(): boolean {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Since electron has not supported fido2 so far, and also there appears to be no movement to support it in the forseeable future, this PR implements fido2 support using the already existing webauthn connector (used by the mobile platforms so far). It uses the same "bitwarden://" protocol handler that the mobile platforms use for webauthn, and the desktop platforms use for sso.

Tested only on Linux (Fedora 38) but since the sso connector also uses the protocol handler, I suspect this should work out of the box on Mac.

## Code changes

- electron-platform-utils.service.ts: SupportsWebauthn is always true now
- main.ts: add handler for "bitwarden://webauthn-callback
- messages.json: add instruction message for webauthn
- twofactor.component.html: "add connector fallback instead of the iframe when on linux/mac"
- twofactor.component.ts: listen for the "webauthnCallback" ipc broadcast from main.ts & launch browser with the webauthn connector & handle webauthn callback

## Screenshots
![image](https://github.com/bitwarden/clients/assets/11866552/03a9ec8a-0571-4177-9a7c-a36f338f46d5)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
