### PR TITLE
[PM-4766] Disable fido2 integration on bw vault page

### DIFF
--- a/apps/browser/src/vault/fido2/content/content-script.ts
+++ b/apps/browser/src/vault/fido2/content/content-script.ts
@@ -10,7 +10,7 @@ function isFido2FeatureEnabled(): Promise<boolean> {
   return new Promise((resolve) => {
     chrome.runtime.sendMessage(
       { command: "checkFido2FeatureEnabled" },
-      (response: { result?: boolean }) => resolve(response.result),
+      (response: { result?: boolean }) => resolve(response.result)
     );
   });
 }
@@ -21,7 +21,7 @@ async function getFromLocalStorage(keys: string | string[]): Promise<Record<stri
   });
 }
 
-async function isDomainExcluded() {
+async function getActiveUserSettings() {
   // TODO: This is code copied from `notification-bar.tsx`. We should refactor this into a shared function.
   // Look up the active user id from storage
   const activeUserIdKey = "activeUserId";
@@ -32,10 +32,14 @@ async function isDomainExcluded() {
     activeUserId = activeUserStorageValue[activeUserIdKey];
   }
 
-  // Look up the user's settings from storage
-  const userSettingsStorageValue = await getFromLocalStorage(activeUserId);
+  const settingsStorage = await getFromLocalStorage(activeUserId);
 
-  const excludedDomains = userSettingsStorageValue[activeUserId]?.settings?.neverDomains;
+  // Look up the user's settings from storage
+  return settingsStorage?.[activeUserId]?.settings;
+}
+
+async function isDomainExcluded(activeUserSettings: Record<string, any>) {
+  const excludedDomains = activeUserSettings?.neverDomains;
   return excludedDomains && window.location.hostname in excludedDomains;
 }
 
@@ -51,6 +55,10 @@ function isSameOriginWithAncestors() {
   } catch {
     return false;
   }
+}
+
+async function isLocationBitwardenVault(activeUserSettings: Record<string, any>) {
+  return window.location.origin === activeUserSettings.serverConfig.environment.vault;
 }
 
 function initializeFido2ContentScript() {
@@ -92,7 +100,7 @@ function initializeFido2ContentScript() {
               type: MessageType.CredentialCreationResponse,
               result: response.result,
             });
-          },
+          }
         );
       });
     }
@@ -120,10 +128,10 @@ function initializeFido2ContentScript() {
               type: MessageType.CredentialGetResponse,
               result: response.result,
             });
-          },
+          }
         );
       }).finally(() =>
-        abortController.signal.removeEventListener("abort", abortHandler),
+        abortController.signal.removeEventListener("abort", abortHandler)
       ) as Promise<Message>;
     }
 
@@ -132,9 +140,21 @@ function initializeFido2ContentScript() {
 }
 
 async function run() {
-  if ((await hasActiveUser()) && (await isFido2FeatureEnabled()) && !(await isDomainExcluded())) {
-    initializeFido2ContentScript();
+  if (!(await hasActiveUser())) {
+    return;
   }
+
+  const activeUserSettings = await getActiveUserSettings();
+  if (
+    activeUserSettings == null ||
+    !(await isFido2FeatureEnabled()) ||
+    (await isDomainExcluded(activeUserSettings)) ||
+    (await isLocationBitwardenVault(activeUserSettings))
+  ) {
+    return;
+  }
+
+  initializeFido2ContentScript();
 }
 
 run();

--- a/apps/browser/src/vault/fido2/content/content-script.ts
+++ b/apps/browser/src/vault/fido2/content/content-script.ts
@@ -10,7 +10,7 @@ function isFido2FeatureEnabled(): Promise<boolean> {
   return new Promise((resolve) => {
     chrome.runtime.sendMessage(
       { command: "checkFido2FeatureEnabled" },
-      (response: { result?: boolean }) => resolve(response.result)
+      (response: { result?: boolean }) => resolve(response.result),
     );
   });
 }
@@ -100,7 +100,7 @@ function initializeFido2ContentScript() {
               type: MessageType.CredentialCreationResponse,
               result: response.result,
             });
-          }
+          },
         );
       });
     }
@@ -128,10 +128,10 @@ function initializeFido2ContentScript() {
               type: MessageType.CredentialGetResponse,
               result: response.result,
             });
-          }
+          },
         );
       }).finally(() =>
-        abortController.signal.removeEventListener("abort", abortHandler)
+        abortController.signal.removeEventListener("abort", abortHandler),
       ) as Promise<Message>;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Disable passkey storage on your own web vault so that you can't register login-passkeys with your own vault

This can be thought of as the equivalent of suppressing the notification bar on the Bitwarden vault (see https://github.com/bitwarden/clients/blob/6c3cb841a2d54e1b61be7f4f6c9df56d99665684/apps/browser/src/autofill/content/notification-bar.ts#L103).

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
