### PR TITLE
[PM-5810] Prevent leaking password fields after toggling visibility

### DIFF
--- a/apps/browser/src/auth/popup/components/set-pin.component.html
+++ b/apps/browser/src/auth/popup/components/set-pin.component.html
@@ -9,7 +9,13 @@
       </p>
       <bit-form-field>
         <bit-label>{{ "pin" | i18n }}</bit-label>
-        <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
+        <input
+          class="tw-font-mono"
+          bitInput
+          appInputVerbatim
+          type="password"
+          formControlName="pin"
+        />
         <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
       </bit-form-field>
       <label class="tw-flex tw-items-start tw-gap-2" *ngIf="showMasterPassOnRestart">

--- a/apps/desktop/src/auth/components/set-pin.component.html
+++ b/apps/desktop/src/auth/components/set-pin.component.html
@@ -9,7 +9,13 @@
       </p>
       <bit-form-field>
         <bit-label>{{ "pin" | i18n }}</bit-label>
-        <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
+        <input
+          class="tw-font-mono"
+          bitInput
+          appInputVerbatim
+          type="password"
+          formControlName="pin"
+        />
         <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
       </bit-form-field>
       <label class="tw-flex tw-items-start tw-gap-2" *ngIf="showMasterPassOnRestart">

--- a/apps/web/src/app/auth/login/login.component.html
+++ b/apps/web/src/app/auth/login/login.component.html
@@ -82,6 +82,7 @@
                 id="login_input_master-password"
                 type="password"
                 bitInput
+                appInputVerbatim
                 #masterPasswordInput
                 formControlName="masterPassword"
               />

--- a/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.html
+++ b/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.html
@@ -21,6 +21,7 @@
           <input
             id="masterPassword"
             bitInput
+            appInputVerbatim
             type="password"
             formControlName="masterPassword"
             appAutofocus

--- a/apps/web/src/app/auth/register-form/register-form.component.html
+++ b/apps/web/src/app/auth/register-form/register-form.component.html
@@ -38,6 +38,7 @@
         <input
           id="register-form_input_master-password"
           bitInput
+          appInputVerbatim
           type="password"
           formControlName="masterPassword"
         />
@@ -69,6 +70,7 @@
         <input
           id="register-form_input_confirm-master-password"
           bitInput
+          appInputVerbatim
           type="password"
           formControlName="confirmMasterPassword"
         />

--- a/apps/web/src/app/auth/settings/account/change-email.component.html
+++ b/apps/web/src/app/auth/settings/account/change-email.component.html
@@ -9,6 +9,7 @@
       <input
         id="change-email_input_masterPassword"
         bitInput
+        appInputVerbatim
         type="password"
         formControlName="masterPassword"
       />

--- a/apps/web/src/app/auth/settings/emergency-access/takeover/emergency-access-takeover.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/takeover/emergency-access-takeover.component.html
@@ -14,6 +14,7 @@
             <bit-label>{{ "newMasterPass" | i18n }}</bit-label>
             <input
               bitInput
+              appInputVerbatim
               type="password"
               autocomplete="new-password"
               formControlName="masterPassword"
@@ -33,6 +34,7 @@
             <bit-label>{{ "confirmNewMasterPass" | i18n }}</bit-label>
             <input
               bitInput
+              appInputVerbatim
               type="password"
               autocomplete="new-password"
               formControlName="masterPasswordRetype"

--- a/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.html
+++ b/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.html
@@ -23,6 +23,7 @@
               required
               formControlName="masterPassword"
               appAutofocus
+              appInputVerbatim
             />
             <button
               type="button"

--- a/apps/web/src/app/tools/generator.component.html
+++ b/apps/web/src/app/tools/generator.component.html
@@ -300,6 +300,7 @@
             type="password"
             [(ngModel)]="usernameOptions.forwardedSimpleLoginApiKey"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
         <div class="form-group col-4" *ngIf="isSelfHosted">
@@ -324,6 +325,7 @@
             name="DuckDuckGoApiKey"
             [(ngModel)]="usernameOptions.forwardedDuckDuckGoToken"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
       </div>
@@ -336,6 +338,7 @@
             type="password"
             [(ngModel)]="usernameOptions.forwardedAnonAddyApiToken"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
         <div class="form-group col-4">
@@ -369,6 +372,7 @@
             type="password"
             [(ngModel)]="usernameOptions.forwardedFirefoxApiToken"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
       </div>
@@ -381,6 +385,7 @@
             type="password"
             [(ngModel)]="usernameOptions.forwardedFastmailApiToken"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
       </div>
@@ -393,6 +398,7 @@
             type="password"
             [(ngModel)]="usernameOptions.forwardedForwardEmailApiToken"
             (blur)="saveUsernameOptions()"
+            appInputVerbatim
           />
         </div>
         <div class="form-group col-4">

--- a/apps/web/src/app/tools/send/add-edit.component.html
+++ b/apps/web/src/app/tools/send/add-edit.component.html
@@ -227,7 +227,7 @@
             <bit-label for="password" *ngIf="!hasPassword">{{ "password" | i18n }}</bit-label>
             <bit-label for="password" *ngIf="hasPassword">{{ "newPassword" | i18n }}</bit-label>
 
-            <input bitInput type="password" formControlName="password" />
+            <input bitInput appInputVerbatim type="password" formControlName="password" />
             <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
             <bit-hint>{{ "sendPasswordDesc" | i18n }}</bit-hint>
           </bit-form-field>

--- a/apps/web/src/app/tools/vault-export/export.component.html
+++ b/apps/web/src/app/tools/vault-export/export.component.html
@@ -65,6 +65,7 @@
             <bit-label>{{ "filePassword" | i18n }}</bit-label>
             <input
               bitInput
+              appInputVerbatim
               type="password"
               id="filePassword"
               formControlName="filePassword"
@@ -86,6 +87,7 @@
           <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>
           <input
             bitInput
+            appInputVerbatim
             type="password"
             id="confirmFilePassword"
             formControlName="confirmFilePassword"

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.html
@@ -50,6 +50,7 @@
     <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
     <input
       bitInput
+      appInputVerbatim
       [type]="showScimKey ? 'text' : 'password'"
       formControlName="clientSecret"
       id="clientSecret"

--- a/libs/angular/src/directives/input-verbatim.directive.ts
+++ b/libs/angular/src/directives/input-verbatim.directive.ts
@@ -20,10 +20,10 @@ export class InputVerbatimDirective {
       this.renderer.setAttribute(this.el.nativeElement, "autocomplete", "off");
     }
     if (!this.el.nativeElement.hasAttribute("autocapitalize")) {
-      this.renderer.setAttribute(this.el.nativeElement, "autocapitalize", "none");
+      this.renderer.setAttribute(this.el.nativeElement, "autocapitalize", "off");
     }
     if (!this.el.nativeElement.hasAttribute("autocorrect")) {
-      this.renderer.setAttribute(this.el.nativeElement, "autocorrect", "none");
+      this.renderer.setAttribute(this.el.nativeElement, "autocorrect", "off");
     }
     if (!this.el.nativeElement.hasAttribute("spellcheck")) {
       this.renderer.setAttribute(this.el.nativeElement, "spellcheck", "false");

--- a/libs/components/src/form-field/password-input-toggle.directive.ts
+++ b/libs/components/src/form-field/password-input-toggle.directive.ts
@@ -64,7 +64,6 @@ export class BitPasswordInputToggleDirective implements AfterContentInit, OnChan
     this.button.icon = this.icon;
     if (this.formField.input?.type != null) {
       this.formField.input.type = this.toggled ? "text" : "password";
-      this.formField.input.spellcheck = this.toggled ? false : undefined;
     }
   }
 }

--- a/libs/components/src/form-field/password-input-toggle.spec.ts
+++ b/libs/components/src/form-field/password-input-toggle.spec.ts
@@ -20,7 +20,7 @@ import { BitPasswordInputToggleDirective } from "./password-input-toggle.directi
     <form>
       <bit-form-field>
         <bit-label>Password</bit-label>
-        <input bitInput type="password" />
+        <input bitInput appInputVerbatim type="password" />
         <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
       </bit-form-field>
     </form>
@@ -69,7 +69,7 @@ describe("PasswordInputToggle", () => {
     });
 
     it("spellcheck is disabled", () => {
-      expect(input.spellcheck).toBe(undefined);
+      expect(input.spellcheck).toBe(false);
     });
   });
 
@@ -106,7 +106,7 @@ describe("PasswordInputToggle", () => {
     });
 
     it("spellcheck is disabled", () => {
-      expect(input.spellcheck).toBe(undefined);
+      expect(input.spellcheck).toBe(false);
     });
   });
 });

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
@@ -80,7 +80,7 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
             <i class="bwi bwi-question-circle"></i>
           </button>
         </bit-label>
-        <input bitInput type="password" formControlName="password" />
+        <input bitInput appInputVerbatim type="password" formControlName="password" />
         <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
       </bit-form-field>
 

--- a/libs/vault/src/components/password-reprompt.component.html
+++ b/libs/vault/src/components/password-reprompt.component.html
@@ -11,6 +11,7 @@
         <input
           bitInput
           appAutofocus
+          appInputVerbatim
           id="masterPassword"
           type="password"
           formControlName="masterPassword"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Mainly don't write master password to user's disk when they click "Toggle visibility" at https://vault.bitwarden.com/#/login .

## Code changes

https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#credential-and-personally-identifiable-information-pii-input-hints

Browsers write toggled input fields to userdata in plain text unless `autocomplete="off"`. Some send them to cloud spellcheckers. `appInputVerbatim` by default disables those behaviors, but it was missing on some password fields.

- **\*.html** Added appInputVerbatim to password fields
- **input-verbatim.directive.ts** `autocorrect="none"` was invalid https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocorrect
- **password-input-toggle.directive.ts** I'm not sure what `spellcheck=undefined` was trying to achieve. Tests say "spellcheck is disabled" for both `false` and `undefined`, but `undefined` depends on browser defaults. So in combination with `appInputVerbatim` it would just re-enable spellchecker in a few cases.

Missing changes (please take over):
- I kept autocomplete="new-password" as is, despite the risk. Maybe you're using it as an important feature.
- Usage in storybooks, tests, and generator.component.html
- Ensuring `appInputVerbatim` is present on togglable password fields. Could do something like the following, but not all togglable password inputs use it (search `? 'text' : 'password'` for others)
  ```diff
  bitPasswordInputToggle
    ngAfterContentInit(): void {
      this.toggled = this.formField.input.type !== "password";
      this.button.icon = this.icon;
  
  +    if (this.formField.input.autocomplete !== 'off') {
  +      // https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#credential-and-personally-identifiable-information-pii-input-hints
  +      // Note: Toggled <input type="text" autocomplete="new-password"> also gets written to disk.
  +      console.error('Insecure: missing appInputVerbatim on a togglable password input', this)
  +    }
    }
  ```

Alternative approach:
- Remove appInputVerbatim from password fields, copy its functionality into `bitPasswordInputToggle`, and consistently use it for all toggles

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
