### PR TITLE
Bugfix - Handle access on undefined cipher properties

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -508,8 +508,8 @@ export class AddEditComponent implements OnInit, OnDestroy {
 
   resetMaskState() {
     // toggle masks off for maskable login properties with no value on init/load
-    this.showTotpSeed = !this.cipher.login?.totp;
-    this.showPassword = !this.cipher.login?.password;
+    this.showTotpSeed = !this.cipher?.login?.totp;
+    this.showPassword = !this.cipher?.login?.password;
   }
 
   togglePassword() {


### PR DESCRIPTION

## Type of change

- Bug fix

## Objective

When creating a new cipher, the view errors on access to the `login` property of `cipher`:

![Screenshot 2024-01-24 at 11 14 47 AM](https://github.com/bitwarden/clients/assets/1556494/ddbef232-44a8-44dd-bf86-885812992a87)

## Code changes

- added optional chaining for `cipher` for cases where it is undefined
