### PR TITLE
[PM-4051] Cannot save passkey on Shopify

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -71,16 +71,16 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
     }
 
     const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
-    const rpId = params.rp.id ?? parsedOrigin.hostname;
+    params.rp.id = params.rp.id ?? parsedOrigin.hostname;
 
     if (parsedOrigin.hostname == undefined || !params.origin.startsWith("https://")) {
       this.logService?.warning(`[Fido2Client] Invalid https origin: ${params.origin}`);
       throw new DOMException("'origin' is not a valid https origin", "SecurityError");
     }
 
-    if (!isValidRpId(rpId, params.origin)) {
+    if (!isValidRpId(params.rp.id, params.origin)) {
       this.logService?.warning(
-        `[Fido2Client] 'rp.id' cannot be used with the current origin: rp.id = ${rpId}; origin = ${params.origin}`
+        `[Fido2Client] 'rp.id' cannot be used with the current origin: rp.id = ${params.rp.id}; origin = ${params.origin}`
       );
       throw new DOMException("'rp.id' cannot be used with the current origin", "SecurityError");
     }
@@ -202,16 +202,16 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
     }
 
     const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
-    const rpId = params.rpId ?? parsedOrigin.hostname;
+    params.rpId = params.rpId ?? parsedOrigin.hostname;
 
     if (parsedOrigin.hostname == undefined || !params.origin.startsWith("https://")) {
       this.logService?.warning(`[Fido2Client] Invalid https origin: ${params.origin}`);
       throw new DOMException("'origin' is not a valid https origin", "SecurityError");
     }
 
-    if (!isValidRpId(rpId, params.origin)) {
+    if (!isValidRpId(params.rpId, params.origin)) {
       this.logService?.warning(
-        `[Fido2Client] 'rp.id' cannot be used with the current origin: rp.id = ${rpId}; origin = ${params.origin}`
+        `[Fido2Client] 'rp.id' cannot be used with the current origin: rp.id = ${params.rpId}; origin = ${params.origin}`
       );
       throw new DOMException("'rp.id' cannot be used with the current origin", "SecurityError");
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This issue arose from this [PR](https://github.com/bitwarden/clients/pull/6322), which refactors the client service. The `rpId` constant, defaulting to the domain when absent, wasn't forwarded to the `mapToMakeCredentialParams` function, leading to an error when creating a passkey.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
