### PR TITLE
[PM-4141] Bugfix - Non-Premium accounts can autofill TOTP codes with the autofill keyboard shortcut

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -153,6 +153,10 @@ export default class AutofillService implements AutofillServiceInterface {
     const canAccessPremium = await this.stateService.getCanAccessPremium();
     const defaultUriMatch = (await this.stateService.getDefaultUriMatch()) ?? UriMatchType.Domain;
 
+    if (!canAccessPremium) {
+      options.cipher.login.totp = null;
+    }
+
     let didAutofill = false;
     await Promise.all(
       options.pageDetails.map(async (pd) => {
@@ -203,6 +207,7 @@ export default class AutofillService implements AutofillServiceInterface {
           { frameId: pd.frameId }
         );
 
+        // Skip getting the TOTP code for clipboard in these cases
         if (
           options.cipher.type !== CipherType.Login ||
           totp !== null ||


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Non-Premium accounts can autofill TOTP codes with the autofill keyboard shortcut; this PR fixes this issue to the expected behaviour.

## Code changes

In the autofill service, `doAutoFill` already does a `canAccessPremium` check to determine if a TOTP code should be copied to the clipboard. These changes leverage `canAccessPremium` to conditionally null out `cipher.login.totp`
