### PR TITLE
[PM-4045] Get error returned when editing an item with a passkey in the CLI

### DIFF
--- a/libs/common/src/models/export/fido2key.export.ts
+++ b/libs/common/src/models/export/fido2key.export.ts
@@ -84,7 +84,6 @@ export class Fido2KeyExport {
       this.rpName = o.rpName;
       this.userDisplayName = o.userDisplayName;
       this.discoverable = String(o.discoverable);
-      this.creationDate = o.creationDate;
     } else {
       this.credentialId = o.credentialId?.encryptedString;
       this.keyType = o.keyType?.encryptedString;
@@ -97,7 +96,7 @@ export class Fido2KeyExport {
       this.rpName = o.rpName?.encryptedString;
       this.userDisplayName = o.userDisplayName?.encryptedString;
       this.discoverable = o.discoverable?.encryptedString;
-      this.creationDate = o.creationDate;
     }
+    this.creationDate = o.creationDate;
   }
 }

--- a/libs/common/src/models/export/fido2key.export.ts
+++ b/libs/common/src/models/export/fido2key.export.ts
@@ -33,7 +33,7 @@ export class Fido2KeyExport {
     view.rpName = req.rpName;
     view.userDisplayName = req.userDisplayName;
     view.discoverable = req.discoverable === "true";
-    view.creationDate = req.creationDate;
+    view.creationDate = new Date(req.creationDate);
     return view;
   }
 

--- a/libs/common/src/models/export/fido2key.export.ts
+++ b/libs/common/src/models/export/fido2key.export.ts
@@ -65,7 +65,7 @@ export class Fido2KeyExport {
   rpName: string;
   userDisplayName: string;
   discoverable: string;
-  creationDate: Date = null;
+  creationDate: Date;
 
   constructor(o?: Fido2KeyView | Fido2KeyDomain) {
     if (o == null) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Editing a login item with passkeys returns **key.creationDate.toISOString** is not a function error in the CLI.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
