### PR TITLE
Switch NodeJS.Timer to NodeJS.Timeout

### DIFF
--- a/apps/desktop/src/auth/login/login-approval.component.ts
+++ b/apps/desktop/src/auth/login/login-approval.component.ts
@@ -29,7 +29,7 @@ export class LoginApprovalComponent implements OnInit, OnDestroy {
   email: string;
   fingerprintPhrase: string;
   authRequestResponse: AuthRequestResponse;
-  interval: NodeJS.Timer;
+  interval: NodeJS.Timeout;
   requestTimeText: string;
   dismissModal: boolean;
 

--- a/apps/desktop/src/main/messaging.main.ts
+++ b/apps/desktop/src/main/messaging.main.ts
@@ -12,7 +12,7 @@ import { MenuUpdateRequest } from "./menu/menu.updater";
 const SyncInterval = 5 * 60 * 1000; // 5 minutes
 
 export class MessagingMain {
-  private syncTimeout: NodeJS.Timer;
+  private syncTimeout: NodeJS.Timeout;
 
   constructor(private main: Main, private stateService: StateService) {}
 

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -26,7 +26,7 @@ export class WindowMain {
   isQuitting = false;
   isClosing = false;
 
-  private windowStateChangeTimer: NodeJS.Timer;
+  private windowStateChangeTimer: NodeJS.Timeout;
   private windowStates: { [key: string]: WindowState } = {};
   private enableAlwaysOnTop = false;
   private session: Electron.Session;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The latest version of `types/node` had some breaking changes related to `Timer` and `Timeout`, #6739. It turns out that we incorrectly used the type `Timer` when `Timeout` was expected in a few places. This PR resolves them, in an effort to unblock the `@types/node` upgrade.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
