### PR TITLE
[PM-2772] add flag to deter process reload if cancel is clicked on biometrics

### DIFF
--- a/apps/desktop/src/auth/lock.component.ts
+++ b/apps/desktop/src/auth/lock.component.ts
@@ -133,6 +133,10 @@ export class LockComponent extends BaseLockComponent {
       return;
     }
 
+    if (await this.stateService.getBiometricPromptCancelled()) {
+      return;
+    }
+
     this.biometricAsked = true;
     if (await ipc.platform.isWindowVisible()) {
       this.unlockBiometric();

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -89,6 +89,8 @@ export class WindowMain {
         // This method will be called when Electron is shutting
         // down the application.
         app.on("before-quit", () => {
+          // Allow biometric to auto-prompt on reload
+          this.stateService.setBiometricPromptCancelled(false);
           this.isQuitting = true;
         });
 

--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -117,11 +117,10 @@ export class LockComponent implements OnInit, OnDestroy {
       return;
     }
 
-    await this.stateService.setSkipProcessReload(true);
+    await this.stateService.setBiometricPromptCancelled(true);
     const userKey = await this.cryptoService.getUserKeyFromStorage(KeySuffixOptions.Biometric);
 
     if (userKey) {
-      await this.stateService.setSkipProcessReload(false);
       await this.setUserKeyAndContinue(userKey, false);
     }
 
@@ -312,6 +311,7 @@ export class LockComponent implements OnInit, OnDestroy {
 
   private async doContinue(evaluatePasswordAfterUnlock: boolean) {
     await this.stateService.setEverBeenUnlocked(true);
+    await this.stateService.setBiometricPromptCancelled(false);
     this.messagingService.send("unlocked");
 
     if (evaluatePasswordAfterUnlock) {

--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -117,11 +117,11 @@ export class LockComponent implements OnInit, OnDestroy {
       return;
     }
 
-    await this.stateService.setDeterProcessReload(true);
+    await this.stateService.setSkipProcessReload(true);
     const userKey = await this.cryptoService.getUserKeyFromStorage(KeySuffixOptions.Biometric);
 
     if (userKey) {
-      await this.stateService.setDeterProcessReload(false);
+      await this.stateService.setSkipProcessReload(false);
       await this.setUserKeyAndContinue(userKey, false);
     }
 

--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -117,9 +117,11 @@ export class LockComponent implements OnInit, OnDestroy {
       return;
     }
 
+    await this.stateService.setDeterProcessReload(true);
     const userKey = await this.cryptoService.getUserKeyFromStorage(KeySuffixOptions.Biometric);
 
     if (userKey) {
+      await this.stateService.setDeterProcessReload(false);
       await this.setUserKeyAndContinue(userKey, false);
     }
 

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -182,13 +182,13 @@ export abstract class StateService<T extends Account = Account> {
    */
   setCryptoMasterKeyBiometric: (value: BiometricKey, options?: StorageOptions) => Promise<void>;
   /**
-   * Gets a flag for detering process reload a single time
+   * Gets a flag for skipping process reload a single time
    */
-  getDeterProcessReload: (options?: StorageOptions) => Promise<boolean>;
+  getSkipProcessReload: (options?: StorageOptions) => Promise<boolean>;
   /**
-   * Sets a flag for detering process reload a single time
+   * Sets a flag for skipping process reload a single time
    */
-  setDeterProcessReload: (value: boolean, options?: StorageOptions) => Promise<void>;
+  setSkipProcessReload: (value: boolean, options?: StorageOptions) => Promise<void>;
   getDecryptedCiphers: (options?: StorageOptions) => Promise<CipherView[]>;
   setDecryptedCiphers: (value: CipherView[], options?: StorageOptions) => Promise<void>;
   getDecryptedCollections: (options?: StorageOptions) => Promise<CollectionView[]>;

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -181,6 +181,14 @@ export abstract class StateService<T extends Account = Account> {
    * @deprecated For migration purposes only, use setUserKeyBiometric instead
    */
   setCryptoMasterKeyBiometric: (value: BiometricKey, options?: StorageOptions) => Promise<void>;
+  /**
+   * Gets a flag for detering process reload a single time
+   */
+  getDeterProcessReload: (options?: StorageOptions) => Promise<boolean>;
+  /**
+   * Sets a flag for detering process reload a single time
+   */
+  setDeterProcessReload: (value: boolean, options?: StorageOptions) => Promise<void>;
   getDecryptedCiphers: (options?: StorageOptions) => Promise<CipherView[]>;
   setDecryptedCiphers: (value: CipherView[], options?: StorageOptions) => Promise<void>;
   getDecryptedCollections: (options?: StorageOptions) => Promise<CollectionView[]>;

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -182,13 +182,17 @@ export abstract class StateService<T extends Account = Account> {
    */
   setCryptoMasterKeyBiometric: (value: BiometricKey, options?: StorageOptions) => Promise<void>;
   /**
-   * Gets a flag for skipping process reload a single time
+   * Gets a flag for if the biometrics process has been cancelled.
+   * Process reload occurs when biometrics is cancelled, so we store to disk to prevent
+   * it from reprompting and creating a loop.
    */
-  getSkipProcessReload: (options?: StorageOptions) => Promise<boolean>;
+  getBiometricPromptCancelled: (options?: StorageOptions) => Promise<boolean>;
   /**
-   * Sets a flag for skipping process reload a single time
+   * Sets a flag for if the biometrics process has been cancelled.
+   * Process reload occurs when biometrics is cancelled, so we store to disk to prevent
+   * it from reprompting and creating a loop.
    */
-  setSkipProcessReload: (value: boolean, options?: StorageOptions) => Promise<void>;
+  setBiometricPromptCancelled: (value: boolean, options?: StorageOptions) => Promise<void>;
   getDecryptedCiphers: (options?: StorageOptions) => Promise<CipherView[]>;
   setDecryptedCiphers: (value: CipherView[], options?: StorageOptions) => Promise<void>;
   getDecryptedCollections: (options?: StorageOptions) => Promise<CollectionView[]>;

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -253,6 +253,7 @@ export class AccountSettings {
   region?: string;
   smOnboardingTasks?: Record<string, Record<string, boolean>>;
   trustDeviceChoiceForDecryption?: boolean;
+  deterProcessReload?: boolean;
 
   /** @deprecated July 2023, left for migration purposes*/
   pinProtected?: EncryptionPair<string, EncString> = new EncryptionPair<string, EncString>();

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -253,7 +253,7 @@ export class AccountSettings {
   region?: string;
   smOnboardingTasks?: Record<string, Record<string, boolean>>;
   trustDeviceChoiceForDecryption?: boolean;
-  deterProcessReload?: boolean;
+  biometricPromptCancelled?: boolean;
 
   /** @deprecated July 2023, left for migration purposes*/
   pinProtected?: EncryptionPair<string, EncString> = new EncryptionPair<string, EncString>();

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -903,6 +903,24 @@ export class StateService<
     await this.saveSecureStorageKey(partialKeys.biometricKey, value, options);
   }
 
+  async getDeterProcessReload(options?: StorageOptions): Promise<boolean> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+    );
+    return account?.settings?.deterProcessReload;
+  }
+
+  async setDeterProcessReload(value: boolean, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+    );
+    account.settings.deterProcessReload = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+    );
+  }
+
   @withPrototypeForArrayMembers(CipherView, CipherView.fromJSON)
   async getDecryptedCiphers(options?: StorageOptions): Promise<CipherView[]> {
     return (

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -903,14 +903,14 @@ export class StateService<
     await this.saveSecureStorageKey(partialKeys.biometricKey, value, options);
   }
 
-  async getDeterProcessReload(options?: StorageOptions): Promise<boolean> {
+  async getSkipProcessReload(options?: StorageOptions): Promise<boolean> {
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );
     return account?.settings?.deterProcessReload;
   }
 
-  async setDeterProcessReload(value: boolean, options?: StorageOptions): Promise<void> {
+  async setSkipProcessReload(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -903,21 +903,21 @@ export class StateService<
     await this.saveSecureStorageKey(partialKeys.biometricKey, value, options);
   }
 
-  async getSkipProcessReload(options?: StorageOptions): Promise<boolean> {
+  async getBiometricPromptCancelled(options?: StorageOptions): Promise<boolean> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
-    return account?.settings?.deterProcessReload;
+    return account?.settings?.biometricPromptCancelled;
   }
 
-  async setSkipProcessReload(value: boolean, options?: StorageOptions): Promise<void> {
+  async setBiometricPromptCancelled(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
-    account.settings.deterProcessReload = value;
+    account.settings.biometricPromptCancelled = value;
     await this.saveAccount(
       account,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
     );
   }
 

--- a/libs/common/src/platform/services/system.service.ts
+++ b/libs/common/src/platform/services/system.service.ts
@@ -47,6 +47,11 @@ export class SystemService implements SystemServiceAbstraction {
       return;
     }
 
+    if (await this.stateService.getDeterProcessReload()) {
+      await this.stateService.setDeterProcessReload(false);
+      return;
+    }
+
     this.cancelProcessReload();
     await this.executeProcessReload();
   }

--- a/libs/common/src/platform/services/system.service.ts
+++ b/libs/common/src/platform/services/system.service.ts
@@ -47,11 +47,6 @@ export class SystemService implements SystemServiceAbstraction {
       return;
     }
 
-    if (await this.stateService.getSkipProcessReload()) {
-      await this.stateService.setSkipProcessReload(false);
-      return;
-    }
-
     this.cancelProcessReload();
     await this.executeProcessReload();
   }

--- a/libs/common/src/platform/services/system.service.ts
+++ b/libs/common/src/platform/services/system.service.ts
@@ -47,8 +47,8 @@ export class SystemService implements SystemServiceAbstraction {
       return;
     }
 
-    if (await this.stateService.getDeterProcessReload()) {
-      await this.stateService.setDeterProcessReload(false);
+    if (await this.stateService.getSkipProcessReload()) {
+      await this.stateService.setSkipProcessReload(false);
       return;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If "Cancel" is chosen on the biometrics prompt for desktop, a process reload will occur. This process reload unfortunately will prompt biometrics again, resulting in a loop.

This change introduces a flag on disk indicating that biometrics has been cancelled to prevent a second reprompt after process reload.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
