### PR TITLE
Remove EU environment feature flag from clients

### DIFF
--- a/apps/web/src/app/components/environment-selector/environment-selector.component.html
+++ b/apps/web/src/app/components/environment-selector/environment-selector.component.html
@@ -20,7 +20,6 @@
         isEuServer ? 'javascript:void(0)' : 'https://vault.bitwarden.eu' + routeAndParams
       "
       class="pr-4"
-      *ngIf="euServerFlagEnabled"
     >
       <i
         class="bwi bwi-fw bwi-sm bwi-check pb-1"

--- a/apps/web/src/app/components/environment-selector/environment-selector.component.ts
+++ b/apps/web/src/app/components/environment-selector/environment-selector.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { RegionDomain } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -12,22 +10,14 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
   templateUrl: "environment-selector.component.html",
 })
 export class EnvironmentSelectorComponent implements OnInit {
-  constructor(
-    private configService: ConfigServiceAbstraction,
-    private platformUtilsService: PlatformUtilsService,
-    private router: Router
-  ) {}
+  constructor(private platformUtilsService: PlatformUtilsService, private router: Router) {}
 
   isEuServer: boolean;
   isUsServer: boolean;
   showRegionSelector = false;
-  euServerFlagEnabled: boolean;
   routeAndParams: string;
 
   async ngOnInit() {
-    this.euServerFlagEnabled = await this.configService.getFeatureFlag<boolean>(
-      FeatureFlag.DisplayEuEnvironmentFlag
-    );
     const domain = Utils.getDomain(window.location.href);
     this.isEuServer = domain.includes(RegionDomain.EU);
     this.isUsServer = domain.includes(RegionDomain.US) || domain.includes(RegionDomain.USQA);

--- a/libs/angular/src/auth/components/environment-selector.component.html
+++ b/libs/angular/src/auth/components/environment-selector.component.html
@@ -63,7 +63,6 @@
         class="environment-selector-dialog-item"
         (click)="toggle(ServerEnvironmentType.EU)"
         [attr.aria-pressed]="selectedEnvironment === ServerEnvironmentType.EU ? 'true' : 'false'"
-        *ngIf="euServerFlagEnabled"
       >
         <i
           class="bwi bwi-fw bwi-sm bwi-check"
@@ -75,7 +74,7 @@
         ></i>
         <span>{{ "euDomain" | i18n }}</span>
       </button>
-      <br *ngIf="euServerFlagEnabled" />
+      <br />
       <button
         type="button"
         class="environment-selector-dialog-item"

--- a/libs/angular/src/auth/components/environment-selector.component.ts
+++ b/libs/angular/src/auth/components/environment-selector.component.ts
@@ -4,7 +4,6 @@ import { Component, EventEmitter, OnDestroy, OnInit, Output } from "@angular/cor
 import { Router } from "@angular/router";
 import { Subject, takeUntil } from "rxjs";
 
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import {
   EnvironmentService as EnvironmentServiceAbstraction,
@@ -37,7 +36,6 @@ import {
 })
 export class EnvironmentSelectorComponent implements OnInit, OnDestroy {
   @Output() onOpenSelfHostedSettings = new EventEmitter();
-  euServerFlagEnabled: boolean;
   isOpen = false;
   showingModal = false;
   selectedEnvironment: Region;
@@ -89,9 +87,6 @@ export class EnvironmentSelectorComponent implements OnInit, OnDestroy {
 
   async updateEnvironmentInfo() {
     this.selectedEnvironment = this.environmentService.selectedRegion;
-    this.euServerFlagEnabled = await this.configService.getFeatureFlag<boolean>(
-      FeatureFlag.DisplayEuEnvironmentFlag
-    );
   }
 
   close() {

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -1,5 +1,4 @@
 export enum FeatureFlag {
-  DisplayEuEnvironmentFlag = "display-eu-environment",
   DisplayLowKdfIterationWarningFlag = "display-kdf-iteration-warning",
   Fido2VaultCredentials = "fido2-vault-credentials",
   TrustedDeviceEncryption = "trusted-device-encryption",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove references to the EU Environment feature flag from the client codebase, now that it is a permanent feature.

## Code changes

- **environment-selector.component.ts:** Removed property for EU environment check.
- **environment-selector.component.html:** Removed conditional checks for EU environment.
- **feature-flag.enum.ts:** Removed feature flag value.

## Screenshots

![EU environment](https://github.com/bitwarden/clients/assets/106564991/7c2e224f-d013-422e-8666-581ce4707d93)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
