### PR TITLE
[PM-6012] Added device identifier header when updating trust on key rotation

### DIFF
--- a/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
@@ -18,7 +18,10 @@ export abstract class DevicesApiServiceAbstraction {
     deviceKeyEncryptedDevicePrivateKey: string,
   ) => Promise<DeviceResponse>;
 
-  updateTrust: (updateDevicesTrustRequestModel: UpdateDevicesTrustRequest) => Promise<void>;
+  updateTrust: (
+    updateDevicesTrustRequestModel: UpdateDevicesTrustRequest,
+    deviceIdentifier: string,
+  ) => Promise<void>;
 
   getDeviceKeys: (
     deviceIdentifier: string,

--- a/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.implementation.ts
@@ -150,7 +150,7 @@ export class DeviceTrustCryptoService implements DeviceTrustCryptoServiceAbstrac
     trustRequest.currentDevice = currentDeviceUpdateRequest;
     trustRequest.otherDevices = [];
 
-    await this.devicesApiService.updateTrust(trustRequest);
+    await this.devicesApiService.updateTrust(trustRequest, deviceIdentifier);
   }
 
   async getDeviceKey(): Promise<DeviceKey> {

--- a/libs/common/src/auth/services/device-trust-crypto.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust-crypto.service.spec.ts
@@ -502,7 +502,7 @@ describe("deviceTrustCryptoService", () => {
 
         await deviceTrustCryptoService.rotateDevicesTrust(fakeNewUserKey, "");
 
-        expect(devicesApiService.updateTrust).not.toBeCalled();
+        expect(devicesApiService.updateTrust).not.toHaveBeenCalled();
       });
 
       describe("is on a trusted device", () => {
@@ -579,7 +579,7 @@ describe("deviceTrustCryptoService", () => {
 
           await deviceTrustCryptoService.rotateDevicesTrust(fakeNewUserKey, "my_password_hash");
 
-          expect(devicesApiService.updateTrust).toBeCalledWith(
+          expect(devicesApiService.updateTrust).toHaveBeenCalledWith(
             matches((updateTrustModel: UpdateDevicesTrustRequest) => {
               return (
                 updateTrustModel.currentDevice.encryptedPublicKey ===
@@ -587,6 +587,7 @@ describe("deviceTrustCryptoService", () => {
                 updateTrustModel.currentDevice.encryptedUserKey === "4.ZW5jcnlwdGVkdXNlcg=="
               );
             }),
+            expect.stringMatching("test_device_identifier"),
           );
         });
       });

--- a/libs/common/src/auth/services/devices-api.service.implementation.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.ts
@@ -71,13 +71,20 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
     return new DeviceResponse(result);
   }
 
-  async updateTrust(updateDevicesTrustRequestModel: UpdateDevicesTrustRequest): Promise<void> {
+  async updateTrust(
+    updateDevicesTrustRequestModel: UpdateDevicesTrustRequest,
+    deviceIdentifier: string,
+  ): Promise<void> {
     await this.apiService.send(
       "POST",
       "/devices/update-trust",
       updateDevicesTrustRequestModel,
       true,
       false,
+      null,
+      (headers) => {
+        headers.set("X-Device-Identifier", deviceIdentifier);
+      },
     );
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When rotating encryption keys with trusted devices, we make a POST to `update-trust` on these devices with the new keys.  However, the server expects that the device identifier is in a header on the request and uses this identifier to initiate the process.  We were not passing that header up.

The reason that we chose to stick with a header and not add the field to the POST body, was to avoid yet another convention in how we pass up the identifier.  We currently use the header as well as the request path in some cases.

## Code changes

- **devices-api.service.implementation.ts:** Added header to request.
- **devices-api.service.abstraction.ts:** Updated method signature
- **device-trust-crypto.service.implementation.ts:** Updated method signature.
- **device-trust-crypto.service.spec.ts:** Updated tests to reflect new parameter, and also replaced deprecated `toBeCalled` with `toHaveBeenCalled`.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
