### PR TITLE
[PM-4296] Cannot login to Bitwarden with FIDO2 WebAuthn if extension is installed and logged in

### DIFF
--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -108,8 +108,6 @@ navigator.credentials.get = async (
   const fallbackSupported = browserNativeWebauthnSupport;
 
   try {
-    const isNotIframe = isSameOriginWithAncestors();
-
     if (options?.mediation && options.mediation !== "optional") {
       throw new FallbackRequestedError();
     }
@@ -120,7 +118,7 @@ navigator.credentials.get = async (
         data: WebauthnUtils.mapCredentialRequestOptions(
           options,
           window.location.origin,
-          isNotIframe,
+          true,
           fallbackSupported
         ),
       },

--- a/libs/common/src/vault/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.spec.ts
@@ -361,18 +361,6 @@ describe("FidoAuthenticatorService", () => {
         await rejects.toThrow(FallbackRequestedError);
       });
 
-      // Spec: If sameOriginWithAncestors is false, return a "NotAllowedError" DOMException.
-      it("should throw error if sameOriginWithAncestors is false", async () => {
-        const params = createParams();
-        params.sameOriginWithAncestors = false; // Simulating the falsey value
-
-        const result = async () => await client.assertCredential(params, tab);
-
-        const rejects = expect(result).rejects;
-        await rejects.toMatchObject({ name: "NotAllowedError" });
-        await rejects.toBeInstanceOf(DOMException);
-      });
-
       it("should throw FallbackRequestedError if user is logged out", async () => {
         const params = createParams();
         authService.getAuthStatus.mockResolvedValue(AuthenticationStatus.LoggedOut);

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -211,13 +211,6 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
       throw new FallbackRequestedError();
     }
 
-    if (!params.sameOriginWithAncestors) {
-      this.logService?.warning(
-        `[Fido2Client] Invalid 'sameOriginWithAncestors' value: ${params.sameOriginWithAncestors}`
-      );
-      throw new DOMException("Invalid 'sameOriginWithAncestors' value", "NotAllowedError");
-    }
-
     const { domain: effectiveDomain } = parse(params.origin, { allowPrivateDomains: true });
     if (effectiveDomain == undefined) {
       this.logService?.warning(`[Fido2Client] Invalid origin: ${params.origin}`);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This bug was introduced from PR  #6057. A verification was added to the client's assertion to prevent passkeys from being requested within iframes.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
