### PR TITLE
[CL-145] add secondary variant to bit-layout side nav

### DIFF
--- a/libs/components/src/layout/layout.component.html
+++ b/libs/components/src/layout/layout.component.html
@@ -1,5 +1,13 @@
 <div class="tw-flex tw-w-full">
   <aside
+    [ngStyle]="
+      variant === 'secondary' && {
+        '--color-text-alt2': 'var(--color-text-main)',
+        '--color-background-alt3': 'var(--color-secondary-100)',
+        '--color-background-alt4': 'var(--color-secondary-300)',
+        '--color-secondary-300': 'var(--color-secondary-500)'
+      }
+    "
     class="tw-fixed tw-inset-y-0 tw-left-0 tw-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
   >
     <ng-content select="[slot=sidebar]"></ng-content>

--- a/libs/components/src/layout/layout.component.ts
+++ b/libs/components/src/layout/layout.component.ts
@@ -1,9 +1,14 @@
-import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { Component, Input } from "@angular/core";
+
+export type LayoutVariant = "primary" | "secondary";
 
 @Component({
   selector: "bit-layout",
   templateUrl: "layout.component.html",
   standalone: true,
-  imports: [],
+  imports: [CommonModule],
 })
-export class LayoutComponent {}
+export class LayoutComponent {
+  @Input() variant: LayoutVariant = "primary";
+}

--- a/libs/components/src/layout/layout.stories.ts
+++ b/libs/components/src/layout/layout.stories.ts
@@ -18,9 +18,10 @@ export default {
        * Applying a CSS transform makes a `position: fixed` element act like it is `position: relative`
        * https://github.com/storybookjs/storybook/issues/8011#issue-490251969
        */
-      (story) => /* HTML */ `<div class="tw-scale-100 tw-border-2 tw-border-solid tw-border-[red]">
-        ${story}
-      </div>`
+      (story) =>
+        /* HTML */ `<div class="tw-scale-100 tw-border-2 tw-border-solid tw-border-[red]">
+          ${story}
+        </div>`,
     ),
     moduleMetadata({
       imports: [NavigationModule, RouterTestingModule, CalloutModule],

--- a/libs/components/src/layout/layout.stories.ts
+++ b/libs/components/src/layout/layout.stories.ts
@@ -18,10 +18,9 @@ export default {
        * Applying a CSS transform makes a `position: fixed` element act like it is `position: relative`
        * https://github.com/storybookjs/storybook/issues/8011#issue-490251969
        */
-      (story) =>
-        /* HTML */ `<div class="tw-scale-100 tw-border-2 tw-border-solid tw-border-[red]">
-          ${story}
-        </div>`,
+      (story) => /* HTML */ `<div class="tw-scale-100 tw-border-2 tw-border-solid tw-border-[red]">
+        ${story}
+      </div>`
     ),
     moduleMetadata({
       imports: [NavigationModule, RouterTestingModule, CalloutModule],
@@ -29,7 +28,10 @@ export default {
         {
           provide: I18nService,
           useFactory: () => {
-            return new I18nMockService({});
+            return new I18nMockService({
+              submenu: "submenu",
+              toggleCollapse: "toggle collapse",
+            });
           },
         },
       ],
@@ -57,6 +59,158 @@ export const WithContent: Story = {
           <bit-nav-divider></bit-nav-divider>
           <bit-nav-item text="Item C" icon="bwi-collection"></bit-nav-item>
           <bit-nav-item text="Item D" icon="bwi-collection"></bit-nav-item>
+          <bit-nav-group text="Tree example" icon="bwi-collection" [open]="true">
+            <bit-nav-group
+              text="Level 1 - with children (empty)"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-group>
+            <bit-nav-item
+              text="Level 1 - no children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-item>
+            <bit-nav-group
+              text="Level 1 - with children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+              [open]="true"
+            >
+              <bit-nav-group
+                text="Level 2 - with children"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+                [open]="true"
+              >
+                <bit-nav-item
+                  text="Level 3 - no children, no icon"
+                  route="#"
+                  variant="tree"
+                ></bit-nav-item>
+                <bit-nav-group
+                  text="Level 3 - with children"
+                  route="#"
+                  icon="bwi-collection"
+                  variant="tree"
+                  [open]="true"
+                >
+                  <bit-nav-item
+                    text="Level 4 - no children, no icon"
+                    route="#"
+                    variant="tree"
+                  ></bit-nav-item>
+                </bit-nav-group>
+              </bit-nav-group>
+              <bit-nav-group
+                text="Level 2 - with children (empty)"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+                [open]="true"
+              ></bit-nav-group>
+              <bit-nav-item
+                text="Level 2 - no children"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+              ></bit-nav-item>
+            </bit-nav-group>
+            <bit-nav-item
+              text="Level 1 - no children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-item>
+          </bit-nav-group>
+        </nav>
+        <bit-callout title="Foobar"> Hello world! </bit-callout>
+      </bit-layout>
+    `,
+  }),
+};
+
+export const Secondary: Story = {
+  render: (args) => ({
+    props: args,
+    template: /* HTML */ `
+      <bit-layout variant="secondary">
+        <nav slot="sidebar">
+          <bit-nav-item text="Item A" icon="bwi-collection"></bit-nav-item>
+          <bit-nav-item text="Item B" icon="bwi-collection"></bit-nav-item>
+          <bit-nav-divider></bit-nav-divider>
+          <bit-nav-item text="Item C" icon="bwi-collection"></bit-nav-item>
+          <bit-nav-item text="Item D" icon="bwi-collection"></bit-nav-item>
+          <bit-nav-group text="Tree example" icon="bwi-collection" [open]="true">
+            <bit-nav-group
+              text="Level 1 - with children (empty)"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-group>
+            <bit-nav-item
+              text="Level 1 - no children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-item>
+            <bit-nav-group
+              text="Level 1 - with children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+              [open]="true"
+            >
+              <bit-nav-group
+                text="Level 2 - with children"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+                [open]="true"
+              >
+                <bit-nav-item
+                  text="Level 3 - no children, no icon"
+                  route="#"
+                  variant="tree"
+                ></bit-nav-item>
+                <bit-nav-group
+                  text="Level 3 - with children"
+                  route="#"
+                  icon="bwi-collection"
+                  variant="tree"
+                  [open]="true"
+                >
+                  <bit-nav-item
+                    text="Level 4 - no children, no icon"
+                    route="#"
+                    variant="tree"
+                  ></bit-nav-item>
+                </bit-nav-group>
+              </bit-nav-group>
+              <bit-nav-group
+                text="Level 2 - with children (empty)"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+                [open]="true"
+              ></bit-nav-group>
+              <bit-nav-item
+                text="Level 2 - no children"
+                route="#"
+                icon="bwi-collection"
+                variant="tree"
+              ></bit-nav-item>
+            </bit-nav-group>
+            <bit-nav-item
+              text="Level 1 - no children"
+              route="#"
+              icon="bwi-collection"
+              variant="tree"
+            ></bit-nav-item>
+          </bit-nav-group>
         </nav>
         <bit-callout title="Foobar"> Hello world! </bit-callout>
       </bit-layout>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds a new color scheme for the sidebar and navigation components, to be used within the Admin console.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/layout/layout.component.html:** Override colors used in nav components based on variant input
- **libs/components/src/layout/layout.component.ts:** Add `variant` input
- **libs/components/src/layout/layout.stories.ts:** Add new `Secondary` story

## Screenshots


https://github.com/bitwarden/clients/assets/17113462/d85040d2-f27b-4e58-b0e3-6be35055d56c



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
