### PR TITLE
[PM-5468] Ensure prototypes available on memory stored objects

### DIFF
--- a/apps/browser/src/platform/popup/header.component.html
+++ b/apps/browser/src/platform/popup/header.component.html
@@ -5,7 +5,7 @@
     <ng-content select=".center"></ng-content>
     <div class="right">
       <ng-content select=".right"></ng-content>
-      <ng-container *ngIf="authedAccounts$ | async">
+      <ng-container *ngIf="(authedAccounts$ | async) && !hideAccountSwitcher">
         <app-current-account></app-current-account>
       </ng-container>
     </div>

--- a/apps/browser/src/platform/popup/header.component.ts
+++ b/apps/browser/src/platform/popup/header.component.ts
@@ -12,6 +12,7 @@ import { flagEnabled } from "../flags";
 })
 export class HeaderComponent {
   @Input() noTheme = false;
+  @Input() hideAccountSwitcher = false;
   authedAccounts$: Observable<boolean>;
   constructor(accountService: AccountService) {
     this.authedAccounts$ = accountService.accounts$.pipe(

--- a/apps/browser/src/tools/popup/generator/generator.component.html
+++ b/apps/browser/src/tools/popup/generator/generator.component.html
@@ -1,4 +1,4 @@
-<app-header>
+<app-header [hideAccountSwitcher]="comingFromAddEdit">
   <div class="left">
     <app-pop-out [show]="!comingFromAddEdit"></app-pop-out>
     <button type="button" (click)="close()" *ngIf="comingFromAddEdit">

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -27,6 +27,7 @@ import { CollectionData } from "../../../vault/models/data/collection.data";
 import { FolderData } from "../../../vault/models/data/folder.data";
 import { CipherView } from "../../../vault/models/view/cipher.view";
 import { CollectionView } from "../../../vault/models/view/collection.view";
+import { AddEditCipherInfo } from "../../../vault/types/add-edit-cipher-info";
 import { KdfType } from "../../enums";
 import { Utils } from "../../misc/utils";
 import { ServerConfigData } from "../../models/data/server-config.data";
@@ -101,10 +102,23 @@ export class AccountData {
     GeneratedPasswordHistory[],
     GeneratedPasswordHistory[]
   > = new EncryptionPair<GeneratedPasswordHistory[], GeneratedPasswordHistory[]>();
-  addEditCipherInfo?: any;
+  addEditCipherInfo?: AddEditCipherInfo;
   eventCollection?: EventData[];
   organizations?: { [id: string]: OrganizationData };
   providers?: { [id: string]: ProviderData };
+
+  static fromJSON(obj: DeepJsonify<AccountData>): AccountData {
+    if (obj == null) {
+      return null;
+    }
+
+    return Object.assign(new AccountData(), obj, {
+      addEditCipherInfo: {
+        cipher: CipherView.fromJSON(obj?.addEditCipherInfo?.cipher),
+        collectionIds: obj?.addEditCipherInfo?.collectionIds,
+      },
+    });
+  }
 }
 
 export class AccountKeys {
@@ -152,7 +166,7 @@ export class AccountKeys {
     if (obj == null) {
       return null;
     }
-    return Object.assign(new AccountKeys(), {
+    return Object.assign(new AccountKeys(), obj, {
       userKey: SymmetricCryptoKey.fromJSON(obj?.userKey),
       masterKey: SymmetricCryptoKey.fromJSON(obj?.masterKey),
       deviceKey: obj?.deviceKey,
@@ -451,6 +465,7 @@ export class Account {
 
     return Object.assign(new Account({}), json, {
       keys: AccountKeys.fromJSON(json?.keys),
+      data: AccountData.fromJSON(json?.data),
       profile: AccountProfile.fromJSON(json?.profile),
       settings: AccountSettings.fromJSON(json?.settings),
       tokens: AccountTokens.fromJSON(json?.tokens),

--- a/libs/common/src/platform/models/domain/enc-string.ts
+++ b/libs/common/src/platform/models/domain/enc-string.ts
@@ -40,7 +40,7 @@ export class EncString implements Encrypted {
   }
 
   toJSON() {
-    return this.encryptedString;
+    return this.encryptedString as string;
   }
 
   static fromJSON(obj: Jsonify<EncString>): EncString {

--- a/libs/common/src/platform/services/memory-storage.service.ts
+++ b/libs/common/src/platform/services/memory-storage.service.ts
@@ -31,8 +31,8 @@ export class MemoryStorageService extends AbstractMemoryStorageService {
     }
     // TODO: Remove once foreground/background contexts are separated in browser
     // Needed to ensure ownership of all memory by the context running the storage service
-    obj = structuredClone(obj);
-    this.store.set(key, obj);
+    const toStore = structuredClone(obj);
+    this.store.set(key, toStore);
     this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();
   }

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -280,9 +280,20 @@ export class StateService<
   }
 
   async getAddEditCipherInfo(options?: StorageOptions): Promise<AddEditCipherInfo> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultInMemoryOptions()))
-    )?.data?.addEditCipherInfo;
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
+    );
+    // ensure prototype on cipher
+    const raw = account?.data?.addEditCipherInfo;
+    return raw == null
+      ? null
+      : {
+          cipher:
+            raw?.cipher.toJSON != null
+              ? raw.cipher
+              : CipherView.fromJSON(raw?.cipher as Jsonify<CipherView>),
+          collectionIds: raw?.collectionIds,
+        };
   }
 
   async setAddEditCipherInfo(value: AddEditCipherInfo, options?: StorageOptions): Promise<void> {

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -1,8 +1,7 @@
-import { Jsonify } from "type-fest";
-
 import { View } from "../../../models/view/view";
 import { InitializerMetadata } from "../../../platform/interfaces/initializer-metadata.interface";
 import { InitializerKey } from "../../../platform/services/cryptography/initializer-key";
+import { DeepJsonify } from "../../../types/deep-jsonify";
 import { LinkedIdType } from "../../enums";
 import { CipherRepromptType } from "../../enums/cipher-reprompt-type";
 import { CipherType } from "../../enums/cipher-type";
@@ -141,7 +140,16 @@ export class CipherView implements View, InitializerMetadata {
     return this.linkedFieldOptions.get(id)?.i18nKey;
   }
 
-  static fromJSON(obj: Partial<Jsonify<CipherView>>): CipherView {
+  // This is used as a marker to indicate that the cipher view object still has its prototype
+  toJSON() {
+    return this;
+  }
+
+  static fromJSON(obj: Partial<DeepJsonify<CipherView>>): CipherView {
+    if (obj == null) {
+      return null;
+    }
+
     const view = new CipherView();
     const revisionDate = obj.revisionDate == null ? null : new Date(obj.revisionDate);
     const deletedDate = obj.deletedDate == null ? null : new Date(obj.deletedDate);

--- a/libs/common/src/vault/models/view/login.view.ts
+++ b/libs/common/src/vault/models/view/login.view.ts
@@ -1,6 +1,5 @@
-import { Jsonify } from "type-fest";
-
 import { Utils } from "../../../platform/misc/utils";
+import { DeepJsonify } from "../../../types/deep-jsonify";
 import { LoginLinkedId as LinkedId, UriMatchType } from "../../enums";
 import { linkedFieldOption } from "../../linked-field-option.decorator";
 import { Login } from "../domain/login";
@@ -81,10 +80,10 @@ export class LoginView extends ItemView {
     return this.uris.some((uri) => uri.matchesUri(targetUri, equivalentDomains, defaultUriMatch));
   }
 
-  static fromJSON(obj: Partial<Jsonify<LoginView>>): LoginView {
+  static fromJSON(obj: Partial<DeepJsonify<LoginView>>): LoginView {
     const passwordRevisionDate =
       obj.passwordRevisionDate == null ? null : new Date(obj.passwordRevisionDate);
-    const uris = obj.uris.map((uri: any) => LoginUriView.fromJSON(uri));
+    const uris = obj.uris.map((uri) => LoginUriView.fromJSON(uri));
     const fido2Credentials = obj.fido2Credentials?.map((key) => Fido2CredentialView.fromJSON(key));
 
     return Object.assign(new LoginView(), obj, {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We had missed an in-memory getter that loses prototype with the new structured clone being used to avoid dead objects.

This would have been an issue for mv3, so we need to adjust behavior at the getter rather than change storage behavior. I'm inspecting the retrieved value and re-applying the appropriate prototype. This is equivalent to what we do with `getDecryptedCiphers`, but without the decorator helper.

I also hide the account switcher in the generator when coming from the add-edit component. It's not relevant there and switching acocunts would result in undefined behavior.

I've audited the other usages of memory objects and it looks like this is our only current one incorrectly accessing potentially prototype-less objects.

## Code changes

**header.component**: add input which allows users to remove the account switcher, if they need to
**generator.component**: Do not show switcher if coming from add-edit
**account, cipher-view, login-view**: update serialization to better handle cipher view data
**enc-string**: opaque types aren't serializable, so returning this as a string allows `Jsonify` type to more appropriately work
**memory-storage.service**: This likely doesn't matter, but ensures we aren't overwriting the original object with the clone
**state-service**: this is the actual fix in MV2, where we don't necessarily deserialize account. This ensures we always apply prototypes here.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
