### PR TITLE
Revert "[PM-4290] Add pop out warning on import page (#6645)"

### DIFF
--- a/apps/browser/src/popup/settings/settings.component.html
+++ b/apps/browser/src/popup/settings/settings.component.html
@@ -183,7 +183,10 @@
         (click)="import()"
       >
         <div class="row-main">{{ "importItems" | i18n }}</div>
-        <i class="bwi bwi-angle-right bwi-lg row-sub-icon" aria-hidden="true"></i>
+        <i
+          class="bwi bwi-external-link bwi-lg row-sub-icon bwi-rotate-270 bwi-fw"
+          aria-hidden="true"
+        ></i>
       </button>
       <button
         type="button"

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -474,7 +474,10 @@ export class SettingsComponent implements OnInit {
   }
 
   async import() {
-    this.router.navigate(["/import"]);
+    await this.router.navigate(["/import"]);
+    if (await BrowserApi.isPopupOpen()) {
+      this.popupUtilsService.popOut(window);
+    }
   }
 
   export() {

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.html
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.html
@@ -16,11 +16,9 @@
   </div>
 </header>
 <div tabindex="-1" class="tw-p-4">
-  <tools-file-popout-callout />
   <tools-import
     (formDisabled)="this.disabled = $event"
     (formLoading)="this.loading = $event"
     (onSuccessfulImport)="this.onSuccessfulImport($event)"
-    [hideFileSelector]="this.hideFileSelector"
   ></tools-import>
 </div>

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -1,13 +1,10 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
 import { ImportComponent } from "@bitwarden/importer/ui";
-
-import { FilePopoutCalloutComponent } from "../../components/file-popout-callout.component";
-import { FilePopoutUtilsService } from "../../services/file-popout-utils.service";
 
 @Component({
   templateUrl: "import-browser.component.html",
@@ -20,20 +17,13 @@ import { FilePopoutUtilsService } from "../../services/file-popout-utils.service
     AsyncActionsModule,
     ButtonModule,
     ImportComponent,
-    FilePopoutCalloutComponent,
   ],
 })
-export class ImportBrowserComponent implements OnInit {
+export class ImportBrowserComponent {
   protected disabled = false;
   protected loading = false;
 
-  protected hideFileSelector = false;
-
-  constructor(private router: Router, private filePopoutUtilsService: FilePopoutUtilsService) {}
-
-  ngOnInit(): void {
-    this.hideFileSelector = this.filePopoutUtilsService.showFilePopoutMessage(window);
-  }
+  constructor(private router: Router) {}
 
   protected async onSuccessfulImport(organizationId: string): Promise<void> {
     this.router.navigate(["/tabs/settings"]);

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -344,7 +344,7 @@
       and save the zip file.
     </ng-container>
   </bit-callout>
-  <bit-form-field *ngIf="!hideFileSelector">
+  <bit-form-field>
     <bit-label>{{ "selectImportFile" | i18n }}</bit-label>
     <div class="file-selector">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -120,8 +120,6 @@ export class ImportComponent implements OnInit, OnDestroy {
       });
   }
 
-  @Input() hideFileSelector: boolean;
-
   protected organization: Organization;
   protected destroy$ = new Subject<void>();
 


### PR DESCRIPTION
This reverts commit 8dc81b603dc56d666c05bed6d89998d186e7c7fe.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Revert the work done on #6645 as we've decided to always popout the import page. The generates a smoother experience with uploading files and also with the login flows for the new Lastpass importer (https://github.com/bitwarden/clients/pull/6541)

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **Revert "[PM-4290] Add pop out warning on import page -** https://github.com/bitwarden/clients/pull/6651/commits/cdfc1007899d5f005067bf929107de611144761e
  - This reverts commit https://github.com/bitwarden/clients/commit/8dc81b603dc56d666c05bed6d89998d186e7c7fe.
- **Change icon on Import items in browser-settings -** https://github.com/bitwarden/clients/pull/6651/commits/05f85237d69791084b1b8080bff5a9e6c3dd588f
  - Replace the bwi-angle-right icon with the bwi-external-link and rotate it
    - Box with arrow pointing to the top right indicates external link
    - Box with arrow pointing to the top left indicates popout window
 
## Screenshots
### Before
![image](https://github.com/bitwarden/clients/assets/2670567/8560a25c-58a4-46e9-bda6-b5f3b99f0abd)

### After
![image](https://github.com/bitwarden/clients/assets/2670567/0475ef2e-dec2-4dd8-bcc5-8b9c7c05588b)
 
## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-4290]: https://bitwarden.atlassian.net/browse/PM-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ