### PR TITLE
[PM-5162] [1pux importer] Fix phone value entry in LoginFieldTypeEnum

### DIFF
--- a/libs/importer/src/importers/onepassword/types/onepassword-1pux-importer-types.ts
+++ b/libs/importer/src/importers/onepassword/types/onepassword-1pux-importer-types.ts
@@ -74,7 +74,7 @@ export enum LoginFieldTypeEnum {
   Number = "N",
   Password = "P",
   TextArea = "A",
-  PhoneNumber = "T",
+  PhoneNumber = "TEL",
   CheckBox = "C",
 }
 export interface LoginFieldsEntity {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
An issue was found with the `LoginFieldTypeEnum` of the `onepassword-1pux-importer` having two identical values for `TextOrHtml` and `PhoneNumber`.

According to [About the 1Password Unencrypted Export format](https://support.1password.com/1pux-format/#item-details)  the PhoneNumber value should actually be `TEL` and not `T`

As far as I know, this has not been an issue, as I haven't been able to create a loginfield of type PhoneNumber within 1Password. Additionally, if the `onepassword-1pux-importer` can't [map a fieldtype](https://github.com/bitwarden/clients/blob/5582d7644c4cfc4516ca1c5fb43c8cf3256e5c02/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts#L166-L177) it will still add the contents as a custom field, retaining all data.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/importer/src/importers/onepassword/types/onepassword-1pux-importer-types.ts.ext:** Description of what was changed and why


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
