### PR TITLE
Modified to use the correct header.

### DIFF
--- a/libs/common/src/auth/services/devices-api.service.implementation.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.ts
@@ -83,7 +83,7 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
       false,
       null,
       (headers) => {
-        headers.set("X-Device-Identifier", deviceIdentifier);
+        headers.set("Device-Identifier", deviceIdentifier);
       },
     );
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We currently have 2 different `Device-Identifier` headers that we expect on the server:

- `Device-Identifier` on [CurrentContext](https://github.com/bitwarden/server/blob/rc/src/Core/Context/CurrentContext.cs#L64)
- `X-Device-Identifier` on the model for the [known device request](https://github.com/bitwarden/server/blob/rc/src/Api/Models/Request/KnownDeviceRequestModel.cs#L13)

In https://github.com/bitwarden/clients/pull/7807, I added the incorrect header to the request.  This PR addresses that by using the `Device-Identifier`.

I have also created https://bitwarden.atlassian.net/browse/PM-6086 to capture the tech debt to consolidate this with a single header name.

## Code changes

- **devices-api.service.implementation.ts:** Changed header to match the one that the server uses to build the context.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
