### PR TITLE
Auth/PM-5001 - WebAuthn Login + MP Decryption fix 

### DIFF
--- a/libs/common/src/auth/login-strategies/webauthn-login.strategy.spec.ts
+++ b/libs/common/src/auth/login-strategies/webauthn-login.strategy.spec.ts
@@ -179,7 +179,11 @@ describe("WebAuthnLoginStrategy", () => {
     // Act
     await webAuthnLoginStrategy.logIn(webAuthnCredentials);
 
-    // // Assert
+    // Assert
+    // Master key encrypted user key should be set
+    expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledTimes(1);
+    expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(idTokenResponse.key);
+
     expect(cryptoService.decryptToBytes).toHaveBeenCalledTimes(1);
     expect(cryptoService.decryptToBytes).toHaveBeenCalledWith(
       idTokenResponse.userDecryptionOptions.webAuthnPrfOption.encryptedPrivateKey,

--- a/libs/common/src/auth/login-strategies/webauthn-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/webauthn-login.strategy.ts
@@ -15,6 +15,13 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
   }
 
   protected override async setUserKey(idTokenResponse: IdentityTokenResponse) {
+    const masterKeyEncryptedUserKey = idTokenResponse.key;
+
+    if (masterKeyEncryptedUserKey) {
+      // set the master key encrypted user key if it exists
+      await this.cryptoService.setMasterKeyEncryptedUserKey(masterKeyEncryptedUserKey);
+    }
+
     const userDecryptionOptions = idTokenResponse?.userDecryptionOptions;
 
     if (userDecryptionOptions?.webAuthnPrfOption) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolve [PM-5001](https://bitwarden.atlassian.net/browse/PM-5001) where, on passkey authN and attempted MP decryption, the user receives `ERROR Error: Uncaught (in promise): Error: No encrypted user key found`. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/auth/login-strategies/webauthn-login.strategy.ts:** Set user key should set the master key encrypted user key if it exists so that the passkey authN + MP decryption flow can work.
- **libs/common/src/auth/login-strategies/webauthn-login.strategy.spec.ts** Update decryption tests to assert for this case
## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
https://github.com/bitwarden/clients/assets/116684653/244ddf1f-4697-4d6a-a222-ba0e66130aa0


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-5001]: https://bitwarden.atlassian.net/browse/PM-5001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ