### PR TITLE
[AC-2115] Update admin view to also collection check manage flag

### DIFF
--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -33,13 +33,13 @@ export class CollectionAdminView extends CollectionView {
 
   override canEdit(org: Organization): boolean {
     return org?.flexibleCollections
-      ? org?.canEditAnyCollection
+      ? org?.canEditAnyCollection || this.manage
       : org?.canEditAnyCollection || (org?.canEditAssignedCollections && this.assigned);
   }
 
   override canDelete(org: Organization): boolean {
     return org?.flexibleCollections
-      ? org?.canDeleteAnyCollection
+      ? org?.canDeleteAnyCollection || (!org?.limitCollectionCreationDeletion && this.manage)
       : org?.canDeleteAnyCollection || (org?.canDeleteAssignedCollections && this.assigned);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `CollectionAdminView` and `CollectionView` had started to diverge causing inconsistent behaviors when flexible collections was enabled. This updates the `CollectionAdminView` to also consider the `manage` flag when FC is enabled. With this change the delete button in the collection dialog now shows correctly in the individual vault.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/vault/core/views/collection-admin.view.ts:** Add `|| this.manage` to the `CanDelete` and `CanEdit` helpers.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
