### PR TITLE
[PM-3033] Allow User to Fill Matching Logins within Overlay

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -94,6 +94,7 @@ type OverlayListPortMessageHandlers = {
   checkAutofillOverlayButtonFocused: () => void;
   overlayPageBlurred: () => void;
   unlockVault: ({ port }: PortConnectionParam) => void;
+  fillSelectedListItem: ({ message, port }: PortOnMessageHandlerParams) => void;
   viewSelectedCipher: ({ message, port }: PortOnMessageHandlerParams) => void;
   redirectOverlayFocusOut: ({ message, port }: PortOnMessageHandlerParams) => void;
 };

--- a/apps/browser/src/autofill/overlay/pages/list/__snapshots__/autofill-overlay-list.spec.ts.snap
+++ b/apps/browser/src/autofill/overlay/pages/list/__snapshots__/autofill-overlay-list.spec.ts.snap
@@ -487,11 +487,3 @@ exports[`AutofillOverlayList initAutofillOverlayList the locked overlay for an u
   </div>
 </div>
 `;
-
-exports[`AutofillOverlayList initAutofillOverlayList the overlay with an empty list of ciphers creates the views for the no results overlay 1`] = `
-<div
-  aria-modal="true"
-  class="overlay-list-container light"
-  role="dialog"
-/>
-`;

--- a/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.spec.ts
+++ b/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.spec.ts
@@ -57,21 +57,6 @@ describe("AutofillOverlayList", () => {
       });
     });
 
-    describe("the overlay with an empty list of ciphers", () => {
-      beforeEach(() => {
-        postWindowMessage(
-          createInitAutofillOverlayListMessageMock({
-            authStatus: AuthenticationStatus.Unlocked,
-            ciphers: [],
-          })
-        );
-      });
-
-      it("creates the views for the no results overlay", () => {
-        expect(autofillOverlayList["overlayListContainer"]).toMatchSnapshot();
-      });
-    });
-
     describe("the list of ciphers for an authenticated user", () => {
       beforeEach(() => {
         postWindowMessage(createInitAutofillOverlayListMessageMock());
@@ -117,6 +102,18 @@ describe("AutofillOverlayList", () => {
       describe("fill cipher button event listeners", () => {
         beforeEach(() => {
           postWindowMessage(createInitAutofillOverlayListMessageMock());
+        });
+
+        it("allows the user to fill a cipher on click", () => {
+          const fillCipherButton =
+            autofillOverlayList["overlayListContainer"].querySelector(".fill-cipher-button");
+
+          fillCipherButton.dispatchEvent(new Event("click"));
+
+          expect(globalThis.parent.postMessage).toHaveBeenCalledWith(
+            { command: "fillSelectedListItem", overlayCipherId: "1" },
+            "https://localhost/"
+          );
         });
 
         it("allows the user to move keyboard focus to the next cipher element on ArrowDown", () => {

--- a/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.ts
+++ b/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.ts
@@ -223,10 +223,28 @@ class AutofillOverlayList extends AutofillOverlayPageElement {
       `${this.getTranslation("partialUsername")}, ${cipher.login.username}`
     );
     fillCipherElement.append(cipherIcon, cipherDetailsElement);
+    fillCipherElement.addEventListener(EVENTS.CLICK, this.handleFillCipherClickEvent(cipher));
     fillCipherElement.addEventListener(EVENTS.KEYUP, this.handleFillCipherKeyUpEvent);
 
     return fillCipherElement;
   }
+
+  /**
+   * Handles the click event for the fill cipher button.
+   * Sends a message to the parent window to fill the selected cipher.
+   *
+   * @param cipher - The cipher to fill.
+   */
+  private handleFillCipherClickEvent = (cipher: OverlayCipherData) => {
+    return this.useEventHandlersMemo(
+      () =>
+        this.postMessageToParent({
+          command: "fillSelectedListItem",
+          overlayCipherId: cipher.id,
+        }),
+      `${cipher.id}-fill-cipher-button-click-handler`
+    );
+  };
 
   /**
    * Handles the keyup event for the fill cipher button. Facilitates


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Allow users to fill credentials with login items that appear within the overlay. This current iteration will present the most recently selected vault item at the top of the list, and will re-arrange the list of items after vault item is filled.

## Code changes

TBD

## Screenshots


https://github.com/bitwarden/clients/assets/16629865/0b88f059-a122-4f96-ac22-555d3a82603b


