### PR TITLE
[AC-1757] ConfigService dependency fix

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -80,7 +80,7 @@
           [showGroups]="showGroups"
           [organizations]="allOrganizations"
           [groups]="allGroups"
-          [canDeleteCollection]="canDeleteCollection(item.collection) | async"
+          [canDeleteCollection]="canDeleteCollection(item.collection)"
           [canEditCollection]="canEditCollection(item.collection)"
           [checked]="selection.isSelected(item)"
           (checkedToggled)="selection.toggle(item)"

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -1,6 +1,4 @@
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { CollectionAccessDetailsResponse } from "@bitwarden/common/src/vault/models/response/collection.response";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 
@@ -37,11 +35,8 @@ export class CollectionAdminView extends CollectionView {
     return org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
   }
 
-  override async canDelete(
-    org: Organization,
-    configService: ConfigServiceAbstraction
-  ): Promise<boolean> {
-    if (await configService.getFeatureFlag(FeatureFlag.FlexibleCollections)) {
+  override canDelete(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
+    if (flexibleCollectionsEnabled) {
       return org?.canDeleteAnyCollection;
     } else {
       return org?.canDeleteAnyCollection || (org?.canDeleteAssignedCollections && this.assigned);

--- a/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.html
@@ -28,9 +28,7 @@
         aria-hidden="true"
       ></i>
       <span>{{ title }}</span>
-      <ng-container
-        *ngIf="collection !== undefined && (canEditCollection || canDeleteCollection())"
-      >
+      <ng-container *ngIf="collection !== undefined && (canEditCollection || canDeleteCollection)">
         <button
           bitIconButton="bwi-angle-down"
           [bitMenuTriggerFor]="editCollectionMenu"
@@ -59,7 +57,7 @@
           </button>
           <button
             type="button"
-            *ngIf="canDeleteCollection()"
+            *ngIf="canDeleteCollection"
             bitMenuItem
             (click)="deleteCollection()"
           >

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -27,9 +27,7 @@
         aria-hidden="true"
       ></i>
       <span>{{ title }}</span>
-      <ng-container
-        *ngIf="collection !== undefined && (canEditCollection || canDeleteCollection())"
-      >
+      <ng-container *ngIf="collection !== undefined && (canEditCollection || canDeleteCollection)">
         <button
           bitIconButton="bwi-angle-down"
           [bitMenuTriggerFor]="editCollectionMenu"
@@ -58,7 +56,7 @@
           </button>
           <button
             type="button"
-            *ngIf="canDeleteCollection()"
+            *ngIf="canDeleteCollection"
             bitMenuItem
             (click)="deleteCollection()"
           >

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -1,8 +1,6 @@
 import { Organization } from "../../../admin-console/models/domain/organization";
-import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ITreeNodeObject } from "../../../models/domain/tree-node";
 import { View } from "../../../models/view/view";
-import { ConfigServiceAbstraction } from "../../../platform/abstractions/config/config.service.abstraction";
 import { Collection } from "../domain/collection";
 import { CollectionAccessDetailsResponse } from "../response/collection.response";
 
@@ -44,14 +42,14 @@ export class CollectionView implements View, ITreeNodeObject {
   }
 
   // For deleting a collection, not the items within it.
-  async canDelete(org: Organization, configService: ConfigServiceAbstraction): Promise<boolean> {
+  canDelete(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
     if (org.id !== this.organizationId) {
       throw new Error(
         "Id of the organization provided does not match the org id of the collection."
       );
     }
 
-    if (await configService.getFeatureFlag(FeatureFlag.FlexibleCollections)) {
+    if (flexibleCollectionsEnabled) {
       return org?.canDeleteAnyCollection || (!org?.limitCollectionCreationDeletion && this.manage);
     } else {
       return org?.canDeleteAnyCollection || org?.canDeleteAssignedCollections;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Lift the `ConfigService` dependency to the parent component in order to alleviate the need for all chained functions to be `async`

## Code changes
- **.../vault/components/vault-items/vault-items.component.html**: Removed `async` pipe
- **.../vault/components/vault-items/vault-items.component.ts**: Elevated `ConfigService` call to `ngOnInit` and passed in boolean result to the view
- **.../vault/core/views/collection-admin.view.ts**: Removed `async` from function and changed parameter to a boolean
- **.../vault/individual-vault/vault-header/vault-header.component.html**: Reverted changes to grab data using the `get` function
- **.../vault/individual-vault/vault-header/vault-header.component.ts**: Elevated `ConfigService` call to `ngOnInit` and passed in boolean result to the view
- **.../vault/org-vault/vault-header/vault-header.component.html**: Reverted changes to grab data using the `get` function
- **.../vault/org-vault/vault-header/vault-header.component.ts**: Elevated `ConfigService` call to `ngOnInit` and passed in boolean result to the view
- **libs/common/src/vault/models/view/collection.view.ts**: Removed `async` from function and changed parameter to a boolean

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
