### PR TITLE
move web layout migration banner logic into a service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,7 @@ apps/browser/src/autofill @bitwarden/team-autofill-dev
 ## Component Library ##
 .storybook @bitwarden/team-component-library
 libs/components @bitwarden/team-component-library
+apps/web/src/app/layouts/header
 
 ## Desktop native module ##
 apps/desktop/desktop_native @bitwarden/team-platform-dev

--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -1,7 +1,7 @@
 <bit-banner
   class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
-  (onClose)="hideBanner()"
-  *ngIf="showBanner$ | async"
+  (onClose)="webLayoutMigrationBannerService.hideBanner()"
+  *ngIf="webLayoutMigrationBannerService.showBanner$ | async"
 >
   {{ "newWebApp" | i18n }}
   <a

--- a/apps/web/src/app/layouts/header/web-header.component.ts
+++ b/apps/web/src/app/layouts/header/web-header.component.ts
@@ -8,20 +8,8 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { AccountProfile } from "@bitwarden/common/platform/models/domain/account";
-import {
-  GlobalStateProvider,
-  KeyDefinition,
-  NEW_WEB_LAYOUT_BANNER_DISK,
-} from "@bitwarden/common/platform/state";
 
-const SHOW_BANNER_KEY = new KeyDefinition<boolean>(NEW_WEB_LAYOUT_BANNER_DISK, "showBanner", {
-  deserializer: (b) => {
-    if (b === null) {
-      return true;
-    }
-    return b;
-  },
-});
+import { WebLayoutMigrationBannerService } from "./web-layout-migration-banner.service";
 
 @Component({
   selector: "app-header",
@@ -44,16 +32,13 @@ export class WebHeaderComponent {
   protected selfHosted: boolean;
   protected hostname = location.hostname;
 
-  private showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
-  protected showBanner$ = this.showBannerState.state$;
-
   constructor(
     private route: ActivatedRoute,
     private stateService: StateService,
     private platformUtilsService: PlatformUtilsService,
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private messagingService: MessagingService,
-    private globalStateProvider: GlobalStateProvider,
+    protected webLayoutMigrationBannerService: WebLayoutMigrationBannerService,
   ) {
     this.routeData$ = this.route.data.pipe(
       map((params) => {
@@ -84,9 +69,5 @@ export class WebHeaderComponent {
 
   protected logout() {
     this.messagingService.send("logout");
-  }
-
-  protected async hideBanner() {
-    await this.showBannerState.update(() => false);
   }
 }

--- a/apps/web/src/app/layouts/header/web-layout-migration-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-layout-migration-banner.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from "@angular/core";
+
+import {
+  GlobalStateProvider,
+  KeyDefinition,
+  NEW_WEB_LAYOUT_BANNER_DISK,
+} from "@bitwarden/common/platform/state";
+
+const SHOW_BANNER_KEY = new KeyDefinition<boolean>(NEW_WEB_LAYOUT_BANNER_DISK, "showBanner", {
+  deserializer: (b) => {
+    if (b === null) {
+      return true;
+    }
+    return b;
+  },
+});
+
+/** Displays a banner that introduces users to the new web vault layout. */
+@Injectable({ providedIn: "root" })
+export class WebLayoutMigrationBannerService {
+  private _showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
+  showBanner$ = this._showBannerState.state$;
+
+  constructor(private globalStateProvider: GlobalStateProvider) {}
+
+  async hideBanner() {
+    await this._showBannerState.update(() => false);
+  }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Components should never access state directly. Business logic should be abstracted behind a service. (This makes refactoring easier and mocking more direct--see the changes to the associated story.)

This PR:
- updates the _web layout migration banner_ to interact with a new service.
- adds CL as codeowner for the web header components, which did not previously have one.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

No visual changes.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
