### PR TITLE
[PM-4053] Add lint to try to limit reappearance of Safari memory leaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -185,6 +185,23 @@
       "rules": {
         "no-restricted-imports": ["error", { "patterns": ["@bitwarden/vault/*", "src/**/*"] }]
       }
+    },
+    {
+      "files": ["apps/browser/src/**/*.ts", "libs/**/*.ts"],
+      "excludedFiles": "apps/browser/src/autofill/{content,notification}/**/*.ts",
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "Using addListener in the browser popup produces a memory leak in Safari, use `BrowserApi.messageListener` instead",
+            "selector": "CallExpression > [object.object.object.name='chrome'][object.object.property.name='runtime'][object.property.name='onMessage'][property.name='addListener']"
+          },
+          {
+            "message": "Using addListener in the browser popup produces a memory leak in Safari, use `BrowserApi.storageChangeListener` instead",
+            "selector": "CallExpression > [object.object.object.name='chrome'][object.object.property.name='storage'][object.property.name='onChanged'][property.name='addListener']"
+          }
+        ]
+      }
     }
   ]
 }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -208,6 +208,7 @@ export class BrowserApi {
     name: string,
     callback: (message: any, sender: chrome.runtime.MessageSender, response: any) => void
   ) {
+    // eslint-disable-next-line no-restricted-syntax
     chrome.runtime.onMessage.addListener(callback);
 
     if (BrowserApi.isSafariApi && !BrowserApi.isBackgroundPage(window)) {
@@ -219,6 +220,7 @@ export class BrowserApi {
   static storageChangeListener(
     callback: Parameters<typeof chrome.storage.onChanged.addListener>[0]
   ) {
+    // eslint-disable-next-line no-restricted-syntax
     chrome.storage.onChanged.addListener(callback);
 
     if (BrowserApi.isSafariApi && !BrowserApi.isBackgroundPage(window)) {


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Created two lints to forbid the usage of the two listeners that have caused memory leaks in Safari in the past. The leaks only seem to occur when the listeners are used in the popup window (and indirectly, in any services or classes that the popup uses). 

The new rules apply to the entirety of `browser` and `libs`, with the exception of some subfolders of `autofill` which use the forbidden functions but don't trigger the leak. If someone can think of a better file selection for all the files loaded in the popup window, let me know.


