### PR TITLE
Squashed commit of the following:

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -685,7 +685,6 @@ export default class MainBackground {
       this.folderApiService,
       this.organizationService,
       this.sendApiService,
-      this.stateProvider,
       logoutCallback,
     );
     this.eventUploadService = new EventUploadService(
@@ -1068,7 +1067,7 @@ export default class MainBackground {
     await this.eventUploadService.uploadEvents(userId);
 
     await Promise.all([
-      this.syncService.setLastSync(new Date(0), userId as UserId),
+      this.syncService.setLastSync(new Date(0), userId),
       this.cryptoService.clearKeys(userId),
       this.settingsService.clear(userId),
       this.cipherService.clear(userId),

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -543,7 +543,6 @@ export class Main {
       this.folderApiService,
       this.organizationService,
       this.sendApiService,
-      this.stateProvider,
       async (expired: boolean) => await this.logout(),
     );
 

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -571,7 +571,7 @@ export class AppComponent implements OnInit, OnDestroy {
     let preLogoutActiveUserId;
     try {
       await this.eventUploadService.uploadEvents(userBeingLoggedOut);
-      await this.syncService.setLastSync(new Date(0), userBeingLoggedOut as UserId);
+      await this.syncService.setLastSync(new Date(0), userBeingLoggedOut);
       await this.cryptoService.clearKeys(userBeingLoggedOut);
       await this.settingsService.clear(userBeingLoggedOut);
       await this.cipherService.clear(userBeingLoggedOut);

--- a/apps/web/src/app/core/state/state.service.ts
+++ b/apps/web/src/app/core/state/state.service.ts
@@ -80,4 +80,14 @@ export class StateService extends BaseStateService<GlobalState, Account> {
     options = this.reconcileOptions(options, await this.defaultInMemoryOptions());
     return await super.setEncryptedSends(value, options);
   }
+
+  override async getLastSync(options?: StorageOptions): Promise<string> {
+    options = this.reconcileOptions(options, await this.defaultInMemoryOptions());
+    return await super.getLastSync(options);
+  }
+
+  override async setLastSync(value: string, options?: StorageOptions): Promise<void> {
+    options = this.reconcileOptions(options, await this.defaultInMemoryOptions());
+    return await super.setLastSync(value, options);
+  }
 }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -135,10 +135,10 @@ import { ValidationService } from "@bitwarden/common/platform/services/validatio
 import { WebCryptoFunctionService } from "@bitwarden/common/platform/services/web-crypto-function.service";
 import {
   ActiveUserStateProvider,
-  DerivedStateProvider,
   GlobalStateProvider,
   SingleUserStateProvider,
   StateProvider,
+  DerivedStateProvider,
 } from "@bitwarden/common/platform/state";
 /* eslint-disable import/no-restricted-paths -- We need the implementations to inject, but generally these should not be accessed */
 import { DefaultActiveUserStateProvider } from "@bitwarden/common/platform/state/implementations/default-active-user-state.provider";
@@ -513,7 +513,6 @@ import { ModalService } from "./modal.service";
         FolderApiServiceAbstraction,
         OrganizationServiceAbstraction,
         SendApiServiceAbstraction,
-        StateProvider,
         LOGOUT_CALLBACK,
       ],
     },

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -332,6 +332,8 @@ export abstract class StateService<T extends Account = Account> {
   setKeyHash: (value: string, options?: StorageOptions) => Promise<void>;
   getLastActive: (options?: StorageOptions) => Promise<number>;
   setLastActive: (value: number, options?: StorageOptions) => Promise<void>;
+  getLastSync: (options?: StorageOptions) => Promise<string>;
+  setLastSync: (value: string, options?: StorageOptions) => Promise<void>;
   getLocalData: (options?: StorageOptions) => Promise<{ [cipherId: string]: LocalData }>;
   setLocalData: (
     value: { [cipherId: string]: LocalData },

--- a/libs/common/src/platform/models/domain/account.ts
+++ b/libs/common/src/platform/models/domain/account.ts
@@ -181,6 +181,7 @@ export class AccountProfile {
   forceSetPasswordReason?: ForceSetPasswordReason;
   hasPremiumPersonally?: boolean;
   hasPremiumFromOrganization?: boolean;
+  lastSync?: string;
   userId?: string;
   usesKeyConnector?: boolean;
   keyHash?: string;

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1655,6 +1655,23 @@ export class StateService<
     await this.storageService.save(keys.accountActivity, accountActivity, options);
   }
 
+  async getLastSync(options?: StorageOptions): Promise<string> {
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()))
+    )?.profile?.lastSync;
+  }
+
+  async setLastSync(value: string, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
+    );
+    account.profile.lastSync = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskMemoryOptions()),
+    );
+  }
+
   async getLocalData(options?: StorageOptions): Promise<{ [cipherId: string]: LocalData }> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -45,8 +45,6 @@ export const PROVIDERS_DISK = new StateDefinition("providers", "disk");
 
 export const FOLDER_DISK = new StateDefinition("folder", "disk", { web: "memory" });
 
-export const SYNC_STATE = new StateDefinition("sync", "disk", { web: "memory" });
-
 export const VAULT_SETTINGS_DISK = new StateDefinition("vaultSettings", "disk", {
   web: "disk-local",
 });

--- a/libs/common/src/state-migrations/migrate.ts
+++ b/libs/common/src/state-migrations/migrate.ts
@@ -20,6 +20,7 @@ import { CollapsedGroupingsMigrator } from "./migrations/22-move-collapsed-group
 import { MoveBiometricPromptsToStateProviders } from "./migrations/23-move-biometric-prompts-to-state-providers";
 import { SmOnboardingTasksMigrator } from "./migrations/24-move-sm-onboarding-key-to-state-providers";
 import { ClearClipboardDelayMigrator } from "./migrations/25-move-clear-clipboard-to-autofill-settings-state-provider";
+import { RevertLastSyncMigrator } from "./migrations/26-revert-move-last-sync-to-state-provider";
 import { FixPremiumMigrator } from "./migrations/3-fix-premium";
 import { RemoveEverBeenUnlockedMigrator } from "./migrations/4-remove-ever-been-unlocked";
 import { AddKeyTypeToOrgKeysMigrator } from "./migrations/5-add-key-type-to-org-keys";
@@ -30,7 +31,7 @@ import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-setting
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 2;
-export const CURRENT_VERSION = 25;
+export const CURRENT_VERSION = 26;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -58,7 +59,8 @@ export function createMigrationBuilder() {
     .with(CollapsedGroupingsMigrator, 21, 22)
     .with(MoveBiometricPromptsToStateProviders, 22, 23)
     .with(SmOnboardingTasksMigrator, 23, 24)
-    .with(ClearClipboardDelayMigrator, 24, CURRENT_VERSION);
+    .with(ClearClipboardDelayMigrator, 24, 25)
+    .with(RevertLastSyncMigrator, 25, 26);
 }
 
 export async function currentVersion(

--- a/libs/common/src/state-migrations/migrations/15-move-folder-state-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/15-move-folder-state-to-state-provider.spec.ts
@@ -1,4 +1,4 @@
-import { any, MockProxy } from "jest-mock-extended";
+import { MockProxy, any } from "jest-mock-extended";
 
 import { MigrationHelper } from "../migration-helper";
 import { mockMigrationHelper } from "../migration-helper.spec";

--- a/libs/common/src/state-migrations/migrations/26-revert-move-last-sync-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/26-revert-move-last-sync-to-state-provider.spec.ts
@@ -1,0 +1,112 @@
+import { any, MockProxy } from "jest-mock-extended";
+
+import { MigrationHelper } from "../migration-helper";
+import { mockMigrationHelper } from "../migration-helper.spec";
+
+import { RevertLastSyncMigrator } from "./26-revert-move-last-sync-to-state-provider";
+
+function rollbackJSON() {
+  return {
+    global: {
+      otherStuff: "otherStuff1",
+    },
+    authenticatedAccounts: ["user-1", "user-2"],
+    "user-1": {
+      profile: {
+        lastSync: "2024-01-24T00:00:00.000Z",
+        otherStuff: "otherStuff4",
+      },
+      otherStuff: "otherStuff5",
+    },
+  };
+}
+
+function exampleJSON() {
+  return {
+    "user_user-1_sync_lastSync": "2024-01-24T00:00:00.000Z",
+    "user_user-2_sync_lastSync": null as any,
+    global: {
+      otherStuff: "otherStuff1",
+    },
+    authenticatedAccounts: ["user-1", "user-2"],
+    "user-1": {
+      profile: {
+        lastSync: "2024-01-24T00:00:00.000Z",
+        otherStuff: "otherStuff4",
+      },
+      otherStuff: "otherStuff5",
+    },
+  };
+}
+
+describe("LastSyncMigrator", () => {
+  let helper: MockProxy<MigrationHelper>;
+  let sut: RevertLastSyncMigrator;
+
+  const keyDefinitionLike = {
+    key: "lastSync",
+    stateDefinition: {
+      name: "sync",
+    },
+  };
+
+  describe("rollback", () => {
+    beforeEach(() => {
+      helper = mockMigrationHelper(rollbackJSON(), 26);
+      sut = new RevertLastSyncMigrator(25, 26);
+    });
+
+    it("should remove lastSync from all accounts", async () => {
+      await sut.rollback(helper);
+      expect(helper.set).toHaveBeenCalledWith("user-1", {
+        profile: {
+          otherStuff: "otherStuff4",
+        },
+        otherStuff: "otherStuff5",
+      });
+    });
+
+    it("should set lastSync provider value for each account", async () => {
+      await sut.rollback(helper);
+
+      expect(helper.setToUser).toHaveBeenCalledWith(
+        "user-1",
+        keyDefinitionLike,
+        "2024-01-24T00:00:00.000Z",
+      );
+
+      expect(helper.setToUser).toHaveBeenCalledWith("user-2", keyDefinitionLike, null);
+    });
+  });
+
+  describe("migrate", () => {
+    beforeEach(() => {
+      helper = mockMigrationHelper(exampleJSON(), 25);
+      sut = new RevertLastSyncMigrator(25, 26);
+    });
+
+    it.each(["user-1", "user-2"])("should null out new values", async (userId) => {
+      await sut.migrate(helper);
+
+      expect(helper.setToUser).toHaveBeenCalledWith(userId, keyDefinitionLike, null);
+    });
+
+    it("should add lastSync back to accounts", async () => {
+      await sut.migrate(helper);
+
+      expect(helper.set).toHaveBeenCalledWith("user-1", {
+        profile: {
+          lastSync: "2024-01-24T00:00:00.000Z",
+          otherStuff: "otherStuff4",
+        },
+        otherStuff: "otherStuff5",
+      });
+    });
+
+    it("should not try to restore values to missing accounts", async () => {
+      await sut.rollback(helper);
+
+      expect(helper.set).not.toHaveBeenCalledWith("user-2", any());
+    });
+  });
+});

--- a/libs/common/src/state-migrations/migrations/26-revert-move-last-sync-to-state-provider.ts
+++ b/libs/common/src/state-migrations/migrations/26-revert-move-last-sync-to-state-provider.ts
@@ -1,0 +1,47 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+type ExpectedAccountType = {
+  profile?: {
+    lastSync?: string;
+  };
+};
+
+const LAST_SYNC_KEY: KeyDefinitionLike = {
+  key: "lastSync",
+  stateDefinition: {
+    name: "sync",
+  },
+};
+
+export class RevertLastSyncMigrator extends Migrator<25, 26> {
+  async rollback(helper: MigrationHelper): Promise<void> {
+    const accounts = await helper.getAccounts<ExpectedAccountType>();
+    async function rollbackAccount(userId: string, account: ExpectedAccountType): Promise<void> {
+      const value = account?.profile?.lastSync;
+      await helper.setToUser(userId, LAST_SYNC_KEY, value ?? null);
+      if (value != null) {
+        delete account.profile.lastSync;
+        await helper.set(userId, account);
+      }
+    }
+
+    await Promise.all([...accounts.map(({ userId, account }) => rollbackAccount(userId, account))]);
+  }
+  async migrate(helper: MigrationHelper): Promise<void> {
+    const accounts = await helper.getAccounts<ExpectedAccountType>();
+
+    async function migrateAccount(userId: string, account: ExpectedAccountType): Promise<void> {
+      const value = await helper.getFromUser(userId, LAST_SYNC_KEY);
+      if (account) {
+        account.profile = Object.assign(account.profile ?? {}, {
+          lastSync: value,
+        });
+        await helper.set(userId, account);
+      }
+      await helper.setToUser(userId, LAST_SYNC_KEY, null);
+    }
+
+    await Promise.all([...accounts.map(({ userId, account }) => migrateAccount(userId, account))]);
+  }
+}

--- a/libs/common/src/vault/abstractions/sync/sync.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/sync/sync.service.abstraction.ts
@@ -1,18 +1,14 @@
-import { Observable } from "rxjs";
-
 import {
   SyncCipherNotification,
   SyncFolderNotification,
   SyncSendNotification,
 } from "../../../models/response/notification.response";
-import { UserId } from "../../../types/guid";
 
 export abstract class SyncService {
   syncInProgress: boolean;
-  lastSync$: Observable<Date | null>;
 
   getLastSync: () => Promise<Date>;
-  setLastSync: (date: Date, userId?: UserId) => Promise<any>;
+  setLastSync: (date: Date, userId?: string) => Promise<any>;
   fullSync: (forceSync: boolean, allowThrowOnError?: boolean) => Promise<boolean>;
   syncUpsertFolder: (notification: SyncFolderNotification, isEdit: boolean) => Promise<boolean>;
   syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -1,5 +1,3 @@
-import { firstValueFrom, map } from "rxjs";
-
 import { ApiService } from "../../../abstractions/api.service";
 import { SettingsService } from "../../../abstractions/settings.service";
 import { InternalOrganizationServiceAbstraction } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
@@ -25,12 +23,10 @@ import { MessagingService } from "../../../platform/abstractions/messaging.servi
 import { StateService } from "../../../platform/abstractions/state.service";
 import { sequentialize } from "../../../platform/misc/sequentialize";
 import { AccountDecryptionOptions } from "../../../platform/models/domain/account";
-import { KeyDefinition, StateProvider, SYNC_STATE } from "../../../platform/state";
 import { SendData } from "../../../tools/send/models/data/send.data";
 import { SendResponse } from "../../../tools/send/models/response/send.response";
 import { SendApiService } from "../../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../../tools/send/services/send.service.abstraction";
-import { UserId } from "../../../types/guid";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "../../../vault/abstractions/folder/folder-api.service.abstraction";
 import { InternalFolderService } from "../../../vault/abstractions/folder/folder.service.abstraction";
@@ -43,22 +39,8 @@ import { CollectionService } from "../../abstractions/collection.service";
 import { CollectionData } from "../../models/data/collection.data";
 import { CollectionDetailsResponse } from "../../models/response/collection.response";
 
-const LAST_SYNC_KEY = new KeyDefinition<string | null>(SYNC_STATE, "lastSync", {
-  deserializer: (value) => value,
-});
-
 export class SyncService implements SyncServiceAbstraction {
-  private lastSyncState = this.stateProvider.getActive(LAST_SYNC_KEY);
-
   syncInProgress = false;
-  lastSync$ = this.lastSyncState.state$.pipe(
-    map((value) => {
-      if (value == null) {
-        return null;
-      }
-      return new Date(value);
-    }),
-  );
 
   constructor(
     private apiService: ApiService,
@@ -77,20 +59,24 @@ export class SyncService implements SyncServiceAbstraction {
     private folderApiService: FolderApiServiceAbstraction,
     private organizationService: InternalOrganizationServiceAbstraction,
     private sendApiService: SendApiService,
-    private stateProvider: StateProvider,
     private logoutCallback: (expired: boolean) => Promise<void>,
   ) {}
 
-  async getLastSync(): Promise<Date | null> {
-    return await firstValueFrom(this.lastSync$);
+  async getLastSync(): Promise<Date> {
+    if ((await this.stateService.getUserId()) == null) {
+      return null;
+    }
+
+    const lastSync = await this.stateService.getLastSync();
+    if (lastSync) {
+      return new Date(lastSync);
+    }
+
+    return null;
   }
 
-  async setLastSync(date: Date, userId?: UserId): Promise<any> {
-    if (userId !== undefined) {
-      await this.stateProvider.getUser(userId, LAST_SYNC_KEY).update(() => date.toJSON());
-    } else {
-      await this.lastSyncState.update(() => date.toJSON());
-    }
+  async setLastSync(date: Date, userId?: string): Promise<any> {
+    await this.stateService.setLastSync(date.toJSON(), { userId: userId });
   }
 
   @sequentialize(() => "fullSync")


### PR DESCRIPTION
commit 1405fc22ccb55469f220a4e5b8eae0713646af26
Author: Matt Gibson <mgibson@bitwarden.com>
Date:   Thu Feb 29 18:24:35 2024 -0500

    Fix missing type import

commit fd38b06ad83df7d6a13df0a2eaf5ea324ef4a34a
Author: Matt Gibson <mgibson@bitwarden.com>
Date:   Thu Feb 29 17:57:34 2024 -0500

    Update ordering of badge settings migrator to be consistent with `rc`, which was cut with only up to version 25

commit fcbb39fe3e1e58c7d431b57a7aedcaa785fd9162
Author: Matt Gibson <mgibson@bitwarden.com>
Date:   Thu Feb 29 17:15:01 2024 -0500

    Prefer revert migrations to noop

    this revert avoids the need to change behavior between released vs unreleased migrations and keeps some dangerous code out of the repo :success:

commit 48aac760c4f5cc50a88b97eb1857bba4e45671cb
Author: Matt Gibson <mgibson@bitwarden.com>
Date:   Thu Feb 29 15:32:41 2024 -0500

    Revert "[PM-5277] Migrate Sync Service to State Provider (#7680)"

    This reverts commit 78008a9e1e25ce30d641226d3abd37c5b36181e9.

    Includes a noop migration builder that allows us to bridge over the deleted migration

(cherry picked from commit 660a7602814d657e06ab6573397e86c47400fa76)



[PM-5277]: https://bitwarden.atlassian.net/browse/PM-5277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ