### PR TITLE
Ps/avoid state emit until updated

### DIFF
--- a/libs/common/spec/fake-storage.service.ts
+++ b/libs/common/spec/fake-storage.service.ts
@@ -59,7 +59,7 @@ export class FakeStorageService implements AbstractStorageService {
     return Promise.resolve(this.store[key] != null);
   }
   save<T>(key: string, obj: T, options?: StorageOptions): Promise<void> {
-    this.mock.save(key, options);
+    this.mock.save(key, obj, options);
     this.store[key] = obj;
     this.updatesSubject.next({ key: key, updateType: "save" });
     return Promise.resolve();

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -69,6 +69,10 @@ export function trackEmissions<T>(observable: Observable<T>): T[] {
       case "boolean":
         emissions.push(value);
         break;
+      case "symbol":
+        // Cheating types to make symbols work at all
+        emissions.push(value.toString() as T);
+        break;
       default: {
         emissions.push(clone(value));
       }

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -85,7 +85,7 @@ function clone(value: any): any {
   }
 }
 
-export async function awaitAsync(ms = 0) {
+export async function awaitAsync(ms = 1) {
   if (ms < 1) {
     await Promise.resolve();
   } else {

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -2,7 +2,7 @@
  * need to update test environment so trackEmissions works appropriately
  * @jest-environment ../shared/test.environment.ts
  */
-import { any, mock } from "jest-mock-extended";
+import { any, anySymbol, mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
@@ -11,7 +11,7 @@ import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { AccountInfo, AccountService } from "../../../auth/abstractions/account.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
 import { UserId } from "../../../types/guid";
-import { KeyDefinition } from "../key-definition";
+import { KeyDefinition, userKeyBuilder } from "../key-definition";
 import { StateDefinition } from "../state-definition";
 
 import { DefaultActiveUserState } from "./default-active-user-state";
@@ -32,9 +32,10 @@ class TestState {
 }
 
 const testStateDefinition = new StateDefinition("fake", "disk");
-
+const cleanupDelayMs = 10;
 const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
   deserializer: TestState.fromJSON,
+  cleanupDelayMs,
 });
 
 describe("DefaultActiveUserState", () => {
@@ -56,8 +57,12 @@ describe("DefaultActiveUserState", () => {
     );
   });
 
+  const makeUserId = (id: string) => {
+    return id != null ? (`00000000-0000-1000-a000-00000000000${id}` as UserId) : undefined;
+  };
+
   const changeActiveUser = async (id: string) => {
-    const userId = id != null ? `00000000-0000-1000-a000-00000000000${id}` : undefined;
+    const userId = makeUserId(id);
     activeAccountSubject.next({
       id: userId as UserId,
       email: `test${id}@example.com`,
@@ -90,7 +95,7 @@ describe("DefaultActiveUserState", () => {
     const emissions = trackEmissions(userState.state$);
 
     // User signs in
-    changeActiveUser("1");
+    await changeActiveUser("1");
     await awaitAsync();
 
     // Service does an update
@@ -111,17 +116,17 @@ describe("DefaultActiveUserState", () => {
     expect(diskStorageService.mock.get).toHaveBeenNthCalledWith(
       1,
       "user_00000000-0000-1000-a000-000000000001_fake_fake",
-      any(),
+      any(), // options
     );
     expect(diskStorageService.mock.get).toHaveBeenNthCalledWith(
       2,
       "user_00000000-0000-1000-a000-000000000001_fake_fake",
-      any(),
+      any(), // options
     );
     expect(diskStorageService.mock.get).toHaveBeenNthCalledWith(
       3,
       "user_00000000-0000-1000-a000-000000000002_fake_fake",
-      any(),
+      any(), // options
     );
 
     // Should only have saved data for the first user
@@ -129,7 +134,8 @@ describe("DefaultActiveUserState", () => {
     expect(diskStorageService.mock.save).toHaveBeenNthCalledWith(
       1,
       "user_00000000-0000-1000-a000-000000000001_fake_fake",
-      any(),
+      updatedState,
+      any(), // options
     );
   });
 
@@ -183,15 +189,17 @@ describe("DefaultActiveUserState", () => {
   });
 
   it("should not emit a previous users value if that user is no longer active", async () => {
+    const user1Data: Jsonify<TestState> = {
+      date: "2020-09-21T13:14:17.648Z",
+      array: ["value"],
+    };
+    const user2Data: Jsonify<TestState> = {
+      date: "2020-09-21T13:14:17.648Z",
+      array: [],
+    };
     diskStorageService.internalUpdateStore({
-      "user_00000000-0000-1000-a000-000000000001_fake_fake": {
-        date: "2020-09-21T13:14:17.648Z",
-        array: ["value"],
-      } as Jsonify<TestState>,
-      "user_00000000-0000-1000-a000-000000000002_fake_fake": {
-        date: "2020-09-21T13:14:17.648Z",
-        array: [],
-      } as Jsonify<TestState>,
+      "user_00000000-0000-1000-a000-000000000001_fake_fake": user1Data,
+      "user_00000000-0000-1000-a000-000000000002_fake_fake": user2Data,
     });
 
     // This starts one subscription on the observable for tracking emissions throughout
@@ -203,7 +211,7 @@ describe("DefaultActiveUserState", () => {
 
     // This should always return a value right await
     const value = await firstValueFrom(userState.state$);
-    expect(value).toBeTruthy();
+    expect(value).toEqual(user1Data);
 
     // Make it such that there is no active user
     await changeActiveUser(undefined);
@@ -222,20 +230,20 @@ describe("DefaultActiveUserState", () => {
         rejectedError = err;
       });
 
-    expect(resolvedValue).toBeFalsy();
-    expect(rejectedError).toBeTruthy();
+    expect(resolvedValue).toBeUndefined();
+    expect(rejectedError).not.toBeUndefined();
     expect(rejectedError.message).toBe("Timeout has occurred");
 
     // We need to figure out if something should be emitted
     // when there becomes no active user, if we don't want that to emit
     // this value is correct.
-    expect(emissions).toHaveLength(2);
+    expect(emissions).toEqual([user1Data]);
   });
 
   describe("update", () => {
     const newData = { date: new Date(), array: ["test"] };
     beforeEach(async () => {
-      changeActiveUser("1");
+      await changeActiveUser("1");
     });
 
     it("should save on update", async () => {
@@ -315,6 +323,8 @@ describe("DefaultActiveUserState", () => {
         return initialData;
       });
 
+      await awaitAsync();
+
       await userState.update((state, dependencies) => {
         expect(state).toEqual(initialData);
         return newData;
@@ -327,6 +337,171 @@ describe("DefaultActiveUserState", () => {
         initialData,
         newData,
       ]);
+    });
+  });
+
+  describe("update races", () => {
+    const newData = { date: new Date(), array: ["test"] };
+    const userId = makeUserId("1");
+
+    beforeEach(async () => {
+      await changeActiveUser("1");
+      await awaitAsync();
+    });
+
+    test("subscriptions during an update should not emit until update is complete", async () => {
+      // Seed with interesting data
+      const initialData = { date: new Date(2020, 1, 1), array: ["value1", "value2"] };
+      await userState.update(() => {
+        return initialData;
+      });
+
+      const emissions = trackEmissions(userState.state$);
+      await awaitAsync();
+      expect(emissions).toEqual([initialData]);
+
+      const originalSave = diskStorageService.save.bind(diskStorageService);
+      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
+        await expect(() => firstValueFrom(userState.state$.pipe(timeout(100)))).rejects.toThrow();
+        await originalSave(key, obj);
+      });
+
+      const val = await userState.update((state) => {
+        return newData;
+      });
+
+      await awaitAsync();
+
+      expect(val).toEqual(newData);
+      expect(emissions).toEqual([initialData, newData]);
+    });
+
+    // test("updates should wait until previous update is complete", async () => {
+    //   trackEmissions(userState.state$);
+    //   await awaitAsync(); // storage updates are behind a promise
+
+    //   diskStorageService.save = jest
+    //     .fn()
+    //     .mockImplementationOnce(async (key: string, obj: any) => {
+    //       let resolved = false;
+    //       await Promise.race([
+    //         userState.update(() => {
+    //           // deadlocks
+    //           resolved = true;
+    //           return newData;
+    //         }),
+    //         awaitAsync(100), // limit test to 100ms
+    //       ]);
+    //       expect(resolved).toBe(false);
+    //     })
+    //     .mockResolvedValue(undefined);
+
+    //   await userState.update((state) => {
+    //     return newData;
+    //   });
+    // });
+
+    test("updates with FAKE_DEFAULT initial value should resolve correctly", async () => {
+      expect(userState["stateSubject"].value).toEqual(anySymbol()); // FAKE_DEFAULT
+      const val = await userState.update((state) => {
+        return newData;
+      });
+
+      expect(val).toEqual(newData);
+      const call = diskStorageService.mock.save.mock.calls[0];
+      expect(call[0]).toEqual(`user_${userId}_fake_fake`);
+      expect(call[1]).toEqual(newData);
+    });
+  });
+
+  describe("cleanup", () => {
+    const newData = { date: new Date(), array: ["test"] };
+    const userId = makeUserId("1");
+    let userKey: string;
+
+    beforeEach(async () => {
+      await changeActiveUser("1");
+      userKey = userKeyBuilder(userId, testKeyDefinition);
+    });
+
+    async function assertClean() {
+      const emissions = trackEmissions(userState["stateSubject"]);
+      const initial = structuredClone(emissions);
+
+      diskStorageService.save(userKey, newData);
+      await awaitAsync(); // storage updates are behind a promise
+
+      expect(emissions).toEqual(initial); // no longer listening to storage updates
+    }
+
+    it("should cleanup after last subscriber", async () => {
+      const subscription = userState.state$.subscribe();
+      await awaitAsync(); // storage updates are behind a promise
+
+      subscription.unsubscribe();
+      expect(userState["subscriberCount"].getValue()).toBe(0);
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      await assertClean();
+    });
+
+    it("should not cleanup if there are still subscribers", async () => {
+      const subscription1 = userState.state$.subscribe();
+      const sub2Emissions: TestState[] = [];
+      const subscription2 = userState.state$.subscribe((v) => sub2Emissions.push(v));
+      await awaitAsync(); // storage updates are behind a promise
+
+      subscription1.unsubscribe();
+
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      expect(userState["subscriberCount"].getValue()).toBe(1);
+
+      // Still be listening to storage updates
+      diskStorageService.save(userKey, newData);
+      await awaitAsync(); // storage updates are behind a promise
+      expect(sub2Emissions).toEqual([null, newData]);
+
+      subscription2.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      await assertClean();
+    });
+
+    it("can re-initialize after cleanup", async () => {
+      const subscription = userState.state$.subscribe();
+      await awaitAsync();
+
+      subscription.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      const emissions = trackEmissions(userState.state$);
+      await awaitAsync();
+
+      diskStorageService.save(userKey, newData);
+      await awaitAsync();
+
+      expect(emissions).toEqual([null, newData]);
+    });
+
+    it("should not cleanup if a subscriber joins during the cleanup delay", async () => {
+      const subscription = userState.state$.subscribe();
+      await awaitAsync();
+
+      await diskStorageService.save(userKey, newData);
+      await awaitAsync();
+
+      subscription.unsubscribe();
+      expect(userState["subscriberCount"].getValue()).toBe(0);
+      // Do not wait long enough for cleanup
+      await awaitAsync(cleanupDelayMs / 2);
+
+      expect(userState["stateSubject"].value).toEqual(newData); // digging in to check that it hasn't been cleared
+      expect(userState["storageUpdateSubscription"]).not.toBeNull(); // still listening to storage updates
     });
   });
 });

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -240,6 +240,20 @@ describe("DefaultActiveUserState", () => {
     expect(emissions).toEqual([user1Data]);
   });
 
+  it("should not emit twice if there are two listeners", async () => {
+    await changeActiveUser("1");
+    const emissions = trackEmissions(userState.state$);
+    const emissions2 = trackEmissions(userState.state$);
+    await awaitAsync();
+
+    expect(emissions).toEqual([
+      null, // Initial value
+    ]);
+    expect(emissions2).toEqual([
+      null, // Initial value
+    ]);
+  });
+
   describe("update", () => {
     const newData = { date: new Date(), array: ["test"] };
     beforeEach(async () => {

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -64,7 +64,7 @@ describe("DefaultActiveUserState", () => {
   const changeActiveUser = async (id: string) => {
     const userId = makeUserId(id);
     activeAccountSubject.next({
-      id: userId as UserId,
+      id: userId,
       email: `test${id}@example.com`,
       name: `Test User ${id}`,
       status: AuthenticationStatus.Unlocked,

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -532,10 +532,6 @@ describe("DefaultActiveUserState", () => {
       await userState.update(() => {
         return newData;
       });
-      await awaitAsync(1000);
-      await awaitAsync();
-      await awaitAsync();
-      await awaitAsync();
       await awaitAsync();
 
       expect(diskStorageService.mock.save).toHaveBeenCalledTimes(2);

--- a/libs/common/src/platform/state/implementations/default-active-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.ts
@@ -158,8 +158,6 @@ export class DefaultActiveUserState<T> implements ActiveUserState<T> {
         .pipe(
           // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
           filter((i) => i !== FAKE_DEFAULT),
-          // We don't want to emit during an update, so they are filtered
-          filter(() => this.updatePromise == null),
         )
         .subscribe(subscriber);
     });

--- a/libs/common/src/platform/state/implementations/default-active-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.ts
@@ -4,12 +4,12 @@ import {
   map,
   shareReplay,
   switchMap,
-  tap,
-  defer,
   firstValueFrom,
   combineLatestWith,
   filter,
   timeout,
+  Subscription,
+  tap,
 } from "rxjs";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
@@ -31,13 +31,22 @@ const FAKE_DEFAULT = Symbol("fakeDefault");
 export class DefaultActiveUserState<T> implements ActiveUserState<T> {
   [activeMarker]: true;
   private formattedKey$: Observable<string>;
+  private updatePromise: Promise<T> | null = null;
+  private updatingKey: string | null = null;
+  private storageUpdateSubscription: Subscription;
+  private activeAccountUpdateSubscription: Subscription;
+  private subscriberCount = new BehaviorSubject<number>(0);
+  private stateObservable: Observable<T>;
 
   protected stateSubject: BehaviorSubject<T | typeof FAKE_DEFAULT> = new BehaviorSubject<
     T | typeof FAKE_DEFAULT
   >(FAKE_DEFAULT);
   private stateSubject$ = this.stateSubject.asObservable();
 
-  state$: Observable<T>;
+  get state$() {
+    this.stateObservable = this.stateObservable ?? this.initializeObservable();
+    return this.stateObservable;
+  }
 
   constructor(
     protected keyDefinition: KeyDefinition<T>,
@@ -51,62 +60,12 @@ export class DefaultActiveUserState<T> implements ActiveUserState<T> {
           ? userKeyBuilder(account.id, this.keyDefinition)
           : null,
       ),
+      tap(() => {
+        // We have a new key, so we should forget about previous update promises
+        this.updatePromise = null;
+      }),
       shareReplay({ bufferSize: 1, refCount: false }),
     );
-
-    const activeAccountData$ = this.formattedKey$.pipe(
-      switchMap(async (key) => {
-        if (key == null) {
-          return FAKE_DEFAULT;
-        }
-        return await getStoredValue(
-          key,
-          this.chosenStorageLocation,
-          this.keyDefinition.deserializer,
-        );
-      }),
-      // Share the execution
-      shareReplay({ refCount: false, bufferSize: 1 }),
-    );
-
-    const storageUpdates$ = this.chosenStorageLocation.updates$.pipe(
-      combineLatestWith(this.formattedKey$),
-      filter(([update, key]) => key !== null && update.key === key),
-      switchMap(async ([update, key]) => {
-        if (update.updateType === "remove") {
-          return null;
-        }
-        const data = await getStoredValue(
-          key,
-          this.chosenStorageLocation,
-          this.keyDefinition.deserializer,
-        );
-        return data;
-      }),
-    );
-
-    // Whomever subscribes to this data, should be notified of updated data
-    // if someone calls my update() method, or the active user changes.
-    this.state$ = defer(() => {
-      const accountChangeSubscription = activeAccountData$.subscribe((data) => {
-        this.stateSubject.next(data);
-      });
-      const storageUpdateSubscription = storageUpdates$.subscribe((data) => {
-        this.stateSubject.next(data);
-      });
-
-      return this.stateSubject$.pipe(
-        tap({
-          complete: () => {
-            accountChangeSubscription.unsubscribe();
-            storageUpdateSubscription.unsubscribe();
-          },
-        }),
-      );
-    })
-      // I fake the generic here because I am filtering out the other union type
-      // and this makes it so that typescript understands the true type
-      .pipe(filter<T>((value) => value != FAKE_DEFAULT));
   }
 
   async update<TCombine>(
@@ -114,6 +73,30 @@ export class DefaultActiveUserState<T> implements ActiveUserState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
+    try {
+      this.updatePromise = this.internalUpdate(configureState, options);
+      const newState = await this.updatePromise;
+      return newState;
+    } finally {
+      this.updatePromise = null;
+      this.updatingKey = null;
+    }
+  }
+
+  // TODO: this should be removed
+  async getFromState(): Promise<T> {
+    const key = await this.createKey();
+    return await getStoredValue(key, this.chosenStorageLocation, this.keyDefinition.deserializer);
+  }
+
+  createDerived<TTo>(converter: Converter<T, TTo>): DerivedUserState<TTo> {
+    return new DefaultDerivedUserState<T, TTo>(converter, this.encryptService, this);
+  }
+
+  private async internalUpdate<TCombine>(
+    configureState: (state: T, dependency: TCombine) => T,
+    options: StateUpdateOptions<T, TCombine>,
+  ) {
     const key = await this.createKey();
     const currentState = await this.getGuaranteedState(key);
     const combinedDependencies =
@@ -130,13 +113,62 @@ export class DefaultActiveUserState<T> implements ActiveUserState<T> {
     return newState;
   }
 
-  async getFromState(): Promise<T> {
-    const key = await this.createKey();
+  private async getState(key: string): Promise<T> {
+    if (this.updatePromise != null && this.updatingKey === key) {
+      return await this.updatePromise;
+    }
     return await getStoredValue(key, this.chosenStorageLocation, this.keyDefinition.deserializer);
   }
 
-  createDerived<TTo>(converter: Converter<T, TTo>): DerivedUserState<TTo> {
-    return new DefaultDerivedUserState<T, TTo>(converter, this.encryptService, this);
+  private initializeObservable() {
+    this.storageUpdateSubscription = this.chosenStorageLocation.updates$
+      .pipe(
+        combineLatestWith(this.formattedKey$),
+        filter(([update, key]) => key !== null && update.key === key),
+        switchMap(async ([update, key]) => {
+          if (update.updateType === "remove") {
+            return null;
+          }
+          return await this.getState(key);
+        }),
+      )
+      .subscribe((v) => this.stateSubject.next(v));
+
+    this.activeAccountUpdateSubscription = this.formattedKey$
+      .pipe(
+        switchMap(async (key) => {
+          if (key == null) {
+            return FAKE_DEFAULT;
+          }
+          return await this.getState(key);
+        }),
+      )
+      .subscribe((v) => this.stateSubject.next(v));
+
+    this.subscriberCount.subscribe((count) => {
+      if (count === 0 && this.stateObservable != null) {
+        this.triggerCleanup();
+      }
+    });
+
+    return new Observable<T>((subscriber) => {
+      this.incrementSubscribers();
+
+      const prevUnsubscribe = subscriber.unsubscribe.bind(subscriber);
+      subscriber.unsubscribe = () => {
+        this.decrementSubscribers();
+        prevUnsubscribe();
+      };
+
+      return this.stateSubject
+        .pipe(
+          // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
+          filter((i) => i !== FAKE_DEFAULT),
+          // We don't want to emit during an update, so they are filtered
+          filter(() => this.updatePromise == null),
+        )
+        .subscribe(subscriber);
+    });
   }
 
   protected async createKey(): Promise<string> {
@@ -148,21 +180,37 @@ export class DefaultActiveUserState<T> implements ActiveUserState<T> {
   }
 
   protected async getGuaranteedState(key: string) {
+    if (this.updatePromise != null && this.updatingKey === key) {
+      return await this.updatePromise;
+    }
     const currentValue = this.stateSubject.getValue();
-    return currentValue === FAKE_DEFAULT ? await this.seedInitial(key) : currentValue;
-  }
-
-  private async seedInitial(key: string): Promise<T> {
-    const value = await getStoredValue(
-      key,
-      this.chosenStorageLocation,
-      this.keyDefinition.deserializer,
-    );
-    this.stateSubject.next(value);
-    return value;
+    return currentValue === FAKE_DEFAULT ? await this.getState(key) : currentValue;
   }
 
   protected saveToStorage(key: string, data: T): Promise<void> {
     return this.chosenStorageLocation.save(key, data);
+  }
+
+  private incrementSubscribers() {
+    this.subscriberCount.next(this.subscriberCount.value + 1);
+  }
+
+  private decrementSubscribers() {
+    this.subscriberCount.next(this.subscriberCount.value - 1);
+  }
+
+  private triggerCleanup() {
+    setTimeout(() => {
+      if (this.subscriberCount.value === 0) {
+        this.updatePromise = null;
+        this.updatingKey = null;
+        this.storageUpdateSubscription?.unsubscribe();
+        this.activeAccountUpdateSubscription?.unsubscribe();
+        this.stateObservable = null;
+        this.subscriberCount.complete();
+        this.subscriberCount = new BehaviorSubject<number>(0);
+        this.stateSubject.next(FAKE_DEFAULT);
+      }
+    }, this.keyDefinition.cleanupDelayMs);
   }
 }

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -3,7 +3,7 @@
  * @jest-environment ../shared/test.environment.ts
  */
 
-import { firstValueFrom, of } from "rxjs";
+import { firstValueFrom, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { trackEmissions, awaitAsync } from "../../../../spec";
@@ -79,6 +79,19 @@ describe("DefaultGlobalState", () => {
       expect(diskStorageService.mock.get).toHaveBeenCalledWith("global_fake_fake", undefined);
       expect(state).toBeTruthy();
     });
+
+    it("should not emit twice if there are two listeners", async () => {
+      const emissions = trackEmissions(globalState.state$);
+      const emissions2 = trackEmissions(globalState.state$);
+      await awaitAsync();
+
+      expect(emissions).toEqual([
+        null, // Initial value
+      ]);
+      expect(emissions2).toEqual([
+        null, // Initial value
+      ]);
+    });
   });
 
   describe("update", () => {
@@ -133,6 +146,7 @@ describe("DefaultGlobalState", () => {
 
     it("should not update if shouldUpdate returns false", async () => {
       const emissions = trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
 
       const result = await globalState.update(
         (state) => {
@@ -196,6 +210,61 @@ describe("DefaultGlobalState", () => {
       expect(actual).toEqual(newState);
       expect(emissions).toHaveLength(2);
       expect(emissions).toEqual(expect.arrayContaining([initialState, newState]));
+    });
+  });
+
+  describe("update races", () => {
+    it("subscriptions during an update should not emit until update is complete", async () => {
+      // Seed with interesting data
+      const initialData = { date: new Date(2020, 1, 1) };
+      await globalState.update((state, dependencies) => {
+        return initialData;
+      });
+
+      await awaitAsync();
+
+      const emissions = trackEmissions(globalState.state$);
+      await awaitAsync();
+      expect(emissions).toEqual([initialData]);
+
+      const originalSave = diskStorageService.save.bind(diskStorageService);
+      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
+        await expect(() =>
+          firstValueFrom(globalState.state$.pipe(timeout(100))),
+        ).rejects.toThrowError();
+        await originalSave(key, obj);
+      });
+
+      const val = await globalState.update((state) => {
+        return newData;
+      });
+
+      await awaitAsync();
+
+      expect(val).toEqual(newData);
+      expect(emissions).toEqual([initialData, newData]);
+    });
+
+    it("updates should should wait until previous update is complete", async () => {
+      trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
+
+      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
+        let resolved = false;
+        await Promise.race([
+          globalState.update(() => {
+            // deadlocks
+            resolved = true;
+            return newData;
+          }),
+          awaitAsync(100), // limit test to 100ms
+        ]);
+        expect(resolved).toBe(false);
+      });
+
+      await globalState.update((state) => {
+        return newData;
+      });
     });
   });
 });

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -215,7 +215,7 @@ describe("DefaultGlobalState", () => {
   });
 
   describe("update races", () => {
-    it("subscriptions during an update should not emit until update is complete", async () => {
+    test("subscriptions during an update should not emit until update is complete", async () => {
       // Seed with interesting data
       const initialData = { date: new Date(2020, 1, 1) };
       await globalState.update((state, dependencies) => {
@@ -230,9 +230,7 @@ describe("DefaultGlobalState", () => {
 
       const originalSave = diskStorageService.save.bind(diskStorageService);
       diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
-        await expect(() =>
-          firstValueFrom(globalState.state$.pipe(timeout(100))),
-        ).rejects.toThrowError();
+        await expect(() => firstValueFrom(globalState.state$.pipe(timeout(100)))).rejects.toThrow();
         await originalSave(key, obj);
       });
 
@@ -246,7 +244,7 @@ describe("DefaultGlobalState", () => {
       expect(emissions).toEqual([initialData, newData]);
     });
 
-    it("updates should should wait until previous update is complete", async () => {
+    test("updates should wait until previous update is complete", async () => {
       trackEmissions(globalState.state$);
       await awaitAsync(); // storage updates are behind a promise
 

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -3,6 +3,7 @@
  * @jest-environment ../shared/test.environment.ts
  */
 
+import { anySymbol } from "jest-mock-extended";
 import { firstValueFrom, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
@@ -264,6 +265,18 @@ describe("DefaultGlobalState", () => {
       await globalState.update((state) => {
         return newData;
       });
+    });
+
+    test("updates with FAKE_DEFAULT initial value should resolve correctly", async () => {
+      expect(globalState["stateSubject"].value).toEqual(anySymbol()); // FAKE_DEFAULT
+      const val = await globalState.update((state) => {
+        return newData;
+      });
+
+      expect(val).toEqual(newData);
+      const call = diskStorageService.mock.save.mock.calls[0];
+      expect(call[0]).toEqual("global_fake_fake");
+      expect(call[1]).toEqual(newData);
     });
   });
 

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -1,14 +1,4 @@
-import {
-  BehaviorSubject,
-  Observable,
-  defer,
-  filter,
-  firstValueFrom,
-  shareReplay,
-  switchMap,
-  tap,
-  timeout,
-} from "rxjs";
+import { BehaviorSubject, Observable, filter, firstValueFrom, switchMap, timeout } from "rxjs";
 
 import {
   AbstractStorageService,
@@ -22,55 +12,29 @@ import { getStoredValue } from "./util";
 const FAKE_DEFAULT = Symbol("fakeDefault");
 
 export class DefaultGlobalState<T> implements GlobalState<T> {
+  // store all subscribers to count them
+  // implement a destroy after x time if no subscribers
+  // store new subscribers during update
+  // update new subscribers if not update
+
   private storageKey: string;
+  private updatePromise: Promise<T> | null = null;
+  private stateObservable: Observable<T>;
 
   protected stateSubject: BehaviorSubject<T | typeof FAKE_DEFAULT> = new BehaviorSubject<
     T | typeof FAKE_DEFAULT
   >(FAKE_DEFAULT);
 
-  state$: Observable<T>;
+  get state$() {
+    this.stateObservable = this.stateObservable ?? this.initializeObservable();
+    return this.stateObservable;
+  }
 
   constructor(
     private keyDefinition: KeyDefinition<T>,
     private chosenLocation: AbstractStorageService & ObservableStorageService,
   ) {
     this.storageKey = globalKeyBuilder(this.keyDefinition);
-
-    const storageUpdates$ = this.chosenLocation.updates$.pipe(
-      filter((update) => update.key === this.storageKey),
-      switchMap(async (update) => {
-        if (update.updateType === "remove") {
-          return null;
-        }
-        return await getStoredValue(
-          this.storageKey,
-          this.chosenLocation,
-          this.keyDefinition.deserializer,
-        );
-      }),
-      shareReplay({ bufferSize: 1, refCount: false }),
-    );
-
-    this.state$ = defer(() => {
-      const storageUpdateSubscription = storageUpdates$.subscribe((value) => {
-        this.stateSubject.next(value);
-      });
-
-      this.getFromState().then((s) => {
-        this.stateSubject.next(s);
-      });
-
-      return this.stateSubject.pipe(
-        tap({
-          complete: () => {
-            storageUpdateSubscription.unsubscribe();
-          },
-        }),
-      );
-    }).pipe(
-      shareReplay({ refCount: false, bufferSize: 1 }),
-      filter<T>((i) => i != FAKE_DEFAULT),
-    );
   }
 
   async update<TCombine>(
@@ -78,7 +42,20 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
-    const currentState = await this.getGuaranteedState();
+
+    this.updatePromise = this.getGuaranteedState().then((currentState) =>
+      this.internalUpdate(currentState, configureState, options),
+    );
+    const newState = await this.updatePromise;
+    this.updatePromise = null;
+    return newState;
+  }
+
+  private async internalUpdate<TCombine>(
+    currentState: T,
+    configureState: (state: T, dependency: TCombine) => T,
+    options: StateUpdateOptions<T, TCombine>,
+  ): Promise<T> {
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
@@ -93,12 +70,52 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     return newState;
   }
 
+  private initializeObservable() {
+    const storageUpdates$ = this.chosenLocation.updates$.pipe(
+      filter((update) => update.key === this.storageKey),
+      switchMap(async (update) => {
+        if (update.updateType === "remove") {
+          return null;
+        }
+        return await this.getFromState();
+      }),
+    );
+
+    // TODO MDG: handle this subscription
+    storageUpdates$.subscribe((value) => {
+      this.stateSubject.next(value);
+    });
+
+    // Intentionally un-awaited promise, we don't want to delay return of observable, but we do want to
+    // trigger populating it immediately.
+    this.getFromState().then((s) => {
+      this.stateSubject.next(s);
+    });
+
+    return new Observable<T>((subscriber) => {
+      return this.stateSubject
+        .pipe(
+          // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
+          filter<T>((i) => i != FAKE_DEFAULT),
+          // We don't want to emit during an update, so they are filtered
+          filter<T>(() => this.updatePromise == null),
+        )
+        .subscribe(subscriber);
+    });
+  }
+
   private async getGuaranteedState() {
+    if (this.updatePromise != null) {
+      return await this.updatePromise;
+    }
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }
 
   async getFromState(): Promise<T> {
+    if (this.updatePromise != null) {
+      return await this.updatePromise;
+    }
     return await getStoredValue(
       this.storageKey,
       this.chosenLocation,

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -78,19 +78,17 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
   }
 
   private initializeObservable() {
-    const storageUpdates$ = this.chosenLocation.updates$.pipe(
-      filter((update) => update.key === this.storageKey),
-      switchMap(async (update) => {
-        if (update.updateType === "remove") {
-          return null;
-        }
-        return await this.getFromState();
-      }),
-    );
-
-    this.storageUpdateSubscription = storageUpdates$.subscribe((value) => {
-      this.stateSubject.next(value);
-    });
+    this.storageUpdateSubscription = this.chosenLocation.updates$
+      .pipe(
+        filter((update) => update.key === this.storageKey),
+        switchMap(async (update) => {
+          if (update.updateType === "remove") {
+            return null;
+          }
+          return await this.getFromState();
+        }),
+      )
+      .subscribe((v) => this.stateSubject.next(v));
 
     this.subscriberCount.subscribe((count) => {
       if (count === 0 && this.stateObservable != null) {

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -20,11 +20,6 @@ import { getStoredValue } from "./util";
 const FAKE_DEFAULT = Symbol("fakeDefault");
 
 export class DefaultGlobalState<T> implements GlobalState<T> {
-  // store all subscribers to count them
-  // implement a destroy after x time if no subscribers
-  // store new subscribers during update
-  // update new subscribers if not update
-
   private storageKey: string;
   private updatePromise: Promise<T> | null = null;
   private storageUpdateSubscription: Subscription;

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -1,12 +1,10 @@
 import {
   BehaviorSubject,
   Observable,
-  Subscriber,
   Subscription,
   filter,
   firstValueFrom,
   switchMap,
-  tap,
   timeout,
 } from "rxjs";
 
@@ -24,7 +22,6 @@ const FAKE_DEFAULT = Symbol("fakeDefault");
 export class DefaultGlobalState<T> implements GlobalState<T> {
   private storageKey: string;
   private updatePromise: Promise<T> | null = null;
-  private toCatchUpSubscribers: Subscriber<T>[] | null = null;
   private storageUpdateSubscription: Subscription;
   private subscriberCount = new BehaviorSubject<number>(0);
   private stateObservable: Observable<T>;
@@ -74,8 +71,6 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
         : null;
 
     if (!options.shouldUpdate(currentState, combinedDependencies)) {
-      this.toCatchUpSubscribers?.forEach((s) => s.next(currentState));
-      this.toCatchUpSubscribers = null;
       return currentState;
     }
 
@@ -118,27 +113,10 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
         prevUnsubscribe();
       };
 
-      let hasEmitted = false;
-
       return this.stateSubject
         .pipe(
           // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
           filter<T>((i) => i != FAKE_DEFAULT),
-          // New subscriptions during an update will be pushed to as part of the update, or as a get,
-          // in which case updatePromise will be null
-          filter<T>(() => {
-            if (this.updatePromise != null) {
-              if (hasEmitted) {
-                return true;
-              } else {
-                this.toCatchUpSubscribers = this.toCatchUpSubscribers ?? [];
-                this.toCatchUpSubscribers.push(subscriber);
-                return false;
-              }
-            }
-            return true;
-          }),
-          tap(() => (hasEmitted = true)),
         )
         .subscribe(subscriber);
     });
@@ -180,7 +158,6 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
         this.subscriberCount.complete();
         this.subscriberCount = new BehaviorSubject<number>(0);
         this.stateSubject.next(FAKE_DEFAULT);
-        this.toCatchUpSubscribers = null;
       }
     }, this.keyDefinition.cleanupDelayMs);
   }

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -64,7 +64,7 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     configureState: (state: T, dependency: TCombine) => T,
     options: StateUpdateOptions<T, TCombine>,
   ): Promise<T> {
-    const currentState = await this.getGuaranteedState();
+    const currentState = await this.getStateForUpdate();
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
@@ -127,7 +127,7 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
   /** For use in update methods, does not wait for update to complete before yielding state.
    * The expectation is that that await is already done
    */
-  private async getGuaranteedState() {
+  private async getStateForUpdate() {
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -52,13 +52,15 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
-
-    this.updatePromise = this.getGuaranteedState().then((currentState) =>
-      this.internalUpdate(currentState, configureState, options),
-    );
-    const newState = await this.updatePromise;
-    this.updatePromise = null;
-    return newState;
+    try {
+      this.updatePromise = this.getGuaranteedState().then((currentState) =>
+        this.internalUpdate(currentState, configureState, options),
+      );
+      const newState = await this.updatePromise;
+      return newState;
+    } finally {
+      this.updatePromise = null;
+    }
   }
 
   private async internalUpdate<TCombine>(

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -47,6 +47,10 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
+    if (this.updatePromise != null) {
+      await this.updatePromise;
+    }
+
     try {
       this.updatePromise = this.internalUpdate(configureState, options);
       const newState = await this.updatePromise;
@@ -120,10 +124,10 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
     });
   }
 
+  /** For use in update methods, does not wait for update to complete before yielding state.
+   * The expectation is that that await is already done
+   */
   private async getGuaranteedState() {
-    if (this.updatePromise != null) {
-      return await this.updatePromise;
-    }
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -48,9 +48,7 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
     try {
-      this.updatePromise = this.getGuaranteedState().then((currentState) =>
-        this.internalUpdate(currentState, configureState, options),
-      );
+      this.updatePromise = this.internalUpdate(configureState, options);
       const newState = await this.updatePromise;
       return newState;
     } finally {
@@ -59,10 +57,10 @@ export class DefaultGlobalState<T> implements GlobalState<T> {
   }
 
   private async internalUpdate<TCombine>(
-    currentState: T,
     configureState: (state: T, dependency: TCombine) => T,
     options: StateUpdateOptions<T, TCombine>,
   ): Promise<T> {
+    const currentState = await this.getGuaranteedState();
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))

--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -3,7 +3,7 @@
  * @jest-environment ../shared/test.environment.ts
  */
 
-import { firstValueFrom, of } from "rxjs";
+import { firstValueFrom, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { trackEmissions, awaitAsync } from "../../../../spec";
@@ -30,9 +30,10 @@ class TestState {
 }
 
 const testStateDefinition = new StateDefinition("fake", "disk");
-
+const cleanupDelayMs = 10;
 const testKeyDefinition = new KeyDefinition<TestState>(testStateDefinition, "fake", {
   deserializer: TestState.fromJSON,
+  cleanupDelayMs,
 });
 const userId = Utils.newGuid() as UserId;
 const userKey = userKeyBuilder(userId, testKeyDefinition);
@@ -144,6 +145,7 @@ describe("DefaultSingleUserState", () => {
 
     it("should not update if shouldUpdate returns false", async () => {
       const emissions = trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
 
       const result = await globalState.update(
         (state) => {
@@ -207,6 +209,140 @@ describe("DefaultSingleUserState", () => {
       expect(actual).toEqual(newState);
       expect(emissions).toHaveLength(2);
       expect(emissions).toEqual(expect.arrayContaining([initialState, newState]));
+    });
+  });
+
+  describe("update races", () => {
+    test("subscriptions during an update should not emit until update is complete", async () => {
+      const initialData = { date: new Date(2020, 1, 1) };
+      await globalState.update((state, dependencies) => {
+        return initialData;
+      });
+
+      await awaitAsync();
+
+      const emissions = trackEmissions(globalState.state$);
+      await awaitAsync();
+      expect(emissions).toEqual([initialData]);
+
+      const originalSave = diskStorageService.save.bind(diskStorageService);
+      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
+        await expect(() => firstValueFrom(globalState.state$.pipe(timeout(100)))).rejects.toThrow();
+        await originalSave(key, obj);
+      });
+
+      const val = await globalState.update((state) => {
+        return newData;
+      });
+
+      await awaitAsync();
+
+      expect(val).toEqual(newData);
+      expect(emissions).toEqual([initialData, newData]);
+    });
+
+    test("updates should wait until previous update is complete", async () => {
+      trackEmissions(globalState.state$);
+      await awaitAsync(); // storage updates are behind a promise
+
+      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
+        let resolved = false;
+        await Promise.race([
+          globalState.update(() => {
+            // deadlocks
+            resolved = true;
+            return newData;
+          }),
+          awaitAsync(100), // limit test to 100ms
+        ]);
+        expect(resolved).toBe(false);
+      });
+
+      await globalState.update((state) => {
+        return newData;
+      });
+    });
+  });
+
+  describe("cleanup", () => {
+    async function assertClean() {
+      const emissions = trackEmissions(globalState["stateSubject"]);
+      const initial = structuredClone(emissions);
+
+      diskStorageService.save(userKey, newData);
+      await awaitAsync(); // storage updates are behind a promise
+
+      expect(emissions).toEqual(initial); // no longer listening to storage updates
+    }
+
+    it("should cleanup after last subscriber", async () => {
+      const subscription = globalState.state$.subscribe();
+      await awaitAsync(); // storage updates are behind a promise
+
+      subscription.unsubscribe();
+      expect(globalState["subscriberCount"].getValue()).toBe(0);
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      await assertClean();
+    });
+
+    it("should not cleanup if there are still subscribers", async () => {
+      const subscription1 = globalState.state$.subscribe();
+      const sub2Emissions: TestState[] = [];
+      const subscription2 = globalState.state$.subscribe((v) => sub2Emissions.push(v));
+      await awaitAsync(); // storage updates are behind a promise
+
+      subscription1.unsubscribe();
+
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      expect(globalState["subscriberCount"].getValue()).toBe(1);
+
+      // Still be listening to storage updates
+      diskStorageService.save(userKey, newData);
+      await awaitAsync(); // storage updates are behind a promise
+      expect(sub2Emissions).toEqual([null, newData]);
+
+      subscription2.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      await assertClean();
+    });
+
+    it("can re-initialize after cleanup", async () => {
+      const subscription = globalState.state$.subscribe();
+      await awaitAsync();
+
+      subscription.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      const emissions = trackEmissions(globalState.state$);
+      await awaitAsync();
+
+      diskStorageService.save(userKey, newData);
+      await awaitAsync();
+
+      expect(emissions).toEqual([null, newData]);
+    });
+
+    it("should not cleanup if a subscriber joins during the cleanup delay", async () => {
+      const subscription = globalState.state$.subscribe();
+      await awaitAsync();
+
+      await diskStorageService.save(userKey, newData);
+      await awaitAsync();
+
+      subscription.unsubscribe();
+      expect(globalState["subscriberCount"].getValue()).toBe(0);
+      // Do not wait long enough for cleanup
+      await awaitAsync(cleanupDelayMs / 2);
+
+      expect(globalState["stateSubject"].value).toEqual(newData); // digging in to check that it hasn't been cleared
+      expect(globalState["storageUpdateSubscription"]).not.toBeNull(); // still listening to storage updates
     });
   });
 });

--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -246,18 +246,22 @@ describe("DefaultSingleUserState", () => {
       trackEmissions(userState.state$);
       await awaitAsync(); // storage updates are behind a promise
 
-      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
-        let resolved = false;
-        await Promise.race([
-          userState.update(() => {
-            // deadlocks
-            resolved = true;
-            return newData;
-          }),
-          awaitAsync(100), // limit test to 100ms
-        ]);
-        expect(resolved).toBe(false);
-      });
+      const originalSave = diskStorageService.save.bind(diskStorageService);
+      diskStorageService.save = jest
+        .fn()
+        .mockImplementationOnce(async () => {
+          let resolved = false;
+          await Promise.race([
+            userState.update(() => {
+              // deadlocks
+              resolved = true;
+              return newData;
+            }),
+            awaitAsync(100), // limit test to 100ms
+          ]);
+          expect(resolved).toBe(false);
+        })
+        .mockImplementation(originalSave);
 
       await userState.update((state) => {
         return newData;

--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -3,6 +3,7 @@
  * @jest-environment ../shared/test.environment.ts
  */
 
+import { anySymbol } from "jest-mock-extended";
 import { firstValueFrom, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
@@ -261,6 +262,18 @@ describe("DefaultSingleUserState", () => {
       await userState.update((state) => {
         return newData;
       });
+    });
+
+    test("updates with FAKE_DEFAULT initial value should resolve correctly", async () => {
+      expect(userState["stateSubject"].value).toEqual(anySymbol()); // FAKE_DEFAULT
+      const val = await userState.update((state) => {
+        return newData;
+      });
+
+      expect(val).toEqual(newData);
+      const call = diskStorageService.mock.save.mock.calls[0];
+      expect(call[0]).toEqual(`user_${userId}_fake_fake`);
+      expect(call[1]).toEqual(newData);
     });
   });
 

--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { anySymbol } from "jest-mock-extended";
-import { firstValueFrom, of, timeout } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { trackEmissions, awaitAsync } from "../../../../spec";
@@ -214,36 +214,11 @@ describe("DefaultSingleUserState", () => {
   });
 
   describe("update races", () => {
-    test("subscriptions during an update should not emit until update is complete", async () => {
-      const initialData = { date: new Date(2020, 1, 1) };
+    test("subscriptions during an update should receive the current and latest data", async () => {
+      const oldData = { date: new Date(2019, 1, 1) };
       await userState.update(() => {
-        return initialData;
+        return oldData;
       });
-
-      await awaitAsync();
-
-      const emissions = trackEmissions(userState.state$);
-      await awaitAsync();
-      expect(emissions).toEqual([initialData]);
-
-      const originalSave = diskStorageService.save.bind(diskStorageService);
-      diskStorageService.save = jest.fn().mockImplementation(async (key: string, obj: any) => {
-        await expect(() => firstValueFrom(userState.state$.pipe(timeout(100)))).rejects.toThrow();
-        await originalSave(key, obj);
-      });
-
-      const val = await userState.update(() => {
-        return newData;
-      });
-
-      await awaitAsync();
-
-      expect(val).toEqual(newData);
-      expect(emissions).toEqual([initialData, newData]);
-    });
-
-    test("subscriptions during an update should receive the latest value", async () => {
-      // Seed with interesting data
       const initialData = { date: new Date(2020, 1, 1) };
       await userState.update(() => {
         return initialData;
@@ -270,7 +245,7 @@ describe("DefaultSingleUserState", () => {
 
       expect(val).toEqual(newData);
       expect(emissions).toEqual([initialData, newData]);
-      expect(emissions2).toEqual([newData]);
+      expect(emissions2).toEqual([initialData, newData]);
     });
 
     test("subscription during an aborted update should receive the last value", async () => {

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -75,7 +75,7 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     configureState: (state: T, dependency: TCombine) => T,
     options: StateUpdateOptions<T, TCombine>,
   ): Promise<T> {
-    const currentState = await this.getGuaranteedState();
+    const currentState = await this.getStateForUpdate();
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
@@ -138,7 +138,7 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
   /** For use in update methods, does not wait for update to complete before yielding state.
    * The expectation is that that await is already done
    */
-  private async getGuaranteedState() {
+  private async getStateForUpdate() {
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,12 +1,10 @@
 import {
   BehaviorSubject,
   Observable,
-  defer,
+  Subscription,
   filter,
   firstValueFrom,
-  shareReplay,
   switchMap,
-  tap,
   timeout,
 } from "rxjs";
 
@@ -23,16 +21,24 @@ import { Converter, SingleUserState } from "../user-state";
 
 import { DefaultDerivedUserState } from "./default-derived-state";
 import { getStoredValue } from "./util";
+
 const FAKE_DEFAULT = Symbol("fakeDefault");
 
 export class DefaultSingleUserState<T> implements SingleUserState<T> {
   private storageKey: string;
+  private updatePromise: Promise<T> | null = null;
+  private storageUpdateSubscription: Subscription;
+  private subscriberCount = new BehaviorSubject<number>(0);
+  private stateObservable: Observable<T>;
 
   protected stateSubject: BehaviorSubject<T | typeof FAKE_DEFAULT> = new BehaviorSubject<
     T | typeof FAKE_DEFAULT
   >(FAKE_DEFAULT);
 
-  state$: Observable<T>;
+  get state$() {
+    this.stateObservable = this.stateObservable ?? this.initializeObservable();
+    return this.stateObservable;
+  }
 
   constructor(
     readonly userId: UserId,
@@ -41,42 +47,6 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     private chosenLocation: AbstractStorageService & ObservableStorageService,
   ) {
     this.storageKey = userKeyBuilder(this.userId, this.keyDefinition);
-
-    const storageUpdates$ = this.chosenLocation.updates$.pipe(
-      filter((update) => update.key === this.storageKey),
-      switchMap(async (update) => {
-        if (update.updateType === "remove") {
-          return null;
-        }
-        return await getStoredValue(
-          this.storageKey,
-          this.chosenLocation,
-          this.keyDefinition.deserializer,
-        );
-      }),
-      shareReplay({ bufferSize: 1, refCount: false }),
-    );
-
-    this.state$ = defer(() => {
-      const storageUpdateSubscription = storageUpdates$.subscribe((value) => {
-        this.stateSubject.next(value);
-      });
-
-      this.getFromState().then((s) => {
-        this.stateSubject.next(s);
-      });
-
-      return this.stateSubject.pipe(
-        tap({
-          complete: () => {
-            storageUpdateSubscription.unsubscribe();
-          },
-        }),
-      );
-    }).pipe(
-      shareReplay({ refCount: false, bufferSize: 1 }),
-      filter<T>((i) => i != FAKE_DEFAULT),
-    );
   }
 
   async update<TCombine>(
@@ -84,7 +54,26 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
-    const currentState = await this.getGuaranteedState();
+    try {
+      this.updatePromise = this.getGuaranteedState().then((currentState) =>
+        this.internalUpdate(currentState, configureState, options),
+      );
+      const newState = await this.updatePromise;
+      return newState;
+    } finally {
+      this.updatePromise = null;
+    }
+  }
+
+  createDerived<TTo>(converter: Converter<T, TTo>): DerivedUserState<TTo> {
+    return new DefaultDerivedUserState<T, TTo>(converter, this.encryptService, this);
+  }
+
+  private async internalUpdate<TCombine>(
+    currentState: T,
+    configureState: (state: T, dependency: TCombine) => T,
+    options: StateUpdateOptions<T, TCombine>,
+  ): Promise<T> {
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
@@ -99,20 +88,90 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     return newState;
   }
 
-  createDerived<TTo>(converter: Converter<T, TTo>): DerivedUserState<TTo> {
-    return new DefaultDerivedUserState<T, TTo>(converter, this.encryptService, this);
+  private initializeObservable() {
+    const storageUpdates$ = this.chosenLocation.updates$.pipe(
+      filter((update) => update.key === this.storageKey),
+      switchMap(async (update) => {
+        if (update.updateType === "remove") {
+          return null;
+        }
+        return await this.getFromState();
+      }),
+    );
+
+    this.storageUpdateSubscription = storageUpdates$.subscribe((value) => {
+      this.stateSubject.next(value);
+    });
+
+    this.subscriberCount.subscribe((count) => {
+      if (count === 0 && this.stateObservable != null) {
+        this.triggerCleanup();
+      }
+    });
+
+    // Intentionally un-awaited promise, we don't want to delay return of observable, but we do want to
+    // trigger populating it immediately.
+    this.getFromState().then((s) => {
+      this.stateSubject.next(s);
+    });
+
+    return new Observable<T>((subscriber) => {
+      this.incrementSubscribers();
+
+      const prevUnsubscribe = subscriber.unsubscribe.bind(subscriber);
+      subscriber.unsubscribe = () => {
+        this.decrementSubscribers();
+        prevUnsubscribe();
+      };
+
+      return this.stateSubject
+        .pipe(
+          // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
+          filter<T>((i) => i != FAKE_DEFAULT),
+          // We don't want to emit during an update, so they are filtered
+          filter<T>(() => this.updatePromise == null),
+        )
+        .subscribe(subscriber);
+    });
   }
 
   private async getGuaranteedState() {
+    if (this.updatePromise != null) {
+      return await this.updatePromise;
+    }
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }
 
   async getFromState(): Promise<T> {
+    if (this.updatePromise != null) {
+      return await this.updatePromise;
+    }
     return await getStoredValue(
       this.storageKey,
       this.chosenLocation,
       this.keyDefinition.deserializer,
     );
+  }
+
+  private incrementSubscribers() {
+    this.subscriberCount.next(this.subscriberCount.value + 1);
+  }
+
+  private decrementSubscribers() {
+    this.subscriberCount.next(this.subscriberCount.value - 1);
+  }
+
+  private triggerCleanup() {
+    setTimeout(() => {
+      if (this.subscriberCount.value === 0) {
+        this.updatePromise = null;
+        this.storageUpdateSubscription.unsubscribe();
+        this.stateObservable = null;
+        this.subscriberCount.complete();
+        this.subscriberCount = new BehaviorSubject<number>(0);
+        this.stateSubject.next(FAKE_DEFAULT);
+      }
+    }, this.keyDefinition.cleanupDelayMs);
   }
 }

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -89,19 +89,17 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
   }
 
   private initializeObservable() {
-    const storageUpdates$ = this.chosenLocation.updates$.pipe(
-      filter((update) => update.key === this.storageKey),
-      switchMap(async (update) => {
-        if (update.updateType === "remove") {
-          return null;
-        }
-        return await this.getFromState();
-      }),
-    );
-
-    this.storageUpdateSubscription = storageUpdates$.subscribe((value) => {
-      this.stateSubject.next(value);
-    });
+    this.storageUpdateSubscription = this.chosenLocation.updates$
+      .pipe(
+        filter((update) => update.key === this.storageKey),
+        switchMap(async (update) => {
+          if (update.updateType === "remove") {
+            return null;
+          }
+          return await this.getFromState();
+        }),
+      )
+      .subscribe((v) => this.stateSubject.next(v));
 
     this.subscriberCount.subscribe((count) => {
       if (count === 0 && this.stateObservable != null) {

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -54,6 +54,10 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     options: StateUpdateOptions<T, TCombine> = {},
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
+    if (this.updatePromise != null) {
+      await this.updatePromise;
+    }
+
     try {
       this.updatePromise = this.internalUpdate(configureState, options);
       const newState = await this.updatePromise;
@@ -131,10 +135,10 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
     });
   }
 
+  /** For use in update methods, does not wait for update to complete before yielding state.
+   * The expectation is that that await is already done
+   */
   private async getGuaranteedState() {
-    if (this.updatePromise != null) {
-      return await this.updatePromise;
-    }
     const currentValue = this.stateSubject.getValue();
     return currentValue === FAKE_DEFAULT ? await this.getFromState() : currentValue;
   }

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -55,9 +55,7 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
   ): Promise<T> {
     options = populateOptionsWithDefault(options);
     try {
-      this.updatePromise = this.getGuaranteedState().then((currentState) =>
-        this.internalUpdate(currentState, configureState, options),
-      );
+      this.updatePromise = this.internalUpdate(configureState, options);
       const newState = await this.updatePromise;
       return newState;
     } finally {
@@ -70,10 +68,10 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
   }
 
   private async internalUpdate<TCombine>(
-    currentState: T,
     configureState: (state: T, dependency: TCombine) => T,
     options: StateUpdateOptions<T, TCombine>,
   ): Promise<T> {
+    const currentState = await this.getGuaranteedState();
     const combinedDependencies =
       options.combineLatestWith != null
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,10 +1,12 @@
 import {
   BehaviorSubject,
   Observable,
+  Subscriber,
   Subscription,
   filter,
   firstValueFrom,
   switchMap,
+  tap,
   timeout,
 } from "rxjs";
 
@@ -27,6 +29,7 @@ const FAKE_DEFAULT = Symbol("fakeDefault");
 export class DefaultSingleUserState<T> implements SingleUserState<T> {
   private storageKey: string;
   private updatePromise: Promise<T> | null = null;
+  private toCatchUpSubscribers: Subscriber<T>[] | null = null;
   private storageUpdateSubscription: Subscription;
   private subscriberCount = new BehaviorSubject<number>(0);
   private stateObservable: Observable<T>;
@@ -82,6 +85,8 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
         : null;
 
     if (!options.shouldUpdate(currentState, combinedDependencies)) {
+      this.toCatchUpSubscribers?.forEach((s) => s.next(currentState));
+      this.toCatchUpSubscribers = null;
       return currentState;
     }
 
@@ -124,12 +129,27 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
         prevUnsubscribe();
       };
 
+      let hasEmitted = false;
+
       return this.stateSubject
         .pipe(
           // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
           filter<T>((i) => i != FAKE_DEFAULT),
-          // We don't want to emit during an update, so they are filtered
-          filter<T>(() => this.updatePromise == null),
+          // New subscriptions during an update will be pushed to as part of the update, or as a get,
+          // in which case updatePromise will be null
+          filter<T>(() => {
+            if (this.updatePromise != null) {
+              if (hasEmitted) {
+                return true;
+              } else {
+                this.toCatchUpSubscribers = this.toCatchUpSubscribers ?? [];
+                this.toCatchUpSubscribers.push(subscriber);
+                return false;
+              }
+            }
+            return true;
+          }),
+          tap(() => (hasEmitted = true)),
         )
         .subscribe(subscriber);
     });

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,12 +1,10 @@
 import {
   BehaviorSubject,
   Observable,
-  Subscriber,
   Subscription,
   filter,
   firstValueFrom,
   switchMap,
-  tap,
   timeout,
 } from "rxjs";
 
@@ -29,7 +27,6 @@ const FAKE_DEFAULT = Symbol("fakeDefault");
 export class DefaultSingleUserState<T> implements SingleUserState<T> {
   private storageKey: string;
   private updatePromise: Promise<T> | null = null;
-  private toCatchUpSubscribers: Subscriber<T>[] | null = null;
   private storageUpdateSubscription: Subscription;
   private subscriberCount = new BehaviorSubject<number>(0);
   private stateObservable: Observable<T>;
@@ -85,8 +82,6 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
         : null;
 
     if (!options.shouldUpdate(currentState, combinedDependencies)) {
-      this.toCatchUpSubscribers?.forEach((s) => s.next(currentState));
-      this.toCatchUpSubscribers = null;
       return currentState;
     }
 
@@ -129,27 +124,10 @@ export class DefaultSingleUserState<T> implements SingleUserState<T> {
         prevUnsubscribe();
       };
 
-      let hasEmitted = false;
-
       return this.stateSubject
         .pipe(
           // Filter out fake default, which is used to indicate that state is not ready to be emitted yet.
           filter<T>((i) => i != FAKE_DEFAULT),
-          // New subscriptions during an update will be pushed to as part of the update, or as a get,
-          // in which case updatePromise will be null
-          filter<T>(() => {
-            if (this.updatePromise != null) {
-              if (hasEmitted) {
-                return true;
-              } else {
-                this.toCatchUpSubscribers = this.toCatchUpSubscribers ?? [];
-                this.toCatchUpSubscribers.push(subscriber);
-                return false;
-              }
-            }
-            return true;
-          }),
-          tap(() => (hasEmitted = true)),
         )
         .subscribe(subscriber);
     });

--- a/libs/common/src/platform/state/key-definition.spec.ts
+++ b/libs/common/src/platform/state/key-definition.spec.ts
@@ -38,24 +38,14 @@ describe("KeyDefinition", () => {
       expect(keyDefinition.cleanupDelayMs).toBe(500);
     });
 
-    it("can be overridden with 0", () => {
-      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
-        deserializer: (value) => value,
-        cleanupDelayMs: 0,
-      });
-
-      expect(keyDefinition).toBeTruthy();
-      expect(keyDefinition.cleanupDelayMs).toBe(0);
-    });
-
-    it("can be overridden with negative", () => {
-      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
-        deserializer: (value) => value,
-        cleanupDelayMs: -1,
-      });
-
-      expect(keyDefinition).toBeTruthy();
-      expect(keyDefinition.cleanupDelayMs).toBe(0);
+    it.each([0, -1])("throws on 0 or negative (%s)", (testValue: number) => {
+      expect(
+        () =>
+          new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+            deserializer: (value) => value,
+            cleanupDelayMs: testValue,
+          }),
+      ).toThrow();
     });
   });
 

--- a/libs/common/src/platform/state/key-definition.spec.ts
+++ b/libs/common/src/platform/state/key-definition.spec.ts
@@ -18,6 +18,47 @@ describe("KeyDefinition", () => {
     });
   });
 
+  describe("cleanupDelayMs", () => {
+    it("defaults to 1000ms", () => {
+      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => value,
+      });
+
+      expect(keyDefinition).toBeTruthy();
+      expect(keyDefinition.cleanupDelayMs).toBe(1000);
+    });
+
+    it("can be overridden", () => {
+      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => value,
+        cleanupDelayMs: 500,
+      });
+
+      expect(keyDefinition).toBeTruthy();
+      expect(keyDefinition.cleanupDelayMs).toBe(500);
+    });
+
+    it("can be overridden with 0", () => {
+      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => value,
+        cleanupDelayMs: 0,
+      });
+
+      expect(keyDefinition).toBeTruthy();
+      expect(keyDefinition.cleanupDelayMs).toBe(0);
+    });
+
+    it("can be overridden with negative", () => {
+      const keyDefinition = new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
+        deserializer: (value) => value,
+        cleanupDelayMs: -1,
+      });
+
+      expect(keyDefinition).toBeTruthy();
+      expect(keyDefinition.cleanupDelayMs).toBe(0);
+    });
+  });
+
   describe("record", () => {
     it("runs custom deserializer for each record value", () => {
       const recordDefinition = KeyDefinition.record<boolean>(fakeStateDefinition, "fake", {

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -47,8 +47,12 @@ export class KeyDefinition<T> {
     private readonly options: KeyDefinitionOptions<T>,
   ) {
     if (options.deserializer == null) {
+      throw new Error(`'deserializer' is a required property on key ${this.errorKeyName}`);
+    }
+
+    if (options.cleanupDelayMs <= 0) {
       throw new Error(
-        `'deserializer' is a required property on key ${stateDefinition.name} > ${key}`,
+        `'cleanupDelayMs' must be greater than 0. Value of ${options.cleanupDelayMs} passed to key ${this.errorKeyName} `,
       );
     }
   }
@@ -148,6 +152,10 @@ export class KeyDefinition<T> {
     return userId === null
       ? `${scope}_${userId}_${this.stateDefinition.name}_${this.key}`
       : `${scope}_${this.stateDefinition.name}_${this.key}`;
+  }
+
+  private get errorKeyName() {
+    return `${this.stateDefinition.name} > ${this.key}`;
   }
 }
 

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -19,6 +19,11 @@ type KeyDefinitionOptions<T> = {
    * @returns The fully typed version of your state.
    */
   readonly deserializer: (jsonValue: Jsonify<T>) => T;
+  /**
+   * The number of milliseconds to wait before cleaning up the state after the last subscriber has unsubscribed.
+   * Defaults to 1000ms.
+   */
+  readonly cleanupDelayMs?: number;
 };
 
 /**
@@ -53,6 +58,13 @@ export class KeyDefinition<T> {
    */
   get deserializer() {
     return this.options.deserializer;
+  }
+
+  /**
+   * Gets the number of milliseconds to wait before cleaning up the state after the last subscriber has unsubscribed.
+   */
+  get cleanupDelayMs() {
+    return this.options.cleanupDelayMs ?? 1000;
   }
 
   /**

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -64,7 +64,7 @@ export class KeyDefinition<T> {
    * Gets the number of milliseconds to wait before cleaning up the state after the last subscriber has unsubscribed.
    */
   get cleanupDelayMs() {
-    return this.options.cleanupDelayMs ?? 1000;
+    return this.options.cleanupDelayMs < 0 ? 0 : this.options.cleanupDelayMs ?? 1000;
   }
 
   /**


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Introduces:
- some update race condition protection, ensuring that storage updates go through an await for pending updates
- Removal of a lot of the hot observables in favor of creating a single observable with defined subscriber behavior. This ensures we run setup behavior _once_
- ref counting of `state$` observers to clean up subscription after a cleanup delay
- A bunch of tests around the above.

No public interface changes

## Code changes

- **fake-storage.service**: fixes a mock bug
- **spec utils**:
  - Add some minor async delay fixed a bunch tests and reduced the number of awaits necessary
  - Added `symbol` processing to `trackEmissions`. This cheats on types, but `symbol` is not serializable or copyable so we're limited on options.
- **state spec additions**:
  - update races: These are intended to test and define expected bahavior subscriptions and updates occurring during an update. They work by mocking the update method to include updates, subscribes, and active user changes in the middle of update saves.
  - cleanup: This PR adds ref counting to our `state$` observable and cleans up storage service observation after a delay. These tests verify that behavior
- **state classes**: Each state class is now tracking a number of new properties
  - updatePromise: This tracks work being done to complete an update request. This is awaited during state retrievals to allow for improved race stability
  - storageUpdateSubscription: The subscription to our chosen storage location's `update$` observable. This is tracked so it can be cleaned up
  - activeAcocuntUpdateSubscription (only on active user state): the subscription to our formatted key observable. This is tracked so it can be cleaned up
  - subscriberCount: the ref count of the number of `state$` subscribers. Tracks subscribers. when this hits 0, the class state is reset and behaves as a new instance of the state class.
  - stateObservable: a singleton observer to provide for `state$`. This handles one-time initialization stuff and then processes subscribers to allow for ref counting
- **KeyDefinition**: Add `cleanupDelayMs` to key definitions.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
