### PR TITLE
[PM-6032] Run migrations in main process

### DIFF
--- a/apps/desktop/src/app/services/init.service.ts
+++ b/apps/desktop/src/app/services/init.service.ts
@@ -43,7 +43,7 @@ export class InitService {
   init() {
     return async () => {
       this.nativeMessagingService.init();
-      await this.stateService.init();
+      await this.stateService.init({ runMigrations: false }); // Desktop will run them in main process
       await this.environmentService.setUrlsFromStorage();
       // Workaround to ignore stateService.activeAccount until URLs are set
       // TODO: Remove this when implementing ticket PM-2637

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,7 +15,8 @@ import { DefaultGlobalStateProvider } from "@bitwarden/common/platform/state/imp
 import { DefaultSingleUserStateProvider } from "@bitwarden/common/platform/state/implementations/default-single-user-state.provider";
 import { DefaultStateProvider } from "@bitwarden/common/platform/state/implementations/default-state.provider";
 import { MemoryStorageService as MemoryStorageServiceForStateProviders } from "@bitwarden/common/platform/state/storage/memory-storage.service";
-/*/ eslint-enable import/no-restricted-paths */
+/* eslint-enable import/no-restricted-paths */
+import { migrate } from "@bitwarden/common/state-migrations";
 
 import { MenuMain } from "./main/menu/menu.main";
 import { MessagingMain } from "./main/messaging.main";
@@ -187,8 +188,10 @@ export class Main {
 
   bootstrap() {
     this.desktopCredentialStorageListener.init();
-    this.windowMain.init().then(
+    // Run migrations first, then other things
+    migrate(this.storageService, this.logService).then(
       async () => {
+        await this.windowMain.init();
         const locale = await this.stateService.getLocale();
         await this.i18nService.init(locale != null ? locale : app.getLocale());
         this.messagingMain.init();

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -36,6 +36,20 @@ import { EncString } from "../models/domain/enc-string";
 import { StorageOptions } from "../models/domain/storage-options";
 import { SymmetricCryptoKey } from "../models/domain/symmetric-crypto-key";
 
+/**
+ * Options for customizing the initiation behavior.
+ */
+export type InitOptions = {
+  /**
+   * Whether or not to run state migrations as part of the init process. Defaults to true.
+   *
+   * If false, the init method will instead wait for migrations to complete before doing its
+   * other init operations. Make sure migrations have either already completed, or will complete
+   * before calling {@link StateService.init} with `runMigrations: false`.
+   */
+  runMigrations: boolean;
+};
+
 export abstract class StateService<T extends Account = Account> {
   accounts$: Observable<{ [userId: string]: T }>;
   activeAccount$: Observable<string>;
@@ -44,7 +58,7 @@ export abstract class StateService<T extends Account = Account> {
   addAccount: (account: T) => Promise<void>;
   setActiveUser: (userId: string) => Promise<void>;
   clean: (options?: StorageOptions) => Promise<UserId>;
-  init: () => Promise<void>;
+  init: (initOptions?: InitOptions) => Promise<void>;
 
   getAccessToken: (options?: StorageOptions) => Promise<string>;
   setAccessToken: (value: string, options?: StorageOptions) => Promise<void>;

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -47,7 +47,7 @@ export type InitOptions = {
    * other init operations. Make sure migrations have either already completed, or will complete
    * before calling {@link StateService.init} with `runMigrations: false`.
    */
-  runMigrations: boolean;
+  runMigrations?: boolean;
 };
 
 export abstract class StateService<T extends Account = Account> {

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -16,6 +16,7 @@ import { VaultTimeoutAction } from "../../enums/vault-timeout-action.enum";
 import { EventData } from "../../models/data/event.data";
 import { WindowState } from "../../models/domain/window-state";
 import { migrate } from "../../state-migrations";
+import { waitForMigrations } from "../../state-migrations/migrate";
 import { GeneratorOptions } from "../../tools/generator/generator-options";
 import { GeneratedPasswordHistory, PasswordGeneratorOptions } from "../../tools/generator/password";
 import { UsernameGeneratorOptions } from "../../tools/generator/username";
@@ -33,7 +34,10 @@ import { CollectionView } from "../../vault/models/view/collection.view";
 import { AddEditCipherInfo } from "../../vault/types/add-edit-cipher-info";
 import { EnvironmentService } from "../abstractions/environment.service";
 import { LogService } from "../abstractions/log.service";
-import { StateService as StateServiceAbstraction } from "../abstractions/state.service";
+import {
+  InitOptions,
+  StateService as StateServiceAbstraction,
+} from "../abstractions/state.service";
 import {
   AbstractMemoryStorageService,
   AbstractStorageService,
@@ -126,12 +130,20 @@ export class StateService<
       .subscribe();
   }
 
-  async init(): Promise<void> {
+  async init(initOptions?: InitOptions): Promise<void> {
+    // Deconstruct and apply defaults
+    const { runMigrations = true } = initOptions;
     if (this.hasBeenInited) {
       return;
     }
 
-    await migrate(this.storageService, this.logService);
+    if (runMigrations) {
+      await migrate(this.storageService, this.logService);
+    } else {
+      // It may have been requested to not run the migrations but we should defensively not
+      // continue this method until migrations have a chance to be completed elsewhere.
+      await waitForMigrations(this.storageService, this.logService);
+    }
 
     await this.state().then(async (state) => {
       if (state == null) {

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -130,7 +130,7 @@ export class StateService<
       .subscribe();
   }
 
-  async init(initOptions?: InitOptions): Promise<void> {
+  async init(initOptions: InitOptions = {}): Promise<void> {
     // Deconstruct and apply defaults
     const { runMigrations = true } = initOptions;
     if (this.hasBeenInited) {

--- a/libs/common/src/state-migrations/migrate.ts
+++ b/libs/common/src/state-migrations/migrate.ts
@@ -69,3 +69,46 @@ export async function currentVersion(
   logService.info(`State version: ${state}`);
   return state;
 }
+
+/**
+ * Waits for migrations to have a chance to run and will resolve the promise once they are.
+ *
+ * @param storageService Disk storage where the `stateVersion` will or is already saved in.
+ * @param logService Log service
+ */
+export async function waitForMigrations(
+  storageService: AbstractStorageService,
+  logService: LogService,
+) {
+  const isReady = async () => {
+    const version = await currentVersion(storageService, logService);
+    // The saved version is what we consider the latest
+    // migrations should be complete
+    return version === CURRENT_VERSION;
+  };
+
+  const wait = async (time: number) => {
+    // Wait exponentially
+    const nextTime = time * 2;
+    if (nextTime > 8192) {
+      // Don't wait longer than ~8 seconds in a single wait,
+      // if the migrations still haven't happened. They aren't
+      // likely to.
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      setTimeout(async () => {
+        if (!(await isReady())) {
+          logService.info(`Waiting for migrations to finish, waiting for ${nextTime}ms`);
+          await wait(nextTime);
+        }
+        resolve();
+      }, time);
+    });
+  };
+
+  if (!(await isReady())) {
+    // Wait for 2ms to start with
+    await wait(2);
+  }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make it possible to run migrations in desktops main process.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/desktop/src/app/services/init.service.ts:** Don't run migrations during state service init in `InitService` since the main process should be running them instead.
- **apps/desktop/src/main.ts:** Run migrations first, and then do the rest of the existing steps.
- **libs/common/src/platform/abstractions/state.service.ts:** Add optional `InitOptions` to `init` method.
- **libs/common/src/platform/services/state.service.ts:** Respect `runMigrations` choice and instead check the migrations are complete if they do not want migrations ran.
- **libs/common/src/state-migrations/migrate.ts:** Add method for waiting for migrations to complete by checking the stateVersion piece of state.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
