### PR TITLE
[PM-3682] Remove ipcRenderer from login-approval

### DIFF
--- a/apps/desktop/src/auth/login/login-approval.component.ts
+++ b/apps/desktop/src/auth/login/login-approval.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, OnDestroy } from "@angular/core";
-import { ipcRenderer } from "electron";
 import { Subject } from "rxjs";
 
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
@@ -76,13 +75,13 @@ export class LoginApprovalComponent implements OnInit, OnDestroy {
         this.updateTimeText();
       }, RequestTimeUpdate);
 
-      const isVisible = await ipcRenderer.invoke("windowVisible");
+      const isVisible = await ipc.platform.isWindowVisible();
       if (!isVisible) {
-        await ipcRenderer.invoke("loginRequest", {
-          alertTitle: this.i18nService.t("logInRequested"),
-          alertBody: this.i18nService.t("confirmLoginAtemptForMail", this.email),
-          buttonText: this.i18nService.t("close"),
-        });
+        await ipc.auth.loginRequest(
+          this.i18nService.t("logInRequested"),
+          this.i18nService.t("confirmLoginAtemptForMail", this.email),
+          this.i18nService.t("close")
+        );
       }
     }
   }

--- a/apps/desktop/src/auth/preload.ts
+++ b/apps/desktop/src/auth/preload.ts
@@ -3,4 +3,11 @@ import { ipcRenderer } from "electron";
 export default {
   getHcaptchaAccessibilityCookie: (): Promise<[string]> =>
     ipcRenderer.invoke("getCookie", { url: "https://www.hcaptcha.com/", name: "hc_accessibility" }),
+
+  loginRequest: (alertTitle: string, alertBody: string, buttonText: string): Promise<void> =>
+    ipcRenderer.invoke("loginRequest", {
+      alertTitle,
+      alertBody,
+      buttonText,
+    }),
 };


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Removed all uses of `ipcRenderer` from login-approval.component.ts, and moves them to use the ipc preload, getting us step closer to enabling electron sandboxing.