### PR TITLE
[PM-6391] Add "fixed-width" class to view icons

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -616,8 +616,7 @@
           class="box-content-row box-content-row-newmulti single-line"
           *ngIf="!(!cipher.edit && editMode)"
         >
-          <i class="bwi bwi-fw bwi-plus-circle bwi-fw bwi-lg" aria-hidden="true"></i>
-          {{ "newUri" | i18n }}
+          <i class="bwi bwi-plus-circle bwi-fw bwi-lg" aria-hidden="true"></i> {{ "newUri" | i18n }}
         </button>
       </div>
     </div>

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -62,7 +62,7 @@
                 (click)="generateUsername()"
                 *ngIf="!(!cipher.edit && editMode)"
               >
-                <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-generate" aria-hidden="true"></i>
               </button>
             </div>
           </div>
@@ -95,12 +95,12 @@
                 *ngIf="cipher.viewPassword"
               >
                 <i
-                  class="bwi bwi-lg bwi-check-circle"
+                  class="bwi bwi-fw bwi-lg bwi-check-circle"
                   [hidden]="$any(checkPasswordBtn).loading"
                   aria-hidden="true"
                 ></i>
                 <i
-                  class="bwi bwi-lg bwi-spinner bwi-spin"
+                  class="bwi bwi-fw bwi-lg bwi-spinner bwi-spin"
                   [hidden]="!$any(checkPasswordBtn).loading"
                   aria-hidden="true"
                 ></i>
@@ -115,7 +115,7 @@
                 [attr.aria-pressed]="showPassword"
               >
                 <i
-                  class="bwi bwi-lg"
+                  class="bwi bwi-fw bwi-lg"
                   aria-hidden="true"
                   [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
                 ></i>
@@ -128,7 +128,7 @@
                 (click)="generatePassword()"
                 *ngIf="cipher.viewPassword && !(!cipher.edit && editMode)"
               >
-                <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-generate" aria-hidden="true"></i>
               </button>
             </div>
           </div>
@@ -177,7 +177,7 @@
                 [attr.aria-pressed]="showTotpSeed"
               >
                 <i
-                  class="bwi bwi-lg"
+                  class="bwi bwi-fw bwi-lg"
                   aria-hidden="true"
                   [ngClass]="{ 'bwi-eye': !showTotpSeed, 'bwi-eye-slash': showTotpSeed }"
                 ></i>
@@ -190,7 +190,7 @@
                 (click)="copy(cipher.login.totp, 'totp', 'TOTP')"
                 *ngIf="cipher.viewPassword"
               >
-                <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-clone" aria-hidden="true"></i>
               </button>
               <button
                 type="button"
@@ -200,7 +200,7 @@
                 (click)="captureTOTPFromTab()"
                 *ngIf="!(!cipher.edit && editMode)"
               >
-                <i class="bwi bwi-lg bwi-camera" aria-hidden="true"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-camera" aria-hidden="true"></i>
               </button>
             </div>
           </div>
@@ -242,7 +242,7 @@
                 [attr.aria-pressed]="showCardNumber"
               >
                 <i
-                  class="bwi bwi-lg"
+                  class="bwi bwi-fw bwi-lg"
                   aria-hidden="true"
                   [ngClass]="{ 'bwi-eye': !showCardNumber, 'bwi-eye-slash': showCardNumber }"
                 ></i>
@@ -319,7 +319,7 @@
                 [attr.aria-pressed]="showCardCode"
               >
                 <i
-                  class="bwi bwi-lg"
+                  class="bwi bwi-fw bwi-lg"
                   aria-hidden="true"
                   [ngClass]="{ 'bwi-eye': !showCardCode, 'bwi-eye-slash': showCardCode }"
                 ></i>
@@ -542,7 +542,7 @@
               (click)="removeUri(u)"
               appA11yTitle="{{ 'remove' | i18n }}"
             >
-              <i class="bwi bwi-minus-circle bwi-lg" aria-hidden="true"></i>
+              <i class="bwi bwi-fw bwi-minus-circle bwi-lg" aria-hidden="true"></i>
             </button>
             <div class="row-main">
               <label for="loginUri{{ i }}">{{ "uriPosition" | i18n: i + 1 }}</label>
@@ -594,7 +594,7 @@
                 (click)="toggleUriInput(u)"
                 [attr.aria-pressed]="$any(u).showCurrentUris === true"
               >
-                <i aria-hidden="true" class="bwi bwi-lg bwi-list"></i>
+                <i aria-hidden="true" class="bwi bwi-fw bwi-lg bwi-list"></i>
               </button>
               <button
                 type="button"
@@ -604,7 +604,7 @@
                 (click)="toggleUriOptions(u)"
                 [attr.aria-pressed]="$any(u).showOptions === true"
               >
-                <i class="bwi bwi-lg bwi-cog" aria-hidden="true"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-cog" aria-hidden="true"></i>
               </button>
             </div>
           </div>
@@ -616,7 +616,8 @@
           class="box-content-row box-content-row-newmulti single-line"
           *ngIf="!(!cipher.edit && editMode)"
         >
-          <i class="bwi bwi-plus-circle bwi-fw bwi-lg" aria-hidden="true"></i> {{ "newUri" | i18n }}
+          <i class="bwi bwi-fw bwi-plus-circle bwi-fw bwi-lg" aria-hidden="true"></i>
+          {{ "newUri" | i18n }}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [X] Bug fix

## Code changes

Add fixed-width class to icons so they take up the same width as their siblings

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-02-23 at 12 16 16 PM](https://github.com/bitwarden/clients/assets/1556494/c699b2cb-a94c-4c51-a7be-abd016cdee21) | ![Screenshot 2024-02-23 at 12 13 36 PM](https://github.com/bitwarden/clients/assets/1556494/2ef92071-1c1b-4310-a440-44c5180874be) |
