### PR TITLE
[PM-4509] submit LP importer on enter keydown

### DIFF
--- a/libs/importer/src/components/lastpass/import-lastpass.component.html
+++ b/libs/importer/src/components/lastpass/import-lastpass.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="formGroup" (keydown.enter)="$event.preventDefault()">
+<div [formGroup]="formGroup">
   <bit-form-field>
     <bit-label>{{ "lastPassEmail" | i18n }}</bit-label>
     <input bitInput type="text" formControlName="email" />
@@ -13,4 +13,4 @@
     />
     <bit-label>{{ "includeSharedFolders" | i18n }}</bit-label>
   </bit-form-control>
-</form>
+</div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a bug where the LP importer form fields wouldn't submit if `enter` was pressed.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/importer/src/components/lastpass/import-lastpass.component.html:** Removed a keydown handler that was preventing the default submit action. This was originally added to prevent the default form submit behavior of refreshing the page--but this is also remedied by removing the `form` element entirely. It isn't needed since this component is used within a larger `form`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->


https://github.com/bitwarden/clients/assets/17113462/6ea13fb1-e68b-4b21-bb92-a2805d7d1c26



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
