### PR TITLE
[PM-5667] Hard code account switching off on Safari

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -9,7 +9,7 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { UriMatchType } from "@bitwarden/common/vault/enums";
 
 import { BrowserApi } from "../../../platform/browser/browser-api";
-import { flagEnabled } from "../../../platform/flags";
+import { enableAccountSwitching } from "../../../platform/flags";
 import { AutofillService } from "../../services/abstractions/autofill.service";
 import { AutofillOverlayVisibility } from "../../utils/autofill-overlay.enum";
 
@@ -65,7 +65,7 @@ export class AutofillComponent implements OnInit {
       { name: i18nService.t("never"), value: UriMatchType.Never },
     ];
 
-    this.accountSwitcherEnabled = flagEnabled("accountSwitching");
+    this.accountSwitcherEnabled = enableAccountSwitching();
     this.disablePasswordManagerLink = this.getDisablePasswordManagerLink();
   }
 

--- a/apps/browser/src/platform/flags.ts
+++ b/apps/browser/src/platform/flags.ts
@@ -8,6 +8,8 @@ import {
 
 import { GroupPolicyEnvironment } from "../admin-console/types/group-policy-environment";
 
+import { BrowserApi } from "./browser/browser-api";
+
 // required to avoid linting errors when there are no flags
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export type Flags = {
@@ -31,4 +33,15 @@ export function devFlagEnabled(flag: keyof DevFlags) {
 
 export function devFlagValue(flag: keyof DevFlags) {
   return baseDevFlagValue(flag);
+}
+
+/** Helper method to sync flag specifically for account switching, which as platform-based values.
+ * If this pattern needs to be repeated, it's better handled by increasing complexity of webpack configurations
+ * Not by expanding these flag getters.
+ */
+export function enableAccountSwitching(): boolean {
+  if (BrowserApi.isSafariApi) {
+    return false;
+  }
+  return flagEnabled("accountSwitching");
 }

--- a/apps/browser/src/platform/popup/header.component.ts
+++ b/apps/browser/src/platform/popup/header.component.ts
@@ -4,7 +4,7 @@ import { Observable, map } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 
-import { flagEnabled } from "../flags";
+import { enableAccountSwitching } from "../flags";
 
 @Component({
   selector: "app-header",
@@ -17,7 +17,7 @@ export class HeaderComponent {
   constructor(accountService: AccountService) {
     this.authedAccounts$ = accountService.accounts$.pipe(
       map((accounts) => {
-        if (!flagEnabled("accountSwitching")) {
+        if (!enableAccountSwitching()) {
           return false;
         }
 

--- a/apps/browser/src/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/popup/settings/excluded-domains.component.ts
@@ -8,7 +8,7 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
-import { flagEnabled } from "../../platform/flags";
+import { enableAccountSwitching } from "../../platform/flags";
 
 interface ExcludedDomain {
   uri: string;
@@ -36,7 +36,7 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
     private ngZone: NgZone,
     private platformUtilsService: PlatformUtilsService,
   ) {
-    this.accountSwitcherEnabled = flagEnabled("accountSwitching");
+    this.accountSwitcherEnabled = enableAccountSwitching();
   }
 
   async ngOnInit() {

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -9,7 +9,7 @@ import { ThemeType } from "@bitwarden/common/platform/enums";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { UriMatchType } from "@bitwarden/common/vault/enums";
 
-import { flagEnabled } from "../../platform/flags";
+import { enableAccountSwitching } from "../../platform/flags";
 
 @Component({
   selector: "app-options",
@@ -77,7 +77,7 @@ export class OptionsComponent implements OnInit {
       { name: i18nService.t("autoFillOnPageLoadNo"), value: false },
     ];
 
-    this.accountSwitcherEnabled = flagEnabled("accountSwitching");
+    this.accountSwitcherEnabled = enableAccountSwitching();
   }
 
   async ngOnInit() {

--- a/apps/browser/src/popup/settings/settings.component.ts
+++ b/apps/browser/src/popup/settings/settings.component.ts
@@ -36,7 +36,7 @@ import { DialogService } from "@bitwarden/components";
 import { SetPinComponent } from "../../auth/popup/components/set-pin.component";
 import { BiometricErrors, BiometricErrorTypes } from "../../models/biometricErrors";
 import { BrowserApi } from "../../platform/browser/browser-api";
-import { flagEnabled } from "../../platform/flags";
+import { enableAccountSwitching } from "../../platform/flags";
 import BrowserPopupUtils from "../../platform/popup/browser-popup-utils";
 
 import { AboutComponent } from "./about.component";
@@ -102,7 +102,7 @@ export class SettingsComponent implements OnInit {
     private dialogService: DialogService,
     private changeDetectorRef: ChangeDetectorRef,
   ) {
-    this.accountSwitcherEnabled = flagEnabled("accountSwitching");
+    this.accountSwitcherEnabled = enableAccountSwitching();
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Disables account switching specifically for safari, which unfortunately isn't ready. The better place for this is arguably in environment configurations, but I don't want to expand that functionality more than it has to in hopes that this is a rare/one-off occurrence.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
