### PR TITLE
[AC-2115] Hide delete collection button in collection dialog

### DIFF
--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -213,12 +213,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
               parent,
               access: accessSelections,
             });
-
-            this.showDeleteButton =
-              this.collection.canDelete(organization) ||
-              (collection?.manage &&
-                organization != null &&
-                !organization.limitCollectionCreationDeletion);
+            this.collection.manage = collection?.manage ?? false; // Get manage flag from sync data collection
+            this.showDeleteButton = this.collection.canDelete(organization);
           } else {
             this.nestOptions = collections;
             const parent = collections.find((c) => c.id === this.params.parentCollectionId);

--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -214,7 +214,11 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
               access: accessSelections,
             });
 
-            this.showDeleteButton = this.collection.canDelete(organization) || collection?.manage;
+            this.showDeleteButton =
+              this.collection.canDelete(organization) ||
+              (collection?.manage &&
+                organization != null &&
+                !organization.limitCollectionCreationDeletion);
           } else {
             this.nestOptions = collections;
             const parent = collections.find((c) => c.id === this.params.parentCollectionId);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add an additional check for the `limitCollectionCreationDeletion` setting when determining if the delete collection button should be shown in collection dialog.

## Code changes

- **apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts:** Update the condition to only show the button if both the `manage` flag is true and the `limitCollectionCreationDeletion` setting is disabled. 
  - The `this.collection.canDelete(organization)` check performs similar logic (including the check for admins) but doesn't yet have the `manage` flag set when opened in the org vault; so we have to check the collection from the sync data. There is planned worked to reduce this weird behavior in [AC-2084](https://bitwarden.atlassian.net/browse/AC-2084) to include all the collection/cipher permissions in the admin endpoints for the org vault.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[AC-2084]: https://bitwarden.atlassian.net/browse/AC-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ