### PR TITLE
[PM-5991] Updated ordering on account switch to route before clearing state

### DIFF
--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -134,9 +134,9 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
 
   async addAccount() {
     this.close();
-    await this.stateService.setActiveUser(null);
     await this.stateService.setRememberedEmail(null);
     await this.router.navigate(["/login"]);
+    await this.stateService.setActiveUser(null);
   }
 
   private async createInactiveAccounts(baseAccounts: {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We have a bug in which adding an account when the current account is locked causes an infinite loading screen.  The issue is that clearing state causes the `LockComponent` to respond to the `activeAccount$` observable and trigger `load()`, which in turn attempts to log the user out - since the `activeAccount` does not have any state (it's `null`) and thus has no lock methods.

Instead, we should route the user to `/login` before clearing state, ensuring that `LockComponent` does not respond to the state change.

## Code changes

- **account-switcher.component.ts:** Changed the order of operations on adding a new account to route to `/login` before clearing state. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
