### PR TITLE
[CL-173] hide nav-group active styles when expanded

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html
@@ -19,7 +19,7 @@
       [ariaLabel]="['organization' | i18n, org.name].join(' ')"
       [route]="['../', org.id]"
       (mainContentClicked)="toggle()"
-      [hideActiveStyles]="true"
+      [exactMatch]="true"
     >
       <i
         slot="end"

--- a/libs/components/src/navigation/nav-group.component.html
+++ b/libs/components/src/navigation/nav-group.component.html
@@ -9,6 +9,7 @@
   (mainContentClicked)="mainContentClicked.emit()"
   [ariaLabel]="ariaLabel"
   [exactMatch]="exactMatch"
+  [hideActiveStyles]="parentHideActiveStyles"
 >
   <ng-template #button>
     <button

--- a/libs/components/src/navigation/nav-group.component.ts
+++ b/libs/components/src/navigation/nav-group.component.ts
@@ -27,6 +27,11 @@ export class NavGroupComponent extends NavBaseComponent implements AfterContentI
   })
   nestedItems!: QueryList<NavItemComponent>;
 
+  /** The parent nav item should not show active styles when open. */
+  protected get parentHideActiveStyles(): boolean {
+    return this.hideActiveStyles || this.open;
+  }
+
   /**
    * UID for `[attr.aria-controls]`
    */


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Updates the `bit-nav-group` to hide active styles when the component is expanded. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **bitwarden_license/bit-web/src/app/secrets-manager/layout/org-switcher.component.html:** Update the `org-switcher` to work with new pattern. Previously, it was hiding active styles for all child nav items. Since the active style of the parent nav group is now hidden, we want to show the active style with the children. If we didn't make this change, active styles would not be shown in the parent or child nav items.
- **libs/components/src/navigation/nav-group.component.ts:** Set the parent `bit-nav-item` to hide active styles when `open` is true.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

**New behavior:** 



https://github.com/bitwarden/clients/assets/17113462/7d2b9291-7ac9-4b40-9aa8-21627598284f




## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
