### PR TITLE
[CL-152] undeprecate openSimpleDialogRef

### DIFF
--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -86,10 +86,7 @@ export class DialogService extends Dialog implements OnDestroy {
    * @returns `boolean` - True if the user accepted the dialog, false otherwise.
    */
   async openSimpleDialog(simpleDialogOptions: SimpleDialogOptions): Promise<boolean> {
-    const dialogRef = this.open<boolean>(SimpleConfigurableDialogComponent, {
-      data: simpleDialogOptions,
-      disableClose: simpleDialogOptions.disableClose,
-    });
+    const dialogRef = this.openSimpleDialogRef(simpleDialogOptions);
 
     return firstValueFrom(dialogRef.closed);
   }
@@ -97,16 +94,15 @@ export class DialogService extends Dialog implements OnDestroy {
   /**
    * Opens a simple dialog.
    *
-   * @deprecated Use `openSimpleDialog` instead. If you find a use case for the `dialogRef`
-   * please let #wg-component-library know and we can un-deprecate this method.
+   * You should probably use `openSimpleDialog` instead, unless you need to programmatically close the dialog.
    *
    * @param {SimpleDialogOptions} simpleDialogOptions - An object containing options for the dialog.
    * @returns `DialogRef` - The reference to the opened dialog.
    * Contains a closed observable which can be subscribed to for determining which button
    * a user pressed
    */
-  openSimpleDialogRef(simpleDialogOptions: SimpleDialogOptions): DialogRef {
-    return this.open(SimpleConfigurableDialogComponent, {
+  openSimpleDialogRef(simpleDialogOptions: SimpleDialogOptions): DialogRef<boolean> {
+    return this.open<boolean, SimpleDialogOptions>(SimpleConfigurableDialogComponent, {
       data: simpleDialogOptions,
       disableClose: simpleDialogOptions.disableClose,
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Undeprecates `DialogService.openSimpleDialogRef`, as it is needed to close simple dialogs programmatically.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
