### PR TITLE
[PM-5322] build: add untracked package names in lockfile from #7233

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,6 +266,7 @@
       "version": "2023.12.0"
     },
     "libs/admin-console": {
+      "name": "@bitwarden/admin-console",
       "version": "0.0.0",
       "license": "GPL-3.0"
     },
@@ -280,6 +281,7 @@
       "license": "GPL-3.0"
     },
     "libs/billing": {
+      "name": "@bitwarden/billing",
       "version": "0.0.0",
       "license": "GPL-3.0"
     },
@@ -318,6 +320,7 @@
       }
     },
     "libs/platform": {
+      "name": "@bitwarden/platform",
       "version": "0.0.0",
       "license": "GPL-3.0"
     },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I started working on a separate issue, and the first step in the contributing guide is to run `npm ci`. Well, instead of a clean-install, I had already ran a plain install, and that updated the lock with these changes. It seems like these are metadata only, and anyone else who runs an npm install or update in the future will also have this diff.

## Code changes

- **package-lock.json:** These changes are the result of an install with both npm v9.6.7 and npm v10.2.5, I tested both
