### PR TITLE
PM-4376 update size for passkey popup

### DIFF
--- a/apps/browser/src/platform/popup/browser-popout-window.service.ts
+++ b/apps/browser/src/platform/popup/browser-popout-window.service.ts
@@ -122,8 +122,7 @@ class BrowserPopoutWindowService implements BrowserPopupWindowServiceInterface {
       promptWindowPath,
       "fido2Popout",
       {
-        width: 200,
-        height: 500,
+        height: 450,
       }
     );
   }


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

With the updates to the `browser-popout-window.service` from https://github.com/bitwarden/clients/pull/6600 we will update the passkey popup size to accommodate the new spacing. 

## Code changes

Remove default width from `openFido2Popout` and updated height to 450. 

Removing width will also fix this half off screen bug here: https://bitwarden.atlassian.net/browse/PM-4295

## Screenshots

New height and width looks good with chrome and firefox

Firefox
<img width="426" alt="450_firefox_popup" src="https://github.com/bitwarden/clients/assets/8302660/0fd2c0fd-1613-45d9-8e63-0e01c041740a">

Chrome
<img width="450" alt="450_chrome_popup" src="https://github.com/bitwarden/clients/assets/8302660/fc535165-a21f-44f0-b8f1-c61194e6bc77">
