### PR TITLE
Add to TotpFieldNames array in autofill-constants.ts

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -26,9 +26,19 @@ export class AutoFillConstants {
     "mfa",
     "totpcode",
     "2facode",
+    "approvals_code",
+    "code",
     "mfacode",
+    "otc",
+    "otc-code",
+    "otp-code",
+    "otpcode",
+    "pin",
+    "security_code",
     "twofactor",
+    "twofa",
     "twofactorcode",
+    "verificationCode",
   ];
 
   static readonly PasswordFieldIgnoreList: string[] = [


### PR DESCRIPTION
"approvals_code", -- facebook.com
"code", -- cash.app, docker.com, dropbox.com, evernote.com, lincolnfinancial.com,  "otc", -- live.com
"otc-code", -- evernote.com
"otp-code", -- getpostman.com
"otpcode", -- amazon.com
"pin", -- linkedin.com
"security_code", -- docusign.com
"twofa", -- https://github.com/bitwarden/clients/pull/6413 (but lowercased to match convention) "verificationCode", -- bestbuy.com

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Add various Totp field names/ids to the TOTPFieldNames array so that TOTP autofill works more consistently.

## Code changes

Add to TotpFieldNames array in autofill-constants.ts
Lower cased "twoFa" added by #6413 
