### PR TITLE
Update CODEOWNERS for Crowdin PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,8 @@ libs/common/src/models/export @bitwarden/team-tools-dev
 libs/common/src/tools @bitwarden/team-tools-dev
 libs/exporter @bitwarden/team-tools-dev
 libs/importer @bitwarden/team-tools-dev
-## Localization/Crowdin
+
+## Localization/Crowdin (Tools team)
 apps/browser/src/_locales @bitwarden/team-tools-dev
 apps/cli/src/locales @bitwarden/team-tools-dev
 apps/desktop/src/locales @bitwarden/team-tools-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,11 @@ libs/common/src/models/export @bitwarden/team-tools-dev
 libs/common/src/tools @bitwarden/team-tools-dev
 libs/exporter @bitwarden/team-tools-dev
 libs/importer @bitwarden/team-tools-dev
+## Localization/Crowdin
+apps/browser/src/_locales @bitwarden/team-tools-dev
+apps/cli/src/locales @bitwarden/team-tools-dev
+apps/desktop/src/locales @bitwarden/team-tools-dev
+apps/web/src/locales @bitwarden/team-tools-dev
 
 ## Vault team files ##
 apps/browser/src/vault @bitwarden/team-vault-dev


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Adding all messages.json files besides en/ into ownership of team-tools-dev
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/CODEOWNERS:** Adding all locales folders into ownership of team-tools-dev. The ownership of ocales/en should be overridden by the [rules added further down](https://github.com/bitwarden/clients/compare/update-codeowners-for-crowdin?expand=1#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R107-R110)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
