### PR TITLE
Remove unnecessary complex types

### DIFF
--- a/apps/browser/src/platform/state/background-derived-state.provider.ts
+++ b/apps/browser/src/platform/state/background-derived-state.provider.ts
@@ -3,15 +3,15 @@ import { Observable } from "rxjs";
 import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- extending this class for this client
 import { DefaultDerivedStateProvider } from "@bitwarden/common/platform/state/implementations/default-derived-state.provider";
-import { ShapeToInstances, Type } from "@bitwarden/common/src/types/state";
+import { DerivedStateDependencies } from "@bitwarden/common/src/types/state";
 
 import { BackgroundDerivedState } from "./background-derived-state";
 
 export class BackgroundDerivedStateProvider extends DefaultDerivedStateProvider {
-  override buildDerivedState<TFrom, TTo, TDeps extends Record<string, Type<unknown>>>(
+  override buildDerivedState<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ): DerivedState<TTo> {
     return new BackgroundDerivedState(
       parentState$,

--- a/apps/browser/src/platform/state/background-derived-state.ts
+++ b/apps/browser/src/platform/state/background-derived-state.ts
@@ -9,14 +9,14 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { DeriveDefinition } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- extending this class for this client
 import { DefaultDerivedState } from "@bitwarden/common/platform/state/implementations/default-derived-state";
-import { ShapeToInstances, Type } from "@bitwarden/common/types/state";
+import { DerivedStateDependencies } from "@bitwarden/common/types/state";
 
 import { BrowserApi } from "../browser/browser-api";
 
 export class BackgroundDerivedState<
   TFrom,
   TTo,
-  TDeps extends Record<string, Type<unknown>>,
+  TDeps extends DerivedStateDependencies,
 > extends DefaultDerivedState<TFrom, TTo, TDeps> {
   private portSubscriptions: Map<
     chrome.runtime.Port,
@@ -27,7 +27,7 @@ export class BackgroundDerivedState<
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
     memoryStorage: AbstractStorageService & ObservableStorageService,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ) {
     super(parentState$, deriveDefinition, memoryStorage, dependencies);
     const portName = deriveDefinition.buildCacheKey();

--- a/apps/browser/src/platform/state/derived-state-service-interactions.spec.ts
+++ b/apps/browser/src/platform/state/derived-state-service-interactions.spec.ts
@@ -10,7 +10,6 @@ import { Subject, firstValueFrom } from "rxjs";
 import { DeriveDefinition } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- needed to define a derive definition
 import { StateDefinition } from "@bitwarden/common/platform/state/state-definition";
-import { Type } from "@bitwarden/common/types/state";
 
 import { mockPorts } from "../../../spec/mock-port.spec-util";
 
@@ -25,7 +24,7 @@ const deriveDefinition = new DeriveDefinition(stateDefinition, "test", {
 
 describe("foreground background derived state interactions", () => {
   let foreground: ForegroundDerivedState<Date>;
-  let background: BackgroundDerivedState<string, Date, Record<string, Type<unknown>>>;
+  let background: BackgroundDerivedState<string, Date, Record<string, unknown>>;
   let parentState$: Subject<string>;
   let memoryStorage: FakeStorageService;
   const initialParent = "2020-01-01";

--- a/apps/browser/src/platform/state/foreground-derived-state.provider.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.provider.ts
@@ -3,15 +3,15 @@ import { Observable } from "rxjs";
 import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- extending this class for this client
 import { DefaultDerivedStateProvider } from "@bitwarden/common/platform/state/implementations/default-derived-state.provider";
-import { ShapeToInstances, Type } from "@bitwarden/common/src/types/state";
+import { DerivedStateDependencies } from "@bitwarden/common/src/types/state";
 
 import { ForegroundDerivedState } from "./foreground-derived-state";
 
 export class ForegroundDerivedStateProvider extends DefaultDerivedStateProvider {
-  override buildDerivedState<TFrom, TTo, TDeps extends Record<string, Type<unknown>>>(
+  override buildDerivedState<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     _parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    _dependencies: ShapeToInstances<TDeps>,
+    _dependencies: TDeps,
   ): DerivedState<TTo> {
     return new ForegroundDerivedState(deriveDefinition);
   }

--- a/apps/browser/src/platform/state/foreground-derived-state.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.ts
@@ -12,7 +12,7 @@ import {
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state";
-import { Type } from "@bitwarden/common/types/state";
+import { DerivedStateDependencies } from "@bitwarden/common/types/state";
 
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
@@ -23,9 +23,7 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
   private backgroundResponses$: Observable<DerivedStateMessage>;
   state$: Observable<TTo>;
 
-  constructor(
-    private deriveDefinition: DeriveDefinition<unknown, TTo, Record<string, Type<unknown>>>,
-  ) {
+  constructor(private deriveDefinition: DeriveDefinition<unknown, TTo, DerivedStateDependencies>) {
     this.state$ = defer(() => this.initializePort()).pipe(
       filter((message) => message.action === "nextState"),
       map((message) => this.hydrateNext(message.data)),

--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -14,7 +14,7 @@ import {
   DerivedStateProvider,
 } from "../src/platform/state";
 import { UserId } from "../src/types/guid";
-import { ShapeToInstances, DerivedStateDependencies } from "../src/types/state";
+import { DerivedStateDependencies } from "../src/types/state";
 
 import {
   FakeActiveUserState,
@@ -92,7 +92,7 @@ export class FakeStateProvider implements StateProvider {
   getDerived<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<unknown, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ): DerivedState<TTo> {
     return this.derived.get(parentState$, deriveDefinition, dependencies);
   }
@@ -108,7 +108,7 @@ export class FakeDerivedStateProvider implements DerivedStateProvider {
   get<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ): DerivedState<TTo> {
     let result = this.states.get(deriveDefinition.buildCacheKey()) as DerivedState<TTo>;
 

--- a/libs/common/src/platform/state/derive-definition.ts
+++ b/libs/common/src/platform/state/derive-definition.ts
@@ -1,6 +1,6 @@
 import { Jsonify } from "type-fest";
 
-import { DerivedStateDependencies, ShapeToInstances, StorageKey } from "../../types/state";
+import { DerivedStateDependencies, StorageKey } from "../../types/state";
 
 import { KeyDefinition } from "./key-definition";
 import { StateDefinition } from "./state-definition";
@@ -19,7 +19,7 @@ type DeriveDefinitionOptions<TFrom, TTo, TDeps extends DerivedStateDependencies 
    * These are constant for the lifetime of the derived state.
    * @returns  The derived state value or a Promise that resolves to the derived state value.
    */
-  derive: (from: TFrom, deps: ShapeToInstances<TDeps>) => TTo | Promise<TTo>;
+  derive: (from: TFrom, deps: TDeps) => TTo | Promise<TTo>;
   /**
    * A function to use to safely convert your type from json to your expected type.
    *

--- a/libs/common/src/platform/state/derived-state.provider.ts
+++ b/libs/common/src/platform/state/derived-state.provider.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { ShapeToInstances, DerivedStateDependencies } from "../../types/state";
+import { DerivedStateDependencies } from "../../types/state";
 
 import { DeriveDefinition } from "./derive-definition";
 import { DerivedState } from "./derived-state";
@@ -20,6 +20,6 @@ export abstract class DerivedStateProvider {
   get: <TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ) => DerivedState<TTo>;
 }

--- a/libs/common/src/platform/state/implementations/default-derived-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.provider.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { DerivedStateDependencies, ShapeToInstances } from "../../../types/state";
+import { DerivedStateDependencies } from "../../../types/state";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -19,7 +19,7 @@ export class DefaultDerivedStateProvider implements DerivedStateProvider {
   get<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ): DerivedState<TTo> {
     const cacheKey = deriveDefinition.buildCacheKey();
     const existingDerivedState = this.cache[cacheKey];
@@ -37,7 +37,7 @@ export class DefaultDerivedStateProvider implements DerivedStateProvider {
   protected buildDerivedState<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ): DerivedState<TTo> {
     return new DefaultDerivedState<TFrom, TTo, TDeps>(
       parentState$,

--- a/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
@@ -14,7 +14,7 @@ import { DefaultDerivedState } from "./default-derived-state";
 let callCount = 0;
 const cleanupDelayMs = 10;
 const stateDefinition = new StateDefinition("test", "memory");
-const deriveDefinition = new DeriveDefinition<string, Date, { date: typeof Date }>(
+const deriveDefinition = new DeriveDefinition<string, Date, { date: Date }>(
   stateDefinition,
   "test",
   {
@@ -30,7 +30,7 @@ const deriveDefinition = new DeriveDefinition<string, Date, { date: typeof Date 
 describe("DefaultDerivedState", () => {
   let parentState$: Subject<string>;
   let memoryStorage: FakeStorageService;
-  let sut: DefaultDerivedState<string, Date, { date: typeof Date }>;
+  let sut: DefaultDerivedState<string, Date, { date: Date }>;
   const deps = {
     date: new Date(),
   };

--- a/libs/common/src/platform/state/implementations/default-derived-state.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.ts
@@ -1,6 +1,6 @@
 import { Observable, ReplaySubject, Subject, concatMap, merge, share, timer } from "rxjs";
 
-import { ShapeToInstances, DerivedStateDependencies } from "../../../types/state";
+import { DerivedStateDependencies } from "../../../types/state";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -23,7 +23,7 @@ export class DefaultDerivedState<TFrom, TTo, TDeps extends DerivedStateDependenc
     private parentState$: Observable<TFrom>,
     protected deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
     private memoryStorage: AbstractStorageService & ObservableStorageService,
-    private dependencies: ShapeToInstances<TDeps>,
+    private dependencies: TDeps,
   ) {
     this.storageKey = deriveDefinition.storageKey;
 

--- a/libs/common/src/platform/state/implementations/default-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-state.provider.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { ShapeToInstances, DerivedStateDependencies } from "../../../types/state";
+import { DerivedStateDependencies } from "../../../types/state";
 import { DeriveDefinition } from "../derive-definition";
 import { DerivedState } from "../derived-state";
 import { DerivedStateProvider } from "../derived-state.provider";
@@ -26,6 +26,6 @@ export class DefaultStateProvider implements StateProvider {
   getDerived: <TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<unknown, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ) => DerivedState<TTo> = this.derivedStateProvider.get.bind(this.derivedStateProvider);
 }

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 
 import { UserId } from "../../types/guid";
-import { ShapeToInstances, DerivedStateDependencies } from "../../types/state";
+import { DerivedStateDependencies } from "../../types/state";
 
 import { DeriveDefinition } from "./derive-definition";
 import { DerivedState } from "./derived-state";
@@ -26,6 +26,6 @@ export abstract class StateProvider {
   getDerived: <TFrom, TTo, TDeps extends DerivedStateDependencies>(
     parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<unknown, TTo, TDeps>,
-    dependencies: ShapeToInstances<TDeps>,
+    dependencies: TDeps,
   ) => DerivedState<TTo>;
 }

--- a/libs/common/src/types/state.d.ts
+++ b/libs/common/src/types/state.d.ts
@@ -2,16 +2,4 @@ import { Opaque } from "type-fest";
 
 type StorageKey = Opaque<string, "StorageKey">;
 
-/**
- * A helper type defining Constructor types for javascript and `typeof T` types for Typescript
- */
-type Type<T> = abstract new (...args: unknown[]) => T;
-
-type DerivedStateDependencies = Record<string, Type<unknown>>;
-
-/**
- * Converts an object of types to an object of instances
- */
-type ShapeToInstances<T> = {
-  [P in keyof T]: T[P] extends Type<infer R> ? R : never;
-};
+type DerivedStateDependencies = Record<string, unknown>;


### PR DESCRIPTION
#7290 introduced these types, but during development we switched over to specifying dependencies in type parameters instead of an object. This change meant we no longer needed these `Type` or `ShapeToInstance` types, greatly simplifying the types related to derived state.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
