### PR TITLE
Ps/pm 5004/add load to account switcher

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -5,11 +5,17 @@
   <div class="center tw-font-bold">{{ "switchAccounts" | i18n }}</div>
 </app-header>
 
+<main
+  *ngIf="loading"
+  class="tw-absolute tw-z-50 tw-box-border tw-flex tw-cursor-not-allowed tw-items-center tw-justify-center tw-bg-background tw-opacity-60"
+>
+  <i class="bwi bwi-spinner bwi-2x bwi-spin" aria-hidden="true"></i>
+</main>
 <main class="tw-p-2">
   <div *ngIf="availableAccounts$ | async as availableAccounts">
     <ul class="tw-grid tw-gap-2" role="listbox">
       <li *ngFor="let availableAccount of availableAccounts" role="option">
-        <auth-account [account]="availableAccount"></auth-account>
+        <auth-account [account]="availableAccount" (loading)="loading = $event"></auth-account>
       </li>
     </ul>
     <!--

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -11,58 +11,60 @@
 >
   <i class="bwi bwi-spinner bwi-2x bwi-spin" aria-hidden="true"></i>
 </main>
-<main class="tw-p-2">
-  <div *ngIf="availableAccounts$ | async as availableAccounts">
-    <ul class="tw-grid tw-list-none tw-gap-2" role="listbox">
-      <li *ngFor="let availableAccount of availableAccounts" role="option">
-        <auth-account [account]="availableAccount" (loading)="loading = $event"></auth-account>
-      </li>
-    </ul>
-    <!--
+<main>
+  <div class="tw-p-2">
+    <div *ngIf="availableAccounts$ | async as availableAccounts">
+      <ul class="tw-grid tw-list-none tw-gap-2" role="listbox">
+        <li *ngFor="let availableAccount of availableAccounts" role="option">
+          <auth-account [account]="availableAccount" (loading)="loading = $event"></auth-account>
+        </li>
+      </ul>
+      <!--
         If the user has not reached the account limit, the last 'availableAccount' will have an 'id' of
         'SPECIAL_ADD_ACCOUNT_ID'. Since we don't want to count this as one of the actual accounts,
         we check to make sure the 'id' of the last 'availableAccount' is not equal to 'SPECIAL_ADD_ACCOUNT_ID'
     -->
-    <p
-      class="tw-text-sm tw-text-muted"
-      *ngIf="
-        availableAccounts.length >= accountLimit &&
-        availableAccounts[availableAccounts.length - 1].id !== specialAddAccountId
-      "
-    >
-      {{ "accountLimitReached" | i18n }}
-    </p>
-  </div>
+      <p
+        class="tw-text-sm tw-text-muted"
+        *ngIf="
+          availableAccounts.length >= accountLimit &&
+          availableAccounts[availableAccounts.length - 1].id !== specialAddAccountId
+        "
+      >
+        {{ "accountLimitReached" | i18n }}
+      </p>
+    </div>
 
-  <div class="tw-mt-8" *ngIf="currentAccount$ | async as currentAccount">
-    <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
-    <div class="tw-grid tw-gap-2">
-      <button
-        type="button"
-        class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
-        (click)="lock()"
-        [disabled]="currentAccount.status === lockedStatus || !activeUserCanLock"
-        [title]="!activeUserCanLock ? ('unlockMethodNeeded' | i18n) : ''"
-      >
-        <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
-        {{ "lockNow" | i18n }}
-      </button>
-      <button
-        type="button"
-        class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
-        (click)="logOut()"
-      >
-        <i class="bwi bwi-sign-out tw-text-2xl" aria-hidden="true"></i>
-        {{ "logOut" | i18n }}
-      </button>
-      <button
-        type="button"
-        class="tw-mt-2 tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
-        (click)="lockAll()"
-      >
-        <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
-        {{ "lockAll" | i18n }}
-      </button>
+    <div class="tw-mt-8" *ngIf="currentAccount$ | async as currentAccount">
+      <div class="tw-mb-2 tw-uppercase tw-text-muted">{{ "options" | i18n }}</div>
+      <div class="tw-grid tw-gap-2">
+        <button
+          type="button"
+          class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
+          (click)="lock()"
+          [disabled]="currentAccount.status === lockedStatus || !activeUserCanLock"
+          [title]="!activeUserCanLock ? ('unlockMethodNeeded' | i18n) : ''"
+        >
+          <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
+          {{ "lockNow" | i18n }}
+        </button>
+        <button
+          type="button"
+          class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+          (click)="logOut()"
+        >
+          <i class="bwi bwi-sign-out tw-text-2xl" aria-hidden="true"></i>
+          {{ "logOut" | i18n }}
+        </button>
+        <button
+          type="button"
+          class="tw-mt-2 tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+          (click)="lockAll()"
+        >
+          <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
+          {{ "lockAll" | i18n }}
+        </button>
+      </div>
     </div>
   </div>
 </main>

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -13,7 +13,7 @@
 </main>
 <main class="tw-p-2">
   <div *ngIf="availableAccounts$ | async as availableAccounts">
-    <ul class="tw-grid tw-gap-2" role="listbox">
+    <ul class="tw-grid tw-list-none tw-gap-2" role="listbox">
       <li *ngFor="let availableAccount of availableAccounts" role="option">
         <auth-account [account]="availableAccount" (loading)="loading = $event"></auth-account>
       </li>

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -20,6 +20,7 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
   readonly lockedStatus = AuthenticationStatus.Locked;
   private destroy$ = new Subject<void>();
 
+  loading = false;
   activeUserCanLock = false;
 
   constructor(
@@ -61,11 +62,13 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
   }
 
   async lock(userId?: string) {
+    this.loading = true;
     await this.vaultTimeoutService.lock(userId ? userId : null);
     this.router.navigate(["lock"]);
   }
 
   async lockAll() {
+    this.loading = true;
     this.availableAccounts$
       .pipe(
         map((accounts) =>
@@ -89,6 +92,7 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
   }
 
   async logOut() {
+    this.loading = true;
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "logOut" },
       content: { key: "logOutConfirmation" },

--- a/apps/browser/src/auth/popup/account-switching/account.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, Location } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -17,6 +17,7 @@ import { AccountSwitcherService, AvailableAccount } from "./services/account-swi
 })
 export class AccountComponent {
   @Input() account: AvailableAccount;
+  @Output() loading = new EventEmitter<boolean>();
 
   constructor(
     private accountSwitcherService: AccountSwitcherService,
@@ -30,6 +31,7 @@ export class AccountComponent {
   }
 
   async selectAccount(id: string) {
+    this.loading.emit(true);
     await this.accountSwitcherService.selectAccount(id);
 
     if (id === this.specialAccountAddId) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds loading overlay to account switcher after interaction. This load is removed naturally upon navigation away from the switcher.

## Code changes

- **component.html**: 
  - This is mostly formatting
  - added a second `<main>` element absolutely positioned to handle the non-interactable overlay
  - pushed accoutn-switcher to a div element to appropriately limit it's width to be consistent with other pages in popouts
  - removed ul bullets
- **switcher-component.ts**: set loading on each navigable piece of work
- **account.component.ts**: output when an account is selected to switch to

## Screenshots

popout is correctly sized
![image](https://github.com/bitwarden/clients/assets/18214891/46ed2c4f-7298-4518-a186-ab5e30086934)

view in popup
![image](https://github.com/bitwarden/clients/assets/18214891/e1fed8fc-d7bb-4d07-bc0b-f2a5d5d7fcd1)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
