### PR TITLE
[PM-5111] Reduce calls to config endpoint

### DIFF
--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -52,6 +52,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
   constructor(private stateService: StateService) {
     this.stateService.activeAccount$
       .pipe(
+        // Use == here to not trigger on undefined -> null transition
         distinctUntilChanged((oldUserId: string, newUserId: string) => oldUserId == newUserId),
         concatMap(async () => {
           if (!this.initialized) {

--- a/libs/common/src/platform/services/environment.service.ts
+++ b/libs/common/src/platform/services/environment.service.ts
@@ -1,4 +1,4 @@
-import { concatMap, Observable, ReplaySubject } from "rxjs";
+import { concatMap, distinctUntilChanged, Observable, ReplaySubject } from "rxjs";
 
 import { EnvironmentUrls } from "../../auth/models/domain/environment-urls";
 import {
@@ -52,6 +52,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
   constructor(private stateService: StateService) {
     this.stateService.activeAccount$
       .pipe(
+        distinctUntilChanged((oldUserId: string, newUserId: string) => oldUserId == newUserId),
         concatMap(async () => {
           if (!this.initialized) {
             return;

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -224,7 +224,6 @@ export class StateService<
       email: account.profile.email,
     });
     await this.setActiveUser(account.profile.userId);
-    this.activeAccountSubject.next(account.profile.userId);
   }
 
   async setActiveUser(userId: string): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We are currently making ~70k calls/minute to the `/config` endpoint.  This compares to around ~6k/minute for `sync`, for comparison.  In testing, I've identified some ways to reduce these calls incrementally.

- There appeared to be a duplicate `next`ing of the `activeAccount$` observable on account change.  The `setActiveAccount` and `addAccount` were both issuing the change.
- I added `distinctUntilChanged` to the subscription on the `EnvironmentService`, so that if the `activeAccount$` were to `next` the same user ID it will not re-retrieve the environment URLs.  The assumption here is that a given user will have the same environment URLs when changing accounts.

## Code changes

- **environment.service.ts:** Added `distinctUntilChanged`
- **state.service.ts:** Removed extra observable `next` on account change

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
