### PR TITLE
Ps/pm-5537/biometric-state-service

### DIFF
--- a/apps/desktop/jest.config.js
+++ b/apps/desktop/jest.config.js
@@ -9,7 +9,10 @@ module.exports = {
   ...sharedConfig,
   preset: "jest-preset-angular",
   setupFilesAfterEnv: ["<rootDir>/test.setup.ts"],
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions?.paths || {}, {
-    prefix: "<rootDir>/",
-  }),
+  moduleNameMapper: pathsToModuleNameMapper(
+    { "@bitwarden/common/spec": ["../../libs/common/spec"], ...(compilerOptions?.paths ?? {}) },
+    {
+      prefix: "<rootDir>/",
+    },
+  ),
 };

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -34,6 +34,7 @@ import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwar
 import { StateService as StateServiceAbstraction } from "@bitwarden/common/platform/abstractions/state.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { SystemService as SystemServiceAbstraction } from "@bitwarden/common/platform/abstractions/system.service";
+import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
 import { MemoryStorageService } from "@bitwarden/common/platform/services/memory-storage.service";
@@ -47,7 +48,10 @@ import { DialogService } from "@bitwarden/components";
 
 import { LoginGuard } from "../../auth/guards/login.guard";
 import { Account } from "../../models/account";
-import { ElectronCryptoService } from "../../platform/services/electron-crypto.service";
+import {
+  DefaultElectronCryptoService,
+  ElectronCryptoService,
+} from "../../platform/services/electron-crypto.service";
 import { ElectronLogService } from "../../platform/services/electron-log.service";
 import { ElectronPlatformUtilsService } from "../../platform/services/electron-platform-utils.service";
 import { ElectronRendererMessagingService } from "../../platform/services/electron-renderer-messaging.service";
@@ -178,7 +182,11 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
     },
     {
       provide: CryptoServiceAbstraction,
-      useClass: ElectronCryptoService,
+      useExisting: ElectronCryptoService,
+    },
+    {
+      provide: ElectronCryptoService,
+      useClass: DefaultElectronCryptoService,
       deps: [
         CryptoFunctionServiceAbstraction,
         EncryptService,
@@ -187,6 +195,7 @@ const RELOAD_CALLBACK = new InjectionToken<() => any>("RELOAD_CALLBACK");
         StateServiceAbstraction,
         AccountServiceAbstraction,
         StateProvider,
+        BiometricStateService,
       ],
     },
   ],

--- a/apps/desktop/src/auth/lock.component.spec.ts
+++ b/apps/desktop/src/auth/lock.component.spec.ts
@@ -21,9 +21,11 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { DialogService } from "@bitwarden/components";
 
+import { ElectronCryptoService } from "../platform/services/electron-crypto.service";
 import { ElectronStateService } from "../platform/services/electron-state.service.abstraction";
 
 import { LockComponent } from "./lock.component";
@@ -76,7 +78,11 @@ describe("LockComponent", () => {
         },
         {
           provide: CryptoService,
-          useValue: mock<CryptoService>(),
+          useExisting: ElectronCryptoService,
+        },
+        {
+          provide: ElectronCryptoService,
+          useValue: mock<ElectronCryptoService>(),
         },
         {
           provide: VaultTimeoutService,
@@ -137,6 +143,10 @@ describe("LockComponent", () => {
         {
           provide: PinCryptoServiceAbstraction,
           useValue: mock<PinCryptoServiceAbstraction>(),
+        },
+        {
+          provide: BiometricStateService,
+          useValue: mock<BiometricStateService>(),
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/apps/desktop/src/auth/lock.component.ts
+++ b/apps/desktop/src/auth/lock.component.ts
@@ -13,7 +13,6 @@ import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abst
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { DeviceType } from "@bitwarden/common/enums";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
-import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -22,6 +21,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { DialogService } from "@bitwarden/components";
 
+import { ElectronCryptoService } from "../platform/services/electron-crypto.service";
 import { ElectronStateService } from "../platform/services/electron-state.service.abstraction";
 
 const BroadcasterSubscriptionId = "LockComponent";
@@ -41,7 +41,7 @@ export class LockComponent extends BaseLockComponent {
     i18nService: I18nService,
     platformUtilsService: PlatformUtilsService,
     messagingService: MessagingService,
-    cryptoService: CryptoService,
+    protected override cryptoService: ElectronCryptoService,
     vaultTimeoutService: VaultTimeoutService,
     vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     environmentService: EnvironmentService,
@@ -171,8 +171,8 @@ export class LockComponent extends BaseLockComponent {
         type: "warning",
       });
 
-      await this.stateService.setBiometricRequirePasswordOnStart(response);
       if (response) {
+        await this.cryptoService.setBiometricClientKeyHalf();
         await this.stateService.setDisableAutoBiometricsPrompt(true);
       }
       this.supportsBiometric = await this.canUseBiometric();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { app } from "electron";
 
 import { AccountServiceImplementation } from "@bitwarden/common/auth/services/account.service";
+import { DefaultBiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
 import { EnvironmentService } from "@bitwarden/common/platform/services/environment.service";
@@ -159,6 +160,8 @@ export class Main {
       this.updaterMain,
     );
 
+    const biometricStateService = new DefaultBiometricStateService(stateProvider);
+
     this.biometricsService = new BiometricsService(
       this.i18nService,
       this.windowMain,
@@ -166,6 +169,7 @@ export class Main {
       this.logService,
       this.messagingService,
       process.platform,
+      biometricStateService,
     );
 
     this.desktopCredentialStorageListener = new DesktopCredentialStorageListener(

--- a/apps/desktop/src/models/account.ts
+++ b/apps/desktop/src/models/account.ts
@@ -1,11 +1,7 @@
-import { Jsonify } from "type-fest";
-
 import {
   Account as BaseAccount,
   AccountSettings as BaseAccountSettings,
-  AccountKeys as BaseAccountKeys,
 } from "@bitwarden/common/platform/models/domain/account";
-import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 
 export class AccountSettings extends BaseAccountSettings {
   vaultTimeout = -1; // On Restart
@@ -13,13 +9,8 @@ export class AccountSettings extends BaseAccountSettings {
   dismissedBiometricRequirePasswordOnStartCallout?: boolean;
 }
 
-export class AccountKeys extends BaseAccountKeys {
-  biometricEncryptionClientKeyHalf?: Jsonify<EncString>;
-}
-
 export class Account extends BaseAccount {
   settings?: AccountSettings = new AccountSettings();
-  keys?: AccountKeys = new AccountKeys();
 
   constructor(init: Partial<Account>) {
     super(init);

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.ts
@@ -1,6 +1,8 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
+import { UserId } from "@bitwarden/common/types/guid";
 
 import { WindowMain } from "../../../main/window.main";
 import { ElectronStateService } from "../../services/electron-state.service.abstraction";
@@ -18,6 +20,7 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     private logService: LogService,
     private messagingService: MessagingService,
     private platform: NodeJS.Platform,
+    private biometricStateService: BiometricStateService,
   ) {
     this.loadPlatformSpecificService(this.platform);
   }
@@ -70,11 +73,9 @@ export class BiometricsService implements BiometricsServiceAbstraction {
   }: {
     service: string;
     key: string;
-    userId: string;
+    userId: UserId;
   }): Promise<boolean> {
-    const requireClientKeyHalf = await this.stateService.getBiometricRequirePasswordOnStart({
-      userId,
-    });
+    const requireClientKeyHalf = await this.biometricStateService.getRequirePasswordOnStart(userId);
     const clientKeyHalfB64 = this.getClientKeyHalf(service, key);
     const clientKeyHalfSatisfied = !requireClientKeyHalf || !!clientKeyHalfB64;
     return clientKeyHalfSatisfied && (await this.osSupportsBiometric());
@@ -169,7 +170,13 @@ export class BiometricsService implements BiometricsServiceAbstraction {
   }
 
   private async enforceClientKeyHalf(service: string, storageKey: string): Promise<void> {
-    const requireClientKeyHalf = await this.stateService.getBiometricRequirePasswordOnStart();
+    // The first half of the storageKey is the userId, separated by `_`
+    // We need to extract from the service because the active user isn't properly synced to the main process,
+    // So we can't use the observables on `biometricStateService`
+    const [userId] = storageKey.split("_");
+    const requireClientKeyHalf = await this.biometricStateService.getRequirePasswordOnStart(
+      userId as UserId,
+    );
     const clientKeyHalfB64 = this.getClientKeyHalf(service, storageKey);
 
     if (requireClientKeyHalf && !clientKeyHalfB64) {

--- a/apps/desktop/src/platform/services/electron-crypto.service.spec.ts
+++ b/apps/desktop/src/platform/services/electron-crypto.service.spec.ts
@@ -1,11 +1,15 @@
 import { FakeStateProvider } from "@bitwarden/common/../spec/fake-state-provider";
 import { mock } from "jest-mock-extended";
+import { firstValueFrom } from "rxjs";
 
 import { CryptoFunctionService } from "@bitwarden/common/platform/abstractions/crypto-function.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { makeEncString, makeStaticByteArray } from "@bitwarden/common/spec";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -15,11 +19,11 @@ import {
   mockAccountServiceWith,
 } from "../../../../../libs/common/spec/fake-account-service";
 
-import { ElectronCryptoService } from "./electron-crypto.service";
+import { DefaultElectronCryptoService } from "./electron-crypto.service";
 import { ElectronStateService } from "./electron-state.service.abstraction";
 
 describe("electronCryptoService", () => {
-  let electronCryptoService: ElectronCryptoService;
+  let sut: DefaultElectronCryptoService;
 
   const cryptoFunctionService = mock<CryptoFunctionService>();
   const encryptService = mock<EncryptService>();
@@ -28,6 +32,7 @@ describe("electronCryptoService", () => {
   const stateService = mock<ElectronStateService>();
   let accountService: FakeAccountService;
   let stateProvider: FakeStateProvider;
+  const biometricStateService = mock<BiometricStateService>();
 
   const mockUserId = "mock user id" as UserId;
 
@@ -35,7 +40,7 @@ describe("electronCryptoService", () => {
     accountService = mockAccountServiceWith("userId" as UserId);
     stateProvider = new FakeStateProvider(accountService);
 
-    electronCryptoService = new ElectronCryptoService(
+    sut = new DefaultElectronCryptoService(
       cryptoFunctionService,
       encryptService,
       platformUtilService,
@@ -43,6 +48,7 @@ describe("electronCryptoService", () => {
       stateService,
       accountService,
       stateProvider,
+      biometricStateService,
     );
   });
 
@@ -51,7 +57,49 @@ describe("electronCryptoService", () => {
   });
 
   it("instantiates", () => {
-    expect(electronCryptoService).not.toBeFalsy();
+    expect(sut).not.toBeFalsy();
+  });
+
+  describe("setBiometricClientKeyHalf", () => {
+    const userKey = new SymmetricCryptoKey(makeStaticByteArray(64, 1)) as UserKey;
+    const keyBytes = makeStaticByteArray(32, 2) as CsprngArray;
+    const encKeyHalf = makeEncString(Utils.fromBufferToUtf8(keyBytes));
+
+    beforeEach(() => {
+      sut.getUserKeyWithLegacySupport = jest.fn().mockResolvedValue(userKey);
+      cryptoFunctionService.randomBytes.mockResolvedValue(keyBytes);
+      encryptService.encrypt.mockResolvedValue(encKeyHalf);
+    });
+
+    it("sets a biometric client key half for the currently active user", async () => {
+      await sut.setBiometricClientKeyHalf();
+
+      expect(biometricStateService.setEncryptedClientKeyHalf).toHaveBeenCalledWith(encKeyHalf);
+      expect(firstValueFrom(biometricStateService.encryptedClientKeyHalf$)).resolves.toEqual(
+        encKeyHalf,
+      );
+    });
+
+    it("should create the key from csprng bytes", async () => {
+      await sut.setBiometricClientKeyHalf();
+
+      expect(cryptoFunctionService.randomBytes).toHaveBeenCalledWith(32);
+    });
+
+    it("should encrypt the key half with the user key", async () => {
+      await sut.setBiometricClientKeyHalf();
+
+      expect(encryptService.encrypt).toHaveBeenCalledWith(expect.any(String), userKey);
+    });
+  });
+
+  describe("removeBiometricClientKeyHalf", () => {
+    it("removes the biometric client key half for the currently active user", async () => {
+      await sut.removeBiometricClientKeyHalf();
+
+      expect(biometricStateService.setEncryptedClientKeyHalf).toHaveBeenCalledWith(null);
+      expect(firstValueFrom(biometricStateService.encryptedClientKeyHalf$)).resolves.toBeNull();
+    });
   });
 
   describe("setUserKey", () => {
@@ -66,9 +114,9 @@ describe("electronCryptoService", () => {
       it("sets an Biometric key if getBiometricUnlock is true and the platform supports secure storage", async () => {
         stateService.getBiometricUnlock.mockResolvedValue(true);
         platformUtilService.supportsSecureStorage.mockReturnValue(true);
-        stateService.getBiometricRequirePasswordOnStart.mockResolvedValue(false);
+        biometricStateService.getRequirePasswordOnStart.mockResolvedValue(true);
 
-        await electronCryptoService.setUserKey(mockUserKey, mockUserId);
+        await sut.setUserKey(mockUserKey, mockUserId);
 
         expect(stateService.setUserKeyBiometric).toHaveBeenCalledWith(
           expect.objectContaining({ key: expect.any(String), clientEncKeyHalf: null }),
@@ -82,7 +130,7 @@ describe("electronCryptoService", () => {
         stateService.getBiometricUnlock.mockResolvedValue(true);
         platformUtilService.supportsSecureStorage.mockReturnValue(false);
 
-        await electronCryptoService.setUserKey(mockUserKey, mockUserId);
+        await sut.setUserKey(mockUserKey, mockUserId);
 
         expect(stateService.setUserKeyBiometric).toHaveBeenCalledWith(null, {
           userId: mockUserId,
@@ -90,7 +138,7 @@ describe("electronCryptoService", () => {
       });
 
       it("clears the old deprecated Biometric key whenever a User Key is set", async () => {
-        await electronCryptoService.setUserKey(mockUserKey, mockUserId);
+        await sut.setUserKey(mockUserKey, mockUserId);
 
         expect(stateService.setCryptoMasterKeyBiometric).toHaveBeenCalledWith(null, {
           userId: mockUserId,

--- a/apps/desktop/src/platform/services/electron-crypto.service.ts
+++ b/apps/desktop/src/platform/services/electron-crypto.service.ts
@@ -62,8 +62,9 @@ export class DefaultElectronCryptoService extends ElectronCryptoService {
 
   override async clearStoredUserKey(keySuffix: KeySuffixOptions, userId?: UserId): Promise<void> {
     if (keySuffix === KeySuffixOptions.Biometric) {
-      this.stateService.setUserKeyBiometric(null, { userId: userId });
-      this.clearDeprecatedKeys(KeySuffixOptions.Biometric, userId);
+      await this.stateService.setUserKeyBiometric(null, { userId: userId });
+      await this.biometricStateService.removeEncryptedClientKeyHalf(userId);
+      await this.clearDeprecatedKeys(KeySuffixOptions.Biometric, userId);
       return;
     }
     super.clearStoredUserKey(keySuffix, userId);
@@ -125,7 +126,7 @@ export class DefaultElectronCryptoService extends ElectronCryptoService {
   }
 
   protected override async clearAllStoredUserKeys(userId?: UserId): Promise<void> {
-    await this.stateService.setUserKeyBiometric(null, { userId: userId });
+    await this.clearStoredUserKey(KeySuffixOptions.Biometric, userId);
     super.clearAllStoredUserKeys(userId);
   }
 

--- a/apps/desktop/src/platform/services/electron-state.service.abstraction.ts
+++ b/apps/desktop/src/platform/services/electron-state.service.abstraction.ts
@@ -1,17 +1,9 @@
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
-import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { StorageOptions } from "@bitwarden/common/platform/models/domain/storage-options";
 
 import { Account } from "../../models/account";
 
 export abstract class ElectronStateService extends StateService<Account> {
-  getBiometricEncryptionClientKeyHalf: (options?: StorageOptions) => Promise<EncString>;
-  setBiometricEncryptionClientKeyHalf: (
-    value: EncString,
-    options?: StorageOptions,
-  ) => Promise<void>;
   getDismissedBiometricRequirePasswordOnStart: (options?: StorageOptions) => Promise<boolean>;
   setDismissedBiometricRequirePasswordOnStart: (options?: StorageOptions) => Promise<void>;
-  getBiometricRequirePasswordOnStart: (options?: StorageOptions) => Promise<boolean>;
-  setBiometricRequirePasswordOnStart: (value: boolean, options?: StorageOptions) => Promise<void>;
 }

--- a/apps/desktop/src/platform/services/electron-state.service.ts
+++ b/apps/desktop/src/platform/services/electron-state.service.ts
@@ -1,5 +1,4 @@
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
 import { StorageOptions } from "@bitwarden/common/platform/models/domain/storage-options";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
@@ -22,49 +21,6 @@ export class ElectronStateService
     // Apply desktop overides to default account values
     account = new Account(account);
     await super.addAccount(account);
-  }
-
-  async getBiometricEncryptionClientKeyHalf(options?: StorageOptions): Promise<EncString> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
-    const key = account?.keys?.biometricEncryptionClientKeyHalf;
-    return key == null ? null : new EncString(key);
-  }
-
-  async setBiometricEncryptionClientKeyHalf(
-    value: EncString,
-    options?: StorageOptions,
-  ): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
-    account.keys.biometricEncryptionClientKeyHalf = value?.encryptedString;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
-  }
-
-  async getBiometricRequirePasswordOnStart(options?: StorageOptions): Promise<boolean> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
-    return account?.settings?.requirePasswordOnStart;
-  }
-
-  async setBiometricRequirePasswordOnStart(
-    value: boolean,
-    options?: StorageOptions,
-  ): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
-    account.settings.requirePasswordOnStart = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions()),
-    );
   }
 
   async getDismissedBiometricRequirePasswordOnStart(options?: StorageOptions): Promise<boolean> {

--- a/apps/desktop/src/platform/services/electron-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-storage.service.ts
@@ -85,6 +85,10 @@ export class ElectronStorageService implements AbstractStorageService {
     if (obj instanceof Set) {
       obj = Array.from(obj);
     }
+    if (obj == null) {
+      // Electron store does not support setting null or undefined
+      return this.remove(key);
+    }
     this.store.set(key, obj);
     this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -95,6 +95,10 @@ import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwar
 import { StateService as StateServiceAbstraction } from "@bitwarden/common/platform/abstractions/state.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { ValidationService as ValidationServiceAbstraction } from "@bitwarden/common/platform/abstractions/validation.service";
+import {
+  BiometricStateService,
+  DefaultBiometricStateService,
+} from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { devFlagEnabled, flagEnabled } from "@bitwarden/common/platform/misc/flags";
 import { Account } from "@bitwarden/common/platform/models/domain/account";
@@ -875,6 +879,11 @@ import { ModalService } from "./modal.service";
         I18nServiceAbstraction,
         OrganizationApiServiceAbstraction,
       ],
+    },
+    {
+      provide: BiometricStateService,
+      useClass: DefaultBiometricStateService,
+      deps: [StateProvider],
     },
   ],
 })

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -3,6 +3,9 @@ import { Observable } from "rxjs";
 
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 
+import { EncryptionType } from "../src/platform/enums";
+import { Utils } from "../src/platform/misc/utils";
+
 function newGuid() {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
@@ -27,6 +30,11 @@ export function mockEnc(s: string): MockProxy<EncString> {
   mocked.decrypt.mockResolvedValue(s);
 
   return mocked;
+}
+
+export function makeEncString(data?: string) {
+  data ??= Utils.newGuid();
+  return new EncString(EncryptionType.AesCbc256_HmacSha256_B64, data, "test", "test");
 }
 
 export function makeStaticByteArray(length: number, start = 0) {

--- a/libs/common/src/platform/biometrics/biometric-state.service.spec.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.spec.ts
@@ -1,0 +1,61 @@
+import { firstValueFrom } from "rxjs";
+
+import { makeEncString } from "../../../spec";
+import { mockAccountServiceWith } from "../../../spec/fake-account-service";
+import { FakeStateProvider } from "../../../spec/fake-state-provider";
+import { UserId } from "../../types/guid";
+
+import { BiometricStateService, DefaultBiometricStateService } from "./biometric-state.service";
+import { ENCRYPTED_CLIENT_KEY_HALF } from "./biometric.state";
+
+describe("BiometricStateService", () => {
+  let sut: BiometricStateService;
+  const userId = "userId" as UserId;
+  const encClientKeyHalf = makeEncString();
+  const encryptedClientKeyHalf = encClientKeyHalf.encryptedString;
+  const accountService = mockAccountServiceWith(userId);
+  let stateProvider: FakeStateProvider;
+
+  beforeEach(() => {
+    stateProvider = new FakeStateProvider(accountService);
+
+    sut = new DefaultBiometricStateService(stateProvider);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("requirePasswordOnStart$", () => {
+    it("should be false when encryptedClientKeyHalf is undefined", async () => {
+      stateProvider.activeUser.getFake(ENCRYPTED_CLIENT_KEY_HALF).nextState(undefined);
+      expect(await firstValueFrom(sut.requirePasswordOnStart$)).toBe(false);
+    });
+
+    it("should be true when encryptedClientKeyHalf is defined", async () => {
+      stateProvider.activeUser.getFake(ENCRYPTED_CLIENT_KEY_HALF).nextState(encryptedClientKeyHalf);
+      expect(await firstValueFrom(sut.requirePasswordOnStart$)).toBe(true);
+    });
+  });
+
+  describe("encryptedClientKeyHalf$", () => {
+    it("should track the encryptedClientKeyHalf state", async () => {
+      const state = stateProvider.activeUser.getFake(ENCRYPTED_CLIENT_KEY_HALF);
+      state.nextState(undefined);
+
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toBe(null);
+
+      state.nextState(encryptedClientKeyHalf);
+
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toEqual(encClientKeyHalf);
+    });
+  });
+
+  describe("setEncryptedClientKeyHalf", () => {
+    it("should update the encryptedClientKeyHalf$", async () => {
+      await sut.setEncryptedClientKeyHalf(encClientKeyHalf);
+
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toEqual(encClientKeyHalf);
+    });
+  });
+});

--- a/libs/common/src/platform/biometrics/biometric-state.service.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.ts
@@ -34,7 +34,7 @@ export class DefaultBiometricStateService implements BiometricStateService {
   constructor(private stateProvider: StateProvider) {
     this.encryptedClientKeyHalfState = this.stateProvider.getActive(ENCRYPTED_CLIENT_KEY_HALF);
     this.encryptedClientKeyHalf$ = this.encryptedClientKeyHalfState.state$.pipe(
-      map((s) => (s == null ? null : new EncString(s))),
+      map(encryptedClientKeyHalfToEncString),
     );
     this.requirePasswordOnStart$ = this.encryptedClientKeyHalf$.pipe(map((keyHalf) => !!keyHalf));
   }
@@ -47,15 +47,20 @@ export class DefaultBiometricStateService implements BiometricStateService {
     if (userId == null) {
       return false;
     }
-    const state = this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF);
-    return !!(await firstValueFrom(state.state$));
+    return !!(await this.getEncryptedClientKeyHalf(userId));
   }
 
   async getEncryptedClientKeyHalf(userId: UserId): Promise<EncString> {
     return await firstValueFrom(
       this.stateProvider
         .getUser(userId, ENCRYPTED_CLIENT_KEY_HALF)
-        .state$.pipe(map((s) => new EncString(s))),
+        .state$.pipe(map(encryptedClientKeyHalfToEncString)),
     );
   }
+}
+
+function encryptedClientKeyHalfToEncString(
+  encryptedKeyHalf: EncryptedString | undefined,
+): EncString {
+  return encryptedKeyHalf == null ? null : new EncString(encryptedKeyHalf);
 }

--- a/libs/common/src/platform/biometrics/biometric-state.service.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.ts
@@ -24,6 +24,7 @@ export abstract class BiometricStateService {
   abstract setEncryptedClientKeyHalf(encryptedKeyHalf: EncString): Promise<void>;
   abstract getEncryptedClientKeyHalf(userId: UserId): Promise<EncString>;
   abstract getRequirePasswordOnStart(userId: UserId): Promise<boolean>;
+  abstract removeEncryptedClientKeyHalf(userId: UserId): Promise<void>;
 }
 
 export class DefaultBiometricStateService implements BiometricStateService {
@@ -43,6 +44,10 @@ export class DefaultBiometricStateService implements BiometricStateService {
     await this.encryptedClientKeyHalfState.update(() => encryptedKeyHalf?.encryptedString);
   }
 
+  async removeEncryptedClientKeyHalf(userId: UserId): Promise<void> {
+    await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => null);
+  }
+
   async getRequirePasswordOnStart(userId: UserId): Promise<boolean> {
     if (userId == null) {
       return false;
@@ -56,6 +61,10 @@ export class DefaultBiometricStateService implements BiometricStateService {
         .getUser(userId, ENCRYPTED_CLIENT_KEY_HALF)
         .state$.pipe(map(encryptedClientKeyHalfToEncString)),
     );
+  }
+
+  async logout(userId: UserId): Promise<void> {
+    await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => null);
   }
 }
 

--- a/libs/common/src/platform/biometrics/biometric-state.service.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.ts
@@ -1,0 +1,61 @@
+import { Observable, firstValueFrom, map } from "rxjs";
+
+import { UserId } from "../../types/guid";
+import { EncryptedString, EncString } from "../models/domain/enc-string";
+import { ActiveUserState, StateProvider } from "../state";
+
+import { ENCRYPTED_CLIENT_KEY_HALF } from "./biometric.state";
+
+export abstract class BiometricStateService {
+  /**
+   * If the user has elected to require a password on first unlock of an application instance, this key will store the
+   * encrypted client key half used to unlock the vault.
+   *
+   * Tracks the currently active user
+   */
+  encryptedClientKeyHalf$: Observable<EncString | undefined>;
+  /**
+   * whether or not a password is required on first unlock after opening the application
+   *
+   * tracks the currently active user
+   */
+  requirePasswordOnStart$: Observable<boolean>;
+
+  abstract setEncryptedClientKeyHalf(encryptedKeyHalf: EncString): Promise<void>;
+  abstract getEncryptedClientKeyHalf(userId: UserId): Promise<EncString>;
+  abstract getRequirePasswordOnStart(userId: UserId): Promise<boolean>;
+}
+
+export class DefaultBiometricStateService implements BiometricStateService {
+  private encryptedClientKeyHalfState: ActiveUserState<EncryptedString | undefined>;
+  encryptedClientKeyHalf$: Observable<EncString | undefined>;
+  requirePasswordOnStart$: Observable<boolean>;
+
+  constructor(private stateProvider: StateProvider) {
+    this.encryptedClientKeyHalfState = this.stateProvider.getActive(ENCRYPTED_CLIENT_KEY_HALF);
+    this.encryptedClientKeyHalf$ = this.encryptedClientKeyHalfState.state$.pipe(
+      map((s) => (s == null ? null : new EncString(s))),
+    );
+    this.requirePasswordOnStart$ = this.encryptedClientKeyHalf$.pipe(map((keyHalf) => !!keyHalf));
+  }
+
+  async setEncryptedClientKeyHalf(encryptedKeyHalf: EncString): Promise<void> {
+    await this.encryptedClientKeyHalfState.update(() => encryptedKeyHalf?.encryptedString);
+  }
+
+  async getRequirePasswordOnStart(userId: UserId): Promise<boolean> {
+    if (userId == null) {
+      return false;
+    }
+    const state = this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF);
+    return !!(await firstValueFrom(state.state$));
+  }
+
+  async getEncryptedClientKeyHalf(userId: UserId): Promise<EncString> {
+    return await firstValueFrom(
+      this.stateProvider
+        .getUser(userId, ENCRYPTED_CLIENT_KEY_HALF)
+        .state$.pipe(map((s) => new EncString(s))),
+    );
+  }
+}

--- a/libs/common/src/platform/biometrics/biometric.state.spec.ts
+++ b/libs/common/src/platform/biometrics/biometric.state.spec.ts
@@ -1,0 +1,13 @@
+import { ENCRYPTED_CLIENT_KEY_HALF } from "./biometric.state";
+
+describe("encrypted client key half", () => {
+  const sut = ENCRYPTED_CLIENT_KEY_HALF;
+
+  it("should deserialize encrypted client key half state", () => {
+    const encryptedClientKeyHalf = "encryptedClientKeyHalf";
+
+    const result = sut.deserializer(JSON.parse(JSON.stringify(encryptedClientKeyHalf)));
+
+    expect(result).toEqual(encryptedClientKeyHalf);
+  });
+});

--- a/libs/common/src/platform/biometrics/biometric.state.ts
+++ b/libs/common/src/platform/biometrics/biometric.state.ts
@@ -1,0 +1,17 @@
+import { EncryptedString } from "../models/domain/enc-string";
+import { KeyDefinition, BIOMETRIC_SETTINGS_DISK } from "../state";
+
+/**
+ * If the user has elected to require a password on first unlock of an application instance, this key will store the
+ * encrypted client key half used to unlock the vault.
+ *
+ * For operating systems without application-level key storage, this key half is concatenated with a signature
+ * provided by the OS and used to encrypt the biometric key prior to storage.
+ */
+export const ENCRYPTED_CLIENT_KEY_HALF = new KeyDefinition<EncryptedString>(
+  BIOMETRIC_SETTINGS_DISK,
+  "clientKeyHalf",
+  {
+    deserializer: (obj) => obj,
+  },
+);

--- a/libs/common/src/platform/services/key-state/org-keys.state.spec.ts
+++ b/libs/common/src/platform/services/key-state/org-keys.state.spec.ts
@@ -1,21 +1,11 @@
 import { mock } from "jest-mock-extended";
 
-import { makeStaticByteArray } from "../../../../spec";
-import { ProviderEncryptedOrganizationKey } from "../../../admin-console/models/domain/encrypted-organization-key";
+import { makeEncString, makeStaticByteArray } from "../../../../spec";
 import { OrgKey } from "../../../types/key";
 import { CryptoService } from "../../abstractions/crypto.service";
-import { EncryptionType } from "../../enums";
-import { Utils } from "../../misc/utils";
-import { EncString } from "../../models/domain/enc-string";
 import { SymmetricCryptoKey } from "../../models/domain/symmetric-crypto-key";
 
 import { USER_ENCRYPTED_ORGANIZATION_KEYS, USER_ORGANIZATION_KEYS } from "./org-keys.state";
-
-function makeEncString(data?: string) {
-  data ??= Utils.newGuid();
-  return new EncString(EncryptionType.AesCbc256_HmacSha256_B64, data, "test", "test");
-}
-ProviderEncryptedOrganizationKey;
 
 describe("encrypted org keys", () => {
   const sut = USER_ENCRYPTED_ORGANIZATION_KEYS;

--- a/libs/common/src/platform/services/key-state/provider-keys.state.spec.ts
+++ b/libs/common/src/platform/services/key-state/provider-keys.state.spec.ts
@@ -1,21 +1,13 @@
 import { mock } from "jest-mock-extended";
 
-import { makeStaticByteArray } from "../../../../spec";
+import { makeEncString, makeStaticByteArray } from "../../../../spec";
 import { ProviderId } from "../../../types/guid";
 import { ProviderKey, UserPrivateKey } from "../../../types/key";
 import { EncryptService } from "../../abstractions/encrypt.service";
-import { EncryptionType } from "../../enums";
-import { Utils } from "../../misc/utils";
-import { EncString, EncryptedString } from "../../models/domain/enc-string";
 import { SymmetricCryptoKey } from "../../models/domain/symmetric-crypto-key";
 import { CryptoService } from "../crypto.service";
 
 import { USER_ENCRYPTED_PROVIDER_KEYS, USER_PROVIDER_KEYS } from "./provider-keys.state";
-
-function makeEncString(data?: string) {
-  data ??= Utils.newGuid();
-  return new EncString(EncryptionType.AesCbc256_HmacSha256_B64, data, "test", "test");
-}
 
 describe("encrypted provider keys", () => {
   const sut = USER_ENCRYPTED_PROVIDER_KEYS;

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -22,7 +22,10 @@ export const ACCOUNT_MEMORY = new StateDefinition("account", "memory");
 export const BILLING_BANNERS_DISK = new StateDefinition("billingBanners", "disk");
 
 export const CRYPTO_DISK = new StateDefinition("crypto", "disk");
+
 export const ENVIRONMENT_DISK = new StateDefinition("environment", "disk");
 
 export const GENERATOR_DISK = new StateDefinition("generator", "disk");
 export const GENERATOR_MEMORY = new StateDefinition("generator", "memory");
+
+export const BIOMETRIC_SETTINGS_DISK = new StateDefinition("biometricSettings", "disk");

--- a/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.spec.ts
+++ b/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.spec.ts
@@ -1,0 +1,153 @@
+import { MockProxy, any } from "jest-mock-extended";
+
+import { MigrationHelper } from "../migration-helper";
+import { mockMigrationHelper } from "../migration-helper.spec";
+
+import {
+  MoveBiometricClientKeyHalfToStateProviders,
+  CLIENT_KEY_HALF,
+} from "./14-move-biometric-client-key-half-state-to-providers";
+
+function exampleJSON() {
+  return {
+    global: {
+      otherStuff: "otherStuff1",
+    },
+    authenticatedAccounts: ["user-1", "user-2", "user-3"],
+    "user-1": {
+      settings: {
+        disableAutoBiometricsPrompt: false,
+        biometricUnlock: true,
+        dismissedBiometricRequirePasswordOnStartCallout: true,
+        otherStuff: "otherStuff2",
+      },
+      keys: {
+        biometricEncryptionClientKeyHalf: "user1-key-half",
+        otherStuff: "overStuff3",
+      },
+      otherStuff: "otherStuff4",
+    },
+    "user-2": {
+      keys: {
+        otherStuff: "otherStuff5",
+      },
+      otherStuff: "otherStuff6",
+    },
+  };
+}
+
+function rollbackJSON() {
+  return {
+    "user_user-1_biometricSettings_clientKeyHalf": "user1-key-half",
+    global: {
+      otherStuff: "otherStuff1",
+    },
+    authenticatedAccounts: ["user-1", "user-2", "user-3"],
+    "user-1": {
+      settings: {
+        disableAutoBiometricsPrompt: false,
+        biometricUnlock: true,
+        dismissedBiometricRequirePasswordOnStartCallout: true,
+        otherStuff: "otherStuff2",
+      },
+      keys: {
+        otherStuff: "overStuff3",
+      },
+      otherStuff: "otherStuff4",
+    },
+    "user-2": {
+      keys: {
+        otherStuff: "otherStuff5",
+      },
+      otherStuff: "otherStuff6",
+    },
+  };
+}
+
+describe("DesktopBiometricState migrator", () => {
+  let helper: MockProxy<MigrationHelper>;
+  let sut: MoveBiometricClientKeyHalfToStateProviders;
+
+  describe("migrate", () => {
+    beforeEach(() => {
+      helper = mockMigrationHelper(exampleJSON(), 13);
+      sut = new MoveBiometricClientKeyHalfToStateProviders(13, 14);
+    });
+
+    it("should remove biometricEncryptionClientKeyHalf from all accounts", async () => {
+      await sut.migrate(helper);
+      expect(helper.set).toHaveBeenCalledTimes(2);
+      expect(helper.set).toHaveBeenCalledWith("user-1", {
+        settings: {
+          disableAutoBiometricsPrompt: false,
+          biometricUnlock: true,
+          dismissedBiometricRequirePasswordOnStartCallout: true,
+          otherStuff: "otherStuff2",
+        },
+        keys: {
+          otherStuff: "overStuff3",
+        },
+        otherStuff: "otherStuff4",
+      });
+      expect(helper.set).toHaveBeenCalledWith("user-2", {
+        keys: {
+          otherStuff: "otherStuff5",
+        },
+        otherStuff: "otherStuff6",
+      });
+    });
+
+    it("should set biometricEncryptionClientKeyHalf value for account that have it", async () => {
+      await sut.migrate(helper);
+
+      expect(helper.setToUser).toHaveBeenCalledWith("user-1", CLIENT_KEY_HALF, "user1-key-half");
+    });
+
+    it("should not call extra setToUser", async () => {
+      await sut.migrate(helper);
+
+      expect(helper.setToUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("rollback", () => {
+    beforeEach(() => {
+      helper = mockMigrationHelper(rollbackJSON(), 14);
+      sut = new MoveBiometricClientKeyHalfToStateProviders(13, 14);
+    });
+
+    it("should null out new values", async () => {
+      await sut.rollback(helper);
+
+      expect(helper.setToUser).toHaveBeenCalledWith("user-1", CLIENT_KEY_HALF, null);
+    });
+
+    it("should add explicit value back to accounts", async () => {
+      await sut.rollback(helper);
+
+      expect(helper.set).toHaveBeenCalledTimes(1);
+      expect(helper.set).toHaveBeenCalledWith("user-1", {
+        settings: {
+          disableAutoBiometricsPrompt: false,
+          biometricUnlock: true,
+          dismissedBiometricRequirePasswordOnStartCallout: true,
+          otherStuff: "otherStuff2",
+        },
+        keys: {
+          biometricEncryptionClientKeyHalf: "user1-key-half",
+          otherStuff: "overStuff3",
+        },
+        otherStuff: "otherStuff4",
+      });
+    });
+
+    it.each(["user-2", "user-3"])(
+      "should not try to restore values to missing accounts",
+      async (userId) => {
+        await sut.rollback(helper);
+
+        expect(helper.set).not.toHaveBeenCalledWith(userId, any());
+      },
+    );
+  });
+});

--- a/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.ts
+++ b/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.ts
@@ -1,0 +1,82 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+type ExpectedAccountType = {
+  settings?: {
+    disableAutoBiometricsPrompt?: boolean;
+    biometricUnlock?: boolean;
+    dismissedBiometricRequirePasswordOnStartCallout?: boolean;
+  };
+  keys?: { biometricEncryptionClientKeyHalf?: string };
+};
+
+// Biometric text, no auto prompt text, fingerprint validated, and prompt cancelled are refreshed on every app start, so we don't need to migrate them
+
+export const BIOMETRIC_UNLOCK_ENABLED: KeyDefinitionLike = {
+  key: "biometricUnlockEnabled",
+  stateDefinition: { name: "biometricSettings" },
+};
+export const DISMISSED_BIOMETRIC_REQUIRE_PASSWORD_ON_START_CALLOUT: KeyDefinitionLike = {
+  key: "dismissedBiometricRequirePasswordOnStartCallout",
+  stateDefinition: { name: "biometricSettings" },
+};
+export const CLIENT_KEY_HALF: KeyDefinitionLike = {
+  key: "clientKeyHalf",
+  stateDefinition: { name: "biometricSettings" },
+};
+
+export const PROMPT_AUTOMATICALLY: KeyDefinitionLike = {
+  key: "promptAutomatically",
+  stateDefinition: { name: "biometricSettings" },
+};
+
+export class MoveBiometricClientKeyHalfToStateProviders extends Migrator<13, 14> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    const legacyAccounts = await helper.getAccounts<ExpectedAccountType>();
+
+    await Promise.all(
+      legacyAccounts.map(async ({ userId, account }) => {
+        if (account == null) {
+          return;
+        }
+        // Move account data
+        if (account?.keys?.biometricEncryptionClientKeyHalf != null) {
+          await helper.setToUser(
+            userId,
+            CLIENT_KEY_HALF,
+            account.keys.biometricEncryptionClientKeyHalf,
+          );
+        }
+
+        // Delete old account data
+        delete account?.keys?.biometricEncryptionClientKeyHalf;
+        await helper.set(userId, account);
+      }),
+    );
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    async function rollbackUser(userId: string, account: ExpectedAccountType) {
+      let updatedAccount = false;
+
+      const userKeyHalf = await helper.getFromUser<string>(userId, CLIENT_KEY_HALF);
+
+      if (userKeyHalf) {
+        account ??= {};
+        account.keys ??= {};
+
+        updatedAccount = true;
+        account.keys.biometricEncryptionClientKeyHalf = userKeyHalf;
+        await helper.setToUser(userId, CLIENT_KEY_HALF, null);
+      }
+
+      if (updatedAccount) {
+        await helper.set(userId, account);
+      }
+    }
+
+    const accounts = await helper.getAccounts<ExpectedAccountType>();
+
+    await Promise.all(accounts.map(({ userId, account }) => rollbackUser(userId, account)));
+  }
+}

--- a/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.ts
+++ b/libs/common/src/state-migrations/migrations/14-move-biometric-client-key-half-state-to-providers.ts
@@ -11,22 +11,8 @@ type ExpectedAccountType = {
 };
 
 // Biometric text, no auto prompt text, fingerprint validated, and prompt cancelled are refreshed on every app start, so we don't need to migrate them
-
-export const BIOMETRIC_UNLOCK_ENABLED: KeyDefinitionLike = {
-  key: "biometricUnlockEnabled",
-  stateDefinition: { name: "biometricSettings" },
-};
-export const DISMISSED_BIOMETRIC_REQUIRE_PASSWORD_ON_START_CALLOUT: KeyDefinitionLike = {
-  key: "dismissedBiometricRequirePasswordOnStartCallout",
-  stateDefinition: { name: "biometricSettings" },
-};
 export const CLIENT_KEY_HALF: KeyDefinitionLike = {
   key: "clientKeyHalf",
-  stateDefinition: { name: "biometricSettings" },
-};
-
-export const PROMPT_AUTOMATICALLY: KeyDefinitionLike = {
-  key: "promptAutomatically",
   stateDefinition: { name: "biometricSettings" },
 };
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Begins conversion of biometric state to state providers. This starts with the client key half, which tracks both the setting the require a password on first unlock, and is used as extra protection in the biometric service.

## Code changes

- **jest.config**: This change allows referencing to `@bitwarden/common/spec` without inclusion in our actual build tsconfigs :smile: I like it.
- **settings.component**: Updates the value of the require password on start setting to presence of a key, and sets a key when updating
- **services.mondule / jslib-services.module / lock.component / main.ts **: update DI. I defined an ElectronCryptoService abstract that provides methods related to biometric keys
- **biometric.service**: update to use biometric state. There's a bit of a hack here since `accountService` isn't fully synced in desktop to extract a userId from the biometric storage key. It's just not worth worrying about syncing accounts to background right now.
- **electron-crypto.service**: defines an abstract interface for crypto service in electron contexts that extends to include biometric settings.
  - Also updates the client key half logic to be less... reactionary and more proactive about setting key halves.
  - coalesces removal of biometric key into one method and calls that for `clearAllStoredKeys`
- **electron-state.service / account**: remove moved methods and account data
- **electron-storage.service**: electron store does not support setting values to null, but state providers doesn't support remove, so we need to route this at the storage level.
- **biometric.state biometric-state.service**: implements the state handling for client key half. These are pretty simple, but includes interpretation of whether or not to require password on start based on presence of a client key half.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
