### PR TITLE
[PM-4744] Page Details that Update after Mutation Observer has Triggered Do Not Update within Overlay Background

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill-overlay-content.service.ts
@@ -13,6 +13,7 @@ interface AutofillOverlayContentService {
   isFieldCurrentlyFocused: boolean;
   isCurrentlyFilling: boolean;
   isOverlayCiphersPopulated: boolean;
+  pageDetailsUpdateRequired: boolean;
   init(): void;
   setupAutofillOverlayListenerOnField(
     autofillFieldElement: ElementWithOpId<FormFieldElement>,

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -808,6 +808,17 @@ describe("AutofillOverlayContentService", () => {
         overlayElement: AutofillOverlayElement.List,
       });
     });
+
+    it("sends an extension message requesting an re-collection of page details if they need to update", () => {
+      jest.spyOn(autofillOverlayContentService as any, "sendExtensionMessage");
+      autofillOverlayContentService.pageDetailsUpdateRequired = true;
+
+      autofillOverlayContentService["openAutofillOverlay"]();
+
+      expect(sendExtensionMessageSpy).toHaveBeenCalledWith("bgCollectPageDetails", {
+        sender: "autofillOverlayContentService",
+      });
+    });
   });
 
   describe("focusMostRecentOverlayField", () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -31,6 +31,7 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
   isFieldCurrentlyFocused = false;
   isCurrentlyFilling = false;
   isOverlayCiphersPopulated = false;
+  pageDetailsUpdateRequired = false;
   private readonly findTabs = tabbable;
   private readonly sendExtensionMessage = sendExtensionMessage;
   private autofillOverlayVisibility: number;
@@ -113,6 +114,13 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
     const { isFocusingFieldElement, isOpeningFullOverlay, authStatus } = options;
     if (!this.mostRecentlyFocusedField) {
       return;
+    }
+
+    if (this.pageDetailsUpdateRequired) {
+      this.sendExtensionMessage("bgCollectPageDetails", {
+        sender: "autofillOverlayContentService",
+      });
+      this.pageDetailsUpdateRequired = false;
     }
 
     if (isFocusingFieldElement && !this.recentlyFocusedFieldIsCurrentlyFocused()) {

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -456,7 +456,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
         labelElementsSet.add(currentElement);
       }
 
-      currentElement = currentElement.parentElement.closest("label");
+      currentElement = currentElement.parentElement?.closest("label");
     }
 
     if (
@@ -937,6 +937,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
           this.isAutofillElementNodeMutated(mutation.addedNodes))
       ) {
         this.domRecentlyMutated = true;
+        this.autofillOverlayContentService.pageDetailsUpdateRequired = true;
         this.noFieldsFound = false;
         continue;
       }
@@ -960,6 +961,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
     this.currentLocationHref = globalThis.location.href;
 
     this.domRecentlyMutated = true;
+    this.autofillOverlayContentService.pageDetailsUpdateRequired = true;
     this.noFieldsFound = false;
 
     this.autofillFormElements.clear();


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

An issue was identified when attempting to trigger autofill from the overlay after the DOM for a page has mutated. The issue comes down to the fact that the overlay attempts to avoid calling for the re-capture of page details by piggy-backing on the response from other sections of the code that collect page details.

The fixes in this ticket facilitate a re-check when opening the overlay that triggers a re-collection of page details if a DOM mutation has been observed within the `CollectPageDetailsContent` service.

## Code changes

- **apps/browser/src/autofill/services/abstractions/autofill-overlay-content.service.ts:** Adding typing data for a new public property that determines if the overlay needs to re-collect page details
- **apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts:** Jest tests updated to verify changes in logic within the AutofillOverlayContentService
- **apps/browser/src/autofill/services/autofill-overlay-content.service.ts:** Adding a property that allows us to identify if we need to do a re-collection of page details when the overlay opens. 
- **apps/browser/src/autofill/services/collect-autofill-content.service.ts:** Fixing a small edge case where the parent element of a node might not exist as we are identifying the label for a field, and added logic that would trigger a re-collection of page details the next time the overlay is opened.

## Video of the issue


https://github.com/bitwarden/clients/assets/16629865/f4a4962d-29e2-4b01-88e8-39e95bc2ccf4

## Video of the fix


https://github.com/bitwarden/clients/assets/16629865/e9d32290-6580-47ea-b7bd-791d4bba943c


