### PR TITLE
[PM-5333] Make overlay visibility off by default

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -88,7 +88,7 @@ const DDG_SHARED_KEY = "DuckDuckGoSharedKey";
 
 export class StateService<
   TGlobalState extends GlobalState = GlobalState,
-  TAccount extends Account = Account
+  TAccount extends Account = Account,
 > implements StateServiceAbstraction<TAccount>
 {
   protected accountsSubject = new BehaviorSubject<{ [userId: string]: TAccount }>({});
@@ -115,7 +115,7 @@ export class StateService<
     protected logService: LogService,
     protected stateFactory: StateFactory<TGlobalState, TAccount>,
     protected accountService: AccountService,
-    protected useAccountCache: boolean = true
+    protected useAccountCache: boolean = true,
   ) {
     // If the account gets changed, verify the new account is unlocked
     this.activeAccountSubject
@@ -130,7 +130,7 @@ export class StateService<
           //  as checking for the existence of the crypto key is a low level
           //  implementation detail.
           this.activeAccountUnlockedSubject.next((await this.getUserKey()) != null);
-        })
+        }),
       )
       .subscribe();
   }
@@ -279,12 +279,12 @@ export class StateService<
 
   async setAddEditCipherInfo(value: AddEditCipherInfo, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.addEditCipherInfo = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -297,12 +297,12 @@ export class StateService<
 
   async setAlwaysShowDock(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.alwaysShowDock = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -339,12 +339,12 @@ export class StateService<
 
   async setAutoConfirmFingerprints(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.autoConfirmFingerPrints = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -357,12 +357,12 @@ export class StateService<
 
   async setAutoFillOnPageLoadDefault(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.autoFillOnPageLoadDefault = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -375,12 +375,12 @@ export class StateService<
 
   async setBiometricAwaitingAcceptance(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.biometricAwaitingAcceptance = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -393,12 +393,12 @@ export class StateService<
 
   async setBiometricFingerprintValidated(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.biometricFingerprintValidated = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -410,12 +410,12 @@ export class StateService<
 
   async setBiometricText(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.biometricText = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -428,12 +428,12 @@ export class StateService<
 
   async setBiometricUnlock(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.biometricUnlock = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -450,25 +450,25 @@ export class StateService<
 
   async getHasPremiumPersonally(options?: StorageOptions): Promise<boolean> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     return account?.profile?.hasPremiumPersonally;
   }
 
   async setHasPremiumPersonally(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.hasPremiumPersonally = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   async getHasPremiumFromOrganization(options?: StorageOptions): Promise<boolean> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
 
     if (account.profile?.hasPremiumFromOrganization) {
@@ -494,12 +494,12 @@ export class StateService<
 
   async setHasPremiumFromOrganization(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.hasPremiumFromOrganization = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -507,7 +507,7 @@ export class StateService<
     return (
       (
         await this.getAccount(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
         )
       )?.settings?.clearClipboard ?? null
     );
@@ -515,12 +515,12 @@ export class StateService<
 
   async setClearClipboard(value: number, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.clearClipboard = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -532,12 +532,12 @@ export class StateService<
 
   async setCollapsedGroupings(value: string[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.collapsedGroupings = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -549,12 +549,12 @@ export class StateService<
 
   async setConvertAccountToKeyConnector(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.convertAccountToKeyConnector = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -563,7 +563,7 @@ export class StateService<
    */
   async getCryptoMasterKey(options?: StorageOptions): Promise<SymmetricCryptoKey> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return account?.keys?.cryptoMasterKey;
   }
@@ -573,12 +573,12 @@ export class StateService<
    */
   async setCryptoMasterKey(value: SymmetricCryptoKey, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.cryptoMasterKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
 
     const nextStatus = value != null ? AuthenticationStatus.Unlocked : AuthenticationStatus.Locked;
@@ -599,7 +599,7 @@ export class StateService<
    */
   async getUserKey(options?: StorageOptions): Promise<UserKey> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return account?.keys?.userKey as UserKey;
   }
@@ -609,12 +609,12 @@ export class StateService<
    */
   async setUserKey(value: UserKey, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.userKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
 
     const nextStatus = value != null ? AuthenticationStatus.Unlocked : AuthenticationStatus.Locked;
@@ -635,7 +635,7 @@ export class StateService<
    */
   async getMasterKey(options?: StorageOptions): Promise<MasterKey> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return account?.keys?.masterKey;
   }
@@ -645,12 +645,12 @@ export class StateService<
    */
   async setMasterKey(value: MasterKey, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.masterKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -670,12 +670,12 @@ export class StateService<
    */
   async setMasterKeyEncryptedUserKey(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.keys.masterKeyEncryptedUserKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -685,14 +685,14 @@ export class StateService<
   async getUserKeyAutoUnlock(options?: StorageOptions): Promise<string> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "auto" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return null;
     }
     return await this.secureStorageService.get<string>(
       `${options.userId}${partialKeys.userAutoKey}`,
-      options
+      options,
     );
   }
 
@@ -702,7 +702,7 @@ export class StateService<
   async setUserKeyAutoUnlock(value: string, options?: StorageOptions): Promise<void> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "auto" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return;
@@ -716,35 +716,35 @@ export class StateService<
   async getUserKeyBiometric(options?: StorageOptions): Promise<string> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return null;
     }
     return await this.secureStorageService.get<string>(
       `${options.userId}${partialKeys.userBiometricKey}`,
-      options
+      options,
     );
   }
 
   async hasUserKeyBiometric(options?: StorageOptions): Promise<boolean> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return false;
     }
     return await this.secureStorageService.has(
       `${options.userId}${partialKeys.userBiometricKey}`,
-      options
+      options,
     );
   }
 
   async setUserKeyBiometric(value: BiometricKey, options?: StorageOptions): Promise<void> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return;
@@ -755,39 +755,39 @@ export class StateService<
   async getPinKeyEncryptedUserKey(options?: StorageOptions): Promise<EncString> {
     return EncString.fromJSON(
       (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.pinKeyEncryptedUserKey
+        ?.settings?.pinKeyEncryptedUserKey,
     );
   }
 
   async setPinKeyEncryptedUserKey(value: EncString, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.pinKeyEncryptedUserKey = value?.encryptedString;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   async getPinKeyEncryptedUserKeyEphemeral(options?: StorageOptions): Promise<EncString> {
     return EncString.fromJSON(
       (await this.getAccount(this.reconcileOptions(options, await this.defaultInMemoryOptions())))
-        ?.settings?.pinKeyEncryptedUserKeyEphemeral
+        ?.settings?.pinKeyEncryptedUserKeyEphemeral,
     );
   }
 
   async setPinKeyEncryptedUserKeyEphemeral(
     value: EncString,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.settings.pinKeyEncryptedUserKeyEphemeral = value?.encryptedString;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -797,14 +797,14 @@ export class StateService<
   async getCryptoMasterKeyAuto(options?: StorageOptions): Promise<string> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "auto" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return null;
     }
     return await this.secureStorageService.get<string>(
       `${options.userId}${partialKeys.autoKey}`,
-      options
+      options,
     );
   }
 
@@ -814,7 +814,7 @@ export class StateService<
   async setCryptoMasterKeyAuto(value: string, options?: StorageOptions): Promise<void> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "auto" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return;
@@ -832,7 +832,7 @@ export class StateService<
     }
     return await this.secureStorageService.get<string>(
       `${options?.userId}${partialKeys.masterKey}`,
-      options
+      options,
     );
   }
 
@@ -853,14 +853,14 @@ export class StateService<
   async getCryptoMasterKeyBiometric(options?: StorageOptions): Promise<string> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return null;
     }
     return await this.secureStorageService.get<string>(
       `${options.userId}${partialKeys.biometricKey}`,
-      options
+      options,
     );
   }
 
@@ -870,14 +870,14 @@ export class StateService<
   async hasCryptoMasterKeyBiometric(options?: StorageOptions): Promise<boolean> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return false;
     }
     return await this.secureStorageService.has(
       `${options.userId}${partialKeys.biometricKey}`,
-      options
+      options,
     );
   }
 
@@ -887,7 +887,7 @@ export class StateService<
   async setCryptoMasterKeyBiometric(value: BiometricKey, options?: StorageOptions): Promise<void> {
     options = this.reconcileOptions(
       this.reconcileOptions(options, { keySuffix: "biometric" }),
-      await this.defaultSecureStorageOptions()
+      await this.defaultSecureStorageOptions(),
     );
     if (options?.userId == null) {
       return;
@@ -904,12 +904,12 @@ export class StateService<
 
   async setDecryptedCiphers(value: CipherView[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.ciphers.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -922,12 +922,12 @@ export class StateService<
 
   async setDecryptedCollections(value: CollectionView[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.collections.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -936,7 +936,7 @@ export class StateService<
    */
   async getDecryptedCryptoSymmetricKey(options?: StorageOptions): Promise<SymmetricCryptoKey> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return account?.keys?.cryptoSymmetricKey?.decrypted;
   }
@@ -946,44 +946,44 @@ export class StateService<
    */
   async setDecryptedCryptoSymmetricKey(
     value: SymmetricCryptoKey,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.cryptoSymmetricKey.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
   async getDecryptedOrganizationKeys(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<Map<string, SymmetricCryptoKey>> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return Utils.recordToMap(account?.keys?.organizationKeys?.decrypted);
   }
 
   async setDecryptedOrganizationKeys(
     value: Map<string, SymmetricCryptoKey>,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.organizationKeys.decrypted = Utils.mapToRecord(value);
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
   @withPrototypeForArrayMembers(GeneratedPasswordHistory)
   async getDecryptedPasswordGenerationHistory(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<GeneratedPasswordHistory[]> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultInMemoryOptions()))
@@ -992,15 +992,15 @@ export class StateService<
 
   async setDecryptedPasswordGenerationHistory(
     value: GeneratedPasswordHistory[],
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.passwordGenerationHistory.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1018,12 +1018,12 @@ export class StateService<
    */
   async setDecryptedPinProtected(value: EncString, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.settings.pinProtected.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1036,12 +1036,12 @@ export class StateService<
 
   async setDecryptedPolicies(value: Policy[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.policies.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1053,35 +1053,35 @@ export class StateService<
 
   async setDecryptedPrivateKey(value: Uint8Array, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.privateKey.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
   async getDecryptedProviderKeys(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<Map<string, SymmetricCryptoKey>> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return Utils.recordToMap(account?.keys?.providerKeys?.decrypted);
   }
 
   async setDecryptedProviderKeys(
     value: Map<string, SymmetricCryptoKey>,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.providerKeys.decrypted = Utils.mapToRecord(value);
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1094,12 +1094,12 @@ export class StateService<
 
   async setDecryptedSends(value: SendView[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.data.sends.decrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1111,12 +1111,12 @@ export class StateService<
 
   async setDefaultUriMatch(value: UriMatchType, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.defaultUriMatch = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1129,12 +1129,12 @@ export class StateService<
 
   async setDisableAddLoginNotification(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.disableAddLoginNotification = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1147,12 +1147,12 @@ export class StateService<
 
   async setDisableAutoBiometricsPrompt(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.disableAutoBiometricsPrompt = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1165,12 +1165,12 @@ export class StateService<
 
   async setDisableAutoTotpCopy(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.disableAutoTotpCopy = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1183,12 +1183,12 @@ export class StateService<
 
   async setDisableBadgeCounter(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.disableBadgeCounter = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1201,15 +1201,15 @@ export class StateService<
 
   async setDisableChangedPasswordNotification(
     value: boolean,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.disableChangedPasswordNotification = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1222,12 +1222,12 @@ export class StateService<
 
   async setEnablePasskeys(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enablePasskeys = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1240,12 +1240,12 @@ export class StateService<
 
   async setDisableContextMenuItem(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.disableContextMenuItem = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1253,7 +1253,7 @@ export class StateService<
     return (
       (
         await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
         )
       )?.disableFavicon ?? false
     );
@@ -1261,12 +1261,12 @@ export class StateService<
 
   async setDisableFavicon(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.disableFavicon = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -1279,12 +1279,12 @@ export class StateService<
 
   async setDisableGa(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.disableGa = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1297,12 +1297,12 @@ export class StateService<
 
   async setDismissedAutofillCallout(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.dismissedAutoFillOnPageLoadCallout = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1315,12 +1315,12 @@ export class StateService<
 
   async setDontShowCardsCurrentTab(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.dontShowCardsCurrentTab = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1333,12 +1333,12 @@ export class StateService<
 
   async setDontShowIdentitiesCurrentTab(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.dontShowIdentitiesCurrentTab = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1409,7 +1409,7 @@ export class StateService<
 
   async setAdminAuthRequest(
     adminAuthRequest: AdminAuthRequestStorable,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
 
@@ -1450,7 +1450,7 @@ export class StateService<
   }
 
   async getAccountDecryptionOptions(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<AccountDecryptionOptions | null> {
     options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
 
@@ -1465,7 +1465,7 @@ export class StateService<
 
   async setAccountDecryptionOptions(
     value: AccountDecryptionOptions,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     options = this.reconcileOptions(options, await this.defaultOnDiskLocalOptions());
 
@@ -1488,12 +1488,12 @@ export class StateService<
 
   async setEmail(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.profile.email = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -1506,12 +1506,12 @@ export class StateService<
 
   async setEmailVerified(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.emailVerified = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1527,42 +1527,40 @@ export class StateService<
 
   async setEnableAlwaysOnTop(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.enableAlwaysOnTop = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
 
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableAlwaysOnTop = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   async getAutoFillOverlayVisibility(options?: StorageOptions): Promise<number> {
-    return (
-      (
-        await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-        )
-      )?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.OnFieldFocus
-    );
+    const locallyStoredOptions = await this.defaultOnDiskLocalOptions();
+    const reconciledOptions = this.reconcileOptions(options, locallyStoredOptions);
+    const globals = await this.getGlobals(reconciledOptions);
+
+    return globals?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.Off;
   }
 
   async setAutoFillOverlayVisibility(value: number, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.autoFillOverlayVisibility = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -1575,12 +1573,12 @@ export class StateService<
 
   async setEnableAutoFillOnPageLoad(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.enableAutoFillOnPageLoad = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1593,12 +1591,12 @@ export class StateService<
 
   async setEnableBrowserIntegration(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableBrowserIntegration = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1611,15 +1609,15 @@ export class StateService<
 
   async setEnableBrowserIntegrationFingerprint(
     value: boolean,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableBrowserIntegrationFingerprint = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1632,12 +1630,12 @@ export class StateService<
 
   async setEnableCloseToTray(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableCloseToTray = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1650,15 +1648,15 @@ export class StateService<
 
   async setEnableDuckDuckGoBrowserIntegration(
     value: boolean,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableDuckDuckGoBrowserIntegration = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1666,7 +1664,7 @@ export class StateService<
     return (
       (
         await this.getAccount(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
         )
       )?.settings?.enableFullWidth ?? false
     );
@@ -1674,12 +1672,12 @@ export class StateService<
 
   async setEnableFullWidth(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.enableFullWidth = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -1692,12 +1690,12 @@ export class StateService<
 
   async setEnableMinimizeToTray(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableMinimizeToTray = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1710,12 +1708,12 @@ export class StateService<
 
   async setEnableStartToTray(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableStartToTray = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1728,12 +1726,12 @@ export class StateService<
 
   async setEnableTray(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.enableTray = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1746,21 +1744,21 @@ export class StateService<
 
   async setEncryptedCiphers(
     value: { [id: string]: CipherData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.data.ciphers.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
   @withPrototypeForObjectValues(CollectionData)
   async getEncryptedCollections(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<{ [id: string]: CollectionData }> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()))
@@ -1769,15 +1767,15 @@ export class StateService<
 
   async setEncryptedCollections(
     value: { [id: string]: CollectionData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.data.collections.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
@@ -1795,12 +1793,12 @@ export class StateService<
    */
   async setEncryptedCryptoSymmetricKey(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.keys.cryptoSymmetricKey.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1813,20 +1811,20 @@ export class StateService<
 
   async setEncryptedFolders(
     value: { [id: string]: FolderData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.data.folders.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
   async getEncryptedOrganizationKeys(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<{ [orgId: string]: EncryptedOrganizationKeyData }> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
@@ -1835,21 +1833,21 @@ export class StateService<
 
   async setEncryptedOrganizationKeys(
     value: { [orgId: string]: EncryptedOrganizationKeyData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.keys.organizationKeys.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   @withPrototypeForArrayMembers(GeneratedPasswordHistory)
   async getEncryptedPasswordGenerationHistory(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<GeneratedPasswordHistory[]> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
@@ -1858,15 +1856,15 @@ export class StateService<
 
   async setEncryptedPasswordGenerationHistory(
     value: GeneratedPasswordHistory[],
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.data.passwordGenerationHistory.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1878,12 +1876,12 @@ export class StateService<
 
   async setEncryptedPinProtected(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.pinProtected.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1896,33 +1894,33 @@ export class StateService<
 
   async setEncryptedPolicies(
     value: { [id: string]: PolicyData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.data.policies.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   async getEncryptedPrivateKey(options?: StorageOptions): Promise<string> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     return account?.keys?.privateKey?.encrypted;
   }
 
   async setEncryptedPrivateKey(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.keys.privateKey.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1934,12 +1932,12 @@ export class StateService<
 
   async setEncryptedProviderKeys(value: any, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.keys.providerKeys.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -1952,15 +1950,15 @@ export class StateService<
 
   async setEncryptedSends(
     value: { [id: string]: SendData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.data.sends.encrypted = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
@@ -1972,12 +1970,12 @@ export class StateService<
 
   async setEntityId(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.profile.entityId = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -1989,12 +1987,12 @@ export class StateService<
 
   async setEntityType(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.profile.entityType = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2010,12 +2008,12 @@ export class StateService<
     // Global values are set on each change and the current global settings are passed to any newly authed accounts.
     // This is to allow setting environment values before an account is active, while still allowing individual accounts to have their own environments.
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.environmentUrls = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2032,12 +2030,12 @@ export class StateService<
     // Global values are set on each change and the current global settings are passed to any newly authed accounts.
     // This is to allow setting region values before an account is active, while still allowing individual accounts to have their own region.
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.region = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2049,12 +2047,12 @@ export class StateService<
 
   async setEquivalentDomains(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.equivalentDomains = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2067,12 +2065,12 @@ export class StateService<
 
   async setEventCollection(value: EventData[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.data.eventCollection = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2085,12 +2083,12 @@ export class StateService<
 
   async setEverHadUserKey(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.everHadUserKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2103,12 +2101,12 @@ export class StateService<
 
   async setEverBeenUnlocked(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.profile.everBeenUnlocked = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -2116,7 +2114,7 @@ export class StateService<
     return (
       (
         await this.getAccount(
-          this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+          this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
         )
       )?.profile?.forceSetPasswordReason ?? ForceSetPasswordReason.None
     );
@@ -2124,15 +2122,15 @@ export class StateService<
 
   async setForceSetPasswordReason(
     value: ForceSetPasswordReason,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.profile.forceSetPasswordReason = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
@@ -2144,12 +2142,12 @@ export class StateService<
 
   async setInstalledVersion(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.installedVersion = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2172,14 +2170,14 @@ export class StateService<
 
   async setKdfConfig(config: KdfConfig, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.kdfIterations = config.iterations;
     account.profile.kdfMemory = config.memory;
     account.profile.kdfParallelism = config.parallelism;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2191,12 +2189,12 @@ export class StateService<
 
   async setKdfType(value: KdfType, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.kdfType = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2208,12 +2206,12 @@ export class StateService<
 
   async setKeyHash(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.keyHash = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2222,7 +2220,7 @@ export class StateService<
 
     const accountActivity = await this.storageService.get<{ [userId: string]: number }>(
       keys.accountActivity,
-      options
+      options,
     );
 
     if (accountActivity == null || Object.keys(accountActivity).length < 1) {
@@ -2240,7 +2238,7 @@ export class StateService<
     const accountActivity =
       (await this.storageService.get<{ [userId: string]: number }>(
         keys.accountActivity,
-        options
+        options,
       )) ?? {};
     accountActivity[options.userId] = value;
     await this.storageService.save(keys.accountActivity, accountActivity, options);
@@ -2254,12 +2252,12 @@ export class StateService<
 
   async setLastSync(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.profile.lastSync = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
@@ -2271,15 +2269,15 @@ export class StateService<
 
   async setLocalData(
     value: { [cipherId: string]: LocalData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.data.localData = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2291,12 +2289,12 @@ export class StateService<
 
   async setLocale(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.locale = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2308,12 +2306,12 @@ export class StateService<
 
   async setMainWindowSize(value: number, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     globals.mainWindowSize = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -2326,12 +2324,12 @@ export class StateService<
 
   async setMinimizeOnCopyToClipboard(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.minimizeOnCopyToClipboard = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2343,12 +2341,12 @@ export class StateService<
 
   async setNeverDomains(value: { [id: string]: unknown }, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.neverDomains = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2360,12 +2358,12 @@ export class StateService<
 
   async setNoAutoPromptBiometricsText(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.noAutoPromptBiometricsText = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2378,12 +2376,12 @@ export class StateService<
 
   async setOpenAtLogin(value: boolean, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.openAtLogin = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2395,12 +2393,12 @@ export class StateService<
 
   async setOrganizationInvitation(value: any, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     globals.organizationInvitation = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -2418,15 +2416,15 @@ export class StateService<
    */
   async setOrganizations(
     value: { [id: string]: OrganizationData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.data.organizations = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2438,15 +2436,15 @@ export class StateService<
 
   async setPasswordGenerationOptions(
     value: PasswordGeneratorOptions,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.passwordGenerationOptions = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2458,15 +2456,15 @@ export class StateService<
 
   async setUsernameGenerationOptions(
     value: UsernameGeneratorOptions,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.usernameGenerationOptions = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2478,12 +2476,12 @@ export class StateService<
 
   async setGeneratorOptions(value: GeneratorOptions, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.generatorOptions = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2495,12 +2493,12 @@ export class StateService<
 
   async setProtectedPin(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.settings.protectedPin = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2513,15 +2511,15 @@ export class StateService<
 
   async setProviders(
     value: { [id: string]: ProviderData },
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.data.providers = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2534,12 +2532,12 @@ export class StateService<
 
   async setPublicKey(value: Uint8Array, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.keys.publicKey = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -2563,12 +2561,12 @@ export class StateService<
 
   async setRememberedEmail(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.rememberedEmail = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2580,12 +2578,12 @@ export class StateService<
 
   async setSecurityStamp(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     account.tokens.securityStamp = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions())
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
   }
 
@@ -2597,12 +2595,12 @@ export class StateService<
 
   async setSettings(value: AccountSettingsSettings, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
     account.settings.settings = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
     );
   }
 
@@ -2614,12 +2612,12 @@ export class StateService<
 
   async setSsoCodeVerifier(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.ssoCodeVerifier = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2631,12 +2629,12 @@ export class StateService<
 
   async setSsoOrganizationIdentifier(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.ssoOrganizationIdentifier = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2648,12 +2646,12 @@ export class StateService<
 
   async setSsoState(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.ssoState = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2665,15 +2663,15 @@ export class StateService<
 
   async setUserSsoOrganizationIdentifier(
     value: string | null,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.loginState.ssoOrganizationIdentifier = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2685,12 +2683,12 @@ export class StateService<
 
   async setTheme(value: ThemeType, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.theme = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2702,12 +2700,12 @@ export class StateService<
 
   async setTwoFactorToken(value: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     globals.twoFactorToken = value;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2725,12 +2723,12 @@ export class StateService<
 
   async setUsesKeyConnector(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     account.profile.usesKeyConnector = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2743,12 +2741,12 @@ export class StateService<
 
   async setVaultTimeout(value: number, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.vaultTimeout = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2764,12 +2762,12 @@ export class StateService<
 
   async setVaultTimeoutAction(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.vaultTimeoutAction = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2782,12 +2780,12 @@ export class StateService<
 
   async setApproveLoginRequests(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.approveLoginRequests = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2800,23 +2798,23 @@ export class StateService<
 
   async setWindow(value: WindowState, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.window = value;
     return await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
   async setServerConfig(value: ServerConfigData, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.serverConfig = value;
     return await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2834,12 +2832,12 @@ export class StateService<
 
   async setAvatarColor(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.avatarColor = value;
     return await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2851,20 +2849,20 @@ export class StateService<
 
   async setActivateAutoFillOnPageLoadFromPolicy(
     value: boolean,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.activateAutoFillOnPageLoadFromPolicy = value;
     return await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
   async getSMOnboardingTasks(
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<Record<string, Record<string, boolean>>> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
@@ -2873,15 +2871,15 @@ export class StateService<
 
   async setSMOnboardingTasks(
     value: Record<string, Record<string, boolean>>,
-    options?: StorageOptions
+    options?: StorageOptions,
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
     account.settings.smOnboardingTasks = value;
     return await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
     );
   }
 
@@ -2893,12 +2891,12 @@ export class StateService<
 
   async setDeepLinkRedirectUrl(url: string, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
     globals.deepLinkRedirectUrl = url;
     await this.saveGlobals(
       globals,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -2998,7 +2996,7 @@ export class StateService<
       ? (await this.secureStorageService.get<TAccount>(options.userId, options)) ??
         (await this.storageService.get<TAccount>(
           options.userId,
-          this.reconcileOptions(options, { htmlStorageLocation: HtmlStorageLocation.Local })
+          this.reconcileOptions(options, { htmlStorageLocation: HtmlStorageLocation.Local }),
         ))
       : await this.storageService.get<TAccount>(options.userId, options);
 
@@ -3019,7 +3017,7 @@ export class StateService<
     options: StorageOptions = {
       storageLocation: StorageLocation.Both,
       useSecureStorage: false,
-    }
+    },
   ) {
     return this.useMemory(options.storageLocation)
       ? await this.saveAccountToMemory(account)
@@ -3062,8 +3060,8 @@ export class StateService<
     const storedAccount = await this.getAccount(
       this.reconcileOptions(
         { userId: account.profile.userId },
-        await this.defaultOnDiskLocalOptions()
-      )
+        await this.defaultOnDiskLocalOptions(),
+      ),
     );
     // EnvironmentUrls and region are set before authenticating and should override whatever is stored from any previous session
     const environmentUrls = account.settings.environmentUrls;
@@ -3090,8 +3088,8 @@ export class StateService<
       account,
       this.reconcileOptions(
         { userId: account.profile.userId },
-        await this.defaultOnDiskLocalOptions()
-      )
+        await this.defaultOnDiskLocalOptions(),
+      ),
     );
   }
 
@@ -3099,8 +3097,8 @@ export class StateService<
     const storedAccount = await this.getAccount(
       this.reconcileOptions(
         { userId: account.profile.userId },
-        await this.defaultOnDiskMemoryOptions()
-      )
+        await this.defaultOnDiskMemoryOptions(),
+      ),
     );
     if (storedAccount?.settings != null) {
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
@@ -3110,20 +3108,20 @@ export class StateService<
     await this.storageService.save(
       account.profile.userId,
       account,
-      await this.defaultOnDiskMemoryOptions()
+      await this.defaultOnDiskMemoryOptions(),
     );
     await this.saveAccount(
       account,
       this.reconcileOptions(
         { userId: account.profile.userId },
-        await this.defaultOnDiskMemoryOptions()
-      )
+        await this.defaultOnDiskMemoryOptions(),
+      ),
     );
   }
 
   protected async scaffoldNewAccountSessionStorage(account: TAccount): Promise<void> {
     const storedAccount = await this.getAccount(
-      this.reconcileOptions({ userId: account.profile.userId }, await this.defaultOnDiskOptions())
+      this.reconcileOptions({ userId: account.profile.userId }, await this.defaultOnDiskOptions()),
     );
     if (storedAccount?.settings != null) {
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
@@ -3133,11 +3131,11 @@ export class StateService<
     await this.storageService.save(
       account.profile.userId,
       account,
-      await this.defaultOnDiskMemoryOptions()
+      await this.defaultOnDiskMemoryOptions(),
     );
     await this.saveAccount(
       account,
-      this.reconcileOptions({ userId: account.profile.userId }, await this.defaultOnDiskOptions())
+      this.reconcileOptions({ userId: account.profile.userId }, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -3155,7 +3153,7 @@ export class StateService<
 
   protected reconcileOptions(
     requestedOptions: StorageOptions,
-    defaultOptions: StorageOptions
+    defaultOptions: StorageOptions,
   ): StorageOptions {
     if (requestedOptions == null) {
       return defaultOptions;
@@ -3220,22 +3218,22 @@ export class StateService<
   protected async removeAccountFromLocalStorage(userId: string = null): Promise<void> {
     userId = userId ?? (await this.state())?.activeUserId;
     const storedAccount = await this.getAccount(
-      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions()),
     );
     await this.saveAccount(
       this.resetAccount(storedAccount),
-      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions())
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions()),
     );
   }
 
   protected async removeAccountFromSessionStorage(userId: string = null): Promise<void> {
     userId = userId ?? (await this.state())?.activeUserId;
     const storedAccount = await this.getAccount(
-      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions())
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions()),
     );
     await this.saveAccount(
       this.resetAccount(storedAccount),
-      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions())
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions()),
     );
   }
 
@@ -3365,7 +3363,7 @@ export class StateService<
   protected async saveSecureStorageKey<T extends JsonValue>(
     key: string,
     value: T,
-    options?: StorageOptions
+    options?: StorageOptions,
   ) {
     return value == null
       ? await this.secureStorageService.remove(`${options.userId}${key}`, options)
@@ -3384,7 +3382,7 @@ export class StateService<
   }
 
   protected async updateState(
-    stateUpdater: (state: State<TGlobalState, TAccount>) => Promise<State<TGlobalState, TAccount>>
+    stateUpdater: (state: State<TGlobalState, TAccount>) => Promise<State<TGlobalState, TAccount>>,
   ) {
     await this.state().then(async (state) => {
       const updatedState = await stateUpdater(state);
@@ -3413,11 +3411,11 @@ export class StateService<
 
 function withPrototypeForArrayMembers<T>(
   memberConstructor: new (...args: any[]) => T,
-  memberConverter: (input: any) => T = (i) => i
+  memberConverter: (input: any) => T = (i) => i,
 ): (
   target: any,
   propertyKey: string | symbol,
-  descriptor: PropertyDescriptor
+  descriptor: PropertyDescriptor,
 ) => { value: (...args: any[]) => Promise<T[]> } {
   return (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value;
@@ -3429,8 +3427,8 @@ function withPrototypeForArrayMembers<T>(
         if (!Utils.isPromise(originalResult)) {
           throw new Error(
             `Error applying prototype to stored value -- result is not a promise for method ${String(
-              propertyKey
-            )}`
+              propertyKey,
+            )}`,
           );
         }
 
@@ -3440,8 +3438,8 @@ function withPrototypeForArrayMembers<T>(
           } else if (!(result instanceof Array)) {
             throw new Error(
               `Attempted to retrieve non array type from state as an array for method ${String(
-                propertyKey
-              )}`
+                propertyKey,
+              )}`,
             );
           } else {
             return result.map((r) => {
@@ -3449,7 +3447,7 @@ function withPrototypeForArrayMembers<T>(
                 r.constructor.name === memberConstructor.prototype.constructor.name
                 ? r
                 : memberConverter(
-                    Object.create(memberConstructor.prototype, Object.getOwnPropertyDescriptors(r))
+                    Object.create(memberConstructor.prototype, Object.getOwnPropertyDescriptors(r)),
                   );
             });
           }
@@ -3461,11 +3459,11 @@ function withPrototypeForArrayMembers<T>(
 
 function withPrototypeForObjectValues<T>(
   valuesConstructor: new (...args: any[]) => T,
-  valuesConverter: (input: any) => T = (i) => i
+  valuesConverter: (input: any) => T = (i) => i,
 ): (
   target: any,
   propertyKey: string | symbol,
-  descriptor: PropertyDescriptor
+  descriptor: PropertyDescriptor,
 ) => { value: (...args: any[]) => Promise<{ [key: string]: T }> } {
   return (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value;
@@ -3477,8 +3475,8 @@ function withPrototypeForObjectValues<T>(
         if (!Utils.isPromise(originalResult)) {
           throw new Error(
             `Error applying prototype to stored value -- result is not a promise for method ${String(
-              propertyKey
-            )}`
+              propertyKey,
+            )}`,
           );
         }
 
@@ -3493,8 +3491,8 @@ function withPrototypeForObjectValues<T>(
                   : valuesConverter(
                       Object.create(
                         valuesConstructor.prototype,
-                        Object.getOwnPropertyDescriptors(val)
-                      )
+                        Object.getOwnPropertyDescriptors(val),
+                      ),
                     );
             }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When the overlay feature flag is on, the default overlay visibility setting should be set to off (to allow users to opt-in if they wish).

**NOTE:** This is a recreation of [this PR](https://github.com/bitwarden/clients/pull/7266) to main. There were prettier changes in main after this release tag was created, so a cherry pick brought in a lot of extra style changes we do not want. 

## Screenshots

![Screenshot 2023-12-18 at 2 04 38 PM](https://github.com/bitwarden/clients/assets/1556494/d4d6844d-fe6a-4031-9cf9-d3e87f581b1a)
