### PR TITLE
[PM-4107] Only call config on successful sync

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -232,8 +232,10 @@ export class AppComponent implements OnInit, OnDestroy {
           case "syncStarted":
             break;
           case "syncCompleted":
-            await this.updateAppMenu();
-            this.configService.triggerServerConfigFetch();
+            if (message.successfully) {
+              this.updateAppMenu();
+              this.configService.triggerServerConfigFetch();
+            }
             break;
           case "openSettings":
             await this.openModal<SettingsComponent>(SettingsComponent, this.settingsRef);

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -134,7 +134,9 @@ export class AppComponent implements OnDestroy, OnInit {
           case "syncStarted":
             break;
           case "syncCompleted":
-            this.configService.triggerServerConfigFetch();
+            if (message.successfully) {
+              this.configService.triggerServerConfigFetch();
+            }
             break;
           case "upgradeOrganization": {
             const upgradeConfirmed = await this.dialogService.openSimpleDialog({


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

If there is an issue connecting to SignalR, we get into a loop that includes calling the `/config` endpoint:

  1. Connect to SignalR
  2. Sync (this will not _actually_ sync most of the time, because `needsSync` will detect that it isn't necessary)
  3. SignalR closes the connection
  4. Attempt to reconnect
 
This loop will continue until successful SignalR connection.  When the sync occurs in step 2 of this loop, the `syncCompleted` message is sent, which is intercepted by the `AppComponent` and triggers a call to the config endpoint.

What this PR does is recognize that the vast majority of the time, the `fullSync()` call in step 2 above will not actually perform a sync.  We can detect that by checking `successfully` in the handler and not refresh the config in that case.

## Code changes

- **app.component.ts:** Added `successfully` check on sync.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
