### PR TITLE
[PM-4510] LP importer disable parseSecureNotesToAccount

### DIFF
--- a/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
@@ -137,7 +137,9 @@ export class LastPassDirectImportService {
     includeSharedFolders: boolean
   ): Promise<string> {
     const clientInfo = await this.createClientInfo(email);
-    await this.vault.open(email, password, clientInfo, this.lastPassDirectImportUIService);
+    await this.vault.open(email, password, clientInfo, this.lastPassDirectImportUIService, {
+      parseSecureNotesToAccount: false,
+    });
 
     return this.vault.accountsToExportedCsvString(!includeSharedFolders);
   }
@@ -159,7 +161,9 @@ export class LastPassDirectImportService {
     federatedUser.username = userState.email;
 
     const clientInfo = await this.createClientInfo(federatedUser.username);
-    await this.vault.openFederated(federatedUser, clientInfo, this.lastPassDirectImportUIService);
+    await this.vault.openFederated(federatedUser, clientInfo, this.lastPassDirectImportUIService, {
+      parseSecureNotesToAccount: false,
+    });
 
     return this.vault.accountsToExportedCsvString(!includeSharedFolders);
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The fixes an issue where the direct LP importer only imports login ciphers, but not types like credit cards, identities, etc. The change here brings [parity with the standalone importer tool.](https://github.com/bitwarden/importer/blob/master/src/Importer/Services/LastPass/LastPassImportService.cs#L37)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/importer/src/components/lastpass/lastpass-direct-import.service.ts:** Set `parseSecureNotesToAccount` to false

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
