### PR TITLE
[PM-4553] [Defect] Browser fallback fails on first click on bitwarden

### DIFF
--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -149,14 +149,14 @@ navigator.credentials.get = async (
  * @returns Promise that resolves when window is focused, or rejects if timeout is reached.
  */
 async function waitForFocus(timeout: number = 5 * 60 * 1000) {
-  if (window.parent.document.hasFocus()) {
+  if (window.top.document.hasFocus()) {
     return;
   }
 
   let focusListener;
   const focusPromise = new Promise<void>((resolve) => {
     focusListener = () => resolve();
-    window.parent.addEventListener("focus", focusListener, { once: true });
+    window.top.addEventListener("focus", focusListener, { once: true });
   });
 
   let timeoutId;
@@ -173,7 +173,7 @@ async function waitForFocus(timeout: number = 5 * 60 * 1000) {
   try {
     await Promise.race([focusPromise, timeoutPromise]);
   } finally {
-    window.parent.removeEventListener("focus", focusListener);
+    window.top.removeEventListener("focus", focusListener);
     window.clearTimeout(timeoutId);
   }
 }

--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -149,14 +149,14 @@ navigator.credentials.get = async (
  * @returns Promise that resolves when window is focused, or rejects if timeout is reached.
  */
 async function waitForFocus(timeout: number = 5 * 60 * 1000) {
-  if (document.hasFocus()) {
+  if (window.parent.document.hasFocus()) {
     return;
   }
 
   let focusListener;
   const focusPromise = new Promise<void>((resolve) => {
     focusListener = () => resolve();
-    window.addEventListener("focus", focusListener, { once: true });
+    window.parent.addEventListener("focus", focusListener, { once: true });
   });
 
   let timeoutId;
@@ -173,7 +173,7 @@ async function waitForFocus(timeout: number = 5 * 60 * 1000) {
   try {
     await Promise.race([focusPromise, timeoutPromise]);
   } finally {
-    window.removeEventListener("focus", focusListener);
+    window.parent.removeEventListener("focus", focusListener);
     window.clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix an issue where `waitForFocus` is running inside of the iframe and so never reacts to the parent window receiving focus.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
