### PR TITLE
[AC-1662] Port over Collection CanEdit/CanDelete methods

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -7,7 +7,6 @@ import { CollectionView } from "@bitwarden/common/vault/models/view/collection.v
 import { TableDataSource } from "@bitwarden/components";
 
 import { GroupView } from "../../../admin-console/organizations/core";
-import { CollectionAdminView } from "../../core/views/collection-admin.view";
 import { Unassigned } from "../../individual-vault/vault-filter/shared/models/routed-vault-filter.model";
 
 import { VaultItem } from "./vault-item";
@@ -81,43 +80,23 @@ export class VaultItemsComponent {
   }
 
   protected canEditCollection(collection: CollectionView): boolean {
-    // We currently don't support editing collections from individual vault
-    if (!(collection instanceof CollectionAdminView)) {
-      return false;
-    }
-
-    // Only allow allow deletion if collection editing is enabled and not deleting "Unassigned"
-    if (!this.editableCollections || collection.id === Unassigned) {
+    // Only edit collections if not editing "Unassigned"
+    if (collection.id === Unassigned) {
       return false;
     }
 
     const organization = this.allOrganizations.find((o) => o.id === collection.organizationId);
-
-    // Otherwise, check if we can edit the specified collection
-    return (
-      organization?.canEditAnyCollection ||
-      (organization?.canEditAssignedCollections && collection.assigned)
-    );
+    return collection.canEdit(organization);
   }
 
   protected canDeleteCollection(collection: CollectionView): boolean {
-    // We currently don't support editing collections from individual vault
-    if (!(collection instanceof CollectionAdminView)) {
-      return false;
-    }
-
-    // Only allow allow deletion if collection editing is enabled and not deleting "Unassigned"
-    if (!this.editableCollections || collection.id === Unassigned) {
+    // Only delete collections if not deleting "Unassigned"
+    if (collection.id === Unassigned) {
       return false;
     }
 
     const organization = this.allOrganizations.find((o) => o.id === collection.organizationId);
-
-    // Otherwise, check if we can delete the specified collection
-    return (
-      organization?.canDeleteAnyCollection ||
-      (organization?.canDeleteAssignedCollections && collection.assigned)
-    );
+    return collection.canDelete(organization);
   }
 
   protected toggleAll() {

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -1,3 +1,4 @@
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { CollectionAccessDetailsResponse } from "@bitwarden/common/src/vault/models/response/collection.response";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 
@@ -28,5 +29,13 @@ export class CollectionAdminView extends CollectionView {
       : [];
 
     this.assigned = response.assigned;
+  }
+
+  override canEdit(org: Organization): boolean {
+    return org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
+  }
+
+  override canDelete(org: Organization): boolean {
+    return org?.canDeleteAnyCollection || (org?.canDeleteAssignedCollections && this.assigned);
   }
 }

--- a/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
@@ -138,4 +138,30 @@ export class VaultHeaderComponent {
   async addCollection(): Promise<void> {
     this.onAddCollection.emit();
   }
+
+  get canEditCollection(): boolean {
+    // Only edit collections if not editing "Unassigned"
+    if (this.collection === undefined) {
+      return false;
+    }
+
+    // Otherwise, check if we can edit the specified collection
+    const organization = this.organizations.find(
+      (o) => o.id === this.collection?.node.organizationId
+    );
+    return this.collection.node.canEdit(organization);
+  }
+
+  get canDeleteCollection(): boolean {
+    // Only delete collections if not deleting "Unassigned"
+    if (this.collection === undefined) {
+      return false;
+    }
+
+    // Otherwise, check if we can edit the specified collection
+    const organization = this.organizations.find(
+      (o) => o.id === this.collection?.node.organizationId
+    );
+    return this.collection.node.canDelete(organization);
+  }
 }

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
@@ -141,10 +141,7 @@ export class VaultHeaderComponent {
     }
 
     // Otherwise, check if we can edit the specified collection
-    return (
-      this.organization.canEditAnyCollection ||
-      (this.organization.canEditAssignedCollections && this.collection?.node.assigned)
-    );
+    return this.collection.node.canEdit(this.organization);
   }
 
   addCipher() {
@@ -174,10 +171,7 @@ export class VaultHeaderComponent {
     }
 
     // Otherwise, check if we can delete the specified collection
-    return (
-      this.organization?.canDeleteAnyCollection ||
-      (this.organization?.canDeleteAssignedCollections && this.collection.node.assigned)
-    );
+    return this.collection.node.canDelete(this.organization);
   }
 
   deleteCollection() {

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -1,3 +1,4 @@
+import { Organization } from "../../../admin-console/models/domain/organization";
 import { ITreeNodeObject } from "../../../models/domain/tree-node";
 import { View } from "../../../models/view/view";
 import { Collection } from "../domain/collection";
@@ -25,5 +26,25 @@ export class CollectionView implements View, ITreeNodeObject {
       this.readOnly = c.readOnly;
       this.hidePasswords = c.hidePasswords;
     }
+  }
+
+  // For editing collection details, not the items within it.
+  canEdit(org: Organization): boolean {
+    if (org.id !== this.organizationId) {
+      throw new Error(
+        "Id of the organization provided does not match the org id of the collection."
+      );
+    }
+    return org?.canEditAnyCollection || org?.canEditAssignedCollections;
+  }
+
+  // For deleting a collection, not the items within it.
+  canDelete(org: Organization): boolean {
+    if (org.id !== this.organizationId) {
+      throw new Error(
+        "Id of the organization provided does not match the org id of the collection."
+      );
+    }
+    return org?.canDeleteAnyCollection || org?.canDeleteAssignedCollections;
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Pre-req: port over changes from an existing [PR](https://github.com/bitwarden/clients/pull/6081) that is targeting `master` that are required to complete [AC-1662]

## Code changes
- **apps/web/src/app/vault/components/vault-items/vault-items.component.ts**: Updated incorrect comments and added returns for new collection based methods
- **apps/web/src/app/vault/core/views/collection-admin.view.ts**: Added new `canEdit` and `canDelete` methods. Kept existing functionality
- **apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts**: Added new `canEditCollections` and `canDeleteCollections` which target the new collection methods
- **apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts**: Updated existing methods to target the new `canEdit` and `canDelete` collection methods
- **libs/common/src/vault/models/view/collection.view.ts**: Added base logic for new `canEdit` and `canDelete` methods. Kept existing functionality.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[AC-1662]: https://bitwarden.atlassian.net/browse/AC-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ