### PR TITLE
[AC-2113] Confirmation dialog for enabling collection enhancements

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -67,7 +67,12 @@
       {{ "collectionEnhancementsLearnMore" | i18n }}
     </a>
   </p>
-  <button type="button" bitButton buttonType="primary" [bitAction]="enableCollectionEnhancements">
+  <button
+    type="button"
+    bitButton
+    buttonType="primary"
+    (click)="showConfirmCollectionEnhancementsDialog()"
+  >
     {{ "enable" | i18n }}
   </button>
 </form>

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -16,7 +16,7 @@ import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.se
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, SimpleDialogOptions } from "@bitwarden/components";
 
 import { ApiKeyComponent } from "../../../auth/settings/security/api-key.component";
 import { PurgeVaultComponent } from "../../../vault/settings/purge-vault.component";
@@ -183,15 +183,25 @@ export class AccountComponent {
     this.platformUtilsService.showToast("success", null, this.i18nService.t("organizationUpdated"));
   };
 
-  enableCollectionEnhancements = async () => {
-    await this.organizationApiService.enableCollectionEnhancements(this.organizationId);
+  async showConfirmCollectionEnhancementsDialog() {
+    const collectionEnhancementsDialogOptions: SimpleDialogOptions = {
+      title: this.i18nService.t("confirmCollectionEnhancementsDialogTitle"),
+      content: this.i18nService.t("confirmCollectionEnhancementsDialogContent"),
+      type: "warning",
+      acceptButtonText: this.i18nService.t("continue"),
+      acceptAction: async () => {
+        await this.organizationApiService.enableCollectionEnhancements(this.organizationId);
 
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("updatedCollectionManagement"),
-    );
-  };
+        this.platformUtilsService.showToast(
+          "success",
+          null,
+          this.i18nService.t("updatedCollectionManagement"),
+        );
+      },
+    };
+
+    await this.dialogService.openSimpleDialog(collectionEnhancementsDialogOptions);
+  }
 
   submitCollectionManagement = async () => {
     // Early exit if self-hosted

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7519,5 +7519,11 @@
   },
   "smFreeTrialConfirmationEmail": {
     "message": "We've sent a confirmation email to your email at "
+  },
+  "confirmCollectionEnhancementsDialogTitle": {
+    "message": "This action is irreversible"
+  },
+  "confirmCollectionEnhancementsDialogContent": {
+    "message": "Turning on this feature will deprecate the manager role and replace it with a Can manage permission. This will take a few moments. Do not make any organization changes until it is complete. Are you sure you want to proceed?"
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

> We want to emphasize that this action is irreversible, hence the addition of the dialog after the user selects Turn on.

## Code changes

- **account.component.html**: Replaced `[bitAction]` with `(click)` listener for opening the dialog instead
- **account.component.ts**: Replaced existing handler with method to launch the simple dialog. Constructed the dialog with the necessary options, including an accept action that will show a spinner until the promise resolves.
- **messages.json**: Added title and content dialog strings

## Screenshots

https://github.com/bitwarden/clients/assets/26154748/4e765ac7-2a2d-4522-bb5e-fafa3b34aaaa

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
