### PR TITLE
Trim otp input

### DIFF
--- a/libs/common/src/services/totp.service.ts
+++ b/libs/common/src/services/totp.service.ts
@@ -16,6 +16,7 @@ export class TotpService implements TotpServiceAbstraction {
     if (key == null) {
       return null;
     }
+    key = key.trim();
     let period = 30;
     let alg: "sha1" | "sha256" | "sha512" = "sha1";
     let digits = 6;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR resolves #6873
When cloning a working entry that has a valid OTP and editing the cloned entry by putting a space at the beginning of otpauth:// a wrong OTP is generated.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->

<!--Also refer to any related changes or PRs in other repositories-->

- **totp.service.ts**: The expected behaviour would be to still have a valid otp and therefore the whitespaces are trimmed.
- similar to https://github.com/bitwarden/mobile/pull/2865 (mobile version has the same issue)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
