### PR TITLE
Rename Duo Redirect Query Param

### DIFF
--- a/apps/web/src/connectors/duo-redirect.ts
+++ b/apps/web/src/connectors/duo-redirect.ts
@@ -6,7 +6,7 @@ const mobileDesktopCallback = "bitwarden://duo-callback";
 
 window.addEventListener("load", () => {
   const client = getQsParam("client");
-  const code = getQsParam("duo_code");
+  const code = getQsParam("code");
 
   if (client === "browser" || client === "web") {
     const channel = new BroadcastChannel("duoResult");


### PR DESCRIPTION
## Type of change

- Bug fix


## Objective

Changes `duo_code` param to `code`. I tested this the same way as shown in https://github.com/bitwarden/clients/pull/7594