### PR TITLE
add zsh completions initialization

### DIFF
--- a/apps/cli/src/commands/completion.command.ts
+++ b/apps/cli/src/commands/completion.command.ts
@@ -46,6 +46,8 @@ export class CompletionCommand {
         return [
           `#compdef _${rootName} ${rootName}`,
           "",
+          `compdef _${rootName} ${rootName}`,
+          "",
           this.renderCommandBlock(rootName, rootCommand),
         ].join("\n");
       },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

current completions were defined for autoload, but were not actually loaded.  ( check [20.2.2 Autoloaded files](https://zsh.sourceforge.io/Doc/Release/Completion-System.html) vs [20.2.3 Functions](https://zsh.sourceforge.io/Doc/Release/Completion-System.html))

That resulted into by default not working completions for `bitwarden-cli` at least if installed with `homebrew`. (had to modify the completion file manually by adding the same line to make it work)

## Code changes

Added missing completions initialization.