### PR TITLE
[PM-4938] Add missing translations on WebAuthn login

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -611,6 +611,15 @@
   "loginWithMasterPassword": {
     "message": "Log in with master password"
   },
+  "readingPasskeyLoading": {
+    "message": "Reading passkey..."
+  },
+  "readingPasskeyLoadingInfo": {
+    "message": "Keep this window open and follow prompts from your browser."
+  },
+  "useADifferentLogInMethod": {
+    "message": "Use a different log in method"
+  },
   "loginWithPasskey": {
     "message": "Log in with passkey"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Added i18n messages for new WebAuthn login component:

## Code changes

- **messages.json:** Added messages for all phrases used in `login-via-webauthn.component.ts`.

## Screenshots

![image](https://github.com/bitwarden/clients/assets/106564991/1cd64264-bb62-4fd2-b010-3228352639a8)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
