### PR TITLE
[PM-4357] remove disableClose on BrowserSyncVerificationDialog and AwaitDesktopDialog

### DIFF
--- a/apps/browser/src/popup/settings/await-desktop-dialog.component.html
+++ b/apps/browser/src/popup/settings/await-desktop-dialog.component.html
@@ -4,7 +4,7 @@
     {{ "awaitDesktopDesc" | i18n }}
   </span>
   <ng-container bitDialogFooter>
-    <button bitButton type="button" buttonType="secondary" [bitDialogClose]="true">
+    <button bitButton type="button" buttonType="secondary" [bitDialogClose]="false">
       {{ "close" | i18n }}
     </button>
   </ng-container>

--- a/apps/browser/src/popup/settings/await-desktop-dialog.component.ts
+++ b/apps/browser/src/popup/settings/await-desktop-dialog.component.ts
@@ -10,8 +10,6 @@ import { ButtonModule, DialogModule, DialogService } from "@bitwarden/components
 })
 export class AwaitDesktopDialogComponent {
   static open(dialogService: DialogService) {
-    return dialogService.open<boolean>(AwaitDesktopDialogComponent, {
-      disableClose: true,
-    });
+    return dialogService.open<boolean>(AwaitDesktopDialogComponent);
   }
 }

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -370,7 +370,7 @@ export class SettingsComponent implements OnInit {
 
       await Promise.race([
         awaitDesktopDialogClosed.then(async (result) => {
-          if (result) {
+          if (result !== true) {
             this.form.controls.biometric.setValue(false);
             await this.stateService.setBiometricAwaitingAcceptance(null);
           }
@@ -402,7 +402,7 @@ export class SettingsComponent implements OnInit {
             });
           })
           .finally(() => {
-            awaitDesktopDialogRef.close(false);
+            awaitDesktopDialogRef.close(true);
           }),
       ]);
     } else {

--- a/apps/desktop/src/app/components/browser-sync-verification-dialog.component.ts
+++ b/apps/desktop/src/app/components/browser-sync-verification-dialog.component.ts
@@ -19,7 +19,6 @@ export class BrowserSyncVerificationDialogComponent {
   static open(dialogService: DialogService, data: BrowserSyncVerificationDialogParams) {
     return dialogService.open(BrowserSyncVerificationDialogComponent, {
       data,
-      disableClose: true,
     });
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a bug where the `BrowserSyncVerificationDialogComponent` and `AwaitDesktopDialogComponent` could not be closed by the user after opening. 

Removes `disableClose` from the dialogs' options. This originally provided parity with SweetAlert's `allowOutsideClick` feature when migrating to the dialog service. However, `disableClose` was [recently updated](https://github.com/bitwarden/clients/blob/2ecd710ab1a1c47e45dff984a8f8a441e55c646a/libs/components/src/dialog/directives/dialog-close.directive.ts#L17-L24) to also disable buttons with the attribute `bitDialogClose`. This means dialogs with `disableClose` will only be closable programmatically.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/app/components/browser-sync-verification-dialog.component:** Remove `disableClose`
- **apps/browser/src/popup/settings/await-desktop-dialog.component:** Remove `disableClose`
- **apps/browser/src/popup/settings/settings.component:** Invert logic to account for closing via backdrop click and esc key

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

<img width="472" alt="image" src="https://github.com/bitwarden/clients/assets/17113462/7a9a30e2-9349-45d2-9ec8-9c685fa44d27">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
