### PR TITLE
[PM-5323] feat(browser): use match strategies with never domains

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1729,6 +1729,15 @@
       }
     }
   },
+  "excludedDomainsInvalidRegex": {
+    "message": "$EXPRESSION$ is not a valid regular expression.",
+    "placeholders": {
+      "expression": {
+        "content": "$1",
+        "example": "[a-z+"
+      }
+    }
+  },
   "send": {
     "message": "Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."

--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -1,3 +1,5 @@
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
 import AutofillField from "../models/autofill-field";
 import { WatchedForm } from "../models/watched-form";
 import AddLoginRuntimeMessage from "../notification/models/add-login-runtime-message";
@@ -98,7 +100,8 @@ async function loadNotificationBar() {
   const userSettingsStorageValue = await getFromLocalStorage(activeUserId);
   if (userSettingsStorageValue[activeUserId]) {
     const userSettings: UserSettings = userSettingsStorageValue[activeUserId].settings;
-    const globalSettings: GlobalSettings = await getFromLocalStorage("global");
+    const globalSettingsValue = await getFromLocalStorage("global");
+    const globalSettings: GlobalSettings = globalSettingsValue["global"];
 
     // Do not show the notification bar on the Bitwarden vault
     // because they can add logins and change passwords there
@@ -108,9 +111,10 @@ async function loadNotificationBar() {
       // NeverDomains is a dictionary of domains that the user has chosen to never
       // show the notification bar on (for login detail collection or password change).
       // It is managed in the Settings > Excluded Domains page in the browser extension.
-      // Example: '{"bitwarden.com":null}'
+      // The key is the domain and the value is an nullable UriMatchType enum value.
+      // Example: '{"bitwarden.com": UriMatchType.Domain, "google.com": null}'
       const excludedDomainsDict = globalSettings.neverDomains;
-      if (!excludedDomainsDict || !(window.location.hostname in excludedDomainsDict)) {
+      if (!excludedDomainsDict || !Utils.isDomainExcluded(excludedDomainsDict, window.location)) {
         // Set local disabled preferences
         disabledAddLoginNotification = globalSettings.disableAddLoginNotification;
         disabledChangedPasswordNotification = globalSettings.disableChangedPasswordNotification;

--- a/apps/browser/src/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/popup/settings/excluded-domains.component.html
@@ -48,9 +48,21 @@
                 inputmode="url"
                 appInputVerbatim
               />
-              <label for="currentUris{{ i }}" class="sr-only">
-                {{ "currentUri" | i18n }} {{ i + 1 }}
+              <label for="match-currentUris{{ i }}" class="sr-only">
+                {{ "match" | i18n }} {{ i + 1 }}
               </label>
+              <select
+                id="match-currentUris{{ i }}"
+                name="match-currentUris{{ i }}"
+                [(ngModel)]="domain.match"
+              >
+                <option *ngFor="let match of matchTypes | keyvalue" [ngValue]="match.value">
+                  {{ match.key | i18n }}
+                </option>
+              </select>
+              <label for="currentUris{{ i }}" class="sr-only"
+                >{{ "currentUri" | i18n }} {{ i + 1 }}</label
+              >
               <select
                 *ngIf="currentUris && currentUris.length"
                 id="currentUris{{ i }}"

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -426,8 +426,11 @@ export abstract class StateService<T extends Account = Account> {
   setMainWindowSize: (value: number, options?: StorageOptions) => Promise<void>;
   getMinimizeOnCopyToClipboard: (options?: StorageOptions) => Promise<boolean>;
   setMinimizeOnCopyToClipboard: (value: boolean, options?: StorageOptions) => Promise<void>;
-  getNeverDomains: (options?: StorageOptions) => Promise<{ [id: string]: unknown }>;
-  setNeverDomains: (value: { [id: string]: unknown }, options?: StorageOptions) => Promise<void>;
+  getNeverDomains: (options?: StorageOptions) => Promise<{ [id: string]: UriMatchType | null }>;
+  setNeverDomains: (
+    value: { [id: string]: UriMatchType | null },
+    options?: StorageOptions,
+  ) => Promise<void>;
   getNoAutoPromptBiometricsText: (options?: StorageOptions) => Promise<string>;
   setNoAutoPromptBiometricsText: (value: string, options?: StorageOptions) => Promise<void>;
   getOpenAtLogin: (options?: StorageOptions) => Promise<boolean>;

--- a/libs/common/src/platform/models/domain/global-state.ts
+++ b/libs/common/src/platform/models/domain/global-state.ts
@@ -1,5 +1,6 @@
 import { EnvironmentUrls } from "../../../auth/models/domain/environment-urls";
 import { WindowState } from "../../../models/domain/window-state";
+import { UriMatchType } from "../../../vault/enums";
 import { ThemeType } from "../../enums";
 
 export class GlobalState {
@@ -35,7 +36,7 @@ export class GlobalState {
   enableBrowserIntegrationFingerprint?: boolean;
   enableDuckDuckGoBrowserIntegration?: boolean;
   region?: string;
-  neverDomains?: { [id: string]: unknown };
+  neverDomains?: { [id: string]: UriMatchType | null };
   enablePasskeys?: boolean;
   disableAddLoginNotification?: boolean;
   disableChangedPasswordNotification?: boolean;

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -2343,13 +2343,16 @@ export class StateService<
     );
   }
 
-  async getNeverDomains(options?: StorageOptions): Promise<{ [id: string]: unknown }> {
+  async getNeverDomains(options?: StorageOptions): Promise<{ [id: string]: UriMatchType | null }> {
     return (
       await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
     )?.neverDomains;
   }
 
-  async setNeverDomains(value: { [id: string]: unknown }, options?: StorageOptions): Promise<void> {
+  async setNeverDomains(
+    value: { [id: string]: UriMatchType | null },
+    options?: StorageOptions,
+  ): Promise<void> {
     const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );

--- a/libs/common/src/types/never-domain.ts
+++ b/libs/common/src/types/never-domain.ts
@@ -1,0 +1,6 @@
+import { UriMatchType } from "../vault/enums";
+
+export interface NeverDomain {
+  uri: string;
+  match: UriMatchType | null;
+}

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -489,7 +489,7 @@ export class CipherService implements CipherServiceAbstraction {
     if (!domains) {
       domains = {};
     }
-    domains[domain] = null;
+    domains[domain] = UriMatchType.Domain;
     await this.stateService.setNeverDomains(domains);
   }
 

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -87,14 +87,14 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
       throw new TypeError("Invalid 'user.id' length");
     }
 
-    const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
-    params.rp.id = params.rp.id ?? parsedOrigin.hostname;
-
     const neverDomains = await this.stateService.getNeverDomains();
-    if (neverDomains != null && parsedOrigin.hostname in neverDomains) {
+    if (neverDomains != null && Utils.isDomainExcluded(neverDomains, new URL(params.origin))) {
       this.logService?.warning(`[Fido2Client] Excluded domain`);
       throw new FallbackRequestedError();
     }
+
+    const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
+    params.rp.id = params.rp.id ?? parsedOrigin.hostname;
 
     if (parsedOrigin.hostname == undefined || !params.origin.startsWith("https://")) {
       this.logService?.warning(`[Fido2Client] Invalid https origin: ${params.origin}`);
@@ -224,14 +224,14 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
       throw new FallbackRequestedError();
     }
 
-    const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
-    params.rpId = params.rpId ?? parsedOrigin.hostname;
-
     const neverDomains = await this.stateService.getNeverDomains();
-    if (neverDomains != null && parsedOrigin.hostname in neverDomains) {
+    if (neverDomains != null && Utils.isDomainExcluded(neverDomains, new URL(params.origin))) {
       this.logService?.warning(`[Fido2Client] Excluded domain`);
       throw new FallbackRequestedError();
     }
+
+    const parsedOrigin = parse(params.origin, { allowPrivateDomains: true });
+    params.rpId = params.rpId ?? parsedOrigin.hostname;
 
     if (parsedOrigin.hostname == undefined || !params.origin.startsWith("https://")) {
       this.logService?.warning(`[Fido2Client] Invalid https origin: ${params.origin}`);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This is a second attempt at #2289. The goal is to allow a way to disable the "Should Bitwarden remember this password for you?" notification bar using more kinds of matching strategies. I was aiming for the same URI match types as regular items use: https://bitwarden.com/help/uri-match-detection/. 

## Code changes

Ultimately, I replaced the `null` value stored at `GlobalState.neverDomains[<uri>]` with a `UriMatchType`. This changed a few other signatures. Previous domain exclusion logic was not centralized, and generally only did something like `window.location.hostname in global.neverDomains`.

To centralize the domain exclusion check, I added and called a new `Utils.isDomainExcluded` static function from areas in the codebase that used the `location.hostname` check I just mentioned.

- **apps/browser/src/autofill/content/notification-bar.ts**:
    - Import the new exclusion check, and call it.
    - There was a separate bug in this code, if I'm not mistaken. The value returned by `getFromLocalStorage` is an object with a single top level key matching the key provided to `getFromLocalStorage`. I'll leave a self-review comment explaining this further.
- **apps/browser/src/popup/settings/excluded-domains.component.html**:
    - Added a new `<select>` element to choose the matching strategy.
- **apps/browser/src/popup/settings/excluded-domains.component.ts**:
    - Manage and save the selected `URIMatchType` to global storage. Also handle the migration from existing user settings in global storage that had null as the neverDomain's value.
- **libs/common/src/platform/abstractions/state.service.ts**:
    - Type signature update
- **libs/common/src/platform/misc/utils.ts**:
    - The actual matching logic for excluded domains. I tested this with the URIs on https://bitwarden.com/help/uri-match-detection/, and now that I think of it, this would be a good set of new unit tests.
- **libs/common/src/platform/models/domain/global-state.ts**:
    - Type update for the new URIMatchType stored in global storage
- **libs/common/src/platform/services/state.service.ts**:
    - Type signature updates
- **libs/common/src/types/never-domain.ts**:
    - New shared type, I intended for this to be the type stored in `GlobalState.neverDomains`, as a `NeverDomain[]`, but for backwards compatibility with existing state, I decided against changing the structure. The new interface is still useful though, and we could still abstract how never domains with if if wanted.
- **libs/common/src/vault/services/cipher.service.ts**:
    - Update the default strategy used when clicking never on the notification bar.
- **libs/common/src/vault/services/fido2/fido2-client.service.ts**:
    - Not so sure about this, but it was using the same neverDomain state just like the notification bar was.
- Internationalization: 
  - **apps/browser/src/_locales/en/messages.json**:
      - Added a new `excludedDomainsInvalidRegex` entry. This PR will need to have it translated to other languages.

## Screenshots

<details><summary>New match type selection in settings > excluded domains</summary>
<img width="250" alt="image" src="https://github.com/bitwarden/clients/assets/11222441/20059795-7273-49f3-a67a-46ad9494c0b2">
</details>

<details><summary>Error for an invalid regex</summary>
<img width="250" alt="image" src="https://github.com/bitwarden/clients/assets/11222441/1e615127-e929-482a-9b61-626d6929b120">
</details>

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
