### PR TITLE
[BEEEP] Add `appsettings.json` Importer Option

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7287,5 +7287,8 @@
   },
   "passkeyNotCopiedAlert": {
     "message": "The passkey will not be copied to the cloned item. Do you want to continue cloning this item?"
+  },
+  "keySeperator": {
+    "message": "Key Seperator"
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/appsettings-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/appsettings-json.importer.ts
@@ -6,7 +6,7 @@ export class AppSettingsJsonSecretsManagerImporter extends JsonSecretsManagerImp
   constructor() {
     super(
       "appsettingsJson",
-      "AppSettings JSON",
+      "App Settings (json)",
       JSON.stringify(
         {
           key1: {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/appsettings-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/appsettings-json.importer.ts
@@ -6,7 +6,7 @@ export class AppSettingsJsonSecretsManagerImporter extends JsonSecretsManagerImp
   constructor() {
     super(
       "appsettingsJson",
-      "App Settings Json",
+      "AppSettings JSON",
       JSON.stringify(
         {
           key1: {
@@ -23,7 +23,7 @@ export class AppSettingsJsonSecretsManagerImporter extends JsonSecretsManagerImp
   buildOptions(organizationId: string): Promise<ImportOption[]> {
     const seperatorOption = new ImportOption({
       key: AppSettingsJsonSecretsManagerImporter.SeperatorKey,
-      label: "Key Seperator",
+      label: { key: "keySeperator" },
       value: ":",
       type: "textbox",
     });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
@@ -2,12 +2,22 @@ import { ImportData, JsonSecretsManagerImporter } from "./importer.abstraction";
 
 export class BitwardenJsonSecretsManagerImporter extends JsonSecretsManagerImporter {
   constructor() {
-    super("bitwardenJson", "Bitwarden (json)");
+    super(
+      "bitwardenJson",
+      "Bitwarden (json)",
+      JSON.stringify(
+        {
+          something: true,
+        },
+        null,
+        2
+      )
+    );
   }
 
   override createImportDataParsed(
     data: unknown,
-    _options: Record<symbol, string>
+    _options: Record<string, string>
   ): Promise<ImportData> {
     return Promise.resolve(data as ImportData);
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
@@ -1,0 +1,14 @@
+import { ImportData, JsonSecretsManagerImporter } from "./importer.abstraction";
+
+export class BitwardenJsonSecretsManagerImporter extends JsonSecretsManagerImporter {
+  constructor() {
+    super("bitwardenJson", "Bitwarden (json)");
+  }
+
+  override createImportDataParsed(
+    data: unknown,
+    _options: Record<symbol, string>
+  ): Promise<ImportData> {
+    return Promise.resolve(data as ImportData);
+  }
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts
@@ -7,7 +7,21 @@ export class BitwardenJsonSecretsManagerImporter extends JsonSecretsManagerImpor
       "Bitwarden (json)",
       JSON.stringify(
         {
-          something: true,
+          projects: [
+            {
+              id: "92ab8d56-73c9-4e4f-8b47-b0a100f1ad0b",
+              name: "Example Project",
+            },
+          ],
+          secrets: [
+            {
+              key: "MySecret",
+              value: "MyValue!",
+              note: "",
+              id: "6e590482-32a9-4e88-9960-466a4be2f105",
+              projectIds: [],
+            },
+          ],
         },
         null,
         2

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
@@ -1,0 +1,62 @@
+export type ImportData = {
+  projects: { id: string; name: string }[];
+  secrets: { id?: string; key: string; value: string; note?: string; projectIds: string[] }[];
+};
+
+export type Translation = {
+  key: string;
+  args?: (string | number)[];
+};
+
+export class ImportOption {
+  value: string | undefined;
+  key: symbol;
+  label: string | Translation;
+  required: boolean;
+  type: "textbox" | "dropdown";
+  options: { key: string; value: string }[];
+
+  constructor(options: {
+    value?: string;
+    key: symbol;
+    label: string | Translation;
+    required?: boolean;
+    type?: "textbox" | "dropdown";
+    options?: { key: string; value: string }[];
+  }) {
+    this.value = options.value;
+    this.key = options.key;
+    this.label = options.label;
+    this.required = options.required || false;
+    this.type = options.type || "textbox";
+    this.options = options.options || [];
+  }
+}
+
+export abstract class SecretsManagerImporter {
+  constructor(
+    readonly id: string,
+    readonly displayInfo: string | Translation,
+    readonly accept: string,
+    readonly placeholder: string = ""
+  ) {}
+  buildOptions(organizationId: string): Promise<ImportOption[]> {
+    return Promise.resolve([]);
+  }
+  abstract createImportData(data: string, options: Record<symbol, string>): Promise<ImportData>;
+}
+
+export abstract class JsonSecretsManagerImporter extends SecretsManagerImporter {
+  constructor(id: string, displayInfo: string | Translation) {
+    super(id, displayInfo, "application/JSON");
+  }
+
+  abstract createImportDataParsed(
+    data: unknown,
+    options: Record<symbol, string>
+  ): Promise<ImportData>;
+
+  override createImportData(data: string, options: Record<symbol, string>): Promise<ImportData> {
+    return this.createImportDataParsed(JSON.parse(data), options);
+  }
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
@@ -10,7 +10,7 @@ export type Translation = {
 
 export class ImportOption {
   value: string | undefined;
-  key: symbol;
+  key: string;
   label: string | Translation;
   required: boolean;
   type: "textbox" | "dropdown";
@@ -18,7 +18,7 @@ export class ImportOption {
 
   constructor(options: {
     value?: string;
-    key: symbol;
+    key: string;
     label: string | Translation;
     required?: boolean;
     type?: "textbox" | "dropdown";
@@ -43,20 +43,20 @@ export abstract class SecretsManagerImporter {
   buildOptions(organizationId: string): Promise<ImportOption[]> {
     return Promise.resolve([]);
   }
-  abstract createImportData(data: string, options: Record<symbol, string>): Promise<ImportData>;
+  abstract createImportData(data: string, options: Record<string, string>): Promise<ImportData>;
 }
 
 export abstract class JsonSecretsManagerImporter extends SecretsManagerImporter {
-  constructor(id: string, displayInfo: string | Translation) {
-    super(id, displayInfo, "application/JSON");
+  constructor(id: string, displayInfo: string | Translation, placeholder: string) {
+    super(id, displayInfo, "application/JSON", placeholder);
   }
 
   abstract createImportDataParsed(
     data: unknown,
-    options: Record<symbol, string>
+    options: Record<string, string>
   ): Promise<ImportData>;
 
-  override createImportData(data: string, options: Record<symbol, string>): Promise<ImportData> {
+  override createImportData(data: string, options: Record<string, string>): Promise<ImportData> {
     return this.createImportDataParsed(JSON.parse(data), options);
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts
@@ -5,7 +5,6 @@ export type ImportData = {
 
 export type Translation = {
   key: string;
-  args?: (string | number)[];
 };
 
 export class ImportOption {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
@@ -1,7 +1,5 @@
 import { NgModule, Type } from "@angular/core";
 
-import { ProjectService } from "../../projects/project.service";
-
 import { AppSettingsJsonSecretsManagerImporter } from "./appsettings-json.importer";
 import { BitwardenJsonSecretsManagerImporter } from "./bitwarden-json.importer";
 import { SecretsManagerImporter } from "./importer.abstraction";
@@ -10,14 +8,9 @@ function simpleImporters<T extends SecretsManagerImporter>(...types: Type<T>[]) 
   return types.map((t) => ({ provide: SecretsManagerImporter, useClass: t, multi: true }));
 }
 
-function depsImporter<T extends SecretsManagerImporter>(type: Type<T>, deps: unknown[]) {
-  return { provide: SecretsManagerImporter, useClass: type, multi: true, deps: deps };
-}
-
 @NgModule({
   providers: [
-    simpleImporters(BitwardenJsonSecretsManagerImporter),
-    depsImporter(AppSettingsJsonSecretsManagerImporter, [ProjectService]),
+    simpleImporters(BitwardenJsonSecretsManagerImporter, AppSettingsJsonSecretsManagerImporter),
   ],
 })
 export class ImporterModule {}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
@@ -2,9 +2,9 @@ import { NgModule, Type } from "@angular/core";
 
 import { ProjectService } from "../../projects/project.service";
 
+import { AppSettingsJsonSecretsManagerImporter } from "./appsettings-json.importer";
 import { BitwardenJsonSecretsManagerImporter } from "./bitwarden-json.importer";
 import { SecretsManagerImporter } from "./importer.abstraction";
-import { KeyValuePairJsonSecretsManagerImporter } from "./key-value-pair-json.importer";
 
 function simpleImporters<T extends SecretsManagerImporter>(...types: Type<T>[]) {
   return types.map((t) => ({ provide: SecretsManagerImporter, useClass: t, multi: true }));
@@ -17,7 +17,7 @@ function depsImporter<T extends SecretsManagerImporter>(type: Type<T>, deps: unk
 @NgModule({
   providers: [
     simpleImporters(BitwardenJsonSecretsManagerImporter),
-    depsImporter(KeyValuePairJsonSecretsManagerImporter, [ProjectService]),
+    depsImporter(AppSettingsJsonSecretsManagerImporter, [ProjectService]),
   ],
 })
 export class ImporterModule {}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.module.ts
@@ -1,0 +1,23 @@
+import { NgModule, Type } from "@angular/core";
+
+import { ProjectService } from "../../projects/project.service";
+
+import { BitwardenJsonSecretsManagerImporter } from "./bitwarden-json.importer";
+import { SecretsManagerImporter } from "./importer.abstraction";
+import { KeyValuePairJsonSecretsManagerImporter } from "./key-value-pair-json.importer";
+
+function simpleImporters<T extends SecretsManagerImporter>(...types: Type<T>[]) {
+  return types.map((t) => ({ provide: SecretsManagerImporter, useClass: t, multi: true }));
+}
+
+function depsImporter<T extends SecretsManagerImporter>(type: Type<T>, deps: unknown[]) {
+  return { provide: SecretsManagerImporter, useClass: type, multi: true, deps: deps };
+}
+
+@NgModule({
+  providers: [
+    simpleImporters(BitwardenJsonSecretsManagerImporter),
+    depsImporter(KeyValuePairJsonSecretsManagerImporter, [ProjectService]),
+  ],
+})
+export class ImporterModule {}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/key-value-pair-json.importer.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/key-value-pair-json.importer.ts
@@ -1,0 +1,126 @@
+import { ProjectService } from "../../projects/project.service";
+
+import { ImportData, ImportOption, JsonSecretsManagerImporter } from "./importer.abstraction";
+
+export class KeyValuePairJsonSecretsManagerImporter extends JsonSecretsManagerImporter {
+  static readonly SeperatorKey = Symbol("seperator");
+  static readonly ProjectKey = Symbol("project");
+
+  constructor(private projectService: ProjectService) {
+    super("keyValuePairJson", "Key Value Pair Json");
+  }
+
+  async buildOptions(organizationId: string): Promise<ImportOption[]> {
+    const projects = await this.projectService.getProjects(organizationId);
+    const options = projects.map((p) => ({ key: p.id, value: p.name }));
+    options.unshift({ key: "", value: "-- None --" });
+    const projectOption = new ImportOption({
+      key: KeyValuePairJsonSecretsManagerImporter.ProjectKey,
+      label: "Project",
+      value: null,
+      type: "dropdown",
+      options: options,
+    });
+
+    const seperatorOption = new ImportOption({
+      key: KeyValuePairJsonSecretsManagerImporter.SeperatorKey,
+      label: "Key Seperator",
+      value: ":",
+      type: "textbox",
+    });
+
+    return [projectOption, seperatorOption];
+  }
+
+  createImportDataParsed(data: unknown, options: Record<symbol, string>): Promise<ImportData> {
+    const seperator = options[KeyValuePairJsonSecretsManagerImporter.SeperatorKey] || ":";
+    const parser = new Parser(seperator);
+    const parsedData = parser.parse(data);
+
+    const projectId = options[KeyValuePairJsonSecretsManagerImporter.ProjectKey] || null;
+
+    const projectIdsArray = projectId != null && projectId != "" ? [projectId] : [];
+
+    return Promise.resolve({
+      secrets: Object.entries(parsedData).map(([key, value]) => ({
+        key: key,
+        value: value || "",
+        note: "",
+        projectIds: projectIdsArray,
+      })),
+      projects: [],
+    });
+  }
+}
+
+class Parser {
+  private data: Record<string, string | null> = {};
+  private paths: string[] = [];
+
+  constructor(private seperator: string) {}
+
+  parse(input: unknown): Record<string, string | null> {
+    if (typeof input !== "object") {
+      throw new Error("Top level json should be an object.");
+    }
+
+    this.visitObjectElement(input);
+
+    return this.data;
+  }
+
+  private visitObjectElement(element: object) {
+    let isEmpty = true;
+    for (const [key, value] of Object.entries(element)) {
+      isEmpty = false;
+      this.enterContext(key);
+      this.visitValue(value);
+      this.exitContext();
+    }
+    this.setNullIfElementIsEmpty(isEmpty);
+  }
+
+  private visitArrayElement(element: unknown[]) {
+    let i = 0;
+    for (; i < element.length; i++) {
+      this.enterContext(i.toString());
+      this.visitValue(element[i]);
+      this.exitContext();
+    }
+    this.setNullIfElementIsEmpty(i == 0);
+  }
+
+  private visitValue(value: unknown) {
+    if (typeof value === "object" && value != null) {
+      this.visitObjectElement(value);
+    } else if (Array.isArray(value)) {
+      this.visitArrayElement(value);
+    } else if (typeof value !== "function") {
+      // This should be what we consider a value
+      const key = this.paths[this.paths.length - 1];
+      if (value == null) {
+        this.data[key] = null;
+      } else {
+        this.data[key] = String(value);
+      }
+    } else {
+      throw new Error(`Unable to convert type ${typeof value} to a string value.`);
+    }
+  }
+
+  private setNullIfElementIsEmpty(isEmpty: boolean) {
+    if (isEmpty && this.paths.length > 0) {
+      this.data[this.paths[this.paths.length - 1]] = null;
+    }
+  }
+
+  private enterContext(context: string) {
+    this.paths.push(
+      this.paths.length > 0 ? this.paths[this.paths.length - 1] + this.seperator + context : context
+    );
+  }
+
+  private exitContext() {
+    this.paths.pop();
+  }
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.html
@@ -1,0 +1,7 @@
+<bit-form-field [formGroup]="form" [ngSwitch]="option.type">
+  <bit-label>{{ option.label }}</bit-label>
+  <input bitInput *ngSwitchCase="'textbox'" [formControlName]="key" [id]="key" type="text" />
+  <bit-select *ngSwitchCase="'dropdown'" [formControlName]="key" [id]="key">
+    <bit-option *ngFor="let opt of option.options" [value]="opt.key" [label]="opt.value" />
+  </bit-select>
+</bit-form-field>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.html
@@ -1,5 +1,5 @@
 <bit-form-field [formGroup]="form" [ngSwitch]="option.type">
-  <bit-label>{{ option.label }}</bit-label>
+  <bit-label>{{ label }}</bit-label>
   <input bitInput *ngSwitchCase="'textbox'" [formControlName]="key" [id]="key" type="text" />
   <bit-select *ngSwitchCase="'dropdown'" [formControlName]="key" [id]="key">
     <bit-option *ngFor="let opt of option.options" [value]="opt.key" [label]="opt.value" />

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input } from "@angular/core";
+import { FormGroup } from "@angular/forms";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { ImportOption } from "../importers/importer.abstraction";
+
+@Component({
+  selector: "sm-dynamic-import-option",
+  templateUrl: "./sm-dynamic-import-option.component.html",
+})
+export class SecretsManagerDynamicImportOptionComponent {
+  constructor(private i18nService: I18nService) {}
+
+  @Input()
+  option: ImportOption;
+
+  @Input()
+  form: FormGroup;
+
+  get key(): string {
+    return this.option.key.toString();
+  }
+
+  get label(): string {
+    return typeof this.option.label === "string"
+      ? this.option.label
+      : this.i18nService.t(this.option.label.key, ...this.option.label.args);
+  }
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.ts
@@ -25,6 +25,6 @@ export class SecretsManagerDynamicImportOptionComponent {
   get label(): string {
     return typeof this.option.label === "string"
       ? this.option.label
-      : this.i18nService.t(this.option.label.key, ...this.option.label.args);
+      : this.i18nService.t(this.option.label.key);
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
@@ -2,41 +2,63 @@
 
 <form [formGroup]="formGroup" [bitSubmit]="submit" class="tw-max-w-xl">
   <bit-form-field>
-    <bit-label>{{ "fileUpload" | i18n }}</bit-label>
-    <div class="file-selector">
-      <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
-        {{ "chooseFile" | i18n }}
-      </button>
-      {{ selectedFile?.name ?? ("noFileChosen" | i18n) }}
+    <bit-label>Importer</bit-label>
+    <bit-select
+      bitInput
+      id="selectedImporter"
+      name="Selected Importer"
+      required
+      formControlName="selectedImporter"
+    >
+      <bit-option
+        *ngFor="let i of selectableImporters"
+        [value]="i.value"
+        [label]="i.label"
+      ></bit-option>
+    </bit-select>
+  </bit-form-field>
+  <sm-dynamic-import-option
+    *ngFor="let option of selectedImporterOptions$ | async"
+    [option]="option"
+    [form]="formGroup.controls.importerOptions"
+  ></sm-dynamic-import-option>
+  <ng-container *ngIf="selectedImporter$ | async as selectedImporter">
+    <bit-form-field>
+      <bit-label>{{ "fileUpload" | i18n }}</bit-label>
+      <div class="file-selector">
+        <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
+          {{ "chooseFile" | i18n }}
+        </button>
+        {{ selectedFile?.name ?? ("noFileChosen" | i18n) }}
+      </div>
+      <input
+        #fileSelector
+        hidden
+        bitInput
+        type="file"
+        id="file"
+        class="form-control-file"
+        name="file"
+        (change)="setSelectedFile($event)"
+        [accept]="selectedImporter.accept"
+      />
+    </bit-form-field>
+    <div class="my-4">
+      {{ "or" | i18n }}
     </div>
-    <input
-      #fileSelector
-      hidden
-      bitInput
-      type="file"
-      id="file"
-      class="form-control-file"
-      name="file"
-      (change)="setSelectedFile($event)"
-      accept="application/JSON"
-    />
-    <bit-hint>{{ "acceptedFormats" | i18n }} Bitwarden (json)</bit-hint>
-  </bit-form-field>
-  <div class="my-4">
-    {{ "or" | i18n }}
-  </div>
-  <bit-form-field>
-    <bit-label for="pastedContents">{{ "copyPasteImportContents" | i18n }}</bit-label>
-    <textarea
-      bitInput
-      id="pastedContents"
-      class="form-control"
-      name="FileContents"
-      formControlName="pastedContents"
-    ></textarea>
-    <bit-hint>{{ "acceptedFormats" | i18n }} Bitwarden (json)</bit-hint>
-  </bit-form-field>
-  <button bitButton bitFormButton type="submit" buttonType="primary">
-    {{ "importData" | i18n }}
-  </button>
+    <bit-form-field>
+      <bit-label for="pastedContents">{{ "copyPasteImportContents" | i18n }}</bit-label>
+      <textarea
+        bitInput
+        id="pastedContents"
+        class="form-control"
+        name="FileContents"
+        formControlName="pastedContents"
+        [placeholder]="selectedImporter.placeholder"
+      ></textarea>
+    </bit-form-field>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      {{ "importData" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.ts
@@ -48,9 +48,7 @@ export class SecretsManagerImportComponent implements OnInit, OnDestroy {
 
   selectableImporters = this.importers.map((i) => ({
     label:
-      typeof i.displayInfo === "string"
-        ? i.displayInfo
-        : this.i18nService.t(i.displayInfo.key, ...i.displayInfo.args),
+      typeof i.displayInfo === "string" ? i.displayInfo : this.i18nService.t(i.displayInfo.key),
     value: i.id,
   }));
   selectedImporter$: Observable<SecretsManagerImporter>;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/settings.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/settings.module.ts
@@ -3,6 +3,8 @@ import { NgModule } from "@angular/core";
 import { SecretsManagerSharedModule } from "../shared/sm-shared.module";
 
 import { SecretsManagerImportErrorDialogComponent } from "./dialog/sm-import-error-dialog.component";
+import { ImporterModule } from "./importers/importer.module";
+import { SecretsManagerDynamicImportOptionComponent } from "./porting/sm-dynamic-import-option.component";
 import { SecretsManagerExportComponent } from "./porting/sm-export.component";
 import { SecretsManagerImportComponent } from "./porting/sm-import.component";
 import { SecretsManagerPortingApiService } from "./services/sm-porting-api.service";
@@ -10,10 +12,11 @@ import { SecretsManagerPortingService } from "./services/sm-porting.service";
 import { SettingsRoutingModule } from "./settings-routing.module";
 
 @NgModule({
-  imports: [SecretsManagerSharedModule, SettingsRoutingModule],
+  imports: [SecretsManagerSharedModule, SettingsRoutingModule, ImporterModule],
   declarations: [
     SecretsManagerImportComponent,
     SecretsManagerExportComponent,
+    SecretsManagerDynamicImportOptionComponent,
     SecretsManagerImportErrorDialogComponent,
   ],
   providers: [SecretsManagerPortingService, SecretsManagerPortingApiService],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds an importer option for importing general JSON into a series of key-value pairs. Example files that this importer is designed to handle can be found in our own [server repo](https://github.com/bitwarden/server/blob/728cd1c0b5eff982351cab7bab32a38caa66ef71/src/Api/appsettings.json). This is essentially a rewrite of how JSON configuration works in .NET ([see](https://github.com/dotnet/runtime/blob/5f653ddd5d9bc0544fbf3ff712244e3f5a398a9f/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs)). The only rule is that it has to be valid JSON with no comments and the top level node must be an object. 

https://github.com/bitwarden/clients/assets/19896123/1e36fc3d-88a1-403b-91e9-c02951c08081

I also took the opportunity to rework the code a bit to make it even easier to add additional importers. Another example could be a `.env` file format. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/appsettings-json.importer.ts:** The appsettings json importer including a helper parser class for reading any json content into key value pairs via a given separator. 
- **bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/bitwarden-json.importer.ts:** Boilerplate for the existing JSON importer.
- **bitwarden_license/bit-web/src/app/secrets-manager/settings/importers/importer.abstraction.ts:** Defines all the abstract types and classes that are needed to create a custom importer.
- **bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-dynamic-import-option.component.html:** Defines a component that can take an importer option and render the UI dynamically. Currently the only options it supports are text boxes and dropdowns but others could be added.
- **bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.ts:** Refactored to support dynamic importers.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
