### PR TITLE
[PM-2331] Disable needs-qa label for renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -253,5 +253,5 @@
       "reviewers": ["team:team-vault-dev"]
     }
   ],
-  "ignoreDeps": ["@types/koa-bodyparser", "bootstrap", "node-ipc", "regedit", "zone.js"]
+  "ignoreDeps": ["@types/koa-bodyparser", "bootstrap", "node-ipc", "npm", "regedit"]
 }

--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -1,5 +1,5 @@
 # Runs creation of Pull Requests
-# If the PR destination branch is master, add a needs-qa label
+# If the PR destination branch is master, add a needs-qa label unless created by renovate[bot]
 ---
 name: Label Issue Pull Request
 
@@ -15,6 +15,7 @@ on:
 jobs:
   add-needs-qa-label:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'renovate[bot]' }}
     steps:
       - name: Add label to pull request
         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Disable `needs-qa` label for renovate PRs. Also add `npm` to ignore list for renovate and remove `zone.js`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
