### PR TITLE
[PM-5505] Replace del with rimraf

### DIFF
--- a/apps/browser/gulpfile.js
+++ b/apps/browser/gulpfile.js
@@ -1,7 +1,7 @@
 const child = require("child_process");
 const fs = require("fs");
 
-const del = require("del");
+const { rimraf } = require("rimraf");
 const gulp = require("gulp");
 const filter = require("gulp-filter");
 const gulpif = require("gulp-if");
@@ -130,7 +130,7 @@ function distSafariApp(cb, subBuildPath) {
     ];
   }
 
-  return del([buildPath + "**/*"])
+  return rimraf([buildPath + "**/*"], { glob: true })
     .then(() => safariCopyAssets(paths.safari + "**/*", buildPath))
     .then(() => safariCopyBuild(paths.build + "**/*", buildPath + "safari/app"))
     .then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,6 @@
         "copy-webpack-plugin": "11.0.0",
         "cross-env": "7.0.3",
         "css-loader": "6.8.1",
-        "del": "6.1.1",
         "electron": "25.9.1",
         "electron-builder": "23.6.0",
         "electron-log": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "copy-webpack-plugin": "11.0.0",
     "cross-env": "7.0.3",
     "css-loader": "6.8.1",
-    "del": "6.1.1",
     "electron": "25.9.1",
     "electron-builder": "23.6.0",
     "electron-log": "5.0.1",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Per our new [dependency management process](https://contributing.bitwarden.com/contributing/dependencies/), we’ve been working on getting the Autofill dependency responsibilities updated. The `clients` project has several packages in use by a single author who has migrated their packages [to pure ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).

In the case of `del`, the package is only used when building the production distributions of the Safari extension, and is used to clear the appropriate subpath of the `dist/Safari` build directory before rebuilding. `rimraf` has been capable of Promise chaining and using glob patterns for a while now (the presumed reason for using `del`), and is used more widely across the clients repo.

## Code changes

I’ve dropped in rimraf in place of del, allowing us to remove the del dependency altogether.