### PR TITLE
[PM-6450] add missing table cell to vault table in AC

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -54,6 +54,7 @@
       [showBulkEditCollectionAccess]="
         (showBulkEditCollectionAccess$ | async) && organization?.flexibleCollections
       "
+      [viewingOrgVault]="true"
     >
     </app-vault-items>
     <ng-container *ngIf="!flexibleCollectionsV1Enabled">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `vault-items` component has a `viewingOrgVault` input that should be set to true in the AC. It not being set causes the table row to have fewer cells then expected. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/vault/org-vault/vault.component.html:** set `viewingOrgVault` to true in template of `app-org-vault`
## Screenshots

After: 

<img width="1277" alt="image" src="https://github.com/bitwarden/clients/assets/17113462/16a56691-58b5-437a-8b99-a434c0cf26ba">

Before:

(Notice misalignment at end of row item)

<img width="1277" alt="image" src="https://github.com/bitwarden/clients/assets/17113462/e4eac52f-21bb-4db3-8189-18ca1f525781">


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
