### PR TITLE
[PM-5736] check credential type explicitly when loading evaluator

### DIFF
--- a/libs/common/src/tools/generator/password/password-generation.service.ts
+++ b/libs/common/src/tools/generator/password/password-generation.service.ts
@@ -198,9 +198,10 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
       options.type = policy.defaultType;
     }
 
-    const evaluator = options.type
-      ? new PasswordGeneratorOptionsEvaluator(policy)
-      : new PassphraseGeneratorOptionsEvaluator(policy);
+    const evaluator =
+      options.type == "password"
+        ? new PasswordGeneratorOptionsEvaluator(policy)
+        : new PassphraseGeneratorOptionsEvaluator(policy);
 
     // Ensure the options to pass the current rules
     const withPolicy = evaluator.applyPolicy(options);
@@ -347,9 +348,10 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
     options: PasswordGeneratorOptions,
     enforcedPolicyOptions: PasswordGeneratorPolicyOptions,
   ) {
-    const evaluator = options.type
-      ? new PasswordGeneratorOptionsEvaluator(enforcedPolicyOptions)
-      : new PassphraseGeneratorOptionsEvaluator(enforcedPolicyOptions);
+    const evaluator =
+      options.type == "password"
+        ? new PasswordGeneratorOptionsEvaluator(enforcedPolicyOptions)
+        : new PassphraseGeneratorOptionsEvaluator(enforcedPolicyOptions);
 
     const evaluatedOptions = evaluator.applyPolicy(options);
     const santizedOptions = evaluator.sanitize(evaluatedOptions);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The password policy generator failed to load the passphrase evaluator because it used a truthy check to load the evaluator. It should have used an explicit check for `options.type`.

## Code changes

* `libs/common/src/tools/generator/password/password-generation.service.ts` - compare `options.type === "password"`.
