### PR TITLE
[PM-4373] Update argon2 to 0.31.1 to fix linux/arm64 install

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@koa/multer": "3.0.2",
     "@koa/router": "12.0.0",
-    "argon2": "0.31.0",
+    "argon2": "0.31.1",
     "big-integer": "1.6.51",
     "browser-hrtime": "1.1.8",
     "chalk": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,7 +198,7 @@
       "dependencies": {
         "@koa/multer": "3.0.2",
         "@koa/router": "12.0.0",
-        "argon2": "0.31.0",
+        "argon2": "0.31.1",
         "big-integer": "1.6.51",
         "browser-hrtime": "1.1.8",
         "chalk": "4.1.2",
@@ -225,6 +225,20 @@
       },
       "bin": {
         "bw": "build/bw.js"
+      }
+    },
+    "apps/cli/node_modules/argon2": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.31.1.tgz",
+      "integrity": "sha512-ik2xnJrLXazya7m4Nz1XfBSRjXj8Koq8qF9PsQC8059p20ifWc9zx/hgU3ItZh/3TnwXkv0RbhvjodPkmFf0bg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "apps/desktop": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes https://github.com/bitwarden/clients/issues/6458

When installing @bitwarden/cli on arm64 the prebuilt binary is not available:
```
 #24 339.6 npm ERR! node-pre-gyp info using node-pre-gyp@1.0.11
#24 339.6 npm ERR! node-pre-gyp info using node@18.18.2 | linux | arm64
#24 339.6 npm ERR! node-pre-gyp info check checked for "/usr/local/lib/node_modules/@bitwarden/cli/node_modules/argon2/lib/binding/napi-v3/argon2.node" (not found)
#24 339.6 npm ERR! node-pre-gyp http GET https://github.com/ranisalt/node-argon2/releases/download/v0.31.0/argon2-v0.31.0-napi-v3-linux-arm64-glibc.tar.gz
#24 339.6 npm ERR! node-pre-gyp ERR! install response status 404 Not Found on https://github.com/ranisalt/node-argon2/releases/download/v0.31.0/argon2-v0.31.0-napi-v3-linux-arm64-glibc.tar.gz 
#24 339.6 npm ERR! node-pre-gyp WARN Pre-built binaries not installable for argon2@0.31.0 and node@18.18.2 (node-v108 ABI, glibc) (falling back to source compile with node-gyp) 
#24 339.6 npm ERR! node-pre-gyp WARN Hit error response status 404 Not Found on https://github.com/ranisalt/node-argon2/releases/download/v0.31.0/argon2-v0.31.0-napi-v3-linux-arm64-glibc.tar.gz 
#24 339.6 npm ERR! gyp info it worked if it ends with ok
```

This was addressed in the next patch release, 0.31.1: https://github.com/ranisalt/node-argon2/releases/tag/v0.31.1

Upgrading from 0.31.0 to 0.31.1 in bitwarden/cli will resolve this build issue.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **package.json:** Upgraded node-argon2 from 0.31.0 to 0.31.1
- - **package-lock.json:** Upgraded node-argon2 from 0.31.0 to 0.31.1

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
