### PR TITLE
[PM-4580] Removed user verification requirement

### DIFF
--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -247,20 +247,14 @@ export class Fido2Component implements OnInit, OnDestroy {
   protected async saveNewLogin() {
     const data = this.message$.value;
     if (data?.type === "ConfirmNewCredentialRequest") {
-      let userVerified = false;
-      if (data.userVerification) {
-        userVerified = await this.passwordRepromptService.showPasswordPrompt();
-      }
+      await this.createNewCipher();
 
-      if (!data.userVerification || userVerified) {
-        await this.createNewCipher();
-      }
-
+      // We are bypassing user verification pending implementation of PIN and biometric support.
       this.send({
         sessionId: this.sessionId,
         cipherId: this.cipher?.id,
         type: "ConfirmNewCredentialResponse",
-        userVerified,
+        userVerified: data.userVerification,
       });
     }
 
@@ -372,17 +366,17 @@ export class Fido2Component implements OnInit, OnDestroy {
   }
 
   private async handleUserVerification(
-    userVerification: boolean,
+    userVerificationRequested: boolean,
     cipher: CipherView
   ): Promise<boolean> {
-    const masterPasswordRepromptRequiered = cipher && cipher.reprompt !== 0;
-    const verificationRequired = userVerification || masterPasswordRepromptRequiered;
+    const masterPasswordRepromptRequired = cipher && cipher.reprompt !== 0;
 
-    if (!verificationRequired) {
-      return false;
+    if (masterPasswordRepromptRequired) {
+      return await this.passwordRepromptService.showPasswordPrompt();
     }
 
-    return await this.passwordRepromptService.showPasswordPrompt();
+    // We are bypassing user verification pending implementation of PIN and biometric support.
+    return userVerificationRequested;
   }
 
   private send(msg: BrowserFido2Message) {

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -122,20 +122,6 @@ export class Fido2Component implements OnInit, OnDestroy {
             return;
           }
 
-          // Show dialog if user account does not have master password
-          if (!(await this.passwordRepromptService.enabled())) {
-            await this.dialogService.openSimpleDialog({
-              title: { key: "featureNotSupported" },
-              content: { key: "passkeyFeatureIsNotImplementedForAccountsWithoutMasterPassword" },
-              acceptButtonText: { key: "ok" },
-              cancelButtonText: null,
-              type: "info",
-            });
-
-            this.abort(true);
-            return;
-          }
-
           return message;
         }),
         filter((message) => !!message),

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,9 +363,14 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
+  const requireUserVerification =
+    params.authenticatorSelection?.userVerification === "required" ||
+    params.authenticatorSelection?.userVerification === "preferred" ||
+    params.authenticatorSelection?.userVerification === undefined;
+
   return {
     requireResidentKey,
-    requireUserVerification: params.authenticatorSelection?.userVerification === "required",
+    requireUserVerification,
     enterpriseAttestationPossible: params.attestation === "enterprise",
     excludeCredentialDescriptorList,
     credTypesAndPubKeyAlgs,
@@ -398,9 +403,14 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
+  const requireUserVerification =
+    params.userVerification === "required" ||
+    params.userVerification === "preferred" ||
+    params.userVerification === undefined;
+
   return {
     rpId: params.rpId,
-    requireUserVerification: params.userVerification === "required",
+    requireUserVerification,
     hash: clientDataHash,
     allowCredentialDescriptorList,
     extensions: {},

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,11 +363,9 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
-  const requireUserVerification = params.authenticatorSelection?.userVerification === "required";
-
   return {
     requireResidentKey,
-    requireUserVerification,
+    requireUserVerification: params.authenticatorSelection?.userVerification === "required",
     enterpriseAttestationPossible: params.attestation === "enterprise",
     excludeCredentialDescriptorList,
     credTypesAndPubKeyAlgs,
@@ -400,11 +398,9 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
-  const requireUserVerification = params.userVerification === "required";
-
   return {
     rpId: params.rpId,
-    requireUserVerification,
+    requireUserVerification: params.userVerification === "required",
     hash: clientDataHash,
     allowCredentialDescriptorList,
     extensions: {},

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -363,9 +363,7 @@ function mapToMakeCredentialParams({
     (params.authenticatorSelection?.residentKey === undefined &&
       params.authenticatorSelection?.requireResidentKey === true);
 
-  const requireUserVerification =
-    params.authenticatorSelection?.userVerification === "required" ||
-    params.authenticatorSelection?.userVerification === undefined;
+  const requireUserVerification = params.authenticatorSelection?.userVerification === "required";
 
   return {
     requireResidentKey,
@@ -402,8 +400,7 @@ function mapToGetAssertionParams({
       type: "public-key",
     }));
 
-  const requireUserVerification =
-    params.userVerification === "required" || params.userVerification === undefined;
+  const requireUserVerification = params.userVerification === "required";
 
   return {
     rpId: params.rpId,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We will be bypassing user verification in the passkey implementation, pending implementation of PIN and biometrics as options for providing user verification.

The logic will map the relying party request as follows:

| Relying Party Request | Interpret as User Verification Required? | Value Returned to RP |
| --- | --- | --- |
| `required` | `true` | `true` |
| `preferred` | `true` | `true` |
| `undefined` (not provided) | `true` | `true` |
| `discouraged` | `false` | `false` |

## Code changes

- **fido2.component.ts:**
  - Removed check for whether a user has a master password when creating or retrieving a passkey
  - Passed through the `userVerification` value to `userVerified`, bypassing user verification until we implement PIN and Biometrics.
- **fido2-client.service.ts:** 
  - Added back logic that treats `preferred` and `undefined` as requiring user verification (and thus returning `userVerified == true` with these latest changes).

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
