### PR TITLE
[AC-1893] Removed logic to downgrade Manager roles and remove Edit/Delete any collection permissions for Flexible Collections

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -578,7 +578,6 @@ export default class MainBackground {
       this.folderApiService,
       this.organizationService,
       this.sendApiService,
-      this.configService,
       logoutCallback,
     );
     this.eventUploadService = new EventUploadService(

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -476,7 +476,6 @@ export class Main {
       this.folderApiService,
       this.organizationService,
       this.sendApiService,
-      this.configService,
       async (expired: boolean) => await this.logout(),
     );
 

--- a/apps/web/src/app/billing/organizations/sm-subscribe-standalone.component.ts
+++ b/apps/web/src/app/billing/organizations/sm-subscribe-standalone.component.ts
@@ -9,8 +9,6 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { SecretsManagerSubscribeRequest } from "@bitwarden/common/billing/models/request/sm-subscribe.request";
 import { BillingCustomerDiscount } from "@bitwarden/common/billing/models/response/organization-subscription.response";
 import { PlanResponse } from "@bitwarden/common/billing/models/response/plan.response";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
@@ -35,7 +33,6 @@ export class SecretsManagerSubscribeStandaloneComponent {
     private i18nService: I18nService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private organizationService: InternalOrganizationServiceAbstraction,
-    private configService: ConfigServiceAbstraction,
   ) {}
 
   submit = async () => {
@@ -55,11 +52,7 @@ export class SecretsManagerSubscribeStandaloneComponent {
       isMember: this.organization.isMember,
       isProviderUser: this.organization.isProviderUser,
     });
-    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.FlexibleCollections,
-      false,
-    );
-    await this.organizationService.upsert(organizationData, flexibleCollectionsEnabled);
+    await this.organizationService.upsert(organizationData);
 
     /*
       Because subscribing to Secrets Manager automatically provides access to Secrets Manager for the

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -459,7 +459,6 @@ import { ModalService } from "./modal.service";
         FolderApiServiceAbstraction,
         OrganizationServiceAbstraction,
         SendApiServiceAbstraction,
-        ConfigServiceAbstraction,
         LOGOUT_CALLBACK,
       ],
     },

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -95,12 +95,6 @@ export abstract class OrganizationService {
 }
 
 export abstract class InternalOrganizationServiceAbstraction extends OrganizationService {
-  replace: (
-    organizations: { [id: string]: OrganizationData },
-    flexibleCollectionsEnabled: boolean,
-  ) => Promise<void>;
-  upsert: (
-    OrganizationData: OrganizationData | OrganizationData[],
-    flexibleCollectionsEnabled: boolean,
-  ) => Promise<void>;
+  replace: (organizations: { [id: string]: OrganizationData }) => Promise<void>;
+  upsert: (OrganizationData: OrganizationData | OrganizationData[]) => Promise<void>;
 }

--- a/libs/common/src/admin-console/services/organization/organization.service.spec.ts
+++ b/libs/common/src/admin-console/services/organization/organization.service.spec.ts
@@ -110,7 +110,7 @@ describe("Organization Service", () => {
   });
 
   it("upsert", async () => {
-    await organizationService.upsert(organizationData("2", "Test 2"), false);
+    await organizationService.upsert(organizationData("2", "Test 2"));
 
     expect(await firstValueFrom(organizationService.organizations$)).toEqual([
       {
@@ -146,7 +146,7 @@ describe("Organization Service", () => {
 
   describe("delete", () => {
     it("exists", async () => {
-      await organizationService.delete("1", false);
+      await organizationService.delete("1");
 
       expect(stateService.getOrganizations).toHaveBeenCalledTimes(2);
 
@@ -154,7 +154,7 @@ describe("Organization Service", () => {
     });
 
     it("does not exist", async () => {
-      organizationService.delete("1", false);
+      organizationService.delete("1");
 
       expect(stateService.getOrganizations).toHaveBeenCalledTimes(2);
     });

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -10,7 +10,6 @@ import { ProviderData } from "../../../admin-console/models/data/provider.data";
 import { PolicyResponse } from "../../../admin-console/models/response/policy.response";
 import { KeyConnectorService } from "../../../auth/abstractions/key-connector.service";
 import { ForceSetPasswordReason } from "../../../auth/models/domain/force-set-password-reason";
-import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { DomainsResponse } from "../../../models/response/domains.response";
 import {
   SyncCipherNotification,
@@ -18,7 +17,6 @@ import {
   SyncSendNotification,
 } from "../../../models/response/notification.response";
 import { ProfileResponse } from "../../../models/response/profile.response";
-import { ConfigServiceAbstraction } from "../../../platform/abstractions/config/config.service.abstraction";
 import { CryptoService } from "../../../platform/abstractions/crypto.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { MessagingService } from "../../../platform/abstractions/messaging.service";
@@ -61,7 +59,6 @@ export class SyncService implements SyncServiceAbstraction {
     private folderApiService: FolderApiServiceAbstraction,
     private organizationService: InternalOrganizationServiceAbstraction,
     private sendApiService: SendApiService,
-    private configService: ConfigServiceAbstraction,
     private logoutCallback: (expired: boolean) => Promise<void>,
   ) {}
 
@@ -321,11 +318,7 @@ export class SyncService implements SyncServiceAbstraction {
 
     await this.setForceSetPasswordReasonIfNeeded(response);
 
-    const flexibleCollectionsEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.FlexibleCollections,
-      false,
-    );
-    await this.syncProfileOrganizations(response, flexibleCollectionsEnabled);
+    await this.syncProfileOrganizations(response);
 
     const providers: { [id: string]: ProviderData } = {};
     response.providers.forEach((p) => {
@@ -393,10 +386,7 @@ export class SyncService implements SyncServiceAbstraction {
     }
   }
 
-  private async syncProfileOrganizations(
-    response: ProfileResponse,
-    flexibleCollectionsEnabled: boolean,
-  ) {
+  private async syncProfileOrganizations(response: ProfileResponse) {
     const organizations: { [id: string]: OrganizationData } = {};
     response.organizations.forEach((o) => {
       organizations[o.id] = new OrganizationData(o, {
@@ -416,7 +406,7 @@ export class SyncService implements SyncServiceAbstraction {
       }
     });
 
-    await this.organizationService.replace(organizations, flexibleCollectionsEnabled);
+    await this.organizationService.replace(organizations);
   }
 
   private async syncFolders(response: FolderResponse[]) {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Removing this logic from clients as it is now implemented on the API side https://github.com/bitwarden/server/pull/3617

## Code changes

- Removed all ConfigService references that were added to get the Flexible Collections feature flag value
- Removed logic to override the Manager type value and Edit/Delete assigned collections permissions

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
