### PR TITLE
[PM-4290] Add pop out warning on import page

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -474,10 +474,7 @@ export class SettingsComponent implements OnInit {
   }
 
   async import() {
-    await this.router.navigate(["/import"]);
-    if (await BrowserApi.isPopupOpen()) {
-      this.popupUtilsService.popOut(window);
-    }
+    this.router.navigate(["/import"]);
   }
 
   export() {

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.html
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.html
@@ -21,5 +21,6 @@
     (formDisabled)="this.disabled = $event"
     (formLoading)="this.loading = $event"
     (onSuccessfulImport)="this.onSuccessfulImport($event)"
+    [showFileSelector]="this.showFileSelector"
   ></tools-import>
 </div>

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.html
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.html
@@ -16,6 +16,7 @@
   </div>
 </header>
 <div tabindex="-1" class="tw-p-4">
+  <tools-file-popout-callout />
   <tools-import
     (formDisabled)="this.disabled = $event"
     (formLoading)="this.loading = $event"

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.html
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.html
@@ -21,6 +21,6 @@
     (formDisabled)="this.disabled = $event"
     (formLoading)="this.loading = $event"
     (onSuccessfulImport)="this.onSuccessfulImport($event)"
-    [showFileSelector]="this.showFileSelector"
+    [hideFileSelector]="this.hideFileSelector"
   ></tools-import>
 </div>

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -6,6 +6,7 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
 import { ImportComponent } from "@bitwarden/importer/ui";
 
+import { FilePopoutCalloutComponent } from "../../components/file-popout-callout.component";
 @Component({
   templateUrl: "import-browser.component.html",
   standalone: true,
@@ -17,6 +18,7 @@ import { ImportComponent } from "@bitwarden/importer/ui";
     AsyncActionsModule,
     ButtonModule,
     ImportComponent,
+    FilePopoutCalloutComponent,
   ],
 })
 export class ImportBrowserComponent {

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -34,6 +34,7 @@ export class ImportBrowserComponent implements OnInit {
   ngOnInit(): void {
     this.hideFileSelector = this.filePopoutUtilsService.showFilePopoutMessage(window);
   }
+
   protected async onSuccessfulImport(organizationId: string): Promise<void> {
     this.router.navigate(["/tabs/settings"]);
   }

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -27,12 +27,12 @@ export class ImportBrowserComponent implements OnInit {
   protected disabled = false;
   protected loading = false;
 
-  protected showFileSelector = true;
+  protected hideFileSelector = false;
 
   constructor(private router: Router, private filePopoutUtilsService: FilePopoutUtilsService) {}
 
   ngOnInit(): void {
-    this.showFileSelector = !this.filePopoutUtilsService.showFilePopoutMessage(window);
+    this.hideFileSelector = this.filePopoutUtilsService.showFilePopoutMessage(window);
   }
   protected async onSuccessfulImport(organizationId: string): Promise<void> {
     this.router.navigate(["/tabs/settings"]);

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -7,6 +7,8 @@ import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/compo
 import { ImportComponent } from "@bitwarden/importer/ui";
 
 import { FilePopoutCalloutComponent } from "../../components/file-popout-callout.component";
+import { FilePopoutUtilsService } from "../../services/file-popout-utils.service";
+
 @Component({
   templateUrl: "import-browser.component.html",
   standalone: true,
@@ -21,12 +23,17 @@ import { FilePopoutCalloutComponent } from "../../components/file-popout-callout
     FilePopoutCalloutComponent,
   ],
 })
-export class ImportBrowserComponent {
+export class ImportBrowserComponent implements OnInit {
   protected disabled = false;
   protected loading = false;
 
-  constructor(private router: Router) {}
+  protected showFileSelector = true;
 
+  constructor(private router: Router, private filePopoutUtilsService: FilePopoutUtilsService) {}
+
+  ngOnInit(): void {
+    this.showFileSelector = !this.filePopoutUtilsService.showFilePopoutMessage(window);
+  }
   protected async onSuccessfulImport(organizationId: string): Promise<void> {
     this.router.navigate(["/tabs/settings"]);
   }

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -344,7 +344,7 @@
       and save the zip file.
     </ng-container>
   </bit-callout>
-  <bit-form-field *ngIf="showFileSelector">
+  <bit-form-field *ngIf="!hideFileSelector">
     <bit-label>{{ "selectImportFile" | i18n }}</bit-label>
     <div class="file-selector">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -344,7 +344,7 @@
       and save the zip file.
     </ng-container>
   </bit-callout>
-  <bit-form-field>
+  <bit-form-field *ngIf="showFileSelector">
     <bit-label>{{ "selectImportFile" | i18n }}</bit-label>
     <div class="file-selector">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -120,6 +120,8 @@ export class ImportComponent implements OnInit, OnDestroy {
       });
   }
 
+  @Input() showFileSelector: boolean;
+
   protected organization: Organization;
   protected destroy$ = new Subject<void>();
 

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -120,7 +120,7 @@ export class ImportComponent implements OnInit, OnDestroy {
       });
   }
 
-  @Input() showFileSelector: boolean;
+  @Input() hideFileSelector: boolean;
 
   protected organization: Organization;
   protected destroy$ = new Subject<void>();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Due to some issues with selecting a file and the popup closing while the FilePickerDialog of the OS is shown, we have added a callout which is shown on certain browsee

This callout component was extracted with https://github.com/bitwarden/clients/pull/6564 as it was previously only used within Send.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **No longer popout automatically -** https://github.com/bitwarden/clients/commit/e6d000e55c38c5d2fb8b50890cea1944ddb9ede7
- **Add FilePopoutCalloutComponent to import-browser -** https://github.com/bitwarden/clients/commit/dce65fdcc24475ef11b5ee73c4cd907067676a50
- **Hide fileSelector on base import.component when callout is shown -** https://github.com/bitwarden/clients/commit/88ff9db0f487adc56b1b59b716590b9098dace3c
  - Extend import.component to receive an input to show/hide the FileSelector (`showFileSelector`)
  - Extend import-browser to check if the callout should be shown via the `filePopoutUtilsService` and pass the returning value onto the base component
  
## Screenshots
### In popup
![image](https://github.com/bitwarden/clients/assets/2670567/304bcdf7-9d48-43fd-88a8-600d6494a6c0)

### After popping out
![image](https://github.com/bitwarden/clients/assets/2670567/0ae3b2ce-652f-4477-b036-446660019101)

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
