### PR TITLE
[PM-5301] Access Returned Object With Global Key

### DIFF
--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -87,6 +87,7 @@ async function loadNotificationBar() {
 
   // Look up the active user id from storage
   const activeUserIdKey = "activeUserId";
+  const globalStorageKey = "global";
   let activeUserId: string;
 
   const activeUserStorageValue = await getFromLocalStorage(activeUserIdKey);
@@ -98,7 +99,9 @@ async function loadNotificationBar() {
   const userSettingsStorageValue = await getFromLocalStorage(activeUserId);
   if (userSettingsStorageValue[activeUserId]) {
     const userSettings: UserSettings = userSettingsStorageValue[activeUserId].settings;
-    const globalSettings: GlobalSettings = await getFromLocalStorage("global");
+    const globalSettings: GlobalSettings = (await getFromLocalStorage(globalStorageKey))[
+      globalStorageKey
+    ];
 
     // Do not show the notification bar on the Bitwarden vault
     // because they can add logins and change passwords there


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`chrome.storage.local.get("key", ...)` will return to you (through callback) an object that contains your key, this is because you can request multiple keys at once. You can see us access that object with the requested key in our chrome storage services [here](https://github.com/bitwarden/clients/blob/96d1c8338557a8f49be7507e4d5ec9dd36bfc34c/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts#L47). I missed that and was not accessing the "global" key so the notification bar logic always thought they had 0 never domains. 

This was found by an amazing community member (@jlcfly) [here](https://github.com/bitwarden/clients/issues/1641#issuecomment-1856983921)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/autofill/content/notification-bar.ts:** Access returned object by key

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
