### PR TITLE
[PM-5318] fix: allow submitting member-invite form on enter

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -22,7 +22,14 @@
             <p>{{ "inviteUserDesc" | i18n }}</p>
             <bit-form-field>
               <bit-label>{{ "email" | i18n }}</bit-label>
-              <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
+              <input
+                id="emails"
+                type="text"
+                appAutoFocus
+                bitInput
+                formControlName="emails"
+                (keyup.enter)="blurAndSubmit($event)"
+              />
               <bit-hint>{{
                 "inviteMultipleEmailDesc"
                   | i18n : (organization.planProductType === ProductType.TeamsStarter ? "10" : "20")

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -28,7 +28,7 @@
                 appAutoFocus
                 bitInput
                 formControlName="emails"
-                (keyup.enter)="blurAndSubmit($event)"
+                (keydown.enter)="blurAndSubmit($event)"
               />
               <bit-hint>{{
                 "inviteMultipleEmailDesc"

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.spec.ts
@@ -1,0 +1,120 @@
+import { DIALOG_DATA, DialogRef } from "@angular/cdk/dialog";
+import {
+  ComponentFixture,
+  ComponentFixtureAutoDetect,
+  TestBed,
+  fakeAsync,
+} from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { mock } from "jest-mock-extended";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DialogService } from "@bitwarden/components";
+
+import { CollectionAdminService } from "../../../../../vault/core/collection-admin.service";
+import { GroupService, UserAdminService } from "../../../core";
+import { MembersModule } from "../../members.module";
+
+import { MemberDialogComponent, MemberDialogTab } from "./member-dialog.component";
+
+
+
+describe("MemberDialogComponent", () => {
+  let component: MemberDialogComponent;
+  let fixture: ComponentFixture<MemberDialogComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MembersModule],
+      providers: [
+        {
+          provide: UserAdminService,
+          useValue: mock<UserAdminService>(),
+        },
+        {
+          provide: GroupService,
+          useValue: mock<GroupService>(),
+        },
+        {
+          provide: CollectionAdminService,
+          useValue: mock<CollectionAdminService>(),
+        },
+        {
+          provide: OrganizationService,
+          useValue: mock<OrganizationService>(),
+        },
+        {
+          provide: OrganizationUserService,
+          useValue: mock<OrganizationUserService>(),
+        },
+        {
+          provide: I18nService,
+          useValue: mock<I18nService>(),
+        },
+        {
+          provide: DialogService,
+          useValue: mock<DialogService>(),
+        },
+        {
+          provide: ConfigServiceAbstraction,
+          useValue: mock<ConfigServiceAbstraction>(),
+        },
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            initialTab: MemberDialogTab.Role,
+            organizationId: 1,
+            allOrganizationUserEmails: [],
+          },
+        },
+        {
+          provide: DialogRef,
+          useValue: mock<DialogRef>(),
+        },
+        {
+          provide: PlatformUtilsService,
+          useValue: mock<PlatformUtilsService>(),
+        },
+        { provide: ComponentFixtureAutoDetect, useValue: true },
+      ],
+      schemas: [],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    const organizationService = TestBed.inject(OrganizationService);
+    const collectionAdminService = TestBed.inject(CollectionAdminService);
+
+    jest.spyOn(organizationService, "get").mockReturnValue({} as unknown as Organization);
+    jest.spyOn(collectionAdminService, "getAll").mockResolvedValue([]);
+
+    fixture = TestBed.createComponent(MemberDialogComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it("should initialize component", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should invite user when pressing enter on email input", fakeAsync(() => {
+    const userServiceMock = TestBed.inject(UserAdminService);
+
+    const emailInput: HTMLInputElement = fixture.nativeElement.querySelector("#emails");
+
+    // Update value and make Angular aware
+    emailInput.value = "test@mydomain.com";
+    emailInput.dispatchEvent(new Event("input"));
+
+    // Trigger keyup.enter, which should submit form.
+    emailInput.dispatchEvent(new KeyboardEvent("keyup", { key: "enter" }));
+
+    expect(userServiceMock.invite).toHaveBeenCalledWith(["test@mydomain.com"], expect.anything());
+  }));
+});

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.spec.ts
@@ -22,8 +22,6 @@ import { MembersModule } from "../../members.module";
 
 import { MemberDialogComponent, MemberDialogTab } from "./member-dialog.component";
 
-
-
 describe("MemberDialogComponent", () => {
   let component: MemberDialogComponent;
   let fixture: ComponentFixture<MemberDialogComponent>;
@@ -113,7 +111,7 @@ describe("MemberDialogComponent", () => {
     emailInput.dispatchEvent(new Event("input"));
 
     // Trigger keyup.enter, which should submit form.
-    emailInput.dispatchEvent(new KeyboardEvent("keyup", { key: "enter" }));
+    emailInput.dispatchEvent(new KeyboardEvent("keydown", { key: "enter" }));
 
     expect(userServiceMock.invite).toHaveBeenCalledWith(["test@mydomain.com"], expect.anything());
   }));

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -502,6 +502,8 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
   };
 
   async blurAndSubmit(e: Event) {
+    e.preventDefault();
+
     const input = e.target as HTMLElement;
     input.dispatchEvent(new Event("blur"));
     await this.submit();

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -501,6 +501,12 @@ export class MemberDialogComponent implements OnInit, OnDestroy {
     this.close(MemberDialogResult.Restored);
   };
 
+  async blurAndSubmit(e: Event) {
+    const input = e.target as HTMLElement;
+    input.dispatchEvent(new Event("blur"));
+    await this.submit();
+  }
+
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Currently, when hitting enter when still focussing the `emails` field when inviting a user to an organization, will try submitting the form.

However, [as `updatedOn` is set to `blur`](https://github.com/bitwarden/clients/blob/main/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts#L94) for the emails field, and[ the `blur` event not being triggered when submitting the form through hitting `enter`](https://jsfiddle.net/ac208g9y/), this results in an error message informing the user that the input is required. 

Closes #7156 

## Code changes

Intercept the `enter` key, trigger the `blur` event on the input, and continue calling submit.
