### PR TITLE
Add Build Number as Step Summary for MacOS jobs in Build Desktop workflow

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -140,8 +140,7 @@ jobs:
   linux:
     name: Linux Build
     runs-on: ubuntu-20.04
-    needs:
-      - setup
+    needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
       _NODE_VERSION: ${{ needs.setup.outputs.node_version }}
@@ -249,8 +248,7 @@ jobs:
   windows:
     name: Windows Build
     runs-on: windows-2019
-    needs:
-      - setup
+    needs: setup
     defaults:
       run:
         shell: pwsh
@@ -457,8 +455,7 @@ jobs:
   macos-build:
     name: MacOS Build
     runs-on: macos-11
-    needs:
-      - setup
+    needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
       _NODE_VERSION: ${{ needs.setup.outputs.node_version }}
@@ -570,6 +567,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
+          echo "### MacOS build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Node dependencies
         run: npm ci
@@ -716,6 +714,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
+          echo "### MacOS GitHub build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Node dependencies
         run: npm ci
@@ -907,6 +906,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
+          echo "### MacOS App Store build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Node dependencies
         run: npm ci
@@ -1085,6 +1085,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
+          echo "### MacOS Dev build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Node dependencies
         run: npm ci

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -567,7 +567,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          echo "### MacOS build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
+          $env:GITHUB_STEP_SUMMARY += "### MacOS build number: $env:BUILD_NUMBER"
 
       - name: Install Node dependencies
         run: npm ci
@@ -714,7 +714,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          echo "### MacOS GitHub build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
+          $env:GITHUB_STEP_SUMMARY += "### MacOS GitHub build number: $env:BUILD_NUMBER"
 
       - name: Install Node dependencies
         run: npm ci
@@ -906,7 +906,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          echo "### MacOS App Store build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
+          $env:GITHUB_STEP_SUMMARY += "### MacOS App Store build number: $env:BUILD_NUMBER"
 
       - name: Install Node dependencies
         run: npm ci
@@ -1085,7 +1085,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          echo "### MacOS Dev build number: $env:BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
+          $env:GITHUB_STEP_SUMMARY += "### MacOS Dev build number: $env:BUILD_NUMBER"
 
       - name: Install Node dependencies
         run: npm ci

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -567,7 +567,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          $env:GITHUB_STEP_SUMMARY += "### MacOS build number: $env:BUILD_NUMBER"
+          "### MacOS build number: $env:BUILD_NUMBER" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Install Node dependencies
         run: npm ci
@@ -714,7 +714,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          $env:GITHUB_STEP_SUMMARY += "### MacOS GitHub build number: $env:BUILD_NUMBER"
+          "### MacOS GitHub build number: $env:BUILD_NUMBER" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Install Node dependencies
         run: npm ci
@@ -906,7 +906,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          $env:GITHUB_STEP_SUMMARY += "### MacOS App Store build number: $env:BUILD_NUMBER"
+          "### MacOS App Store build number: $env:BUILD_NUMBER" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Install Node dependencies
         run: npm ci
@@ -1085,7 +1085,7 @@ jobs:
           $package = Get-Content -Raw -Path electron-builder.json | ConvertFrom-Json
           $package | Add-Member -MemberType NoteProperty -Name buildVersion -Value "$env:BUILD_NUMBER"
           $package | ConvertTo-Json -Depth 32 | Set-Content -Path electron-builder.json
-          $env:GITHUB_STEP_SUMMARY += "### MacOS Dev build number: $env:BUILD_NUMBER"
+          "### MacOS Dev build number: $env:BUILD_NUMBER" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Install Node dependencies
         run: npm ci


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR adds the build number as a GitHub step summary for all of the MacOS jobs in the Build Desktop workflow.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build-desktop.yml:** Add build number to GitHub step summary.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
