### PR TITLE
[PM-6124] Default Passkey Setting not correct

### DIFF
--- a/libs/common/src/vault/services/vault-settings/vault-settings.service.ts
+++ b/libs/common/src/vault/services/vault-settings/vault-settings.service.ts
@@ -15,7 +15,7 @@ export class VaultSettingsService implements VaultSettingsServiceAbstraction {
    * {@link VaultSettingsServiceAbstraction.enablePasskeys$}
    */
   readonly enablePasskeys$: Observable<boolean> = this.enablePasskeysState.state$.pipe(
-    map((x) => x ?? false),
+    map((x) => x ?? true),
   );
 
   constructor(private stateProvider: StateProvider) {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
During the migration of the enable passkeys state to the state provider framework, the default option setting was set to `false` instead of `true.`
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
