### PR TITLE
[PM-4906] Allow bitmenu to overflow and scroll when needed

### DIFF
--- a/libs/components/src/menu/menu.component.html
+++ b/libs/components/src/menu/menu.component.html
@@ -1,7 +1,7 @@
 <ng-template>
   <div
     (click)="closed.emit()"
-    class="tw-flex tw-shrink-0 tw-flex-col tw-rounded tw-border tw-border-solid tw-border-secondary-500 tw-bg-background tw-bg-clip-padding tw-py-2"
+    class="tw-flex tw-shrink-0 tw-flex-col tw-rounded tw-border tw-border-solid tw-border-secondary-500 tw-bg-background tw-bg-clip-padding tw-py-2 tw-overflow-y-auto"
     [attr.role]="ariaRole"
     [attr.aria-label]="ariaLabel"
     cdkTrapFocus


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When a user is a member of a lot of organizations and has a small screen device (or rotated 90 degrees) and want's to select an organization or maybe even add a new organization, that isn't possible because those links in the menu are not visible because they overflow the screen.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This PR simply adds the `tw-overflow-y-auto` class to the menu `div` and will automatically add a scrollbar when needed.

- **libs/components/src/menu/menu.component.html:** adds the `tw-overflow-y-auto` class to the menu `div` to allow auto overflow to add a scrollbar when needed.

## Screenshots

![image](https://user-images.githubusercontent.com/610450/212979219-c0d36765-9ee7-43c4-8fcd-974d4ee5302a.png)

| Without scrolling patch |With scrolling patch|
| -------------------------- | -------------------------- |
|![without_scrolling](https://user-images.githubusercontent.com/610450/214311970-6a5a806d-d29e-4da3-9ade-9747f5e250df.gif)|![with_scrolling](https://user-images.githubusercontent.com/610450/214312181-4a7bbbb7-18a6-43c4-9468-3f281a03fd61.gif)|

Replaces #4495