### PR TITLE
Update version bump workflow

### DIFF
--- a/.github/workflows/_cut_rc.yml
+++ b/.github/workflows/_cut_rc.yml
@@ -1,0 +1,29 @@
+---
+name: Cut RC Branch
+
+on:
+  workflow_call:
+
+jobs:
+  cut-rc:
+    name: Cut RC branch
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: main
+
+      - name: Check if RC branch exists
+        run: |
+          remote_rc_branch_check=$(git ls-remote --heads origin rc | wc -l)
+          if [[ "${remote_rc_branch_check}" -gt 0 ]]; then
+            echo "Remote RC branch exists."
+            echo "Please delete current RC branch before running again."
+            exit 1
+          fi
+
+      - name: Cut RC branch
+        run: |
+          git switch --quiet --create rc
+          git push --quiet --set-upstream origin rc

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,29 +25,6 @@ on:
         description: "New version (example: '2024.1.0')"
         required: true
 
-  workflow_call:
-    inputs:
-      bump_browser:
-        description: "Bump Browser?"
-        type: boolean
-        default: false
-      bump_cli:
-        description: "Bump CLI?"
-        type: boolean
-        default: false
-      bump_desktop:
-        description: "Bump Desktop?"
-        type: boolean
-        default: false
-      bump_web:
-        description: "Bump Web?"
-        type: boolean
-        default: false
-      version_number:
-        description: "New version (example: '2024.1.0')"
-        required: true
-        type: string
-
 jobs:
   bump_version:
     name: "Bump Version to v${{ inputs.version_number }}"
@@ -72,7 +49,6 @@ jobs:
         with:
           repository: bitwarden/clients
           ref: main
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
@@ -313,3 +289,10 @@ jobs:
           GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         run: gh pr merge $PR_NUMBER --squash --auto --delete-branch
+
+  cut_rc:
+    name: Cut RC Branch
+    if: ${{ inputs.cut_rc_branch == true }}
+    needs: bump_version
+    uses: ./.github/workflows/_cut_rc.yml
+    secrets: inherit

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,6 +24,10 @@ on:
       version_number:
         description: "New version (example: '2024.1.0')"
         required: true
+      cut_rc_branch:
+        description: "Cut RC branch?"
+        default: true
+        type: boolean
 
 jobs:
   bump_version:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR updates how we bump version numbers and cut the `rc` branch.  The new procedure is outlined below.

If you have more than one project to cut `rc` for:

- Go to the `DevOps` repository and run the `RC Branch Manager` workflow with the following inputs.
  - `cut`mode.
  -  Desired projects checked.
  - `Version Number` filled out.

You can also just run the `Version Bump` workflow in the repository by itself if you don't need to cut `rc` for multiple projects.

The following will take place:
- The version number is verified.
- The `Version Bump` workflow in the each repository is called via the GitHub CLI.
- The version will be bumped, committed to a branch, PR created, PR approved, PR merged.
- The `Cut RC Branch` workflow will run to create and push the `rc` branch.
- A Slack message will be sent to notify of the PR.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/_cut_rc.yml:** Added to help cut the `rc` branch.
* **.github/workflows/version-bump.yml:** Removed `workflow_call` trigger as it's no longer needed. Added input for cutting the `rc` branch.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
