### PR TITLE
Added separate function for GUID validation for passkeys

### DIFF
--- a/libs/common/src/vault/services/fido2/guid-utils.ts
+++ b/libs/common/src/vault/services/fido2/guid-utils.ts
@@ -7,14 +7,12 @@
   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 
-import { Utils } from "../../../platform/misc/utils";
-
 /** Private array used for optimization */
 const byteToHex = Array.from({ length: 256 }, (_, i) => (i + 0x100).toString(16).substring(1));
 
 /** Convert standard format (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX) UUID to raw 16 byte array. */
 export function guidToRawFormat(guid: string) {
-  if (!Utils.isGuid(guid)) {
+  if (!isValidGuid(guid)) {
     throw TypeError("GUID parameter is invalid");
   }
 
@@ -83,13 +81,15 @@ export function guidToStandardFormat(bufferSource: BufferSource) {
   ).toLowerCase();
 
   // Consistency check for valid UUID.  If this throws, it's likely due to one
-  // of the following:
-  // - One or more input array values don't map to a hex octet (leading to
-  // "undefined" in the uuid)
-  // - Invalid input values for the RFC `version` or `variant` fields
-  if (!Utils.isGuid(guid)) {
+  // or more input array values not mapping to a hex octet (leading to "undefined" in the uuid)
+  if (!isValidGuid(guid)) {
     throw TypeError("Converted GUID is invalid");
   }
 
   return guid;
+}
+
+// Perform format validation, without enforcing any variant restrictions as Utils.isGuid does
+function isValidGuid(guid: string): boolean {
+  return RegExp(/^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/, "i").test(guid);
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/clients/pull/6792, we updated `Utils.isGuid` to perform a more relaxed check for GUID formatting, in order to support passkey GUIDs that don't match the variant restrictions. In order to support a release of the passkey implementation without requiring a regression of all other uses if `isGuid`, we have decided to take that relaxed logic and apply it just in the passkey use case.

We will introduce https://github.com/bitwarden/clients/pull/6792 after this change and remove this code, assuming it does not break anything else.

## Code changes

- **guid-utils.ts:** Added method to validate GUID.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
