### PR TITLE
Fix reporting of server-side errors in "bw sync"

### DIFF
--- a/apps/cli/src/models/response.ts
+++ b/apps/cli/src/models/response.ts
@@ -1,19 +1,34 @@
+import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
+
 import { BaseResponse } from "./response/base.response";
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof ErrorResponse) {
+    const message = error.getSingleMessage();
+    if (message) {
+      return message;
+    }
+  }
+  if (error instanceof Error) {
+    return String(error);
+  }
+  if (error) {
+    const errorWithMessage: { message?: unknown } = error; // To placate TypeScript.
+    if (errorWithMessage.message && typeof errorWithMessage.message === "string") {
+      return errorWithMessage.message;
+    }
+  }
+  return JSON.stringify(error);
+}
 
 export class Response {
   static error(error: any, data?: any): Response {
     const res = new Response();
     res.success = false;
-    if (typeof error === "string") {
-      res.message = error;
-    } else {
-      res.message =
-        error.message != null
-          ? error.message
-          : error.toString() === "[object Object]"
-          ? JSON.stringify(error)
-          : error.toString();
-    }
+    res.message = getErrorMessage(error);
     res.data = data;
     return res;
   }

--- a/apps/cli/src/vault/sync.command.ts
+++ b/apps/cli/src/vault/sync.command.ts
@@ -19,7 +19,9 @@ export class SyncCommand {
       const res = new MessageResponse("Syncing complete.", null);
       return Response.success(res);
     } catch (e) {
-      return Response.error("Syncing failed: " + e.toString());
+      const response = Response.error(e);
+      response.message = "Syncing failed: " + response.message;
+      return response;
     }
   }
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -235,11 +235,7 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async refreshIdentityToken(): Promise<any> {
-    try {
-      await this.doAuthRefresh();
-    } catch (e) {
-      return Promise.reject(null);
-    }
+    await this.doAuthRefresh();
   }
 
   // TODO: PM-3519: Create and move to AuthRequest Api service
@@ -1892,7 +1888,6 @@ export class ApiService implements ApiServiceAbstraction {
           responseJson.error === "invalid_grant")
       ) {
         await this.logoutCallback(true);
-        return null;
       }
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The Bitwarden CLI command `bw sync` performs up to 6 HTTP requests:

* `POST https://identity.bitwarden.com/connect/token`
* `GET https://api.bitwarden.com/config`
* `POST https://identity.bitwarden.com/connect/token`
* `GET https://api.bitwarden.com/accounts/revision-date`
* `POST https://identity.bitwarden.com/connect/token`
* `GET https://api.bitwarden.com/sync?excludeDomains=true`

These requests can fail. Either with network errors, or with HTTP 4xx/5xx response status codes. In case of network errors, `bw sync` prints a useful error message. If the server sends a HTTP 4xx/5xx response, `bw sync` prints a useless error:

```
Syncing failed: [object Object]
```

This case was previously reported in PR #4591. This PR aims to replace that PR.

In some cases (e.g. if the status is 401, or if the *last* `/connect/token` request fails) it prints this instead:

```
/snapshot/clients/apps/cli/build/bw.js:41217
                return Response.error("Syncing failed: " + e.toString());
                                                             ^

TypeError: Cannot read properties of null (reading 'toString')
    at SyncCommand.<anonymous> (/snapshot/clients/apps/cli/build/bw.js:41217:62)
    at Generator.throw (<anonymous>)
    at rejected (/snapshot/clients/apps/cli/build/bw.js:41192:65)

Node.js v18.5.0
```

This case was previously reported in issue #4587. It was closed because it couldn't be reproduced. This PR fixes #4587 properly.

These server-side errors are very rare. Anecdote: I have a cron script that runs `bw sync` every day since May 2021, and I only saw the "[object Object]" message twice and the "Cannot read properties of null" message once. Still, they could be better.

Examples of error messages after this PR:

```ini
# for network errors (same as before this PR):
Syncing failed: FetchError: request to https://identity.bitwarden.com/connect/token failed, reason: getaddrinfo EAI_AGAIN localhost
Syncing failed: FetchError: request to https://identity.bitwarden.com/connect/token failed, reason: socket hang up
# for responses with a text/plain body:
Syncing failed: Example server-sent plain text error message.
# for responses with validationErrors in JSON:
Syncing failed: Example server-sent validation error message.
# for responses with a message in JSON:
Syncing failed: Example server-sent JSON error message.
# for HTTP 429 responses:
Syncing failed: Rate limit exceeded. Try again later.
# for responses with "content-length: 0", let's at least print the status code:
Syncing failed: {"response":null,"statusCode":400}
```

## Code changes

JavaScript code can `throw` or `Promise.reject()` any value, not just objects. It is generally recommended to only throw instances of `Error` or its subclasses (by [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw#description) and e.g. [Google's style guide](https://google.github.io/styleguide/jsguide.html#features-exceptions)). Unfortunately the Bitwarden codebase does not follow this best practice. It also throws instances of `ErrorResponse` (from error.response.ts), and even `null`. They don't have a stack trace, so it's very hard to diagnose where they're coming them, and they can cause problems in `catch` statements that naively assume that all caught values are Errors.

- **response.ts:** Improve logic in Response.error to better handle all kinds of error values. The code is inspired by [validation.service.ts](https://github.com/bitwarden/clients/blob/master/libs/common/src/platform/services/validation.service.ts). It would be best to deduplicate them, but there are some differences.

  In practice, the main change in Response.error is that for instances of Error it'll show "Type: message" instead of just "message". E.g. `FetchError: foo` instead of `foo`. This also affects other bw CLI commands.
- **sync.command.ts:** Rely on Response.error to stringify the error, and add the "Sync failed: " prefix afterwards.
- **api.service.ts:** Do not throw `null` if refreshIdentityToken fails or if the user gets logged out. Instead throw the original error. Note that `Promise.reject(null)` is equivalent to `throw null`, and it's a bad idea for the same reasons.

  This PR's primary focus is `bw sync`, but other CLI commands also benefit from this. E.g. if `bw create item` gets a HTTP 401 from `POST /ciphers`, it used to also fail with "Cannot read properties of null", and now it prints `{"response":null,"statusCode":401}`.

  Code archeology: ApiService.refreshIdentityToken and ApiService.handleError have been throwing `null` ever since it was originally created (in 7ce34ac1399fa041d79c1fe1a57036c3626dd321 by @kspearrin). I don't understand why. I haven't found any code that catches `null` specifically. ValidationService also just renders null as "An unexpected error has occurred.". This code is shared between Bitwarden CLI and other apps, so I hope I didn't overlook some good reason for it.

## Manual testing

I wrote an advanced test script for this PR that uses Mitmproxy to inject many different errors in the HTTP requests. You can read my script's full output to compare `bw sync` output before and after this PR, or run it yourself if you'd like.

It is here: **https://gist.github.com/TomiBelan/aef2ccaa59726ea5cc8d5576478c8ddd**

<details><summary>Some remarks on my test output</summary>

* `Unable to fetch ServerConfig: undefined`: I didn't change [config.service.ts](https://github.com/bitwarden/clients/blob/e1b5b83723f92bf242f583bbb2caa8f5bfd457ac/libs/common/src/platform/services/config/config.service.ts#L62C6-L62C6) in this PR. It would be good to fix it too one day.
* `Unable to fetch ServerConfig: Invalid response body while trying to fetch https://api.bitwarden.com/config: read ECONNRESET`: I suspect it's a rare nondeterministic issue in my test script or in Mitmproxy, not in Bitwarden itself.
* `Syncing failed: TypeError: Cannot read properties of null (reading 'settings')`: ConfigService and SyncService are in a race for the first /connect/token request. This error can rarely happen if ConfigService wins that race and receives a 401 response. It calls logoutCallback while SyncService is still running. It's only in my "after" output, but I think it was already possible before this PR.

</details>

I expect that the most attention worthy part of this PR is the ApiService change, because it affects all other apps. It would be best to also test the desktop app or browser extension, to see how it handles for example a HTTP 401 error (when the server says your session is logged out). I don't have a test setup for that.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
