### PR TITLE
[CL-170] Fix size of radio group legend

### DIFF
--- a/libs/components/src/radio-button/radio-button.stories.ts
+++ b/libs/components/src/radio-button/radio-button.stories.ts
@@ -105,21 +105,22 @@ export const Block: Story = {
         radio: new FormControl(0),
       }),
     },
-    template: `
+
+    template: /* HTML */ `
       <form [formGroup]="formObj">
         <bit-radio-group formControlName="radio" aria-label="Example radio group" [block]="true">
           <bit-label>Group of radio buttons</bit-label>
-  
+
           <bit-radio-button id="radio-first" [value]="0">
             <bit-label>First</bit-label>
             <bit-hint>This is a hint for the first option</bit-hint>
           </bit-radio-button>
-  
+
           <bit-radio-button id="radio-second" [value]="1">
             <bit-label>Second</bit-label>
             <bit-hint>This is a hint for the second option</bit-hint>
           </bit-radio-button>
-  
+
           <bit-radio-button id="radio-third" [value]="2">
             <bit-label>Third</bit-label>
             <bit-hint>This is a hint for the third option</bit-hint>

--- a/libs/components/src/radio-button/radio-button.stories.ts
+++ b/libs/components/src/radio-button/radio-button.stories.ts
@@ -45,19 +45,19 @@ export const Inline: Story = {
         radio: new FormControl(0),
       }),
     },
-    template: `
+    template: /* HTML */ `
       <form [formGroup]="formObj">
         <bit-radio-group formControlName="radio" aria-label="Example radio group">
           <bit-label>Group of radio buttons</bit-label>
-  
+
           <bit-radio-button id="radio-first" [value]="0">
             <bit-label>First</bit-label>
           </bit-radio-button>
-  
+
           <bit-radio-button id="radio-second" [value]="1">
             <bit-label>Second</bit-label>
           </bit-radio-button>
-  
+
           <bit-radio-button id="radio-third" [value]="2">
             <bit-label>Third</bit-label>
           </bit-radio-button>
@@ -74,26 +74,26 @@ export const InlineHint: Story = {
         radio: new FormControl(0),
       }),
     },
-    template: `
-    <form [formGroup]="formObj">
-      <bit-radio-group formControlName="radio" aria-label="Example radio group">
-        <bit-label>Group of radio buttons</bit-label>
+    template: /* HTML */ `
+      <form [formGroup]="formObj">
+        <bit-radio-group formControlName="radio" aria-label="Example radio group">
+          <bit-label>Group of radio buttons</bit-label>
 
-        <bit-radio-button id="radio-first" [value]="0">
-          <bit-label>First</bit-label>
-        </bit-radio-button>
+          <bit-radio-button id="radio-first" [value]="0">
+            <bit-label>First</bit-label>
+          </bit-radio-button>
 
-        <bit-radio-button id="radio-second" [value]="1">
-          <bit-label>Second</bit-label>
-        </bit-radio-button>
+          <bit-radio-button id="radio-second" [value]="1">
+            <bit-label>Second</bit-label>
+          </bit-radio-button>
 
-        <bit-radio-button id="radio-third" [value]="2">
-          <bit-label>Third</bit-label>
-        </bit-radio-button>
+          <bit-radio-button id="radio-third" [value]="2">
+            <bit-label>Third</bit-label>
+          </bit-radio-button>
 
-        <bit-hint>This is a hint for the radio group</bit-hint>
-      </bit-radio-group>
-    </form>
+          <bit-hint>This is a hint for the radio group</bit-hint>
+        </bit-radio-group>
+      </form>
     `,
   }),
 };
@@ -138,7 +138,7 @@ export const BlockHint: Story = {
         radio: new FormControl(0),
       }),
     },
-    template: `
+    template: /* HTML */ `
       <form [formGroup]="formObj">
         <bit-radio-group formControlName="radio" aria-label="Example radio group" [block]="true">
           <bit-label>Group of radio buttons</bit-label>

--- a/libs/components/src/radio-button/radio-group.component.html
+++ b/libs/components/src/radio-button/radio-group.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="label">
   <fieldset>
-    <legend class="tw-mb-1 tw-block tw-text-sm tw-font-semibold tw-text-main">
+    <legend class="tw-mb-1 tw-block tw-text-base tw-font-semibold tw-text-main">
       <ng-content select="bit-label"></ng-content>
       <span *ngIf="required" class="tw-text-xs tw-font-normal"> ({{ "required" | i18n }})</span>
     </legend>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The font size of the radio group legend was incorrect and did not match design specifications. This PR updates the size.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **radio-button.stories.ts:** Also added `html` comment for editor support for the template string, which caused a couple formatting changes

## Screenshots

**Before (prod)**

Web
![Screenshot 2024-02-29 at 11 51 38 AM](https://github.com/bitwarden/clients/assets/32983157/2f205732-cf35-406d-8123-12f73629eea6)

Storybook
![Screenshot 2024-02-29 at 11 53 50 AM](https://github.com/bitwarden/clients/assets/32983157/ec82c4a0-5143-4881-aee5-b18917786145)


**After (local)**

Web
![Screenshot 2024-02-29 at 11 51 17 AM](https://github.com/bitwarden/clients/assets/32983157/95f0c6cd-f0ec-401b-a6cf-0311d2a368e2)

Storybook
![Screenshot 2024-02-29 at 11 53 21 AM](https://github.com/bitwarden/clients/assets/32983157/9c637e05-dba3-4336-b1f9-2b6f7ae7f109)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
