### PR TITLE
ActiveUserState Update should return the userId of the impacted user.

### DIFF
--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -147,11 +147,15 @@ export class FakeStateProvider implements StateProvider {
     return this.getActive<T>(keyDefinition).state$;
   }
 
-  async setUserState<T>(keyDefinition: KeyDefinition<T>, value: T, userId?: UserId): Promise<void> {
+  async setUserState<T>(
+    keyDefinition: KeyDefinition<T>,
+    value: T,
+    userId?: UserId,
+  ): Promise<[UserId, T]> {
     if (userId) {
-      await this.getUser(userId, keyDefinition).update(() => value);
+      return [userId, await this.getUser(userId, keyDefinition).update(() => value)];
     } else {
-      await this.getActive(keyDefinition).update(() => value);
+      return await this.getActive(keyDefinition).update(() => value);
     }
   }
 

--- a/libs/common/spec/fake-state.ts
+++ b/libs/common/spec/fake-state.ts
@@ -170,7 +170,7 @@ export class FakeActiveUserState<T> implements ActiveUserState<T> {
   async update<TCombine>(
     configureState: (state: T, dependency: TCombine) => T,
     options?: StateUpdateOptions<T, TCombine>,
-  ): Promise<T> {
+  ): Promise<[UserId, T]> {
     options = populateOptionsWithDefault(options);
     const current = await firstValueFrom(this.state$.pipe(timeout(options.msTimeout)));
     const combinedDependencies =
@@ -178,12 +178,12 @@ export class FakeActiveUserState<T> implements ActiveUserState<T> {
         ? await firstValueFrom(options.combineLatestWith.pipe(timeout(options.msTimeout)))
         : null;
     if (!options.shouldUpdate(current, combinedDependencies)) {
-      return current;
+      return [this.userId, current];
     }
     const newState = configureState(current, combinedDependencies);
     this.stateSubject.next([this.userId, newState]);
     this.nextMock([this.userId, newState]);
-    return newState;
+    return [this.userId, newState];
   }
 
   updateMock = this.update as jest.MockedFunction<typeof this.update>;

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -266,12 +266,13 @@ describe("DefaultActiveUserState", () => {
     });
 
     it("should save on update", async () => {
-      const result = await userState.update((state, dependencies) => {
+      const [setUserId, result] = await userState.update((state, dependencies) => {
         return newData;
       });
 
       expect(diskStorageService.mock.save).toHaveBeenCalledTimes(1);
       expect(result).toEqual(newData);
+      expect(setUserId).toEqual("00000000-0000-1000-a000-000000000001");
     });
 
     it("should emit once per update", async () => {
@@ -316,7 +317,7 @@ describe("DefaultActiveUserState", () => {
       const emissions = trackEmissions(userState.state$);
       await awaitAsync(); // Need to await for the initial value to be emitted
 
-      const result = await userState.update(
+      const [userIdResult, result] = await userState.update(
         (state, dependencies) => {
           return newData;
         },
@@ -328,6 +329,7 @@ describe("DefaultActiveUserState", () => {
       await awaitAsync();
 
       expect(diskStorageService.mock.save).not.toHaveBeenCalled();
+      expect(userIdResult).toEqual("00000000-0000-1000-a000-000000000001");
       expect(result).toBeNull();
       expect(emissions).toEqual([null]);
     });
@@ -422,12 +424,13 @@ describe("DefaultActiveUserState", () => {
         await originalSave(key, obj);
       });
 
-      const val = await userState.update(() => {
+      const [userIdResult, val] = await userState.update(() => {
         return newData;
       });
 
       await awaitAsync(10);
 
+      expect(userIdResult).toEqual(userId);
       expect(val).toEqual(newData);
       expect(emissions).toEqual([initialData, newData]);
       expect(emissions2).toEqual([initialData, newData]);
@@ -447,7 +450,7 @@ describe("DefaultActiveUserState", () => {
       expect(emissions).toEqual([initialData]);
 
       let emissions2: TestState[];
-      const val = await userState.update(
+      const [userIdResult, val] = await userState.update(
         (state) => {
           return newData;
         },
@@ -461,6 +464,7 @@ describe("DefaultActiveUserState", () => {
 
       await awaitAsync();
 
+      expect(userIdResult).toEqual(userId);
       expect(val).toEqual(initialData);
       expect(emissions).toEqual([initialData]);
 
@@ -497,10 +501,11 @@ describe("DefaultActiveUserState", () => {
 
     test("updates with FAKE_DEFAULT initial value should resolve correctly", async () => {
       expect(diskStorageService["updatesSubject"]["observers"]).toHaveLength(0);
-      const val = await userState.update((state) => {
+      const [userIdResult, val] = await userState.update((state) => {
         return newData;
       });
 
+      expect(userIdResult).toEqual(userId);
       expect(val).toEqual(newData);
       const call = diskStorageService.mock.save.mock.calls[0];
       expect(call[0]).toEqual(`user_${userId}_fake_fake`);

--- a/libs/common/src/platform/state/implementations/default-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-state.provider.ts
@@ -32,11 +32,15 @@ export class DefaultStateProvider implements StateProvider {
     }
   }
 
-  async setUserState<T>(keyDefinition: KeyDefinition<T>, value: T, userId?: UserId): Promise<void> {
+  async setUserState<T>(
+    keyDefinition: KeyDefinition<T>,
+    value: T,
+    userId?: UserId,
+  ): Promise<[UserId, T]> {
     if (userId) {
-      await this.getUser<T>(userId, keyDefinition).update(() => value);
+      return [userId, await this.getUser<T>(userId, keyDefinition).update(() => value)];
     } else {
-      await this.getActive<T>(keyDefinition).update(() => value);
+      return await this.getActive<T>(keyDefinition).update(() => value);
     }
   }
 

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -36,7 +36,11 @@ export abstract class StateProvider {
    * @param value - The value to set the state to.
    * @param userId - The userId for which you want to set the state for. If not provided, the state for the currently active user will be set.
    */
-  setUserState: <T>(keyDefinition: KeyDefinition<T>, value: T, userId?: UserId) => Promise<void>;
+  setUserState: <T>(
+    keyDefinition: KeyDefinition<T>,
+    value: T,
+    userId?: UserId,
+  ) => Promise<[UserId, T]>;
   /** @see{@link ActiveUserStateProvider.get} */
   getActive: <T>(keyDefinition: KeyDefinition<T>) => ActiveUserState<T>;
   /** @see{@link SingleUserStateProvider.get} */

--- a/libs/common/src/platform/state/user-state.ts
+++ b/libs/common/src/platform/state/user-state.ts
@@ -19,6 +19,28 @@ export interface UserState<T> {
    * Emits a stream of data alongside the user id the data corresponds to.
    */
   readonly combinedState$: Observable<CombinedState<T>>;
+}
+
+export const activeMarker: unique symbol = Symbol("active");
+export interface ActiveUserState<T> extends UserState<T> {
+  readonly [activeMarker]: true;
+  /**
+   * Updates backing stores for the active user.
+   * @param configureState function that takes the current state and returns the new state
+   * @param options Defaults to @see {module:state-update-options#DEFAULT_OPTIONS}
+   * @param options.shouldUpdate A callback for determining if you want to update state. Defaults to () => true
+   * @param options.combineLatestWith An observable that you want to combine with the current state for callbacks. Defaults to null
+   * @param options.msTimeout A timeout for how long you are willing to wait for a `combineLatestWith` option to complete. Defaults to 1000ms. Only applies if `combineLatestWith` is set.
+
+   * @returns The new state
+   */
+  readonly update: <TCombine>(
+    configureState: (state: T, dependencies: TCombine) => T,
+    options?: StateUpdateOptions<T, TCombine>,
+  ) => Promise<[UserId, T]>;
+}
+export interface SingleUserState<T> extends UserState<T> {
+  readonly userId: UserId;
 
   /**
    * Updates backing stores for the active user.
@@ -34,12 +56,4 @@ export interface UserState<T> {
     configureState: (state: T, dependencies: TCombine) => T,
     options?: StateUpdateOptions<T, TCombine>,
   ) => Promise<T>;
-}
-
-export const activeMarker: unique symbol = Symbol("active");
-export interface ActiveUserState<T> extends UserState<T> {
-  readonly [activeMarker]: true;
-}
-export interface SingleUserState<T> extends UserState<T> {
-  readonly userId: UserId;
 }


### PR DESCRIPTION
This allows us to ensure that linked updates all go to the same user without risking active account changes in the middle of an operation.

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Small interface change that returns the impacted userId for active user updates.

This allows complex update methods to ensure that they update the same UserId for the entire transaction.

I didn't find any usages of the return value other than tests, which were updated.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
