### PR TITLE
[PM-5749] Make cipher decryption faster by replacing promise.all in encrypt.service.implementation

### DIFF
--- a/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
+++ b/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
@@ -155,7 +155,12 @@ export class EncryptServiceImplementation implements EncryptService {
       return [];
     }
 
-    return await Promise.all(items.map((item) => item.decrypt(key)));
+    // don't use promise.all because this task is not io bound
+    let results = [];
+    for (let i = 0; i < items.length; i++) {
+      results.push(await items[i].decrypt(key));
+    }
+    return results;
   }
 
   private async aesEncrypt(data: Uint8Array, key: SymmetricCryptoKey): Promise<EncryptedObject> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Another partial fix for https://github.com/bitwarden/clients/issues/1597

When developing https://github.com/bitwarden/clients/pull/6465 I also considered looking at what is bottlenecking the single threaded "decryption" speed when having large (10k+ cipher) vaults, but did not investigate further at the time. When looking at the unlock process in a profiler, the actual decryption did not play a significant role in the unlock time. Instead, there are many smaller overheads here and there (GC's due to many heap allocations, overhead from async await, and others) that cause the slowness during unlock.

This PR addresses one aspect, but there are other gains left to be had.

One small and simple fix is simply replacing a Promise.all with a for loop. While Promise.all would be faster in an io-bound scenario (HTTP requests, Disk access), it is much slower for this type of CPU-bound task. I have validated this over hundreds of runs over decrypting a 10k+ cipher test vault, and replacing Promise.all with a simple for loop ~~speeds "decryption" of the ciphers up by 70-100% (measured inside the worker)~~ (this was in dev mode), speeds up the decryption by **20-30% in prod builds in chrome**, and **50% in Firefox**, with quite some variance.

```
// these numbers are for dev builds, in prod the difference is still there but not as pronounced
// before (in milliseconds)
{
    "Avg": 268.58,
    "Median": 234,
    "Min": 220,
    "Max": 301,
    "Ciphers Per Second Median": 42854.70085470085
}

// after (in milliseconds)
{
    "Avg": 182.25,
    "Median": 144,
    "Min": 138,
    "Max": 295,
    "Ciphers Per Second Median": 69638.88888888889
}
```

Beware when replicating this result to close the browser console during unlock, and measuring over hundreds of test runs, otherwise the results are fairly noisy.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **encrypt.service.implementation.ts**: Replace Promise.all with a for loop for performance (and add a comment explaining this)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
