### PR TITLE
[PM-5049] Shallow copy credentials in login strategies that store them to prevent Dead Objects in Firefox

### DIFF
--- a/libs/common/src/auth/login-strategies/auth-request-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/auth-request-login.strategy.ts
@@ -58,7 +58,9 @@ export class AuthRequestLoginStrategy extends LoginStrategy {
   }
 
   override async logIn(credentials: AuthRequestLoginCredentials) {
-    this.authRequestCredentials = credentials;
+    // NOTE: To avoid DeadObject references on Firefox, do not set the credentials object directly
+    // Use deep copy in future if objects are added that were created in popup
+    this.authRequestCredentials = { ...credentials };
 
     this.tokenRequest = new PasswordTokenRequest(
       credentials.email,

--- a/libs/common/src/auth/login-strategies/webauthn-login.strategy.ts
+++ b/libs/common/src/auth/login-strategies/webauthn-login.strategy.ts
@@ -61,7 +61,9 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
   }
 
   async logIn(credentials: WebAuthnLoginCredentials) {
-    this.credentials = credentials;
+    // NOTE: To avoid DeadObject references on Firefox, do not set the credentials object directly
+    // Use deep copy in future if objects are added that were created in popup
+    this.credentials = { ...credentials };
 
     this.tokenRequest = new WebAuthnLoginTokenRequest(
       credentials.token,

--- a/libs/common/src/auth/services/auth.service.ts
+++ b/libs/common/src/auth/services/auth.service.ts
@@ -208,6 +208,8 @@ export class AuthService implements AuthServiceAbstraction {
         break;
     }
 
+    // Note: Do not set the credentials object directly on the strategy. They are
+    // created in the popup and can cause DeadObject references on Firefox.
     const result = await strategy.logIn(credentials as any);
 
     if (result?.requiresTwoFactor) {


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Firefox can't handle memory thats created in the popup context and passed to the background context when the popup is closed, it results in Dead Objects. In order to prevent this in the login strategies, we need to make sure and never store objects for later use.

Here I'm shallow copying the credentials in a couple strategies that were storing them.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
