### PR TITLE
Remove routing logic from login and 2fa

### DIFF
--- a/apps/browser/src/auth/popup/login.component.ts
+++ b/apps/browser/src/auth/popup/login.component.ts
@@ -19,7 +19,6 @@ import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/ge
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 
 import { flagEnabled } from "../../platform/flags";
-import { BrowserRouterService } from "../../platform/popup/services/browser-router.service";
 
 @Component({
   selector: "app-login",
@@ -45,8 +44,7 @@ export class LoginComponent extends BaseLoginComponent {
     formBuilder: FormBuilder,
     formValidationErrorService: FormValidationErrorsService,
     route: ActivatedRoute,
-    loginService: LoginService,
-    private routerService: BrowserRouterService
+    loginService: LoginService
   ) {
     super(
       devicesApiService,
@@ -71,16 +69,6 @@ export class LoginComponent extends BaseLoginComponent {
     };
 
     super.successRoute = "/tabs/vault";
-
-    super.onSuccessfulLoginNavigate = async () => {
-      const previousUrl = this.routerService.getPreviousUrl();
-
-      if (previousUrl) {
-        this.router.navigateByUrl(previousUrl);
-      } else {
-        this.router.navigate([this.successRoute]);
-      }
-    };
 
     this.showPasswordless = flagEnabled("showPasswordless");
 

--- a/apps/browser/src/auth/popup/two-factor.component.ts
+++ b/apps/browser/src/auth/popup/two-factor.component.ts
@@ -22,7 +22,6 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { DialogService } from "@bitwarden/components";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
-import { BrowserRouterService } from "../../platform/popup/services/browser-router.service";
 import { PopupUtilsService } from "../../popup/services/popup-utils.service";
 
 const BroadcasterSubscriptionId = "TwoFactorComponent";
@@ -53,7 +52,6 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     loginService: LoginService,
     configService: ConfigServiceAbstraction,
     private dialogService: DialogService,
-    private routerService: BrowserRouterService,
     @Inject(WINDOW) protected win: Window
   ) {
     super(
@@ -85,16 +83,6 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     };
 
     super.successRoute = "/tabs/vault";
-
-    super.onSuccessfulLoginNavigate = async () => {
-      const previousUrl = this.routerService.getPreviousUrl();
-
-      if (previousUrl) {
-        this.router.navigateByUrl(previousUrl);
-      } else {
-        this.router.navigate([this.successRoute]);
-      }
-    };
 
     // FIXME: Chromium 110 has broken WebAuthn support in extensions via an iframe
     this.webAuthnNewTab = true;

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -73,7 +73,7 @@ const routes: Routes = [
     path: "home",
     component: HomeComponent,
     canActivate: [UnauthGuard],
-    data: { state: "home", doNotSaveUrl: true },
+    data: { state: "home" },
   },
   {
     path: "fido2",
@@ -85,7 +85,7 @@ const routes: Routes = [
     path: "login",
     component: LoginComponent,
     canActivate: [UnauthGuard],
-    data: { state: "login", doNotSaveUrl: true },
+    data: { state: "login" },
   },
   {
     path: "login-with-device",
@@ -109,13 +109,13 @@ const routes: Routes = [
     path: "2fa",
     component: TwoFactorComponent,
     canActivate: [UnauthGuard],
-    data: { state: "2fa", doNotSaveUrl: true },
+    data: { state: "2fa" },
   },
   {
     path: "2fa-options",
     component: TwoFactorOptionsComponent,
     canActivate: [UnauthGuard],
-    data: { state: "2fa-options", doNotSaveUrl: true },
+    data: { state: "2fa-options" },
   },
   {
     path: "login-initiated",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Routing logic is no longer needed on `login` and `2fa` components as we decided to default to the browser implementation if not logged in.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
