### PR TITLE
[PM-4927] Temporarily load all auth states on init of state service

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -201,10 +201,15 @@ export class StateService<
     });
 
     // TODO: Temporary update to avoid routing all account status changes through account service for now.
+    // The determination of state should be handled by the various services that control those values.
+    const token = await this.getAccessToken({ userId: userId });
+    const autoKey = await this.getUserKeyAutoUnlock({ userId: userId });
     const accountStatus =
-      (await this.getAccessToken({ userId: userId })) != null
+      token == null
+        ? AuthenticationStatus.LoggedOut
+        : autoKey == null
         ? AuthenticationStatus.Locked
-        : AuthenticationStatus.LoggedOut;
+        : AuthenticationStatus.Unlocked;
     await this.accountService.addAccount(userId as UserId, {
       status: accountStatus,
       name: diskAccount.profile.name,


### PR DESCRIPTION
This is a temporary fix until the owning services can update state themselves. It uses the presence of an auto key to surmise unlocked state on init. This is safe since it's run only once on extension start.