### PR TITLE
[AC-2248][PM-5352] Bugfix - Fix non-working policy state in autofill settings service

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -4,6 +4,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { NOTIFICATION_BAR_LIFESPAN_MS } from "@bitwarden/common/autofill/constants";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ThemeType } from "@bitwarden/common/platform/enums";
@@ -19,7 +20,6 @@ import { openUnlockPopout } from "../../auth/popup/utils/auth-popout-window";
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { BrowserStateService } from "../../platform/services/abstractions/browser-state.service";
 import { openAddEditVaultItemPopout } from "../../vault/popup/utils/vault-popout-window";
-import { NOTIFICATION_BAR_LIFESPAN_MS } from "../constants";
 import { NotificationQueueMessageType } from "../enums/notification-queue-message-type.enum";
 import { AutofillService } from "../services/abstractions/autofill.service";
 

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -2,6 +2,10 @@ import { mock, mockReset } from "jest-mock-extended";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { AuthService } from "@bitwarden/common/auth/services/auth.service";
+import {
+  SHOW_AUTOFILL_BUTTON,
+  AutofillOverlayVisibility,
+} from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsService } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { ThemeType } from "@bitwarden/common/platform/enums";
 import { EnvironmentService } from "@bitwarden/common/platform/services/environment.service";
@@ -15,7 +19,6 @@ import { CipherService } from "@bitwarden/common/vault/services/cipher.service";
 import { BrowserApi } from "../../platform/browser/browser-api";
 import BrowserPlatformUtilsService from "../../platform/services/browser-platform-utils.service";
 import { BrowserStateService } from "../../platform/services/browser-state.service";
-import { SHOW_AUTOFILL_BUTTON } from "../constants";
 import { AutofillService } from "../services/abstractions/autofill.service";
 import {
   createAutofillPageDetailsMock,
@@ -28,7 +31,6 @@ import { flushPromises, sendExtensionRuntimeMessage, sendPortMessage } from "../
 import {
   AutofillOverlayElement,
   AutofillOverlayPort,
-  AutofillOverlayVisibility,
   RedirectFocusDirection,
 } from "../utils/autofill-overlay.enum";
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -3,7 +3,9 @@ import { firstValueFrom } from "rxjs";
 import { SettingsService } from "@bitwarden/common/abstractions/settings.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { SHOW_AUTOFILL_BUTTON } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
+import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -22,13 +24,8 @@ import {
   openViewVaultItemPopout,
   openAddEditVaultItemPopout,
 } from "../../vault/popup/utils/vault-popout-window";
-import { SHOW_AUTOFILL_BUTTON } from "../constants";
 import { AutofillService, PageDetail } from "../services/abstractions/autofill.service";
-import {
-  InlineMenuVisibilitySetting,
-  AutofillOverlayElement,
-  AutofillOverlayPort,
-} from "../utils/autofill-overlay.enum";
+import { AutofillOverlayElement, AutofillOverlayPort } from "../utils/autofill-overlay.enum";
 
 import { LockedVaultPendingNotificationsData } from "./abstractions/notification.background";
 import {

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.spec.ts
@@ -3,14 +3,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-
 import {
   AUTOFILL_ID,
   COPY_PASSWORD_ID,
@@ -18,7 +10,14 @@ import {
   COPY_VERIFICATION_CODE_ID,
   GENERATE_PASSWORD_ID,
   NOOP_COMMAND_SUFFIX,
-} from "../constants";
+} from "@bitwarden/common/autofill/constants";
+import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import {
   CopyToClipboardAction,

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -2,6 +2,20 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import {
+  AUTOFILL_CARD_ID,
+  AUTOFILL_ID,
+  AUTOFILL_IDENTITY_ID,
+  COPY_IDENTIFIER_ID,
+  COPY_PASSWORD_ID,
+  COPY_USERNAME_ID,
+  COPY_VERIFICATION_CODE_ID,
+  CREATE_CARD_ID,
+  CREATE_IDENTITY_ID,
+  CREATE_LOGIN_ID,
+  GENERATE_PASSWORD_ID,
+  NOOP_COMMAND_SUFFIX,
+} from "@bitwarden/common/autofill/constants";
 import { EventType } from "@bitwarden/common/enums";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
@@ -38,20 +52,6 @@ import { LockedVaultPendingNotificationsData } from "../background/abstractions/
 import { autofillServiceFactory } from "../background/service_factories/autofill-service.factory";
 import { copyToClipboard, GeneratePasswordToClipboardCommand } from "../clipboard";
 import { AutofillTabCommand } from "../commands/autofill-tab-command";
-import {
-  AUTOFILL_CARD_ID,
-  AUTOFILL_ID,
-  AUTOFILL_IDENTITY_ID,
-  COPY_IDENTIFIER_ID,
-  COPY_PASSWORD_ID,
-  COPY_USERNAME_ID,
-  COPY_VERIFICATION_CODE_ID,
-  CREATE_CARD_ID,
-  CREATE_IDENTITY_ID,
-  CREATE_LOGIN_ID,
-  GENERATE_PASSWORD_ID,
-  NOOP_COMMAND_SUFFIX,
-} from "../constants";
 import { AutofillCipherTypeId } from "../types";
 
 export type CopyToClipboardOptions = { text: string; tab: chrome.tabs.Tab };

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
@@ -1,5 +1,6 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
+import { NOOP_COMMAND_SUFFIX } from "@bitwarden/common/autofill/constants";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -7,7 +8,6 @@ import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { BrowserStateService } from "../../platform/services/abstractions/browser-state.service";
-import { NOOP_COMMAND_SUFFIX } from "../constants";
 
 import { MainContextMenuHandler } from "./main-context-menu-handler";
 

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -1,3 +1,19 @@
+import {
+  AUTOFILL_CARD_ID,
+  AUTOFILL_ID,
+  AUTOFILL_IDENTITY_ID,
+  COPY_IDENTIFIER_ID,
+  COPY_PASSWORD_ID,
+  COPY_USERNAME_ID,
+  COPY_VERIFICATION_CODE_ID,
+  CREATE_CARD_ID,
+  CREATE_IDENTITY_ID,
+  CREATE_LOGIN_ID,
+  GENERATE_PASSWORD_ID,
+  NOOP_COMMAND_SUFFIX,
+  ROOT_ID,
+  SEPARATOR_ID,
+} from "@bitwarden/common/autofill/constants";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
@@ -21,22 +37,6 @@ import {
   StateServiceInitOptions,
 } from "../../platform/background/service-factories/state-service.factory";
 import { BrowserStateService } from "../../platform/services/abstractions/browser-state.service";
-import {
-  AUTOFILL_CARD_ID,
-  AUTOFILL_ID,
-  AUTOFILL_IDENTITY_ID,
-  COPY_IDENTIFIER_ID,
-  COPY_PASSWORD_ID,
-  COPY_USERNAME_ID,
-  COPY_VERIFICATION_CODE_ID,
-  CREATE_CARD_ID,
-  CREATE_IDENTITY_ID,
-  CREATE_LOGIN_ID,
-  GENERATE_PASSWORD_ID,
-  NOOP_COMMAND_SUFFIX,
-  ROOT_ID,
-  SEPARATOR_ID,
-} from "../constants";
 
 import { InitContextMenuItems } from "./abstractions/main-context-menu-handler";
 

--- a/apps/browser/src/autofill/content/autofill-init.spec.ts
+++ b/apps/browser/src/autofill/content/autofill-init.spec.ts
@@ -1,12 +1,13 @@
 import { mock } from "jest-mock-extended";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 
 import AutofillPageDetails from "../models/autofill-page-details";
 import AutofillScript from "../models/autofill-script";
 import AutofillOverlayContentService from "../services/autofill-overlay-content.service";
 import { flushPromises, sendExtensionRuntimeMessage } from "../spec/testing-utils";
-import { AutofillOverlayVisibility, RedirectFocusDirection } from "../utils/autofill-overlay.enum";
+import { RedirectFocusDirection } from "../utils/autofill-overlay.enum";
 
 import { AutofillExtensionMessage } from "./abstractions/autofill-init";
 import AutofillInit from "./autofill-init";

--- a/apps/browser/src/autofill/overlay/iframe-content/autofill-overlay-iframe.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/iframe-content/autofill-overlay-iframe.service.spec.ts
@@ -1,8 +1,8 @@
 import { mock } from "jest-mock-extended";
 
+import { EVENTS } from "@bitwarden/common/autofill/constants";
 import { ThemeType } from "@bitwarden/common/platform/enums";
 
-import { EVENTS } from "../../constants";
 import { createPortSpyMock } from "../../spec/autofill-mocks";
 import {
   flushPromises,

--- a/apps/browser/src/autofill/overlay/iframe-content/autofill-overlay-iframe.service.ts
+++ b/apps/browser/src/autofill/overlay/iframe-content/autofill-overlay-iframe.service.ts
@@ -1,6 +1,6 @@
+import { EVENTS } from "@bitwarden/common/autofill/constants";
 import { ThemeType } from "@bitwarden/common/platform/enums";
 
-import { EVENTS } from "../../constants";
 import { setElementStyles } from "../../utils";
 import {
   BackgroundPortMessageHandlers,

--- a/apps/browser/src/autofill/overlay/pages/button/autofill-overlay-button.ts
+++ b/apps/browser/src/autofill/overlay/pages/button/autofill-overlay-button.ts
@@ -1,8 +1,8 @@
 import "@webcomponents/custom-elements";
 import "lit/polyfill-support.js";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { EVENTS } from "@bitwarden/common/autofill/constants";
 
-import { EVENTS } from "../../../constants";
 import { buildSvgDomElement } from "../../../utils";
 import { logoIcon, logoLockedIcon } from "../../../utils/svg-icons";
 import {

--- a/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.ts
+++ b/apps/browser/src/autofill/overlay/pages/list/autofill-overlay-list.ts
@@ -1,9 +1,9 @@
 import "@webcomponents/custom-elements";
 import "lit/polyfill-support.js";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { EVENTS } from "@bitwarden/common/autofill/constants";
 
 import { OverlayCipherData } from "../../../background/abstractions/overlay.background";
-import { EVENTS } from "../../../constants";
 import { buildSvgDomElement } from "../../../utils";
 import { globeIcon, lockIcon, plusIcon, viewCipherIcon } from "../../../utils/svg-icons";
 import {

--- a/apps/browser/src/autofill/overlay/pages/shared/autofill-overlay-page-element.ts
+++ b/apps/browser/src/autofill/overlay/pages/shared/autofill-overlay-page-element.ts
@@ -1,4 +1,5 @@
-import { EVENTS } from "../../../constants";
+import { EVENTS } from "@bitwarden/common/autofill/constants";
+
 import { RedirectFocusDirection } from "../../../utils/autofill-overlay.enum";
 import {
   AutofillOverlayPageElementWindowMessage,

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -2,7 +2,9 @@ import { Component, OnInit } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
 import { SettingsService } from "@bitwarden/common/abstractions/settings.service";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
+import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
@@ -12,10 +14,6 @@ import { DialogService } from "@bitwarden/components";
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import { enableAccountSwitching } from "../../../platform/flags";
 import { AutofillService } from "../../services/abstractions/autofill.service";
-import {
-  AutofillOverlayVisibility,
-  InlineMenuVisibilitySetting,
-} from "../../utils/autofill-overlay.enum";
 
 @Component({
   selector: "app-autofill",

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1,17 +1,13 @@
 import { mock } from "jest-mock-extended";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { EVENTS, AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 
-import { EVENTS } from "../constants";
 import AutofillField from "../models/autofill-field";
 import { createAutofillFieldMock } from "../spec/autofill-mocks";
 import { flushPromises } from "../spec/testing-utils";
 import { ElementWithOpId, FormFieldElement } from "../types";
-import {
-  AutofillOverlayElement,
-  AutofillOverlayVisibility,
-  RedirectFocusDirection,
-} from "../utils/autofill-overlay.enum";
+import { AutofillOverlayElement, RedirectFocusDirection } from "../utils/autofill-overlay.enum";
 
 import { AutoFillConstants } from "./autofill-constants";
 import AutofillOverlayContentService from "./autofill-overlay-content.service";

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -3,9 +3,9 @@ import "lit/polyfill-support.js";
 import { FocusableElement, tabbable } from "tabbable";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { EVENTS, AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 
 import { FocusedFieldData } from "../background/abstractions/overlay.background";
-import { EVENTS } from "../constants";
 import AutofillField from "../models/autofill-field";
 import AutofillOverlayButtonIframe from "../overlay/iframe-content/autofill-overlay-button-iframe";
 import AutofillOverlayListIframe from "../overlay/iframe-content/autofill-overlay-list-iframe";
@@ -16,11 +16,7 @@ import {
   sendExtensionMessage,
   setElementStyles,
 } from "../utils";
-import {
-  AutofillOverlayElement,
-  RedirectFocusDirection,
-  AutofillOverlayVisibility,
-} from "../utils/autofill-overlay.enum";
+import { AutofillOverlayElement, RedirectFocusDirection } from "../utils/autofill-overlay.enum";
 
 import {
   AutofillOverlayContentService as AutofillOverlayContentServiceInterface,

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -1,6 +1,7 @@
 import { mock, mockReset } from "jest-mock-extended";
 
 import { UserVerificationService } from "@bitwarden/common/auth/services/user-verification/user-verification.service";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsService } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { EventType } from "@bitwarden/common/enums";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -37,7 +38,6 @@ import {
   createGenerateFillScriptOptionsMock,
 } from "../spec/autofill-mocks";
 import { triggerTestFailure } from "../spec/testing-utils";
-import { AutofillOverlayVisibility } from "../utils/autofill-overlay.enum";
 
 import {
   AutoFillOptions,

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -4,6 +4,7 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { SettingsService } from "@bitwarden/common/abstractions/settings.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
+import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
 import { EventType } from "@bitwarden/common/enums";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -20,7 +21,6 @@ import { AutofillPort } from "../enums/autofill-port.enums";
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
 import AutofillScript from "../models/autofill-script";
-import { InlineMenuVisibilitySetting } from "../utils/autofill-overlay.enum";
 
 import {
   AutoFillOptions,

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -1,4 +1,5 @@
-import { EVENTS } from "../constants";
+import { EVENTS } from "@bitwarden/common/autofill/constants";
+
 import AutofillScript, { FillScript, FillScriptActions } from "../models/autofill-script";
 import { FillableFormFieldElement, FormElementWithAttribute, FormFieldElement } from "../types";
 

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -1,4 +1,5 @@
-import { EVENTS, TYPE_CHECK } from "../constants";
+import { EVENTS, TYPE_CHECK } from "@bitwarden/common/autofill/constants";
+
 import AutofillScript, { AutofillInsertActions, FillScript } from "../models/autofill-script";
 import { FormFieldElement } from "../types";
 import {

--- a/apps/browser/src/autofill/utils/autofill-overlay.enum.ts
+++ b/apps/browser/src/autofill/utils/autofill-overlay.enum.ts
@@ -14,19 +14,4 @@ const RedirectFocusDirection = {
   Next: "next",
 } as const;
 
-const AutofillOverlayVisibility = {
-  Off: 0,
-  OnButtonClick: 1,
-  OnFieldFocus: 2,
-} as const;
-
-type InlineMenuVisibilitySetting =
-  (typeof AutofillOverlayVisibility)[keyof typeof AutofillOverlayVisibility];
-
-export {
-  AutofillOverlayElement,
-  AutofillOverlayPort,
-  RedirectFocusDirection,
-  AutofillOverlayVisibility,
-  InlineMenuVisibilitySetting,
-};
+export { AutofillOverlayElement, AutofillOverlayPort, RedirectFocusDirection };

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -1,4 +1,5 @@
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { ConfigServiceAbstraction } from "@bitwarden/common/platform/abstractions/config/config.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -15,7 +16,6 @@ import {
 } from "../auth/popup/utils/auth-popout-window";
 import { LockedVaultPendingNotificationsData } from "../autofill/background/abstractions/notification.background";
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
-import { AutofillOverlayVisibility } from "../autofill/utils/autofill-overlay.enum";
 import { BrowserApi } from "../platform/browser/browser-api";
 import { BrowserStateService } from "../platform/services/abstractions/browser-state.service";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -5,6 +5,7 @@ import { AbstractThemingService } from "@bitwarden/angular/platform/services/the
 import { SettingsService } from "@bitwarden/common/abstractions/settings.service";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BadgeSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/badge-settings.service";
+import { ClearClipboardDelaySetting } from "@bitwarden/common/autofill/types";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
@@ -12,7 +13,6 @@ import { ThemeType } from "@bitwarden/common/platform/enums";
 import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
 import { UriMatchType } from "@bitwarden/common/vault/enums";
 
-import { ClearClipboardDelaySetting } from "../../../../../apps/browser/src/autofill/constants";
 import { enableAccountSwitching } from "../../platform/flags";
 
 @Component({

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -5,6 +5,7 @@ import { debounceTime, takeUntil } from "rxjs/operators";
 
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -19,7 +20,6 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { AutofillService } from "../../../../autofill/services/abstractions/autofill.service";
-import { AutofillOverlayVisibility } from "../../../../autofill/utils/autofill-overlay.enum";
 import { BrowserApi } from "../../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../../platform/popup/browser-popup-utils";
 import { VaultFilterService } from "../../../services/vault-filter.service";

--- a/apps/browser/tsconfig.json
+++ b/apps/browser/tsconfig.json
@@ -31,5 +31,9 @@
     "strictTemplates": true,
     "preserveWhitespaces": true
   },
-  "include": ["src", "../../libs/common/src/platform/services/**/*.worker.ts"]
+  "include": [
+    "src",
+    "../../libs/common/src/platform/services/**/*.worker.ts",
+    "../../libs/common/src/autofill/constants"
+  ]
 }

--- a/libs/common/src/autofill/constants/index.ts
+++ b/libs/common/src/autofill/constants/index.ts
@@ -32,9 +32,6 @@ export const ClearClipboardDelay = {
   FiveMinutes: 300,
 } as const;
 
-export type ClearClipboardDelaySetting =
-  (typeof ClearClipboardDelay)[keyof typeof ClearClipboardDelay];
-
 /* Context Menu item Ids */
 export const AUTOFILL_CARD_ID = "autofill-card";
 export const AUTOFILL_ID = "autofill";
@@ -53,3 +50,9 @@ export const ROOT_ID = "root";
 export const SEPARATOR_ID = "separator";
 
 export const NOTIFICATION_BAR_LIFESPAN_MS = 150000; // 150 seconds
+
+export const AutofillOverlayVisibility = {
+  Off: 0,
+  OnButtonClick: 1,
+  OnFieldFocus: 2,
+} as const;

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -33,6 +33,14 @@ const AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED = new KeyDefinition(
   },
 );
 
+const AUTOFILL_ON_PAGE_LOAD_POLICY_TOAST_HAS_DISPLAYED = new KeyDefinition(
+  AUTOFILL_SETTINGS_DISK,
+  "autofillOnPageLoadPolicyToastHasDisplayed",
+  {
+    deserializer: (value: boolean) => value ?? false,
+  },
+);
+
 const AUTO_COPY_TOTP = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
   deserializer: (value: boolean) => value ?? false,
 });
@@ -61,8 +69,8 @@ export abstract class AutofillSettingsServiceAbstraction {
   autofillOnPageLoadCalloutIsDismissed$: Observable<boolean>;
   setAutofillOnPageLoadCalloutIsDismissed: (newValue: boolean) => Promise<void>;
   activateAutofillOnPageLoadFromPolicy$: Observable<boolean>;
-  autofillOnPageLoadPolicyToastHasDisplayed: boolean;
-  setAutofillOnPageLoadPolicyToastHasDisplayed: (newValue: boolean) => void;
+  setAutofillOnPageLoadPolicyToastHasDisplayed: (newValue: boolean) => Promise<void>;
+  autofillOnPageLoadPolicyToastHasDisplayed$: Observable<boolean>;
   autoCopyTotp$: Observable<boolean>;
   setAutoCopyTotp: (newValue: boolean) => Promise<void>;
   inlineMenuVisibility$: Observable<InlineMenuVisibilitySetting>;
@@ -83,7 +91,8 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
 
   readonly activateAutofillOnPageLoadFromPolicy$: Observable<boolean>;
 
-  autofillOnPageLoadPolicyToastHasDisplayed: boolean = false;
+  private autofillOnPageLoadPolicyToastHasDisplayedState: ActiveUserState<boolean>;
+  readonly autofillOnPageLoadPolicyToastHasDisplayed$: Observable<boolean>;
 
   private autoCopyTotpState: ActiveUserState<boolean>;
   readonly autoCopyTotp$: Observable<boolean>;
@@ -118,6 +127,13 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
       PolicyType.ActivateAutofill,
     );
 
+    this.autofillOnPageLoadPolicyToastHasDisplayedState = this.stateProvider.getActive(
+      AUTOFILL_ON_PAGE_LOAD_POLICY_TOAST_HAS_DISPLAYED,
+    );
+    this.autofillOnPageLoadPolicyToastHasDisplayed$ = this.autofillOnPageLoadState.state$.pipe(
+      map((x) => x ?? false),
+    );
+
     this.autoCopyTotpState = this.stateProvider.getActive(AUTO_COPY_TOTP);
     this.autoCopyTotp$ = this.autoCopyTotpState.state$.pipe(map((x) => x ?? false));
 
@@ -144,8 +160,8 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     await this.autofillOnPageLoadCalloutIsDismissedState.update(() => newValue);
   }
 
-  setAutofillOnPageLoadPolicyToastHasDisplayed(newValue: boolean): void {
-    this.autofillOnPageLoadPolicyToastHasDisplayed = newValue;
+  async setAutofillOnPageLoadPolicyToastHasDisplayed(newValue: boolean): Promise<void> {
+    await this.autofillOnPageLoadPolicyToastHasDisplayedState.update(() => newValue);
   }
 
   async setAutoCopyTotp(newValue: boolean): Promise<void> {

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -1,15 +1,7 @@
 import { map, Observable } from "rxjs";
 
-import {
-  ClearClipboardDelaySetting,
-  ClearClipboardDelay,
-} from "../../../../../apps/browser/src/autofill/constants";
-import {
-  AutofillOverlayVisibility,
-  InlineMenuVisibilitySetting,
-} from "../../../../../apps/browser/src/autofill/utils/autofill-overlay.enum";
 import { PolicyService } from "../../admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType } from "../../admin-console/enums/index";
+import { PolicyType } from "../../admin-console/enums";
 import {
   AUTOFILL_SETTINGS_DISK,
   AUTOFILL_SETTINGS_DISK_LOCAL,
@@ -18,6 +10,8 @@ import {
   KeyDefinition,
   StateProvider,
 } from "../../platform/state";
+import { ClearClipboardDelay, AutofillOverlayVisibility } from "../constants";
+import { ClearClipboardDelaySetting, InlineMenuVisibilitySetting } from "../types";
 
 const AUTOFILL_ON_PAGE_LOAD = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autofillOnPageLoad", {
   deserializer: (value: boolean) => value ?? false,
@@ -31,10 +25,6 @@ const AUTOFILL_ON_PAGE_LOAD_DEFAULT = new KeyDefinition(
   },
 );
 
-const AUTO_COPY_TOTP = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
-  deserializer: (value: boolean) => value ?? false,
-});
-
 const AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED = new KeyDefinition(
   AUTOFILL_SETTINGS_DISK,
   "autofillOnPageLoadCalloutIsDismissed",
@@ -42,6 +32,10 @@ const AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED = new KeyDefinition(
     deserializer: (value: boolean) => value ?? false,
   },
 );
+
+const AUTO_COPY_TOTP = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
+  deserializer: (value: boolean) => value ?? false,
+});
 
 const INLINE_MENU_VISIBILITY = new KeyDefinition(
   AUTOFILL_SETTINGS_DISK_LOCAL,
@@ -64,13 +58,13 @@ export abstract class AutofillSettingsServiceAbstraction {
   setAutofillOnPageLoad: (newValue: boolean) => Promise<void>;
   autofillOnPageLoadDefault$: Observable<boolean>;
   setAutofillOnPageLoadDefault: (newValue: boolean) => Promise<void>;
-  autoCopyTotp$: Observable<boolean>;
-  setAutoCopyTotp: (newValue: boolean) => Promise<void>;
   autofillOnPageLoadCalloutIsDismissed$: Observable<boolean>;
   setAutofillOnPageLoadCalloutIsDismissed: (newValue: boolean) => Promise<void>;
   activateAutofillOnPageLoadFromPolicy$: Observable<boolean>;
   autofillOnPageLoadPolicyToastHasDisplayed: boolean;
   setAutofillOnPageLoadPolicyToastHasDisplayed: (newValue: boolean) => void;
+  autoCopyTotp$: Observable<boolean>;
+  setAutoCopyTotp: (newValue: boolean) => Promise<void>;
   inlineMenuVisibility$: Observable<InlineMenuVisibilitySetting>;
   setInlineMenuVisibility: (newValue: InlineMenuVisibilitySetting) => Promise<void>;
   clearClipboardDelay$: Observable<ClearClipboardDelaySetting>;
@@ -84,15 +78,15 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
   private autofillOnPageLoadDefaultState: ActiveUserState<boolean>;
   readonly autofillOnPageLoadDefault$: Observable<boolean>;
 
-  private autoCopyTotpState: ActiveUserState<boolean>;
-  readonly autoCopyTotp$: Observable<boolean>;
-
   private autofillOnPageLoadCalloutIsDismissedState: ActiveUserState<boolean>;
   readonly autofillOnPageLoadCalloutIsDismissed$: Observable<boolean>;
 
   readonly activateAutofillOnPageLoadFromPolicy$: Observable<boolean>;
 
   autofillOnPageLoadPolicyToastHasDisplayed: boolean = false;
+
+  private autoCopyTotpState: ActiveUserState<boolean>;
+  readonly autoCopyTotp$: Observable<boolean>;
 
   private inlineMenuVisibilityState: GlobalState<InlineMenuVisibilitySetting>;
   readonly inlineMenuVisibility$: Observable<InlineMenuVisibilitySetting>;
@@ -114,9 +108,6 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
       map((x) => x ?? true),
     );
 
-    this.autoCopyTotpState = this.stateProvider.getActive(AUTO_COPY_TOTP);
-    this.autoCopyTotp$ = this.autoCopyTotpState.state$.pipe(map((x) => x ?? false));
-
     this.autofillOnPageLoadCalloutIsDismissedState = this.stateProvider.getActive(
       AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED,
     );
@@ -126,6 +117,9 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     this.activateAutofillOnPageLoadFromPolicy$ = this.policyService.policyAppliesToActiveUser$(
       PolicyType.ActivateAutofill,
     );
+
+    this.autoCopyTotpState = this.stateProvider.getActive(AUTO_COPY_TOTP);
+    this.autoCopyTotp$ = this.autoCopyTotpState.state$.pipe(map((x) => x ?? false));
 
     this.inlineMenuVisibilityState = this.stateProvider.getGlobal(INLINE_MENU_VISIBILITY);
     this.inlineMenuVisibility$ = this.inlineMenuVisibilityState.state$.pipe(
@@ -146,16 +140,16 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     await this.autofillOnPageLoadDefaultState.update(() => newValue);
   }
 
-  async setAutoCopyTotp(newValue: boolean): Promise<void> {
-    await this.autoCopyTotpState.update(() => newValue);
-  }
-
   async setAutofillOnPageLoadCalloutIsDismissed(newValue: boolean): Promise<void> {
     await this.autofillOnPageLoadCalloutIsDismissedState.update(() => newValue);
   }
 
   setAutofillOnPageLoadPolicyToastHasDisplayed(newValue: boolean): void {
     this.autofillOnPageLoadPolicyToastHasDisplayed = newValue;
+  }
+
+  async setAutoCopyTotp(newValue: boolean): Promise<void> {
+    await this.autoCopyTotpState.update(() => newValue);
   }
 
   async setInlineMenuVisibility(newValue: InlineMenuVisibilitySetting): Promise<void> {

--- a/libs/common/src/autofill/types/index.ts
+++ b/libs/common/src/autofill/types/index.ts
@@ -1,0 +1,7 @@
+import { ClearClipboardDelay, AutofillOverlayVisibility } from "../constants";
+
+export type ClearClipboardDelaySetting =
+  (typeof ClearClipboardDelay)[keyof typeof ClearClipboardDelay];
+
+export type InlineMenuVisibilitySetting =
+  (typeof AutofillOverlayVisibility)[keyof typeof AutofillOverlayVisibility];

--- a/libs/common/src/state-migrations/migrations/18-move-autofill-settings-to-state-providers.ts
+++ b/libs/common/src/state-migrations/migrations/18-move-autofill-settings-to-state-providers.ts
@@ -1,6 +1,14 @@
-import { InlineMenuVisibilitySetting } from "../../../../../apps/browser/src/autofill/utils/autofill-overlay.enum";
 import { StateDefinitionLike, MigrationHelper } from "../migration-helper";
 import { Migrator } from "../migrator";
+
+const AutofillOverlayVisibility = {
+  Off: 0,
+  OnButtonClick: 1,
+  OnFieldFocus: 2,
+} as const;
+
+type InlineMenuVisibilitySetting =
+  (typeof AutofillOverlayVisibility)[keyof typeof AutofillOverlayVisibility];
 
 type ExpectedAccountState = {
   settings?: {

--- a/libs/common/src/state-migrations/migrations/25-move-clear-clipboard-to-autofill-settings-state-provider.ts
+++ b/libs/common/src/state-migrations/migrations/25-move-clear-clipboard-to-autofill-settings-state-provider.ts
@@ -1,6 +1,17 @@
-import { ClearClipboardDelaySetting } from "../../../../../apps/browser/src/autofill/constants";
 import { StateDefinitionLike, MigrationHelper } from "../migration-helper";
 import { Migrator } from "../migrator";
+
+const ClearClipboardDelay = {
+  Never: null as null,
+  TenSeconds: 10,
+  TwentySeconds: 20,
+  ThirtySeconds: 30,
+  OneMinute: 60,
+  TwoMinutes: 120,
+  FiveMinutes: 300,
+} as const;
+
+type ClearClipboardDelaySetting = (typeof ClearClipboardDelay)[keyof typeof ClearClipboardDelay];
 
 type ExpectedAccountState = {
   settings?: {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix
- Tech debt (refactoring, code cleanup, dependency upgrades, etc)

## Objective

After the [Autofill Settings state migration](https://github.com/bitwarden/clients/pull/7767), the org policy for the autofill on page load setting was not being properly retrieved. This resulted in the default value of the policy being disabled.

This has been addressed by proxying a request to the policy service for the `ActivateAutofill` (`11`) policy from the autofill settings service. Additionally, state has been added to track the policy toast display, as the policy state was being used to track the toast state in the original code (conflation of concerns). Unaddressed, this would result in the policy state being overwritten and not being used after the first load (e.g. the user could change the setting and the org policy would not come back).

## Code changes

The changes in this PR should reintroduce these original/expected behaviours:
  - org policy for autofill on load will overwrite (not override) the user setting
  - The user setting in the extension options menu is _not_ disabled and can be toggled by the user

They should also introduce these new behaviours:
  - When the current tab view in the extension is revisited, the org policy will be checked again (as it now has it's own state). Consequently, if the user has changed their autofill on page load setting, the org policy will be re-applied and the toast message shown again.
  - previously, the policy would not be re-checked

Additionally, some constants and types were cleaned up/re-organized in 21dc1de7b1ca1a3280ec0d1fc06d2ec2ebaffd33

## Notes / Future work
- The org policy is checked every time the user visits the "current tab" view of the extension (the default view)
- The toast message is only shown when the org policy actually changes the user setting.
- The org policies update on vault sync, so changed org policies will still not go into effect until such a sync has occurred (via manual user intervention or as a side-effect)
- Admin users are excluded from org policies (at the policy service level) and so will not be part of this UX.
- part of why I presume the policy overwrites the user setting rather than overriding it (being reconciled against it without modification) is that we don't use this policy state anywhere else, instead checking the user setting for autofill on page load. In follow up work, we should consider updating call-sites of the user setting and updating them to also check the policy setting.
- We should also consider updating the extension's settings interface ("Settings" -> "Auto-fill" -> "Auto-fill on page load") to disable the user controls when this org policy should prevent modification of the setting.
- By preserving the user's original setting (rather than overwriting it), we can gracefully fall back to it when the org policy is disabled (or non-existent).
- per @eliykat, we should look at moving the toast logic up to app.component.
  - More generally, we should think about moving this policy checking to it's appropriate context (settings view) (also need to consider when and where the toast should appear to be useful and not annoying to the user).
  - an additional note to consider with the design team is that the toast currently blocks tab navigation in the extension view

## Video demo

https://github.com/bitwarden/clients/assets/1556494/d426d96c-b112-4113-9f7a-bb1d512f39b0
