### PR TITLE
[AC-1689] Add hidePasswords property to collection data and response models

### DIFF
--- a/libs/common/src/vault/models/data/collection.data.ts
+++ b/libs/common/src/vault/models/data/collection.data.ts
@@ -6,6 +6,7 @@ export class CollectionData {
   name: string;
   externalId: string;
   readOnly: boolean;
+  hidePasswords: boolean;
 
   constructor(response: CollectionDetailsResponse) {
     this.id = response.id;
@@ -13,5 +14,6 @@ export class CollectionData {
     this.name = response.name;
     this.externalId = response.externalId;
     this.readOnly = response.readOnly;
+    this.hidePasswords = response.hidePasswords;
   }
 }

--- a/libs/common/src/vault/models/domain/collection.spec.ts
+++ b/libs/common/src/vault/models/domain/collection.spec.ts
@@ -13,6 +13,7 @@ describe("Collection", () => {
       name: "encName",
       externalId: "extId",
       readOnly: true,
+      hidePasswords: true,
     };
   });
 
@@ -39,7 +40,7 @@ describe("Collection", () => {
       name: { encryptedString: "encName", encryptionType: 0 },
       externalId: "extId",
       readOnly: true,
-      hidePasswords: null,
+      hidePasswords: true,
     });
   });
 

--- a/libs/common/src/vault/models/response/collection.response.ts
+++ b/libs/common/src/vault/models/response/collection.response.ts
@@ -18,10 +18,12 @@ export class CollectionResponse extends BaseResponse {
 
 export class CollectionDetailsResponse extends CollectionResponse {
   readOnly: boolean;
+  hidePasswords: boolean;
 
   constructor(response: any) {
     super(response);
     this.readOnly = this.getResponseProperty("ReadOnly") || false;
+    this.hidePasswords = this.getResponseProperty("HidePasswords") || false;
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As discussed [in this comment](https://github.com/bitwarden/clients/pull/6417#discussion_r1337930412), `collection.hidePasswords` is included in sync data from the server, but isn't set by the response model on the client. This means it won't flow through to the view model.

This PR fixes this by adding the missing properties in the chain of response -> data -> domain -> view models.

CC @djsmith85 you mentioned that this property is not sent by the server, however your link was to the public API. The private sync endpoint does appear to include this data.

No QA required as this is not currently used, although we expect it to be in the near future.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
