### PR TITLE
[AC-2147] Show grant collection access helper text

### DIFF
--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
@@ -64,11 +64,15 @@
           </bit-form-field>
         </bit-tab>
         <bit-tab label="{{ 'access' | i18n }}">
-          <div class="tw-mb-3" *ngIf="flexibleCollectionsV1Enabled$ | async">
+          <div class="tw-mb-3" *ngIf="organization.flexibleCollections">
             {{ "grantCollectionAccess" | i18n }}
-            <span *ngIf="organization.allowAdminAccessToAllCollectionItems">{{
-              " " + ("adminCollectionAccess" | i18n)
-            }}</span>
+            <span
+              *ngIf="
+                (flexibleCollectionsV1Enabled$ | async) &&
+                organization.allowAdminAccessToAllCollectionItems
+              "
+              >{{ " " + ("adminCollectionAccess" | i18n) }}</span
+            >
           </div>
           <div
             class="tw-mb-3 tw-text-danger"


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

> When creating/viewing a collection from the individual vault or organization tab, the Group label is missing from the Group/Member permission table. 

## Code changes

- **apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html**: Moved the `v1` flag check down to the necessary child `span`. Replaced with `organization.flexibleCollections` check.

## Screenshots

![Screenshot 2024-02-06 at 2 18 01 PM](https://github.com/bitwarden/clients/assets/26154748/ad30ee4e-4e82-4be5-aa23-36daa4c22fe0)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
