### PR TITLE
Start of prototype for import selection

### DIFF
--- a/libs/importer/src/components/dialog/import-selection-dialog.component.html
+++ b/libs/importer/src/components/dialog/import-selection-dialog.component.html
@@ -1,0 +1,41 @@
+<form [formGroup]="formGroup" [bitSubmit]="submit">
+  <bit-dialog>
+    <span bitDialogTitle>
+      {{ "Select Import Items" }}
+    </span>
+    <div bitDialogContent>
+      <bit-table [dataSource]="dataSource">
+        <ng-container header>
+          <tr>
+            <th bitCell>
+              <input type="checkbox" bitCheckbox id="checkAll" (change)="toggleAll($event)" />
+            </th>
+            <th bitCell>{{ "type" | i18n }}</th>
+            <th bitCell>{{ "Name" }}</th>
+          </tr>
+        </ng-container>
+        <ng-template body let-rows$>
+          <tr bitRow *ngFor="let r of rows$ | async">
+            <td bitCell>
+              <input
+                type="checkbox"
+                formControlName="importSelection"
+                (change)="this.importItemSelected(r)"
+              />
+            </td>
+            <td bitCell>
+              <i class="bwi bwi-fw bwi-{{ r.icon }}" aria-hidden="true"></i>
+              {{ r.type | i18n }}
+            </td>
+            <td bitCell>{{ r.name }}</td>
+          </tr>
+        </ng-template>
+      </bit-table>
+    </div>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary" bitFormButton type="submit">
+        {{ "save" | i18n }}
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/libs/importer/src/components/dialog/import-selection-dialog.component.ts
+++ b/libs/importer/src/components/dialog/import-selection-dialog.component.ts
@@ -1,0 +1,134 @@
+import { DialogRef, DIALOG_DATA } from "@angular/cdk/dialog";
+import { CommonModule } from "@angular/common";
+import { Component, Inject, OnInit } from "@angular/core";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import {
+  ButtonModule,
+  DialogModule,
+  TableDataSource,
+  TableModule,
+  AsyncActionsModule,
+  FormFieldModule,
+} from "@bitwarden/components";
+
+import { ImportResult } from "../../models";
+
+type SelectImportListItem = {
+  checked?: boolean;
+  index: number;
+  icon: string;
+  type: string;
+  name: string;
+  cipher?: CipherView;
+  folder?: FolderView;
+  collection?: CollectionView;
+};
+
+@Component({
+  templateUrl: "import-selection-dialog.component.html",
+  standalone: true,
+  imports: [
+    CommonModule,
+    JslibModule,
+    DialogModule,
+    FormFieldModule,
+    AsyncActionsModule,
+    TableModule,
+    ButtonModule,
+    ReactiveFormsModule,
+  ],
+})
+export class ImportSelectionDialogComponent implements OnInit {
+  protected dataSource = new TableDataSource<SelectImportListItem>();
+  rows: SelectImportListItem[];
+  protected formGroup = this.formBuilder.group({
+    importSelection: [false],
+  });
+  constructor(
+    public dialogRef: DialogRef,
+    @Inject(DIALOG_DATA) public data: ImportResult,
+    protected formBuilder: FormBuilder,
+  ) {}
+
+  ngOnInit(): void {
+    if (this.data != null) {
+      const rows = this.buildSelectList();
+      this.dataSource.data = rows;
+      this.rows = rows;
+    }
+  }
+
+  private buildSelectList(): SelectImportListItem[] {
+    const list: SelectImportListItem[] = [];
+    this.data.ciphers.map((c, idx) => {
+      switch (c.type) {
+        case CipherType.Login:
+          list.push({ cipher: c, index: idx, icon: "globe", type: "typeLogin", name: c.name });
+          break;
+        case CipherType.Card:
+          list.push({ cipher: c, index: idx, icon: "credit-card", type: "typeCard", name: c.name });
+          break;
+        case CipherType.SecureNote:
+          list.push({
+            cipher: c,
+            index: idx,
+            icon: "sticky-note",
+            type: "typeSecureNote",
+            name: c.name,
+          });
+          break;
+        case CipherType.Identity:
+          list.push({ cipher: c, index: idx, icon: "id-card", type: "typeIdentity", name: c.name });
+          break;
+        default:
+          break;
+      }
+    });
+
+    if (this.data.collections.length > 0) {
+      this.data.collections.map((cl, idx) => {
+        list.push({
+          collection: cl,
+          index: idx,
+          icon: "collection",
+          type: "collections",
+          name: cl.name,
+        });
+      });
+    }
+
+    if (this.data.folders.length > 0) {
+      this.data.folders.map((f, idx) => {
+        list.push({ folder: f, index: idx, icon: "folder", type: "folders", name: f.name });
+      });
+    }
+    return list;
+  }
+
+  toggleAll(event: Event) {
+    this.dataSource.data.forEach((x) => (x.checked = (event.target as HTMLInputElement).checked));
+  }
+
+  importItemSelected(item: SelectImportListItem) {
+    item.checked = !item.checked;
+  }
+
+  submit = async () => {
+    this.formGroup.markAsTouched();
+
+    const importResult = new ImportResult();
+    this.dataSource.data.forEach((x) => {
+      if (x.checked) {
+        importResult.ciphers.push(x.cipher);
+      }
+    });
+
+    this.dialogRef.close(importResult);
+  };
+}

--- a/libs/importer/src/components/dialog/index.ts
+++ b/libs/importer/src/components/dialog/index.ts
@@ -1,3 +1,4 @@
 export * from "./import-error-dialog.component";
 export * from "./import-success-dialog.component";
 export * from "./file-password-prompt.component";
+export * from "./import-selection-dialog.component";

--- a/libs/importer/src/services/import.service.abstraction.ts
+++ b/libs/importer/src/services/import.service.abstraction.ts
@@ -13,6 +13,18 @@ export abstract class ImportServiceAbstraction {
     selectedImportTarget?: string,
     canAccessImportExport?: boolean,
   ) => Promise<ImportResult>;
+  importResults: (
+    importResult: ImportResult,
+    organizationId?: string,
+    selectedImportTarget?: string,
+  ) => Promise<ImportResult>;
+  prepareImport: (
+    importer: Importer,
+    fileContents: string,
+    organizationId?: string,
+    selectedImportTarget?: string,
+    isUserAdmin?: boolean,
+  ) => Promise<ImportResult>;
   getImporter: (
     format: ImportType | "bitwardenpasswordprotected",
     promptForPassword_callback: () => Promise<string>,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When importing the user can select which ciphers they wish to import. 

## Code changes

Adding an import selection dialog and the ability to check off which ciphers to import. 

- **libs/importer/src/components/dialog/import-selection-dialog.component.html:** Dialog to hold the import selection data table
- **libs/importer/src/components/dialog/import-selection-dialog.component.ts:** Component which controls the selection of imported data and the dialog. 
- **libs/importer/src/components/dialog/index.ts:** Adding the new import selection to the index.
- **libs/importer/src/components/import.component.ts:** Breaking up the import logic to prepare the import, open dialog, and to retrieve selected imports from the dialog result. 
- **libs/importer/src/services/import.service.abstraction.ts:** Adding the prepareImport to the service abstraction.
- **libs/importer/src/services/import.service.ts:** Breaking up the import function to prepare and finalize of the import. 


