### PR TITLE
Ps/improve state provider fakers

### DIFF
--- a/libs/common/spec/fake-account-service.ts
+++ b/libs/common/spec/fake-account-service.ts
@@ -1,0 +1,69 @@
+import { mock } from "jest-mock-extended";
+import { Observable, ReplaySubject } from "rxjs";
+
+import { AccountInfo, AccountService } from "../src/auth/abstractions/account.service";
+import { AuthenticationStatus } from "../src/auth/enums/authentication-status";
+import { UserId } from "../src/types/guid";
+
+export function mockAccountServiceWith(
+  userId: UserId,
+  info: Partial<AccountInfo> = {},
+): FakeAccountService {
+  const fullInfo: AccountInfo = {
+    ...info,
+    ...{
+      name: "name",
+      email: "email",
+      status: AuthenticationStatus.Locked,
+    },
+  };
+  const service = new FakeAccountService({ [userId]: fullInfo });
+  service.activeAccountSubject.next({ id: userId, ...fullInfo });
+  return service;
+}
+
+export class FakeAccountService implements AccountService {
+  mock = mock<AccountService>();
+  // eslint-disable-next-line rxjs/no-exposed-subjects -- test class
+  accountsSubject = new ReplaySubject<Record<UserId, AccountInfo>>(1);
+  // eslint-disable-next-line rxjs/no-exposed-subjects -- test class
+  activeAccountSubject = new ReplaySubject<{ id: UserId } & AccountInfo>(1);
+  private _activeUserId: UserId;
+  get activeUserId() {
+    return this._activeUserId;
+  }
+  get accounts$() {
+    return this.accountsSubject.asObservable();
+  }
+  get activeAccount$() {
+    return this.activeAccountSubject.asObservable();
+  }
+  accountLock$: Observable<UserId>;
+  accountLogout$: Observable<UserId>;
+
+  constructor(initialData: Record<UserId, AccountInfo>) {
+    this.accountsSubject.next(initialData);
+    this.activeAccountSubject.subscribe((data) => (this._activeUserId = data?.id));
+    this.activeAccountSubject.next(null);
+  }
+
+  async addAccount(userId: UserId, accountData: AccountInfo): Promise<void> {
+    this.mock.addAccount(userId, accountData);
+  }
+
+  async setAccountName(userId: UserId, name: string): Promise<void> {
+    this.mock.setAccountName(userId, name);
+  }
+
+  async setAccountEmail(userId: UserId, email: string): Promise<void> {
+    this.mock.setAccountEmail(userId, email);
+  }
+
+  async setAccountStatus(userId: UserId, status: AuthenticationStatus): Promise<void> {
+    this.mock.setAccountStatus(userId, status);
+  }
+
+  async switchAccount(userId: UserId): Promise<void> {
+    this.mock.switchAccount(userId);
+  }
+}

--- a/libs/common/spec/fake-state.ts
+++ b/libs/common/spec/fake-state.ts
@@ -1,11 +1,19 @@
 import { Observable, ReplaySubject, firstValueFrom, map, timeout } from "rxjs";
 
-import { DerivedState, GlobalState, SingleUserState, ActiveUserState } from "../src/platform/state";
+import {
+  DerivedState,
+  GlobalState,
+  SingleUserState,
+  ActiveUserState,
+  KeyDefinition,
+} from "../src/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- using unexposed options for clean typing in test class
 import { StateUpdateOptions } from "../src/platform/state/state-update-options";
 // eslint-disable-next-line import/no-restricted-paths -- using unexposed options for clean typing in test class
-import { CombinedState, UserState, activeMarker } from "../src/platform/state/user-state";
+import { CombinedState, activeMarker } from "../src/platform/state/user-state";
 import { UserId } from "../src/types/guid";
+
+import { FakeAccountService } from "./fake-account-service";
 
 const DEFAULT_TEST_OPTIONS: StateUpdateOptions<any, any> = {
   shouldUpdate: () => true,
@@ -25,6 +33,10 @@ function populateOptionsWithDefault(
 export class FakeGlobalState<T> implements GlobalState<T> {
   // eslint-disable-next-line rxjs/no-exposed-subjects -- exposed for testing setup
   stateSubject = new ReplaySubject<T>(1);
+
+  constructor(initialValue?: T) {
+    this.stateSubject.next(initialValue ?? null);
+  }
 
   update: <TCombine>(
     configureState: (state: T, dependency: TCombine) => T,
@@ -47,34 +59,56 @@ export class FakeGlobalState<T> implements GlobalState<T> {
     }
     const newState = configureState(current, combinedDependencies);
     this.stateSubject.next(newState);
+    this.nextMock(newState);
     return newState;
   });
 
   updateMock = this.update as jest.MockedFunction<typeof this.update>;
+  nextMock = jest.fn<void, [T]>();
 
   get state$() {
     return this.stateSubject.asObservable();
   }
+
+  private _keyDefinition: KeyDefinition<T> | null = null;
+  get keyDefinition() {
+    if (this._keyDefinition == null) {
+      throw new Error(
+        "Key definition not yet set, usually this means your sut has not asked for this state yet",
+      );
+    }
+    return this._keyDefinition;
+  }
+  set keyDefinition(value: KeyDefinition<T>) {
+    this._keyDefinition = value;
+  }
 }
 
-abstract class FakeUserState<T> implements UserState<T> {
+export class FakeSingleUserState<T> implements SingleUserState<T> {
   // eslint-disable-next-line rxjs/no-exposed-subjects -- exposed for testing setup
   stateSubject = new ReplaySubject<CombinedState<T>>(1);
-
-  protected userId: UserId;
 
   state$: Observable<T>;
   combinedState$: Observable<CombinedState<T>>;
 
-  constructor() {
+  constructor(
+    readonly userId: UserId,
+    initialValue?: T,
+  ) {
+    this.stateSubject.next([userId, initialValue ?? null]);
+
     this.combinedState$ = this.stateSubject.asObservable();
     this.state$ = this.combinedState$.pipe(map(([_userId, state]) => state));
   }
 
-  update: <TCombine>(
+  nextState(state: T) {
+    this.stateSubject.next([this.userId, state]);
+  }
+
+  async update<TCombine>(
     configureState: (state: T, dependency: TCombine) => T,
     options?: StateUpdateOptions<T, TCombine>,
-  ) => Promise<T> = jest.fn(async (configureState, options) => {
+  ): Promise<T> {
     options = populateOptionsWithDefault(options);
     const current = await firstValueFrom(this.state$.pipe(timeout(options.msTimeout)));
     const combinedDependencies =
@@ -86,22 +120,87 @@ abstract class FakeUserState<T> implements UserState<T> {
     }
     const newState = configureState(current, combinedDependencies);
     this.stateSubject.next([this.userId, newState]);
+    this.nextMock(newState);
     return newState;
-  });
+  }
 
   updateMock = this.update as jest.MockedFunction<typeof this.update>;
-}
 
-export class FakeSingleUserState<T> extends FakeUserState<T> implements SingleUserState<T> {
-  constructor(readonly userId: UserId) {
-    super();
-    this.userId = userId;
+  nextMock = jest.fn<void, [T]>();
+  private _keyDefinition: KeyDefinition<T> | null = null;
+  get keyDefinition() {
+    if (this._keyDefinition == null) {
+      throw new Error(
+        "Key definition not yet set, usually this means your sut has not asked for this state yet",
+      );
+    }
+    return this._keyDefinition;
+  }
+  set keyDefinition(value: KeyDefinition<T>) {
+    this._keyDefinition = value;
   }
 }
-export class FakeActiveUserState<T> extends FakeUserState<T> implements ActiveUserState<T> {
+export class FakeActiveUserState<T> implements ActiveUserState<T> {
   [activeMarker]: true;
-  changeActiveUser(userId: UserId) {
-    this.userId = userId;
+
+  // eslint-disable-next-line rxjs/no-exposed-subjects -- exposed for testing setup
+  stateSubject = new ReplaySubject<CombinedState<T>>(1);
+
+  state$: Observable<T>;
+  combinedState$: Observable<CombinedState<T>>;
+
+  constructor(
+    private accountService: FakeAccountService,
+    initialValue?: T,
+  ) {
+    this.stateSubject.next([accountService.activeUserId, initialValue ?? null]);
+
+    this.combinedState$ = this.stateSubject.asObservable();
+    this.state$ = this.combinedState$.pipe(map(([_userId, state]) => state));
+  }
+
+  get userId() {
+    return this.accountService.activeUserId;
+  }
+
+  nextState(state: T) {
+    this.stateSubject.next([this.userId, state]);
+  }
+
+  async update<TCombine>(
+    configureState: (state: T, dependency: TCombine) => T,
+    options?: StateUpdateOptions<T, TCombine>,
+  ): Promise<T> {
+    options = populateOptionsWithDefault(options);
+    const current = await firstValueFrom(this.state$.pipe(timeout(options.msTimeout)));
+    const combinedDependencies =
+      options.combineLatestWith != null
+        ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
+        : null;
+    if (!options.shouldUpdate(current, combinedDependencies)) {
+      return current;
+    }
+    const newState = configureState(current, combinedDependencies);
+    this.stateSubject.next([this.userId, newState]);
+    this.nextMock(this.userId, newState);
+    return newState;
+  }
+
+  updateMock = this.update as jest.MockedFunction<typeof this.update>;
+
+  nextMock = jest.fn<void, [UserId, T]>();
+
+  private _keyDefinition: KeyDefinition<T> | null = null;
+  get keyDefinition() {
+    if (this._keyDefinition == null) {
+      throw new Error(
+        "Key definition not yet set, usually this means your sut has not asked for this state yet",
+      );
+    }
+    return this._keyDefinition;
+  }
+  set keyDefinition(value: KeyDefinition<T>) {
+    this._keyDefinition = value;
   }
 }
 

--- a/libs/common/src/auth/services/account.service.spec.ts
+++ b/libs/common/src/auth/services/account.service.spec.ts
@@ -36,8 +36,6 @@ describe("accountService", () => {
     sut = new AccountServiceImplementation(messagingService, logService, globalStateProvider);
 
     accountsState = globalStateProvider.getFake(ACCOUNT_ACCOUNTS);
-    // initialize to empty
-    accountsState.stateSubject.next({});
     activeAccountIdState = globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID);
   });
 
@@ -57,7 +55,10 @@ describe("accountService", () => {
       accountsState.stateSubject.next({ [userId]: userInfo(AuthenticationStatus.Unlocked) });
       activeAccountIdState.stateSubject.next(userId);
 
-      expect(emissions).toEqual([{ id: userId, ...userInfo(AuthenticationStatus.Unlocked) }]);
+      expect(emissions).toEqual([
+        undefined, // initial value
+        { id: userId, ...userInfo(AuthenticationStatus.Unlocked) },
+      ]);
     });
 
     it("should update the status if the account status changes", async () => {

--- a/libs/common/src/platform/state/implementations/default-state.provider.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-state.provider.spec.ts
@@ -1,5 +1,6 @@
 import { of } from "rxjs";
 
+import { FakeAccountService, mockAccountServiceWith } from "../../../../spec/fake-account-service";
 import {
   FakeActiveUserStateProvider,
   FakeDerivedStateProvider,
@@ -19,9 +20,11 @@ describe("DefaultStateProvider", () => {
   let singleUserStateProvider: FakeSingleUserStateProvider;
   let globalStateProvider: FakeGlobalStateProvider;
   let derivedStateProvider: FakeDerivedStateProvider;
+  let accountService: FakeAccountService;
 
   beforeEach(() => {
-    activeUserStateProvider = new FakeActiveUserStateProvider();
+    accountService = mockAccountServiceWith("fakeUserId" as UserId);
+    activeUserStateProvider = new FakeActiveUserStateProvider(accountService);
     singleUserStateProvider = new FakeSingleUserStateProvider();
     globalStateProvider = new FakeGlobalStateProvider();
     derivedStateProvider = new FakeDerivedStateProvider();

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -151,8 +151,8 @@ export class KeyDefinition<T> {
       throw new Error("You must provide a userId when building a user scoped cache key.");
     }
     return userId === null
-      ? `${scope}_${userId}_${this.stateDefinition.name}_${this.key}`
-      : `${scope}_${this.stateDefinition.name}_${this.key}`;
+      ? `${this.stateDefinition.storageLocation}_${scope}_${userId}_${this.stateDefinition.name}_${this.key}`
+      : `${this.stateDefinition.storageLocation}_${scope}_${this.stateDefinition.name}_${this.key}`;
   }
 
   private get errorKeyName() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Expand state provider fakes
- default null initial value for fake states
- Easier mocking of key definitions through just the use of key names
  - allows for not exporting KeyDefinition as long as the key doesn't collide
- mock of fake state provider to verify `get` calls
- `nextMock` for use of the fn mock matchers on emissions of `state$`
- `FakeAccountService` which allows for easy initialization and working with account switching


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
