### PR TITLE
Add missing state provider factories

### DIFF
--- a/apps/browser/src/platform/background/service-factories/active-user-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/active-user-state-provider.factory.ts
@@ -1,0 +1,43 @@
+import { ActiveUserStateProvider } from "@bitwarden/common/platform/state";
+// eslint-disable-next-line import/no-restricted-paths -- We need the implementation to inject, but generally this should not be accessed
+import { DefaultActiveUserStateProvider } from "@bitwarden/common/platform/state/implementations/default-active-user-state.provider";
+
+import {
+  AccountServiceInitOptions,
+  accountServiceFactory,
+} from "../../../auth/background/service-factories/account-service.factory";
+
+import { EncryptServiceInitOptions, encryptServiceFactory } from "./encrypt-service.factory";
+import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import {
+  DiskStorageServiceInitOptions,
+  MemoryStorageServiceInitOptions,
+  observableDiskStorageServiceFactory,
+  observableMemoryStorageServiceFactory,
+} from "./storage-service.factory";
+
+type ActiveUserStateProviderFactory = FactoryOptions;
+
+export type ActiveUserStateProviderInitOptions = ActiveUserStateProviderFactory &
+  AccountServiceInitOptions &
+  EncryptServiceInitOptions &
+  MemoryStorageServiceInitOptions &
+  DiskStorageServiceInitOptions;
+
+export async function activeUserStateProviderFactory(
+  cache: { activeUserStateProvider?: ActiveUserStateProvider } & CachedServices,
+  opts: ActiveUserStateProviderInitOptions,
+): Promise<ActiveUserStateProvider> {
+  return factory(
+    cache,
+    "activeUserStateProvider",
+    opts,
+    async () =>
+      new DefaultActiveUserStateProvider(
+        await accountServiceFactory(cache, opts),
+        await encryptServiceFactory(cache, opts),
+        await observableMemoryStorageServiceFactory(cache, opts),
+        await observableDiskStorageServiceFactory(cache, opts),
+      ),
+  );
+}

--- a/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
@@ -1,0 +1,36 @@
+import { SingleUserStateProvider } from "@bitwarden/common/platform/state";
+// eslint-disable-next-line import/no-restricted-paths -- We need the implementation to inject, but generally this should not be accessed
+import { DefaultSingleUserStateProvider } from "@bitwarden/common/platform/state/implementations/default-single-user-state.provider";
+
+import { EncryptServiceInitOptions, encryptServiceFactory } from "./encrypt-service.factory";
+import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import {
+  DiskStorageServiceInitOptions,
+  MemoryStorageServiceInitOptions,
+  observableDiskStorageServiceFactory,
+  observableMemoryStorageServiceFactory,
+} from "./storage-service.factory";
+
+type SingleUserStateProviderFactoryOptions = FactoryOptions;
+
+export type SingleUserStateProviderInitOptions = SingleUserStateProviderFactoryOptions &
+  EncryptServiceInitOptions &
+  MemoryStorageServiceInitOptions &
+  DiskStorageServiceInitOptions;
+
+export async function singleUserStateProviderFactory(
+  cache: { singleUserStateProvider?: SingleUserStateProvider } & CachedServices,
+  opts: SingleUserStateProviderInitOptions,
+): Promise<SingleUserStateProvider> {
+  return factory(
+    cache,
+    "singleUserStateProvider",
+    opts,
+    async () =>
+      new DefaultSingleUserStateProvider(
+        await encryptServiceFactory(cache, opts),
+        await observableMemoryStorageServiceFactory(cache, opts),
+        await observableDiskStorageServiceFactory(cache, opts),
+      ),
+  );
+}

--- a/apps/browser/src/platform/background/service-factories/state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/state-provider.factory.ts
@@ -1,0 +1,41 @@
+import { StateProvider } from "@bitwarden/common/platform/state";
+// eslint-disable-next-line import/no-restricted-paths -- We need the implementation to inject, but generally this should not be accessed
+import { DefaultStateProvider } from "@bitwarden/common/platform/state/implementations/default-state.provider";
+
+import {
+  ActiveUserStateProviderInitOptions,
+  activeUserStateProviderFactory,
+} from "./active-user-state-provider.factory";
+import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import {
+  GlobalStateProviderInitOptions,
+  globalStateProviderFactory,
+} from "./global-state-provider.factory";
+import {
+  SingleUserStateProviderInitOptions,
+  singleUserStateProviderFactory,
+} from "./single-user-state-provider.factory";
+
+type StateProviderFactoryOptions = FactoryOptions;
+
+export type StateProviderInitOptions = StateProviderFactoryOptions &
+  GlobalStateProviderInitOptions &
+  ActiveUserStateProviderInitOptions &
+  SingleUserStateProviderInitOptions;
+
+export async function stateProviderFactory(
+  cache: { stateProvider?: StateProvider } & CachedServices,
+  opts: StateProviderInitOptions,
+): Promise<StateProvider> {
+  return factory(
+    cache,
+    "stateProvider",
+    opts,
+    async () =>
+      new DefaultStateProvider(
+        await activeUserStateProviderFactory(cache, opts),
+        await singleUserStateProviderFactory(cache, opts),
+        await globalStateProviderFactory(cache, opts),
+      ),
+  );
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We neglected to add a factory for `ActiveUserStateProvider`, `SingleUserStateProvider`, and  the combined `StateProvider` classes.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
