### PR TITLE
Do not early return from logout

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -890,17 +890,16 @@ export default class MainBackground {
     //Needs to be checked before state is cleaned
     const needStorageReseed = await this.needsStorageReseed();
 
+    const currentUserId = await this.stateService.getUserId();
     const newActiveUser = await this.stateService.clean({ userId: userId });
 
     if (newActiveUser != null) {
       // we have a new active user, do not continue tearing down application
       await this.switchAccount(newActiveUser as UserId);
       this.messagingService.send("switchAccountFinish");
-      this.messagingService.send("doneLoggingOut", { expired: expired, userId: userId });
-      return;
     }
 
-    if (userId == null || userId === (await this.stateService.getUserId())) {
+    if (userId == null || userId === currentUserId) {
       this.searchService.clearIndex();
       this.messagingService.send("doneLoggingOut", { expired: expired, userId: userId });
     }


### PR DESCRIPTION
The subsequent path helps to trigger process reload when the active user logs out and the new active is locked.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove early return from logout callback -- this was blocking process reload in the legitimate case of a locked second account and logout of a primary account.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
