### PR TITLE
[AC-2195] Fixes for FC V1 for Custom Users

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -278,13 +278,8 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     this.editableCollections$ = allCollectionsWithoutUnassigned$.pipe(
       map((collections) => {
-        if (
-          this.organization.canEditAnyCollection &&
-          this.organization.allowAdminAccessToAllCollectionItems
-        ) {
-          return collections;
-        }
-        if (this.organization.isProviderUser) {
+        // Users that can edit all ciphers can implicitly edit all collections
+        if (this.organization.canEditAllCiphers(this.flexibleCollectionsV1Enabled)) {
           return collections;
         }
         return collections.filter((c) => c.assigned && !c.readOnly);

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -408,8 +408,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       map(([filter, collection, organization]) => {
         return (
           (filter.collectionId === Unassigned && !organization.canUseAdminCollections) ||
-          (!organization.allowAdminAccessToAllCollectionItems &&
-            !organization.canEditAllCiphers(this.flexibleCollectionsV1Enabled) &&
+          (!organization.canEditAllCiphers(this.flexibleCollectionsV1Enabled) &&
             collection != undefined &&
             !collection.node.assigned)
         );

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -141,7 +141,11 @@ export class VaultComponent implements OnInit, OnDestroy {
     FeatureFlag.BulkCollectionAccess,
     false,
   );
-  protected flexibleCollectionsV1Enabled: boolean;
+  private _flexibleCollectionsV1FlagEnabled: boolean;
+
+  protected get flexibleCollectionsV1Enabled(): boolean {
+    return this._flexibleCollectionsV1FlagEnabled && this.organization?.flexibleCollections;
+  }
 
   private searchText$ = new Subject<string>();
   private refresh$ = new BehaviorSubject<void>(null);
@@ -184,7 +188,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         : "trashCleanupWarning",
     );
 
-    this.flexibleCollectionsV1Enabled = await this.configService.getFeatureFlag(
+    this._flexibleCollectionsV1FlagEnabled = await this.configService.getFeatureFlag(
       FeatureFlag.FlexibleCollectionsV1,
       false,
     );

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -202,11 +202,11 @@ export class Organization {
       return this.canEditAnyCollection;
     }
     // Post Flexible Collections V1, the allowAdminAccessToAllCollectionItems flag can restrict admins
-    // Providers are not affected by allowAdminAccessToAllCollectionItems flag
-    // note: canEditAnyCollection may change in the V1 to also ignore the allowAdminAccessToAllCollectionItems flag
+    // Providers and custom users with canEditAnyCollection are not affected by allowAdminAccessToAllCollectionItems flag
     return (
       this.isProviderUser ||
-      (this.allowAdminAccessToAllCollectionItems && this.canEditAnyCollection)
+      (this.type === OrganizationUserType.Custom && this.permissions.editAnyCollection) ||
+      (this.allowAdminAccessToAllCollectionItems && this.isAdmin)
     );
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a couple edge cases for Custom Users with `editAnyCollection` and `deleteAnyCollection` permissions and cleans up some feature flagging logic that was leaking FC functionality to non-FC orgs when the V1 flag is enabled.

Related Server PR: https://github.com/bitwarden/server/pull/3837

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

### **`libs/common/src/admin-console/models/domain/organization.ts`** 

Update the `canEditAllCiphers()` method to allow custom users with the `editAnyCollection` permission to always be able to edit any cipher, regardless of the collection management setting that restricts admins/owners.

### **`apps/web/src/app/vault/org-vault/vault.component.ts`**

_I recommend reading each commit to get a better understanding of why each line/section was modified._

- Update the V1 flexible collections flag check to include a check to ensure the organization has migrated to FC.
- The `editableCollections$` observable now re-uses the `canEditAllCiphers()` helper because they have the same underlying logic. Users that can edit any cipher are implicitly granted access to all collections.
- Update the `showCollectionAccessRestricted$` observable logic to remove a check for the collection management setting  that did not consider custom users with `deleteAnyCollection` permission. The management setting is checked within the `canEditAllCiphers()` helper already.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
