### PR TITLE
[PM-4329] Add Options to KeyDefinition

### DIFF
--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -28,11 +28,10 @@ class TestState {
 
 const testStateDefinition = new StateDefinition("fake", "disk");
 
-const testKeyDefinition = new KeyDefinition<TestState>(
-  testStateDefinition,
-  "fake",
-  TestState.fromJSON
-);
+const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
+  deserializer: TestState.fromJSON,
+  initialValue: new TestState(),
+});
 const globalKey = globalKeyBuilder(testKeyDefinition);
 
 describe("DefaultGlobalState", () => {

--- a/libs/common/src/platform/state/implementations/default-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-user-state.spec.ts
@@ -29,11 +29,10 @@ class TestState {
 
 const testStateDefinition = new StateDefinition("fake", "disk");
 
-const testKeyDefinition = new KeyDefinition<TestState>(
-  testStateDefinition,
-  "fake",
-  TestState.fromJSON
-);
+const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
+  deserializer: TestState.fromJSON,
+  initialValue: new TestState(),
+});
 
 describe("DefaultUserState", () => {
   const accountService = mock<AccountService>();

--- a/libs/common/src/platform/state/key-definition.spec.ts
+++ b/libs/common/src/platform/state/key-definition.spec.ts
@@ -1,0 +1,130 @@
+import { Opaque } from "type-fest";
+
+import { KeyDefinition } from "./key-definition";
+import { StateDefinition } from "./state-definition";
+
+const fakeStateDefinition = new StateDefinition("fake", "disk");
+
+type FancyString = Opaque<string, "FancyString">;
+
+describe("KeyDefinition", () => {
+  describe("constructor", () => {
+    it("throws on undefined initialValue", () => {
+      expect(
+        () =>
+          new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+            deserializer: (value) => value,
+            initialValue: undefined,
+          })
+      ).toThrowError();
+    });
+
+    it("throws on null initialValue", () => {
+      expect(() => {
+        new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+          deserializer: (value) => value,
+          initialValue: null,
+        });
+      });
+    });
+
+    it("allows falsy initialValue", () => {
+      expect(() => {
+        new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+          deserializer: (value) => value,
+          initialValue: false,
+        });
+      }).not.toThrowError();
+    });
+
+    it("throws on undefined deserializer", () => {
+      expect(() => {
+        new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+          deserializer: undefined,
+          initialValue: true,
+        });
+      });
+    });
+  });
+
+  describe("record", () => {
+    it("runs custom deserializer for each record value", () => {
+      const recordDefinition = KeyDefinition.record<boolean>(fakeStateDefinition, "fake", {
+        // Intentionally negate the value for testing
+        deserializer: (value) => !value,
+      });
+
+      expect(recordDefinition).toBeTruthy();
+      expect(recordDefinition.deserializer).toBeTruthy();
+
+      const deserializedValue = recordDefinition.deserializer({
+        test1: false,
+        test2: true,
+      });
+
+      expect(Object.keys(deserializedValue)).toHaveLength(2);
+
+      // Values should have swapped from their initial value
+      expect(deserializedValue["test1"]).toBeTruthy();
+      expect(deserializedValue["test2"]).toBeFalsy();
+    });
+
+    it.each([null, undefined])("returns empty object value when deserializing %s", (value) => {
+      const recordDefinition = KeyDefinition.record<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => !value,
+      });
+
+      const deserializedValue = recordDefinition.deserializer(value);
+      expect(deserializedValue).toBeTruthy();
+      expect(Object.keys(deserializedValue)).toHaveLength(0);
+    });
+
+    it("can handle fancy string type", () => {
+      // This test is more of a test that I got the typescript typing correctly than actually testing any business logic
+      const recordDefinition = KeyDefinition.record<boolean, FancyString>(
+        fakeStateDefinition,
+        "fake",
+        {
+          deserializer: (value) => !value,
+        }
+      );
+
+      const fancyRecord = recordDefinition.deserializer(
+        JSON.parse(`{ "myKey": false, "mySecondKey": true }`)
+      );
+
+      expect(fancyRecord).toBeTruthy();
+      expect(Object.keys(fancyRecord)).toHaveLength(2);
+      expect(fancyRecord["myKey" as FancyString]).toBeTruthy();
+      expect(fancyRecord["mySecondKey" as FancyString]).toBeFalsy();
+    });
+  });
+
+  describe("array", () => {
+    it("run custom deserializer for each array element", () => {
+      const arrayDefinition = KeyDefinition.array<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => !value,
+      });
+
+      expect(arrayDefinition).toBeTruthy();
+      expect(arrayDefinition.deserializer).toBeTruthy();
+      expect(arrayDefinition.initialValue).toEqual([]);
+
+      const deserializedValue = arrayDefinition.deserializer([false, true]);
+
+      expect(deserializedValue).toBeTruthy();
+      expect(deserializedValue).toHaveLength(2);
+      expect(deserializedValue[0]).toBeTruthy();
+      expect(deserializedValue[1]).toBeFalsy();
+    });
+
+    it.each([null, undefined])("returns empty array when deserializing %s", (value) => {
+      const arrayDefinition = KeyDefinition.array<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => !value,
+      });
+
+      const deserializedValue = arrayDefinition.deserializer(value);
+      expect(deserializedValue).toHaveLength(0);
+    });
+  });
+});

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -6,6 +6,22 @@ import { Utils } from "../misc/utils";
 import { StateDefinition } from "./state-definition";
 
 /**
+ * A set of options for customizing the behavior of a {@link KeyDefinition}
+ */
+type KeyDefinitionOptions<T> = {
+  /**
+   * A function to use to safely convert your type from json to your expected type.
+   * @param jsonValue The JSON representation of your state.
+   * @returns The fully typed version of your state.
+   */
+  readonly deserializer: (jsonValue: Jsonify<T>) => T;
+  /**
+   * The initial value of your state, this value will be returned to you instead of `null` or `undefined` on first load of your data.
+   */
+  readonly initialValue: T;
+};
+
+/**
  * KeyDefinitions describe the precise location to store data for a given piece of state.
  * The StateDefinition is used to describe the domain of the state, and the KeyDefinition
  * sub-divides that domain into specific keys.
@@ -14,30 +30,65 @@ export class KeyDefinition<T> {
   /**
    * Creates a new instance of a KeyDefinition
    * @param stateDefinition The state definition for which this key belongs to.
-   * @param key The name of the key, this should be unique per domain
-   * @param deserializer A function to use to safely convert your type from json to your expected type.
+   * @param key The name of the key, this should be unique per domain.
+   * @param options A set of options to customize the behavior of {@link KeyDefinition}.
    */
   constructor(
     readonly stateDefinition: StateDefinition,
     readonly key: string,
-    readonly deserializer: (jsonValue: Jsonify<T>) => T
-  ) {}
+    private readonly options: KeyDefinitionOptions<T>
+  ) {
+    if (options.deserializer == null) {
+      throw new Error("'deserializer' is a required property.");
+    }
+
+    if (options.initialValue == null) {
+      throw new Error("'initialValue' is not allowed to be equal to null.");
+    }
+  }
+
+  /**
+   * Gets the deserializer configured for this {@link KeyDefinition}
+   */
+  get deserializer() {
+    return this.options.deserializer;
+  }
+
+  /**
+   * Gets the initialValue configured for this {@link KeyDefinition}
+   */
+  get initialValue() {
+    return this.options.initialValue;
+  }
 
   /**
    * Creates a {@link KeyDefinition} for state that is an array.
    * @param stateDefinition The state definition to be added to the KeyDefinition
    * @param key The key to be added to the KeyDefinition
-   * @param deserializer The deserializer for the element of the array in your state.
-   * @returns A {@link KeyDefinition} that contains a serializer that will run the provided deserializer for each
-   * element of an array **unless that array is null in which case it will return an empty list.**
+   * @param options The options to customize the final {@link KeyDefinition}.
+   * @returns A {@link KeyDefinition} that contains a options specially crafted for arrays, the options run
+   * the deserializer on the provided options for each element of an array
+   * **unless that array is null in which case it will return an empty list.**
+   *
+   * @example
+   * ```typescript
+   * const MY_KEY = KeyDefinition.array<MyArrayElement>(MY_STATE, "key", {
+   *   deserializer: (myJsonElement) => convertToElement(myJsonElement),
+   * });
+   * ```
    */
   static array<T>(
     stateDefinition: StateDefinition,
     key: string,
-    deserializer: (jsonValue: Jsonify<T>) => T
+    // We have them provide options for the element of the array, depending on future options we add, this could get a little weird.
+    options: Omit<KeyDefinitionOptions<T>, "initialValue"> // The array helper forces  an initialValue of an empty array
   ) {
-    return new KeyDefinition<T[]>(stateDefinition, key, (jsonValue) => {
-      return jsonValue?.map((v) => deserializer(v)) ?? [];
+    return new KeyDefinition<T[]>(stateDefinition, key, {
+      ...options,
+      deserializer: (jsonValue) => {
+        return jsonValue?.map((v) => options.deserializer(v)) ?? [];
+      },
+      initialValue: [],
     });
   }
 
@@ -45,32 +96,44 @@ export class KeyDefinition<T> {
    * Creates a {@link KeyDefinition} for state that is a record.
    * @param stateDefinition The state definition to be added to the KeyDefinition
    * @param key The key to be added to the KeyDefinition
-   * @param deserializer The deserializer for the value part of a record.
+   * @param options The options to customize the final {@link KeyDefinition}.
    * @returns A {@link KeyDefinition} that contains a serializer that will run the provided deserializer for each
    * value in a record and returns every key as a string **unless that record is null in which case it will return an record.**
+   *
+   * @example
+   * ```typescript
+   * const MY_KEY = KeyDefinition.record<MyRecordValue>(MY_STATE, "key", {
+   *   deserializer: (myJsonValue) => convertToValue(myJsonValue),
+   * });
+   * ```
    */
-  static record<T>(
+  static record<T, TKey extends string = string>(
     stateDefinition: StateDefinition,
     key: string,
-    deserializer: (jsonValue: Jsonify<T>) => T
+    // We have them provide options for the value of the record, depending on future options we add, this could get a little weird.
+    options: Omit<KeyDefinitionOptions<T>, "initialValue"> // The array helper forces an initialValue of an empty record
   ) {
-    return new KeyDefinition<Record<string, T>>(stateDefinition, key, (jsonValue) => {
-      const output: Record<string, T> = {};
+    return new KeyDefinition<Record<TKey, T>>(stateDefinition, key, {
+      ...options,
+      deserializer: (jsonValue) => {
+        const output: Record<string, T> = {};
 
-      if (jsonValue == null) {
+        if (jsonValue == null) {
+          return output;
+        }
+
+        for (const key in jsonValue) {
+          output[key] = options.deserializer((jsonValue as Record<string, Jsonify<T>>)[key]);
+        }
         return output;
-      }
-
-      for (const key in jsonValue) {
-        output[key] = deserializer((jsonValue as Record<string, Jsonify<T>>)[key]);
-      }
-      return output;
+      },
+      initialValue: {} as Record<TKey, T>,
     });
   }
 
   /**
-   *
-   * @returns
+   * Create a string that should be unique across the entire application.
+   * @returns A string that can be used to cache instances created via this key.
    */
   buildCacheKey(): string {
     return `${this.stateDefinition.storageLocation}_${this.stateDefinition.name}_${this.key}`;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add `KeyDefinitionOptions<T>` and move the `deserializer` to the options along with an `initialValue` option. Both of these options are required but also taken care of via the 2 built-in helpers. This allows for further expansion of customizable options while hopefully not incurring any breaking changes to consumers. 

Also, made the `record` helper allow you to customize the key value of the record to better support using custom `Opaque` types vs plain strings.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/platform/state/implementations/{default|user}-global-state.spec.tst:** React to breaking changes of KeyDefinition constructor.
- **libs/common/src/platform/state/key-definition.spec.ts:** Add tests for expected KeyDefinition behaviors
- **libs/common/src/platform/state/key-definition.ts:** Expand KeyDefinition to take an options parameter.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
