### PR TITLE
[AC-1139] Flexible collections: deprecate Manage/Edit/Delete Assigned Collections custom permissions

### DIFF
--- a/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.spec.ts
@@ -9,6 +9,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -52,7 +53,8 @@ describe("Organization Permissions Guard", () => {
       organizationService,
       mock<PlatformUtilsService>(),
       mock<I18nService>(),
-      mock<SyncService>()
+      mock<SyncService>(),
+      mock<ConfigServiceAbstraction>()
     );
   });
 

--- a/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.ts
@@ -6,6 +6,8 @@ import {
   OrganizationService,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -19,7 +21,8 @@ export class OrganizationPermissionsGuard implements CanActivate {
     private organizationService: OrganizationService,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
-    private syncService: SyncService
+    private syncService: SyncService,
+    private configService: ConfigServiceAbstraction
   ) {}
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -42,9 +45,17 @@ export class OrganizationPermissionsGuard implements CanActivate {
       return this.router.createUrlTree(["/"]);
     }
 
-    const permissionsCallback: (organization: Organization) => boolean =
-      route.data?.organizationPermissions;
-    const hasPermissions = permissionsCallback == null || permissionsCallback(org);
+    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections,
+      false
+    );
+
+    const permissionsCallback: (
+      organization: Organization,
+      flexibleCollectionsEnabled: boolean
+    ) => boolean = route.data?.organizationPermissions;
+    const hasPermissions =
+      permissionsCallback == null || permissionsCallback(org, flexibleCollectionsEnabled);
 
     if (!hasPermissions) {
       // Handle linkable ciphers for organizations the user only has view access to
@@ -60,7 +71,7 @@ export class OrganizationPermissionsGuard implements CanActivate {
       }
 
       this.platformUtilsService.showToast("error", null, this.i18nService.t("accessDenied"));
-      return canAccessOrgAdmin(org)
+      return canAccessOrgAdmin(org, flexibleCollectionsEnabled)
         ? this.router.createUrlTree(["/organizations", org.id])
         : this.router.createUrlTree(["/"]);
     }

--- a/apps/web/src/app/admin-console/organizations/guards/org-redirect.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/org-redirect.guard.ts
@@ -27,7 +27,7 @@ export class OrganizationRedirectGuard implements CanActivate {
 
     const customRedirect = route.data?.autoRedirectCallback;
     if (customRedirect) {
-      let redirectPath = customRedirect(org);
+      let redirectPath = customRedirect(org, flexibleCollectionsEnabled);
       if (typeof redirectPath === "string") {
         redirectPath = [redirectPath];
       }

--- a/apps/web/src/app/admin-console/organizations/guards/org-redirect.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/org-redirect.guard.ts
@@ -5,15 +5,25 @@ import {
   canAccessOrgAdmin,
   OrganizationService,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 
 @Injectable({
   providedIn: "root",
 })
 export class OrganizationRedirectGuard implements CanActivate {
-  constructor(private router: Router, private organizationService: OrganizationService) {}
+  constructor(
+    private router: Router,
+    private organizationService: OrganizationService,
+    private configService: ConfigServiceAbstraction
+  ) {}
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     const org = this.organizationService.get(route.params.organizationId);
+    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections,
+      false
+    );
 
     const customRedirect = route.data?.autoRedirectCallback;
     if (customRedirect) {
@@ -24,7 +34,7 @@ export class OrganizationRedirectGuard implements CanActivate {
       return this.router.createUrlTree([state.url, ...redirectPath]);
     }
 
-    if (canAccessOrgAdmin(org)) {
+    if (canAccessOrgAdmin(org, flexibleCollectionsEnabled)) {
       return this.router.createUrlTree(["/organizations", org.id]);
     }
     return this.router.createUrlTree(["/"]);

--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
@@ -13,6 +13,8 @@ import {
   OrganizationService,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 
 @Component({
   selector: "app-organization-layout",
@@ -22,11 +24,20 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
   organization$: Observable<Organization>;
 
   private _destroy = new Subject<void>();
+  private flexibleCollectionsEnabled: boolean;
 
-  constructor(private route: ActivatedRoute, private organizationService: OrganizationService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private organizationService: OrganizationService,
+    private configService: ConfigServiceAbstraction
+  ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
     document.body.classList.remove("layout_frontend");
+
+    this.flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections
+    );
 
     this.organization$ = this.route.params
       .pipe(takeUntil(this._destroy))
@@ -46,7 +57,7 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
   }
 
   canShowVaultTab(organization: Organization): boolean {
-    return canAccessVaultTab(organization);
+    return canAccessVaultTab(organization, this.flexibleCollectionsEnabled);
   }
 
   canShowSettingsTab(organization: Organization): boolean {

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -138,25 +138,128 @@
             </div>
           </fieldset>
           <ng-container *ngIf="customUserTypeSelected">
-            <h3 class="mt-4 d-flex tw-font-semibold">
-              {{ "permissions" | i18n }}
-            </h3>
-            <div class="row" [formGroup]="permissionsGroup">
-              <div class="col-6">
-                <div class="mb-3">
-                  <label class="tw-font-semibold">{{ "managerPermissions" | i18n }}</label>
-                  <hr class="tw-mb-2 tw-mr-2 tw-mt-0" />
-                  <app-nested-checkbox
-                    parentId="manageAssignedCollections"
-                    [checkboxes]="permissionsGroup.controls.manageAssignedCollectionsGroup"
-                  >
-                  </app-nested-checkbox>
+            <ng-container *ngIf="!(flexibleCollectionsEnabled$ | async); else customPermissionsFC">
+              <h3 class="mt-4 d-flex tw-font-semibold">
+                {{ "permissions" | i18n }}
+              </h3>
+              <div class="row" [formGroup]="permissionsGroup">
+                <div class="col-6">
+                  <div class="mb-3">
+                    <label class="tw-font-semibold">{{ "managerPermissions" | i18n }}</label>
+                    <hr class="tw-mb-2 tw-mr-2 tw-mt-0" />
+                    <app-nested-checkbox
+                      parentId="manageAssignedCollections"
+                      [checkboxes]="permissionsGroup.controls.manageAssignedCollectionsGroup"
+                    >
+                    </app-nested-checkbox>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <div class="mb-3">
+                    <label class="tw-font-semibold">{{ "adminPermissions" | i18n }}</label>
+                    <hr class="tw-mb-2 tw-mr-2 tw-mt-0" />
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="accessEventLogs"
+                        id="accessEventLogs"
+                        formControlName="accessEventLogs"
+                      />
+                      <label class="!tw-font-normal" for="accessEventLogs">
+                        {{ "accessEventLogs" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="accessImportExport"
+                        id="accessImportExport"
+                        formControlName="accessImportExport"
+                      />
+                      <label class="!tw-font-normal" for="accessImportExport">
+                        {{ "accessImportExport" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="accessReports"
+                        id="accessReports"
+                        formControlName="accessReports"
+                      />
+                      <label class="!tw-font-normal" for="accessReports">
+                        {{ "accessReports" | i18n }}
+                      </label>
+                    </div>
+                    <app-nested-checkbox
+                      parentId="manageAllCollections"
+                      [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
+                    >
+                    </app-nested-checkbox>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageGroups"
+                        id="manageGroups"
+                        formControlName="manageGroups"
+                      />
+                      <label class="!tw-font-normal" for="manageGroups">
+                        {{ "manageGroups" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageSso"
+                        id="manageSso"
+                        formControlName="manageSso"
+                      />
+                      <label class="!tw-font-normal" for="manageSso">
+                        {{ "manageSso" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="managePolicies"
+                        id="managePolicies"
+                        formControlName="managePolicies"
+                      />
+                      <label class="!tw-font-normal" for="managePolicies">
+                        {{ "managePolicies" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageUsers"
+                        id="manageUsers"
+                        formControlName="manageUsers"
+                        (change)="handleDependentPermissions()"
+                      />
+                      <label class="!tw-font-normal" for="manageUsers">
+                        {{ "manageUsers" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageResetPassword"
+                        id="manageResetPassword"
+                        formControlName="manageResetPassword"
+                        (change)="handleDependentPermissions()"
+                      />
+                      <label class="!tw-font-normal" for="manageResetPassword">
+                        {{ "manageAccountRecovery" | i18n }}
+                      </label>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <div class="col-6">
-                <div class="mb-3">
-                  <label class="tw-font-semibold">{{ "adminPermissions" | i18n }}</label>
-                  <hr class="tw-mb-2 tw-mr-2 tw-mt-0" />
+            </ng-container>
+            <ng-template #customPermissionsFC>
+              <div class="row" [formGroup]="permissionsGroup">
+                <div class="col-4">
                   <div>
                     <input
                       type="checkbox"
@@ -190,71 +293,77 @@
                       {{ "accessReports" | i18n }}
                     </label>
                   </div>
+                </div>
+                <div class="col-4">
                   <app-nested-checkbox
                     parentId="manageAllCollections"
                     [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
                   >
                   </app-nested-checkbox>
-                  <div>
-                    <input
-                      type="checkbox"
-                      name="manageGroups"
-                      id="manageGroups"
-                      formControlName="manageGroups"
-                    />
-                    <label class="!tw-font-normal" for="manageGroups">
-                      {{ "manageGroups" | i18n }}
-                    </label>
-                  </div>
-                  <div>
-                    <input
-                      type="checkbox"
-                      name="manageSso"
-                      id="manageSso"
-                      formControlName="manageSso"
-                    />
-                    <label class="!tw-font-normal" for="manageSso">
-                      {{ "manageSso" | i18n }}
-                    </label>
-                  </div>
-                  <div>
-                    <input
-                      type="checkbox"
-                      name="managePolicies"
-                      id="managePolicies"
-                      formControlName="managePolicies"
-                    />
-                    <label class="!tw-font-normal" for="managePolicies">
-                      {{ "managePolicies" | i18n }}
-                    </label>
-                  </div>
-                  <div>
-                    <input
-                      type="checkbox"
-                      name="manageUsers"
-                      id="manageUsers"
-                      formControlName="manageUsers"
-                      (change)="handleDependentPermissions()"
-                    />
-                    <label class="!tw-font-normal" for="manageUsers">
-                      {{ "manageUsers" | i18n }}
-                    </label>
-                  </div>
-                  <div>
-                    <input
-                      type="checkbox"
-                      name="manageResetPassword"
-                      id="manageResetPassword"
-                      formControlName="manageResetPassword"
-                      (change)="handleDependentPermissions()"
-                    />
-                    <label class="!tw-font-normal" for="manageResetPassword">
-                      {{ "manageAccountRecovery" | i18n }}
-                    </label>
+                </div>
+                <div class="col-4">
+                  <div class="mb-3">
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageGroups"
+                        id="manageGroups"
+                        formControlName="manageGroups"
+                      />
+                      <label class="!tw-font-normal" for="manageGroups">
+                        {{ "manageGroups" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageSso"
+                        id="manageSso"
+                        formControlName="manageSso"
+                      />
+                      <label class="!tw-font-normal" for="manageSso">
+                        {{ "manageSso" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="managePolicies"
+                        id="managePolicies"
+                        formControlName="managePolicies"
+                      />
+                      <label class="!tw-font-normal" for="managePolicies">
+                        {{ "managePolicies" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageUsers"
+                        id="manageUsers"
+                        formControlName="manageUsers"
+                        (change)="handleDependentPermissions()"
+                      />
+                      <label class="!tw-font-normal" for="manageUsers">
+                        {{ "manageUsers" | i18n }}
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="manageResetPassword"
+                        id="manageResetPassword"
+                        formControlName="manageResetPassword"
+                        (change)="handleDependentPermissions()"
+                      />
+                      <label class="!tw-font-normal" for="manageResetPassword">
+                        {{ "manageAccountRecovery" | i18n }}
+                      </label>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </ng-template>
           </ng-container>
           <ng-container *ngIf="canUseSecretsManager">
             <h3 class="mt-4">

--- a/apps/web/src/app/admin-console/organizations/organization-routing.module.ts
+++ b/apps/web/src/app/admin-console/organizations/organization-routing.module.ts
@@ -78,8 +78,11 @@ const routes: Routes = [
   },
 ];
 
-function getOrganizationRoute(organization: Organization): string {
-  if (canAccessVaultTab(organization)) {
+function getOrganizationRoute(
+  organization: Organization,
+  flexibleCollectionsEnabled: boolean
+): string {
+  if (canAccessVaultTab(organization, flexibleCollectionsEnabled)) {
     return "vault";
   }
   if (canAccessMembersTab(organization)) {

--- a/apps/web/src/app/tools/import/import-web.component.ts
+++ b/apps/web/src/app/tools/import/import-web.component.ts
@@ -6,6 +6,8 @@ import {
   OrganizationService,
   canAccessVaultTab,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { ImportComponent } from "@bitwarden/importer/ui";
 
 import { SharedModule } from "../../shared";
@@ -20,14 +22,20 @@ export class ImportWebComponent implements OnInit {
   protected loading = false;
   protected disabled = false;
 
+  private flexibleCollectionsEnabled: boolean;
+
   constructor(
     private route: ActivatedRoute,
     private organizationService: OrganizationService,
-    private router: Router
+    private router: Router,
+    private configService: ConfigServiceAbstraction
   ) {}
 
-  ngOnInit(): void {
+  async ngOnInit() {
     this.routeOrgId = this.route.snapshot.paramMap.get("organizationId");
+    this.flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections
+    );
   }
 
   /**
@@ -44,7 +52,7 @@ export class ImportWebComponent implements OnInit {
       return;
     }
 
-    if (canAccessVaultTab(organization)) {
+    if (canAccessVaultTab(organization, this.flexibleCollectionsEnabled)) {
       await this.router.navigate(["organizations", organizationId, "vault"]);
     }
   }

--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
@@ -109,7 +109,10 @@
         {{ "cancel" | i18n }}
       </button>
       <button
-        *ngIf="editMode && organization?.canDeleteAssignedCollections"
+        *ngIf="
+          editMode &&
+          ((flexibleCollectionsEnabled$ | async) || organization?.canDeleteAssignedCollections)
+        "
         type="button"
         bitIconButton="bwi-trash"
         buttonType="danger"

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -106,7 +106,7 @@ export class VaultItemsComponent {
     }
 
     const organization = this.allOrganizations.find((o) => o.id === collection.organizationId);
-    return collection.canEdit(organization);
+    return collection.canEdit(organization, this.flexibleCollectionsEnabled);
   }
 
   protected canDeleteCollection(collection: CollectionView): boolean {

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -31,8 +31,12 @@ export class CollectionAdminView extends CollectionView {
     this.assigned = response.assigned;
   }
 
-  override canEdit(org: Organization): boolean {
-    return org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
+  override canEdit(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
+    if (flexibleCollectionsEnabled) {
+      return org?.canEditAnyCollection;
+    } else {
+      return org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
+    }
   }
 
   override canDelete(org: Organization, flexibleCollectionsEnabled: boolean): boolean {

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -33,7 +33,7 @@ export class CollectionAdminView extends CollectionView {
 
   override canEdit(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
     if (flexibleCollectionsEnabled) {
-      return org?.canEditAnyCollection;
+      return org?.canEditAnyCollection || this.assigned;
     } else {
       return org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
     }

--- a/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
@@ -143,7 +143,7 @@ export class VaultHeaderComponent {
     const organization = this.organizations.find(
       (o) => o.id === this.collection?.node.organizationId
     );
-    return this.collection.node.canEdit(organization);
+    return this.collection.node.canEdit(organization, this.flexibleCollectionsEnabled);
   }
 
   async editCollection(tab: CollectionDialogTabType): Promise<void> {

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -687,7 +687,14 @@ export class VaultComponent implements OnInit, OnDestroy {
 
   async deleteCollection(collection: CollectionView): Promise<void> {
     const organization = this.organizationService.get(collection.organizationId);
-    if (!organization.canDeleteAssignedCollections && !organization.canDeleteAnyCollection) {
+    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections,
+      false
+    );
+    if (
+      (flexibleCollectionsEnabled || !organization.canDeleteAssignedCollections) &&
+      !organization.canDeleteAnyCollection
+    ) {
       this.platformUtilsService.showToast(
         "error",
         this.i18nService.t("errorOccurred"),

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
@@ -152,7 +152,7 @@ export class VaultHeaderComponent {
     }
 
     // Otherwise, check if we can edit the specified collection
-    return this.collection.node.canEdit(this.organization);
+    return this.collection.node.canEdit(this.organization, this.flexibleCollectionsEnabled);
   }
 
   addCipher() {

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -132,6 +132,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     FeatureFlag.BulkCollectionAccess,
     false
   );
+  protected flexibleCollectionsEnabled: boolean;
 
   private searchText$ = new Subject<string>();
   private refresh$ = new BehaviorSubject<void>(null);
@@ -750,8 +751,12 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async deleteCollection(collection: CollectionView): Promise<void> {
+    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.FlexibleCollections,
+      false
+    );
     if (
-      !this.organization.canDeleteAssignedCollections &&
+      (flexibleCollectionsEnabled || !this.organization.canDeleteAssignedCollections) &&
       !this.organization.canDeleteAnyCollection
     ) {
       this.platformUtilsService.showToast(

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -5,8 +5,12 @@ import { Utils } from "../../../platform/misc/utils";
 import { OrganizationData } from "../../models/data/organization.data";
 import { Organization } from "../../models/domain/organization";
 
-export function canAccessVaultTab(org: Organization): boolean {
-  return org.canViewAssignedCollections || org.canViewAllCollections;
+export function canAccessVaultTab(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
+  if (flexibleCollectionsEnabled) {
+    return org.canViewAllCollections;
+  } else {
+    return org.canViewAssignedCollections || org.canViewAllCollections;
+  }
 }
 
 export function canAccessSettingsTab(org: Organization): boolean {
@@ -36,14 +40,14 @@ export function canAccessBillingTab(org: Organization): boolean {
   return org.isOwner;
 }
 
-export function canAccessOrgAdmin(org: Organization): boolean {
+export function canAccessOrgAdmin(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
   return (
     canAccessMembersTab(org) ||
     canAccessGroupsTab(org) ||
     canAccessReportingTab(org) ||
     canAccessBillingTab(org) ||
     canAccessSettingsTab(org) ||
-    canAccessVaultTab(org)
+    canAccessVaultTab(org, flexibleCollectionsEnabled)
   );
 }
 
@@ -51,9 +55,11 @@ export function getOrganizationById(id: string) {
   return map<Organization[], Organization | undefined>((orgs) => orgs.find((o) => o.id === id));
 }
 
-export function canAccessAdmin(i18nService: I18nService) {
+export function canAccessAdmin(i18nService: I18nService, flexibleCollectionsEnabled: boolean) {
   return map<Organization[], Organization[]>((orgs) =>
-    orgs.filter(canAccessOrgAdmin).sort(Utils.getSortFunction(i18nService, "name"))
+    orgs
+      .filter((org) => canAccessOrgAdmin(org, flexibleCollectionsEnabled))
+      .sort(Utils.getSortFunction(i18nService, "name"))
   );
 }
 

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -184,14 +184,26 @@ export class Organization {
     return this.canEditAnyCollection || this.canDeleteAnyCollection;
   }
 
+  /**
+   * @deprecated
+   * This is deprecated with the introduction of Flexible Collections.
+   */
   get canEditAssignedCollections() {
     return this.isManager || this.permissions.editAssignedCollections;
   }
 
+  /**
+   * @deprecated
+   * This is deprecated with the introduction of Flexible Collections.
+   */
   get canDeleteAssignedCollections() {
     return this.isManager || this.permissions.deleteAssignedCollections;
   }
 
+  /**
+   * @deprecated
+   * This is deprecated with the introduction of Flexible Collections.
+   */
   get canViewAssignedCollections() {
     return this.canDeleteAssignedCollections || this.canEditAssignedCollections;
   }

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -32,13 +32,17 @@ export class CollectionView implements View, ITreeNodeObject {
   }
 
   // For editing collection details, not the items within it.
-  canEdit(org: Organization): boolean {
+  canEdit(org: Organization, flexibleCollectionsEnabled: boolean): boolean {
     if (org.id !== this.organizationId) {
       throw new Error(
         "Id of the organization provided does not match the org id of the collection."
       );
     }
-    return org?.canEditAnyCollection || org?.canEditAssignedCollections;
+    if (flexibleCollectionsEnabled) {
+      return org?.canEditAnyCollection || this.manage;
+    } else {
+      return org?.canEditAnyCollection || org?.canEditAssignedCollections;
+    }
   }
 
   // For deleting a collection, not the items within it.


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Deprecate all Manager-related custom permissions:
- Manage assigned collections
- Edit assigned collections
- Delete assigned collections

## Code changes
Coupled with [Server PR](https://github.com/bitwarden/server/pull/3360)

* **apps/web/src/app/admin-console/components/organization-switcher.component.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `canAccessAdmin`
* **apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.spec.ts:** Mocking new dependency `ConfigServiceAbstraction`
* **apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `permissionsCallback` and `canAccessOrgAdmin`
* **apps/web/src/app/admin-console/organizations/guards/org-redirect.guard.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into redirect call back and `canAccessOrgAdmin`
* **apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `canAccessVaultTab`
* **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html:** Added new custom permissions template when Flexible Collections feature flag is enabled
* **apps/web/src/app/admin-console/organizations/organization-routing.module.ts:** Added parameter `flexibleCollectionsEnabled` to pass into `canAccessVaultTab`
* **apps/web/src/app/layouts/navbar.component.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `canAccessAdmin`
* **apps/web/src/app/tools/import/import-web.component.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `canAccessVaultTab`
* **apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html:** Modified condition to check if Flexible Collections feature flag is enabled
* **apps/web/src/app/vault/components/vault-items/vault-items.component.ts:** Passing `flexibleCollectionsEnabled` value into `collection.canEdit`
* **apps/web/src/app/vault/core/views/collection-admin.view.ts:** Added parameter `flexibleCollectionsEnabled` into `canEdit` and if true then ignore `canEditAssignedCollections`
* **apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts:** Injected `ConfigServiceAbstraction` to check Flexible Collections feature flag and used that to pass into `canEdit` and if enabled then ignore the `canDeleteAssignedCollections` checks
* **apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts:** Pass `this.flexibleCollectionsEnabled` into `this.collection.node.canEdit`
* **apps/web/src/app/vault/individual-vault/vault.component.ts:** Get `flexibleCollectionsEnabled` value and if true then ignore `canDeleteAssignedCollections` permission
* **apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts:** Pass `this.flexibleCollectionsEnabled` into `canEdit`
* **apps/web/src/app/vault/org-vault/vault.component.ts:** Get `flexibleCollectionsEnabled` value and if true then ignore `canDeleteAssignedCollections` permission
* **libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts:** Added parameter `flexibleCollectionsEnabled: boolean` where necessary
* **libs/common/src/admin-console/models/domain/organization.ts:** Marked methods as deprecated
* **libs/common/src/vault/models/view/collection.view.ts:** Added parameter `flexibleCollectionsEnabled` and if enabled then ignore `canEditAssignedCollections` permission

## Screenshots

<img width="647" alt="image" src="https://github.com/bitwarden/clients/assets/108268980/26771f49-06a5-4548-9a23-6b46a219799b">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
