### PR TITLE
[AC-1843] PM discount for SM Trial

### DIFF
--- a/apps/web/src/app/billing/accounts/trial-initiation/secrets-manager-trial-billing.component.ts
+++ b/apps/web/src/app/billing/accounts/trial-initiation/secrets-manager-trial-billing.component.ts
@@ -81,7 +81,7 @@ export class SecretsManagerTrialBillingComponent implements OnInit {
     private formBuilder: FormBuilder,
     private messagingService: MessagingService,
     private organizationApiService: OrganizationApiService,
-    private platformUtilsService: PlatformUtilsService,
+    private platformUtilsService: PlatformUtilsService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -106,7 +106,7 @@ export class SecretsManagerTrialBillingComponent implements OnInit {
     this.platformUtilsService.showToast(
       "success",
       this.i18nService.t("organizationCreated"),
-      this.i18nService.t("organizationReadyToGo"),
+      this.i18nService.t("organizationReadyToGo")
     );
 
     this.organizationCreated.emit({
@@ -138,7 +138,7 @@ export class SecretsManagerTrialBillingComponent implements OnInit {
     request.key = keys.encryptedKey.encryptedString;
     request.keys = new OrganizationKeysRequest(
       keys.publicKey,
-      keys.encryptedPrivateKey.encryptedString,
+      keys.encryptedPrivateKey.encryptedString
     );
     request.collectionName = keys.encryptedCollectionName.encryptedString;
 
@@ -165,6 +165,8 @@ export class SecretsManagerTrialBillingComponent implements OnInit {
       request.billingAddressCity = this.taxInfoComponent.taxInfo.city;
       request.billingAddressState = this.taxInfoComponent.taxInfo.state;
     }
+
+    request.isFromSecretsManagerTrial = true;
 
     const organization = await this.organizationApiService.create(request);
     return organization.id;
@@ -211,7 +213,7 @@ export class SecretsManagerTrialBillingComponent implements OnInit {
     const [publicKey, encryptedPrivateKey] = await this.cryptoService.makeKeyPair(key);
     const encryptedCollectionName = await this.encryptService.encrypt(
       this.i18nService.t("defaultCollection"),
-      key,
+      key
     );
     return {
       encryptedKey,

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -140,7 +140,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   get subscriptionLineItems() {
     return this.lineItems.map((lineItem: BillingSubscriptionItemResponse) => ({
       name: lineItem.name,
-      amount: this.discountPrice(lineItem.amount),
+      amount: this.discountPrice(lineItem.amount, lineItem.productId),
       quantity: lineItem.quantity,
       interval: lineItem.interval,
       sponsoredSubscriptionItem: lineItem.sponsoredSubscriptionItem,
@@ -404,9 +404,12 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     }
   };
 
-  discountPrice = (price: number) => {
+  discountPrice = (price: number, productId: string = null) => {
     const discount =
-      !!this.customerDiscount && this.customerDiscount.active
+      this.customerDiscount?.active &&
+      (!productId ||
+        !this.customerDiscount.appliesTo.length ||
+        this.customerDiscount.appliesTo.includes(productId))
         ? price * (this.customerDiscount.percentOff / 100)
         : 0;
 

--- a/libs/common/src/admin-console/models/request/organization-create.request.ts
+++ b/libs/common/src/admin-console/models/request/organization-create.request.ts
@@ -27,4 +27,5 @@ export class OrganizationCreateRequest {
   useSecretsManager: boolean;
   additionalSmSeats: number;
   additionalServiceAccounts: number;
+  isFromSecretsManagerTrial: boolean;
 }

--- a/libs/common/src/billing/models/response/organization-subscription.response.ts
+++ b/libs/common/src/billing/models/response/organization-subscription.response.ts
@@ -40,12 +40,14 @@ export class BillingCustomerDiscount extends BaseResponse {
   id: string;
   active: boolean;
   percentOff?: number;
+  appliesTo: string[];
 
   constructor(response: any) {
     super(response);
     this.id = this.getResponseProperty("Id");
     this.active = this.getResponseProperty("Active");
     this.percentOff = this.getResponseProperty("PercentOff");
+    this.appliesTo = this.getResponseProperty("AppliesTo");
   }
 
   discountPrice = (price: number) => {

--- a/libs/common/src/billing/models/response/subscription.response.ts
+++ b/libs/common/src/billing/models/response/subscription.response.ts
@@ -41,7 +41,7 @@ export class BillingSubscriptionResponse extends BaseResponse {
 
   constructor(response: any) {
     super(response);
-    this.trialEndDate = this.getResponseProperty("TrialStartDate");
+    this.trialStartDate = this.getResponseProperty("TrialStartDate");
     this.trialEndDate = this.getResponseProperty("TrialEndDate");
     this.periodStartDate = this.getResponseProperty("PeriodStartDate");
     this.periodEndDate = this.getResponseProperty("PeriodEndDate");
@@ -57,6 +57,7 @@ export class BillingSubscriptionResponse extends BaseResponse {
 }
 
 export class BillingSubscriptionItemResponse extends BaseResponse {
+  productId: string;
   name: string;
   amount: number;
   quantity: number;
@@ -67,6 +68,7 @@ export class BillingSubscriptionItemResponse extends BaseResponse {
 
   constructor(response: any) {
     super(response);
+    this.productId = this.getResponseProperty("ProductId");
     this.name = this.getResponseProperty("Name");
     this.amount = this.getResponseProperty("Amount");
     this.quantity = this.getResponseProperty("Quantity");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a customer signs up for a Secrets Manager trial or plan, they will automatically subscribe to Password Manager. The Password Manager subscription should be automatically discounted. The `sm-standalone` discount in Stripe will be used to comp everything but Secrets Manager.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **secrets-manager-trial-billing.component.ts:** Setting `isFromSecretsManagerTrial` flag. Ran prettier
- **organization-subscription-cloud.component.ts:** Updated logic to display discounted price only if the discount applies to the product shown
- **organization-create.request.ts:** Added `isFromSecretsManagerTrial` flag to notify API that it should apply the discount
- **organization-subscription.response.ts:** Added `appliesTo` to the org subscription object, which includes the array of `productIds` that a particular discount/coupon applies to in Stripe
- **subscription.response.ts:** Added `productId` to `BillingSubscriptionItemResponse`. Spotted a defect where no value was being set to `trialStartDate`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
