### PR TITLE
Updated CryptoService DI to use getBgService again

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -114,7 +114,6 @@ import { BrowserApi } from "../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../platform/popup/browser-popup-utils";
 import { BrowserStateService as StateServiceAbstraction } from "../../platform/services/abstractions/browser-state.service";
 import { BrowserConfigService } from "../../platform/services/browser-config.service";
-import { BrowserCryptoService } from "../../platform/services/browser-crypto.service";
 import { BrowserEnvironmentService } from "../../platform/services/browser-environment.service";
 import { BrowserFileDownloadService } from "../../platform/services/browser-file-download.service";
 import { BrowserI18nService } from "../../platform/services/browser-i18n.service";
@@ -269,39 +268,12 @@ function getBgService<T>(service: keyof MainBackground) {
     },
     {
       provide: CryptoService,
-      useFactory: (
-        keyGenerationService: KeyGenerationService,
-        cryptoFunctionService: CryptoFunctionService,
-        encryptService: EncryptService,
-        platformUtilsService: PlatformUtilsService,
-        logService: LogServiceAbstraction,
-        stateService: StateServiceAbstraction,
-        accountService: AccountServiceAbstraction,
-        stateProvider: StateProvider,
-      ) => {
-        const cryptoService = new BrowserCryptoService(
-          keyGenerationService,
-          cryptoFunctionService,
-          encryptService,
-          platformUtilsService,
-          logService,
-          stateService,
-          accountService,
-          stateProvider,
-        );
+      useFactory: (encryptService: EncryptService) => {
+        const cryptoService = getBgService<CryptoService>("cryptoService")();
         new ContainerService(cryptoService, encryptService).attachToGlobal(self);
         return cryptoService;
       },
-      deps: [
-        KeyGenerationService,
-        CryptoFunctionService,
-        EncryptService,
-        PlatformUtilsService,
-        LogServiceAbstraction,
-        StateServiceAbstraction,
-        AccountServiceAbstraction,
-        StateProvider,
-      ],
+      deps: [EncryptService],
     },
     {
       provide: AuthRequestServiceAbstraction,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Reverted the change in https://github.com/bitwarden/clients/pull/7970 that updated `CryptoService` DI to remove the reliance on `getBgService`.  This is still necessary until further state provider migrations are complete.

## Code changes

- **services.module.ts:** Added back use of `getBgService`.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
