### PR TITLE
[PM-6125] fix: handle cases when `kp.alg` is `string` in `createCredential` for…

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-client.service.ts
@@ -110,9 +110,18 @@ export class Fido2ClientService implements Fido2ClientServiceAbstraction {
     let credTypesAndPubKeyAlgs: PublicKeyCredentialParam[];
     if (params.pubKeyCredParams?.length > 0) {
       // Filter out all unsupported algorithms
-      credTypesAndPubKeyAlgs = params.pubKeyCredParams.filter(
-        (kp) => kp.alg === -7 && kp.type === "public-key",
-      );
+      credTypesAndPubKeyAlgs = params.pubKeyCredParams.filter((kp) => {
+        if (typeof kp.alg == "string") {
+          const val = Number(kp.alg);
+          if (isNaN(val)) {
+            return false;
+          }
+
+          kp.alg = val;
+        }
+
+        return kp.alg === -7 && kp.type === "public-key";
+      });
     } else {
       // Assign default algorithms
       credTypesAndPubKeyAlgs = [


### PR DESCRIPTION
… `Fido2`

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

I was trying to add passkeys from a website that uses a version of KeycloakJS that sends `kp.alg` as string.
I know this deviates from standard but it would help passkeys adoption in Bitwarden while providers fix their code (and organizations install the new version).

With this PR, `createCredential` handles passkeys creation when `kp.alg` is `string` by parsing it as a `Number`.
Let me know if you think this should be handled differently, thanks!

## Code changes

Parse `kp.alg` as `Number` if it is a `string`.

Fixes #6804 .