### PR TITLE
[PM-4437] Bug - Exclude non-standard search inputs from autofill

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -42,7 +42,7 @@ export class AutoFillConstants {
     "verificationCode",
   ];
 
-  static readonly SearchFieldNames: string[] = ["search", "query"];
+  static readonly SearchFieldNames: string[] = ["search", "query", "find", "go"];
 
   static readonly PasswordFieldIgnoreList: string[] = [
     "onetimepassword",

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -51,15 +51,19 @@ export class AutoFillConstants {
     "forgot",
   ];
 
-  static readonly ExcludedAutofillTypes: string[] = [
-    "radio",
-    "checkbox",
+  static readonly ExcludedAutofillLoginTypes: string[] = [
     "hidden",
     "file",
     "button",
     "image",
     "reset",
     "search",
+  ];
+
+  static readonly ExcludedAutofillTypes: string[] = [
+    "radio",
+    "checkbox",
+    ...AutoFillConstants.ExcludedAutofillLoginTypes,
   ];
 }
 

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -42,6 +42,8 @@ export class AutoFillConstants {
     "verificationCode",
   ];
 
+  static readonly SearchFieldNames: string[] = ["search", "query"];
+
   static readonly PasswordFieldIgnoreList: string[] = [
     "onetimepassword",
     "captcha",

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2260,8 +2260,7 @@ describe("AutofillService", () => {
           tagName: "span",
         });
         pageDetails.fields = [spanField];
-        jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedField");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2270,8 +2269,7 @@ describe("AutofillService", () => {
           options,
         );
 
-        expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(spanField);
-        expect(AutofillService["isExcludedType"]).not.toHaveBeenCalled();
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
 
@@ -2285,8 +2283,7 @@ describe("AutofillService", () => {
             type: excludedType,
           });
           pageDetails.fields = [invalidField];
-          jest.spyOn(AutofillService, "forCustomFieldsOnly");
-          jest.spyOn(AutofillService, "isExcludedType");
+          jest.spyOn(AutofillService, "isExcludedField");
 
           const value = autofillService["generateCardFillScript"](
             fillScript,
@@ -2295,9 +2292,8 @@ describe("AutofillService", () => {
             options,
           );
 
-          expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(invalidField);
-          expect(AutofillService["isExcludedType"]).toHaveBeenCalledWith(
-            invalidField.type,
+          expect(AutofillService["isExcludedField"]).toHaveBeenCalledWith(
+            invalidField,
             AutoFillConstants.ExcludedAutofillTypes,
           );
           expect(value).toStrictEqual(unmodifiedFillScriptValues);
@@ -2315,7 +2311,7 @@ describe("AutofillService", () => {
         });
         pageDetails.fields = [notViewableField];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedField");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2325,7 +2321,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(notViewableField);
-        expect(AutofillService["isExcludedType"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
     });
@@ -2410,7 +2406,7 @@ describe("AutofillService", () => {
         options.cipher.card.code = "testCode";
         options.cipher.card.brand = "testBrand";
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedField");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(AutofillService, "hasValue");
@@ -2428,7 +2424,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledTimes(6);
-        expect(AutofillService["isExcludedType"]).toHaveBeenCalledTimes(6);
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalledTimes(6);
         expect(AutofillService["isFieldMatch"]).toHaveBeenCalled();
         expect(autofillService["makeScriptAction"]).toHaveBeenCalledTimes(4);
         expect(AutofillService["hasValue"]).toHaveBeenCalledTimes(6);
@@ -2877,7 +2873,7 @@ describe("AutofillService", () => {
       beforeEach(() => {
         pageDetails.fields = [];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedField");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(autofillService as any, "makeScriptActionWithValue");
@@ -2895,7 +2891,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(customField);
-        expect(AutofillService["isExcludedType"]).not.toHaveBeenCalled();
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });
@@ -2912,8 +2908,8 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(excludedField);
-        expect(AutofillService["isExcludedType"]).toHaveBeenCalledWith(
-          excludedField.type,
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalledWith(
+          excludedField,
           AutoFillConstants.ExcludedAutofillTypes,
         );
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
@@ -2932,7 +2928,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(viewableField);
-        expect(AutofillService["isExcludedType"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });
@@ -3327,6 +3323,34 @@ describe("AutofillService", () => {
         "text",
         AutoFillConstants.ExcludedAutofillTypes,
       );
+
+      expect(value).toBe(false);
+    });
+  });
+
+  describe("isSearchField", () => {
+    it("returns true if the passed field type is 'search'", () => {
+      const typedSearchField = createAutofillFieldMock({ type: "search" });
+      const value = AutofillService["isSearchField"](typedSearchField);
+
+      expect(value).toBe(true);
+    });
+
+    it("returns true if the passed field type is missing and another checked attribute value contains a reference to search", () => {
+      const untypedSearchField = createAutofillFieldMock({
+        htmlID: "aSearchInput",
+        placeholder: null,
+        type: null,
+        value: null,
+      });
+      const value = AutofillService["isSearchField"](untypedSearchField);
+
+      expect(value).toBe(true);
+    });
+
+    it("returns false if the passed field is not a search field", () => {
+      const typedSearchField = createAutofillFieldMock();
+      const value = AutofillService["isSearchField"](typedSearchField);
 
       expect(value).toBe(false);
     });

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2261,7 +2261,7 @@ describe("AutofillService", () => {
         });
         pageDetails.fields = [spanField];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(autofillService as any, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedType");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2271,7 +2271,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(spanField);
-        expect(autofillService["isExcludedType"]).not.toHaveBeenCalled();
+        expect(AutofillService["isExcludedType"]).not.toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
 
@@ -2286,7 +2286,7 @@ describe("AutofillService", () => {
           });
           pageDetails.fields = [invalidField];
           jest.spyOn(AutofillService, "forCustomFieldsOnly");
-          jest.spyOn(autofillService as any, "isExcludedType");
+          jest.spyOn(AutofillService, "isExcludedType");
 
           const value = autofillService["generateCardFillScript"](
             fillScript,
@@ -2296,7 +2296,7 @@ describe("AutofillService", () => {
           );
 
           expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(invalidField);
-          expect(autofillService["isExcludedType"]).toHaveBeenCalledWith(
+          expect(AutofillService["isExcludedType"]).toHaveBeenCalledWith(
             invalidField.type,
             AutoFillConstants.ExcludedAutofillTypes,
           );
@@ -2315,7 +2315,7 @@ describe("AutofillService", () => {
         });
         pageDetails.fields = [notViewableField];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(autofillService as any, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedType");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2325,7 +2325,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(notViewableField);
-        expect(autofillService["isExcludedType"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedType"]).toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
     });
@@ -2410,7 +2410,7 @@ describe("AutofillService", () => {
         options.cipher.card.code = "testCode";
         options.cipher.card.brand = "testBrand";
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(autofillService as any, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedType");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(AutofillService, "hasValue");
@@ -2428,7 +2428,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledTimes(6);
-        expect(autofillService["isExcludedType"]).toHaveBeenCalledTimes(6);
+        expect(AutofillService["isExcludedType"]).toHaveBeenCalledTimes(6);
         expect(AutofillService["isFieldMatch"]).toHaveBeenCalled();
         expect(autofillService["makeScriptAction"]).toHaveBeenCalledTimes(4);
         expect(AutofillService["hasValue"]).toHaveBeenCalledTimes(6);
@@ -2877,7 +2877,7 @@ describe("AutofillService", () => {
       beforeEach(() => {
         pageDetails.fields = [];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(autofillService as any, "isExcludedType");
+        jest.spyOn(AutofillService, "isExcludedType");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(autofillService as any, "makeScriptActionWithValue");
@@ -2895,7 +2895,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(customField);
-        expect(autofillService["isExcludedType"]).not.toHaveBeenCalled();
+        expect(AutofillService["isExcludedType"]).not.toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });
@@ -2912,7 +2912,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(excludedField);
-        expect(autofillService["isExcludedType"]).toHaveBeenCalledWith(
+        expect(AutofillService["isExcludedType"]).toHaveBeenCalledWith(
           excludedField.type,
           AutoFillConstants.ExcludedAutofillTypes,
         );
@@ -2932,7 +2932,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(viewableField);
-        expect(autofillService["isExcludedType"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedType"]).toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });
@@ -3314,7 +3314,7 @@ describe("AutofillService", () => {
 
   describe("isExcludedType", () => {
     it("returns true if the passed type is within the excluded type list", () => {
-      const value = autofillService["isExcludedType"](
+      const value = AutofillService["isExcludedType"](
         "hidden",
         AutoFillConstants.ExcludedAutofillTypes,
       );
@@ -3323,7 +3323,7 @@ describe("AutofillService", () => {
     });
 
     it("returns true if the passed type is within the excluded type list", () => {
-      const value = autofillService["isExcludedType"](
+      const value = AutofillService["isExcludedType"](
         "text",
         AutoFillConstants.ExcludedAutofillTypes,
       );

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -1122,6 +1122,11 @@ export default class AutofillService implements AutofillServiceInterface {
         return;
       }
 
+      // Check if the input is an untyped/mistyped search input
+      if (this.isSearchField(f)) {
+        return;
+      }
+
       for (let i = 0; i < IdentityAutoFillConstants.IdentityAttributes.length; i++) {
         const attr = IdentityAutoFillConstants.IdentityAttributes[i];
         // eslint-disable-next-line
@@ -1345,6 +1350,13 @@ export default class AutofillService implements AutofillServiceInterface {
    */
   private isExcludedType(type: string, excludedTypes: string[]) {
     return excludedTypes.indexOf(type) > -1;
+  }
+
+  private isSearchField(field: AutofillField) {
+    const matchFieldAttributeValues = [field.type, field.htmlName, field.htmlID, field.placeholder];
+    const matchPattern = new RegExp(AutoFillConstants.SearchFieldNames.join("|"), "gi");
+
+    return !!matchFieldAttributeValues.join(" ").match(matchPattern);
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -480,6 +480,11 @@ export default class AutofillService implements AutofillServiceInterface {
           return;
         }
 
+        // Check if the input is an untyped/mistyped search input
+        if (AutofillService.isSearchField(field)) {
+          return;
+        }
+
         const matchingIndex = this.findMatchingFieldIndex(field, fieldNames);
         if (matchingIndex > -1) {
           const matchingField: FieldView = fields[matchingIndex];
@@ -737,6 +742,11 @@ export default class AutofillService implements AutofillServiceInterface {
       }
 
       if (this.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
+        return;
+      }
+
+      // Check if the input is an untyped/mistyped search input
+      if (AutofillService.isSearchField(f)) {
         return;
       }
 
@@ -1123,7 +1133,7 @@ export default class AutofillService implements AutofillServiceInterface {
       }
 
       // Check if the input is an untyped/mistyped search input
-      if (this.isSearchField(f)) {
+      if (AutofillService.isSearchField(f)) {
         return;
       }
 
@@ -1352,7 +1362,7 @@ export default class AutofillService implements AutofillServiceInterface {
     return excludedTypes.indexOf(type) > -1;
   }
 
-  private isSearchField(field: AutofillField) {
+  static isSearchField(field: AutofillField) {
     const matchFieldAttributeValues = [field.type, field.htmlName, field.htmlID, field.placeholder];
     const matchPattern = new RegExp(AutoFillConstants.SearchFieldNames.join("|"), "gi");
 
@@ -1489,6 +1499,11 @@ export default class AutofillService implements AutofillServiceInterface {
     const arr: AutofillField[] = [];
     pageDetails.fields.forEach((f) => {
       if (AutofillService.forCustomFieldsOnly(f)) {
+        return;
+      }
+
+      // Check if the input is an untyped/mistyped search input
+      if (AutofillService.isSearchField(f)) {
         return;
       }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -737,16 +737,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const fillFields: { [id: string]: AutofillField } = {};
 
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.forCustomFieldsOnly(f)) {
-        return;
-      }
-
-      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
-        return;
-      }
-
-      // Check if the input is an untyped/mistyped search input
-      if (AutofillService.isSearchField(f)) {
+      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1124,16 +1115,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const fillFields: { [id: string]: AutofillField } = {};
 
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.forCustomFieldsOnly(f)) {
-        return;
-      }
-
-      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
-        return;
-      }
-
-      // Check if the input is an untyped/mistyped search input
-      if (AutofillService.isSearchField(f)) {
+      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1358,15 +1340,32 @@ export default class AutofillService implements AutofillServiceInterface {
    * @returns {boolean}
    * @private
    */
-  static isExcludedType(type: string, excludedTypes: string[]) {
+  private static isExcludedType(type: string, excludedTypes: string[]) {
     return excludedTypes.indexOf(type) > -1;
   }
 
-  static isSearchField(field: AutofillField) {
+  private static isSearchField(field: AutofillField) {
     const matchFieldAttributeValues = [field.type, field.htmlName, field.htmlID, field.placeholder];
     const matchPattern = new RegExp(AutoFillConstants.SearchFieldNames.join("|"), "gi");
 
-    return !!matchFieldAttributeValues.join(" ").match(matchPattern);
+    return Boolean(matchFieldAttributeValues.join(" ").match(matchPattern));
+  }
+
+  static isExcludedField(field: AutofillField, excludedTypes: string[]) {
+    if (AutofillService.forCustomFieldsOnly(field)) {
+      return true;
+    }
+
+    if (this.isExcludedType(field.type, excludedTypes)) {
+      return true;
+    }
+
+    // Check if the input is an untyped/mistyped search input
+    if (this.isSearchField(field)) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -1498,16 +1497,7 @@ export default class AutofillService implements AutofillServiceInterface {
   ) {
     const arr: AutofillField[] = [];
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.forCustomFieldsOnly(f)) {
-        return;
-      }
-
-      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillLoginTypes)) {
-        return;
-      }
-
-      // Check if the input is an untyped/mistyped search input
-      if (AutofillService.isSearchField(f)) {
+      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillLoginTypes)) {
         return;
       }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -741,7 +741,7 @@ export default class AutofillService implements AutofillServiceInterface {
         return;
       }
 
-      if (this.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
+      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1128,7 +1128,7 @@ export default class AutofillService implements AutofillServiceInterface {
         return;
       }
 
-      if (this.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
+      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1358,7 +1358,7 @@ export default class AutofillService implements AutofillServiceInterface {
    * @returns {boolean}
    * @private
    */
-  private isExcludedType(type: string, excludedTypes: string[]) {
+  static isExcludedType(type: string, excludedTypes: string[]) {
     return excludedTypes.indexOf(type) > -1;
   }
 
@@ -1499,6 +1499,10 @@ export default class AutofillService implements AutofillServiceInterface {
     const arr: AutofillField[] = [];
     pageDetails.fields.forEach((f) => {
       if (AutofillService.forCustomFieldsOnly(f)) {
+        return;
+      }
+
+      if (AutofillService.isExcludedType(f.type, AutoFillConstants.ExcludedAutofillLoginTypes)) {
         return;
       }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Autofilling ciphers will sometimes fill values in search inputs with a missing / non-search type attribute

## Code changes

These changes aim to improve overall early disqualification of fields when autofilling. The strategies are progressively broadened with each commit:

2bcec716d881d260d2e57b6bb6309fb78f97b065 - exclude non-standard search inputs from identity autofill
97c5704f40485ea94b82df162de7d017065e1535 - exclude non-standard search inputs from all autofill
e5f457ede6f1b521dfcbe5bc423c19d1dfd6706d - check against excluded login field types when loading password fields

## Screenshots

### Before
https://github.com/bitwarden/clients/assets/1556494/49564171-6f1c-40aa-99fd-d6baf10a6dbf

### After
https://github.com/bitwarden/clients/assets/1556494/2297c671-9ced-4b7f-a31d-3fbc692803da

## Other Notes

Before these changes, we've relied only on field-specific name values in autofill-constants to avoid filling fields that are unrelated to the target field category. An untyped or mistyped search input would normally not pass unless it happened to have a value in one of the checked attributes that happened to match one of the targeted field category names.

In the case of `groww.in`, their (untyped) search input has the placeholder value of "What are you looking for today?". When we do our comparisons against known field attribute values in `isFieldMatch`, we transform that string into "whatareyoulookingfortoday". In this case, no matches are found until we get to checking `CityFieldNames`; in that array of values, we have the (German-language) value of "ort". This matches against the portion of the field string because we're removed the space between "for" and "today".

Because of this, the original behaviour (before these changes) is likely to run into what seem like random cases of untyped search inputs incorrectly filling simply because of coincidental word concatenation during this comparison.

Even if we preserve internal whitespace (and other relevant characters) from the original string (handling the transformation of the option values being compared as well), it's reasonable to have a search placeholder read something like "search for a city", which would still match against identity fields. It's worth noting that this isn't limited to identity ciphers; the same effect can be seen with a search input filling a login cipher using placeholder values such as "Search for a user name", "Find an email", or even "Lookup a product code" (totp match).