### PR TITLE
[PM-4358] Passkey can be Created but not Retrieved on eBay

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,9 +363,14 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
+  const requireUserVerification =
+    params.authenticatorSelection?.userVerification === "required" ||
+    params.authenticatorSelection?.userVerification === "preferred" ||
+    params.authenticatorSelection?.userVerification === undefined;
+
   return {
     requireResidentKey,
-    requireUserVerification: params.authenticatorSelection?.userVerification === "required",
+    requireUserVerification: requireUserVerification,
     enterpriseAttestationPossible: params.attestation === "enterprise",
     excludeCredentialDescriptorList,
     credTypesAndPubKeyAlgs,
@@ -398,9 +403,14 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
+  const requireUserVerification =
+    params.userVerification === "required" ||
+    params.userVerification === "preferred" ||
+    params.userVerification === undefined;
+
   return {
     rpId: params.rpId,
-    requireUserVerification: params.userVerification === "required",
+    requireUserVerification,
     hash: clientDataHash,
     allowCredentialDescriptorList,
     extensions: {},

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -370,7 +370,7 @@ function mapToMakeCredentialParams({
 
   return {
     requireResidentKey,
-    requireUserVerification: requireUserVerification,
+    requireUserVerification,
     enterpriseAttestationPossible: params.attestation === "enterprise",
     excludeCredentialDescriptorList,
     credTypesAndPubKeyAlgs,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On eBay, there are two options for passkey creation “Face/Fingerprint/PIN Passkey” and “Security Key Sign In”. Creating and retrieving using the passkeys approach works, but with the security key, creation is successful, but retrieval throws an error, and this happens because eBay requires userVerification on creation but omits this on retrieval. To address this issue, userVerification should also be required on `preferred`. 

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes
Added a change to require user verification when userVerification is `preferred` or `undefined`.
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
