### PR TITLE
[PM-4580] Bypass user verification of passkeys on add-edit component

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -330,11 +330,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     sessionId: string,
     userVerification: boolean
   ): Promise<boolean> {
-    if (userVerification && !(await this.passwordRepromptService.showPasswordPrompt())) {
-      BrowserFido2UserInterfaceSession.abortPopout(sessionId);
-      return false;
-    }
-
+    // We are bypassing user verification pending implementation of PIN and biometric support.
     return true;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In #6711 we removed the user verification requirement from the `Fido2Component`.  This PR missed a case where the verification was being performed in the `AddEditComponent` as well.

## Code changes

- **add-edit.component.ts:** Defaulted the user verification check to `true`.  I opted to leave the method there so that we can add the proper user verification when ready and have the structure in place for it.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
