### PR TITLE
PM-4828 Align disable and menu icon in vault filter

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
@@ -83,7 +83,7 @@
             ></i>
             &nbsp;{{ f.node.name }}
           </button>
-          <span class="ml-auto">
+          <span class="ml-auto tw-flex tw-items-center">
             <button
               type="button"
               *ngIf="editInfo && f.node.id"


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Previously on long organization names, if an organization was disabled the `bwi-exclamation-triangle` would misalign with the menu icon inside of `vault-filter-section`. Added styles to center and inline these elements. 

## Code changes

Added `tw-flex tw-items-center` to the wrapper of the two icons inside `vault-filter-section`

## Screenshots

![Screenshot 2023-11-22 at 11 33 15 AM](https://github.com/bitwarden/clients/assets/8302660/227e6655-a156-47fd-81d4-2aebc709c452)
