### PR TITLE
[pm-5333] Make autofill overlay setting off by default

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1546,13 +1546,11 @@ export class StateService<
   }
 
   async getAutoFillOverlayVisibility(options?: StorageOptions): Promise<number> {
-    return (
-      (
-        await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-        )
-      )?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.OnFieldFocus
-    );
+    const locallyStoredOptions = await this.defaultOnDiskLocalOptions();
+    const reconciledOptions = this.reconcileOptions(options, locallyStoredOptions);
+    const globals = await this.getGlobals(reconciledOptions);
+
+    return globals?.autoFillOverlayVisibility ?? AutofillOverlayVisibility.Off;
   }
 
   async setAutoFillOverlayVisibility(value: number, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When the overlay feature flag is on, the default overlay visibility setting should be set to off (to allow users to opt-in if they wish)

**NOTE:** This is a recreation of https://github.com/bitwarden/clients/pull/7266 to main. There were prettier changes in `main` after this release tag was created, so a cherry-pick brought in a lot of extra style changes we did not want.

## Screenshots

![Screenshot 2023-12-18 at 2 04 38 PM](https://github.com/bitwarden/clients/assets/1556494/d4d6844d-fe6a-4031-9cf9-d3e87f581b1a)
