### PR TITLE
[PM-5792] Bump LSMinimumSystemVersion to 10.15

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -122,7 +122,7 @@
     "entitlementsLoginHelper": "resources/entitlements.mas.loginhelper.plist",
     "hardenedRuntime": false,
     "extendInfo": {
-      "LSMinimumSystemVersion": "10.14.0"
+      "LSMinimumSystemVersion": "10.15.0"
     }
   },
   "nsisWeb": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
With the last release we bumped [Electron to V27](https://github.com/bitwarden/clients/pull/7134). With V27 Electron has [dropped support](https://www.electronjs.org/docs/latest/breaking-changes#removed-macos-1013--1014-support) for MacOs 10.13 and 10.14.
This PR bump the LSMinimumSystemVersion to 10.15 which tells the Mac App Store, that the next release will require 10.15 as a min OS version.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
