### PR TITLE
[PM-4358] No longer prompt for user verification when "preferred" is supplied by the Relying Party

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -365,7 +365,6 @@ function mapToMakeCredentialParams({
 
   const requireUserVerification =
     params.authenticatorSelection?.userVerification === "required" ||
-    params.authenticatorSelection?.userVerification === "preferred" ||
     params.authenticatorSelection?.userVerification === undefined;
 
   return {
@@ -404,9 +403,7 @@ function mapToGetAssertionParams({
     }));
 
   const requireUserVerification =
-    params.userVerification === "required" ||
-    params.userVerification === "preferred" ||
-    params.userVerification === undefined;
+    params.userVerification === "required" || params.userVerification === undefined;
 
   return {
     rpId: params.rpId,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/6617/, we added a check to require user verification if the relying party supplied a `preferred` status, or if it was `undefined`.  After discussion with Product, they felt that this was too restrictive and we should not require it on `preferred`.

## Code changes

- **fido2-client.service.ts:** Removed `preferred` from UV check.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
