### PR TITLE
[PM-5060] Add flexible collection feature flag to export vault selector

### DIFF
--- a/apps/web/src/app/admin-console/organizations/tools/vault-export/org-vault-export.component.ts
+++ b/apps/web/src/app/admin-console/organizations/tools/vault-export/org-vault-export.component.ts
@@ -7,6 +7,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { EventType } from "@bitwarden/common/enums";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -35,6 +36,7 @@ export class OrganizationVaultExportComponent extends ExportComponent {
     fileDownloadService: FileDownloadService,
     dialogService: DialogService,
     organizationService: OrganizationService,
+    configService: ConfigServiceAbstraction,
   ) {
     super(
       i18nService,
@@ -48,6 +50,7 @@ export class OrganizationVaultExportComponent extends ExportComponent {
       fileDownloadService,
       dialogService,
       organizationService,
+      configService,
     );
   }
 

--- a/apps/web/src/app/tools/vault-export/export.component.html
+++ b/apps/web/src/app/tools/vault-export/export.component.html
@@ -15,7 +15,7 @@
     *ngIf="!disabledByPolicy"
   ></app-export-scope-callout>
 
-  <bit-form-field>
+  <bit-form-field *ngIf="flexibleCollectionsEnabled$ | async">
     <bit-label>{{ "exportFrom" | i18n }}</bit-label>
     <bit-select formControlName="vaultSelector">
       <bit-option [label]="'myVault' | i18n" value="myVault" icon="bwi-user" />

--- a/apps/web/src/app/tools/vault-export/export.component.ts
+++ b/apps/web/src/app/tools/vault-export/export.component.ts
@@ -7,6 +7,8 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -25,6 +27,11 @@ export class ExportComponent extends BaseExportComponent {
   encryptedExportType = EncryptedExportType;
   protected showFilePassword: boolean;
 
+  protected flexibleCollectionsEnabled$ = this.configService.getFeatureFlag$(
+    FeatureFlag.FlexibleCollections,
+    false,
+  );
+
   constructor(
     i18nService: I18nService,
     platformUtilsService: PlatformUtilsService,
@@ -37,6 +44,7 @@ export class ExportComponent extends BaseExportComponent {
     fileDownloadService: FileDownloadService,
     dialogService: DialogService,
     organizationService: OrganizationService,
+    protected configService: ConfigServiceAbstraction,
   ) {
     super(
       i18nService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Hide the vault selector on export page behing the flexible collections feature flag

## Code changes
- **web/export.component.ts:** added property with flexible collections feature flag
- **web/export.component.html:** Reading flexible collections flag to decide if should show or not the vault selector

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
