### PR TITLE
Remove Fido2VaultCredentials feature flag

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -1,6 +1,4 @@
 export enum FeatureFlag {
-  DisplayLowKdfIterationWarningFlag = "display-kdf-iteration-warning",
-  Fido2VaultCredentials = "fido2-vault-credentials",
   TrustedDeviceEncryption = "trusted-device-encryption",
   PasswordlessLogin = "passwordless-login",
   AutofillV2 = "autofill-v2",

--- a/libs/common/src/vault/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.spec.ts
@@ -42,7 +42,6 @@ describe("FidoAuthenticatorService", () => {
     stateService = mock<StateService>();
 
     client = new Fido2ClientService(authenticator, configService, authService, stateService);
-    configService.getFeatureFlag.mockResolvedValue(true);
     configService.serverConfig$ = of({ environment: { vault: VaultUrl } } as any);
     stateService.getEnablePasskeys.mockResolvedValue(true);
     authService.getAuthStatus.mockResolvedValue(AuthenticationStatus.Unlocked);
@@ -225,16 +224,6 @@ describe("FidoAuthenticatorService", () => {
         await rejects.toBeInstanceOf(DOMException);
       });
 
-      it("should throw FallbackRequestedError if feature flag is not enabled", async () => {
-        const params = createParams();
-        configService.getFeatureFlag.mockResolvedValue(false);
-
-        const result = async () => await client.createCredential(params, tab);
-
-        const rejects = expect(result).rejects;
-        await rejects.toThrow(FallbackRequestedError);
-      });
-
       it("should throw FallbackRequestedError if passkeys state is not enabled", async () => {
         const params = createParams();
         stateService.getEnablePasskeys.mockResolvedValue(false);
@@ -403,16 +392,6 @@ describe("FidoAuthenticatorService", () => {
         const rejects = expect(result).rejects;
         await rejects.toMatchObject({ name: "NotAllowedError" });
         await rejects.toBeInstanceOf(DOMException);
-      });
-
-      it("should throw FallbackRequestedError if feature flag is not enabled", async () => {
-        const params = createParams();
-        configService.getFeatureFlag.mockResolvedValue(false);
-
-        const result = async () => await client.assertCredential(params, tab);
-
-        const rejects = expect(result).rejects;
-        await rejects.toThrow(FallbackRequestedError);
       });
 
       it("should throw FallbackRequestedError if passkeys state is not enabled", async () => {

--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -3,7 +3,6 @@ import { parse } from "tldts";
 
 import { AuthService } from "../../../auth/abstractions/auth.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
-import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigServiceAbstraction } from "../../../platform/abstractions/config/config.service.abstraction";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { StateService } from "../../../platform/abstractions/state.service";
@@ -57,20 +56,9 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
     const serverConfig = await firstValueFrom(this.configService.serverConfig$);
     const isOriginEqualBitwardenVault = origin === serverConfig.environment?.vault;
 
-    if (
-      !userEnabledPasskeys ||
-      !isUserLoggedIn ||
-      isExcludedDomain ||
-      isOriginEqualBitwardenVault
-    ) {
-      return false;
-    }
-
-    const featureFlagEnabled = await this.configService.getFeatureFlag<boolean>(
-      FeatureFlag.Fido2VaultCredentials,
+    return (
+      userEnabledPasskeys && isUserLoggedIn && !isExcludedDomain && !isOriginEqualBitwardenVault
     );
-
-    return featureFlagEnabled;
   }
 
   async createCredential(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove the feature flag for storing credentials in the vault now that the feature has been released.

## Code changes

- **fido2-client.service.ts:** Removed feature flag check and restructured conditional to be clearer.
- **fido2-client.service.spec.ts:** Removed tests for feature flag support.
- **feature-flag.enum.ts:** Removed `Fido2VaultCredentials` feature flag as well as `DisplayLowKdfIterationWarningFlag` which was not used in code.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
