### PR TITLE
[PM-6006] Restrict desktop devtools to dev mode only

### DIFF
--- a/apps/desktop/src/main/menu/menu.view.ts
+++ b/apps/desktop/src/main/menu/menu.view.ts
@@ -3,6 +3,8 @@ import { MenuItemConstructorOptions } from "electron";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 
+import { isDev } from "../../utils";
+
 import { IMenubarMenu } from "./menubar";
 
 export class ViewMenu implements IMenubarMenu {
@@ -13,7 +15,7 @@ export class ViewMenu implements IMenubarMenu {
   }
 
   get items(): MenuItemConstructorOptions[] {
-    return [
+    const items = [
       this.searchVault,
       this.separator,
       this.generator,
@@ -26,8 +28,13 @@ export class ViewMenu implements IMenubarMenu {
       this.toggleFullscreen,
       this.separator,
       this.reload,
-      this.toggleDevTools,
     ];
+
+    if (isDev()) {
+      items.push(this.toggleDevTools);
+    }
+
+    return items;
   }
 
   private readonly _i18nService: I18nService;

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -162,6 +162,7 @@ export class WindowMain {
         backgroundThrottling: false,
         contextIsolation: false,
         session: this.session,
+        devTools: isDev(),
       },
     });
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Disable devtools when not running the application in development mode. Of note is that our `isDev` function can be enabled with an environment variable and we should evaluate if we want `isDev` to use https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly instead.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/main/menu/menu.view.ts:** Hide menu item
- **apps/desktop/src/main/window.main.ts**: Only allow devtools in dev mode

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
