### PR TITLE
[PM-4508] add YubiKey specific copy to LastPass import mfa dialog

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2674,5 +2674,8 @@
   },
   "collection": {
     "message": "Collection"
+  },
+  "lastPassYubikeyDesc": {
+    "message": "Insert the YubiKey associated with your LastPass account into your computer's USB port, then touch its button."
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2602,5 +2602,8 @@
   },
   "collection": {
     "message": "Collection"
+  },
+  "lastPassYubikeyDesc": {
+    "message": "Insert the YubiKey associated with your LastPass account into your computer's USB port, then touch its button."
   }
 }

--- a/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.html
+++ b/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.html
@@ -5,7 +5,7 @@
     </span>
 
     <div bitDialogContent>
-      <p>{{ description | i18n }}</p>
+      <p>{{ descriptionI18nKey | i18n }}</p>
       <bit-form-field class="!tw-mb-0">
         <bit-label>{{ "passcode" | i18n }}</bit-label>
         <input bitInput type="text" formControlName="passcode" appAutofocus appInputVerbatim />

--- a/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.ts
+++ b/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.ts
@@ -14,8 +14,10 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 
+export type LastPassMultifactorPromptVariant = "otp" | "oob" | "yubikey";
+
 type LastPassMultifactorPromptData = {
-  isOOB?: boolean;
+  variant: LastPassMultifactorPromptVariant;
 };
 
 @Component({
@@ -34,7 +36,19 @@ type LastPassMultifactorPromptData = {
   ],
 })
 export class LastPassMultifactorPromptComponent {
-  protected description = this.data?.isOOB ? "lastPassOOBDesc" : "lastPassMFADesc";
+  private variant = this.data.variant;
+
+  protected get descriptionI18nKey(): string {
+    switch (this.variant) {
+      case "oob":
+        return "lastPassOOBDesc";
+      case "yubikey":
+        return "lastPassYubikeyDesc";
+      case "otp":
+      default:
+        return "lastPassMFADesc";
+    }
+  }
 
   protected formGroup = new FormGroup({
     passcode: new FormControl("", {
@@ -56,7 +70,7 @@ export class LastPassMultifactorPromptComponent {
     this.dialogRef.close(this.formGroup.value.passcode);
   };
 
-  static open(dialogService: DialogService, data?: LastPassMultifactorPromptData) {
+  static open(dialogService: DialogService, data: LastPassMultifactorPromptData) {
     return dialogService.open<string>(LastPassMultifactorPromptComponent, { data });
   }
 }

--- a/libs/importer/src/components/lastpass/lastpass-direct-import-ui.service.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import-ui.service.ts
@@ -8,6 +8,10 @@ import { OtpResult, OobResult } from "../../importers/lastpass/access/models";
 import { Ui } from "../../importers/lastpass/access/ui";
 
 import { LastPassMultifactorPromptComponent } from "./dialog";
+import { LastPassMultifactorPromptVariant } from "./dialog/lastpass-multifactor-prompt.component";
+
+type OtpDialogVariant = Extract<LastPassMultifactorPromptVariant, "otp" | "yubikey">;
+type OobDialogVariant = Extract<LastPassMultifactorPromptVariant, "oob">;
 
 @Injectable({
   providedIn: "root",
@@ -17,18 +21,21 @@ export class LastPassDirectImportUIService implements Ui {
 
   constructor(private dialogService: DialogService) {}
 
-  private async getOTPResult() {
-    this.mfaDialogRef = LastPassMultifactorPromptComponent.open(this.dialogService);
-    const passcode = await firstValueFrom(this.mfaDialogRef.closed);
+  private async getOTPResult(variant: OtpDialogVariant) {
+    const passcode = await this.openMFADialog(variant);
     return new OtpResult(passcode, false);
   }
 
-  private async getOOBResult() {
-    this.mfaDialogRef = LastPassMultifactorPromptComponent.open(this.dialogService, {
-      isOOB: true,
-    });
-    const passcode = await firstValueFrom(this.mfaDialogRef.closed);
+  private async getOOBResult(variant: OobDialogVariant) {
+    const passcode = await this.openMFADialog(variant);
     return new OobResult(false, passcode, false);
+  }
+
+  private openMFADialog(variant: LastPassMultifactorPromptVariant) {
+    this.mfaDialogRef = LastPassMultifactorPromptComponent.open(this.dialogService, {
+      variant,
+    });
+    return firstValueFrom(this.mfaDialogRef.closed);
   }
 
   closeMFADialog() {
@@ -36,24 +43,24 @@ export class LastPassDirectImportUIService implements Ui {
   }
 
   async provideGoogleAuthPasscode() {
-    return this.getOTPResult();
+    return this.getOTPResult("otp");
   }
 
   async provideMicrosoftAuthPasscode() {
-    return this.getOTPResult();
+    return this.getOTPResult("otp");
   }
 
   async provideYubikeyPasscode() {
-    return this.getOTPResult();
+    return this.getOTPResult("yubikey");
   }
 
   async approveLastPassAuth() {
-    return this.getOOBResult();
+    return this.getOOBResult("oob");
   }
   async approveDuo() {
-    return this.getOOBResult();
+    return this.getOOBResult("oob");
   }
   async approveSalesforceAuth() {
-    return this.getOOBResult();
+    return this.getOOBResult("oob");
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Updates the `lastpass-multifactor-prompt.component` to handle different _variants._ Adds a variant for YubiKey authentication (so the dialog shows relevant copy when using a YubiKey as opposed to an authenticator app).
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **messages.json:** Add new entry to desktop and browser
- **libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component:** Add `variant` dialog data field; base the dialog copy off of it
- **libs/importer/src/components/lastpass/lastpass-direct-import-ui.service.ts:** Open different dialog variants based on the calling context

## Screenshots

<img width="563" alt="Screenshot 2023-10-24 at 5 36 56 PM" src="https://github.com/bitwarden/clients/assets/17113462/abe335b7-7abb-491f-bf6c-4c85c2bd8357">


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
