### PR TITLE
[AC-2071] Fix bulk collection access API call

### DIFF
--- a/apps/web/src/app/vault/core/collection-admin.service.ts
+++ b/apps/web/src/app/vault/core/collection-admin.service.ts
@@ -91,7 +91,7 @@ export class CollectionAdminService {
 
     await this.apiService.send(
       "POST",
-      `organizations/${organizationId}/collections/bulk-access`,
+      `/organizations/${organizationId}/collections/bulk-access`,
       request,
       true,
       false,

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -55,7 +55,9 @@
         [cloneableOrganizationCiphers]="true"
         [showAdminActions]="true"
         (onEvent)="onVaultItemsEvent($event)"
-        [showBulkEditCollectionAccess]="showBulkEditCollectionAccess$ | async"
+        [showBulkEditCollectionAccess]="
+          (showBulkEditCollectionAccess$ | async) && organization?.flexibleCollections
+        "
         [viewingOrgVault]="true"
       >
       </app-vault-items>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We were missing a forward slash at the start of the bulk collection access URL. This wasn't a problem locally, but when deploying to a QA cloud environment it means the POST request is sent to `/apiorganizations/collections/bulk-access`.

I also noticed that the bulk access button depends on that flag but not on `organization.flexibleCollections`. I fixed that while I was here.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
