### PR TITLE
[PM-5716] Add help icon on TargetSelector (folders/collections)

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2670,6 +2670,12 @@
   "learnAboutImportOptions": {
     "message": "Learn about your import options"
   },
+  "learnAboutCollections": {
+    "message": "Learn about collections"
+  },
+  "learnAboutFolders": {
+    "message": "Learn about folders"
+  },
   "selectImportFolder": {
     "message": "Select a folder"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2500,6 +2500,12 @@
   "learnAboutImportOptions": {
     "message": "Learn about your import options"
   },
+  "learnAboutCollections": {
+    "message": "Learn about collections"
+  },
+  "learnAboutFolders": {
+    "message": "Learn about folders"
+  },
   "selectImportFolder": {
     "message": "Select a folder"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1398,6 +1398,12 @@
   "learnAboutImportOptions": {
     "message": "Learn about your import options"
   },
+  "learnAboutCollections": {
+    "message": "Learn about collections"
+  },
+  "learnAboutFolders": {
+    "message": "Learn about folders"
+  },
   "selectImportFolder": {
     "message": "Select a folder"
   },

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -31,7 +31,23 @@
   </bit-form-field>
 
   <bit-form-field>
-    <bit-label>{{ organizationId ? ("collection" | i18n) : ("folder" | i18n) }}</bit-label>
+    <bit-label
+      >{{ organizationId ? ("collection" | i18n) : ("folder" | i18n) }}
+      <a
+        target="_blank"
+        rel="noopener"
+        appA11yTitle="{{
+          organizationId ? ('learnAboutCollections' | i18n) : ('learnAboutFolders' | i18n)
+        }}"
+        href="{{
+          organizationId
+            ? 'https://bitwarden.com/help/about-collections'
+            : 'https://bitwarden.com/help/folders'
+        }}"
+      >
+        <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+      </a>
+    </bit-label>
     <bit-select formControlName="targetSelector">
       <ng-container *ngIf="!organizationId">
         <bit-option [value]="null" label="-- {{ 'selectImportFolder' | i18n }} --" />


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
New users, that are about to import into their vault, are likely not familiar, how folders and collections work within Bitwarden. Adding a help icon and linking to the Bitwarden help site will give more information, to users that require it.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/importer/src/components/import.component.html:** Add help icon on targetSelector. Includes showing a different tooltip and help-link when on folders vs collections.
- ** messages.json updates for browser, desktop and web: **
  - **apps/browser/src/_locales/en/messages.json:** 
  - **apps/desktop/src/locales/en/messages.json:** 
  - **apps/web/src/locales/en/messages.json:** 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
