### PR TITLE
[AC-1786] deprecate manager role

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -60,7 +60,10 @@
                 </div>
               </label>
             </div>
-            <div class="tw-mb-2 tw-flex tw-items-baseline">
+            <div
+              *ngIf="!(flexibleCollectionsEnabled$ | async)"
+              class="tw-mb-2 tw-flex tw-items-baseline"
+            >
               <input
                 type="radio"
                 id="userTypeManager"

--- a/libs/common/src/admin-console/enums/organization-user-type.enum.ts
+++ b/libs/common/src/admin-console/enums/organization-user-type.enum.ts
@@ -2,6 +2,10 @@ export enum OrganizationUserType {
   Owner = 0,
   Admin = 1,
   User = 2,
+  /**
+   * @deprecated
+   * This is deprecated with the introduction of Flexible Collections.
+   */
   Manager = 3,
   Custom = 4,
 }

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -131,6 +131,9 @@ export class Organization {
 
   /**
    * Whether a user has Manager permissions or greater
+   *
+   * @deprecated
+   * This is deprecated with the introduction of Flexible Collections.
    */
   get isManager() {
     return this.type === OrganizationUserType.Manager || this.isAdmin;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR is stacked on top of https://github.com/bitwarden/clients/pull/6906/ because they overlap a good bit.

Deprecates the ability to designate a user as `OrganizationUserType.Manager` behind `FeatureFlags.FlexibleCollections`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html:** Hides the Manager option in the member dialog UI
- ~~**apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts:** Maps Manager role to User role when form group loads~~ Reverted, as this will be handled on the server instead.
- **libs/common/src/admin-console/enums/organization-user-type.enum.ts:** Add deprecation comment to enum
- **libs/common/src/admin-console/models/domain/organization.ts:** Add deprecation comment to model

## Screenshots

`FeatureFlag.FlexibleCollections` is **false**:

![image](https://github.com/bitwarden/clients/assets/17113462/bd3f0108-a633-4e98-8245-158cab882400)


`FeatureFlag.FlexibleCollections` is **true**:

![image](https://github.com/bitwarden/clients/assets/17113462/cd3f01f8-6c5e-43dc-8cba-fa1ff6c7d667)



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
