### PR TITLE
Add state definitions for Admin Console services

### DIFF
--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -26,3 +26,10 @@ export const ENVIRONMENT_DISK = new StateDefinition("environment", "disk");
 
 export const GENERATOR_DISK = new StateDefinition("generator", "disk");
 export const GENERATOR_MEMORY = new StateDefinition("generator", "memory");
+
+// Admin Console
+export const ORGANIZATIONS_DISK = new StateDefinition("organizations", "disk");
+export const POLICIES_DISK = new StateDefinition("policies", "disk");
+export const POLICIES_MEMORY = new StateDefinition("policies", "memory");
+export const PROVIDERS_DISK = new StateDefinition("providers", "disk");
+//


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Instantiate `StateDefinition` objects for Admin Console services.

Implementation will come in subsequent PRs, but this PR creates state that will be used by `OrganizationService`, `ProviderService`, and `PolicyService`.

## Code changes

1. Create `StateDefinitions` for each admin console service. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)

## References

This relates to the following items in Jira:

* [**AC-2008**: Transition `PolicyService` to use `StateProvider`](https://bitwarden.atlassian.net/browse/AC-2008)
* [**AC-2009**: Transition `OrganizationService` to use `StateProvider`](https://bitwarden.atlassian.net/browse/AC-2009)
* [**AC-2010**: Transition `ProviderService` to use `StateProvider`](https://bitwarden.atlassian.net/browse/AC-2010)