### PR TITLE
Auth/PM-5762 - Fix org invite acceptance not working if user email or org has "lock" in the name

### DIFF
--- a/apps/web/src/app/auth/guards/deep-link.guard.ts
+++ b/apps/web/src/app/auth/guards/deep-link.guard.ts
@@ -51,6 +51,6 @@ export function deepLinkGuard(): CanActivateFn {
   };
 
   function isValidUrl(url: string | null | undefined): boolean {
-    return !Utils.isNullOrEmpty(url) && !url?.toLocaleLowerCase().includes("lock");
+    return !Utils.isNullOrEmpty(url) && !url?.toLocaleLowerCase().includes("/lock");
   }
 }


### PR DESCRIPTION

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolve [PM-5762](https://bitwarden.atlassian.net/browse/PM-5762)

`DeepLinkGuard` - Fix issue in which org invite acceptance was broken due to us not properly checking for the lock url: if an org name or org user email contained lock, then the login redirect url would not persist and take the user to the accept org invite page after login.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/auth/guards/deep-link.guard.ts:** Check for `/lock` url instead of `lock` text

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
https://github.com/bitwarden/clients/assets/116684653/7045b792-45ff-40a1-87ac-df4b9fe6075c


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-5762]: https://bitwarden.atlassian.net/browse/PM-5762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ