### PR TITLE
[PM-3572] 'Custom/Log out' vault timeout changes to 'Lock'

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -272,7 +272,7 @@ export class SettingsComponent implements OnInit {
 
     await this.vaultTimeoutSettingsService.setVaultTimeoutOptions(
       newValue,
-      this.form.value.vaultTimeoutAction
+      await firstValueFrom(this.vaultTimeoutSettingsService.vaultTimeoutAction$())
     );
     if (newValue == null) {
       this.messagingService.send("bgReseedStorage");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
'Custom/Log out' vault timeout changes to 'Lock' in the Chrome extension when leaving the settings page and reentering it the second time.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
**VaultTimeout** change was being triggered in a time where the value of **VaultTimeoutAction** was not yet loaded. This was setting a new **VaultTimeoutAction** from the UI form value instead of state, always defaulting to **lock.**

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
