### PR TITLE
Handle active user not logged in

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -173,7 +173,18 @@ export class StateService<
       await this.pushAccounts();
       this.activeAccountSubject.next(state.activeUserId);
       // TODO: Temporary update to avoid routing all account status changes through account service for now.
+      // account service tracks logged out accounts, but State service does not, so we need to add the active account
+      // if it's not in the accounts list.
+      if (this.accountsSubject.value[state.activeUserId] == null) {
+        const activeDiskAccount = await this.getAccountFromDisk({ userId: state.activeUserId });
+        this.accountService.addAccount(state.activeUserId as UserId, {
+          name: activeDiskAccount.profile.name,
+          email: activeDiskAccount.profile.email,
+          status: AuthenticationStatus.LoggedOut,
+        });
+      }
       this.accountService.switchAccount(state.activeUserId as UserId);
+      // End TODO
 
       return state;
     });


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This is a partial fix to `account does not exist` errors experienced from #6622. This occurs when all users are logged out, we use the last logged in user as the active user to indicate which settings should be loaded by default.

This is a partial fix to PM-4515. We still experience null accounts in the stateService, but this is no longer due to account service by what I can tell.

## Code changes

- **stateService**: detect when an active account is not in the authed accounts list (by its abscence in the `accounts` subject) and add to accountService prior to switching. This should only occur at initialization so no changes to the `setActiveUser` method, as `addAccount` should be called prior to setting active User.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
