### PR TITLE
[PM-4763] Fixing Issues with the Overlay UI Positioning and Presentation

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -971,6 +971,15 @@ describe("OverlayBackground", () => {
       jest.spyOn(overlayBackground as any, "getOverlayCipherData").mockImplementation();
     });
 
+    it("skips setting up the overlay port if the port connection is not for an overlay element", () => {
+      const port = createPortSpyMock("not-an-overlay-element");
+
+      overlayBackground["handlePortOnConnect"](port);
+
+      expect(port.onMessage.addListener).not.toHaveBeenCalled();
+      expect(port.postMessage).not.toHaveBeenCalled();
+    });
+
     it("sets up the overlay list port if the port connection is for the overlay list", async () => {
       initOverlayElementPorts({ initList: true, initButton: false });
       await flushPromises();

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -706,6 +706,11 @@ class OverlayBackground implements OverlayBackgroundInterface {
    */
   private handlePortOnConnect = async (port: chrome.runtime.Port) => {
     const isOverlayListPort = port.name === AutofillOverlayPort.List;
+    const isOverlayButtonPort = port.name === AutofillOverlayPort.Button;
+
+    if (!isOverlayListPort && !isOverlayButtonPort) {
+      return;
+    }
 
     if (isOverlayListPort) {
       this.overlayListPort = port;

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -81,6 +81,20 @@ describe("AutofillOverlayContentService", () => {
       expect(setupGlobalEventListenersSpy).not.toHaveBeenCalled();
     });
 
+    it("sets up a visibility change listener for the DOM", () => {
+      const handleVisibilityChangeEventSpy = jest.spyOn(
+        autofillOverlayContentService as any,
+        "handleVisibilityChangeEvent"
+      );
+
+      autofillOverlayContentService.init();
+
+      expect(document.addEventListener).toHaveBeenCalledWith(
+        "visibilitychange",
+        handleVisibilityChangeEventSpy
+      );
+    });
+
     it("sets up a focus out listener for the window", () => {
       const handleFormFieldBlurEventSpy = jest.spyOn(
         autofillOverlayContentService as any,
@@ -1564,6 +1578,28 @@ describe("AutofillOverlayContentService", () => {
 
       expect(blurMostRecentOverlayFieldSpy).toHaveBeenCalled();
       expect(removeAutofillOverlaySpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleVisibilityChangeEvent", () => {
+    it("skips removing the overlay if the document is visible", () => {
+      jest.spyOn(autofillOverlayContentService as any, "removeAutofillOverlay");
+
+      autofillOverlayContentService["handleVisibilityChangeEvent"]();
+
+      expect(autofillOverlayContentService["removeAutofillOverlay"]).not.toHaveBeenCalled();
+    });
+
+    it("removes the overlay if the document is not visible", () => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        writable: true,
+      });
+      jest.spyOn(autofillOverlayContentService as any, "removeAutofillOverlay");
+
+      autofillOverlayContentService["handleVisibilityChangeEvent"]();
+
+      expect(autofillOverlayContentService["removeAutofillOverlay"]).toHaveBeenCalled();
     });
   });
 });

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1523,7 +1523,8 @@ describe("AutofillOverlayContentService", () => {
       expect(globalThis.document.body.appendChild).not.toHaveBeenCalled();
     });
 
-    it("appends the identified node to the body", () => {
+    it("appends the identified node to the body", async () => {
+      jest.useFakeTimers();
       const injectedElement = document.createElement("div");
       injectedElement.id = "test";
       document.documentElement.appendChild(injectedElement);
@@ -1533,6 +1534,7 @@ describe("AutofillOverlayContentService", () => {
           addedNodes: document.querySelectorAll("#test"),
         } as unknown as MutationRecord,
       ]);
+      jest.advanceTimersByTime(10);
 
       expect(globalThis.document.body.appendChild).toHaveBeenCalledWith(injectedElement);
     });

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -55,6 +55,7 @@ describe("AutofillOverlayContentService", () => {
 
     beforeEach(() => {
       jest.spyOn(document, "addEventListener");
+      jest.spyOn(window, "addEventListener");
       setupGlobalEventListenersSpy = jest.spyOn(
         autofillOverlayContentService as any,
         "setupGlobalEventListeners"
@@ -80,18 +81,15 @@ describe("AutofillOverlayContentService", () => {
       expect(setupGlobalEventListenersSpy).not.toHaveBeenCalled();
     });
 
-    it("sets up a visibility change listener for the DOM", () => {
-      const handleVisibilityChangeEventSpy = jest.spyOn(
+    it("sets up a focus out listener for the window", () => {
+      const handleFormFieldBlurEventSpy = jest.spyOn(
         autofillOverlayContentService as any,
-        "handleVisibilityChangeEvent"
+        "handleFormFieldBlurEvent"
       );
 
       autofillOverlayContentService.init();
 
-      expect(document.addEventListener).toHaveBeenCalledWith(
-        "visibilitychange",
-        handleVisibilityChangeEventSpy
-      );
+      expect(window.addEventListener).toHaveBeenCalledWith("focusout", handleFormFieldBlurEventSpy);
     });
 
     it("sets up mutation observers for the body and html element", () => {
@@ -1565,42 +1563,6 @@ describe("AutofillOverlayContentService", () => {
       await flushPromises();
 
       expect(blurMostRecentOverlayFieldSpy).toHaveBeenCalled();
-      expect(removeAutofillOverlaySpy).toHaveBeenCalled();
-    });
-  });
-
-  describe("handleVisibilityChangeEvent", () => {
-    let removeAutofillOverlaySpy: jest.SpyInstance;
-    beforeEach(() => {
-      removeAutofillOverlaySpy = jest.spyOn(
-        autofillOverlayContentService as any,
-        "removeAutofillOverlay"
-      );
-      autofillOverlayContentService["mostRecentlyFocusedField"] = document.createElement(
-        "div"
-      ) as ElementWithOpId<FormFieldElement>;
-    });
-
-    it("skips removing the autofill overlay if the visibility state is `visible`", () => {
-      Object.defineProperty(document, "visibilityState", {
-        value: "visible",
-        writable: true,
-      });
-
-      autofillOverlayContentService["handleVisibilityChangeEvent"]();
-
-      expect(removeAutofillOverlaySpy).not.toHaveBeenCalled();
-    });
-
-    it("resets the most recently focused field and removes the autofill overlay if the visibility state is not `visible`", () => {
-      Object.defineProperty(document, "visibilityState", {
-        value: "hidden",
-        writable: true,
-      });
-
-      autofillOverlayContentService["handleVisibilityChangeEvent"]();
-
-      expect(autofillOverlayContentService["mostRecentlyFocusedField"]).toEqual(null);
       expect(removeAutofillOverlaySpy).toHaveBeenCalled();
     });
   });

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -64,11 +64,11 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    */
   init() {
     if (globalThis.document.readyState === "loading") {
-      globalThis.document.addEventListener(EVENTS.DOMCONTENTLOADED, this.setupMutationObserver);
+      globalThis.document.addEventListener(EVENTS.DOMCONTENTLOADED, this.setupGlobalEventListeners);
       return;
     }
 
-    this.setupMutationObserver();
+    this.setupGlobalEventListeners();
   }
 
   /**
@@ -859,6 +859,31 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
       clearTimeout(this.userInteractionEventTimeout);
     }
   }
+
+  /**
+   * Sets up global event listeners and the mutation
+   * observer to facilitate required changes to the
+   * overlay elements.
+   */
+  private setupGlobalEventListeners() {
+    document.addEventListener("visibilitychange", this.handleVisibilityChangeEvent);
+    this.setupMutationObserver();
+  }
+
+  /**
+   * Handles removing the autofill overlay when the document
+   * visibility changes to hidden. This method will also clear
+   * the most recently focused field to ensure that the overlay
+   * positioning is fresh when re-opening the overlay.
+   */
+  private handleVisibilityChangeEvent = () => {
+    if (document.visibilityState === "visible") {
+      return;
+    }
+
+    this.mostRecentlyFocusedField = null;
+    this.removeAutofillOverlay();
+  };
 
   /**
    * Sets up mutation observers for the overlay elements, the body element, and the

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -867,8 +867,22 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * overlay elements.
    */
   private setupGlobalEventListeners = () => {
+    document.addEventListener("visibilitychange", this.handleVisibilityChangeEvent);
     window.addEventListener("focusout", this.handleFormFieldBlurEvent);
     this.setupMutationObserver();
+  };
+
+  /**
+   * Handles the visibility change event. This method will remove the
+   * autofill overlay if the document is not visible.
+   */
+  private handleVisibilityChangeEvent = () => {
+    if (document.visibilityState === "visible") {
+      return;
+    }
+
+    this.mostRecentlyFocusedField = null;
+    this.removeAutofillOverlay();
   };
 
   /**

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -867,8 +867,8 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * overlay elements.
    */
   private setupGlobalEventListeners = () => {
-    document.addEventListener("visibilitychange", this.handleVisibilityChangeEvent);
-    window.addEventListener("focusout", this.handleFormFieldBlurEvent);
+    globalThis.document.addEventListener("visibilitychange", this.handleVisibilityChangeEvent);
+    globalThis.addEventListener("focusout", this.handleFormFieldBlurEvent);
     this.setupMutationObserver();
   };
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1006,13 +1006,22 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
       }
     }
 
-    if (isRemovingNodes) {
-      for (let elementIndex = 0; elementIndex < mutatedElements.length; elementIndex++) {
+    for (let elementIndex = 0; elementIndex < mutatedElements.length; elementIndex++) {
+      const node = mutatedElements[elementIndex];
+      if (isRemovingNodes) {
         this.deleteCachedAutofillElement(
-          mutatedElements[elementIndex] as
-            | ElementWithOpId<HTMLFormElement>
-            | ElementWithOpId<FormFieldElement>
+          node as ElementWithOpId<HTMLFormElement> | ElementWithOpId<FormFieldElement>
         );
+        continue;
+      }
+
+      if (
+        this.isNodeFormFieldElement(node) &&
+        !this.autofillFieldElements.get(node as ElementWithOpId<FormFieldElement>)
+      ) {
+        // We are setting this item to a -1 index because we do not know its position in the DOM.
+        // This value should be updated with the next call to collect page details.
+        this.buildAutofillFieldItem(node as ElementWithOpId<FormFieldElement>, -1);
       }
     }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR includes a number of fixes that hopefully will address the weird UI issues that are being seen when the overlay is open on a stale tab. These include the following:

- A guard within the overlay background that ensures the correct ports are registered for the overlay list and button
- A `focusout` listener that ensures the overlay elements will be cleaned up if the Window loses focus
- A `visibilitychange` listener that ensures the overlay elements will be cleaned up if the window becomes hidden
- Fixes for how we handle repositioning dom elements within the root `html` element to ensure the overlay only updates those when it is injected
- A method to ensure the overlay is built if the DOM injects form field elements after a mutation has occurred in the DOM

## Code changes

- **apps/browser/src/autofill/background/overlay.background.spec.ts:** Jest tests to validate that ports who do not belong to the overlay are ignored on connect
- **apps/browser/src/autofill/background/overlay.background.ts:**Setting up a guard to ensure that only overlay ports are handled by the overlay's onConnect listener.
- **apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts:** Adding jest tests to validate changes made within the overlay content service
- **apps/browser/src/autofill/services/autofill-overlay-content.service.ts:** Adding the listeners referenced above to ensure that the overlay is removed when the DOM has been hidden or blurred.
- **apps/browser/src/autofill/services/collect-autofill-content.service.ts:** Adding logic that ensures all input elements that load after the initial collect page details call are registered for use with the overlay. This makes sure that any form elements that are loaded in a deferred manner will still have an overlay on click.

