### PR TITLE
[PM-5887] Refactor WebCryptoFunctionService to Remove Usage of the window Object in the Background Script

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -308,7 +308,7 @@ export default class MainBackground {
       ? new BrowserMessagingPrivateModeBackgroundService()
       : new BrowserMessagingService();
     this.logService = new ConsoleLogService(false);
-    this.cryptoFunctionService = new WebCryptoFunctionService(window);
+    this.cryptoFunctionService = new WebCryptoFunctionService(self);
     this.storageService = new BrowserLocalStorageService();
     this.secureStorageService = new BrowserLocalStorageService();
     this.memoryStorageService =

--- a/libs/common/src/platform/services/web-crypto-function.service.ts
+++ b/libs/common/src/platform/services/web-crypto-function.service.ts
@@ -12,10 +12,10 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
   private subtle: SubtleCrypto;
   private wasmSupported: boolean;
 
-  constructor(win: Window | typeof global) {
-    this.crypto = typeof win.crypto !== "undefined" ? win.crypto : null;
+  constructor(globalContext: Window | typeof global) {
+    this.crypto = typeof globalContext.crypto !== "undefined" ? globalContext.crypto : null;
     this.subtle =
-      !!this.crypto && typeof win.crypto.subtle !== "undefined" ? win.crypto.subtle : null;
+      !!this.crypto && typeof this.crypto.subtle !== "undefined" ? this.crypto.subtle : null;
     this.wasmSupported = this.checkIfWasmSupported();
   }
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This work in this PR refactors how we reference the `crypto` API within the `WebCryptoFunctionService`. 

When instantiating the WebCryptoFunctionService, we pass a window object to facilitate access to the global crypto API. This [API is available in web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API), but it needs to be referenced off the global variable self instead of window.

This will ensure that the passed global reference is valid within the mv2 background page and mv3 background service worker.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/background/main.background.ts:** Updating the passed reference of `window` to `self` within the `MainBackground` class.
- **libs/common/src/platform/services/web-crypto-function.service.ts:** Applying smaller refactors to clarify the parameter passed to the `WebCryptoFunctionService` as a `globalContext` rather than explicitly the `window` object.
