### PR TITLE
[PM-5299] Extract a danger-zone component

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -79,8 +79,6 @@
   </button>
 </form>
 
-<h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5 !tw-text-danger">{{ "dangerZone" | i18n }}</h1>
-
 <app-danger-zone>
   <button type="button" bitButton buttonType="danger" (click)="deleteOrganization()">
     {{ "deleteOrganization" | i18n }}

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -78,16 +78,18 @@
     {{ "save" | i18n }}
   </button>
 </form>
+
 <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5 !tw-text-danger">{{ "dangerZone" | i18n }}</h1>
-<div class="tw-rounded tw-border tw-border-solid tw-border-danger-500 tw-bg-background tw-p-5">
-  <p>{{ "dangerZoneDesc" | i18n }}</p>
+
+<app-danger-zone>
   <button type="button" bitButton buttonType="danger" (click)="deleteOrganization()">
     {{ "deleteOrganization" | i18n }}
   </button>
   <button type="button" bitButton buttonType="danger" (click)="purgeVault()">
     {{ "purgeVault" | i18n }}
   </button>
-</div>
+</app-danger-zone>
+
 <ng-template #purgeOrganizationTemplate></ng-template>
 <ng-template #apiKeyTemplate></ng-template>
 <ng-template #rotateApiKeyTemplate></ng-template>

--- a/apps/web/src/app/auth/settings/account/account.component.html
+++ b/apps/web/src/app/auth/settings/account/account.component.html
@@ -2,12 +2,11 @@
   <h1>{{ "myAccount" | i18n }}</h1>
 </div>
 <app-profile></app-profile>
-<ng-container *ngIf="showChangeEmail">
-  <div class="secondary-header">
-    <h1>{{ "changeEmail" | i18n }}</h1>
-  </div>
+
+<div *ngIf="showChangeEmail" class="tw-mt-16">
+  <h1 bitTypography="h1">{{ "changeEmail" | i18n }}</h1>
   <app-change-email></app-change-email>
-</ng-container>
+</div>
 
 <app-danger-zone>
   <button type="button" bitButton buttonType="danger" (click)="deauthorizeSessions()">

--- a/apps/web/src/app/auth/settings/account/account.component.html
+++ b/apps/web/src/app/auth/settings/account/account.component.html
@@ -8,23 +8,23 @@
   </div>
   <app-change-email></app-change-email>
 </ng-container>
+
 <div class="secondary-header text-danger border-0 mb-0">
   <h1>{{ "dangerZone" | i18n }}</h1>
 </div>
-<div class="card border-danger">
-  <div class="card-body">
-    <p>{{ "dangerZoneDesc" | i18n }}</p>
-    <button type="button" bitButton buttonType="danger" (click)="deauthorizeSessions()">
-      {{ "deauthorizeSessions" | i18n }}
-    </button>
-    <button type="button" bitButton buttonType="danger" (click)="purgeVault()">
-      {{ "purgeVault" | i18n }}
-    </button>
-    <button type="button" bitButton buttonType="danger" (click)="deleteAccount()">
-      {{ "deleteAccount" | i18n }}
-    </button>
-  </div>
-</div>
+
+<app-danger-zone>
+  <button type="button" bitButton buttonType="danger" (click)="deauthorizeSessions()">
+    {{ "deauthorizeSessions" | i18n }}
+  </button>
+  <button type="button" bitButton buttonType="danger" (click)="purgeVault()">
+    {{ "purgeVault" | i18n }}
+  </button>
+  <button type="button" bitButton buttonType="danger" (click)="deleteAccount()">
+    {{ "deleteAccount" | i18n }}
+  </button>
+</app-danger-zone>
+
 <ng-template #deauthorizeSessionsTemplate></ng-template>
 <ng-template #purgeVaultTemplate></ng-template>
 <ng-template #deleteAccountTemplate></ng-template>

--- a/apps/web/src/app/auth/settings/account/account.component.html
+++ b/apps/web/src/app/auth/settings/account/account.component.html
@@ -9,10 +9,6 @@
   <app-change-email></app-change-email>
 </ng-container>
 
-<div class="secondary-header text-danger border-0 mb-0">
-  <h1>{{ "dangerZone" | i18n }}</h1>
-</div>
-
 <app-danger-zone>
   <button type="button" bitButton buttonType="danger" (click)="deauthorizeSessions()">
     {{ "deauthorizeSessions" | i18n }}

--- a/apps/web/src/app/auth/settings/account/danger-zone.component.html
+++ b/apps/web/src/app/auth/settings/account/danger-zone.component.html
@@ -1,3 +1,5 @@
+<h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5 !tw-text-danger">{{ "dangerZone" | i18n }}</h1>
+
 <div class="tw-rounded tw-border tw-border-solid tw-border-danger-500 tw-p-5">
   <p>{{ "dangerZoneDesc" | i18n }}</p>
 

--- a/apps/web/src/app/auth/settings/account/danger-zone.component.html
+++ b/apps/web/src/app/auth/settings/account/danger-zone.component.html
@@ -1,0 +1,7 @@
+<div class="tw-rounded tw-border tw-border-solid tw-border-danger-500 tw-p-5">
+  <p>{{ "dangerZoneDesc" | i18n }}</p>
+
+  <div class="tw-flex tw-flex-row tw-gap-2">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/apps/web/src/app/auth/settings/account/danger-zone.component.ts
+++ b/apps/web/src/app/auth/settings/account/danger-zone.component.ts
@@ -1,0 +1,14 @@
+import { Component } from "@angular/core";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+
+/**
+ * Component for the Danger Zone section of the Account/Organization Settings page.
+ */
+@Component({
+  selector: "app-danger-zone",
+  templateUrl: "danger-zone.component.html",
+  standalone: true,
+  imports: [JslibModule],
+})
+export class DangerZoneComponent {}

--- a/apps/web/src/app/auth/settings/account/danger-zone.component.ts
+++ b/apps/web/src/app/auth/settings/account/danger-zone.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { TypographyModule } from "@bitwarden/components";
 
 /**
  * Component for the Danger Zone section of the Account/Organization Settings page.
@@ -9,6 +10,6 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
   selector: "app-danger-zone",
   templateUrl: "danger-zone.component.html",
   standalone: true,
-  imports: [JslibModule],
+  imports: [TypographyModule, JslibModule],
 })
 export class DangerZoneComponent {}

--- a/apps/web/src/app/auth/settings/account/danger-zone.stories.ts
+++ b/apps/web/src/app/auth/settings/account/danger-zone.stories.ts
@@ -1,0 +1,36 @@
+import { importProvidersFrom } from "@angular/core";
+import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { ButtonModule } from "@bitwarden/components";
+
+import { PreloadedEnglishI18nModule } from "../../../core/tests";
+
+import { DangerZoneComponent } from "./danger-zone.component";
+
+export default {
+  title: "Web/Danger Zone",
+  component: DangerZoneComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonModule, JslibModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+} as Meta;
+
+type Story = StoryObj<DangerZoneComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <app-danger-zone>
+        <button type="button" bitButton buttonType="danger">Danger A</button>
+        <button type="button" bitButton buttonType="danger">Danger B</button>
+      </app-danger-zone>
+      `,
+  }),
+};

--- a/apps/web/src/app/shared/loose-components.module.ts
+++ b/apps/web/src/app/shared/loose-components.module.ts
@@ -27,6 +27,7 @@ import { SetPasswordComponent } from "../auth/set-password.component";
 import { AccountComponent } from "../auth/settings/account/account.component";
 import { ChangeAvatarComponent } from "../auth/settings/account/change-avatar.component";
 import { ChangeEmailComponent } from "../auth/settings/account/change-email.component";
+import { DangerZoneComponent } from "../auth/settings/account/danger-zone.component";
 import { DeauthorizeSessionsComponent } from "../auth/settings/account/deauthorize-sessions.component";
 import { DeleteAccountComponent } from "../auth/settings/account/delete-account.component";
 import { ProfileComponent } from "../auth/settings/account/profile.component";
@@ -107,6 +108,7 @@ import { SharedModule } from "./shared.module";
     OrganizationBadgeModule,
     PipesModule,
     PasswordCalloutComponent,
+    DangerZoneComponent,
   ],
   declarations: [
     AcceptFamilySponsorshipComponent,
@@ -271,6 +273,7 @@ import { SharedModule } from "./shared.module";
     VerifyEmailTokenComponent,
     VerifyRecoverDeleteComponent,
     LowKdfComponent,
+    DangerZoneComponent,
   ],
 })
 export class LooseComponentsModule {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Extract a re-useable danger-zone component instead of needing to duplicate the code. I wasn't sure which team should own it, but defaulted to auth since ac is more an extension.

This results in a minimal change in the visual UI on the users account settings. But it matches the current styling of the AC which I consider acceptable.

## Screenshot

|Before|After|
|-|-|
|![image](https://github.com/bitwarden/clients/assets/137855/192ea9a3-de0c-4ccf-bbc1-c8086ccb0785)|![image](https://github.com/bitwarden/clients/assets/137855/c6f9fba6-b13e-4cfe-bbf9-e4a447d24c68)|

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
