### PR TITLE
[PM-5877] Update the extension's webpack compilation process to include `path-browserify` in manifest v3

### DIFF
--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -318,7 +318,7 @@ if (manifestVersion == 2) {
       plugins: [new TsconfigPathsPlugin()],
       fallback: {
         fs: false,
-        path: false,
+        path: require.resolve("path-browserify"),
       },
     },
     dependencies: ["main"],


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `path-browserify` dependency needs to be enqueued within the `Webpack` build for the browser extension as a fallback script. This is already done for mv2, so that example can be used to facilitate this inclusion.

This should present as a very small addition to the implementation, both in effort and impact. The inclusion of the package does not seem to cause any verifiable issues with manifest v3.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/webpack.config.js:** Adding `path-browserify` dependency when build manifest v3.

