### PR TITLE
[PM-6156] Add derive option to clear state after cleanup

### DIFF
--- a/libs/common/src/platform/state/derive-definition.ts
+++ b/libs/common/src/platform/state/derive-definition.ts
@@ -48,6 +48,10 @@ type DeriveDefinitionOptions<TFrom, TTo, TDeps extends DerivedStateDependencies 
    * Defaults to 1000ms.
    */
   cleanupDelayMs?: number;
+  /**
+   * Whether or not to clear the derived state when cleanup occurs. Defaults to true.
+   */
+  clearOnCleanup?: boolean;
 };
 
 /**
@@ -115,6 +119,10 @@ export class DeriveDefinition<TFrom, TTo, TDeps extends DerivedStateDependencies
 
   get cleanupDelayMs() {
     return this.options.cleanupDelayMs < 0 ? 0 : this.options.cleanupDelayMs ?? 1000;
+  }
+
+  get clearOnCleanup() {
+    return this.options.clearOnCleanup ?? true;
   }
 
   buildCacheKey(): string {

--- a/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
@@ -144,6 +144,42 @@ describe("DefaultDerivedState", () => {
       expect(parentState$.observed).toBe(false);
     });
 
+    it("should clear state after cleanup", async () => {
+      const subscription = sut.state$.subscribe();
+      parentState$.next(newDate);
+      await awaitAsync();
+
+      expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
+        new Date(newDate),
+      );
+
+      subscription.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toBeUndefined();
+    });
+
+    it("should not clear state after cleanup if clearOnCleanup is false", async () => {
+      deriveDefinition.options.clearOnCleanup = false;
+
+      const subscription = sut.state$.subscribe();
+      parentState$.next(newDate);
+      await awaitAsync();
+
+      expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
+        new Date(newDate),
+      );
+
+      subscription.unsubscribe();
+      // Wait for cleanup
+      await awaitAsync(cleanupDelayMs * 2);
+
+      expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
+        new Date(newDate),
+      );
+    });
+
     it("should not cleanup if there are still subscribers", async () => {
       const subscription1 = sut.state$.subscribe();
       const sub2Emissions: Date[] = [];

--- a/libs/common/src/platform/state/implementations/default-derived-state.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.ts
@@ -44,7 +44,15 @@ export class DefaultDerivedState<TFrom, TTo, TDeps extends DerivedStateDependenc
         connector: () => {
           return new ReplaySubject<TTo>(1);
         },
-        resetOnRefCountZero: () => timer(this.deriveDefinition.cleanupDelayMs),
+        resetOnRefCountZero: () =>
+          timer(this.deriveDefinition.cleanupDelayMs).pipe(
+            concatMap(async () => {
+              if (this.deriveDefinition.clearOnCleanup) {
+                await this.memoryStorage.remove(this.storageKey);
+              }
+              return true;
+            }),
+          ),
       }),
     );
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds option to ensure that memory storage is clear or derived values on cleanup. This is useful since parent state emissions are not recorded unless something is subscribed to derived state. This ensures no cached data remains.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
