### PR TITLE
[PM-4406] fix bit-select popover not visible on zoomed browser extension

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,6 +5,8 @@ import type { Preview } from "@storybook/angular";
 import docJson from "../documentation.json";
 setCompodocJson(docJson);
 
+document.body.classList.add("bit-select-container");
+
 const decorator = componentWrapperDecorator(
   (story) => {
     return `

--- a/libs/components/src/multi-select/multi-select.component.html
+++ b/libs/components/src/multi-select/multi-select.component.html
@@ -17,7 +17,7 @@
   [clearSearchOnAdd]="true"
   [labelForId]="labelForId"
   [keyDownFn]="keyDown"
-  appendTo="app-root"
+  appendTo="app-root, .bit-select-container"
 >
   <ng-template ng-loadingspinner-tmp>
     <i class="bwi bwi-spinner bwi-spin tw-mr-1" [title]="loadingText" aria-hidden="true"></i>

--- a/libs/components/src/multi-select/multi-select.component.html
+++ b/libs/components/src/multi-select/multi-select.component.html
@@ -17,7 +17,7 @@
   [clearSearchOnAdd]="true"
   [labelForId]="labelForId"
   [keyDownFn]="keyDown"
-  appendTo="body"
+  appendTo="app-root"
 >
   <ng-template ng-loadingspinner-tmp>
     <i class="bwi bwi-spinner bwi-spin tw-mr-1" [title]="loadingText" aria-hidden="true"></i>

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -7,7 +7,7 @@
   (blur)="onBlur()"
   [labelForId]="labelForId"
   [clearable]="false"
-  appendTo="body"
+  appendTo="app-root"
 >
   <ng-template ng-option-tmp let-item="item">
     <div class="tw-flex">

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -7,7 +7,7 @@
   (blur)="onBlur()"
   [labelForId]="labelForId"
   [clearable]="false"
-  appendTo="app-root"
+  appendTo="app-root, .bit-select-container"
 >
   <ng-template ng-option-tmp let-item="item">
     <div class="tw-flex">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes an issue where the dropdown for `bit-select` and `bit-multi-select` was not visible on a browser extension page with zoom greater than 100%. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/multi-select/multi-select.component.html:** set `appendTo` to `"app-root"`
- **libs/components/src/select/select.component.html:** set `appendTo` to `"app-root"`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
