### PR TITLE
Prefer get methods to return single user states unless specified active

### DIFF
--- a/libs/common/spec/fake-account-service.ts
+++ b/libs/common/spec/fake-account-service.ts
@@ -48,32 +48,24 @@ export class FakeAccountService implements AccountService {
   }
 
   async addAccount(userId: UserId, accountData: AccountInfo): Promise<void> {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.mock.addAccount(userId, accountData);
+    const current = this.accountsSubject["_buffer"][0] ?? {};
+    this.accountsSubject.next({ ...current, [userId]: accountData });
+    await this.mock.addAccount(userId, accountData);
   }
 
   async setAccountName(userId: UserId, name: string): Promise<void> {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.mock.setAccountName(userId, name);
+    await this.mock.setAccountName(userId, name);
   }
 
   async setAccountEmail(userId: UserId, email: string): Promise<void> {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.mock.setAccountEmail(userId, email);
+    await this.mock.setAccountEmail(userId, email);
   }
 
   async setAccountStatus(userId: UserId, status: AuthenticationStatus): Promise<void> {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.mock.setAccountStatus(userId, status);
+    await this.mock.setAccountStatus(userId, status);
   }
 
   async switchAccount(userId: UserId): Promise<void> {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.mock.switchAccount(userId);
+    await this.mock.switchAccount(userId);
   }
 }

--- a/libs/common/src/platform/state/implementations/default-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-state.provider.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs";
+import { Observable, switchMap, take } from "rxjs";
 
 import { UserId } from "../../../types/guid";
 import { DerivedStateDependencies } from "../../../types/state";
@@ -25,7 +25,10 @@ export class DefaultStateProvider implements StateProvider {
     if (userId) {
       return this.getUser<T>(userId, keyDefinition).state$;
     } else {
-      return this.getActive<T>(keyDefinition).state$;
+      return this.activeUserId$.pipe(
+        take(1),
+        switchMap((userId) => this.getUser<T>(userId, keyDefinition).state$),
+      );
     }
   }
 

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -22,6 +22,9 @@ export abstract class StateProvider {
   /**
    * Gets a state observable for a given key and userId.
    *
+   * @remarks If userId is nullish the observable returned will point to the currently active user _and not update if the active user changes_.
+   * This is different to how `getActive` works and more similar to `getUser` for whatever user happens to be active at the time of the call.
+   *
    * @param keyDefinition - The key definition for the state you want to get.
    * @param userId - The userId for which you want the state for. If not provided, the state for the currently active user will be returned.
    */

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -22,7 +22,7 @@ export abstract class StateProvider {
   /**
    * Gets a state observable for a given key and userId.
    *
-   * @remarks If userId is nullish the observable returned will point to the currently active user _and not update if the active user changes_.
+   * @remarks If userId is falsy the observable returned will point to the currently active user _and not update if the active user changes_.
    * This is different to how `getActive` works and more similar to `getUser` for whatever user happens to be active at the time of the call.
    *
    * @param keyDefinition - The key definition for the state you want to get.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Updates `getUserState$` helper method implemented in #7824 to not update the user being observed as active user changes.

Internal discussions revealed this to be somewhat unexpected and an observable that watches the state of whatever user was active at the time of the call is more consistent to expectations.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
