### PR TITLE
fix: replace isAdmin conditional with isManager for CanCreateNewColle…

### DIFF
--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -164,7 +164,9 @@ export class Organization {
 
   get canCreateNewCollections() {
     return (
-      !this.limitCollectionCreationDeletion || this.isAdmin || this.permissions.createNewCollections
+      !this.limitCollectionCreationDeletion ||
+      this.isManager ||
+      this.permissions.createNewCollections
     );
   }
 


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> When moving over to feature flag the `FlexibleCollections` effort, we missed a change from `isManager` -> `isAdmin`. This is the intended end state, however it does not support the transitional phase until the flags are enabled.

## Code changes
- **libs/common/src/admin-console/models/domain/organization.ts** Remove `isAdmin` check and add back the `isManager` check until fully transitioned away from the manager role.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
