### PR TITLE
[PM-4396] Corrected navigation when browser extension is popped out on SendAddEdit

### DIFF
--- a/apps/browser/src/tools/popup/send/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send/send-add-edit.component.ts
@@ -147,8 +147,8 @@ export class SendAddEditComponent extends BaseAddEditComponent {
 
   cancel() {
     // If true, the window was pop'd out on the add-send page. location.back will not work
-    if ((window as any).previousPopupUrl.startsWith("/add-send")) {
-      this.router.navigate(["tabs/send"]);
+    if ((window as any).previousPopupUrl == null) {
+      this.router.navigate(["/tabs/send"], { replaceUrl: true });
     } else {
       this.location.back();
     }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

After clicking the callout popout the navigation is not working properly on the SendAddEdit page and this fixes it.

## Code changes

- **send-add-edit.component.ts:** When popping out the `window.previousPopupUrl` is being returned as `undefined`, also added the `replaceUrl: true` to not allow navigating back to this page

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
