### PR TITLE
[PM-5113] MacOS support for opening app hidden

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -137,6 +137,7 @@ export class WindowMain {
     );
     this.enableAlwaysOnTop = await this.stateService.getEnableAlwaysOnTop();
 
+    const hidden = this.session === undefined && isMac() && app.isHidden();
     this.session = session.fromPartition("persist:bitwarden", { cache: false });
 
     // Create the browser window.
@@ -172,7 +173,9 @@ export class WindowMain {
     }
 
     // Show it later since it might need to be maximized.
-    this.win.show();
+    if (!hidden) {
+      this.win.show();
+    }
 
     // and load the index.html of the app.
     this.win.loadURL(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

MacOS supports opening an application that is hidden from launch. One use of this feature is with the MacOS [`open -j` option](https://keith.github.io/xcode-man-pages/open.1.html#j) and another is [login items](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions-macos-windows).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **[window.main.ts](https://github.com/kentslaney/bitwarden-clients-hidden/commit/89a74017bbf4a57bc22becf894402bb8c2885d71#diff-329e0465d1ce6029fa8b2d5138f854b6c3f39117e2fa55148a6062edce664c34):** patch checks if it's the first time creating a window and whether the [application is hidden](https://www.electronjs.org/docs/latest/api/app#appishidden-macos). If so, it doesn't show the created window.