### PR TITLE
Fix version bump workflow on call

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -55,6 +55,9 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          repository: bitwarden/clients
+          ref: master
 
       - name: Login to Azure - Prod Subscription
         uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
@@ -282,7 +285,7 @@ jobs:
           TITLE: "Bump ${{ steps.create-branch.outputs.client }} version to ${{ inputs.version_number }}"
         run: |
           PR_URL=$(gh pr create --title "$TITLE" \
-            --base "$GITHUB_REF" \
+            --base "master" \
             --head "$PR_BRANCH" \
             --label "version update" \
             --label "automated pr" \


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR updates the checkout step to always be `master`. This limits the use of the workflow to only bump the version on `master`, but we shouldn't be using it on any other branch anyways.  This was needed because when the workflow was called from another repository it was checking out the wrong repository.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/version-bump.yml:** Force checkout step to use `master` and create PR for merging into `master`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
