### PR TITLE
[PM-5806] Remove the Inline Auto-fill Menu From `textarea` Fields

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -65,6 +65,11 @@ export class AutoFillConstants {
     "checkbox",
     ...AutoFillConstants.ExcludedAutofillLoginTypes,
   ];
+
+  static readonly ExcludedOverlayTypes: string[] = [
+    "textarea",
+    ...AutoFillConstants.ExcludedAutofillTypes,
+  ];
 }
 
 export class CreditCardAutoFillConstants {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -195,8 +195,8 @@ describe("AutofillOverlayContentService", () => {
         expect(autofillFieldElement.addEventListener).not.toHaveBeenCalled();
       });
 
-      it("ignores fields that are part of the ExcludedAutofillTypes", () => {
-        AutoFillConstants.ExcludedAutofillTypes.forEach((excludedType) => {
+      it("ignores fields that are part of the ExcludedOverlayTypes", () => {
+        AutoFillConstants.ExcludedOverlayTypes.forEach((excludedType) => {
           autofillFieldData.type = excludedType;
 
           autofillOverlayContentService.setupAutofillOverlayListenerOnField(
@@ -206,17 +206,6 @@ describe("AutofillOverlayContentService", () => {
 
           expect(autofillFieldElement.addEventListener).not.toHaveBeenCalled();
         });
-      });
-
-      it("ignores fields that have a input type of `textarea`", () => {
-        autofillFieldData.type = "textarea";
-
-        autofillOverlayContentService.setupAutofillOverlayListenerOnField(
-          autofillFieldElement,
-          autofillFieldData,
-        );
-
-        expect(autofillFieldElement.addEventListener).not.toHaveBeenCalled();
       });
 
       it("ignores fields that contain the keyword `search`", () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -208,6 +208,17 @@ describe("AutofillOverlayContentService", () => {
         });
       });
 
+      it("ignores fields that have a input type of `textarea`", () => {
+        autofillFieldData.type = "textarea";
+
+        autofillOverlayContentService.setupAutofillOverlayListenerOnField(
+          autofillFieldElement,
+          autofillFieldData,
+        );
+
+        expect(autofillFieldElement.addEventListener).not.toHaveBeenCalled();
+      });
+
       it("ignores fields that contain the keyword `search`", () => {
         autofillFieldData.placeholder = "search";
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -32,10 +32,7 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
   private readonly findTabs = tabbable;
   private readonly sendExtensionMessage = sendExtensionMessage;
   private formFieldElements: Set<ElementWithOpId<FormFieldElement>> = new Set([]);
-  private ignoredFieldTypes: Set<string> = new Set([
-    ...AutoFillConstants.ExcludedAutofillTypes,
-    "textarea",
-  ]);
+  private ignoredFieldTypes: Set<string> = new Set(AutoFillConstants.ExcludedOverlayTypes);
   private userFilledFields: Record<string, FillableFormFieldElement> = {};
   private authStatus: AuthenticationStatus;
   private focusableElements: FocusableElement[] = [];

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -32,6 +32,10 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
   private readonly findTabs = tabbable;
   private readonly sendExtensionMessage = sendExtensionMessage;
   private formFieldElements: Set<ElementWithOpId<FormFieldElement>> = new Set([]);
+  private ignoredFieldTypes: Set<string> = new Set([
+    ...AutoFillConstants.ExcludedAutofillTypes,
+    "textarea",
+  ]);
   private userFilledFields: Record<string, FillableFormFieldElement> = {};
   private authStatus: AuthenticationStatus;
   private focusableElements: FocusableElement[] = [];
@@ -715,12 +719,11 @@ class AutofillOverlayContentService implements AutofillOverlayContentServiceInte
    * @param autofillFieldData - Autofill field data captured from the form field element.
    */
   private isIgnoredField(autofillFieldData: AutofillField): boolean {
-    const ignoredFieldTypes = new Set(AutoFillConstants.ExcludedAutofillTypes);
     if (
       autofillFieldData.readonly ||
       autofillFieldData.disabled ||
       !autofillFieldData.viewable ||
-      ignoredFieldTypes.has(autofillFieldData.type) ||
+      this.ignoredFieldTypes.has(autofillFieldData.type) ||
       this.keywordsFoundInFieldData(autofillFieldData, ["search", "captcha"])
     ) {
       return true;

--- a/clients.code-workspace
+++ b/clients.code-workspace
@@ -51,7 +51,7 @@
       "libs",
       "web vault",
       "web vault (bit)",
-      "root"
+      "root",
     ],
     "jest.jestCommandLine": "npx jest",
     "angular.enable-strict-mode-prompt": false,


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

An [issue was identified](https://github.com/bitwarden/clients/issues/7628) where the inline auto-fill menu can display on `textarea` input fields, even if those fields are not fillable. This behavior on the prod version of the extension can be seen on https://translate.google.com by adding the word `email` to the field. 

This issue presents as a bit more of a nuanced concern, especially when it comes to the fact that we do allow `textarea` fields to be captured within the collect process. By default, we do not fill these `textarea` fields, however. To fill these, a user would have to add a custom element to their cipher, and at that point we qualify it as a fillable field. 

Because of that, for the moment I'm making the decision to move forward with ignoring `textarea` fields with the autofill menu. We can revisit this train of thought at a later time when time permits, but for the moment this makes sense to incorporate.

This PR resolves https://github.com/bitwarden/clients/issues/7628.

## Code changes

- **apps/browser/src/autofill/services/autofill-constants.ts:** Adding a new constant that defines the types of fields that disqualify the setup of the autofill overlay.
- **apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts:** Adding a test that validates that `textarea` fields are treated as an ignored field by the `AutofillOverlayContentService`.
- **apps/browser/src/autofill/services/autofill-overlay-content.service.ts:** Adding `textarea` type to the list of disallowed field types. 
- **clients.code-workspace:** Fixing a linter error
