### PR TITLE
[AC-1921] Fix undefined property errors when bulk deleting collections

### DIFF
--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
@@ -7,7 +7,7 @@
       <span *ngIf="cipherIds?.length">
         {{ "deleteSelectedItemsDesc" | i18n: cipherIds.length }}
       </span>
-      <span *ngIf="collections.length">
+      <span *ngIf="collections?.length">
         {{ "deleteSelectedCollectionsDesc" | i18n: collections.length }}
       </span>
       {{ "deleteSelectedConfirmation" | i18n }}

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.html
@@ -7,8 +7,8 @@
       <span *ngIf="cipherIds?.length">
         {{ "deleteSelectedItemsDesc" | i18n: cipherIds.length }}
       </span>
-      <span *ngIf="collectionIds?.length">
-        {{ "deleteSelectedCollectionsDesc" | i18n: collectionIds.length }}
+      <span *ngIf="collections.length">
+        {{ "deleteSelectedCollectionsDesc" | i18n: collections.length }}
       </span>
       {{ "deleteSelectedConfirmation" | i18n }}
     </ng-container>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -160,7 +160,7 @@ export class BulkDeleteDialogComponent {
         }
         const orgCollectionIds = orgCollections.map((c) => c.id);
         deletePromises.push(
-          this.apiService.deleteManyCollections(this.organization.id, orgCollectionIds),
+          this.apiService.deleteManyCollections(organization.id, orgCollectionIds),
         );
       }
       return await Promise.all(deletePromises);

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -15,7 +15,6 @@ import { DialogService } from "@bitwarden/components";
 
 export interface BulkDeleteDialogParams {
   cipherIds?: string[];
-  collectionIds?: string[];
   permanent?: boolean;
   organization?: Organization;
   organizations?: Organization[];
@@ -47,7 +46,6 @@ export const openBulkDeleteDialog = (
 })
 export class BulkDeleteDialogComponent {
   cipherIds: string[];
-  collectionIds: string[];
   permanent = false;
   organization: Organization;
   organizations: Organization[];
@@ -64,7 +62,6 @@ export class BulkDeleteDialogComponent {
     private configService: ConfigServiceAbstraction,
   ) {
     this.cipherIds = params.cipherIds ?? [];
-    this.collectionIds = params.collectionIds ?? [];
     this.permanent = params.permanent;
     this.organization = params.organization;
     this.organizations = params.organizations;
@@ -85,7 +82,7 @@ export class BulkDeleteDialogComponent {
       }
     }
 
-    if (this.collectionIds.length) {
+    if (this.collections.length) {
       deletePromises.push(this.deleteCollections());
     }
 
@@ -98,8 +95,8 @@ export class BulkDeleteDialogComponent {
         this.i18nService.t(this.permanent ? "permanentlyDeletedItems" : "deletedItems"),
       );
     }
-    if (this.collectionIds.length) {
-      await this.collectionService.delete(this.collectionIds);
+    if (this.collections.length) {
+      await this.collectionService.delete(this.collections.map((c) => c.id));
       this.platformUtilsService.showToast(
         "success",
         null,
@@ -144,7 +141,10 @@ export class BulkDeleteDialogComponent {
         );
         return;
       }
-      return await this.apiService.deleteManyCollections(this.organization.id, this.collectionIds);
+      return await this.apiService.deleteManyCollections(
+        this.organization.id,
+        this.collections.map((c) => c.id),
+      );
       // From individual vault, so there can be multiple organizations
     } else if (this.organizations && this.collections) {
       const deletePromises: Promise<any>[] = [];

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -856,7 +856,6 @@ export class VaultComponent implements OnInit, OnDestroy {
       data: {
         permanent: this.filter.type === "trash",
         cipherIds: ciphers.map((c) => c.id),
-        collectionIds: collections.map((c) => c.id),
         organizations: organizations,
         collections: collections,
       },

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -816,7 +816,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       data: {
         permanent: this.filter.type === "trash",
         cipherIds: ciphers.map((c) => c.id),
-        collectionIds: collections.map((c) => c.id),
+        collections: collections,
         organization,
       },
     });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Bulk deleting collections did not work from org or individual vaults.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* To fix individual vault: the `apiService` call was referencing `this.organization` instead of the local variable `organization`: https://github.com/bitwarden/clients/commit/dbce6014d4b1c50fcbb0392902bc4d99ebe5321d

* To fix the admin vault: the dialog took both `collections` and `collectionIds`. In the org vault, `collections` was not being set. However, these refer to the same collections, so I deleted the duplicate `collectionIds` property and made everyone use the `collections` property instead. https://github.com/bitwarden/clients/commit/17e1ad5b7491d67d63001eb7b51db44114be9317

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
