### PR TITLE
[PM-5757] Update local collection data when a collection is updated

### DIFF
--- a/apps/web/src/app/vault/core/collection-admin.service.ts
+++ b/apps/web/src/app/vault/core/collection-admin.service.ts
@@ -4,6 +4,8 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
+import { CollectionData } from "@bitwarden/common/vault/models/data/collection.data";
 import { CollectionRequest } from "@bitwarden/common/vault/models/request/collection.request";
 import {
   CollectionAccessDetailsResponse,
@@ -21,6 +23,7 @@ export class CollectionAdminService {
   constructor(
     private apiService: ApiService,
     private cryptoService: CryptoService,
+    private collectionService: CollectionService,
   ) {}
 
   async getAll(organizationId: string): Promise<CollectionAdminView[]> {
@@ -65,6 +68,12 @@ export class CollectionAdminService {
         collection.id,
         request,
       );
+    }
+
+    if (response.assigned) {
+      await this.collectionService.upsert(new CollectionData(response));
+    } else {
+      await this.collectionService.delete(collection.id);
     }
 
     return response;

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -11,6 +11,7 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 import {
   BehaviorSubject,
   combineLatest,
+  defer,
   firstValueFrom,
   lastValueFrom,
   Observable,
@@ -250,7 +251,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     const allCollectionsWithoutUnassigned$ = combineLatest([
       organizationId$.pipe(switchMap((orgId) => this.collectionAdminService.getAll(orgId))),
-      this.collectionService.getAllDecrypted(),
+      defer(() => this.collectionService.getAllDecrypted()),
     ]).pipe(
       map(([adminCollections, syncCollections]) => {
         const syncCollectionDict = Object.fromEntries(syncCollections.map((c) => [c.id, c]));

--- a/libs/common/src/vault/models/response/collection.response.ts
+++ b/libs/common/src/vault/models/response/collection.response.ts
@@ -20,12 +20,17 @@ export class CollectionDetailsResponse extends CollectionResponse {
   readOnly: boolean;
   manage: boolean;
   hidePasswords: boolean;
+  assigned: boolean;
 
   constructor(response: any) {
     super(response);
     this.readOnly = this.getResponseProperty("ReadOnly") || false;
     this.manage = this.getResponseProperty("Manage") || false;
     this.hidePasswords = this.getResponseProperty("HidePasswords") || false;
+
+    // Temporary until the API is updated to return this property in AC-2084
+    // For now, we can assume that if the object is 'collectionDetails' then the user is assigned
+    this.assigned = this.getResponseProperty("object") == "collectionDetails";
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The Org Vault permission column information comes from the local sync collection data which is not immediately updated after a collection is modified/created. This PR uses the `collectionService` to `upsert` or `delete` the collection from the user's local data based on the `assigned` value in the response. Inspired by #7926, thanks @eliykat!

The `assigned` value is being interpreted by the response type (`response.object`) set by the API as the `assigned` property is not explicitly set. The API already returns the extra permission information when a user is assigned by specifically returning a `CollectionDetailsResponseModel`. When not assigned, the `CollectionResponseModel` is returned. 

The work in AC-2084 will make this more explicit and ensure the `assigned` property is returned explicitly. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **`collection-admin.service.ts`:** Update the local collection data using the `collectionService` based on the `assigned` value from the response.
- **`collection.response.ts`:** Add the `assigned` property that is set by interpreting the meta `response.object` property.
- **`vault.component.ts`:** Use `defer()` on the `collectionService.getAllDecrypted()` so that is re-evaluated on `refresh$`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
