### PR TITLE
[CL-178] contain overflow in bit-layout main content

### DIFF
--- a/libs/components/src/layout/layout.component.html
+++ b/libs/components/src/layout/layout.component.html
@@ -29,7 +29,7 @@
   <main
     [id]="mainContentId"
     tabindex="-1"
-    class="tw-min-h-screen tw-min-w-0 tw-flex-1 tw-bg-background tw-p-6"
+    class="tw-overflow-auto tw-h-screen tw-min-w-0 tw-flex-1 tw-bg-background tw-p-6"
   >
     <ng-content></ng-content>
   </main>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `main` element in `bit-layout` should become a scroll container when it is overflowed. If it doesn't, the sidebar won't appear fixed.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/layout/layout.component.html:** Add `tw-overflow-auto` and `tw-h-screen` to `main` el

## Screenshots



Before:

https://github.com/bitwarden/clients/assets/17113462/fa79ebc6-ea9e-4f75-9057-9f3b26aa074a



After:

https://github.com/bitwarden/clients/assets/17113462/001f573a-f8f3-49e1-9cde-b225bcd82bdf



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
