### PR TITLE
[PM-5453] Route on `switchAccountFinish` Message

### DIFF
--- a/apps/browser/src/auth/popup/update-temp-password.component.ts
+++ b/apps/browser/src/auth/popup/update-temp-password.component.ts
@@ -1,9 +1,27 @@
 import { Component } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
 import { UpdateTempPasswordComponent as BaseUpdateTempPasswordComponent } from "@bitwarden/angular/auth/components/update-temp-password.component";
+
+import { postLogoutMessageListener$ } from "./utils/post-logout-message-listener";
 
 @Component({
   selector: "app-update-temp-password",
   templateUrl: "update-temp-password.component.html",
 })
-export class UpdateTempPasswordComponent extends BaseUpdateTempPasswordComponent {}
+export class UpdateTempPasswordComponent extends BaseUpdateTempPasswordComponent {
+  onSuccessfulChangePassword: () => Promise<void> = this.doOnSuccessfulChangePassword.bind(this);
+
+  private async doOnSuccessfulChangePassword() {
+    // start listening for "switchAccountFinish" or "doneLoggingOut"
+    const messagePromise = firstValueFrom(postLogoutMessageListener$);
+    this.messagingService.send("logout");
+    // wait for messages
+    const command = await messagePromise;
+
+    // doneLoggingOut already has a message handler that will navigate us
+    if (command === "switchAccountFinish") {
+      this.router.navigate(["/"]);
+    }
+  }
+}

--- a/libs/angular/src/auth/components/update-temp-password.component.ts
+++ b/libs/angular/src/auth/components/update-temp-password.component.ts
@@ -54,7 +54,7 @@ export class UpdateTempPasswordComponent extends BaseChangePasswordComponent {
     private syncService: SyncService,
     private logService: LogService,
     private userVerificationService: UserVerificationService,
-    private router: Router,
+    protected router: Router,
     dialogService: DialogService,
   ) {
     super(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Listen to a logout finish message just before sending the `logout` message. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/update-temp-password.component.ts:** Set the `onSuccessfulChangePassword` action so that it gets ran instead of the default of only sending the logout message. Have that method start listening for finishing messages before calling the logout message.
- **libs/angular/src/auth/components/update-temp-password.component.ts:** Make `Router` available to inherited classes.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
