### PR TITLE
[SM-996] Fix access removal dialog bug

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/models/view/access-policy.view.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/models/view/access-policy.view.ts
@@ -11,6 +11,7 @@ export class UserProjectAccessPolicyView extends BaseAccessPolicyView {
   organizationUserName: string;
   grantedProjectId: string;
   userId: string;
+  currentUser: boolean;
 }
 
 export class UserServiceAccountAccessPolicyView extends BaseAccessPolicyView {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
@@ -18,6 +18,7 @@ import {
   convertPotentialGranteesToApItemViewType,
   convertToAccessPolicyItemViews,
 } from "../../shared/access-policies/access-policy-selector/models/ap-item-view.type";
+import { ApItemEnum } from "../../shared/access-policies/access-policy-selector/models/enums/ap-item.enum";
 import { AccessPolicyService } from "../../shared/access-policies/access-policy.service";
 
 @Component({
@@ -148,6 +149,8 @@ export class ProjectPeopleComponent implements OnInit, OnDestroy {
           type: m.type,
           id: m.id,
           permission: m.permission,
+          currentUser: m.type == ApItemEnum.User ? m.currentUser : null,
+          currentUserInGroup: m.type == ApItemEnum.Group ? m.currentUserInGroup : null,
         })),
       });
     }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/models/ap-item-view.type.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/models/ap-item-view.type.ts
@@ -44,6 +44,7 @@ export function convertToAccessPolicyItemViews(
       listName: policy.organizationUserName,
       permission: ApPermissionEnumUtil.toApPermissionEnum(policy.read, policy.write),
       userId: policy.userId,
+      currentUser: policy.currentUser,
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy.service.ts
@@ -369,6 +369,7 @@ export class AccessPolicyService {
       organizationUserId: response.organizationUserId,
       organizationUserName: response.organizationUserName,
       userId: response.userId,
+      currentUser: response.currentUser,
     };
   }
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/models/responses/access-policy.response.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/models/responses/access-policy.response.ts
@@ -22,6 +22,7 @@ export class UserProjectAccessPolicyResponse extends BaseAccessPolicyResponse {
   organizationUserName: string;
   grantedProjectId: string;
   userId: string;
+  currentUser: boolean;
 
   constructor(response: any) {
     super(response);
@@ -29,6 +30,7 @@ export class UserProjectAccessPolicyResponse extends BaseAccessPolicyResponse {
     this.organizationUserName = this.getResponseProperty("OrganizationUserName");
     this.grantedProjectId = this.getResponseProperty("GrantedProjectId");
     this.userId = this.getResponseProperty("UserId");
+    this.currentUser = this.getResponseProperty("CurrentUser");
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to fix an access removal dialog bug that occurs when initially landing on the page without making changes.
When patching the form group value, `currentUser` and `currentUserInGroup` properties need to be set.


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/models/view/access-policy.view.ts:** 
Add `currentUser` to the view, so the property can be set on the access policy selector form group.

- **bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts:**
Add code to setting `currentUser` and `currentUserInGroup` during form group patch.

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/models/ap-item-view.type.ts:**
Add `currentUser` in model conversion.

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy.service.ts:**
Add `currentUser` in response to view conversion.

- **bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/models/responses/access-policy.response.ts:**
Add `currentUser` in response model.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
