### PR TITLE
[AC-1806] Hide Teams Starter plan for MSP creating client organization

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -236,7 +236,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
           plan.product === ProductType.TeamsStarter) &&
         (this.currentProductType !== ProductType.TeamsStarter ||
           plan.product === ProductType.Teams ||
-          plan.product === ProductType.Enterprise)
+          plan.product === ProductType.Enterprise) &&
+        (!this.providerId || plan.product !== ProductType.TeamsStarter)
     );
 
     result.sort((planA, planB) => planA.displaySortOrder - planB.displaySortOrder);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR hides the Teams Starter plan option in the `organization-plans.component` for MSPs who are creating client organizations.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organization-plans.component.ts:** Filter out the Teams Starter plan when the `providerId` input exists.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

New client organization for Provider:
![Screenshot 2023-11-08 at 2 40 57 PM](https://github.com/bitwarden/clients/assets/144709477/9bd7b30a-fff7-4401-812e-97ac3e2fae59)

New organization for User:
![Screenshot 2023-11-08 at 2 41 27 PM](https://github.com/bitwarden/clients/assets/144709477/0c26564d-57b7-48b1-8445-264ba3b6f446)

Upgrade free organization for User:
![Screenshot 2023-11-08 at 2 41 52 PM](https://github.com/bitwarden/clients/assets/144709477/e4e95904-deb2-4ff4-9063-fff07ec3ac98)

I only see the `organization-plans.component` used in one other place and that's the `families-for-enterprise-setup.component`, but I'm not familiar with that flow nor how to trigger it.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
