### PR TITLE
Duo Redirect Handoff Message Fix

### DIFF
--- a/apps/web/src/connectors/duo-redirect.ts
+++ b/apps/web/src/connectors/duo-redirect.ts
@@ -24,8 +24,8 @@ window.addEventListener("load", () => {
 });
 
 /**
- * The `duoHandOffMessage` is set in the client via a cookie. This allows us to
- * make use of i18n translations.
+ * The `duoHandOffMessage` must be set in the client via a cookie. This is so
+ * we can make use of i18n translations.
  *
  * Format the message as an object and set is as a cookie. The following gives an
  * example (be sure to replace strings with i18n translated text):
@@ -35,7 +35,7 @@ window.addEventListener("load", () => {
  *  title: "You successfully logged in",
  *  message: "This window will automatically close in 5 seconds",
  *  buttonText: "Close",
- *  countdown: 5
+ *  isCountdown: true
  * };
  *
  * document.cookie = `duoHandOffMessage=${encodeURIComponent(JSON.stringify(duoHandOffMessage))};SameSite=strict`;
@@ -43,10 +43,19 @@ window.addEventListener("load", () => {
  * ```
  *
  * The `title`, `message`, and `buttonText` properties will be used to create the relevant
- * DOM elements. The `countdown` property will be used for the starting value of the countdown.
- * Make sure the `countdown` number matches the number set in the `message` property.
+ * DOM elements.
  *
- * If no `countdown` property is given, there will be no countdown timer and the user will simply
+ * Countdown timer:
+ * The `isCountdown` signifies that you want to start a countdown timer that will automatically
+ * close the tab when finished. The starting point for the timer will be based upon the first number
+ * that can be parsed from the `message` property (so be sure to only add one number).
+ *
+ * This implementation makes it so the client does not have to split up the `message` into
+ * three spans/translations, such as:
+ *    ['This window will automatically close in', '5', 'seconds']
+ * Doing so would cause bad translations in languages that swap the order of words.
+ *
+ * If `isCountdown` is undefined/false, there will be no countdown timer and the user will simply
  * have to close the tab manually.
  */
 function processAndDisplayHandoffMessage() {
@@ -86,12 +95,12 @@ function processAndDisplayHandoffMessage() {
   content.appendChild(button);
 
   // Countdown timer (closes tab upon completion)
-  if (handOffMessage.countdown && Number.isInteger(handOffMessage.countdown)) {
-    let num = handOffMessage.countdown;
+  if (handOffMessage.isCountdown) {
+    let num = Number(p.textContent.match(/\d+/)[0]);
 
     const interval = setInterval(() => {
       if (num > 1) {
-        p.textContent = `This window will automatically close in ${num - 1} seconds`;
+        p.textContent = p.textContent.replace(String(num), String(num - 1));
         num--;
       } else {
         clearInterval(interval);

--- a/apps/web/src/connectors/duo-redirect.ts
+++ b/apps/web/src/connectors/duo-redirect.ts
@@ -42,21 +42,22 @@ window.addEventListener("load", () => {
  *
  * ```
  *
- * The `title`, `message`, and `buttonText` properties will be used to create the relevant
- * DOM elements.
+ * The `title`, `message`, and `buttonText` properties will be used to create the
+ * relevant DOM elements.
  *
  * Countdown timer:
- * The `isCountdown` signifies that you want to start a countdown timer that will automatically
- * close the tab when finished. The starting point for the timer will be based upon the first number
- * that can be parsed from the `message` property (so be sure to only add one number).
+ * The `isCountdown` signifies that you want to start a countdown timer that will
+ * automatically close the tab when finished. The starting point for the timer will
+ * be based upon the first number that can be parsed from the `message` property
+ * (so be sure to add exactly one number to the `message`).
  *
  * This implementation makes it so the client does not have to split up the `message` into
- * three spans/translations, such as:
+ * three translations, such as:
  *    ['This window will automatically close in', '5', 'seconds']
- * Doing so would cause bad translations in languages that swap the order of words.
+ * ...which would cause bad translations in languages that swap the order of words.
  *
- * If `isCountdown` is undefined/false, there will be no countdown timer and the user will simply
- * have to close the tab manually.
+ * If `isCountdown` is undefined/false, there will be no countdown timer and the user
+ * will simply have to close the tab manually.
  */
 function processAndDisplayHandoffMessage() {
   const handOffMessageCookie = ("; " + document.cookie)


### PR DESCRIPTION
## Type of change

- Bug fix

## Objective

Refactors the `duoHandOffMessage` feature. The handoff message must be added by clients to allow for translations.

The key to this implementation is in parsing a number out of the translated `message` and using that as the starting point for the countdown timer. Parsing the number this way allows us to leave the translated text in tact during the countdown. This way the client does not have to split up the `message` text into several translations, such as:
`['This window will automatically close in', 5, 'seconds']`
...which would cause bad translations in languages that swap word order.

## Screen Recordings

### Showing 5 second countdown that automatically closes the tab

https://github.com/bitwarden/clients/assets/102181210/860dc80c-6ff9-4e40-8d1d-74d428ded5b7

### Closing the tab manually, despite countdown timer

https://github.com/bitwarden/clients/assets/102181210/cfe3ece4-c1cb-4c6c-8d5f-91d937907f22

### Showing a message with no countdown timer

https://github.com/bitwarden/clients/assets/102181210/84846343-1e19-4472-9641-028191c10d00