### PR TITLE
[PM-4226] Add Cipher With Passkey Flow Change

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -332,8 +332,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     userVerification: boolean
   ): Promise<boolean> {
     if (userVerification) {
-      const userVerified = await this.passwordRepromptService.showPasswordPrompt();
-      if (!userVerified) {
+      if (!(await this.passwordRepromptService.showPasswordPrompt())) {
         BrowserFido2UserInterfaceSession.abortPopout(sessionId);
         return false;
       }

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -331,11 +331,9 @@ export class AddEditComponent extends BaseAddEditComponent {
     sessionId: string,
     userVerification: boolean
   ): Promise<boolean> {
-    if (userVerification) {
-      if (!(await this.passwordRepromptService.showPasswordPrompt())) {
-        BrowserFido2UserInterfaceSession.abortPopout(sessionId);
-        return false;
-      }
+    if (userVerification && !(await this.passwordRepromptService.showPasswordPrompt())) {
+      BrowserFido2UserInterfaceSession.abortPopout(sessionId);
+      return false;
     }
 
     return true;

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -166,17 +166,29 @@ export class AddEditComponent extends BaseAddEditComponent {
   }
 
   async submit(): Promise<boolean> {
+    const fido2SessionData = await firstValueFrom(this.fido2PopoutSessionData$);
+    // Would be refactored after rework is done on the windows popout service
+    if (
+      this.inPopout &&
+      fido2SessionData.isFido2Session &&
+      !(await this.handleFido2UserVerification(
+        fido2SessionData.sessionId,
+        fido2SessionData.userVerification
+      ))
+    ) {
+      return false;
+    }
+
     const success = await super.submit();
     if (!success) {
       return false;
     }
 
-    // Would be refactored after rework is done on the windows popout service
-    const sessionData = await firstValueFrom(this.fido2PopoutSessionData$);
-    if (this.inPopout && sessionData.isFido2Session) {
-      await this.confirmFido2CredentialResponse(
-        sessionData.sessionId,
-        sessionData.userVerification
+    if (this.inPopout && fido2SessionData.isFido2Session) {
+      BrowserFido2UserInterfaceSession.confirmNewCredentialResponse(
+        fido2SessionData.sessionId,
+        this.cipher.id,
+        fido2SessionData.userVerification
       );
       return true;
     }
@@ -315,16 +327,19 @@ export class AddEditComponent extends BaseAddEditComponent {
     }, 200);
   }
 
-  private async confirmFido2CredentialResponse(sessionId: string, userVerification: boolean) {
-    const userVerified = userVerification
-      ? await this.passwordRepromptService.showPasswordPrompt()
-      : false;
+  private async handleFido2UserVerification(
+    sessionId: string,
+    userVerification: boolean
+  ): Promise<boolean> {
+    if (userVerification) {
+      const userVerified = await this.passwordRepromptService.showPasswordPrompt();
+      if (!userVerified) {
+        BrowserFido2UserInterfaceSession.abortPopout(sessionId);
+        return false;
+      }
+    }
 
-    BrowserFido2UserInterfaceSession.confirmNewCredentialResponse(
-      sessionId,
-      this.cipher.id,
-      userVerified
-    );
+    return true;
   }
 
   repromptChanged() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Previously, when using the `+` button for creating a cipher with a passkey item, the cipher item was initially created and then, if user verification was required, the user was prompted for the master password. With this update, the master password prompt is presented before the cipher creation.

## Screenshots

https://github.com/bitwarden/clients/assets/13024008/62a12ef4-18dc-492a-9c7f-a349fe12a082


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
