### PR TITLE
Hide lock now for locked users

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -365,6 +365,9 @@
   "unlockMethodNeededToChangeTimeoutActionDesc": {
     "message": "Set up an unlock method to change your vault timeout action."
   },
+  "unlockMethodNeeded": {
+    "message": "Set up an unlock method in Settings"
+  },
   "rateExtension": {
     "message": "Rate the extension"
   },

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -32,10 +32,11 @@
     <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
     <div class="tw-grid tw-gap-2">
       <button
-        *ngIf="activeUserCanLock && currentAccount.status !== lockedStatus"
+        *ngIf="activeUserCanLock"
         type="button"
-        class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+        class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
         (click)="lock()"
+        [disabled]="currentAccount.status === lockedStatus"
       >
         <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
         {{ "lockNow" | i18n }}

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -32,11 +32,11 @@
     <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
     <div class="tw-grid tw-gap-2">
       <button
-        *ngIf="activeUserCanLock"
         type="button"
         class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
         (click)="lock()"
-        [disabled]="currentAccount.status === lockedStatus"
+        [disabled]="currentAccount.status === lockedStatus || !activeUserCanLock"
+        [title]="!activeUserCanLock ? ('unlockMethodNeeded' | i18n) : ''"
       >
         <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
         {{ "lockNow" | i18n }}

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -28,11 +28,11 @@
     </p>
   </div>
 
-  <div class="tw-mt-8" *ngIf="currentAccount$ | async">
+  <div class="tw-mt-8" *ngIf="currentAccount$ | async as currentAccount">
     <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
     <div class="tw-grid tw-gap-2">
       <button
-        *ngIf="activeUserCanLock"
+        *ngIf="activeUserCanLock && currentAccount.status !== lockedStatus"
         type="button"
         class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
         (click)="lock()"

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -6,6 +6,7 @@ import { Subject, firstValueFrom, map, switchMap, takeUntil } from "rxjs";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
 import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { VaultTimeoutAction } from "@bitwarden/common/enums/vault-timeout-action.enum";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { DialogService } from "@bitwarden/components";
@@ -16,6 +17,7 @@ import { AccountSwitcherService } from "./services/account-switcher.service";
   templateUrl: "account-switcher.component.html",
 })
 export class AccountSwitcherComponent implements OnInit, OnDestroy {
+  readonly lockedStatus = AuthenticationStatus.Locked;
   private destroy$ = new Subject<void>();
 
   activeUserCanLock = false;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Disables lock button for locked users. Also changes the hide behavior for non-lockable accounts to disable with a tooltip


## Screenshots

<img width="293" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/b66676e6-3c29-4e4a-998b-99232488febe">

<img width="293" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/9d2e0596-1084-4adb-8da6-94ecaab2b058">

<img width="293" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/1b9f6761-dfba-45a1-a2ef-70bd6ac81429">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
