### PR TITLE
Ps/pm 2910/state framework improvements

### DIFF
--- a/apps/browser/src/platform/decorators/session-sync-observable/session-syncer.spec.ts
+++ b/apps/browser/src/platform/decorators/session-sync-observable/session-syncer.spec.ts
@@ -1,4 +1,4 @@
-import { awaitAsync } from "@bitwarden/angular/../test-utils";
+import { awaitAsync } from "@bitwarden/common/../spec/utils";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, ReplaySubject } from "rxjs";
 

--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -11,6 +11,9 @@ import { fromChromeEvent } from "../../browser/from-chrome-event";
 export default abstract class AbstractChromeStorageService implements AbstractStorageService {
   constructor(protected chromeStorageApi: chrome.storage.StorageArea) {}
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$(): Observable<StorageUpdate> {
     return fromChromeEvent(this.chromeStorageApi.onChanged).pipe(
       mergeMap(([changes]) => {

--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -27,7 +27,6 @@ export default abstract class AbstractChromeStorageService implements AbstractSt
             key: key,
             // For removes this property will not exist but then it will just be
             // undefined which is fine.
-            value: change.newValue,
             updateType: updateType,
           };
         });

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -35,6 +35,10 @@ export class LocalBackedSessionStorageService extends AbstractMemoryStorageServi
     super();
   }
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
+
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/apps/cli/src/platform/services/lowdb-storage.service.ts
+++ b/apps/cli/src/platform/services/lowdb-storage.service.ts
@@ -133,7 +133,7 @@ export class LowdbStorageService implements AbstractStorageService {
     return this.lockDbFile(() => {
       this.readForNoCache();
       this.db.set(key, obj).write();
-      this.updatesSubject.next({ key, value: obj, updateType: "save" });
+      this.updatesSubject.next({ key, updateType: "save" });
       this.logService.debug(`Successfully wrote ${key} to db`);
       return;
     });
@@ -144,7 +144,7 @@ export class LowdbStorageService implements AbstractStorageService {
     return this.lockDbFile(() => {
       this.readForNoCache();
       this.db.unset(key).write();
-      this.updatesSubject.next({ key, value: null, updateType: "remove" });
+      this.updatesSubject.next({ key, updateType: "remove" });
       this.logService.debug(`Successfully removed ${key} from db`);
       return;
     });

--- a/apps/cli/src/platform/services/lowdb-storage.service.ts
+++ b/apps/cli/src/platform/services/lowdb-storage.service.ts
@@ -107,6 +107,9 @@ export class LowdbStorageService implements AbstractStorageService {
     this.ready = true;
   }
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/apps/cli/src/platform/services/node-env-secure-storage.service.ts
+++ b/apps/cli/src/platform/services/node-env-secure-storage.service.ts
@@ -14,6 +14,10 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
     private cryptoService: () => CryptoService
   ) {}
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
+
   get updates$() {
     return throwError(
       () => new Error("Secure storage implementations cannot have their updates subscribed to.")

--- a/apps/desktop/src/platform/services/electron-renderer-secure-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-renderer-secure-storage.service.ts
@@ -4,6 +4,9 @@ import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/
 import { StorageOptions } from "@bitwarden/common/platform/models/domain/storage-options";
 
 export class ElectronRendererSecureStorageService implements AbstractStorageService {
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$() {
     return throwError(
       () => new Error("Secure storage implementations cannot have their updates subscribed to.")

--- a/apps/desktop/src/platform/services/electron-renderer-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-renderer-storage.service.ts
@@ -8,6 +8,9 @@ import {
 export class ElectronRendererStorageService implements AbstractStorageService {
   private updatesSubject = new Subject<StorageUpdate>();
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/apps/desktop/src/platform/services/electron-renderer-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-renderer-storage.service.ts
@@ -22,11 +22,11 @@ export class ElectronRendererStorageService implements AbstractStorageService {
 
   async save<T>(key: string, obj: T): Promise<void> {
     await ipc.platform.storage.save(key, obj);
-    this.updatesSubject.next({ key, value: obj, updateType: "save" });
+    this.updatesSubject.next({ key, updateType: "save" });
   }
 
   async remove(key: string): Promise<void> {
     await ipc.platform.storage.remove(key);
-    this.updatesSubject.next({ key, value: null, updateType: "remove" });
+    this.updatesSubject.next({ key, updateType: "remove" });
   }
 }

--- a/apps/desktop/src/platform/services/electron-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-storage.service.ts
@@ -65,6 +65,9 @@ export class ElectronStorageService implements AbstractStorageService {
     });
   }
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/apps/desktop/src/platform/services/electron-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-storage.service.ts
@@ -84,13 +84,13 @@ export class ElectronStorageService implements AbstractStorageService {
       obj = Array.from(obj);
     }
     this.store.set(key, obj);
-    this.updatesSubject.next({ key, value: obj, updateType: "save" });
+    this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();
   }
 
   remove(key: string): Promise<void> {
     this.store.delete(key);
-    this.updatesSubject.next({ key, value: null, updateType: "remove" });
+    this.updatesSubject.next({ key, updateType: "remove" });
     return Promise.resolve();
   }
 }

--- a/apps/web/src/app/core/html-storage.service.ts
+++ b/apps/web/src/app/core/html-storage.service.ts
@@ -16,6 +16,9 @@ export class HtmlStorageService implements AbstractStorageService {
     return { htmlStorageLocation: HtmlStorageLocation.Session };
   }
 
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/apps/web/src/app/core/html-storage.service.ts
+++ b/apps/web/src/app/core/html-storage.service.ts
@@ -62,7 +62,7 @@ export class HtmlStorageService implements AbstractStorageService {
         window.sessionStorage.setItem(key, json);
         break;
     }
-    this.updatesSubject.next({ key, value: obj, updateType: "save" });
+    this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();
   }
 
@@ -76,7 +76,7 @@ export class HtmlStorageService implements AbstractStorageService {
         window.sessionStorage.removeItem(key);
         break;
     }
-    this.updatesSubject.next({ key, value: null, updateType: "remove" });
+    this.updatesSubject.next({ key, updateType: "remove" });
     return Promise.resolve();
   }
 }

--- a/libs/angular/test-utils.ts
+++ b/libs/angular/test-utils.ts
@@ -1,3 +1,0 @@
-export async function awaitAsync(ms = 0) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/libs/common/spec/fake-storage.service.ts
+++ b/libs/common/spec/fake-storage.service.ts
@@ -10,6 +10,7 @@ import { StorageOptions } from "../src/platform/models/domain/storage-options";
 export class FakeStorageService implements AbstractStorageService {
   private store: Record<string, unknown>;
   private updatesSubject = new Subject<StorageUpdate>();
+  private _valuesRequireDeserialization = false;
 
   /**
    * Returns a mock of a {@see AbstractStorageService} for asserting the expected
@@ -30,6 +31,14 @@ export class FakeStorageService implements AbstractStorageService {
    */
   internalUpdateStore(store: Record<string, unknown>) {
     this.store = store;
+  }
+
+  internalUpdateValuesRequireDeserialization(value: boolean) {
+    this._valuesRequireDeserialization = value;
+  }
+
+  get valuesRequireDeserialization(): boolean {
+    return this._valuesRequireDeserialization;
   }
 
   get updates$() {

--- a/libs/common/spec/fake-storage.service.ts
+++ b/libs/common/spec/fake-storage.service.ts
@@ -48,13 +48,13 @@ export class FakeStorageService implements AbstractStorageService {
   save<T>(key: string, obj: T, options?: StorageOptions): Promise<void> {
     this.mock.save(key, options);
     this.store[key] = obj;
-    this.updatesSubject.next({ key: key, value: obj, updateType: "save" });
+    this.updatesSubject.next({ key: key, updateType: "save" });
     return Promise.resolve();
   }
   remove(key: string, options?: StorageOptions): Promise<void> {
     this.mock.remove(key, options);
     delete this.store[key];
-    this.updatesSubject.next({ key: key, value: undefined, updateType: "remove" });
+    this.updatesSubject.next({ key: key, updateType: "remove" });
     return Promise.resolve();
   }
 }

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -84,3 +84,11 @@ function clone(value: any): any {
     return JSON.parse(JSON.stringify(value));
   }
 }
+
+export async function awaitAsync(ms = 0) {
+  if (ms < 1) {
+    await Promise.resolve();
+  } else {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/libs/common/src/platform/abstractions/storage.service.ts
+++ b/libs/common/src/platform/abstractions/storage.service.ts
@@ -9,6 +9,7 @@ export type StorageUpdate = {
 };
 
 export abstract class AbstractStorageService {
+  abstract get valuesRequireDeserialization(): boolean;
   /**
    * Provides an {@link Observable} that represents a stream of updates that
    * have happened in this storage service or in the storage this service provides

--- a/libs/common/src/platform/abstractions/storage.service.ts
+++ b/libs/common/src/platform/abstractions/storage.service.ts
@@ -5,7 +5,6 @@ import { MemoryStorageOptions, StorageOptions } from "../models/domain/storage-o
 export type StorageUpdateType = "save" | "remove";
 export type StorageUpdate = {
   key: string;
-  value?: unknown;
   updateType: StorageUpdateType;
 };
 

--- a/libs/common/src/platform/services/memory-storage.service.ts
+++ b/libs/common/src/platform/services/memory-storage.service.ts
@@ -27,13 +27,13 @@ export class MemoryStorageService extends AbstractMemoryStorageService {
       return this.remove(key);
     }
     this.store.set(key, obj);
-    this.updatesSubject.next({ key, value: obj, updateType: "save" });
+    this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();
   }
 
   remove(key: string): Promise<void> {
     this.store.delete(key);
-    this.updatesSubject.next({ key, value: null, updateType: "remove" });
+    this.updatesSubject.next({ key, updateType: "remove" });
     return Promise.resolve();
   }
 

--- a/libs/common/src/platform/services/memory-storage.service.ts
+++ b/libs/common/src/platform/services/memory-storage.service.ts
@@ -6,6 +6,9 @@ export class MemoryStorageService extends AbstractMemoryStorageService {
   private store = new Map<string, unknown>();
   private updatesSubject = new Subject<StorageUpdate>();
 
+  get valuesRequireDeserialization(): boolean {
+    return false;
+  }
   get updates$() {
     return this.updatesSubject.asObservable();
   }

--- a/libs/common/src/platform/state/global-state.ts
+++ b/libs/common/src/platform/state/global-state.ts
@@ -16,7 +16,6 @@ export interface GlobalState<T> {
    * @param options.msTimeout A timeout for how long you are willing to wait for a `combineLatestWith` option to complete. Defaults to 1000ms. Only applies if `combineLatestWith` is set.
    * @returns A promise that must be awaited before your next action to ensure the update has been written to state.
    */
-  // TODO: Add a should update callback?
   update: <TCombine>(
     configureState: (state: T, dependency: TCombine) => T,
     options?: StateUpdateOptions<T, TCombine>

--- a/libs/common/src/platform/state/global-state.ts
+++ b/libs/common/src/platform/state/global-state.ts
@@ -1,5 +1,7 @@
 import { Observable } from "rxjs";
 
+import { StateUpdateOptions } from "./state-update-options";
+
 /**
  * A helper object for interacting with state that is scoped to a specific domain
  * but is not scoped to a user. This is application wide storage.
@@ -8,9 +10,17 @@ export interface GlobalState<T> {
   /**
    * Method for allowing you to manipulate state in an additive way.
    * @param configureState callback for how you want manipulate this section of state
+   * @param options Defaults given by @see {module:state-update-options#DEFAULT_OPTIONS}
+   * @param options.shouldUpdate A callback for determining if you want to update state. Defaults to () => true
+   * @param options.combineLatestWith An observable that you want to combine with the current state for callbacks. Defaults to null
+   * @param options.msTimeout A timeout for how long you are willing to wait for a `combineLatestWith` option to complete. Defaults to 1000ms. Only applies if `combineLatestWith` is set.
    * @returns A promise that must be awaited before your next action to ensure the update has been written to state.
    */
-  update: (configureState: (state: T) => T) => Promise<T>;
+  // TODO: Add a should update callback?
+  update: <TCombine>(
+    configureState: (state: T, dependency: TCombine) => T,
+    options?: StateUpdateOptions<T, TCombine>
+  ) => Promise<T>;
 
   /**
    * An observable stream of this state, the first emission of this will be the current state on disk

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -85,10 +85,13 @@ describe("DefaultGlobalState", () => {
 
     it("should emit once per update", async () => {
       const emissions = trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
 
       await globalState.update((state) => {
         return newData;
       });
+
+      await awaitAsync();
 
       expect(emissions).toEqual([
         null, // Initial value
@@ -98,6 +101,8 @@ describe("DefaultGlobalState", () => {
 
     it("should provided combined dependencies", async () => {
       const emissions = trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
+
       const combinedDependencies = { date: new Date() };
 
       await globalState.update(
@@ -109,6 +114,8 @@ describe("DefaultGlobalState", () => {
           combineLatestWith: of(combinedDependencies),
         }
       );
+
+      await awaitAsync();
 
       expect(emissions).toEqual([
         null, // Initial value
@@ -135,16 +142,22 @@ describe("DefaultGlobalState", () => {
 
     it("should provide the update callback with the current State", async () => {
       const emissions = trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
+
       // Seed with interesting data
       const initialData = { date: new Date(2020, 1, 1) };
       await globalState.update((state, dependencies) => {
         return initialData;
       });
 
+      await awaitAsync();
+
       await globalState.update((state) => {
         expect(state).toEqual(initialData);
         return newData;
       });
+
+      await awaitAsync();
 
       expect(emissions).toEqual([
         null, // Initial value

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -6,7 +6,7 @@
 import { of } from "rxjs";
 import { Jsonify } from "type-fest";
 
-import { trackEmissions } from "../../../../spec";
+import { trackEmissions, awaitAsync } from "../../../../spec";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { KeyDefinition, globalKeyBuilder } from "../key-definition";
 import { StateDefinition } from "../state-definition";
@@ -53,6 +53,7 @@ describe("DefaultGlobalState", () => {
   it("should emit when storage updates", async () => {
     const emissions = trackEmissions(globalState.state$);
     await diskStorageService.save(globalKey, newData);
+    await awaitAsync(); // storage updates are behind a promise
 
     expect(emissions).toEqual([
       null, // Initial value

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -29,11 +29,9 @@ class TestState {
 
 const testStateDefinition = new StateDefinition("fake", "disk");
 
-const testKeyDefinition = new KeyDefinition<TestState>(
-  testStateDefinition,
-  "fake",
-  TestState.fromJSON
-);
+const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
+  deserializer: TestState.fromJSON,
+});
 const globalKey = globalKeyBuilder(testKeyDefinition);
 
 describe("DefaultGlobalState", () => {

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -16,6 +16,8 @@ import { GlobalState } from "../global-state";
 import { KeyDefinition, globalKeyBuilder } from "../key-definition";
 import { StateUpdateOptions, populateOptionsWithDefault } from "../state-update-options";
 
+import { getStoredValue } from "./util";
+
 export class DefaultGlobalState<T> implements GlobalState<T> {
   private storageKey: string;
   private seededPromise: Promise<void>;
@@ -41,9 +43,11 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
         if (update.updateType === "remove") {
           return null;
         }
-        const jsonData = await this.chosenLocation.get<Jsonify<T>>(this.storageKey);
-        const data = this.keyDefinition.deserializer(jsonData);
-        return data;
+        return await getStoredValue(
+          this.storageKey,
+          this.chosenLocation,
+          this.keyDefinition.deserializer
+        );
       }),
       shareReplay({ bufferSize: 1, refCount: false })
     );
@@ -83,7 +87,10 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
   }
 
   async getFromState(): Promise<T> {
-    const data = await this.chosenLocation.get<Jsonify<T>>(this.storageKey);
-    return this.keyDefinition.deserializer(data);
+    return await getStoredValue(
+      this.storageKey,
+      this.chosenLocation,
+      this.keyDefinition.deserializer
+    );
   }
 }

--- a/libs/common/src/platform/state/implementations/default-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-user-state.spec.ts
@@ -33,11 +33,9 @@ class TestState {
 
 const testStateDefinition = new StateDefinition("fake", "disk");
 
-const testKeyDefinition = new KeyDefinition<TestState>(
-  testStateDefinition,
-  "fake",
-  TestState.fromJSON
-);
+const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
+  deserializer: TestState.fromJSON,
+});
 
 describe("DefaultUserState", () => {
   const accountService = mock<AccountService>();

--- a/libs/common/src/platform/state/implementations/default-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-user-state.ts
@@ -67,8 +67,13 @@ export class DefaultUserState<T> implements UserState<T> {
     const storageUpdates$ = this.chosenStorageLocation.updates$.pipe(
       combineLatestWith(this.formattedKey$),
       filter(([update, key]) => key !== null && update.key === key),
-      map(([update]) => {
-        return keyDefinition.deserializer(update.value as Jsonify<T>);
+      switchMap(async ([update, key]) => {
+        if (update.updateType === "remove") {
+          return FAKE_DEFAULT;
+        }
+        const jsonData = await this.chosenStorageLocation.get<Jsonify<T>>(key);
+        const data = keyDefinition.deserializer(jsonData);
+        return data;
       })
     );
 

--- a/libs/common/src/platform/state/implementations/default-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-user-state.ts
@@ -71,7 +71,7 @@ export class DefaultUserState<T> implements UserState<T> {
       filter(([update, key]) => key !== null && update.key === key),
       switchMap(async ([update, key]) => {
         if (update.updateType === "remove") {
-          return FAKE_DEFAULT;
+          return null;
         }
         const data = await getStoredValue(
           key,

--- a/libs/common/src/platform/state/implementations/util.spec.ts
+++ b/libs/common/src/platform/state/implementations/util.spec.ts
@@ -1,0 +1,50 @@
+import { FakeStorageService } from "../../../../spec/fake-storage.service";
+
+import { getStoredValue } from "./util";
+
+describe("getStoredValue", () => {
+  const key = "key";
+  const deserializedValue = { value: 1 };
+  const value = JSON.stringify(deserializedValue);
+  const deserializer = (v: string) => JSON.parse(v);
+  let storageService: FakeStorageService;
+
+  beforeEach(() => {
+    storageService = new FakeStorageService();
+  });
+
+  describe("when the storage service requires deserialization", () => {
+    beforeEach(() => {
+      storageService.internalUpdateValuesRequireDeserialization(true);
+    });
+
+    it("should deserialize", async () => {
+      storageService.save(key, value);
+
+      const result = await getStoredValue(key, storageService, deserializer);
+
+      expect(result).toEqual(deserializedValue);
+    });
+  });
+  describe("when the storage service does not require deserialization", () => {
+    beforeEach(() => {
+      storageService.internalUpdateValuesRequireDeserialization(false);
+    });
+
+    it("should not deserialize", async () => {
+      storageService.save(key, value);
+
+      const result = await getStoredValue(key, storageService, deserializer);
+
+      expect(result).toEqual(value);
+    });
+
+    it("should convert undefined to null", async () => {
+      storageService.save(key, undefined);
+
+      const result = await getStoredValue(key, storageService, deserializer);
+
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/libs/common/src/platform/state/implementations/util.ts
+++ b/libs/common/src/platform/state/implementations/util.ts
@@ -1,0 +1,18 @@
+import { Jsonify } from "type-fest";
+
+import { AbstractStorageService } from "../../abstractions/storage.service";
+
+export async function getStoredValue<T>(
+  key: string,
+  storage: AbstractStorageService,
+  deserializer: (jsonValue: Jsonify<T>) => T
+) {
+  if (storage.valuesRequireDeserialization) {
+    const jsonValue = await storage.get<Jsonify<T>>(key);
+    const value = deserializer(jsonValue);
+    return value;
+  } else {
+    const value = await storage.get<T>(key);
+    return value ?? null;
+  }
+}

--- a/libs/common/src/platform/state/key-definition.spec.ts
+++ b/libs/common/src/platform/state/key-definition.spec.ts
@@ -1,0 +1,81 @@
+import { Opaque } from "type-fest";
+
+import { KeyDefinition } from "./key-definition";
+import { StateDefinition } from "./state-definition";
+
+const fakeStateDefinition = new StateDefinition("fake", "disk");
+
+type FancyString = Opaque<string, "FancyString">;
+
+describe("KeyDefinition", () => {
+  describe("constructor", () => {
+    it("throws on undefined deserializer", () => {
+      expect(() => {
+        new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+          deserializer: undefined,
+        });
+      });
+    });
+  });
+
+  describe("record", () => {
+    it("runs custom deserializer for each record value", () => {
+      const recordDefinition = KeyDefinition.record<boolean>(fakeStateDefinition, "fake", {
+        // Intentionally negate the value for testing
+        deserializer: (value) => !value,
+      });
+
+      expect(recordDefinition).toBeTruthy();
+      expect(recordDefinition.deserializer).toBeTruthy();
+
+      const deserializedValue = recordDefinition.deserializer({
+        test1: false,
+        test2: true,
+      });
+
+      expect(Object.keys(deserializedValue)).toHaveLength(2);
+
+      // Values should have swapped from their initial value
+      expect(deserializedValue["test1"]).toBeTruthy();
+      expect(deserializedValue["test2"]).toBeFalsy();
+    });
+
+    it("can handle fancy string type", () => {
+      // This test is more of a test that I got the typescript typing correctly than actually testing any business logic
+      const recordDefinition = KeyDefinition.record<boolean, FancyString>(
+        fakeStateDefinition,
+        "fake",
+        {
+          deserializer: (value) => !value,
+        }
+      );
+
+      const fancyRecord = recordDefinition.deserializer(
+        JSON.parse(`{ "myKey": false, "mySecondKey": true }`)
+      );
+
+      expect(fancyRecord).toBeTruthy();
+      expect(Object.keys(fancyRecord)).toHaveLength(2);
+      expect(fancyRecord["myKey" as FancyString]).toBeTruthy();
+      expect(fancyRecord["mySecondKey" as FancyString]).toBeFalsy();
+    });
+  });
+
+  describe("array", () => {
+    it("run custom deserializer for each array element", () => {
+      const arrayDefinition = KeyDefinition.array<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => !value,
+      });
+
+      expect(arrayDefinition).toBeTruthy();
+      expect(arrayDefinition.deserializer).toBeTruthy();
+
+      const deserializedValue = arrayDefinition.deserializer([false, true]);
+
+      expect(deserializedValue).toBeTruthy();
+      expect(deserializedValue).toHaveLength(2);
+      expect(deserializedValue[0]).toBeTruthy();
+      expect(deserializedValue[1]).toBeFalsy();
+    });
+  });
+});

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -42,7 +42,9 @@ export class KeyDefinition<T> {
     private readonly options: KeyDefinitionOptions<T>
   ) {
     if (options.deserializer == null) {
-      throw new Error("'deserializer' is a required property.");
+      throw new Error(
+        `'deserializer' is a required property on key ${stateDefinition.name} > ${key}`
+      );
     }
   }
 

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -6,6 +6,22 @@ import { Utils } from "../misc/utils";
 import { StateDefinition } from "./state-definition";
 
 /**
+ * A set of options for customizing the behavior of a {@link KeyDefinition}
+ */
+type KeyDefinitionOptions<T> = {
+  /**
+   * A function to use to safely convert your type from json to your expected type.
+   *
+   * **Important:** Your data may be serialized/deserialized at any time and this
+   *  callback needs to be able to faithfully re-initialize from the JSON object representation of your type.
+   *
+   * @param jsonValue The JSON object representation of your state.
+   * @returns The fully typed version of your state.
+   */
+  readonly deserializer: (jsonValue: Jsonify<T>) => T;
+};
+
+/**
  * KeyDefinitions describe the precise location to store data for a given piece of state.
  * The StateDefinition is used to describe the domain of the state, and the KeyDefinition
  * sub-divides that domain into specific keys.
@@ -14,30 +30,59 @@ export class KeyDefinition<T> {
   /**
    * Creates a new instance of a KeyDefinition
    * @param stateDefinition The state definition for which this key belongs to.
-   * @param key The name of the key, this should be unique per domain
-   * @param deserializer A function to use to safely convert your type from json to your expected type.
+   * @param key The name of the key, this should be unique per domain.
+   * @param options A set of options to customize the behavior of {@link KeyDefinition}. All options are required.
+   * @param options.deserializer A function to use to safely convert your type from json to your expected type.
+   *   Your data may be serialized/deserialized at any time and this needs callback needs to be able to faithfully re-initialize
+   *   from the JSON object representation of your type.
    */
   constructor(
     readonly stateDefinition: StateDefinition,
     readonly key: string,
-    readonly deserializer: (jsonValue: Jsonify<T>) => T
-  ) {}
+    private readonly options: KeyDefinitionOptions<T>
+  ) {
+    if (options.deserializer == null) {
+      throw new Error("'deserializer' is a required property.");
+    }
+  }
+
+  /**
+   * Gets the deserializer configured for this {@link KeyDefinition}
+   */
+  get deserializer() {
+    return this.options.deserializer;
+  }
 
   /**
    * Creates a {@link KeyDefinition} for state that is an array.
    * @param stateDefinition The state definition to be added to the KeyDefinition
    * @param key The key to be added to the KeyDefinition
-   * @param deserializer The deserializer for the element of the array in your state.
-   * @returns A {@link KeyDefinition} that contains a serializer that will run the provided deserializer for each
-   * element of an array **unless that array is null in which case it will return an empty list.**
+   * @param options The options to customize the final {@link KeyDefinition}.
+   * @returns A {@link KeyDefinition} initialized for arrays, the options run
+   * the deserializer on the provided options for each element of an array
+   * **unless that array is null, in which case it will return an empty list.**
+   *
+   * @example
+   * ```typescript
+   * const MY_KEY = KeyDefinition.array<MyArrayElement>(MY_STATE, "key", {
+   *   deserializer: (myJsonElement) => convertToElement(myJsonElement),
+   * });
+   * ```
    */
   static array<T>(
     stateDefinition: StateDefinition,
     key: string,
-    deserializer: (jsonValue: Jsonify<T>) => T
+    // We have them provide options for the element of the array, depending on future options we add, this could get a little weird.
+    options: KeyDefinitionOptions<T> // The array helper forces  an initialValue of an empty array
   ) {
-    return new KeyDefinition<T[]>(stateDefinition, key, (jsonValue) => {
-      return jsonValue?.map((v) => deserializer(v)) ?? [];
+    return new KeyDefinition<T[]>(stateDefinition, key, {
+      ...options,
+      deserializer: (jsonValue) => {
+        if (jsonValue == null) {
+          return null;
+        }
+        return jsonValue.map((v) => options.deserializer(v));
+      },
     });
   }
 
@@ -45,32 +90,42 @@ export class KeyDefinition<T> {
    * Creates a {@link KeyDefinition} for state that is a record.
    * @param stateDefinition The state definition to be added to the KeyDefinition
    * @param key The key to be added to the KeyDefinition
-   * @param deserializer The deserializer for the value part of a record.
+   * @param options The options to customize the final {@link KeyDefinition}.
    * @returns A {@link KeyDefinition} that contains a serializer that will run the provided deserializer for each
-   * value in a record and returns every key as a string **unless that record is null in which case it will return an record.**
+   * value in a record and returns every key as a string **unless that record is null, in which case it will return an record.**
+   *
+   * @example
+   * ```typescript
+   * const MY_KEY = KeyDefinition.record<MyRecordValue>(MY_STATE, "key", {
+   *   deserializer: (myJsonValue) => convertToValue(myJsonValue),
+   * });
+   * ```
    */
-  static record<T>(
+  static record<T, TKey extends string = string>(
     stateDefinition: StateDefinition,
     key: string,
-    deserializer: (jsonValue: Jsonify<T>) => T
+    // We have them provide options for the value of the record, depending on future options we add, this could get a little weird.
+    options: KeyDefinitionOptions<T> // The array helper forces an initialValue of an empty record
   ) {
-    return new KeyDefinition<Record<string, T>>(stateDefinition, key, (jsonValue) => {
-      const output: Record<string, T> = {};
+    return new KeyDefinition<Record<TKey, T>>(stateDefinition, key, {
+      ...options,
+      deserializer: (jsonValue) => {
+        if (jsonValue == null) {
+          return null;
+        }
 
-      if (jsonValue == null) {
+        const output: Record<string, T> = {};
+        for (const key in jsonValue) {
+          output[key] = options.deserializer((jsonValue as Record<string, Jsonify<T>>)[key]);
+        }
         return output;
-      }
-
-      for (const key in jsonValue) {
-        output[key] = deserializer((jsonValue as Record<string, Jsonify<T>>)[key]);
-      }
-      return output;
+      },
     });
   }
 
   /**
-   *
-   * @returns
+   * Create a string that should be unique across the entire application.
+   * @returns A string that can be used to cache instances created via this key.
    */
   buildCacheKey(): string {
     return `${this.stateDefinition.storageLocation}_${this.stateDefinition.name}_${this.key}`;

--- a/libs/common/src/platform/state/state-update-options.ts
+++ b/libs/common/src/platform/state/state-update-options.ts
@@ -1,0 +1,26 @@
+import { Observable } from "rxjs";
+
+export const DEFAULT_OPTIONS = {
+  shouldUpdate: () => true,
+  combineLatestWith: null as Observable<unknown>,
+  msTimeout: 1000,
+};
+
+type DefinitelyTypedDefault<T, TCombine> = Omit<
+  typeof DEFAULT_OPTIONS,
+  "shouldUpdate" | "combineLatestWith"
+> & {
+  shouldUpdate: (state: T, dependency: TCombine) => boolean;
+  combineLatestWith?: Observable<TCombine>;
+};
+
+export type StateUpdateOptions<T, TCombine> = Partial<DefinitelyTypedDefault<T, TCombine>>;
+
+export function populateOptionsWithDefault<T, TCombine>(
+  options: StateUpdateOptions<T, TCombine>
+): StateUpdateOptions<T, TCombine> {
+  return {
+    ...(DEFAULT_OPTIONS as StateUpdateOptions<T, TCombine>),
+    ...options,
+  };
+}

--- a/libs/common/src/platform/state/user-state.ts
+++ b/libs/common/src/platform/state/user-state.ts
@@ -4,6 +4,8 @@ import { UserId } from "../../types/guid";
 import { EncryptService } from "../abstractions/encrypt.service";
 import { UserKey } from "../models/domain/symmetric-crypto-key";
 
+import { StateUpdateOptions } from "./state-update-options";
+
 import { DerivedUserState } from ".";
 
 export class DeriveContext {
@@ -21,16 +23,33 @@ export interface UserState<T> {
   /**
    * Updates backing stores for the active user.
    * @param configureState function that takes the current state and returns the new state
+   * @param options Defaults to @see {module:state-update-options#DEFAULT_OPTIONS}
+   * @param options.shouldUpdate A callback for determining if you want to update state. Defaults to () => true
+   * @param options.combineLatestWith An observable that you want to combine with the current state for callbacks. Defaults to null
+   * @param options.msTimeout A timeout for how long you are willing to wait for a `combineLatestWith` option to complete. Defaults to 1000ms. Only applies if `combineLatestWith` is set.
+
    * @returns The new state
    */
-  readonly update: (configureState: (state: T) => T) => Promise<T>;
+  readonly update: <TCombine>(
+    configureState: (state: T, dependencies: TCombine) => T,
+    options?: StateUpdateOptions<T, TCombine>
+  ) => Promise<T>;
   /**
    * Updates backing stores for the given userId, which may or may not be active.
    * @param userId the UserId to target the update for
    * @param configureState function that takes the current state for the targeted user and returns the new state
+   * @param options Defaults given by @see {module:state-update-options#DEFAULT_OPTIONS}
+   * @param options.shouldUpdate A callback for determining if you want to update state. Defaults to () => true
+   * @param options.combineLatestWith An observable that you want to combine with the current state for callbacks. Defaults to null
+   * @param options.msTimeout A timeout for how long you are willing to wait for a `combineLatestWith` option to complete. Defaults to 1000ms. Only applies if `combineLatestWith` is set.
+
    * @returns The new state
    */
-  readonly updateFor: (userId: UserId, configureState: (state: T) => T) => Promise<T>;
+  readonly updateFor: <TCombine>(
+    userId: UserId,
+    configureState: (state: T, dependencies: TCombine) => T,
+    options?: StateUpdateOptions<T, TCombine>
+  ) => Promise<T>;
 
   /**
    * Creates a derives state from the current state. Derived states are always tied to the active user.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds three improvements needed for the state provider framework (#6640).
1. Options in update logic to include dependencies and to provide a `shouldUpdate` callback to use as a guard clause to updates
2. Removes the `value` from storage service updates and allows the subscriber to `get` the update, if it's relevant. This reduces messaging sizes, limits platform differences in object messaging, and centralizes all state reads to a single location, which is relevant for...
3. Limit calls to `KeyDefinition.deserializer` to only when the storage service itself informs that data has been serialized. This allows us to transparently swap out storage providers that may or may not serialize data. Otherwise, the deserializer needs to handle data differences resulting from that proccess (like `Date` or `TypedArray`).

## Code changes

- **storage service impls**: 
  - A new bool getter that informs whether or not the storage service serializes.
  - Removes the `value` property from updates stream
- **global and user state**:
  - add state update callback options and handle them appropriately
  - get value from relevant storage updates
- **state-update-options**: Central place to handle update callback options and default settings

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
