### PR TITLE
AC-2057 3dot menu missing in individual vault

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -65,7 +65,7 @@
   ></app-collection-badge>
 </td>
 <td bitCell [ngClass]="RowHeightClass" *ngIf="showGroups"></td>
-<td bitCell [ngClass]="RowHeightClass" *ngIf="!showCollections"></td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="showCollections"></td>
 <td bitCell [ngClass]="RowHeightClass" class="tw-text-right">
   <button
     [disabled]="disabled"

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -65,7 +65,7 @@
   ></app-collection-badge>
 </td>
 <td bitCell [ngClass]="RowHeightClass" *ngIf="showGroups"></td>
-<td bitCell [ngClass]="RowHeightClass" *ngIf="showCollections"></td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="viewingOrgVault"></td>
 <td bitCell [ngClass]="RowHeightClass" class="tw-text-right">
   <button
     [disabled]="disabled"

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
@@ -26,6 +26,7 @@ export class VaultCipherRowComponent {
   @Input() cloneable: boolean;
   @Input() organizations: Organization[];
   @Input() collections: CollectionView[];
+  @Input() viewingOrgVault: boolean;
 
   @Output() onEvent = new EventEmitter<VaultItemEvent>();
 

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -103,6 +103,7 @@
           [showGroups]="showGroups"
           [showPremiumFeatures]="showPremiumFeatures"
           [useEvents]="useEvents"
+          [viewingOrgVault]="viewingOrgVault"
           [cloneable]="canClone(item)"
           [organizations]="allOrganizations"
           [collections]="allCollections"

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -47,6 +47,7 @@ export class VaultItemsComponent {
   @Input() allGroups: GroupView[] = [];
   @Input() showBulkEditCollectionAccess = false;
   @Input() showPermissionsColumn = false;
+  @Input() viewingOrgVault: boolean;
 
   private _ciphers?: CipherView[] = [];
   @Input() get ciphers(): CipherView[] {

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -56,6 +56,7 @@
         [showAdminActions]="true"
         (onEvent)="onVaultItemsEvent($event)"
         [showBulkEditCollectionAccess]="showBulkEditCollectionAccess$ | async"
+        [viewingOrgVault]="true"
       >
       </app-vault-items>
       <div


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The 3 dot menu was missing from the cipher rows in the individual vault. updated logic in individual vault so 3dot menu does not get pushed off page

## Code changes

the boolean logic of `showCollections` for the empty column wasn't enough to address both vaults. Instead added a boolean `viewingOrgVault` from the `org vault component html` to `vault items` to `vault cipher row` 

## Screenshots

INDIVIDUAL VAULT
<img width="1056" alt="Screenshot 2024-01-11 at 4 26 19 PM" src="https://github.com/bitwarden/clients/assets/8302660/1eca42f2-ee63-4e0e-a935-b9be88aa80ad">


ORG VAULT
<img width="1066" alt="Screenshot 2024-01-11 at 4 27 26 PM" src="https://github.com/bitwarden/clients/assets/8302660/53935dbc-ef1b-4035-832f-bead91dde2c7">


ORG VAULT NESTED COLLECTION
<img width="1077" alt="Screenshot 2024-01-11 at 4 55 59 PM" src="https://github.com/bitwarden/clients/assets/8302660/aca392e9-3dbd-4199-b612-f3515c3c6f47">


