### PR TITLE
[PM-6507] Disregard collection of form input elements when they are children of a submit button

### DIFF
--- a/apps/browser/src/autofill/content/autofill-init.ts
+++ b/apps/browser/src/autofill/content/autofill-init.ts
@@ -99,9 +99,7 @@ class AutofillInit implements AutofillInitInterface {
       return pageDetails;
     }
 
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    chrome.runtime.sendMessage({
+    void chrome.runtime.sendMessage({
       command: "collectPageDetailsResponse",
       tab: message.tab,
       details: pageDetails,

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -805,6 +805,36 @@ describe("CollectAutofillContentService", () => {
   });
 
   describe("buildAutofillFieldItem", () => {
+    it("returns a `null` value if the field is a child of a `button[type='submit']`", async () => {
+      const usernameField = {
+        labelText: "Username",
+        id: "username-id",
+        type: "text",
+      };
+      document.body.innerHTML = `
+        <form>
+          <div>
+            <div>
+              <label for="${usernameField.id}">${usernameField.labelText}</label>
+              <button type="submit">
+                <input id="${usernameField.id}" type="${usernameField.type}" />
+              </button>
+            </div>
+          </div>
+        </form>
+      `;
+      const usernameInput = document.getElementById(
+        usernameField.id,
+      ) as ElementWithOpId<FillableFormFieldElement>;
+
+      const autofillFieldItem = await collectAutofillContentService["buildAutofillFieldItem"](
+        usernameInput,
+        0,
+      );
+
+      expect(autofillFieldItem).toBeNull();
+    });
+
     it("returns an existing autofill field item if it exists", async () => {
       const index = 0;
       const usernameField = {
@@ -824,27 +854,6 @@ describe("CollectAutofillContentService", () => {
         value: "username-value",
         dataStripe: "data-stripe",
       };
-      document.body.innerHTML = `
-        <form>
-          <label for="${usernameField.id}">${usernameField.labelText}</label>
-          <input
-            id="${usernameField.id}"
-            class="${usernameField.classes}"
-            name="${usernameField.name}"
-            type="${usernameField.type}"
-            maxlength="${usernameField.maxLength}"
-            tabindex="${usernameField.tabIndex}"
-            title="${usernameField.title}"
-            autocomplete="${usernameField.autocomplete}"
-            data-label="${usernameField.dataLabel}"
-            aria-label="${usernameField.ariaLabel}"
-            placeholder="${usernameField.placeholder}"
-            rel="${usernameField.rel}"
-            value="${usernameField.value}"
-            data-stripe="${usernameField.dataStripe}"
-          />
-        </form>
-      `;
       document.body.innerHTML = `
         <form>
           <label for="${usernameField.id}">${usernameField.labelText}</label>

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -183,7 +183,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
       url: (document.defaultView || window).location.href,
       documentUrl: document.location.href,
       forms: autofillFormsData,
-      fields: autofillFieldsData,
+      fields: autofillFieldsData.filter(Boolean),
       collectedTimestamp: Date.now(),
     };
   }
@@ -327,15 +327,18 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
    * Builds an AutofillField object from the given form element. Will only return
    * shared field values if the element is a span element. Will not return any label
    * values if the element is a hidden input element.
-   * @param {ElementWithOpId<FormFieldElement>} element
-   * @param {number} index
-   * @returns {Promise<AutofillField>}
-   * @private
+   *
+   * @param element - The form field element to build the AutofillField object from
+   * @param index - The index of the form field element
    */
   private buildAutofillFieldItem = async (
     element: ElementWithOpId<FormFieldElement>,
     index: number,
-  ): Promise<AutofillField> => {
+  ): Promise<AutofillField | null> => {
+    if (element.closest("button[type='submit']")) {
+      return null;
+    }
+
     element.opid = `__${index}`;
 
     const existingAutofillField = this.autofillFieldElements.get(element);

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -86,9 +86,9 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
     const { formElements, formFieldElements } = this.queryAutofillFormAndFieldElements();
     const autofillFormsData: Record<string, AutofillForm> =
       this.buildAutofillFormsData(formElements);
-    const autofillFieldsData: AutofillField[] = await this.buildAutofillFieldsData(
-      formFieldElements as FormFieldElement[],
-    );
+    const autofillFieldsData: AutofillField[] = (
+      await this.buildAutofillFieldsData(formFieldElements as FormFieldElement[])
+    ).filter(Boolean);
     this.sortAutofillFieldElementsMap();
 
     if (!autofillFieldsData.length) {
@@ -183,7 +183,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
       url: (document.defaultView || window).location.href,
       documentUrl: document.location.href,
       forms: autofillFormsData,
-      fields: autofillFieldsData.filter(Boolean),
+      fields: autofillFieldsData,
       collectedTimestamp: Date.now(),
     };
   }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -88,7 +88,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
       this.buildAutofillFormsData(formElements);
     const autofillFieldsData: AutofillField[] = (
       await this.buildAutofillFieldsData(formFieldElements as FormFieldElement[])
-    ).filter(Boolean);
+    ).filter((field) => !!field);
     this.sortAutofillFieldElementsMap();
 
     if (!autofillFieldsData.length) {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Form input elements that are nested within `<button type="submit">` elements can trigger some undesired behaviors when triggering autofill. This PR removes any form elements found which are children of a these types of button elements. 

## Code changes

- **apps/browser/src/autofill/content/autofill-init.ts:** Removing a floating promise on the `chrome.runtime.sendMessage` call.
- **apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts:** Adding Jest tests to verify that a found `input` element will not render autofill page details when it is nested within a submit button element
- **apps/browser/src/autofill/services/collect-autofill-content.service.ts:** Implementing a methodology that ensure we do not collect the input field data for fields that are nested within `button type="submit"` elements.
