### PR TITLE
[PM-4401] fix: wait for focus before triggering fallback

### DIFF
--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -141,12 +141,39 @@ navigator.credentials.get = async (
   }
 };
 
-function waitForFocus() {
+/**
+ * Wait for window to be focused.
+ * Safari doesn't allow scripts to trigger webauthn when window is not focused.
+ *
+ * @param timeout Maximum time to wait for focus in milliseconds. Defaults to 5 minutes.
+ * @returns Promise that resolves when window is focused, or rejects if timeout is reached.
+ */
+async function waitForFocus(timeout: number = 5 * 60 * 1000) {
   if (document.hasFocus()) {
     return;
   }
 
-  return new Promise<void>((resolve) => {
-    window.addEventListener("focus", () => resolve(), { once: true });
+  let focusListener;
+  const focusPromise = new Promise<void>((resolve) => {
+    focusListener = () => resolve();
+    window.addEventListener("focus", focusListener, { once: true });
   });
+
+  let timeoutId;
+  const timeoutPromise = new Promise<void>((_, reject) => {
+    timeoutId = window.setTimeout(
+      () =>
+        reject(
+          new DOMException("The operation either timed out or was not allowed.", "AbortError")
+        ),
+      timeout
+    );
+  });
+
+  try {
+    await Promise.race([focusPromise, timeoutPromise]);
+  } finally {
+    window.removeEventListener("focus", focusListener);
+    window.clearTimeout(timeoutId);
+  }
 }

--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -94,6 +94,7 @@ navigator.credentials.create = async (
     return WebauthnUtils.mapCredentialRegistrationResult(response.result);
   } catch (error) {
     if (error && error.fallbackRequested && fallbackSupported) {
+      await waitForFocus();
       return await browserCredentials.create(options);
     }
 
@@ -132,9 +133,20 @@ navigator.credentials.get = async (
     return WebauthnUtils.mapCredentialAssertResult(response.result);
   } catch (error) {
     if (error && error.fallbackRequested && fallbackSupported) {
+      await waitForFocus();
       return await browserCredentials.get(options);
     }
 
     throw error;
   }
 };
+
+function waitForFocus() {
+  if (document.hasFocus()) {
+    return;
+  }
+
+  return new Promise<void>((resolve) => {
+    window.addEventListener("focus", () => resolve(), { once: true });
+  });
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Race condition causes safari to try to request native webauthn before the window has gotten focus back, resulting in an error. This fix waits for focus before triggering the request

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
