### PR TITLE
[PM-290][Browser] Make Change MP Link Direct to Login Page

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -440,9 +440,7 @@ export class SettingsComponent implements OnInit {
       type: "info",
     });
     if (confirmed) {
-      BrowserApi.createNewTab(
-        "https://bitwarden.com/help/master-password/#change-your-master-password"
-      );
+      BrowserApi.createNewTab(this.environmentService.getWebVaultUrl());
     }
   }
 


### PR DESCRIPTION
## Type of change

- Tech debt (refactoring, code cleanup, dependency upgrades, etc)


## Objective

Make the "Change Master Password" link on Browser settings direct to the Login page (for the user's environment) instead of the Help site.

## Code changes

- `apps/browser/src/popup/settings/settings.component.ts`

## Screencast (showing EU account)

https://github.com/bitwarden/clients/assets/102181210/d3e58547-3a28-4497-9b19-7f5f9345e6f2