### PR TITLE
[PM-4531] Completely disable fido2 injection for excluded sites

### DIFF
--- a/apps/browser/src/vault/fido2/content/content-script.ts
+++ b/apps/browser/src/vault/fido2/content/content-script.ts
@@ -1,18 +1,46 @@
 import { Message, MessageType } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
-function checkFido2FeatureEnabled() {
-  chrome.runtime.sendMessage(
-    { command: "checkFido2FeatureEnabled" },
-    (response: { result?: boolean }) => initializeFido2ContentScript(response.result)
-  );
+function isFido2FeatureEnabled(): Promise<boolean> {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(
+      { command: "checkFido2FeatureEnabled" },
+      (response: { result?: boolean }) => resolve(response.result)
+    );
+  });
 }
 
-function initializeFido2ContentScript(isFido2FeatureEnabled: boolean) {
-  if (isFido2FeatureEnabled !== true) {
-    return;
+async function getFromLocalStorage(keys: string | string[]): Promise<Record<string, any>> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(keys, (storage: Record<string, any>) => resolve(storage));
+  });
+}
+
+async function isDomainExcluded() {
+  // TODO: This is code copied from `notification-bar.tsx`. We should refactor this into a shared function.
+  // Look up the active user id from storage
+  const activeUserIdKey = "activeUserId";
+  let activeUserId: string;
+
+  const activeUserStorageValue = await getFromLocalStorage(activeUserIdKey);
+  if (activeUserStorageValue[activeUserIdKey]) {
+    activeUserId = activeUserStorageValue[activeUserIdKey];
   }
 
+  // Look up the user's settings from storage
+  const userSettingsStorageValue = await getFromLocalStorage(activeUserId);
+
+  const excludedDomains = userSettingsStorageValue[activeUserId]?.settings?.neverDomains;
+  return excludedDomains && window.location.hostname in excludedDomains;
+}
+
+async function hasActiveUser() {
+  const activeUserIdKey = "activeUserId";
+  const activeUserStorageValue = await getFromLocalStorage(activeUserIdKey);
+  return activeUserStorageValue[activeUserIdKey] !== undefined;
+}
+
+function initializeFido2ContentScript() {
   const s = document.createElement("script");
   s.src = chrome.runtime.getURL("content/fido2/page-script.js");
   (document.head || document.documentElement).appendChild(s);
@@ -78,4 +106,10 @@ function initializeFido2ContentScript(isFido2FeatureEnabled: boolean) {
   };
 }
 
-checkFido2FeatureEnabled();
+async function run() {
+  if ((await hasActiveUser()) && (await isFido2FeatureEnabled()) && !(await isDomainExcluded())) {
+    initializeFido2ContentScript();
+  }
+}
+
+run();


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Followup to: https://github.com/bitwarden/clients/pull/6790

Previous PR added logic to the background script which automatically fell back to the browsers native implementation if the hostname was found to be excluded. This PR check the same thing but completely disables the fido2 page-script injection if:
  - Hostname is excluded
  - No user is logged in

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
