### PR TITLE
[PM-2772] only reload process on init when using browser

### DIFF
--- a/libs/common/src/platform/services/system.service.ts
+++ b/libs/common/src/platform/services/system.service.ts
@@ -2,6 +2,7 @@ import { firstValueFrom } from "rxjs";
 
 import { AuthService } from "../../auth/abstractions/auth.service";
 import { AuthenticationStatus } from "../../auth/enums/authentication-status";
+import { ClientType } from "../../enums";
 import { MessagingService } from "../abstractions/messaging.service";
 import { PlatformUtilsService } from "../abstractions/platform-utils.service";
 import { StateService } from "../abstractions/state.service";
@@ -9,8 +10,8 @@ import { SystemService as SystemServiceAbstraction } from "../abstractions/syste
 import { Utils } from "../misc/utils";
 
 export class SystemService implements SystemServiceAbstraction {
-  private reloadInterval: any = null;
-  private clearClipboardTimeout: any = null;
+  private reloadInterval: NodeJS.Timer = null;
+  private clearClipboardTimeout: NodeJS.Timer = null;
   private clearClipboardTimeoutFunction: () => Promise<any> = null;
 
   constructor(
@@ -51,7 +52,10 @@ export class SystemService implements SystemServiceAbstraction {
   private async executeProcessReload() {
     const biometricLockedFingerprintValidated =
       await this.stateService.getBiometricFingerprintValidated();
-    if (!biometricLockedFingerprintValidated) {
+    if (
+      !biometricLockedFingerprintValidated &&
+      this.platformUtilsService.getClientType() === ClientType.Browser
+    ) {
       clearInterval(this.reloadInterval);
       this.reloadInterval = null;
       this.messagingService.send("reloadProcess");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The desktop app currently initiates a process reload when a biometrics request is cancelled. This is due to the functionality that prevents process reload from occurring while waiting for a biometrics response. When you call `startProcessReload` in the System Service, the biometric fingerprint validity is checked. If false, we immediately reload the process.

As far as I can tell, biometric fingerprint validity is only used for the browser-desktop integration. I believe the intention of the `executeProcessReload` method is activate process reload if the fingerprint verification fails, but that should only be applicable on browser.

I have done some testing to verify that using the fingerprint validity still works with this change.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
