### PR TITLE
PM-4865 - Browser Account Switcher - Only show lock button for lockable accounts

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -32,6 +32,7 @@
     <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
     <div class="tw-grid tw-gap-2">
       <button
+        *ngIf="activeUserCanLock"
         type="button"
         class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
         (click)="lock()"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
To resolve [PM-4865](https://bitwarden.atlassian.net/browse/PM-4865). 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- **apps/browser/src/auth/popup/account-switching/account-switcher.component.ts:** - On init, pull available vault timeout actions and check if the active user can lock and assign result to a public variable `activeUserCanLock`
- **apps/browser/src/auth/popup/account-switching/account-switcher.component.html:** Use `activeUserCanLock` to determine if the lock button should be shown. 


## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/116684653/18e001ee-5b95-4596-90d1-75e81e4e1447

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-4865]: https://bitwarden.atlassian.net/browse/PM-4865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ