### PR TITLE
[PM-6495] Remove extra parameters in biometrics constructors

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -178,7 +178,6 @@ export class Main {
     this.biometricsService = new BiometricsService(
       this.i18nService,
       this.windowMain,
-      this.stateService,
       this.logService,
       this.messagingService,
       process.platform,

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.spec.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.spec.ts
@@ -3,7 +3,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 
@@ -24,7 +23,6 @@ jest.mock("@bitwarden/desktop-native", () => {
 describe("biometrics tests", function () {
   const i18nService = mock<I18nService>();
   const windowMain = mock<WindowMain>();
-  const stateService = mock<StateService>();
   const logService = mock<LogService>();
   const messagingService = mock<MessagingService>();
   const biometricStateService = mock<BiometricStateService>();
@@ -34,7 +32,6 @@ describe("biometrics tests", function () {
     const sut = new BiometricsService(
       i18nService,
       windowMain,
-      stateService,
       logService,
       messagingService,
       process.platform,
@@ -59,7 +56,6 @@ describe("biometrics tests", function () {
       const sut = new BiometricsService(
         i18nService,
         windowMain,
-        stateService,
         logService,
         messagingService,
         "win32",
@@ -75,7 +71,6 @@ describe("biometrics tests", function () {
       const sut = new BiometricsService(
         i18nService,
         windowMain,
-        stateService,
         logService,
         messagingService,
         "darwin",
@@ -96,7 +91,6 @@ describe("biometrics tests", function () {
       sut = new BiometricsService(
         i18nService,
         windowMain,
-        stateService,
         logService,
         messagingService,
         process.platform,

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.ts
@@ -1,7 +1,6 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 
@@ -16,7 +15,6 @@ export class BiometricsService implements BiometricsServiceAbstraction {
   constructor(
     private i18nService: I18nService,
     private windowMain: WindowMain,
-    private stateService: StateService,
     private logService: LogService,
     private messagingService: MessagingService,
     private platform: NodeJS.Platform,
@@ -41,7 +39,6 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     this.platformSpecificService = new BiometricWindowsMain(
       this.i18nService,
       this.windowMain,
-      this.stateService,
       this.logService,
     );
   }
@@ -49,7 +46,7 @@ export class BiometricsService implements BiometricsServiceAbstraction {
   private loadMacOSService() {
     // eslint-disable-next-line
     const BiometricDarwinMain = require("./biometric.darwin.main").default;
-    this.platformSpecificService = new BiometricDarwinMain(this.i18nService, this.stateService);
+    this.platformSpecificService = new BiometricDarwinMain(this.i18nService);
   }
 
   private loadNoopBiometricsService() {


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Remove extra stateService parameters. Because we're loading the `BiometricWindowsMain` with a dynamic `require` the service was loaded as `any` and not type checked, causing the extra stateService param was being interpreted as a logService and causing errors.
