### PR TITLE
[PM-4746] Fix fastmail username forwarder by changing url: to forDomain: in the...

### DIFF
--- a/libs/common/src/tools/generator/username/email-forwarders/fastmail-forwarder.ts
+++ b/libs/common/src/tools/generator/username/email-forwarders/fastmail-forwarder.ts
@@ -35,7 +35,7 @@ export class FastmailForwarder implements Forwarder {
               "new-masked-email": {
                 state: "enabled",
                 description: "",
-                url: options.website,
+                forDomain: options.website,
                 emailPrefix: options.fastmail.prefix,
               },
             },


### PR DESCRIPTION
… API request

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

Resolves #4033 

## Objective
The current Bitwarden fastmail username forwarder is able to generate a Masked Email via the API, but it does not correctly set the domain name associated with the Masked Email. This results in each Masked Email entry on the user's Fastmail settings page displaying a mask icon instead of the domain name associated with the email address. This makes managing Masked emails, especially deleting unused address, difficult.
The BW extension code attempts to properly set the domain name by populating the `url:` metadata field of the API request, but this is incorrect. According to the current API description at https://www.fastmail.com/for-developers/masked-email/, the correct metadata field for the domain name is `forDomain:`. This is the only reason setting the domain name does not work.

## Code changes

- **libs/common/src/tools/generator/username/email-forwarders/fastmail-forwarder.ts:** Replaced `url:` with `forDomain:` in the Masked Email API request

## Screenshots
**A Masked Email entry in Fastmail before the change for the domain google.com:**
![image](https://github.com/bitwarden/clients/assets/16997120/7a499a65-ab41-4294-a934-eaffb3a7bdbd)

**A Mashed Email entry in Fastmail after the change for the domain google.com:**
![image](https://github.com/bitwarden/clients/assets/16997120/e908bd01-faed-43dc-828a-46f19a6bedae)

## Testing
This was tested by using the Firefox extension inspection tool to first capture an API request sent by the stock extension, modifying the captured API request (i.e. replacing `url:` with `forDomain:`, and resending the API request.

