### PR TITLE
[PM-4433] fix scrolling in browser importer

### DIFF
--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.html
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.html
@@ -15,10 +15,12 @@
     </button>
   </div>
 </header>
-<div tabindex="-1" class="tw-p-4">
-  <tools-import
-    (formDisabled)="this.disabled = $event"
-    (formLoading)="this.loading = $event"
-    (onSuccessfulImport)="this.onSuccessfulImport($event)"
-  ></tools-import>
-</div>
+<main tabindex="-1">
+  <div class="tw-p-4">
+    <tools-import
+      (formDisabled)="this.disabled = $event"
+      (formLoading)="this.loading = $event"
+      (onSuccessfulImport)="this.onSuccessfulImport($event)"
+    ></tools-import>
+  </div>
+</main>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The importer on browser does not allow scrolling of overflow content. This PR fixes that by adding a `main` element, which is expected on browser extension page components. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/tools/popup/settings/import/import-browser.component.html:** Add `main` element

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/17113462/687bd15f-0eb2-49a8-b89e-4db649f15023


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
