### PR TITLE
[PM-4919] Add typePasskey phrase to browser

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2679,6 +2679,9 @@
   "confirmFilePassword": {
     "message": "Confirm file password"
   },
+  "typePasskey": {
+    "message": "Passkey"
+  },
   "passkeyNotCopied": {
     "message": "Passkey will not be copied"
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `typePasskey` phrase was missing from browser, so the "Passkey" label was missing from the add/edit and view components on the extension.  It is now displaying above the created time as expected.

## Code changes

- **messages.json:** Added `typePasskey` phrase for the passkey label in browser.

## Screenshots

![image](https://github.com/bitwarden/clients/assets/106564991/f9457245-5c5e-4fc1-bc19-cb302db85810)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
