### PR TITLE
[PM-5801] refactor(get): define object types as sub commands instead of argument

### DIFF
--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -140,28 +140,37 @@ export class SendProgram extends Program {
   }
 
   private templateCommand(): program.Command {
+    const getInstance = new GetCommand(
+      this.main.cipherService,
+      this.main.folderService,
+      this.main.collectionService,
+      this.main.totpService,
+      this.main.auditService,
+      this.main.cryptoService,
+      this.main.stateService,
+      this.main.searchService,
+      this.main.apiService,
+      this.main.organizationService,
+      this.main.eventCollectionService,
+    );
     return new program.Command("template")
-      .arguments("<object>")
-      .description("Get json templates for send objects", {
-        object: "Valid objects are: send.text, send.file",
-      })
-      .action(async (object) => {
-        const cmd = new GetCommand(
-          this.main.cipherService,
-          this.main.folderService,
-          this.main.collectionService,
-          this.main.totpService,
-          this.main.auditService,
-          this.main.cryptoService,
-          this.main.stateService,
-          this.main.searchService,
-          this.main.apiService,
-          this.main.organizationService,
-          this.main.eventCollectionService,
-        );
-        const response = await cmd.run("template", object, null);
-        this.processResponse(response);
-      });
+      .description("Get json templates for send objects")
+      .addCommand(
+        new program.Command("send.text")
+          .description("Get json template for send.text object")
+          .action(async () => {
+            const response = await getInstance.getTemplate("send.text");
+            this.processResponse(response);
+          }),
+      )
+      .addCommand(
+        new program.Command("send.file")
+          .description("Get json template for send.file object")
+          .action(async () => {
+            const response = await getInstance.getTemplate("send.file");
+            this.processResponse(response);
+          }),
+      );
   }
 
   private getCommand(): program.Command {

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -141,7 +141,7 @@ export class VaultProgram extends Program {
     );
 
     const template = new program.Command("template")
-      .description("Get an template from the vault.")
+      .description("Get a template for create or update.")
       .on("--help", () => {
         writeLn("");
         writeLn("  Examples:");
@@ -200,7 +200,7 @@ export class VaultProgram extends Program {
       })
       .addCommand(
         new program.Command("item")
-          .description("Get an object from the vault.", {
+          .description("Get an item from the vault.", {
             id: "Search term or items's globally unique `id`.",
           })
           .on("--help", () => {
@@ -219,7 +219,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("username")
-          .description("Get an object from the vault.", {
+          .description("Get an items username from the vault.", {
             id: "Search term or username's globally unique `id`.",
           })
           .arguments("<id>")
@@ -238,7 +238,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("password")
-          .description("Get an object from the vault.", {
+          .description("Get an items password from the vault.", {
             id: "Search url or password's globally unique `id`.",
           })
           .arguments("<search>")
@@ -258,7 +258,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("uri")
-          .description("Get an object from the vault.", {
+          .description("Get an items uri from the vault.", {
             id: "Search term or uri's globally unique `id`.",
           })
           .arguments("<id>")
@@ -277,7 +277,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("totp")
-          .description("Get an object from the vault.", {
+          .description("Get an items totp from the vault.", {
             id: "Search term or totp's globally unique `id`.",
           })
           .arguments("<id>")
@@ -297,7 +297,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("notes")
-          .description("Get an object from the vault.", {
+          .description("Get an items notes from the vault.", {
             id: "Search term or notes's globally unique `id`.",
           })
           .arguments("<id>")
@@ -317,7 +317,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("exposed")
-          .description("Get an object from the vault.", {
+          .description("Get exposed for an item in the vault.", {
             id: "Search term or exposed's globally unique `id`.",
           })
           .arguments("<id>")
@@ -397,7 +397,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("folder")
-          .description("Get an folder from the vault.", {
+          .description("Get a folder from the vault.", {
             id: "Search term or folder's globally unique `id`.",
           })
           .arguments("<id>")
@@ -417,7 +417,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("collection")
-          .description("Get an collection from the vault.", {
+          .description("Get a collection from the vault.", {
             id: "Search term or collection's globally unique `id`.",
           })
           .arguments("<id>")
@@ -436,7 +436,7 @@ export class VaultProgram extends Program {
       )
       .addCommand(
         new program.Command("organization")
-          .description("Get an organization from the vault.", {
+          .description("Get a organization from the vault.", {
             id: "Search term or organization's globally unique `id`.",
           })
           .arguments("<id>")
@@ -456,7 +456,7 @@ export class VaultProgram extends Program {
       .addCommand(template)
       .addCommand(
         new program.Command("fingerprint")
-          .description("Get an fingerprint from the vault.", {
+          .description("Get a fingerprint from the vault.", {
             id: "Search term or fingerprint's globally unique `id`.",
           })
           .arguments("<id>")


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

- **better help output for get sub-commands**
- **better completion on ZSH for get sub-commands**

Currently, the help of the different get sub commands is inaccurate and does not meet the facts.

When I make:

```sh
$ bw get item --help
Usage: bw get [options] <object> <id>

Get an object from the vault.

Arguments:
  object                             Valid objects are: item, username, password, uri, totp, notes, exposed, attachment, folder, collection, org-collection, organization, template, fingerprint, send
  id                                 Search term or object's globally unique `id`.

Options:
  --itemid <itemid>                  Attachment's item id.
  --output <output>                  Output directory or filename for attachment.
  --organizationid <organizationid>  Organization id for an organization object.
...
```
But the itemid, output, and organizationid options are not relevant for this, and the implementation will simply ignore them.

This has also implications for the ZSH completion:

```sh
$ $ bw get item -
--help            -h  -- output usage information
--itemid              -- Attachment's item id.
--organizationid      -- Organization id for an organization object.
--output              -- Output directory or filename for attachment.
```

### The new help output is more specific

And the output of `bw completion --shell zsh` will be more useful as well.

```sh
$ bw get --help
Usage: bw get [options] [command]

Get an object from the vault.

Options:
  -h, --help                     display help for command

Commands:
  item <id>                      Get an object from the vault.
  username <id>                  Get an object from the vault.
  password <search>              Get an object from the vault.
  uri <id>                       Get an object from the vault.
  totp <id>                      Get an object from the vault.
  notes <id>                     Get an object from the vault.
  exposed <id>                   Get an object from the vault.
  attachment [options] <id>      Get an attachment from the vault.
  org-collection [options] <id>  Get an org-collection from the vault.
  folder <id>                    Get an folder from the vault.
  collection <id>                Get an collection from the vault.
  organization <id>              Get an organization from the vault.
  template                       Get an template from the vault.
  fingerprint <id>               Get an fingerprint from the vault.
  help [command]                 display help for command
```

And the subcommands show specific helps:

```sh
$ bw get item --help
Usage: bw get item [options] <id>

Get an object from the vault.

Arguments:
  id          Search term or items's globally unique `id`.

Options:
  -h, --help  display help for command

  Examples:

    bw get item 99ee88d2-6046-4ea7-92c2-acac464b1412
$ bw get attachment --help
Usage: bw get attachment [options] <id>

Get an attachment from the vault.

Arguments:
  id                 Search term or attachment's globally unique `id`.

Options:
  --itemid <itemid>  Attachment's item id.
  --output <output>  Output directory or filename for attachment.
  -h, --help         display help for command

  If raw output is specified and no output filename or directory is given for
  an attachment query, the attachment content is written to stdout.

  Examples:

    bw get attachment b857igwl1dzrs2 --itemid 99ee88d2-6046-4ea7-92c2-acac464b1412 --output ./photo.jpg
    bw get attachment photo.jpg --itemid 99ee88d2-6046-4ea7-92c2-acac464b1412 --raw
$ bw get template --help
Usage: bw get template [options] [command]

Get an template from the vault.

Options:
  -h, --help        display help for command

Commands:
  item              Get a item template.
  item.field        Get a item.field template.
  item.login        Get a item.login template.
  item.login.uri    Get a item.login.uri template.
  item.card         Get a item.card template.
  item.identity     Get a item.identity template.
  item.securenote   Get a item.securenote template.
  folder            Get a folder template.
  collection        Get a collection template.
  item-collections  Get a item-collections template.
  org-collection    Get a org-collection template.
  send.text         Get a send.text template.
  send.file         Get a send.file template.
  help [command]    display help for command

  Examples:

    bw get template item
    bw get template item.field
    bw get template item.login
    bw get template item.login.uri
    bw get template item.card
    bw get template item.identity
    bw get template item.securenote
    bw get template folder
    bw get template collection
    bw get template item-collections
    bw get template org-collection
    bw get template send.text
    bw get template send.file
```



## Code changes

The actual implementation of the methods has not really been changed. Only the commander wrapping of the commands is now different.

### apps/cli/src/commands/get.command.ts

- the command methods had to be turned public, so I could create the commands in apps/cli/src/vault.program.ts
- removed the Options class, in favor of more explicit argument types on the methods, containing only the properties the method needs
- define readonly constant `templateIds` for programmatic template sub-sub command definitions

### apps/cli/src/vault.program.ts

Refactor the getCommand() method to implement the former getObjects arguments as commands.

### apps/cli/src/tools/send/send.program.ts

Refactor the templateCommand() method to implement the former send.text, send.file argument as subcommands.

This allows also better help and better zsh completion.
