### PR TITLE
[PM-4882] Passkeys: funnel rp name or id to the cipher name on save

### DIFF
--- a/apps/browser/src/vault/fido2/browser-fido2-user-interface.service.ts
+++ b/apps/browser/src/vault/fido2/browser-fido2-user-interface.service.ts
@@ -67,6 +67,7 @@ export type BrowserFido2Message = { sessionId: string } & (
       userName: string;
       userVerification: boolean;
       fallbackSupported: boolean;
+      rpId: string;
     }
   | {
       type: "ConfirmNewCredentialResponse";
@@ -242,6 +243,7 @@ export class BrowserFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     credentialName,
     userName,
     userVerification,
+    rpId,
   }: NewCredentialParams): Promise<{ cipherId: string; userVerified: boolean }> {
     const data: BrowserFido2Message = {
       type: "ConfirmNewCredentialRequest",
@@ -250,6 +252,7 @@ export class BrowserFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       userName,
       userVerification,
       fallbackSupported: this.fallbackSupported,
+      rpId,
     };
 
     await this.send(data);

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -347,7 +347,7 @@ export class Fido2Component implements OnInit, OnDestroy {
 
   private buildCipher(name: string) {
     this.cipher = new CipherView();
-    this.cipher.name = name; // get data here
+    this.cipher.name = name;
     this.cipher.type = CipherType.Login;
     this.cipher.login = new LoginView();
     this.cipher.login.uris = [new LoginUriView()];

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -16,7 +16,6 @@ import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { SettingsService } from "@bitwarden/common/abstractions/settings.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SecureNoteType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
@@ -297,7 +296,7 @@ export class Fido2Component implements OnInit, OnDestroy {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.router.navigate(["/add-cipher"], {
       queryParams: {
-        name: Utils.getHostname(this.url),
+        name: data.credentialName || data.rpId,
         uri: this.url,
         uilocation: "popout",
         senderTabId: this.senderTabId,

--- a/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2.component.ts
@@ -245,7 +245,8 @@ export class Fido2Component implements OnInit, OnDestroy {
   protected async saveNewLogin() {
     const data = this.message$.value;
     if (data?.type === "ConfirmNewCredentialRequest") {
-      await this.createNewCipher();
+      const name = data.credentialName || data.rpId;
+      await this.createNewCipher(name);
 
       // We are bypassing user verification pending implementation of PIN and biometric support.
       this.send({
@@ -344,9 +345,9 @@ export class Fido2Component implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  private buildCipher() {
+  private buildCipher(name: string) {
     this.cipher = new CipherView();
-    this.cipher.name = Utils.getHostname(this.url);
+    this.cipher.name = name; // get data here
     this.cipher.type = CipherType.Login;
     this.cipher.login = new LoginView();
     this.cipher.login.uris = [new LoginUriView()];
@@ -358,8 +359,8 @@ export class Fido2Component implements OnInit, OnDestroy {
     this.cipher.reprompt = CipherRepromptType.None;
   }
 
-  private async createNewCipher() {
-    this.buildCipher();
+  private async createNewCipher(name: string) {
+    this.buildCipher(name);
     const cipher = await this.cipherService.encrypt(this.cipher);
     try {
       await this.cipherService.createWithServer(cipher);

--- a/libs/common/src/vault/abstractions/fido2/fido2-user-interface.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/fido2/fido2-user-interface.service.abstraction.ts
@@ -16,6 +16,10 @@ export interface NewCredentialParams {
    * Whether or not the user must be verified before completing the operation.
    */
   userVerification: boolean;
+  /**
+   * The relying party ID is usually the URL
+   */
+  rpId: string;
 }
 
 /**

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -216,6 +216,7 @@ describe("FidoAuthenticatorService", () => {
             credentialName: params.rpEntity.name,
             userName: params.userEntity.displayName,
             userVerification,
+            rpId: params.rpEntity.id,
           } as NewCredentialParams);
         });
       }

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -113,6 +113,7 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
         credentialName: params.rpEntity.name,
         userName: params.userEntity.displayName,
         userVerification: params.requireUserVerification,
+        rpId: params.rpEntity.id,
       });
       const cipherId = response.cipherId;
       userVerified = response.userVerified;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When creating a passkey and a new vault item, we want to set `name` to be `rp`'s name value (`rp.name`). If the `rp` does not provide a name then we save rp.id which is the url

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots
(see the "target" name in the extension)
|Client| Before      | After |
| ----------- | ----------- | ----------- |
|Safari | ![Screenshot 2024-02-15 at 2 42 18 PM](https://github.com/bitwarden/clients/assets/14082576/4910a986-342f-483f-a409-f06d15c426be) |  <img width="506" alt="Screenshot 2024-02-16 at 12 34 27 PM" src="https://github.com/bitwarden/clients/assets/14082576/efccd03b-6a48-4ddb-b63e-77bc0076343b">|
|Firefox | |<img width="434" alt="Screenshot 2024-02-16 at 12 06 11 PM" src="https://github.com/bitwarden/clients/assets/14082576/0a7666d2-4ea4-4364-9f7d-648999d5f717">|
|Safari ||<img width="389" alt="Screenshot 2024-02-16 at 12 31 20 PM" src="https://github.com/bitwarden/clients/assets/14082576/d11378da-9813-4957-99a2-c25bca76477d">|
|Adding a new cipher (in chrome)|<img width="394" alt="Screenshot 2024-02-28 at 3 01 59 PM" src="https://github.com/bitwarden/clients/assets/14082576/5beb0604-4b2c-4191-8e61-07141acaac3d">|<img width="396" alt="Screenshot 2024-02-28 at 3 01 36 PM" src="https://github.com/bitwarden/clients/assets/14082576/41c3a05d-524b-4151-a12e-534dccc424b3">|


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
