### PR TITLE
[PM-5212] Account Switching Theme Styling

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -40,7 +40,7 @@
       <div class="tw-grid tw-gap-2">
         <button
           type="button"
-          class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
+          class="account-switcher-row tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-p-3 disabled:tw-cursor-not-allowed disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60"
           (click)="lock()"
           [disabled]="currentAccount.status === lockedStatus || !activeUserCanLock"
           [title]="!activeUserCanLock ? ('unlockMethodNeeded' | i18n) : ''"
@@ -50,7 +50,7 @@
         </button>
         <button
           type="button"
-          class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+          class="account-switcher-row tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-p-3"
           (click)="logOut()"
         >
           <i class="bwi bwi-sign-out tw-text-2xl" aria-hidden="true"></i>
@@ -58,7 +58,7 @@
         </button>
         <button
           type="button"
-          class="tw-mt-2 tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+          class="account-switcher-row tw-mt-2 tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-p-3"
           (click)="lockAll()"
         >
           <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>

--- a/apps/browser/src/auth/popup/account-switching/account.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account.component.html
@@ -1,7 +1,7 @@
 <button
   *ngIf="account.id !== specialAccountAddId"
   type="button"
-  class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-border-none tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+  class="account-switcher-row tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-border-none tw-p-3"
   (click)="selectAccount(account.id)"
 >
   <div class="tw-flex-shrink-0">
@@ -18,32 +18,35 @@
     <span class="tw-sr-only" *ngIf="status.text !== 'active'">
       {{ "switchToAccount" | i18n }}
     </span>
-    <div class="tw-max-w-64 tw-truncate tw-text-main">
+    <div class="tw-max-w-64 tw-truncate">
       {{ account.email }}
     </div>
-    <div class="tw-max-w-64 tw-truncate tw-text-sm tw-text-muted">
+    <div class="account-switcher-row-details tw-max-w-64 tw-truncate tw-text-sm">
       <span class="tw-sr-only">{{ "hostedAt" | i18n }}</span>
       {{ account.server }}
     </div>
-    <div class="tw-text-sm tw-italic tw-text-muted" [attr.aria-hidden]="status.text === 'active'">
+    <div
+      class="account-switcher-row-details tw-text-sm tw-italic"
+      [attr.aria-hidden]="status.text === 'active'"
+    >
       <span class="tw-sr-only">(</span>
       {{ status.text }}
       <span class="tw-sr-only">)</span>
     </div>
   </div>
   <div class="tw-ml-auto tw-flex-shrink-0">
-    <i class="bwi tw-text-2xl tw-text-main" [ngClass]="status.icon" aria-hidden="true"></i>
+    <i class="bwi tw-text-2xl" [ngClass]="status.icon" aria-hidden="true"></i>
   </div>
 </button>
 
 <button
   *ngIf="account.id === specialAccountAddId"
   type="button"
-  class="tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-border-none tw-bg-background tw-p-3 hover:tw-bg-background-alt"
+  class="account-switcher-row tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-border-none tw-p-3"
   (click)="selectAccount(account.id)"
 >
-  <i class="bwi bwi-plus tw-text-2xl tw-text-main" aria-hidden="true"></i>
-  <div class="tw-text-main">
+  <i class="bwi bwi-plus tw-text-2xl" aria-hidden="true"></i>
+  <div>
     {{ account.name }}
   </div>
 </button>

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -767,3 +767,24 @@ form {
     }
   }
 }
+
+.account-switcher-row {
+  @include themify($themes) {
+    color: themed("textColor");
+    background-color: themed("boxBackgroundColor");
+  }
+
+  &:hover,
+  &:focus,
+  &.active {
+    @include themify($themes) {
+      background-color: themed("listItemBackgroundHoverColor");
+    }
+  }
+
+  &-details {
+    @include themify($themes) {
+      color: themed("mutedColor");
+    }
+  }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Tech debt (refactoring, code cleanup, dependency upgrades, etc)

## Objective

The contrast for the account switcher page is low on the Dark theme. The Solorized Dark theme colors are completely incorrect. This PR updates styles on the Account Switcher page to work for every theme by adding a temporary stop-gap class `account-switcher-row`.

## Code changes

- Add `account-switcher-row` class
  - `apps/browser/src/popup/scss/box.scss`
- Add `account-switcher-row` class to relevant elements on the Account Switcher page
  - `apps/browser/src/auth/popup/account-switching/account-switcher.component.html`
  - `apps/browser/src/auth/popup/account-switching/account.component.html`


## Screenshots

![Screenshot 2023-12-11 at 3 15 44 PM](https://github.com/bitwarden/clients/assets/102181210/9f721d71-53ed-4344-ad1f-114a0c482053)

![Screenshot 2023-12-11 at 3 16 04 PM](https://github.com/bitwarden/clients/assets/102181210/26914db6-3dc4-4248-8a3c-65c242890152)

![Screenshot 2023-12-11 at 3 16 21 PM](https://github.com/bitwarden/clients/assets/102181210/42583116-b28b-4ba4-83b1-e5fb93b7fc24)

![Screenshot 2023-12-11 at 3 16 44 PM](https://github.com/bitwarden/clients/assets/102181210/0f5ef453-4b3e-4262-95b6-ae0da42ddfa0)
