### PR TITLE
[PM-4704] Filter non-webauthn calls to credmanager apis

### DIFF
--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -66,6 +66,10 @@ navigator.credentials.create = async (
   options?: CredentialCreationOptions,
   abortController?: AbortController
 ): Promise<Credential> => {
+  if (!isWebauthnCall(options)) {
+    return await browserCredentials.create(options);
+  }
+
   const fallbackSupported =
     (options?.publicKey?.authenticatorSelection.authenticatorAttachment === "platform" &&
       browserNativeWebauthnPlatformAuthenticatorSupport) ||
@@ -106,6 +110,10 @@ navigator.credentials.get = async (
   options?: CredentialRequestOptions,
   abortController?: AbortController
 ): Promise<Credential> => {
+  if (!isWebauthnCall(options)) {
+    return await browserCredentials.get(options);
+  }
+
   const fallbackSupported = browserNativeWebauthnSupport;
 
   try {
@@ -140,6 +148,10 @@ navigator.credentials.get = async (
     throw error;
   }
 };
+
+function isWebauthnCall(options?: CredentialCreationOptions | CredentialRequestOptions) {
+  return options && "publicKey" in options;
+}
 
 /**
  * Wait for window to be focused.


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Tested using: https://fedcm-rp-demo.glitch.me/

Filter non-webauthn calls to credmanager apis and just forward those to the browser

## Screenshots

![image](https://github.com/bitwarden/clients/assets/2285588/da8969df-b9b3-4a60-959f-f64c91df76b7)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
