### PR TITLE
[PM-5429] Change Active Account Status to Green

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account.component.html
@@ -30,7 +30,9 @@
       [attr.aria-hidden]="status.text === 'active'"
     >
       <span class="tw-sr-only">(</span>
-      {{ status.text }}
+      <span [ngClass]="status.text === 'active' ? 'tw-font-bold tw-text-success' : ''">{{
+        status.text
+      }}</span>
       <span class="tw-sr-only">)</span>
     </div>
   </div>


### PR DESCRIPTION
## Type of change

- Tech debt (refactoring, code cleanup, dependency upgrades, etc)

## Objective

- Simply changes the color of the active account status to be green for better visibility.

## Code changes

- `apps/browser/src/auth/popup/account-switching/account.component.html` - add conditional classes if account is the active account

## Screenshots

![Screenshot 2023-12-27 at 12 13 45 PM](https://github.com/bitwarden/clients/assets/102181210/7473ce69-8788-491d-84e5-ed9e1805da96)

![Screenshot 2023-12-27 at 12 12 47 PM](https://github.com/bitwarden/clients/assets/102181210/4be2ef90-7a6a-45de-9966-55424d9be6d6)