### PR TITLE
[PM-5740] Update the `LocalBackSessionStorageService` class to ensure that it updates the data for its observables

### DIFF
--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -71,8 +71,10 @@ export class LocalBackedSessionStorageService extends AbstractMemoryStorageServi
   async save<T>(key: string, obj: T): Promise<void> {
     if (obj == null) {
       this.cache.delete(key);
+      this.updatesSubject.next({ key, updateType: "remove" });
     } else {
       this.cache.set(key, obj);
+      this.updatesSubject.next({ key, updateType: "save" });
     }
 
     const sessionEncKey = await this.getSessionEncKey();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This is an mv3 specific fix, and does not affect manifest v2 in any regard.

The changes in this ticket fixes an issue with the `LocalBackedSessionStorageService` that does not trigger updates within the `updatesSubject` observable. 

Fixing this allows the vault popup to load and show account data. It does not resolve all issues present within the vault, but is an important fix to ensure we can load the popup as expected.

## Code changes

- **apps/browser/src/platform/services/local-backed-session-storage.service.ts:** Adding a set of `.next` references to the `updatesSubject` to ensure propagation of local storage affects other observables.