### PR TITLE
[AC-1873] Only assign user in the front-end if using Flexible Collections

### DIFF
--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -72,7 +72,7 @@ export enum CollectionDialogAction {
 export class CollectionDialogComponent implements OnInit, OnDestroy {
   protected flexibleCollectionsEnabled$ = this.configService.getFeatureFlag$(
     FeatureFlag.FlexibleCollections,
-    false
+    false,
   );
 
   private destroy$ = new Subject<void>();
@@ -107,7 +107,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     private organizationUserService: OrganizationUserService,
     private dialogService: DialogService,
     private changeDetectorRef: ChangeDetectorRef,
-    private configService: ConfigServiceAbstraction
+    private configService: ConfigServiceAbstraction,
   ) {
     this.tabIndex = params.initialTab ?? CollectionDialogTabType.Info;
   }
@@ -123,8 +123,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         map((orgs) =>
           orgs
             .filter((o) => o.canCreateNewCollections && !o.isProviderUser)
-            .sort(Utils.getSortFunction(this.i18nService, "name"))
-        )
+            .sort(Utils.getSortFunction(this.i18nService, "name")),
+        ),
       );
       // patchValue will trigger a call to loadOrg() in this case, so no need to call it again here
       this.formGroup.patchValue({ selectedOrg: this.params.organizationId });
@@ -141,7 +141,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
 
   async loadOrg(orgId: string, collectionIds: string[]) {
     const organization$ = of(this.organizationService.get(orgId)).pipe(
-      shareReplay({ refCount: true, bufferSize: 1 })
+      shareReplay({ refCount: true, bufferSize: 1 }),
     );
     const groups$ = organization$.pipe(
       switchMap((organization) => {
@@ -150,7 +150,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         }
 
         return this.groupService.getAll(orgId);
-      })
+      }),
     );
     combineLatest({
       organization: organization$,
@@ -168,7 +168,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           this.organization = organization;
           this.accessItems = [].concat(
             groups.map(mapGroupToAccessItemView),
-            users.data.map(mapUserToAccessItemView)
+            users.data.map(mapUserToAccessItemView),
           );
 
           // Force change detection to update the access selector's items
@@ -201,9 +201,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           } else {
             this.nestOptions = collections;
             const parent = collections.find((c) => c.id === this.params.parentCollectionId);
-            const currentOrgUserId = users.data.find(
-              (u) => u.userId === this.organization?.userId
-            )?.id;
+            const currentOrgUserId = users.data.find((u) => u.userId === this.organization?.userId)
+              ?.id;
             const initialSelection: AccessItemValue[] =
               currentOrgUserId !== undefined && flexibleCollections
                 ? [
@@ -222,7 +221,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           }
 
           this.loading = false;
-        }
+        },
       );
   }
 
@@ -248,13 +247,13 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         this.platformUtilsService.showToast(
           "error",
           null,
-          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("collectionInfo"))
+          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("collectionInfo")),
         );
       } else if (this.tabIndex === CollectionDialogTabType.Info && accessTabError) {
         this.platformUtilsService.showToast(
           "error",
           null,
-          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("access"))
+          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("access")),
         );
       }
       return;
@@ -285,8 +284,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
       null,
       this.i18nService.t(
         this.editMode ? "editedCollectionId" : "createdCollectionId",
-        collectionView.name
-      )
+        collectionView.name,
+      ),
     );
 
     this.close(CollectionDialogAction.Saved, savedCollection);
@@ -308,7 +307,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     this.platformUtilsService.showToast(
       "success",
       null,
-      this.i18nService.t("deletedCollectionId", this.collection?.name)
+      this.i18nService.t("deletedCollectionId", this.collection?.name),
     );
 
     this.close(CollectionDialogAction.Deleted, this.collection);
@@ -346,7 +345,7 @@ function mapToAccessSelections(collectionDetails: CollectionAdminView): AccessIt
       id: selection.id,
       type: AccessItemType.Member,
       permission: convertToPermission(selection),
-    }))
+    })),
   );
 }
 
@@ -367,10 +366,10 @@ function validateCanManagePermission(control: AbstractControl) {
  */
 export function openCollectionDialog(
   dialogService: DialogService,
-  config: DialogConfig<CollectionDialogParams>
+  config: DialogConfig<CollectionDialogParams>,
 ) {
   return dialogService.open<CollectionDialogResult, CollectionDialogParams>(
     CollectionDialogComponent,
-    config
+    config,
   );
 }

--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -72,7 +72,7 @@ export enum CollectionDialogAction {
 export class CollectionDialogComponent implements OnInit, OnDestroy {
   protected flexibleCollectionsEnabled$ = this.configService.getFeatureFlag$(
     FeatureFlag.FlexibleCollections,
-    false,
+    false
   );
 
   private destroy$ = new Subject<void>();
@@ -107,7 +107,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     private organizationUserService: OrganizationUserService,
     private dialogService: DialogService,
     private changeDetectorRef: ChangeDetectorRef,
-    private configService: ConfigServiceAbstraction,
+    private configService: ConfigServiceAbstraction
   ) {
     this.tabIndex = params.initialTab ?? CollectionDialogTabType.Info;
   }
@@ -123,8 +123,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         map((orgs) =>
           orgs
             .filter((o) => o.canCreateNewCollections && !o.isProviderUser)
-            .sort(Utils.getSortFunction(this.i18nService, "name")),
-        ),
+            .sort(Utils.getSortFunction(this.i18nService, "name"))
+        )
       );
       // patchValue will trigger a call to loadOrg() in this case, so no need to call it again here
       this.formGroup.patchValue({ selectedOrg: this.params.organizationId });
@@ -141,7 +141,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
 
   async loadOrg(orgId: string, collectionIds: string[]) {
     const organization$ = of(this.organizationService.get(orgId)).pipe(
-      shareReplay({ refCount: true, bufferSize: 1 }),
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
     const groups$ = organization$.pipe(
       switchMap((organization) => {
@@ -150,7 +150,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         }
 
         return this.groupService.getAll(orgId);
-      }),
+      })
     );
     combineLatest({
       organization: organization$,
@@ -168,7 +168,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           this.organization = organization;
           this.accessItems = [].concat(
             groups.map(mapGroupToAccessItemView),
-            users.data.map(mapUserToAccessItemView),
+            users.data.map(mapUserToAccessItemView)
           );
 
           // Force change detection to update the access selector's items
@@ -201,17 +201,16 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           } else {
             this.nestOptions = collections;
             const parent = collections.find((c) => c.id === this.params.parentCollectionId);
-            const currentOrgUserId = users.data.find((u) => u.userId === this.organization?.userId)
-              ?.id;
+            const currentOrgUserId = users.data.find(
+              (u) => u.userId === this.organization?.userId
+            )?.id;
             const initialSelection: AccessItemValue[] =
-              currentOrgUserId !== undefined
+              currentOrgUserId !== undefined && flexibleCollections
                 ? [
                     {
                       id: currentOrgUserId,
                       type: AccessItemType.Member,
-                      permission: flexibleCollections
-                        ? CollectionPermission.Manage
-                        : CollectionPermission.Edit,
+                      permission: CollectionPermission.Manage,
                     },
                   ]
                 : [];
@@ -223,7 +222,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           }
 
           this.loading = false;
-        },
+        }
       );
   }
 
@@ -249,13 +248,13 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         this.platformUtilsService.showToast(
           "error",
           null,
-          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("collectionInfo")),
+          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("collectionInfo"))
         );
       } else if (this.tabIndex === CollectionDialogTabType.Info && accessTabError) {
         this.platformUtilsService.showToast(
           "error",
           null,
-          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("access")),
+          this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("access"))
         );
       }
       return;
@@ -286,8 +285,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
       null,
       this.i18nService.t(
         this.editMode ? "editedCollectionId" : "createdCollectionId",
-        collectionView.name,
-      ),
+        collectionView.name
+      )
     );
 
     this.close(CollectionDialogAction.Saved, savedCollection);
@@ -309,7 +308,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     this.platformUtilsService.showToast(
       "success",
       null,
-      this.i18nService.t("deletedCollectionId", this.collection?.name),
+      this.i18nService.t("deletedCollectionId", this.collection?.name)
     );
 
     this.close(CollectionDialogAction.Deleted, this.collection);
@@ -347,7 +346,7 @@ function mapToAccessSelections(collectionDetails: CollectionAdminView): AccessIt
       id: selection.id,
       type: AccessItemType.Member,
       permission: convertToPermission(selection),
-    })),
+    }))
   );
 }
 
@@ -368,10 +367,10 @@ function validateCanManagePermission(control: AbstractControl) {
  */
 export function openCollectionDialog(
   dialogService: DialogService,
-  config: DialogConfig<CollectionDialogParams>,
+  config: DialogConfig<CollectionDialogParams>
 ) {
   return dialogService.open<CollectionDialogResult, CollectionDialogParams>(
     CollectionDialogComponent,
-    config,
+    config
   );
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Restore previous behaviour when creating a new collection:
* front-end - no users are added by default
* server - if you're a Manager or have EditAssignedCollections permission, you're assigned to the collection on creation

The server PR is https://github.com/bitwarden/server/pull/3498.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- only add the current user on the front-end if flexible collections is ON.
- in that case, we add them with Can Manage permissions, per the new flexible collections permission system.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
