### PR TITLE
[PM-5531] Improve captcha field autofill disqualification

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -44,11 +44,11 @@ export class AutoFillConstants {
 
   static readonly SearchFieldNames: string[] = ["search", "query", "find", "go"];
 
-  static readonly PasswordFieldIgnoreList: string[] = [
+  static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];
+
+  static readonly PasswordFieldExcludeList: string[] = [
+    ...AutoFillConstants.FieldIgnoreList,
     "onetimepassword",
-    "captcha",
-    "findanything",
-    "forgot",
   ];
 
   static readonly ExcludedAutofillLoginTypes: string[] = [

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -3668,6 +3668,15 @@ describe("AutofillService", () => {
         expect(result).toStrictEqual([passwordField]);
       });
 
+      it("returns the an empty array if the field's htmlID contains the words `password` and `captcha`", () => {
+        passwordField.htmlID = "inputPasswordCaptcha";
+        pageDetails.fields = [passwordField];
+
+        const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
+
+        expect(result).toStrictEqual([]);
+      });
+
       it("returns the field in an array if the field's htmlName contains the word `password`", () => {
         passwordField.htmlName = "password";
         pageDetails.fields = [passwordField];
@@ -3677,6 +3686,15 @@ describe("AutofillService", () => {
         expect(result).toStrictEqual([passwordField]);
       });
 
+      it("returns the an empty array if the field's htmlName contains the words `password` and `captcha`", () => {
+        passwordField.htmlName = "inputPasswordCaptcha";
+        pageDetails.fields = [passwordField];
+
+        const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
+
+        expect(result).toStrictEqual([]);
+      });
+
       it("returns the field in an array if the field's placeholder contains the word `password`", () => {
         passwordField.placeholder = "password";
         pageDetails.fields = [passwordField];
@@ -3684,6 +3702,26 @@ describe("AutofillService", () => {
         const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
 
         expect(result).toStrictEqual([passwordField]);
+      });
+
+      it("returns the an empty array if the field's placeholder contains the words `password` and `captcha`", () => {
+        passwordField.placeholder = "inputPasswordCaptcha";
+        pageDetails.fields = [passwordField];
+
+        const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
+
+        expect(result).toStrictEqual([]);
+      });
+
+      it("returns the an empty array if any of the field's checked attributed contain the words `captcha` while any other attribute contains the word `password` and no excluded terms", () => {
+        passwordField.htmlID = "inputPasswordCaptcha";
+        passwordField.htmlName = "captcha";
+        passwordField.placeholder = "Enter password";
+        pageDetails.fields = [passwordField];
+
+        const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
+
+        expect(result).toStrictEqual([]);
       });
     });
 

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2260,7 +2260,7 @@ describe("AutofillService", () => {
           tagName: "span",
         });
         pageDetails.fields = [spanField];
-        jest.spyOn(AutofillService, "isExcludedField");
+        jest.spyOn(AutofillService, "isExcludedFieldType");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2269,7 +2269,7 @@ describe("AutofillService", () => {
           options,
         );
 
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
 
@@ -2283,7 +2283,7 @@ describe("AutofillService", () => {
             type: excludedType,
           });
           pageDetails.fields = [invalidField];
-          jest.spyOn(AutofillService, "isExcludedField");
+          jest.spyOn(AutofillService, "isExcludedFieldType");
 
           const value = autofillService["generateCardFillScript"](
             fillScript,
@@ -2292,7 +2292,7 @@ describe("AutofillService", () => {
             options,
           );
 
-          expect(AutofillService["isExcludedField"]).toHaveBeenCalledWith(
+          expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalledWith(
             invalidField,
             AutoFillConstants.ExcludedAutofillTypes,
           );
@@ -2311,7 +2311,7 @@ describe("AutofillService", () => {
         });
         pageDetails.fields = [notViewableField];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedField");
+        jest.spyOn(AutofillService, "isExcludedFieldType");
 
         const value = autofillService["generateCardFillScript"](
           fillScript,
@@ -2321,7 +2321,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(notViewableField);
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalled();
         expect(value).toStrictEqual(unmodifiedFillScriptValues);
       });
     });
@@ -2406,7 +2406,7 @@ describe("AutofillService", () => {
         options.cipher.card.code = "testCode";
         options.cipher.card.brand = "testBrand";
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedField");
+        jest.spyOn(AutofillService, "isExcludedFieldType");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(AutofillService, "hasValue");
@@ -2424,7 +2424,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledTimes(6);
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalledTimes(6);
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalledTimes(6);
         expect(AutofillService["isFieldMatch"]).toHaveBeenCalled();
         expect(autofillService["makeScriptAction"]).toHaveBeenCalledTimes(4);
         expect(AutofillService["hasValue"]).toHaveBeenCalledTimes(6);
@@ -2873,7 +2873,7 @@ describe("AutofillService", () => {
       beforeEach(() => {
         pageDetails.fields = [];
         jest.spyOn(AutofillService, "forCustomFieldsOnly");
-        jest.spyOn(AutofillService, "isExcludedField");
+        jest.spyOn(AutofillService, "isExcludedFieldType");
         jest.spyOn(AutofillService as any, "isFieldMatch");
         jest.spyOn(autofillService as any, "makeScriptAction");
         jest.spyOn(autofillService as any, "makeScriptActionWithValue");
@@ -2891,7 +2891,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(customField);
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });
@@ -2908,7 +2908,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(excludedField);
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalledWith(
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalledWith(
           excludedField,
           AutoFillConstants.ExcludedAutofillTypes,
         );
@@ -2928,7 +2928,7 @@ describe("AutofillService", () => {
         );
 
         expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(viewableField);
-        expect(AutofillService["isExcludedField"]).toHaveBeenCalled();
+        expect(AutofillService["isExcludedFieldType"]).toHaveBeenCalled();
         expect(AutofillService["isFieldMatch"]).not.toHaveBeenCalled();
         expect(value.script).toStrictEqual([]);
       });

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -737,7 +737,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const fillFields: { [id: string]: AutofillField } = {};
 
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillTypes)) {
+      if (AutofillService.isExcludedFieldType(f, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1115,7 +1115,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const fillFields: { [id: string]: AutofillField } = {};
 
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillTypes)) {
+      if (AutofillService.isExcludedFieldType(f, AutoFillConstants.ExcludedAutofillTypes)) {
         return;
       }
 
@@ -1351,7 +1351,7 @@ export default class AutofillService implements AutofillServiceInterface {
     return Boolean(matchFieldAttributeValues.join(" ").match(matchPattern));
   }
 
-  static isExcludedField(field: AutofillField, excludedTypes: string[]) {
+  static isExcludedFieldType(field: AutofillField, excludedTypes: string[]) {
     if (AutofillService.forCustomFieldsOnly(field)) {
       return true;
     }
@@ -1478,6 +1478,44 @@ export default class AutofillService implements AutofillServiceInterface {
     }
   }
 
+  static valueIsLikePassword(value: string) {
+    if (value == null) {
+      return false;
+    }
+    // Removes all whitespace, _ and - characters
+    const cleanedValue = value.toLowerCase().replace(/[\s_-]/g, "");
+
+    if (cleanedValue.indexOf("password") < 0) {
+      return false;
+    }
+
+    if (AutoFillConstants.PasswordFieldExcludeList.some((i) => cleanedValue.indexOf(i) > -1)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  static fieldHasDisqualifyingAttributeValue(field: AutofillField) {
+    const checkedAttributeValues = [field.htmlID, field.htmlName, field.placeholder];
+    let valueIsOnExclusionList = false;
+
+    for (let i = 0; i < checkedAttributeValues.length; i++) {
+      const checkedAttributeValue = checkedAttributeValues[i];
+      const cleanedValue = checkedAttributeValue?.toLowerCase().replace(/[\s_-]/g, "");
+
+      valueIsOnExclusionList = Boolean(
+        cleanedValue && AutoFillConstants.FieldIgnoreList.some((i) => cleanedValue.indexOf(i) > -1),
+      );
+
+      if (valueIsOnExclusionList) {
+        break;
+      }
+    }
+
+    return valueIsOnExclusionList;
+  }
+
   /**
    * Accepts a pageDetails object with a list of fields and returns a list of
    * fields that are likely to be password fields.
@@ -1496,45 +1534,39 @@ export default class AutofillService implements AutofillServiceInterface {
     fillNewPassword: boolean,
   ) {
     const arr: AutofillField[] = [];
+
     pageDetails.fields.forEach((f) => {
-      if (AutofillService.isExcludedField(f, AutoFillConstants.ExcludedAutofillLoginTypes)) {
+      if (AutofillService.isExcludedFieldType(f, AutoFillConstants.ExcludedAutofillLoginTypes)) {
+        return;
+      }
+
+      // If any attribute values match disqualifying values, the entire field should not be used
+      if (AutofillService.fieldHasDisqualifyingAttributeValue(f)) {
         return;
       }
 
       const isPassword = f.type === "password";
-      const valueIsLikePassword = (value: string) => {
-        if (value == null) {
-          return false;
-        }
-        // Removes all whitespace, _ and - characters
-        // eslint-disable-next-line
-        const cleanedValue = value.toLowerCase().replace(/[\s_\-]/g, "");
 
-        if (cleanedValue.indexOf("password") < 0) {
-          return false;
-        }
-
-        if (AutoFillConstants.PasswordFieldIgnoreList.some((i) => cleanedValue.indexOf(i) > -1)) {
-          return false;
-        }
-
-        return true;
-      };
       const isLikePassword = () => {
         if (f.type !== "text") {
           return false;
         }
-        if (valueIsLikePassword(f.htmlID)) {
+
+        if (AutofillService.valueIsLikePassword(f.htmlID)) {
           return true;
         }
-        if (valueIsLikePassword(f.htmlName)) {
+
+        if (AutofillService.valueIsLikePassword(f.htmlName)) {
           return true;
         }
-        if (valueIsLikePassword(f.placeholder)) {
+
+        if (AutofillService.valueIsLikePassword(f.placeholder)) {
           return true;
         }
+
         return false;
       };
+
       if (
         !f.disabled &&
         (canBeReadOnly || !f.readonly) &&
@@ -1546,6 +1578,7 @@ export default class AutofillService implements AutofillServiceInterface {
         arr.push(f);
       }
     });
+
     return arr;
   }
 
@@ -1622,7 +1655,10 @@ export default class AutofillService implements AutofillServiceInterface {
         continue;
       }
 
+      const fieldIsDisqualified = AutofillService.fieldHasDisqualifyingAttributeValue(f);
+
       if (
+        !fieldIsDisqualified &&
         !f.disabled &&
         (canBeReadOnly || !f.readonly) &&
         (withoutForm || f.form === passwordField.form) &&


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix

## Objective

When gathering/finding login fields to fill, we were qualifying fields (in part) by the values of the field attributes. We would then disqualify _attributes_ based on a constant list of values to ignore (e.g. "captcha, "findanything", etc). However, we weren't disqualifying the whole field, so as long as it qualified otherwise (with a later attribute, for example), we'd use it in autofill.

In Paypal's case, they have a field in their login workflow with an `id` value of "splitPasswordCaptcha" and a `placeholder` value of "Enter code" (what ultimately qualifies the field).

![Screenshot 2024-01-16 at 3 36 09 PM](https://github.com/bitwarden/clients/assets/1556494/b5896481-b1b6-461b-8421-29a671db9b8c)

This field would be autofilled with TOTP (when it should be left alone, causing the first step of login to fail with an error (see: https://github.com/bitwarden/clients/issues/5915).

## Code changes

These changes update our logic (in `loadPasswordFields` and `findTotpField`) to properly disqualify the entire field if it has a disqualifying attribute value, so cases like `<input id="captchaforpassword" placeholder="code" />` will no longer autofill.
