### PR TITLE
[PM-4743] Windows Chromium Browser is Not Updating Overlay Ciphers on Tab Update

### DIFF
--- a/apps/browser/src/autofill/background/tabs.background.spec.ts
+++ b/apps/browser/src/autofill/background/tabs.background.spec.ts
@@ -164,6 +164,16 @@ describe("TabsBackground", () => {
         expect(overlayBackground.removePageDetails).toHaveBeenCalledWith(focusedWindowId);
       });
 
+      it("skips updating the current tab data the focusedWindowId is set to a value less than zero", async () => {
+        tab.windowId = -1;
+        triggerTabOnUpdatedEvent(focusedWindowId, { status: "loading" }, tab);
+        await flushPromises();
+
+        expect(mainBackground.refreshBadge).not.toHaveBeenCalled();
+        expect(mainBackground.refreshMenu).not.toHaveBeenCalled();
+        expect(overlayBackground.updateOverlayCiphers).not.toHaveBeenCalled();
+      });
+
       it("skips updating the current tab data if the updated tab is not for the focusedWindowId", async () => {
         tab.windowId = 20;
         triggerTabOnUpdatedEvent(focusedWindowId, { status: "loading" }, tab);

--- a/apps/browser/src/autofill/background/tabs.background.ts
+++ b/apps/browser/src/autofill/background/tabs.background.ts
@@ -81,7 +81,7 @@ export default class TabsBackground {
       this.overlayBackground.removePageDetails(tabId);
     }
 
-    if (this.focusedWindowId && tab.windowId !== this.focusedWindowId) {
+    if (this.focusedWindowId > 0 && tab.windowId !== this.focusedWindowId) {
       return;
     }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

An issue was introduced when the tabs.background.ts file was refactored for the overlay. Windows does not correctly track focus changes within Chrome windows, and often will return a -1 instead of an actual value when the focus listener is triggered. Logic has been reverted to what was present before to ensure we update cipher data in the overlay and other parts of the extension.

## Code changes

- **apps/browser/src/autofill/background/tabs.background.spec.ts:** Adding a test to verify reverted behavior.
- **apps/browser/src/autofill/background/tabs.background.ts:** Reverting logic when checking for the focused window ID to ensure cipher data updates.

## Video


https://github.com/bitwarden/clients/assets/16629865/bb11a2d3-0496-4c7c-930c-ee49c5cbcfe9


