### PR TITLE
[PM-1337] Hide Organization options for users without master password

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.component.html
@@ -1,9 +1,0 @@
-<a
-  class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main tw-no-underline hover:tw-bg-secondary-100 hover:tw-no-underline focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-  href="#"
-  appStopClick
-  (click)="submit(returnUri, true)"
->
-  <i class="bwi bwi-fw bwi-link" aria-hidden="true"></i>
-  {{ "linkSso" | i18n }}
-</a>

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.directive.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, Input } from "@angular/core";
+import { AfterContentInit, Directive, HostListener, Input } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 
 import { SsoComponent } from "@bitwarden/angular/auth/components/sso.component";
@@ -14,13 +14,18 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
 
-@Component({
-  selector: "app-link-sso",
-  templateUrl: "link-sso.component.html",
+@Directive({
+  selector: "[app-link-sso]",
 })
-export class LinkSsoComponent extends SsoComponent implements AfterContentInit {
+export class LinkSsoDirective extends SsoComponent implements AfterContentInit {
   @Input() organization: Organization;
   returnUri = "/settings/organizations";
+
+  @HostListener("click", ["$event"])
+  async onClick($event: MouseEvent) {
+    $event.preventDefault();
+    await this.submit(this.returnUri, true);
+  }
 
   constructor(
     platformUtilsService: PlatformUtilsService,

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
@@ -45,7 +45,10 @@
           {{ "unlinkSso" | i18n }}
         </button>
         <ng-template #linkSso>
-          <app-link-sso [organization]="organization"> </app-link-sso>
+          <a href="#" bitMenuItem app-link-sso [organization]="organization">
+            <i class="bwi bwi-fw bwi-link" aria-hidden="true"></i>
+            {{ "linkSso" | i18n }}
+          </a>
         </ng-template>
       </ng-container>
       <button *ngIf="showLeaveOrgOption" type="button" bitMenuItem (click)="leave(organization)">

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
@@ -19,7 +19,7 @@
       <button
         type="button"
         *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
-        class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+        bitMenuItem
         (click)="toggleResetPasswordEnrollment(organization)"
       >
         <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
@@ -28,7 +28,7 @@
       <button
         type="button"
         *ngIf="allowEnrollmentChanges(organization) && organization.resetPasswordEnrolled"
-        class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+        bitMenuItem
         (click)="toggleResetPasswordEnrollment(organization)"
       >
         <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
@@ -38,7 +38,7 @@
         <button
           type="button"
           *ngIf="organization.ssoBound; else linkSso"
-          class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+          bitMenuItem
           (click)="unlinkSso(organization)"
         >
           <i class="bwi bwi-fw bwi-chain-broken" aria-hidden="true"></i>
@@ -48,14 +48,9 @@
           <app-link-sso [organization]="organization"> </app-link-sso>
         </ng-template>
       </ng-container>
-      <button
-        *ngIf="showLeaveOrgOption"
-        type="button"
-        class="text-danger tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-        (click)="leave(organization)"
-      >
-        <i class="bwi bwi-fw bwi-sign-out" aria-hidden="true"></i>
-        {{ "leave" | i18n }}
+      <button *ngIf="showLeaveOrgOption" type="button" bitMenuItem (click)="leave(organization)">
+        <i class="bwi bwi-fw bwi-sign-out tw-text-danger" aria-hidden="true"></i>
+        <span class="tw-text-danger">{{ "leave" | i18n }}</span>
       </button>
     </div>
   </bit-menu>

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
@@ -1,54 +1,62 @@
-<ng-container *ngIf="!loaded">
-  <i
-    class="bwi bwi-spinner bwi-spin text-muted tw-m-2"
-    title="{{ 'loading' | i18n }}"
-    aria-hidden="true"
-  ></i>
-  <span class="sr-only">{{ "loading" | i18n }}</span>
-</ng-container>
-<div
-  *ngIf="loaded"
-  class="tw-flex tw-min-w-[200px] tw-max-w-[300px] tw-flex-col"
-  [appApiAction]="actionPromise"
->
-  <button
-    type="button"
-    *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
-    class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-    (click)="toggleResetPasswordEnrollment(organization)"
-  >
-    <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
-    {{ "enrollAccountRecovery" | i18n }}
+<ng-container *ngIf="!hideMenu">
+  <button type="button" [bitMenuTriggerFor]="optionsMenu" class="filter-options-icon">
+    <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
   </button>
-  <button
-    type="button"
-    *ngIf="allowEnrollmentChanges(organization) && organization.resetPasswordEnrolled"
-    class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-    (click)="toggleResetPasswordEnrollment(organization)"
-  >
-    <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
-    {{ "withdrawAccountRecovery" | i18n }}
-  </button>
-  <ng-container *ngIf="organization.useSso && organization.identifier">
-    <button
-      type="button"
-      *ngIf="organization.ssoBound; else linkSso"
-      class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-      (click)="unlinkSso(organization)"
+  <bit-menu class="filter-organization-options" #optionsMenu>
+    <ng-container *ngIf="!loaded">
+      <i
+        class="bwi bwi-spinner bwi-spin tw-m-2 tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+    </ng-container>
+    <div
+      *ngIf="loaded"
+      class="tw-flex tw-min-w-[200px] tw-max-w-[300px] tw-flex-col"
+      [appApiAction]="actionPromise"
     >
-      <i class="bwi bwi-fw bwi-chain-broken" aria-hidden="true"></i>
-      {{ "unlinkSso" | i18n }}
-    </button>
-    <ng-template #linkSso>
-      <app-link-sso [organization]="organization"> </app-link-sso>
-    </ng-template>
-  </ng-container>
-  <button
-    type="button"
-    class="text-danger tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
-    (click)="leave(organization)"
-  >
-    <i class="bwi bwi-fw bwi-sign-out" aria-hidden="true"></i>
-    {{ "leave" | i18n }}
-  </button>
-</div>
+      <button
+        type="button"
+        *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
+        class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+        (click)="toggleResetPasswordEnrollment(organization)"
+      >
+        <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
+        {{ "enrollAccountRecovery" | i18n }}
+      </button>
+      <button
+        type="button"
+        *ngIf="allowEnrollmentChanges(organization) && organization.resetPasswordEnrolled"
+        class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+        (click)="toggleResetPasswordEnrollment(organization)"
+      >
+        <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
+        {{ "withdrawAccountRecovery" | i18n }}
+      </button>
+      <ng-container *ngIf="showSsoOptions(organization)">
+        <button
+          type="button"
+          *ngIf="organization.ssoBound; else linkSso"
+          class="tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left !tw-text-main hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+          (click)="unlinkSso(organization)"
+        >
+          <i class="bwi bwi-fw bwi-chain-broken" aria-hidden="true"></i>
+          {{ "unlinkSso" | i18n }}
+        </button>
+        <ng-template #linkSso>
+          <app-link-sso [organization]="organization"> </app-link-sso>
+        </ng-template>
+      </ng-container>
+      <button
+        *ngIf="showLeaveOrgOption"
+        type="button"
+        class="text-danger tw-block tw-cursor-pointer tw-border-none tw-bg-background tw-px-4 tw-py-2 tw-text-left hover:tw-bg-secondary-100 focus:tw-z-50 focus:tw-bg-secondary-100 focus:tw-outline-none focus:tw-ring focus:tw-ring-primary-700 focus:tw-ring-offset-2 active:!tw-ring-0 active:!tw-ring-offset-0"
+        (click)="leave(organization)"
+      >
+        <i class="bwi bwi-fw bwi-sign-out" aria-hidden="true"></i>
+        {{ "leave" | i18n }}
+      </button>
+    </div>
+  </bit-menu>
+</ng-container>

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
@@ -1,7 +1,6 @@
 import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
 import { map, Subject, takeUntil } from "rxjs";
 
-import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationUserService } from "@bitwarden/common/abstractions/organization-user/organization-user.service";
 import { OrganizationUserResetPasswordEnrollmentRequest } from "@bitwarden/common/abstractions/organization-user/requests";
@@ -38,7 +37,6 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
     private apiService: ApiService,
     private syncService: SyncService,
     private policyService: PolicyService,
-    private modalService: ModalService,
     private logService: LogService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private organizationUserService: OrganizationUserService,

--- a/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
@@ -11,10 +11,7 @@ import {
   switchMap,
 } from "rxjs";
 
-import {
-  isMember,
-  OrganizationService,
-} from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -48,7 +45,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
   );
 
   organizationTree$: Observable<TreeNode<OrganizationFilter>> =
-    this.organizationService.organizations$.pipe(
+    this.organizationService.memberOrganizations$.pipe(
       switchMap((orgs) => this.buildOrganizationTree(orgs))
     );
 
@@ -139,7 +136,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     }
     if (orgs) {
       const orgNodes: TreeNode<OrganizationFilter>[] = [];
-      orgs.filter(isMember).forEach((org) => {
+      orgs.forEach((org) => {
         const orgCopy = org as OrganizationFilter;
         orgCopy.icon = "bwi-business";
         const node = new TreeNode<OrganizationFilter>(orgCopy, headNode, orgCopy.name);

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
@@ -98,16 +98,11 @@
               class="org-options bwi bwi-fw bwi-exclamation-triangle text-danger"
               [attr.aria-label]="'organizationIsDisabled' | i18n"
               appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
-            ></i
-            ><ng-container *ngIf="optionsInfo && !f.node.hideOptions"
-              ><button type="button" [bitMenuTriggerFor]="optionsMenu" class="filter-options-icon">
-                <i class="bwi bwi-ellipsis-v" aria-hidden="true"></i>
-              </button>
-              <bit-menu class="filter-organization-options" #optionsMenu>
-                <ng-container
-                  *ngComponentOutlet="optionsInfo.component; injector: createInjector(f.node)"
-                ></ng-container>
-              </bit-menu>
+            ></i>
+            <ng-container *ngIf="optionsInfo && !f.node.hideOptions">
+              <ng-container
+                *ngComponentOutlet="optionsInfo.component; injector: createInjector(f.node)"
+              ></ng-container>
             </ng-container>
           </span>
         </span>

--- a/apps/web/src/app/vault/individual-vault/vault-filter/vault-filter.module.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/vault-filter.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from "@angular/core";
 
 import { VaultFilterSharedModule } from "../../individual-vault/vault-filter/shared/vault-filter-shared.module";
 
-import { LinkSsoComponent } from "./components/link-sso.component";
+import { LinkSsoDirective } from "./components/link-sso.directive";
 import { OrganizationOptionsComponent } from "./components/organization-options.component";
 import { VaultFilterComponent } from "./components/vault-filter.component";
 import { VaultFilterService as VaultFilterServiceAbstraction } from "./services/abstractions/vault-filter.service";
@@ -10,7 +10,7 @@ import { VaultFilterService } from "./services/vault-filter.service";
 
 @NgModule({
   imports: [VaultFilterSharedModule],
-  declarations: [VaultFilterComponent, OrganizationOptionsComponent, LinkSsoComponent],
+  declarations: [VaultFilterComponent, OrganizationOptionsComponent, LinkSsoDirective],
   exports: [VaultFilterComponent],
   providers: [
     {


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Users using TDE or Key Connector without a master password should not be shown the menu option to leave an organization  as it would effectively lock them out of their account. This PR hides the option in that particular case and updates the organization menu options to use more of our current practices (also fixes some small bugs).  

## Code changes

#### `organization-options.component.html`

- Move the 3 dot menu button trigger into the options component so that it can have better control of hiding/showing the menu in cases where there are no actions available to the user. 
- Wrap the entire options component in a container that can be hidden if no actions are available.
- Update menu items to use the `bitMenuItem` directive instead of repeating the style with Tailwind classes.

#### `organization-options.component.ts`
- Switch to an observable pattern in `ngOnInit()`
- Update the `OptionsInput` to use an `Observable<OrganizationFilter>` instead of a normal `OrganizationFilter`.
  - This is necessary because the `OptionsComponent` is created dynamically which does not support data binding (only available in Angular 16). So, whenever the filter was updated the options component would become stale and out of sync until the page was refreshed. Now with an observable we can subscribe and the component will respond to any changes.
- Update `policies` to `resetPasswordPolicy?` as we only care about a single policy for the current organization, so it was unnecessary to repeatedly filter the list of policies; now its only done once in the subscribe body.

#### `individual-vault/vault-filter/shared/components/vault-filter-section.component.html|.ts`
- Remove `bitMenuTrigger` as its now internal to `organization-options.component`
- Create an observable for the current organization filter from `this.section.data$` and pass it into the injector used by `organization-options.component` 

#### `individual-vault/vault-filter/services/vault-filter.service.ts`
- Remove deprecate usage of `isMember` and use `memberOrganizations$` instead

#### `individual-vault/vault-filter/components/link-sso.directive.ts`
- Convert this component into a directive to avoid the need for an additional template. With the change to `bitMenuItems` it was a lot of extra boilerplate that wasn't necessary.

## Screenshots

#### User With TDE / KeyConnector and no MasterPassword
![image](https://github.com/bitwarden/clients/assets/8764515/8b8f847e-c69b-4329-ba80-333a0b75d12a)

#### Owner with MasterPassword
![image](https://github.com/bitwarden/clients/assets/8764515/6a268776-9e2c-40e1-8bf8-21ab1cb6fd1f)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
