### PR TITLE
[PM-5757] Update local data when a collection is upserted

### DIFF
--- a/apps/web/src/app/vault/core/collection-admin.service.ts
+++ b/apps/web/src/app/vault/core/collection-admin.service.ts
@@ -4,6 +4,8 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
+import { CollectionData } from "@bitwarden/common/vault/models/data/collection.data";
 import { CollectionRequest } from "@bitwarden/common/vault/models/request/collection.request";
 import {
   CollectionAccessDetailsResponse,
@@ -21,6 +23,7 @@ export class CollectionAdminService {
   constructor(
     private apiService: ApiService,
     private cryptoService: CryptoService,
+    private collectionService: CollectionService,
   ) {}
 
   async getAll(organizationId: string): Promise<CollectionAdminView[]> {
@@ -65,6 +68,12 @@ export class CollectionAdminService {
         collection.id,
         request,
       );
+    }
+
+    if (collection.assigned) {
+      await this.collectionService.upsert(new CollectionData(response));
+    } else {
+      await this.collectionService.delete(collection.id);
     }
 
     return response;

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -11,6 +11,7 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 import {
   BehaviorSubject,
   combineLatest,
+  defer,
   firstValueFrom,
   lastValueFrom,
   Observable,
@@ -250,7 +251,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     const allCollectionsWithoutUnassigned$ = combineLatest([
       organizationId$.pipe(switchMap((orgId) => this.collectionAdminService.getAll(orgId))),
-      this.collectionService.getAllDecrypted(),
+      defer(() => this.collectionService.getAllDecrypted()),
     ]).pipe(
       map(([adminCollections, syncCollections]) => {
         const syncCollectionDict = Object.fromEntries(syncCollections.map((c) => [c.id, c]));


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In the org vault, the permissions column was not updating when a collection was created or edited. It looks like these come from local data, so one solution (presented here) is to upsert local data on save, which seems like a good idea anyway.

I'm not very familiar with vault data flows, so the reviewer should look at this closely - this is a suggested solution only.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **collection-dialog.component** - set additional properties on the `CollectionAdminView` when saving
- **collection-admin.service** - if the collection is assigned to the user, upsert the response to local data; if not, delete it from local data
- **vault.component** - use `defer()` so that this promise is reevaluated when `refresh$` emits. Transitioning to reactive data should fix this properly.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
