### PR TITLE
[PM-4926] Only Keep Active User Alive When A View is Open

### DIFF
--- a/libs/common/src/services/vault-timeout/vault-timeout.service.ts
+++ b/libs/common/src/services/vault-timeout/vault-timeout.service.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, timeout } from "rxjs";
 
 import { SearchService } from "../../abstractions/search.service";
 import { VaultTimeoutSettingsService } from "../../abstractions/vault-timeout/vault-timeout-settings.service";
@@ -52,13 +52,14 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
   }
 
   async checkVaultTimeout(): Promise<void> {
-    if (await this.platformUtilsService.isViewOpen()) {
-      return;
-    }
+    // Get whether or not the view is open a single time so it can be compared for each user
+    const isViewOpen = await this.platformUtilsService.isViewOpen();
+
+    const activeUserId = await firstValueFrom(this.stateService.activeAccount$.pipe(timeout(500)));
 
     const accounts = await firstValueFrom(this.stateService.accounts$);
     for (const userId in accounts) {
-      if (userId != null && (await this.shouldLock(userId))) {
+      if (userId != null && (await this.shouldLock(userId, activeUserId, isViewOpen))) {
         await this.executeTimeoutAction(userId);
       }
     }
@@ -108,7 +109,18 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     }
   }
 
-  private async shouldLock(userId: string): Promise<boolean> {
+  private async shouldLock(
+    userId: string,
+    activeUserId: string,
+    isViewOpen: boolean,
+  ): Promise<boolean> {
+    if (isViewOpen && userId === activeUserId) {
+      // We know a view is open and this is the currently active user
+      // which means they are likely looking at their vault
+      // and they should not lock.
+      return false;
+    }
+
     const authStatus = await this.authService.getAuthStatus(userId);
     if (
       authStatus === AuthenticationStatus.Locked ||


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This changes the behavior of `checkVaultTimeout` to only consider the view being open as being in indicator for the currently active user. If they are not the active user, even if we know a view is open their vault timeout will lock them out once it has passed enough time without other activity. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/services/vault-timeout/vault-timeout.service.ts:** Pass the result of the view being open and active user to the `shouldLock` so that it can determine whether or not it cares about the view being open for that user.
- **libs/common/src/services/vault-timeout/vault-timeout.service.spec.ts:** Rewrote one test because the behavior is expected to be different, the view being open used to matter for all users and now it should only matter for the active user.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
