### PR TITLE
[PM-5455] Listen for Finish Message

### DIFF
--- a/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
@@ -1,6 +1,9 @@
 import { Component } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
 import { BaseLoginDecryptionOptionsComponent } from "@bitwarden/angular/auth/components/base-login-decryption-options.component";
+
+import { postLogoutMessageListener$ } from "../utils/post-logout-message-listener";
 
 @Component({
   selector: "browser-login-decryption-options",
@@ -13,6 +16,19 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
       await this.router.navigate(["/tabs/vault"]);
     } catch (error) {
       this.validationService.showError(error);
+    }
+  }
+
+  override async logOut(): Promise<void> {
+    // start listening for "switchAccountFinish" or "doneLoggingOut"
+    const messagePromise = firstValueFrom(postLogoutMessageListener$);
+    super.logOut();
+    // wait for messages
+    const command = await messagePromise;
+
+    // doneLoggingOut already has a message handler that will navigate us
+    if (command === "switchAccountFinish") {
+      this.router.navigate(["/"]);
     }
   }
 }

--- a/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
+++ b/apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts
@@ -26,6 +26,9 @@ export class LoginDecryptionOptionsComponent extends BaseLoginDecryptionOptionsC
     // wait for messages
     const command = await messagePromise;
 
+    // We should be routed/routing very soon but just in case, turn loading back off.
+    this.loading = false;
+
     // doneLoggingOut already has a message handler that will navigate us
     if (command === "switchAccountFinish") {
       this.router.navigate(["/"]);

--- a/apps/browser/src/auth/popup/utils/post-logout-message-listener.ts
+++ b/apps/browser/src/auth/popup/utils/post-logout-message-listener.ts
@@ -12,9 +12,9 @@ import { fromChromeEvent } from "../../../platform/browser/from-chrome-event";
  * const message = await messagePromise;
  * ```
  */
-export const postLogoutMessageListener$ = fromChromeEvent<[message: { command: string }]>(
-  chrome.runtime.onMessage,
-).pipe(
+export const postLogoutMessageListener$ = fromChromeEvent<
+  [message?: { command: "switchAccountFinish" | "doneLoggingOut" }]
+>(chrome.runtime.onMessage).pipe(
   map(([message]) => message?.command),
   filter((command) => command === "switchAccountFinish" || command === "doneLoggingOut"),
   timeout({

--- a/apps/browser/src/auth/popup/utils/post-logout-message-listener.ts
+++ b/apps/browser/src/auth/popup/utils/post-logout-message-listener.ts
@@ -1,0 +1,24 @@
+import { filter, map, throwError, timeout } from "rxjs";
+
+import { fromChromeEvent } from "../../../platform/browser/from-chrome-event";
+
+/**
+ * Listens to `switchAccountFinish` and `doneLoggingOut` messages and returns which message was heard.
+ *
+ * @example
+ * ```ts
+ * const messagePromise = firstValueFrom(postLogoutMessageListener$);
+ * this.messagingService.send("logout");
+ * const message = await messagePromise;
+ * ```
+ */
+export const postLogoutMessageListener$ = fromChromeEvent<[message: { command: string }]>(
+  chrome.runtime.onMessage,
+).pipe(
+  map(([message]) => message?.command),
+  filter((command) => command === "switchAccountFinish" || command === "doneLoggingOut"),
+  timeout({
+    first: 60_000,
+    with: () => throwError(() => new Error("Did not receive message from logout.")),
+  }),
+);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The `Not you` button on this screen initiates a logout for the current account. If you have an additional account this will mean we switch accounts to the next account. We need to listen for that message and route them appropriately. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/utils/post-logout-message-listener.ts:** Create a helper listener for listening to post logout messages, this is because I believe this exact logic will be reused to fix a different bug. 
- **apps/browser/src/auth/popup/login-decryption-options/login-decryption-options.component.ts:** Override the `super.logOut` method by starting to listen to messages, doing the super implementation, then waiting until that message comes or we timeout. If the `switchAccountMessage` was sent, then route them to home.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
