### PR TITLE
[PM-5056] Edge and Opera users cannot override/disable the default browser autofill from the extension

### DIFF
--- a/apps/browser/src/popup/settings/autofill.component.ts
+++ b/apps/browser/src/popup/settings/autofill.component.ts
@@ -70,7 +70,10 @@ export class AutofillComponent implements OnInit {
   }
 
   async ngOnInit() {
-    this.canOverrideBrowserAutofillSetting = this.platformUtilsService.isChrome();
+    this.canOverrideBrowserAutofillSetting =
+      this.platformUtilsService.isChrome() ||
+      this.platformUtilsService.isEdge() ||
+      this.platformUtilsService.isOpera();
 
     this.defaultBrowserAutofillDisabled = await this.browserAutofillSettingCurrentlyOverridden();
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In a similar manner to Chrome, users who are using the browser extension on Edge and Opera are capable of turning off the default browser autofill behavior by going to Settings > Auto-fill and turning on Override browser auto-fill settings. Currently, that option does not show up for Edge and Opera users in the same manner.

## Code changes

- **apps/browser/src/popup/settings/autofill.component.ts:** Updating the reference to `canOverrideBrowserAutofillSetting` to ensure that Edge and Opera present the setting that allows users to disable the default browser autofill settings.
