### PR TITLE
PM-4299 Passkey Popup search bar is empty only show matching uri ciphers

### DIFF
--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.html
@@ -20,7 +20,7 @@
             placeholder="{{ 'searchVault' | i18n }}"
             id="search"
             [(ngModel)]="searchText"
-            (input)="search(200)"
+            (input)="search()"
             autocomplete="off"
             appAutofocus
           />

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -319,46 +319,23 @@ export class Fido2Component implements OnInit, OnDestroy {
     });
   }
 
-  async loadLoginCiphers() {
-    this.ciphers = (await this.cipherService.getAllDecrypted()).filter(
-      (cipher) => cipher.type === CipherType.Login && !cipher.isDeleted
-    );
-    if (!this.hasLoadedAllCiphers) {
-      this.hasLoadedAllCiphers = !this.searchService.isSearchable(this.searchText);
-    }
-    await this.search(null);
-  }
-
-  async search(timeout: number = null) {
-    this.searchPending = false;
-    if (this.searchTimeout != null) {
-      clearTimeout(this.searchTimeout);
-    }
-
-    if (timeout == null) {
-      this.hasSearched = this.searchService.isSearchable(this.searchText);
+  protected async search() {
+    this.hasSearched = this.searchService.isSearchable(this.searchText);
+    this.searchPending = true;
+    if (this.hasSearched) {
       this.displayedCiphers = await this.searchService.searchCiphers(
         this.searchText,
         null,
         this.ciphers
       );
-      return;
+    } else {
+      const equivalentDomains = this.settingsService.getEquivalentDomains(this.url);
+      this.displayedCiphers = this.ciphers.filter((cipher) =>
+        cipher.login.matchesUri(this.url, equivalentDomains)
+      );
     }
-    this.searchPending = true;
-    this.searchTimeout = setTimeout(async () => {
-      this.hasSearched = this.searchService.isSearchable(this.searchText);
-      if (!this.hasLoadedAllCiphers && !this.hasSearched) {
-        await this.loadLoginCiphers();
-      } else {
-        this.displayedCiphers = await this.searchService.searchCiphers(
-          this.searchText,
-          null,
-          this.ciphers
-        );
-      }
-      this.searchPending = false;
-      this.selectedPasskey(this.displayedCiphers[0]);
-    }, timeout);
+    this.searchPending = false;
+    this.selectedPasskey(this.displayedCiphers[0]);
   }
 
   abort(fallback: boolean) {


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When the passkey popup is open, if a user uses the search bar, the filtered ciphers will match properly. If the user were to delete the text in the search bar, the filtered ciphers should only show ciphers with a matching URI

## Code changes

refactored the search method in the `fido2.component` and it's invocation in the corresponding html. Also removed redundant code. 

NOTE: If you pull this branch to try this locally and the popup looks half sized, there is a fix for it located in this PR: https://github.com/bitwarden/clients/pull/6615

## Screen Recording showing the filtered ciphers throughout search bar use


https://github.com/bitwarden/clients/assets/8302660/f77de9bd-f74c-410c-8c8f-c2fa32180268

