### PR TITLE
[PM-6110] Folders don't show up on Folders page on Browser

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -68,7 +68,7 @@ import { GlobalState } from "@bitwarden/common/platform/models/domain/global-sta
 import { ConfigService } from "@bitwarden/common/platform/services/config/config.service";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
-import { DerivedStateProvider, StateProvider } from "@bitwarden/common/platform/state";
+import { StateProvider } from "@bitwarden/common/platform/state";
 import { SearchService } from "@bitwarden/common/services/search.service";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
 import { UsernameGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/username";
@@ -111,7 +111,6 @@ import BrowserLocalStorageService from "../../platform/services/browser-local-st
 import BrowserMessagingPrivateModePopupService from "../../platform/services/browser-messaging-private-mode-popup.service";
 import BrowserMessagingService from "../../platform/services/browser-messaging.service";
 import { BrowserStateService } from "../../platform/services/browser-state.service";
-import { ForegroundDerivedStateProvider } from "../../platform/state/foreground-derived-state.provider";
 import { ForegroundMemoryStorageService } from "../../platform/storage/foreground-memory-storage.service";
 import { BrowserSendService } from "../../services/browser-send.service";
 import { BrowserSettingsService } from "../../services/browser-settings.service";
@@ -551,11 +550,12 @@ function getBgService<T>(service: keyof MainBackground) {
       },
       deps: [PlatformUtilsService],
     },
-    {
-      provide: DerivedStateProvider,
-      useClass: ForegroundDerivedStateProvider,
-      deps: [OBSERVABLE_MEMORY_STORAGE],
-    },
+    // Commenting this out due to a bug affecting derived state
+    // {
+    //   provide: DerivedStateProvider,
+    //   useClass: ForegroundDerivedStateProvider,
+    //   deps: [OBSERVABLE_MEMORY_STORAGE],
+    // },
   ],
 })
 export class ServicesModule {}

--- a/apps/browser/src/popup/settings/folders.component.html
+++ b/apps/browser/src/popup/settings/folders.component.html
@@ -15,20 +15,24 @@
   </div>
 </header>
 <main tabindex="-1">
-  <div class="box list full-list" *ngIf="(folders$ | async)?.length">
-    <div class="box-content">
-      <button
-        type="button"
-        appStopClick
-        (click)="folderSelected(f)"
-        class="box-content-row padded"
-        *ngFor="let f of folders$ | async"
-      >
-        {{ f.name }}
-      </button>
+  <ng-container *ngIf="folders$ | async as folders">
+    <div class="box list full-list" *ngIf="folders.length; else noFoldersTemplate">
+      <div class="box-content">
+        <button
+          type="button"
+          appStopClick
+          (click)="folderSelected(f)"
+          class="box-content-row padded"
+          *ngFor="let f of folders"
+        >
+          {{ f.name }}
+        </button>
+      </div>
     </div>
-  </div>
-  <div class="no-items" *ngIf="!(folders$ | async)?.length">
-    <p>{{ "noFolders" | i18n }}</p>
-  </div>
+  </ng-container>
+  <ng-template #noFoldersTemplate>
+    <div class="no-items">
+      <p>{{ "noFolders" | i18n }}</p>
+    </div>
+  </ng-template>
 </main>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When you navigate to the Folders page in browser, no folders load. When you click back, the folders briefly appear. Confirmed on Firefox/Mac and Chrome/Windows
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
