### PR TITLE
[AC-1662] Add LimitCollecitonCreationDeletion conditional to CanDelete logic

### DIFF
--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -36,6 +36,6 @@ export class CollectionAdminView extends CollectionView {
   }
 
   override canDelete(org: Organization): boolean {
-    return org?.canDeleteAnyCollection || (org?.canDeleteAssignedCollections && this.assigned);
+    return org?.canDeleteAnyCollection || (!org?.limitCollectionCreationDeletion && this.manage);
   }
 }

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -48,6 +48,6 @@ export class CollectionView implements View, ITreeNodeObject {
         "Id of the organization provided does not match the org id of the collection."
       );
     }
-    return org?.canDeleteAnyCollection || org?.canDeleteAssignedCollections;
+    return org?.canDeleteAnyCollection || (!org?.limitCollectionCreationDeletion && this.manage);
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Update conditional for the `CanDelete` functionality to include the collection management setting `LimitCollectionCreationDeletion` 

## Code changes

- **libs/common/src/vault/models/view/collection.view.ts:** Removed soon to be deprecated `assign` logic and implemented conditional with the `limitCollectionCreationDeletion` collection management setting.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
