### PR TITLE
[PM-4240] Screenreader does not announce if the item is selected or not when creating a passkey

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2479,8 +2479,8 @@
   "choosePasskey": {
     "message": "Choose a login to save this passkey to"
   },
-  "fido2Item": {
-    "message": "Fido2 Item"
+  "passkeysItem": {
+    "message": "Passkey Item"
   },
   "overwritePasskey": {
     "message": "Overwrite passkey?"
@@ -2502,5 +2502,8 @@
   },
   "useBrowserName": {
     "message": "Use browser"
+  },
+  "selected": {
+    "message": "Selected"
   }
 }

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
@@ -1,4 +1,5 @@
 <div
+  role="group"
   appA11yTitle="{{ cipher.name }}"
   class="virtual-scroll-item"
   [ngClass]="{ 'override-last': !last }"

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
@@ -1,6 +1,5 @@
 <div
-  role="group"
-  appA11yTitle="{{ cipher.name }} {{ cipher.subTitle }}"
+  appA11yTitle="{{ cipher.name }}"
   class="virtual-scroll-item"
   [ngClass]="{ 'override-last': !last }"
 >
@@ -9,8 +8,8 @@
       type="button"
       (click)="selectCipher(cipher)"
       tabindex="0"
-      appStopClick
       title="{{ title }} - {{ cipher.name }}"
+      appStopClick
       [ngClass]="{ 'row-main': true, 'row-selected': isSelected && !isSearching }"
     >
       <app-vault-icon [cipher]="cipher"></app-vault-icon>
@@ -22,6 +21,7 @@
         </span>
         <span class="detail" *ngIf="cipher.subTitle">{{ cipher.subTitle }}</span>
       </div>
+      <span class="sr-only">{{ isSelected ? ("selected" | i18n) : "" }}</span>
     </button>
   </div>
 </div>

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.html
@@ -48,12 +48,12 @@
           <!-- Display when ciphers exist -->
           <ng-container *ngIf="displayedCiphers.length > 0">
             <div class="box list">
-              <div class="box-content">
+              <div class="box-content" role="listbox">
                 <app-fido2-cipher-row
                   *ngFor="let cipherItem of displayedCiphers"
                   [cipher]="cipherItem"
                   [isSearching]="searchPending"
-                  title="{{ 'fido2Item' | i18n }}"
+                  title="{{ 'passkeysItem' | i18n }}"
                   (onSelected)="selectedPasskey($event)"
                   [isSelected]="cipher === cipherItem"
                 ></app-fido2-cipher-row>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When you have an item selected on the create passkey pop-up, the screen reader does not announce if the item is selected or not.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/_locales/en/messages.json:** Renamed from ``Fido2Item` to `Passkey Item` because it gives a better user experience.
- **apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html:** Added `span` element to read `selected` when an item is selected.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
