### PR TITLE
[AC-1680] Add manage property to collection view and response models

### DIFF
--- a/libs/common/src/vault/models/data/collection.data.ts
+++ b/libs/common/src/vault/models/data/collection.data.ts
@@ -6,6 +6,7 @@ export class CollectionData {
   name: string;
   externalId: string;
   readOnly: boolean;
+  manage: boolean;
 
   constructor(response: CollectionDetailsResponse) {
     this.id = response.id;
@@ -13,5 +14,6 @@ export class CollectionData {
     this.name = response.name;
     this.externalId = response.externalId;
     this.readOnly = response.readOnly;
+    this.manage = response.manage;
   }
 }

--- a/libs/common/src/vault/models/domain/collection.spec.ts
+++ b/libs/common/src/vault/models/domain/collection.spec.ts
@@ -13,6 +13,7 @@ describe("Collection", () => {
       name: "encName",
       externalId: "extId",
       readOnly: true,
+      manage: true,
     };
   });
 
@@ -27,6 +28,7 @@ describe("Collection", () => {
       name: null,
       organizationId: null,
       readOnly: null,
+      manage: null,
     });
   });
 
@@ -40,6 +42,7 @@ describe("Collection", () => {
       externalId: "extId",
       readOnly: true,
       hidePasswords: null,
+      manage: true,
     });
   });
 
@@ -51,6 +54,7 @@ describe("Collection", () => {
     collection.externalId = "extId";
     collection.readOnly = false;
     collection.hidePasswords = false;
+    collection.manage = true;
 
     const view = await collection.decrypt();
 
@@ -61,6 +65,7 @@ describe("Collection", () => {
       name: "encName",
       organizationId: "orgId",
       readOnly: false,
+      manage: true,
     });
   });
 });

--- a/libs/common/src/vault/models/domain/collection.ts
+++ b/libs/common/src/vault/models/domain/collection.ts
@@ -10,6 +10,7 @@ export class Collection extends Domain {
   externalId: string;
   readOnly: boolean;
   hidePasswords: boolean;
+  manage: boolean;
 
   constructor(obj?: CollectionData) {
     super();
@@ -27,8 +28,9 @@ export class Collection extends Domain {
         externalId: null,
         readOnly: null,
         hidePasswords: null,
+        manage: null,
       },
-      ["id", "organizationId", "externalId", "readOnly", "hidePasswords"]
+      ["id", "organizationId", "externalId", "readOnly", "hidePasswords", "manage"]
     );
   }
 

--- a/libs/common/src/vault/models/response/collection.response.ts
+++ b/libs/common/src/vault/models/response/collection.response.ts
@@ -18,10 +18,12 @@ export class CollectionResponse extends BaseResponse {
 
 export class CollectionDetailsResponse extends CollectionResponse {
   readOnly: boolean;
+  manage: boolean;
 
   constructor(response: any) {
     super(response);
     this.readOnly = this.getResponseProperty("ReadOnly") || false;
+    this.manage = this.getResponseProperty("Manage") || false;
   }
 }
 

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -12,6 +12,7 @@ export class CollectionView implements View, ITreeNodeObject {
   externalId: string = null;
   readOnly: boolean = null;
   hidePasswords: boolean = null;
+  manage: boolean = null;
 
   constructor(c?: Collection | CollectionAccessDetailsResponse) {
     if (!c) {
@@ -24,6 +25,7 @@ export class CollectionView implements View, ITreeNodeObject {
     if (c instanceof Collection) {
       this.readOnly = c.readOnly;
       this.hidePasswords = c.hidePasswords;
+      this.manage = c.manage;
     }
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The manage property was added to the `CollectionAccessSelectionView`, but it was never added to the primary collection view even though it is being sent down from the server.

We need to add the manage property to both `CollectionDetailsResponse` and `CollectionView` models in the Clients (used in sync data) so it can be used for future client side work.

There are no server changes as it the flag is already being [sent down in the sync data](https://github.com/bitwarden/server/blob/4e7b9d2edd0d1a70df5cc6a1b634f4f7a30af4e9/src/Api/Vault/Models/Response/SyncResponseModel.cs#L38-L39).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
