### PR TITLE
Ps/run-foreground-derived-state-in-zone

### DIFF
--- a/apps/browser/src/platform/state/derived-state-interactions.spec.ts
+++ b/apps/browser/src/platform/state/derived-state-interactions.spec.ts
@@ -35,7 +35,7 @@ describe("foreground background derived state interactions", () => {
     memoryStorage = new FakeStorageService();
 
     background = new BackgroundDerivedState(parentState$, deriveDefinition, memoryStorage, {});
-    foreground = new ForegroundDerivedState(deriveDefinition);
+    foreground = new ForegroundDerivedState(deriveDefinition, memoryStorage);
   });
 
   afterEach(() => {
@@ -50,12 +50,12 @@ describe("foreground background derived state interactions", () => {
     parentState$.next(initialParent);
     await awaitAsync(10);
 
-    expect(foregroundEmissions).toEqual([new Date(initialParent)]);
     expect(backgroundEmissions).toEqual([new Date(initialParent)]);
+    expect(foregroundEmissions).toEqual([new Date(initialParent)]);
   });
 
   it("should initialize a late-connected foreground", async () => {
-    const newForeground = new ForegroundDerivedState(deriveDefinition);
+    const newForeground = new ForegroundDerivedState(deriveDefinition, memoryStorage);
     const backgroundEmissions = trackEmissions(background.state$);
     parentState$.next(initialParent);
     await awaitAsync();
@@ -74,7 +74,7 @@ describe("foreground background derived state interactions", () => {
 
       // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      foreground.forceValue(new Date(dateString));
+      await foreground.forceValue(new Date(dateString));
       await awaitAsync();
 
       expect(emissions).toEqual([new Date(dateString)]);

--- a/apps/browser/src/platform/state/foreground-derived-state.provider.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.provider.ts
@@ -1,5 +1,10 @@
+import { NgZone } from "@angular/core";
 import { Observable } from "rxjs";
 
+import {
+  AbstractStorageService,
+  ObservableStorageService,
+} from "@bitwarden/common/platform/abstractions/storage.service";
 import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- extending this class for this client
 import { DefaultDerivedStateProvider } from "@bitwarden/common/platform/state/implementations/default-derived-state.provider";
@@ -8,11 +13,17 @@ import { DerivedStateDependencies } from "@bitwarden/common/src/types/state";
 import { ForegroundDerivedState } from "./foreground-derived-state";
 
 export class ForegroundDerivedStateProvider extends DefaultDerivedStateProvider {
+  constructor(
+    memoryStorage: AbstractStorageService & ObservableStorageService,
+    private ngZone: NgZone,
+  ) {
+    super(memoryStorage);
+  }
   override buildDerivedState<TFrom, TTo, TDeps extends DerivedStateDependencies>(
     _parentState$: Observable<TFrom>,
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
     _dependencies: TDeps,
   ): DerivedState<TTo> {
-    return new ForegroundDerivedState(deriveDefinition, this.memoryStorage);
+    return new ForegroundDerivedState(deriveDefinition, this.memoryStorage, this.ngZone);
   }
 }

--- a/apps/browser/src/platform/state/foreground-derived-state.provider.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.provider.ts
@@ -13,6 +13,6 @@ export class ForegroundDerivedStateProvider extends DefaultDerivedStateProvider 
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
     _dependencies: TDeps,
   ): DerivedState<TTo> {
-    return new ForegroundDerivedState(deriveDefinition);
+    return new ForegroundDerivedState(deriveDefinition, this.memoryStorage);
   }
 }

--- a/apps/browser/src/platform/state/foreground-derived-state.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.ts
@@ -1,3 +1,4 @@
+import { NgZone } from "@angular/core";
 import {
   Observable,
   ReplaySubject,
@@ -23,6 +24,7 @@ import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state
 import { DerivedStateDependencies } from "@bitwarden/common/types/state";
 
 import { fromChromeEvent } from "../browser/from-chrome-event";
+import { runInsideAngular } from "../browser/run-inside-angular.operator";
 
 export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
   private storageKey: string;
@@ -33,6 +35,7 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
   constructor(
     private deriveDefinition: DeriveDefinition<unknown, TTo, DerivedStateDependencies>,
     private memoryStorage: AbstractStorageService & ObservableStorageService,
+    private ngZone: NgZone,
   ) {
     this.storageKey = deriveDefinition.storageKey;
 
@@ -63,6 +66,7 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
         resetOnRefCountZero: () =>
           timer(this.deriveDefinition.cleanupDelayMs).pipe(tap(() => this.tearDownPort())),
       }),
+      runInsideAngular(this.ngZone),
     );
   }
 

--- a/apps/browser/src/platform/state/foreground-derived-state.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.ts
@@ -5,11 +5,19 @@ import {
   filter,
   firstValueFrom,
   map,
+  merge,
+  of,
   share,
+  switchMap,
   tap,
   timer,
 } from "rxjs";
+import { Jsonify, JsonObject } from "type-fest";
 
+import {
+  AbstractStorageService,
+  ObservableStorageService,
+} from "@bitwarden/common/platform/abstractions/storage.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { DeriveDefinition, DerivedState } from "@bitwarden/common/platform/state";
 import { DerivedStateDependencies } from "@bitwarden/common/types/state";
@@ -17,23 +25,43 @@ import { DerivedStateDependencies } from "@bitwarden/common/types/state";
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
 export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
+  private storageKey: string;
   private port: chrome.runtime.Port;
-  // For testing purposes
-  private replaySubject: ReplaySubject<TTo>;
   private backgroundResponses$: Observable<DerivedStateMessage>;
   state$: Observable<TTo>;
 
-  constructor(private deriveDefinition: DeriveDefinition<unknown, TTo, DerivedStateDependencies>) {
-    this.state$ = defer(() => this.initializePort()).pipe(
-      filter((message) => message.action === "nextState"),
-      map((message) => this.hydrateNext(message.data)),
+  constructor(
+    private deriveDefinition: DeriveDefinition<unknown, TTo, DerivedStateDependencies>,
+    private memoryStorage: AbstractStorageService & ObservableStorageService,
+  ) {
+    this.storageKey = deriveDefinition.storageKey;
+
+    const initialStorageGet$ = defer(() => {
+      return this.getStoredValue();
+    }).pipe(
+      filter((s) => s.derived),
+      map((s) => s.value),
+    );
+
+    const latestStorage$ = this.memoryStorage.updates$.pipe(
+      filter((s) => s.key === this.storageKey),
+      switchMap(async (storageUpdate) => {
+        if (storageUpdate.updateType === "remove") {
+          return null;
+        }
+
+        return await this.getStoredValue();
+      }),
+      filter((s) => s.derived),
+      map((s) => s.value),
+    );
+
+    this.state$ = defer(() => of(this.initializePort())).pipe(
+      switchMap(() => merge(initialStorageGet$, latestStorage$)),
       share({
-        connector: () => {
-          this.replaySubject = new ReplaySubject<TTo>(1);
-          return this.replaySubject;
-        },
+        connector: () => new ReplaySubject<TTo>(1),
         resetOnRefCountZero: () =>
-          timer(this.deriveDefinition.cleanupDelayMs).pipe(tap(() => this.tearDown())),
+          timer(this.deriveDefinition.cleanupDelayMs).pipe(tap(() => this.tearDownPort())),
       }),
     );
   }
@@ -51,7 +79,7 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
     return value;
   }
 
-  private initializePort(): Observable<DerivedStateMessage> {
+  private initializePort() {
     if (this.port != null) {
       return;
     }
@@ -88,11 +116,6 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
     });
   }
 
-  private hydrateNext(value: string): TTo {
-    const jsonObj = JSON.parse(value);
-    return this.deriveDefinition.deserialize(jsonObj);
-  }
-
   private tearDownPort() {
     if (this.port == null) {
       return;
@@ -103,8 +126,27 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
     this.backgroundResponses$ = null;
   }
 
-  private tearDown() {
-    this.tearDownPort();
-    this.replaySubject.complete();
+  protected async getStoredValue(): Promise<{ derived: boolean; value: TTo | null }> {
+    if (this.memoryStorage.valuesRequireDeserialization) {
+      const storedJson = await this.memoryStorage.get<
+        Jsonify<{ derived: true; value: JsonObject }>
+      >(this.storageKey);
+
+      if (!storedJson?.derived) {
+        return { derived: false, value: null };
+      }
+
+      const value = this.deriveDefinition.deserialize(storedJson.value as any);
+
+      return { derived: true, value };
+    } else {
+      const stored = await this.memoryStorage.get<{ derived: true; value: TTo }>(this.storageKey);
+
+      if (!stored?.derived) {
+        return { derived: false, value: null };
+      }
+
+      return { derived: true, value: stored.value };
+    }
   }
 }

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, LOCALE_ID, NgModule } from "@angular/core";
+import { APP_INITIALIZER, LOCALE_ID, NgModule, NgZone } from "@angular/core";
 
 import { UnauthGuard as BaseUnauthGuardService } from "@bitwarden/angular/auth/guards";
 import { ThemingService } from "@bitwarden/angular/platform/services/theming/theming.service";
@@ -554,7 +554,7 @@ function getBgService<T>(service: keyof MainBackground) {
     {
       provide: DerivedStateProvider,
       useClass: ForegroundDerivedStateProvider,
-      deps: [OBSERVABLE_MEMORY_STORAGE],
+      deps: [OBSERVABLE_MEMORY_STORAGE, NgZone],
     },
   ],
 })

--- a/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.spec.ts
@@ -73,12 +73,12 @@ describe("DefaultDerivedState", () => {
     await awaitAsync();
 
     expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
-      new Date(dateString),
+      derivedValue(new Date(dateString)),
     );
     const calls = memoryStorage.mock.save.mock.calls;
     expect(calls.length).toBe(1);
     expect(calls[0][0]).toBe(deriveDefinition.buildCacheKey());
-    expect(calls[0][1]).toEqual(new Date(dateString));
+    expect(calls[0][1]).toEqual(derivedValue(new Date(dateString)));
   });
 
   describe("forceValue", () => {
@@ -94,7 +94,9 @@ describe("DefaultDerivedState", () => {
 
       it("should store the forced value", async () => {
         await sut.forceValue(forced);
-        expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(forced);
+        expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
+          derivedValue(forced),
+        );
       });
     });
 
@@ -107,7 +109,9 @@ describe("DefaultDerivedState", () => {
 
       it("should store the forced value", async () => {
         await sut.forceValue(forced);
-        expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(forced);
+        expect(memoryStorage.internalStore[deriveDefinition.buildCacheKey()]).toEqual(
+          derivedValue(forced),
+        );
       });
 
       it("should force the value", async () => {
@@ -256,3 +260,7 @@ describe("DefaultDerivedState", () => {
     });
   });
 });
+
+function derivedValue<T>(value: T) {
+  return { derived: true, value };
+}

--- a/libs/common/src/platform/state/implementations/default-derived-state.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.ts
@@ -34,7 +34,7 @@ export class DefaultDerivedState<TFrom, TTo, TDeps extends DerivedStateDependenc
           derivedStateOrPromise = await derivedStateOrPromise;
         }
         const derivedState = derivedStateOrPromise;
-        await this.memoryStorage.save(this.storageKey, derivedState);
+        await this.storeValue(derivedState);
         return derivedState;
       }),
     );
@@ -58,8 +58,12 @@ export class DefaultDerivedState<TFrom, TTo, TDeps extends DerivedStateDependenc
   }
 
   async forceValue(value: TTo) {
-    await this.memoryStorage.save(this.storageKey, value);
+    await this.storeValue(value);
     this.forcedValueSubject.next(value);
     return value;
+  }
+
+  private storeValue(value: TTo) {
+    return this.memoryStorage.save(this.storageKey, { derived: true, value });
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes angular change detection of foreground derived state values.

The first commit, `Sync derived state through memory storage` is not necessary for this fix, but does make the derived state syncronize more similarly to other state. The only special thing about it now is that it shares subscriptions through the port interface between foreground and background.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
