### PR TITLE
[PM-4375] Reuse show file selector callout logic

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -103,6 +103,7 @@ import BrowserMessagingService from "../../platform/services/browser-messaging.s
 import { BrowserStateService } from "../../platform/services/browser-state.service";
 import { BrowserSendService } from "../../services/browser-send.service";
 import { BrowserSettingsService } from "../../services/browser-settings.service";
+import { FilePopoutUtilsService } from "../../tools/popup/services/file-popout-utils.service";
 import { BrowserFolderService } from "../../vault/services/browser-folder.service";
 import { VaultFilterService } from "../../vault/services/vault-filter.service";
 
@@ -510,6 +511,16 @@ function getBgService<T>(service: keyof MainBackground) {
         EnvironmentService,
         LogService,
       ],
+    },
+    {
+      provide: FilePopoutUtilsService,
+      useFactory: (
+        platformUtilsService: PlatformUtilsService,
+        popupUtilsService: PopupUtilsService
+      ) => {
+        return new FilePopoutUtilsService(platformUtilsService, popupUtilsService);
+      },
+      deps: [PlatformUtilsService, PopupUtilsService],
     },
   ],
 })

--- a/apps/browser/src/tools/popup/components/file-popout-callout.component.ts
+++ b/apps/browser/src/tools/popup/components/file-popout-callout.component.ts
@@ -2,10 +2,10 @@ import { CommonModule } from "@angular/common";
 import { Component, OnInit } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CalloutModule } from "@bitwarden/components";
 
 import { PopupUtilsService } from "../../../popup/services/popup-utils.service";
+import { FilePopoutUtilsService } from "../services/file-popout-utils.service";
 
 @Component({
   selector: "tools-file-popout-callout",
@@ -14,50 +14,21 @@ import { PopupUtilsService } from "../../../popup/services/popup-utils.service";
   imports: [CommonModule, JslibModule, CalloutModule],
 })
 export class FilePopoutCalloutComponent implements OnInit {
-  isSafari = false;
-  isFirefox = false;
-  inPopout = false;
-  inSidebar = false;
-  isLinux = false;
-  isUnsupportedMac = false;
+  protected showFilePopoutMessage: boolean;
+  protected showFirefoxFileWarning: boolean;
+  protected showSafariFileWarning: boolean;
+  protected showChromiumFileWarning: boolean;
 
   constructor(
-    private platformUtilsService: PlatformUtilsService,
-    private popupUtilsService: PopupUtilsService
+    private popupUtilsService: PopupUtilsService,
+    private filePopoutUtilsService: FilePopoutUtilsService
   ) {}
 
-  async ngOnInit() {
-    // File visibility
-    this.isSafari = this.platformUtilsService.isSafari();
-    this.isFirefox = this.platformUtilsService.isFirefox();
-    this.inPopout = this.popupUtilsService.inPopout(window);
-    this.inSidebar = this.popupUtilsService.inSidebar(window);
-    this.isLinux = window?.navigator?.userAgent.indexOf("Linux") !== -1;
-    this.isUnsupportedMac =
-      this.platformUtilsService.isChrome() && window?.navigator?.appVersion.includes("Mac OS X 11");
-  }
-
-  get showFilePopoutMessage(): boolean {
-    return (
-      this.showFirefoxFileWarning || this.showSafariFileWarning || this.showChromiumFileWarning
-    );
-  }
-
-  get showFirefoxFileWarning(): boolean {
-    return this.isFirefox && !(this.inSidebar || this.inPopout);
-  }
-
-  get showSafariFileWarning(): boolean {
-    return this.isSafari && !this.inPopout;
-  }
-
-  // Only show this for Chromium based browsers in Linux and Mac > Big Sur
-  get showChromiumFileWarning(): boolean {
-    return (
-      (this.isLinux || this.isUnsupportedMac) &&
-      !this.isFirefox &&
-      !(this.inSidebar || this.inPopout)
-    );
+  ngOnInit() {
+    this.showFilePopoutMessage = this.filePopoutUtilsService.showFilePopoutMessage(window);
+    this.showFirefoxFileWarning = this.filePopoutUtilsService.showFirefoxFileWarning(window);
+    this.showSafariFileWarning = this.filePopoutUtilsService.showSafariFileWarning(window);
+    this.showChromiumFileWarning = this.filePopoutUtilsService.showChromiumFileWarning(window);
   }
 
   popOutWindow() {

--- a/apps/browser/src/tools/popup/send/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send/send-add-edit.component.ts
@@ -17,6 +17,7 @@ import { DialogService } from "@bitwarden/components";
 
 import { BrowserStateService } from "../../../platform/services/abstractions/browser-state.service";
 import { PopupUtilsService } from "../../../popup/services/popup-utils.service";
+import { FilePopoutUtilsService } from "../services/file-popout-utils.service";
 
 @Component({
   selector: "app-send-add-edit",
@@ -29,6 +30,7 @@ export class SendAddEditComponent extends BaseAddEditComponent {
   // File visibility
   isFirefox = false;
   inPopout = false;
+  showFileSelector = false;
 
   constructor(
     i18nService: I18nService,
@@ -46,7 +48,8 @@ export class SendAddEditComponent extends BaseAddEditComponent {
     logService: LogService,
     sendApiService: SendApiService,
     dialogService: DialogService,
-    formBuilder: FormBuilder
+    formBuilder: FormBuilder,
+    private filePopoutUtilsService: FilePopoutUtilsService
   ) {
     super(
       i18nService,
@@ -64,18 +67,16 @@ export class SendAddEditComponent extends BaseAddEditComponent {
     );
   }
 
-  get showFileSelector(): boolean {
-    return !this.editMode;
-  }
-
   popOutWindow() {
     this.popupUtilsService.popOut(window);
   }
 
   async ngOnInit() {
     // File visibility
-    this.isFirefox = this.platformUtilsService.isFirefox();
+    this.showFileSelector =
+      !this.editMode && !this.filePopoutUtilsService.showFilePopoutMessage(window);
     this.inPopout = this.popupUtilsService.inPopout(window);
+    this.isFirefox = this.platformUtilsService.isFirefox();
 
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
     this.route.queryParams.pipe(first()).subscribe(async (params) => {

--- a/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
+++ b/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from "@angular/core";
+
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
+import { PopupUtilsService } from "../../../popup/services/popup-utils.service";
+
+@Injectable()
+export class FilePopoutUtilsService {
+  constructor(
+    private platformUtilsService: PlatformUtilsService,
+    private popupUtilsService: PopupUtilsService
+  ) {}
+
+  showFilePopoutMessage(win: Window): boolean {
+    return (
+      this.showFirefoxFileWarning(win) ||
+      this.showSafariFileWarning(win) ||
+      this.showChromiumFileWarning(win)
+    );
+  }
+
+  showFirefoxFileWarning(win: Window): boolean {
+    return (
+      this.platformUtilsService.isFirefox() &&
+      !(this.popupUtilsService.inSidebar(win) || this.popupUtilsService.inPopout(win))
+    );
+  }
+
+  showSafariFileWarning(win: Window): boolean {
+    return this.platformUtilsService.isSafari() && !this.popupUtilsService.inPopout(win);
+  }
+
+  showChromiumFileWarning(win: Window): boolean {
+    return (
+      (this.isLinux(win) || this.isUnsupportedMac(win)) &&
+      !this.platformUtilsService.isFirefox() &&
+      !(this.popupUtilsService.inSidebar(win) || this.popupUtilsService.inPopout(win))
+    );
+  }
+
+  private isLinux(win: Window): boolean {
+    return win?.navigator?.userAgent.indexOf("Linux") !== -1;
+  }
+
+  private isUnsupportedMac(win: Window): boolean {
+    return (
+      this.platformUtilsService.isChrome() && win?.navigator?.appVersion.includes("Mac OS X 11")
+    );
+  }
+}

--- a/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
+++ b/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
@@ -4,8 +4,14 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 
 import { PopupUtilsService } from "../../../popup/services/popup-utils.service";
 
+/**
+ * Service for determining whether to display file popout callout messages.
+ */
 @Injectable()
 export class FilePopoutUtilsService {
+  /**
+   * Creates an instance of FilePopoutUtilsService.
+   */
   constructor(
     private platformUtilsService: PlatformUtilsService,
     private popupUtilsService: PopupUtilsService

--- a/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
+++ b/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
@@ -11,6 +11,11 @@ export class FilePopoutUtilsService {
     private popupUtilsService: PopupUtilsService
   ) {}
 
+  /**
+   * Determines whether to show any file popout callout message in the current browser.
+   * @param win - The window context in which the check should be performed.
+   * @returns True if a file popout callout message should be displayed; otherwise, false.
+   */
   showFilePopoutMessage(win: Window): boolean {
     return (
       this.showFirefoxFileWarning(win) ||
@@ -19,6 +24,11 @@ export class FilePopoutUtilsService {
     );
   }
 
+  /**
+   * Determines whether to show a file popout callout message for the Firefox browser
+   * @param win - The window context in which the check should be performed.
+   * @returns True if the extension is not in a sidebar or popout; otherwise, false.
+   */
   showFirefoxFileWarning(win: Window): boolean {
     return (
       this.platformUtilsService.isFirefox() &&
@@ -26,10 +36,20 @@ export class FilePopoutUtilsService {
     );
   }
 
+  /**
+   * Determines whether to show a file popout message for the Safari browser
+   * @param win - The window context in which the check should be performed.
+   * @returns True if the extension is not in a popout; otherwise, false.
+   */
   showSafariFileWarning(win: Window): boolean {
     return this.platformUtilsService.isSafari() && !this.popupUtilsService.inPopout(win);
   }
 
+  /**
+   * Determines whether to show a file popout callout message for Chromium-based browsers in Linux and Mac OS X Big Sur
+   * @param win - The window context in which the check should be performed.
+   * @returns True if the extension is not in a sidebar or popout; otherwise, false.
+   */
   showChromiumFileWarning(win: Window): boolean {
     return (
       (this.isLinux(win) || this.isUnsupportedMac(win)) &&


### PR DESCRIPTION
## Type of change

Separating the logic from the `FilePopoutCalloutComponent` into a new Service

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The logic used on the `FilePopoutCalloutComponent` is also necessary to Parent Components. We are separating that logic into a service so that it can be used by all the components.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **services.module.ts:** Added the new `FilePopoutUtilsService`
- **file-popout-callout.component.ts:** Removed the logic regarding which callout should be shown and using the new service that deals with that.
- **send-add-edit.component.ts:** Using the `FilePopoutUtilsService` to check if the callout is visible
- **file-popout-utils.service.ts:** Service containing all the logic if the callout should be visible and which text should present to the user

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
