### PR TITLE
[PM-4266] Create folder for tools owned features

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ libs/common/src/models/export @bitwarden/team-tools-dev
 libs/common/src/tools @bitwarden/team-tools-dev
 libs/exporter @bitwarden/team-tools-dev
 libs/importer @bitwarden/team-tools-dev
+libs/tools @bitwarden/team-tools-dev
 
 ## Localization/Crowdin (Tools team)
 apps/browser/src/_locales @bitwarden/team-tools-dev

--- a/.github/whitelist-capital-letters.txt
+++ b/.github/whitelist-capital-letters.txt
@@ -25,6 +25,7 @@
 ./libs/common/src/abstractions/anonymousHub.service.ts
 ./libs/common/src/services/anonymousHub.service.ts
 ./libs/auth/README.md
+./libs/tools/README.md
 ./libs/vault/README.md
 ./README.md
 ./LICENSE_BITWARDEN.txt

--- a/libs/tools/README.md
+++ b/libs/tools/README.md
@@ -1,0 +1,3 @@
+# Tools
+
+This lib represents the public API of the Tools team at Bitwarden. Modules are imported using `@bitwarden/{feature-name}` for example `@bitwarden/send-core` and `@bitwarden/send-components`.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I want to slightly deviate from the pattern that Auth and Vault have taken with their libs.

Instead of having `libs/{team-name}/src` and having all features the team owns under one lib, I'd prefer to have a folder we own (libs/tools) and under this folder we have several packages which encapsulate the feature/product.

Next move for this would be creating:
i.e 
`libs/tools/send/package.json`
or
`libs/tools/password-generator/package.json`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.libs/tools/README.md:** Create the libs/tools folderUpdate CODEOWNERS for `libs/tools` to be owned by `team-tools-dev`
- **.github/whitelist-capital-letters.txt:** Add exception for the capital `README.md` in `libs/tools`
- **.github/CODEOWNERS:** Update CODEOWNERS for `libs/tools` to be owned by `team-tools-dev`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
