### PR TITLE
[PM-2917] Fixing Duplicate Inactive 2-FA Reports

### DIFF
--- a/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts
@@ -67,7 +67,10 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
               if (this.services.get(domain) != null) {
                 docs.set(id, this.services.get(domain));
               }
+              // If the uri is in the 2fa list. Add the cipher to the inactive
+              // collection. No need to check any additional uris for the cipher.
               inactive2faCiphers.push(ciph);
+              return;
             }
           }
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When a login item has more than one URI associated with it and 2fa can be enabled. The inactive two-step login report will display the cipher for any URIs associated that 2fa can be enabled for. This causes duplicate ciphers to be displayed

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/reports/pages/inactive-two-factor-report.component.ts:** If the cipher is added to the inactive2faCIphers array. There is no need to check any additional URIs for this cipher. Returning from the for loop after adding to the array removes the chance for duplicate cipher items to be added. 

## Screenshots

Cipher Item: 
![image](https://github.com/bitwarden/clients/assets/144813356/1774c8bd-1d78-4fb1-b70a-c3bd02734468)

Report:
![image](https://github.com/bitwarden/clients/assets/144813356/a6bb3936-9415-4dbc-8904-ddab4f405df8)

