### PR TITLE
[PM-5842] add firefox relay forwarder

### DIFF
--- a/libs/common/src/tools/generator/username/forwarders/firefox-relay.spec.ts
+++ b/libs/common/src/tools/generator/username/forwarders/firefox-relay.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * include Request in test environment.
+ * @jest-environment ../../../../shared/test.environment.ts
+ */
+import { Forwarders } from "../options/constants";
+
+import { FirefoxRelayForwarder } from "./firefox-relay";
+import { mockApiService, mockI18nService } from "./mocks.jest";
+
+describe("Firefox Relay Forwarder", () => {
+  describe("generate(string | null, SelfHostedApiOptions & EmailDomainOptions)", () => {
+    it.each([null, ""])("throws an error if the token is missing (token = %p)", async (token) => {
+      const apiService = mockApiService(200, {});
+      const i18nService = mockI18nService();
+
+      const forwarder = new FirefoxRelayForwarder(apiService, i18nService);
+
+      await expect(
+        async () =>
+          await forwarder.generate(null, {
+            token,
+          }),
+      ).rejects.toEqual("forwaderInvalidToken");
+
+      expect(apiService.nativeFetch).not.toHaveBeenCalled();
+      expect(i18nService.t).toHaveBeenCalledWith(
+        "forwaderInvalidToken",
+        Forwarders.FirefoxRelay.name,
+      );
+    });
+
+    it.each([
+      ["forwarderGeneratedByWithWebsite", "provided", "bitwarden.com", "bitwarden.com"],
+      ["forwarderGeneratedByWithWebsite", "provided", "httpbin.org", "httpbin.org"],
+      ["forwarderGeneratedBy", "not provided", null, ""],
+      ["forwarderGeneratedBy", "not provided", "", ""],
+    ])(
+      "describes the website with %p when the website is %s (= %p)",
+      async (translationKey, _ignored, website, expectedWebsite) => {
+        const apiService = mockApiService(200, {});
+        const i18nService = mockI18nService();
+
+        const forwarder = new FirefoxRelayForwarder(apiService, i18nService);
+
+        await forwarder.generate(website, {
+          token: "token",
+        });
+
+        // counting instances is terribly flaky over changes, but jest doesn't have a better way to do this
+        expect(i18nService.t).toHaveBeenCalledWith(translationKey, expectedWebsite);
+      },
+    );
+
+    it.each([
+      ["jane.doe@duck.com", 201],
+      ["john.doe@duck.com", 201],
+      ["jane.doe@duck.com", 200],
+      ["john.doe@duck.com", 200],
+    ])(
+      "returns the generated email address (= %p) if the request is successful (status = %p)",
+      async (full_address, status) => {
+        const apiService = mockApiService(status, { full_address });
+        const i18nService = mockI18nService();
+
+        const forwarder = new FirefoxRelayForwarder(apiService, i18nService);
+
+        const result = await forwarder.generate(null, {
+          token: "token",
+        });
+
+        expect(result).toEqual(full_address);
+        expect(apiService.nativeFetch).toHaveBeenCalledWith(expect.any(Request));
+      },
+    );
+
+    it("throws an invalid token error if the request fails with a 401", async () => {
+      const apiService = mockApiService(401, {});
+      const i18nService = mockI18nService();
+
+      const forwarder = new FirefoxRelayForwarder(apiService, i18nService);
+
+      await expect(
+        async () =>
+          await forwarder.generate(null, {
+            token: "token",
+          }),
+      ).rejects.toEqual("forwaderInvalidToken");
+
+      expect(apiService.nativeFetch).toHaveBeenCalledWith(expect.any(Request));
+      // counting instances is terribly flaky over changes, but jest doesn't have a better way to do this
+      expect(i18nService.t).toHaveBeenNthCalledWith(
+        2,
+        "forwaderInvalidToken",
+        Forwarders.FirefoxRelay.name,
+      );
+    });
+
+    it.each([100, 202, 300, 418, 500, 600])(
+      "throws an unknown error if the request returns any other status code (= %i)",
+      async (statusCode) => {
+        const apiService = mockApiService(statusCode, {});
+        const i18nService = mockI18nService();
+
+        const forwarder = new FirefoxRelayForwarder(apiService, i18nService);
+
+        await expect(
+          async () =>
+            await forwarder.generate(null, {
+              token: "token",
+            }),
+        ).rejects.toEqual("forwarderUnknownError");
+
+        expect(apiService.nativeFetch).toHaveBeenCalledWith(expect.any(Request));
+        // counting instances is terribly flaky over changes, but jest doesn't have a better way to do this
+        expect(i18nService.t).toHaveBeenNthCalledWith(
+          2,
+          "forwarderUnknownError",
+          Forwarders.FirefoxRelay.name,
+        );
+      },
+    );
+  });
+});

--- a/libs/common/src/tools/generator/username/forwarders/firefox-relay.ts
+++ b/libs/common/src/tools/generator/username/forwarders/firefox-relay.ts
@@ -1,0 +1,57 @@
+import { ApiService } from "../../../../abstractions/api.service";
+import { I18nService } from "../../../../platform/abstractions/i18n.service";
+import { Forwarders } from "../options/constants";
+import { Forwarder, ApiOptions } from "../options/forwarder-options";
+
+/** Generates a forwarding address for Firefox Relay */
+export class FirefoxRelayForwarder implements Forwarder {
+  /** Instantiates the forwarder
+   *  @param apiService used for ajax requests to the forwarding service
+   *  @param i18nService used to look up error strings
+   */
+  constructor(
+    private apiService: ApiService,
+    private i18nService: I18nService,
+  ) {}
+
+  /** {@link Forwarder.generate} */
+  async generate(website: string | null, options: ApiOptions): Promise<string> {
+    if (!options.token || options.token === "") {
+      const error = this.i18nService.t("forwaderInvalidToken", Forwarders.FirefoxRelay.name);
+      throw error;
+    }
+
+    const url = "https://relay.firefox.com/api/v1/relayaddresses/";
+
+    const descriptionId =
+      website && website !== "" ? "forwarderGeneratedByWithWebsite" : "forwarderGeneratedBy";
+    const description = this.i18nService.t(descriptionId, website ?? "");
+
+    const request = new Request(url, {
+      redirect: "manual",
+      cache: "no-store",
+      method: "POST",
+      headers: new Headers({
+        Authorization: "Token " + options.token,
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        enabled: true,
+        generated_for: website,
+        description,
+      }),
+    });
+
+    const response = await this.apiService.nativeFetch(request);
+    if (response.status === 401) {
+      const error = this.i18nService.t("forwaderInvalidToken", Forwarders.FirefoxRelay.name);
+      throw error;
+    } else if (response.status === 200 || response.status === 201) {
+      const json = await response.json();
+      return json?.full_address;
+    } else {
+      const error = this.i18nService.t("forwarderUnknownError", Forwarders.FirefoxRelay.name);
+      throw error;
+    }
+  }
+}

--- a/libs/common/src/tools/generator/username/forwarders/firefox-relay.ts
+++ b/libs/common/src/tools/generator/username/forwarders/firefox-relay.ts
@@ -48,7 +48,7 @@ export class FirefoxRelayForwarder implements Forwarder {
       throw error;
     } else if (response.status === 200 || response.status === 201) {
       const json = await response.json();
-      return json?.full_address;
+      return json.full_address;
     } else {
       const error = this.i18nService.t("forwarderUnknownError", Forwarders.FirefoxRelay.name);
       throw error;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective


* Internationalize error strings
* Introduce structural options
* Reduce cyclomatic complexity (It's still high, but lower than the legacy forwarder.)

Split from https://github.com/bitwarden/clients/pull/6924. 
These changes do not require QA testing; they are not yet consumed by external code.
These changes omit i18n messages; those will be included in a later PR.

## Code changes

* `libs/common/src/tools/generator/username/forwarders/firefox-relay.spec.ts` - unit tests
* `libs/common/src/tools/generator/username/forwarders/firefox-relay.ts` - replacement forwarder for `libs/common/src/tools/generator/username/email-forwarders/firefox-relay-forwarder.ts`