### PR TITLE
[CL-192][CL-193] fix virtual scroll

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -6,12 +6,6 @@
   margin: 0;
 }
 
-html {
-  &.cdk-global-scrollblock {
-    position: unset;
-  }
-}
-
 html,
 body {
   font-family: $font-family-sans-serif;

--- a/libs/components/src/layout/layout.component.html
+++ b/libs/components/src/layout/layout.component.html
@@ -22,14 +22,14 @@
         '--color-background-alt4': 'var(--color-secondary-300)'
       }
     "
-    class="tw-inset-y-0 tw-left-0 tw-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
+    class="tw-sticky tw-inset-y-0 tw-h-screen tw-w-60 tw-overflow-auto tw-bg-background-alt3"
   >
     <ng-content select="[slot=sidebar]"></ng-content>
   </aside>
   <main
     [id]="mainContentId"
     tabindex="-1"
-    class="tw-overflow-auto tw-h-screen tw-min-w-0 tw-flex-1 tw-bg-background tw-p-6"
+    class="tw-overflow-auto tw-min-w-0 tw-flex-1 tw-bg-background tw-p-6"
   >
     <ng-content></ng-content>
   </main>

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -200,3 +200,9 @@ summary.tw-list-none::-webkit-details-marker {
 .cdk-overlay-pane {
   z-index: 2000 !important;
 }
+
+.cdk-global-scrollblock {
+  position: unset;
+  height: 100%;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes two issues related to CDK virtual scroll:
- virtual scroll containers will clip their content when scrolling if a parent element has height set to `100vh`
- when opening a dialog that utilizes scroll blocking, virtual scroll containers will change scroll position

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/layout/layout.component.html:** Update layout css to not use `100vh`. Instead, the intended style is achieved through the sidebar having `position: sticky` and unsetting `left` 
- **libs/components/src/tw-theme.css:** override `.cdk-global-scrollblock` to not use position fixed
- **apps/browser/src/popup/scss/base.scss:** remove `.cdk-global-scrollblock` override because it is now capture in `tw-theme.css`.

## Screenshots

I tested these changes alongside #7981 and #6957 to verify that `bit-layout`, `bit-dialog`, and virtual scrolling work well together.

https://github.com/bitwarden/clients/assets/17113462/30e1432d-ffd6-4055-ba42-3321cb0a3586



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
