### PR TITLE
[PM-4688] Automatically fallback on passkey retrieval if no passkeys are found

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -586,7 +586,8 @@ export default class MainBackground {
     this.browserPopoutWindowService = new BrowserPopoutWindowService();
 
     this.fido2UserInterfaceService = new BrowserFido2UserInterfaceService(
-      this.browserPopoutWindowService
+      this.browserPopoutWindowService,
+      this.authService
     );
     this.fido2AuthenticatorService = new Fido2AuthenticatorService(
       this.cipherService,

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -9,6 +9,7 @@ import {
   Fido2AuthenticatorGetAssertionParams,
   Fido2AuthenticatorMakeCredentialsParams,
 } from "../../abstractions/fido2/fido2-authenticator.service.abstraction";
+import { FallbackRequestedError } from "../../abstractions/fido2/fido2-client.service.abstraction";
 import {
   Fido2UserInterfaceService,
   Fido2UserInterfaceSession,
@@ -469,7 +470,8 @@ describe("FidoAuthenticatorService", () => {
        * Spec: If credentialOptions is now empty, return an error code equivalent to "NotAllowedError" and terminate the operation.
        * Deviation: We do not throw error but instead inform the user and allow the user to fallback to browser implementation.
        **/
-      it("should inform user if no credential exists", async () => {
+      it("should inform user if no credential exists when fallback is not supported", async () => {
+        params.fallbackSupported = false;
         cipherService.getAllDecrypted.mockResolvedValue([]);
         userInterfaceSession.informCredentialNotFound.mockResolvedValue();
 
@@ -479,6 +481,17 @@ describe("FidoAuthenticatorService", () => {
         } catch {}
 
         expect(userInterfaceSession.informCredentialNotFound).toHaveBeenCalled();
+      });
+
+      it("should automatically fallback if no credential exists when fallback is supported", async () => {
+        params.fallbackSupported = true;
+        cipherService.getAllDecrypted.mockResolvedValue([]);
+        userInterfaceSession.informCredentialNotFound.mockResolvedValue();
+
+        const result = async () => await authenticator.getAssertion(params, tab);
+
+        await expect(result).rejects.toThrowError(FallbackRequestedError);
+        expect(userInterfaceSession.informCredentialNotFound).not.toHaveBeenCalled();
       });
 
       it("should inform user if credential exists but rpId does not match", async () => {

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -12,6 +12,7 @@ import {
   Fido2AuthenticatorService as Fido2AuthenticatorServiceAbstraction,
   PublicKeyCredentialDescriptor,
 } from "../../abstractions/fido2/fido2-authenticator.service.abstraction";
+import { FallbackRequestedError } from "../../abstractions/fido2/fido2-client.service.abstraction";
 import { Fido2UserInterfaceService } from "../../abstractions/fido2/fido2-user-interface.service.abstraction";
 import { SyncService } from "../../abstractions/sync/sync.service.abstraction";
 import { CipherRepromptType } from "../../enums/cipher-reprompt-type";
@@ -221,6 +222,11 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
         this.logService?.info(
           `[Fido2Authenticator] Aborting because no matching credentials were found in the vault.`
         );
+
+        if (params.fallbackSupported) {
+          throw new FallbackRequestedError();
+        }
+
         await userInterfaceSession.informCredentialNotFound();
         throw new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
       }

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -259,6 +259,11 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
         abortController
       );
     } catch (error) {
+      if (error instanceof FallbackRequestedError) {
+        this.logService?.info(`[Fido2Client] Aborting because of auto fallback`);
+        throw error;
+      }
+
       if (
         abortController.signal.aborted &&
         abortController.signal.reason === UserRequestedFallbackAbortReason


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Automatically fallback to browser if no passkeys are found in bitwarden vault

## Code changes
- **fido2 authenticator/client**: Handle automatic fallback exceptions
- **browser-user-interface**: Don't show popup during `ensureVaultUnlocked` if the vault is already unlocked

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
