### PR TITLE
[PM-5333] Bugfix - Autofill overlay visibility setting should be off by default

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1554,13 +1554,11 @@ export class StateService<
   }
 
   async getAutoFillOverlayVisibility(options?: StorageOptions): Promise<number> {
-    return (
-      (
-        await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
-        )
-      )?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.OnFieldFocus
-    );
+    const locallyStoredOptions = await this.defaultOnDiskLocalOptions();
+    const reconciledOptions = this.reconcileOptions(options, locallyStoredOptions);
+    const globals = await this.getGlobals(reconciledOptions);
+
+    return globals?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.Off;
   }
 
   async setAutoFillOverlayVisibility(value: number, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When the overlay feature flag is on, the default overlay visibility setting should be set to off (to allow users to opt-in if they wish)

## Screenshots

![Screenshot 2023-12-18 at 2 04 38 PM](https://github.com/bitwarden/clients/assets/1556494/d4d6844d-fe6a-4031-9cf9-d3e87f581b1a)
