### PR TITLE
Add a `KeyDefinition` for `providers`

### DIFF
--- a/libs/common/src/admin-console/services/provider.service.spec.ts
+++ b/libs/common/src/admin-console/services/provider.service.spec.ts
@@ -1,0 +1,23 @@
+import { ProviderUserStatusType, ProviderUserType } from "../enums";
+import { ProviderData } from "../models/data/provider.data";
+
+import { PROVIDERS } from "./provider.service";
+
+describe("PROVIDERS key definition", () => {
+  const sut = PROVIDERS;
+  it("should deserialize to a proper ProviderData object", async () => {
+    const expectedResult: Record<string, ProviderData> = {
+      "1": {
+        id: "string",
+        name: "string",
+        status: ProviderUserStatusType.Accepted,
+        type: ProviderUserType.ServiceUser,
+        enabled: true,
+        userId: "string",
+        useEvents: true,
+      },
+    };
+    const result = sut.deserializer(JSON.parse(JSON.stringify(expectedResult)));
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/libs/common/src/admin-console/services/provider.service.ts
+++ b/libs/common/src/admin-console/services/provider.service.ts
@@ -1,7 +1,12 @@
 import { StateService } from "../../platform/abstractions/state.service";
+import { KeyDefinition, PROVIDERS_DISK } from "../../platform/state";
 import { ProviderService as ProviderServiceAbstraction } from "../abstractions/provider.service";
 import { ProviderData } from "../models/data/provider.data";
 import { Provider } from "../models/domain/provider";
+
+export const PROVIDERS = KeyDefinition.record<ProviderData>(PROVIDERS_DISK, "providers", {
+  deserializer: (obj: ProviderData) => obj,
+});
 
 export class ProviderService implements ProviderServiceAbstraction {
   constructor(private stateService: StateService) {}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR takes steps toward supporting the new `StateProvider` APIs in the `ProviderService'.

The focus of this change is to add and test a key definition for the only data point owned by this service: the `providers` list.

> 💡 This PR does not have any impact on the system at large. The key definition and `StateProvider` will be implemented in follow up steps.

## Code changes

1. Add a key definition to `provider.service.ts` for `PROVIDERS` and test to assert it deserializes properly.

## References

* Jira work item: [`AC-2010`](https://bitwarden.atlassian.net/browse/AC-2010?atlOrigin=eyJpIjoiNjAxZWUxNjRkNjdhNDQ4MWExOWE5ZGQ0NTU3NDM3MTAiLCJwIjoiaiJ9)
* https://github.com/bitwarden/clients/pull/7781 does the same thing for `OrganizationService`, and is a good source to compare to for reviews. That said, it has a few key differences:
    * That PR is larger and not scoped quite as small
    * The tests are written against `organization.data.ts` (the data model) instead of the service. This is because `OrganizationData` required a custom deserializer, but `ProviderData` uses the stock functionality from `KeyDefinition`.
