### PR TITLE
Add "twoFa" to the TotpFieldNames array in autofill-constants.ts

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -28,6 +28,7 @@ export class AutoFillConstants {
     "2facode",
     "mfacode",
     "twofactor",
+    "twoFa"
     "twofactorcode",
   ];
 

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -28,7 +28,7 @@ export class AutoFillConstants {
     "2facode",
     "mfacode",
     "twofactor",
-    "twoFa"
+    "twoFa",
     "twofactorcode",
   ];
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Improvement of TOTP field recognition. This change adds `"twoFa"` to the `TotpFieldNames` array in apps/browser/src/autofill/services/autofill-constants.ts.

Many websites now use `"twoFa"` as an ID for their TOTP text input fields. By including it in the `TotpFieldNames` array, Bitwarden will be better equipped to identify and autofill these fields, enhancing the user experience for a wide range of websites.
