### PR TITLE
[PM-2424] Return current environment on remove-password CLI command

### DIFF
--- a/apps/cli/src/commands/serve.command.ts
+++ b/apps/cli/src/commands/serve.command.ts
@@ -160,6 +160,7 @@ export class ServeCommand {
     this.sendRemovePasswordCommand = new SendRemovePasswordCommand(
       this.main.sendService,
       this.main.sendApiService,
+      this.main.environmentService,
     );
   }
 

--- a/apps/cli/src/tools/send/commands/remove-password.command.ts
+++ b/apps/cli/src/tools/send/commands/remove-password.command.ts
@@ -1,3 +1,4 @@
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { SendService } from "@bitwarden/common/tools/send/services//send.service.abstraction";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 
@@ -8,6 +9,7 @@ export class SendRemovePasswordCommand {
   constructor(
     private sendService: SendService,
     private sendApiService: SendApiService,
+    private environmentService: EnvironmentService,
   ) {}
 
   async run(id: string) {
@@ -16,7 +18,8 @@ export class SendRemovePasswordCommand {
 
       const updatedSend = await this.sendService.get(id);
       const decSend = await updatedSend.decrypt();
-      const res = new SendResponse(decSend);
+      const webVaultUrl = this.environmentService.getWebVaultUrl();
+      const res = new SendResponse(decSend, webVaultUrl);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);

--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -297,7 +297,11 @@ export class SendProgram extends Program {
       })
       .action(async (id: string) => {
         await this.exitIfLocked();
-        const cmd = new SendRemovePasswordCommand(this.main.sendService, this.main.sendApiService);
+        const cmd = new SendRemovePasswordCommand(
+          this.main.sendService,
+          this.main.sendApiService,
+          this.main.environmentService,
+        );
         const response = await cmd.run(id);
         this.processResponse(response);
       });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `accessUrl` returned after removing a password from a send should take into consideration the environment

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **remove-password.command.ts:** Get the `webVaultUrl` and pass it to the `SendResponse`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
