### PR TITLE
[PM-4321] [Defect] When trying to import a password protected file the user is logged out

### DIFF
--- a/libs/importer/src/components/dialog/file-password-prompt.component.html
+++ b/libs/importer/src/components/dialog/file-password-prompt.component.html
@@ -1,4 +1,4 @@
-<form (submit)="submit()">
+<form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog>
     <span bitDialogTitle>
       {{ "confirmVaultImport" | i18n }}

--- a/libs/importer/src/components/dialog/file-password-prompt.component.ts
+++ b/libs/importer/src/components/dialog/file-password-prompt.component.ts
@@ -1,7 +1,7 @@
 import { DialogRef } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
-import { FormControl, Validators } from "@angular/forms";
+import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
@@ -23,18 +23,21 @@ import {
     AsyncActionsModule,
     ButtonModule,
     IconButtonModule,
+    ReactiveFormsModule,
   ],
 })
 export class FilePasswordPromptComponent {
-  filePassword = new FormControl("", Validators.required);
+  formGroup = this.formBuilder.group({
+    filePassword: ["", Validators.required],
+  });
 
-  constructor(public dialogRef: DialogRef) {}
+  constructor(public dialogRef: DialogRef, protected formBuilder: FormBuilder) {}
 
-  submit() {
-    this.filePassword.markAsTouched();
-    if (!this.filePassword.valid) {
+  submit = () => {
+    this.formGroup.markAsTouched();
+    if (!this.formGroup.valid) {
       return;
     }
-    this.dialogRef.close(this.filePassword.value);
-  }
+    this.dialogRef.close(this.formGroup.value.filePassword);
+  };
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When importing a password protected file, we prompt the user to enter their password. When entering the password the import got canceled and on some occasions the user got logged out.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/importer/src/components/dialog/file-password-prompt.component.html and libs/importer/src/components/dialog/file-password-prompt.component.ts:** Use a FormGroup instead of single FormControl and use BitSubmitDirective which overrides the forms preventDefault


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
