### PR TITLE
[PM-5725] New passkeys should always return 0 as counter value

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -656,7 +656,7 @@ describe("FidoAuthenticatorService", () => {
       beforeEach(init);
 
       /** Spec: Increment the credential associated signature counter */
-      it("should increment counter", async () => {
+      it("should increment counter when stored counter is larger than zero", async () => {
         const encrypted = Symbol();
         cipherService.encrypt.mockResolvedValue(encrypted as any);
 
@@ -671,6 +671,30 @@ describe("FidoAuthenticatorService", () => {
               fido2Credentials: [
                 expect.objectContaining({
                   counter: 9001,
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      /** Spec: Authenticators that do not implement a signature counter leave the signCount in the authenticator data constant at zero. */
+      it("should not increment counter when stored counter is zero", async () => {
+        const encrypted = Symbol();
+        cipherService.encrypt.mockResolvedValue(encrypted as any);
+        ciphers[0].login.fido2Credentials[0].counter = 0;
+
+        await authenticator.getAssertion(params, tab);
+
+        expect(cipherService.updateWithServer).toHaveBeenCalledWith(encrypted);
+
+        expect(cipherService.encrypt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: ciphers[0].id,
+            login: expect.objectContaining({
+              fido2Credentials: [
+                expect.objectContaining({
+                  counter: 0,
                 }),
               ],
             }),

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.spec.ts
@@ -656,14 +656,14 @@ describe("FidoAuthenticatorService", () => {
       beforeEach(init);
 
       /** Spec: Increment the credential associated signature counter */
-      it("should increment counter when stored counter is larger than zero", async () => {
+      it("should increment counter and save to server when stored counter is larger than zero", async () => {
         const encrypted = Symbol();
         cipherService.encrypt.mockResolvedValue(encrypted as any);
+        ciphers[0].login.fido2Credentials[0].counter = 9000;
 
         await authenticator.getAssertion(params, tab);
 
         expect(cipherService.updateWithServer).toHaveBeenCalledWith(encrypted);
-
         expect(cipherService.encrypt).toHaveBeenCalledWith(
           expect.objectContaining({
             id: ciphers[0].id,
@@ -679,27 +679,14 @@ describe("FidoAuthenticatorService", () => {
       });
 
       /** Spec: Authenticators that do not implement a signature counter leave the signCount in the authenticator data constant at zero. */
-      it("should not increment counter when stored counter is zero", async () => {
+      it("should not save to server when stored counter is zero", async () => {
         const encrypted = Symbol();
         cipherService.encrypt.mockResolvedValue(encrypted as any);
         ciphers[0].login.fido2Credentials[0].counter = 0;
 
         await authenticator.getAssertion(params, tab);
 
-        expect(cipherService.updateWithServer).toHaveBeenCalledWith(encrypted);
-
-        expect(cipherService.encrypt).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: ciphers[0].id,
-            login: expect.objectContaining({
-              fido2Credentials: [
-                expect.objectContaining({
-                  counter: 0,
-                }),
-              ],
-            }),
-          }),
-        );
+        expect(cipherService.updateWithServer).not.toHaveBeenCalled();
       });
 
       it("should return an assertion result", async () => {

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -257,7 +257,9 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
         const selectedFido2Credential = selectedCipher.login.fido2Credentials[0];
         const selectedCredentialId = selectedFido2Credential.credentialId;
 
-        ++selectedFido2Credential.counter;
+        if (selectedFido2Credential.counter > 0) {
+          ++selectedFido2Credential.counter;
+        }
 
         selectedCipher.localData = {
           ...selectedCipher.localData,

--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -265,8 +265,11 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
           ...selectedCipher.localData,
           lastUsedDate: new Date().getTime(),
         };
-        const encrypted = await this.cipherService.encrypt(selectedCipher);
-        await this.cipherService.updateWithServer(encrypted);
+
+        if (selectedFido2Credential.counter > 0) {
+          const encrypted = await this.cipherService.encrypt(selectedCipher);
+          await this.cipherService.updateWithServer(encrypted);
+        }
 
         const authenticatorData = await generateAuthData({
           rpId: selectedFido2Credential.rpId,


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove incrementing counter for new passkeys. Will help us in the future with export/import, improving performance, etc.

Note: Older clients will still increment these new passkeys and "activate" the counter incrementing function. This is ok. Browser extensions are usually updated fairly quickly and so the amount of passkeys that this happens to should be limited.

## Code changes

- Only increment counter if stored value is larger than zero

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
