### PR TITLE
[PM-5144] Use sync fs in desktop i18n loading

### DIFF
--- a/apps/desktop/src/platform/services/i18n.main.service.ts
+++ b/apps/desktop/src/platform/services/i18n.main.service.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "fs";
+import * as fs from "fs";
 import * as path from "path";
 
 import { ipcMain } from "electron";
@@ -76,14 +76,14 @@ export class I18nMainService extends BaseI18nService {
     ];
   }
 
-  private async readLanguageFile(formattedLocale: string): Promise<any> {
+  private readLanguageFile(formattedLocale: string): Promise<any> {
     // Check that the provided locale only contains letters and dashes and underscores to avoid possible path traversal
     if (!/^[a-zA-Z_-]+$/.test(formattedLocale)) {
       return Promise.resolve({});
     }
 
     const filePath = path.join(__dirname, this.localesDirectory, formattedLocale, "messages.json");
-    const localesJson = await fs.readFile(filePath, "utf8");
+    const localesJson = fs.readFileSync(filePath, "utf8");
     const locales = JSON.parse(localesJson.replace(/^\uFEFF/, "")); // strip the BOM
     return Promise.resolve(locales);
   }


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This issue was introduced in #6482, where I changed the file loading to use the promise version of `readFile`. This seemed to work correctly for most cases, but it breaks the "start to menu bar" feature, as the menu bar icon refuses to appear.

I can't quite make heads or tails on why the promise version of this function would break on this specific case, I tried to make sure there wasn't a missing await but couldn't get anywhere, so I'll just revert that change and go back to the sync function 🤷 
