### PR TITLE
Remove constructor from link-sso

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.directive.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/link-sso.directive.ts
@@ -1,19 +1,7 @@
 import { AfterContentInit, Directive, HostListener, Input } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
 
 import { SsoComponent } from "@bitwarden/angular/auth/components/sso.component";
-import { LoginStrategyServiceAbstraction } from "@bitwarden/auth/common";
-import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
-import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
-import { CryptoFunctionService } from "@bitwarden/common/platform/abstractions/crypto-function.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
-import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
 
 @Directive({
   selector: "[app-link-sso]",
@@ -21,47 +9,13 @@ import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/ge
 export class LinkSsoDirective extends SsoComponent implements AfterContentInit {
   @Input() organization: Organization;
   returnUri = "/settings/organizations";
+  redirectUri = window.location.origin + "/sso-connector.html";
+  clientId = "web";
 
   @HostListener("click", ["$event"])
   async onClick($event: MouseEvent) {
     $event.preventDefault();
     await this.submit(this.returnUri, true);
-  }
-
-  constructor(
-    ssoLoginService: SsoLoginServiceAbstraction,
-    platformUtilsService: PlatformUtilsService,
-    i18nService: I18nService,
-    apiService: ApiService,
-    loginStrategyService: LoginStrategyServiceAbstraction,
-    router: Router,
-    route: ActivatedRoute,
-    cryptoFunctionService: CryptoFunctionService,
-    passwordGenerationService: PasswordGenerationServiceAbstraction,
-    stateService: StateService,
-    environmentService: EnvironmentService,
-    logService: LogService,
-    configService: ConfigServiceAbstraction,
-  ) {
-    super(
-      ssoLoginService,
-      loginStrategyService,
-      router,
-      i18nService,
-      route,
-      stateService,
-      platformUtilsService,
-      apiService,
-      cryptoFunctionService,
-      environmentService,
-      passwordGenerationService,
-      logService,
-      configService,
-    );
-
-    this.returnUri = "/settings/organizations";
-    this.redirectUri = window.location.origin + "/sso-connector.html";
-    this.clientId = "web";
   }
 
   async ngAfterContentInit() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The link-sso component has a couple of properties set in its constructor. Unfortunately this means that whenever Auth updates the base component dependencies, vault has to review the PR since the link-sso constructor needs to be updated.

Properties outside the constructor are treated the same in the generated JS. `window.location.origin` will also work as seen below:
![image](https://github.com/bitwarden/clients/assets/24985544/09e608f7-e3fb-41fc-86e6-93ecf5b6aa4f)

Auth will do its best to not use derived properties on the base class that could cause issues:
```
class Parent {
  constructor() {
    this.hi = "hi";
    this.greeting = this.hi + " parent"
  }
}

class Child extends Parent {
  constructor() {
    super();
    this.hi = "jake";
  }
}

var k = new Child();

console.log(k.greeting);
// "hi parent"
```
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/24985544/8479fbf9-f58a-4623-b260-8b3cdcf55e18


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
