### PR TITLE
[PM-105] Premium Badge Send File

### DIFF
--- a/apps/web/src/app/tools/send/add-edit.component.html
+++ b/apps/web/src/app/tools/send/add-edit.component.html
@@ -25,9 +25,7 @@
       </bit-form-field>
       <div class="tw-flex" *ngIf="!editMode">
         <bit-radio-group formControlName="type">
-          <div class="tw-mb-4">
-            <bit-label>{{ "whatTypeOfSend" | i18n }}</bit-label>
-          </div>
+          <bit-label>{{ "whatTypeOfSend" | i18n }}</bit-label>
 
           <bit-radio-button
             *ngFor="let o of typeOptions"

--- a/apps/web/src/app/tools/send/add-edit.component.html
+++ b/apps/web/src/app/tools/send/add-edit.component.html
@@ -25,15 +25,24 @@
       </bit-form-field>
       <div class="tw-flex" *ngIf="!editMode">
         <bit-radio-group formControlName="type">
-          <bit-label>{{ "whatTypeOfSend" | i18n }}</bit-label>
+          <div class="tw-mb-4">
+            <bit-label>{{ "whatTypeOfSend" | i18n }}</bit-label>
+          </div>
 
           <bit-radio-button
             *ngFor="let o of typeOptions"
             id="type_{{ o.value }}"
             class="tw-block"
             [value]="o.value"
+            [disabled]="!canAccessPremium && o.premium"
           >
-            <bit-label>{{ o.name }}</bit-label>
+            <bit-label>
+              {{ o.name }}
+              <app-premium-badge
+                class="tw-mx-1"
+                *ngIf="!canAccessPremium && o.premium"
+              ></app-premium-badge>
+            </bit-label>
           </bit-radio-button>
         </bit-radio-group>
       </div>

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -118,8 +118,8 @@ export class AddEditComponent implements OnInit, OnDestroy {
     protected formBuilder: FormBuilder
   ) {
     this.typeOptions = [
-      { name: i18nService.t("sendTypeFile"), value: SendType.File },
-      { name: i18nService.t("sendTypeText"), value: SendType.Text },
+      { name: i18nService.t("sendTypeFile"), value: SendType.File, premium: true },
+      { name: i18nService.t("sendTypeText"), value: SendType.Text, premium: false },
     ];
     this.sendLinkBaseUrl = this.environmentService.getSendUrl();
   }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In the send item popup add a premium badge to the File option and disable it's selection.

## Code changes

- **libs/angular/src/tools/send/add-edit.component.ts:** For the typeOptions items I added a new property for premium. Set the File type to true and the Text type to false. 
- **apps/web/src/app/tools/send/add-edit.component.html:** Added the app-premium-badge component to the radio group label and to display if the user does not have premium and if the current typeOption is a premium option. The radio button is also disabled if the user does not have premium and if the typeOption is a premium option. 

## Screenshots

![image](https://github.com/bitwarden/clients/assets/144813356/b94e4028-e0d4-49b3-bdd6-a9980f33421e)
