### PR TITLE
Add exception for en/messages.json to not be owned by anyone

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,3 +97,10 @@ apps/desktop/desktop_native @bitwarden/team-platform-dev
 **/*.Dockerfile @bitwarden/dept-devops
 **/.dockerignore @bitwarden/dept-devops
 **/entrypoint.sh @bitwarden/dept-devops
+
+## Locales ##
+apps/browser/src/_locales/en/messages.json
+apps/browser/store/locales/en
+apps/cli/src/locales/en/messages.json
+apps/desktop/src/locales/en/messages.json
+apps/web/src/locales/en/messages.json


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
With https://github.com/bitwarden/clients/pull/6986 we removed @bitwarden/tech-leads as default owners. With that the exception for the en/messages.json to not be owned by anyone was also removed. This resulted in the @bitwarden/team-tools-dev also owning these files. This fixes it.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/CODEOWNERS:** Add previous exception of ownership for the en/messages.json files

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
