### PR TITLE
[PM-5051] Fix hide text toggle on Send access

### DIFF
--- a/apps/web/src/app/tools/send/send-access-text.component.ts
+++ b/apps/web/src/app/tools/send/send-access-text.component.ts
@@ -55,5 +55,8 @@ export class SendAccessTextComponent {
 
   protected toggleText() {
     this.showText = !this.showText;
+    this.formGroup.controls.sendText.patchValue(
+      this.showText ? this.send.text.text : this.send.text.maskedText
+    );
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This fixes the following regression:
- User is unable to toggle hidden text when opening a send that has hide text by default enabled 

## Code changes
- **apps/web/src/app/tools/send/send-access-text.component.ts:** Update the content of the textArea when toggling the text visibility

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
