### PR TITLE
AC-1694 Remove Can Edit Except PW ciphers from Inactive 2FA

### DIFF
--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -47,13 +47,14 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
       const docs = new Map<string, string>();
 
       allCiphers.forEach((ciph) => {
-        const { type, login, isDeleted, edit, id } = ciph;
+        const { type, login, isDeleted, edit, id, viewPassword } = ciph;
         if (
           type !== CipherType.Login ||
           (login.totp != null && login.totp !== "") ||
           !login.hasUris ||
           isDeleted ||
-          (!this.organization && !edit)
+          (!this.organization && !edit) ||
+          !viewPassword
         ) {
           return;
         }


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove `Can Edit, Except Passwords` from inactive 2fa reports. This is a follow up to the [Vault Health Reports Ticket](https://bitwarden.atlassian.net/browse/AC-1333)

## Code changes

Update inside `setCiphers` logic of `inactive-two-factor-report`. Add `!viewPassword` to check.

## Video

https://github.com/bitwarden/clients/assets/8302660/9482456c-3114-4949-af45-13babdce5ee0

