### PR TITLE
[PM-6381] Bugfix- handle org plans uncovered undefined case

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -288,12 +288,13 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
 
   get selectablePlans() {
     const selectedProductType = this.formGroup.controls.product.value;
-    const result = this.passwordManagerPlans?.filter(
-      (plan) =>
-        plan.product === selectedProductType &&
-        ((!this.isProviderQualifiedFor2020Plan() && this.planIsEnabled(plan)) ||
-          (this.isProviderQualifiedFor2020Plan() && Allowed2020PlanTypes.includes(plan.type))),
-    );
+    const result =
+      this.passwordManagerPlans?.filter(
+        (plan) =>
+          plan.product === selectedProductType &&
+          ((!this.isProviderQualifiedFor2020Plan() && this.planIsEnabled(plan)) ||
+            (this.isProviderQualifiedFor2020Plan() && Allowed2020PlanTypes.includes(plan.type))),
+      ) || [];
 
     result.sort((planA, planB) => planA.displaySortOrder - planB.displaySortOrder);
     return result;


### PR DESCRIPTION
In `selectablePlans`, optional chaining is used, but no fallback is provided in undefined cases, resulting in errors in the subsequent sort:

![Screenshot 2024-02-19 at 12 59 54 PM](https://github.com/bitwarden/clients/assets/1556494/dacabf3e-e769-42df-862d-24ca65aef58f)

https://github.com/bitwarden/clients/blob/main/apps/web/src/app/billing/organizations/organization-plans.component.ts#L291

This case can be seen by visiting https://localhost:8443/#/create-organization of a self-hosted instance