### PR TITLE
[PM-4790] Overlay not resetting on scroll of websites that do not scroll body element

### DIFF
--- a/apps/browser/src/autofill/constants.ts
+++ b/apps/browser/src/autofill/constants.ts
@@ -18,6 +18,8 @@ export const EVENTS = {
   DOMCONTENTLOADED: "DOMContentLoaded",
   LOAD: "load",
   MESSAGE: "message",
+  WHEEL: "wheel",
+  TOUCHMOVE: "touchmove",
 } as const;
 
 /* Context Menu item Ids */

--- a/apps/browser/src/autofill/constants.ts
+++ b/apps/browser/src/autofill/constants.ts
@@ -18,8 +18,8 @@ export const EVENTS = {
   DOMCONTENTLOADED: "DOMContentLoaded",
   LOAD: "load",
   MESSAGE: "message",
-  WHEEL: "wheel",
-  TOUCHMOVE: "touchmove",
+  VISIBILITYCHANGE: "visibilitychange",
+  FOCUSOUT: "focusout",
 } as const;
 
 /* Context Menu item Ids */

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -939,12 +939,11 @@ describe("AutofillOverlayContentService", () => {
       autofillOverlayContentService.removeAutofillOverlay();
 
       expect(globalThis.removeEventListener).toHaveBeenCalledWith(
-        EVENTS.WHEEL,
-        handleOverlayRepositionEventSpy
-      );
-      expect(globalThis.removeEventListener).toHaveBeenCalledWith(
-        EVENTS.TOUCHMOVE,
-        handleOverlayRepositionEventSpy
+        EVENTS.SCROLL,
+        handleOverlayRepositionEventSpy,
+        {
+          capture: true,
+        }
       );
       expect(globalThis.removeEventListener).toHaveBeenCalledWith(
         EVENTS.RESIZE,
@@ -1171,7 +1170,7 @@ describe("AutofillOverlayContentService", () => {
     });
 
     it("hides the overlay elements", () => {
-      globalThis.dispatchEvent(new Event(EVENTS.WHEEL));
+      globalThis.dispatchEvent(new Event(EVENTS.SCROLL));
 
       expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillOverlayHidden", {
         display: "none",
@@ -1185,7 +1184,7 @@ describe("AutofillOverlayContentService", () => {
       const clearTimeoutSpy = jest.spyOn(globalThis, "clearTimeout");
       autofillOverlayContentService["userInteractionEventTimeout"] = setTimeout(jest.fn(), 123);
 
-      globalThis.dispatchEvent(new Event(EVENTS.WHEEL));
+      globalThis.dispatchEvent(new Event(EVENTS.SCROLL));
 
       expect(clearTimeoutSpy).toHaveBeenCalledWith(expect.anything());
     });
@@ -1201,7 +1200,7 @@ describe("AutofillOverlayContentService", () => {
       );
       autofillOverlayContentService["mostRecentlyFocusedField"] = undefined;
 
-      globalThis.dispatchEvent(new Event(EVENTS.TOUCHMOVE));
+      globalThis.dispatchEvent(new Event(EVENTS.SCROLL));
       jest.advanceTimersByTime(800);
 
       expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillOverlayHidden", {
@@ -1229,7 +1228,7 @@ describe("AutofillOverlayContentService", () => {
         "clearUserInteractionEventTimeout"
       );
 
-      globalThis.dispatchEvent(new Event(EVENTS.WHEEL));
+      globalThis.dispatchEvent(new Event(EVENTS.SCROLL));
       jest.advanceTimersByTime(800);
       await flushPromises();
 
@@ -1259,7 +1258,7 @@ describe("AutofillOverlayContentService", () => {
         "removeAutofillOverlay"
       );
 
-      globalThis.dispatchEvent(new Event(EVENTS.TOUCHMOVE));
+      globalThis.dispatchEvent(new Event(EVENTS.SCROLL));
       jest.advanceTimersByTime(800);
       await flushPromises();
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -870,8 +870,8 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * overlay elements.
    */
   private setupGlobalEventListeners = () => {
-    globalThis.document.addEventListener("visibilitychange", this.handleVisibilityChangeEvent);
-    globalThis.addEventListener("focusout", this.handleFormFieldBlurEvent);
+    globalThis.document.addEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChangeEvent);
+    globalThis.addEventListener(EVENTS.FOCUSOUT, this.handleFormFieldBlurEvent);
     this.setupMutationObserver();
   };
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -797,8 +797,9 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * the autofill overlay on scroll or resize.
    */
   private setOverlayRepositionEventListeners() {
-    globalThis.addEventListener(EVENTS.WHEEL, this.handleOverlayRepositionEvent);
-    globalThis.addEventListener(EVENTS.TOUCHMOVE, this.handleOverlayRepositionEvent);
+    globalThis.addEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent, {
+      capture: true,
+    });
     globalThis.addEventListener(EVENTS.RESIZE, this.handleOverlayRepositionEvent);
   }
 
@@ -807,8 +808,9 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * the autofill overlay on scroll or resize.
    */
   private removeOverlayRepositionEventListeners() {
-    globalThis.removeEventListener(EVENTS.WHEEL, this.handleOverlayRepositionEvent);
-    globalThis.removeEventListener(EVENTS.TOUCHMOVE, this.handleOverlayRepositionEvent);
+    globalThis.removeEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent, {
+      capture: true,
+    });
     globalThis.removeEventListener(EVENTS.RESIZE, this.handleOverlayRepositionEvent);
   }
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -362,8 +362,9 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * the overlay will be opened and the list will be focused after a short delay. Ensures
    * that the overlay list is focused when the user presses the down arrow key.
    */
-  private focusOverlayList() {
-    if (!this.isOverlayListVisible) {
+  private async focusOverlayList() {
+    if (!this.isOverlayListVisible && this.mostRecentlyFocusedField) {
+      await this.updateMostRecentlyFocusedField(this.mostRecentlyFocusedField);
       this.openAutofillOverlay({ isOpeningFullOverlay: true });
       setTimeout(() => this.sendExtensionMessage("focusAutofillOverlayList"), 125);
       return;
@@ -796,8 +797,8 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * the autofill overlay on scroll or resize.
    */
   private setOverlayRepositionEventListeners() {
-    globalThis.document.body?.addEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent);
-    globalThis.addEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent);
+    globalThis.addEventListener(EVENTS.WHEEL, this.handleOverlayRepositionEvent);
+    globalThis.addEventListener(EVENTS.TOUCHMOVE, this.handleOverlayRepositionEvent);
     globalThis.addEventListener(EVENTS.RESIZE, this.handleOverlayRepositionEvent);
   }
 
@@ -806,8 +807,8 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * the autofill overlay on scroll or resize.
    */
   private removeOverlayRepositionEventListeners() {
-    globalThis.document.body?.removeEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent);
-    globalThis.removeEventListener(EVENTS.SCROLL, this.handleOverlayRepositionEvent);
+    globalThis.removeEventListener(EVENTS.WHEEL, this.handleOverlayRepositionEvent);
+    globalThis.removeEventListener(EVENTS.TOUCHMOVE, this.handleOverlayRepositionEvent);
     globalThis.removeEventListener(EVENTS.RESIZE, this.handleOverlayRepositionEvent);
   }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The autofill overlay isn't resetting on websites that set up the `html` and `body` elements with a fixed position. As a result, we're modifying the listeners that trigger this behavior to facilitate globally caught triggers for scroll events. This ensures that we can reposition the overlay when any element scrolls within the DOM.

## Code changes


- **apps/browser/src/autofill/constants.ts:** Adding events to the list of constants so that we aren't referenced the string value when setting up visibility change and focus out listeners.
- **apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts:** Updating jest tests to verify logic changes made to scroll listener within the AutofillOverlayContentService
- **apps/browser/src/autofill/services/autofill-overlay-content.service.ts:** Updating scroll event references to ensure that we capture any nested scroll events that are triggered within the window.

## Demo of error

https://github.com/bitwarden/clients/assets/16629865/ff17959e-8fd6-40c6-9a77-23b876f4a073


## Demo of fix

https://github.com/bitwarden/clients/assets/16629865/2d882fd9-5ab9-4878-95fa-f38fc1f8ea58

