### PR TITLE
[BEEEP] Mask TOTP seeds in cipher edit view - similar to how the password is hidden

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -70,6 +70,7 @@
             <div class="row-main">
               <label for="loginPassword">{{ "password" | i18n }}</label>
               <input
+                *ngIf="showPassword"
                 id="loginPassword"
                 class="monospaced"
                 type="{{ showPassword ? 'text' : 'password' }}"
@@ -79,6 +80,9 @@
                 [disabled]="!cipher.viewPassword"
                 [readonly]="!cipher.edit && editMode"
               />
+              <div *ngIf="!showPassword" class="monospaced">
+                {{ cipher.login.maskedPassword }}
+              </div>
             </div>
             <div class="action-buttons">
               <button
@@ -141,18 +145,41 @@
             </div>
           </div>
 
-          <div class="box-content-row" appBoxRow>
-            <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>
-            <input
-              id="loginTotp"
-              type="{{ cipher.viewPassword ? 'text' : 'password' }}"
-              name="Login.Totp"
-              class="monospaced"
-              [(ngModel)]="cipher.login.totp"
-              appInputVerbatim
-              [disabled]="!cipher.viewPassword"
-              [readonly]="!cipher.edit && editMode"
-            />
+          <div class="box-content-row box-content-row-flex" appBoxRow>
+            <div class="row-main">
+              <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>
+              <input
+                *ngIf="showPassword"
+                id="loginTotp"
+                type="{{ cipher.viewPassword ? 'text' : 'password' }}"
+                name="Login.Totp"
+                class="monospaced"
+                [(ngModel)]="cipher.login.totp"
+                appInputVerbatim
+                [disabled]="!cipher.viewPassword"
+                [readonly]="!cipher.edit && editMode"
+              />
+              <div *ngIf="!showPassword" class="monospaced">
+                {{ cipher.login.maskedPassword }}
+              </div>
+            </div>
+            <div class="action-buttons">
+              <button
+                type="button"
+                class="row-btn"
+                appStopClick
+                appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                (click)="togglePassword()"
+                *ngIf="cipher.viewPassword"
+                [attr.aria-pressed]="showPassword"
+              >
+                <i
+                  class="bwi bwi-lg"
+                  aria-hidden="true"
+                  [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
+                ></i>
+              </button>
+            </div>
           </div>
         </div>
         <!-- Card -->

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -73,11 +73,11 @@
                 *ngIf="showPassword"
                 id="loginPassword"
                 class="monospaced"
-                type="{{ showPassword ? 'text' : 'password' }}"
+                type="text"
                 name="Login.Password"
                 [(ngModel)]="cipher.login.password"
                 appInputVerbatim
-                [disabled]="!cipher.viewPassword"
+                [disabled]="false"
                 [readonly]="!cipher.edit && editMode"
               />
               <div *ngIf="!showPassword" class="monospaced">
@@ -149,17 +149,17 @@
             <div class="row-main">
               <label for="loginTotp">{{ "authenticatorKeyTotp" | i18n }}</label>
               <input
-                *ngIf="showPassword"
+                *ngIf="showTotpSeed"
                 id="loginTotp"
-                type="{{ cipher.viewPassword ? 'text' : 'password' }}"
+                type="text"
                 name="Login.Totp"
                 class="monospaced"
                 [(ngModel)]="cipher.login.totp"
                 appInputVerbatim
-                [disabled]="!cipher.viewPassword"
+                [disabled]="false"
                 [readonly]="!cipher.edit && editMode"
               />
-              <div *ngIf="!showPassword" class="monospaced">
+              <div *ngIf="!showTotpSeed" class="monospaced">
                 {{ cipher.login.maskedPassword }}
               </div>
             </div>
@@ -169,14 +169,14 @@
                 class="row-btn"
                 appStopClick
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
-                (click)="togglePassword()"
+                (click)="toggleTotpSeed()"
                 *ngIf="cipher.viewPassword"
-                [attr.aria-pressed]="showPassword"
+                [attr.aria-pressed]="showTotpSeed"
               >
                 <i
                   class="bwi bwi-lg"
                   aria-hidden="true"
-                  [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
+                  [ngClass]="{ 'bwi-eye': !showTotpSeed, 'bwi-eye-slash': showTotpSeed }"
                 ></i>
               </button>
             </div>

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -63,6 +63,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   restorePromise: Promise<any>;
   checkPasswordPromise: Promise<number>;
   showPassword = false;
+  showTotpSeed = false;
   showCardNumber = false;
   showCardCode = false;
   cipherType = CipherType;
@@ -495,6 +496,17 @@ export class AddEditComponent implements OnInit, OnDestroy {
     if (this.editMode && this.showPassword) {
       this.eventCollectionService.collect(
         EventType.Cipher_ClientToggledPasswordVisible,
+        this.cipherId
+      );
+    }
+  }
+
+  toggleTotpSeed() {
+    this.showTotpSeed = !this.showTotpSeed;
+    document.getElementById("loginTotp").focus();
+    if (this.editMode && this.showTotpSeed) {
+      this.eventCollectionService.collect(
+        EventType.Cipher_ClientToggledTOTPSeedVisible,
         this.cipherId
       );
     }

--- a/libs/common/src/enums/event-type.enum.ts
+++ b/libs/common/src/enums/event-type.enum.ts
@@ -30,6 +30,7 @@ export enum EventType {
   Cipher_SoftDeleted = 1115,
   Cipher_Restored = 1116,
   Cipher_ClientToggledCardNumberVisible = 1117,
+  Cipher_ClientToggledTOTPSeedVisible = 1118,
 
   Collection_Created = 1300,
   Collection_Updated = 1301,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

TOTP seeds (visible in cipher edit mode) should be considered protected secrets just like login passwords, and should be masked until the user explicitly toggles their visibility. Additionally, masked passwords in edit mode should use a static length (should not reveal the length of the value).

This PR handles this update for the browser client (extension).

## Code changes

See comments

## Screenshots

### Before

https://github.com/bitwarden/clients/assets/1556494/26cf81e9-f4cc-42df-b646-1f3fc0d83c14

### After

https://github.com/bitwarden/clients/assets/1556494/9f4cb7b6-2ff4-4822-84e5-ff63c3ee4437
