### PR TITLE
[PM-4271] Move clearing of passkey when cloning from submit to load

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -267,6 +267,11 @@ export class AddEditComponent implements OnInit, OnDestroy {
       }
     }
 
+    // We don't want to copy passkeys when we clone a cipher
+    if (this.cloneMode && this.cipher?.login?.hasFido2Credentials) {
+      this.cipher.login.fido2Credentials = null;
+    }
+
     this.folders$ = this.folderService.folderViews$;
 
     if (this.editMode && this.previousCipherId !== this.cipherId) {
@@ -324,13 +329,9 @@ export class AddEditComponent implements OnInit, OnDestroy {
           : this.collections.filter((c) => (c as any).checked).map((c) => c.id);
     }
 
-    // Clear current Cipher Id and Fido2Credentials if exists to trigger "Add" cipher flow
+    // Clear current Cipher Id if exists to trigger "Add" cipher flow
     if (this.cloneMode) {
       this.cipher.id = null;
-
-      if (this.cipher.type === CipherType.Login && this.cipher.login.hasFido2Credentials) {
-        this.cipher.login.fido2Credentials = null;
-      }
     }
 
     const cipher = await this.encryptCipher();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixed bug in which passkey was being displayed on cloned item but not saved with it.
 
## Code changes

- **add-edit.component.ts:** Removed passkey on `load()` and not on `submit()` so that it isn't displayed in the UI.

## Screenshots

![image](https://github.com/bitwarden/clients/assets/106564991/cea05ed7-78e3-43e5-b4b2-96dc0eebd9cb)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
