### PR TITLE
[PM-6163] Speed up list items command - Only call GetGlobals() when we actually need them

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -2525,10 +2525,14 @@ export class StateService<
     const accountVaultTimeoutAction = (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
     )?.settings?.vaultTimeoutAction;
-    const globalVaultTimeoutAction = (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.vaultTimeoutAction;
-    return accountVaultTimeoutAction ?? globalVaultTimeoutAction;
+    return (
+      accountVaultTimeoutAction ??
+      (
+        await this.getGlobals(
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()),
+        )
+      )?.vaultTimeoutAction
+    );
   }
 
   async setVaultTimeoutAction(value: string, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Speed up the CLI list items command (see issue https://github.com/bitwarden/clients/issues/7742)

## Code changes

- **state.service.ts** : Only call GetGlobals() when we actually need them

Since we only need it as a backup if `accountVaultTimeoutAction` is null/undefined, there should be no need to call this function every time.

While the overhead may seem trivial at first glance, it can add up to a massive increase in runtime when the function is called repeatedly in quick succession (e.g. when running `bw list items` where it is executed once for every item).

In my concrete case this change leads to a 25x speedup.

Before:
```
❯ time node build/bw.js list items > /dev/null
node build/bw.js list items > /dev/null  14.33s user 4.59s system 23% cpu 1:21.04 total
```

After:
```
❯ time node build/bw.js list items > /dev/null
node build/bw.js list items > /dev/null  1.42s user 0.25s system 50% cpu 3.294 total
```
