### PR TITLE
[PM-4146] Move Passkey Above Verification Code when Viewing an Item

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -142,6 +142,18 @@
             </button>
           </div>
         </div>
+
+        <!--Passkey-->
+        <div class="box" *ngIf="cipher.login.fido2Keys[0]">
+          <div class="box-content">
+            <div class="box-content-row text-muted">
+              <span class="row-label">{{ "typePasskey" | i18n }}</span>
+              {{ "dateCreated" | i18n }}
+              {{ cipher.login.fido2Keys[0].creationDate | date : "short" }}
+            </div>
+          </div>
+        </div>
+
         <div
           class="box-content-row box-content-row-flex totp"
           [ngClass]="{ low: totpLow }"
@@ -190,7 +202,6 @@
             </button>
           </div>
         </div>
-
         <div class="box-content-row box-content-row-flex totp" *ngIf="showPremiumRequiredTotp">
           <div class="row-main">
             <span class="row-label">{{ "verificationCodeTotp" | i18n }}</span>
@@ -199,17 +210,6 @@
                 {{ "premiumSubcriptionRequired" | i18n }}
               </a>
             </span>
-          </div>
-        </div>
-
-        <!--Passkey-->
-        <div class="box" *ngIf="cipher.login.fido2Keys[0]">
-          <div class="box-content">
-            <div class="box-content-row text-muted">
-              <span class="row-label">{{ "typePasskey" | i18n }}</span>
-              {{ "dateCreated" | i18n }}
-              {{ cipher.login.fido2Keys[0].creationDate | date : "short" }}
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
To create parity with other clients, we need to move the “Passkey” field to be above the “Verification Code (TOTP)” field when viewing an item in browser. The “Edit Item” screen already has this layout, so we just need the View screen to match.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Screenshots
<img width="373" alt="Screenshot 2023-09-29 at 5 18 15 PM" src="https://github.com/bitwarden/clients/assets/13024008/2a973e95-56fd-4d6d-9fc2-27e6e527ee48">

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
