### PR TITLE
[PM-4358] Do not require user verification on passkey when relying party does not supply a UV preference

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,11 +363,9 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
-  const requireUserVerification = params.authenticatorSelection?.userVerification === "required";
-
   return {
     requireResidentKey,
-    requireUserVerification,
+    requireUserVerification: params.authenticatorSelection?.userVerification === "required",
     enterpriseAttestationPossible: params.attestation === "enterprise",
     excludeCredentialDescriptorList,
     credTypesAndPubKeyAlgs,
@@ -400,11 +398,9 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
-  const requireUserVerification = params.userVerification === "required";
-
   return {
     rpId: params.rpId,
-    requireUserVerification,
+    requireUserVerification: params.userVerification === "required",
     hash: clientDataHash,
     allowCredentialDescriptorList,
     extensions: {},

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,9 +363,7 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
-  const requireUserVerification =
-    params.authenticatorSelection?.userVerification === "required" ||
-    params.authenticatorSelection?.userVerification === undefined;
+  const requireUserVerification = params.authenticatorSelection?.userVerification === "required";
 
   return {
     requireResidentKey,
@@ -402,8 +400,7 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
-  const requireUserVerification =
-    params.userVerification === "required" || params.userVerification === undefined;
+  const requireUserVerification = params.userVerification === "required";
 
   return {
     rpId: params.rpId,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/6617, we added a check to require user verification if the relying party supplied a `preferred` status, or if it was undefined.  In https://github.com/bitwarden/clients/pull/6697, we removed the check when `preferred`.  After discussing with the the team, the spec indicates that when the relying party does not supply a `userVerification` value (i.e. it is undefined), it should default to `preferred`.  This means that our treatment of undefined as different from `preferred` is not valid and need to be removed as well.

## Code changes

- **fido2-client.service.ts:** Removed check for `undefined` on `userVerification` on credential creation and retrieval.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
