### PR TITLE
[CL-179][PM-6011] open parent bit-nav-groups when bit-nav-item becomes active

### DIFF
--- a/libs/components/src/navigation/nav-group.stories.ts
+++ b/libs/components/src/navigation/nav-group.stories.ts
@@ -1,5 +1,6 @@
-import { RouterTestingModule } from "@angular/router/testing";
-import { StoryObj, Meta, moduleMetadata } from "@storybook/angular";
+import { Component, importProvidersFrom } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { StoryObj, Meta, moduleMetadata, applicationConfig } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
@@ -9,12 +10,18 @@ import { I18nMockService } from "../utils/i18n-mock.service";
 import { NavGroupComponent } from "./nav-group.component";
 import { NavigationModule } from "./navigation.module";
 
+@Component({
+  standalone: true,
+  template: "",
+})
+class DummyContentComponent {}
+
 export default {
   title: "Component Library/Nav/Nav Group",
   component: NavGroupComponent,
   decorators: [
     moduleMetadata({
-      imports: [SharedModule, RouterTestingModule, NavigationModule],
+      imports: [SharedModule, RouterModule, NavigationModule, DummyContentComponent],
       providers: [
         {
           provide: I18nService,
@@ -25,6 +32,19 @@ export default {
             });
           },
         },
+      ],
+    }),
+    applicationConfig({
+      providers: [
+        importProvidersFrom(
+          RouterModule.forRoot(
+            [
+              { path: "", redirectTo: "a", pathMatch: "full" },
+              { path: "**", component: DummyContentComponent },
+            ],
+            { useHash: true },
+          ),
+        ),
       ],
     }),
   ],
@@ -40,10 +60,10 @@ export const Default: StoryObj<NavGroupComponent> = {
   render: (args) => ({
     props: args,
     template: `
-      <bit-nav-group text="Hello World (Anchor)" [route]="['']" icon="bwi-filter" [open]="true">
-        <bit-nav-item text="Child A" route="#" icon="bwi-filter"></bit-nav-item>
-        <bit-nav-item text="Child B" route="#"></bit-nav-item>
-        <bit-nav-item text="Child C" route="#" icon="bwi-filter"></bit-nav-item>
+      <bit-nav-group text="Hello World (Anchor)" [route]="['a']" icon="bwi-filter">
+        <bit-nav-item text="Child A" route="a" icon="bwi-filter"></bit-nav-item>
+        <bit-nav-item text="Child B" route="b"></bit-nav-item>
+        <bit-nav-item text="Child C" route="c" icon="bwi-filter"></bit-nav-item>
       </bit-nav-group>
       <bit-nav-group text="Lorem Ipsum (Button)" icon="bwi-filter">
         <bit-nav-item text="Child A" icon="bwi-filter"></bit-nav-item>
@@ -59,19 +79,19 @@ export const Tree: StoryObj<NavGroupComponent> = {
     props: args,
     template: `
       <bit-nav-group text="Tree example" icon="bwi-collection" [open]="true">
-        <bit-nav-group text="Level 1 - with children (empty)" route="#" icon="bwi-collection" variant="tree"></bit-nav-group>
-        <bit-nav-item text="Level 1 - no children" route="#" icon="bwi-collection" variant="tree"></bit-nav-item>
-        <bit-nav-group text="Level 1 - with children" route="#" icon="bwi-collection" variant="tree" [open]="true">
-          <bit-nav-group text="Level 2 - with children" route="#" icon="bwi-collection" variant="tree" [open]="true">
-            <bit-nav-item text="Level 3 - no children, no icon" route="#" variant="tree"></bit-nav-item>
-            <bit-nav-group text="Level 3 - with children" route="#" icon="bwi-collection" variant="tree" [open]="true">
-              <bit-nav-item text="Level 4 - no children, no icon" route="#" variant="tree"></bit-nav-item>
+        <bit-nav-group text="Level 1 - with children (empty)" route="t1" icon="bwi-collection" variant="tree"></bit-nav-group>
+        <bit-nav-item text="Level 1 - no children" route="t2" icon="bwi-collection" variant="tree"></bit-nav-item>
+        <bit-nav-group text="Level 1 - with children" route="t3" icon="bwi-collection" variant="tree" [open]="true">
+          <bit-nav-group text="Level 2 - with children" route="t4" icon="bwi-collection" variant="tree" [open]="true">
+            <bit-nav-item text="Level 3 - no children, no icon" route="t5" variant="tree"></bit-nav-item>
+            <bit-nav-group text="Level 3 - with children" route="t6" icon="bwi-collection" variant="tree" [open]="true">
+              <bit-nav-item text="Level 4 - no children, no icon" route="t7" variant="tree"></bit-nav-item>
             </bit-nav-group>
           </bit-nav-group>
-          <bit-nav-group text="Level 2 - with children (empty)" route="#" icon="bwi-collection" variant="tree" [open]="true"></bit-nav-group>
-          <bit-nav-item text="Level 2 - no children" route="#" icon="bwi-collection" variant="tree"></bit-nav-item>
+          <bit-nav-group text="Level 2 - with children (empty)" route="t8" icon="bwi-collection" variant="tree" [open]="true"></bit-nav-group>
+          <bit-nav-item text="Level 2 - no children" route="t9" icon="bwi-collection" variant="tree"></bit-nav-item>
         </bit-nav-group>
-        <bit-nav-item text="Level 1 - no children" route="#" icon="bwi-collection" variant="tree"></bit-nav-item>
+        <bit-nav-item text="Level 1 - no children" route="t10" icon="bwi-collection" variant="tree"></bit-nav-item>
       </bit-nav-group>
     `,
   }),

--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -55,7 +55,7 @@
         routerLinkActive
         [routerLinkActiveOptions]="rlaOptions"
         [ariaCurrentWhenActive]="'page'"
-        (isActiveChange)="setActive($event)"
+        (isActiveChange)="setIsActive($event)"
         (click)="mainContentClicked.emit()"
       >
         <ng-container *ngTemplateOutlet="anchorAndButtonContent"></ng-container>

--- a/libs/components/src/navigation/nav-item.component.ts
+++ b/libs/components/src/navigation/nav-item.component.ts
@@ -1,23 +1,28 @@
-import { Component, HostListener, Input } from "@angular/core";
+import { Component, HostListener, Input, Optional } from "@angular/core";
 import { IsActiveMatchOptions } from "@angular/router";
 import { BehaviorSubject, map } from "rxjs";
 
 import { NavBaseComponent } from "./nav-base.component";
+import { NavGroupComponent } from "./nav-group.component";
 
 @Component({
   selector: "bit-nav-item",
   templateUrl: "./nav-item.component.html",
+  providers: [{ provide: NavBaseComponent, useExisting: NavItemComponent }],
 })
 export class NavItemComponent extends NavBaseComponent {
   /**
    * Is `true` if `to` matches the current route
    */
-  private _active = false;
-  protected setActive(isActive: boolean) {
-    this._active = isActive;
+  private _isActive = false;
+  protected setIsActive(isActive: boolean) {
+    this._isActive = isActive;
+    if (this._isActive && this.parentNavGroup) {
+      this.parentNavGroup.setOpen(true);
+    }
   }
   protected get showActiveStyles() {
-    return this._active && !this.hideActiveStyles;
+    return this._isActive && !this.hideActiveStyles;
   }
   protected rlaOptions: IsActiveMatchOptions = {
     paths: "subset",
@@ -53,5 +58,9 @@ export class NavItemComponent extends NavBaseComponent {
   @HostListener("focusout")
   onFocusOut() {
     this.focusVisibleWithin$.next(false);
+  }
+
+  constructor(@Optional() private parentNavGroup: NavGroupComponent) {
+    super();
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

If the route associated with a `bit-nav-item` becomes active, it should open parent `bit-nav-group`s.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/navigation/nav-group.component.ts:** 
  - Inject parent `bit-nav-group`
  - bubble `open` change to parent
  - refactor `ContentChildren` to use abstract base class injection token; this prevents a circular reference between nav group and item
- **libs/components/src/navigation/nav-item.component.ts:**
  -  Inject parent `bit-nav-group`
  -  call parent open method when route becomes active
  - rename `active` to `isActive` to be more consistent with `ActiveRoute` props
- **libs/components/src/navigation/nav-group.stories.ts:**
  - replace `RouterTestingModule` with actual router, so we can better test active route styles in Storybook. 
  
## Screenshots

`bit-nav-group` with child active route opens after page refresh:



https://github.com/bitwarden/clients/assets/17113462/5e8d1608-b32e-4207-83cd-c2e95ee3b395




## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
