### PR TITLE
[PM-3686] Remove ipcRenderer from native-message-handler

### DIFF
--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -2,6 +2,7 @@ import { ipcRenderer } from "electron";
 
 import { DeviceType, ThemeType, KeySuffixOptions } from "@bitwarden/common/enums";
 
+import { EncryptedMessageResponse, UnencryptedMessageResponse } from "../models/native-messaging";
 import { BiometricMessage, BiometricAction } from "../types/biometric-message";
 import { isDev, isWindowsStore } from "../utils";
 
@@ -51,6 +52,12 @@ const clipboard = {
   write: (message: ClipboardWriteMessage) => ipcRenderer.invoke("clipboard.write", message),
 };
 
+const nativeMessaging = {
+  sendReply: (message: EncryptedMessageResponse | UnencryptedMessageResponse) => {
+    ipcRenderer.send("nativeMessagingReply", message);
+  },
+};
+
 export default {
   versions: {
     app: (): Promise<string> => ipcRenderer.invoke("appVersion"),
@@ -93,6 +100,7 @@ export default {
   passwords,
   biometric,
   clipboard,
+  nativeMessaging,
 };
 
 function deviceType(): DeviceType {

--- a/apps/desktop/src/services/native-message-handler.service.ts
+++ b/apps/desktop/src/services/native-message-handler.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@angular/core";
-import { ipcRenderer } from "electron";
 import { firstValueFrom } from "rxjs";
 
 import { NativeMessagingVersion } from "@bitwarden/common/enums";
@@ -225,7 +224,7 @@ export class NativeMessageHandlerService {
   }
 
   private sendResponse(response: EncryptedMessageResponse | UnencryptedMessageResponse) {
-    ipcRenderer.send("nativeMessagingReply", response);
+    ipc.platform.nativeMessaging.sendReply(response);
   }
 
   // Trim all null bytes padded at the end of messages. This happens with C encryption libraries.


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Removed all uses of `ipcRenderer` from native-message-handler.service.ts, and moves them to use the ipc preload, getting us step closer to enabling electron sandboxing.