### PR TITLE
[PM-6584] [PM-6632] [Defects] Vertical Vault Refresh Product Switcher

### DIFF
--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
@@ -8,6 +8,7 @@ import {
   canAccessBillingTab,
   canAccessGroupsTab,
   canAccessMembersTab,
+  canAccessOrgAdmin,
   canAccessReportingTab,
   canAccessSettingsTab,
   canAccessVaultTab,
@@ -43,7 +44,7 @@ import { AdminConsoleLogo } from "../../icons/admin-console-logo";
 export class OrganizationLayoutComponent implements OnInit, OnDestroy {
   protected readonly logo = AdminConsoleLogo;
 
-  protected orgFilter = (org: Organization) => org.isAdmin;
+  protected orgFilter = (org: Organization) => canAccessOrgAdmin(org);
 
   organization$: Observable<Organization>;
   showPaymentAndHistory$: Observable<boolean>;

--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.ts
@@ -58,9 +58,9 @@ export class ProductSwitcherContentComponent {
 
       // If the active route org doesn't have access to AC, find the first org that does.
       const acOrg =
-        routeOrg != null && canAccessOrgAdmin(routeOrg) && routeOrg.enabled
+        routeOrg != null && canAccessOrgAdmin(routeOrg)
           ? routeOrg
-          : orgs.find((o) => canAccessOrgAdmin(o) && o.enabled);
+          : orgs.find((o) => canAccessOrgAdmin(o));
 
       // TODO: This should be migrated to an Observable provided by the provider service and moved to the combineLatest above. See AC-2092.
       const providers = await this.providerService.getAll();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
- `PM-6584` When a user is part of only one org, and that org is deactivated, they do not see the admin console in the product switcher.
- `PM-6632` Users with admin custom permissions cannot see the organization in the organization switcher
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/layouts/product-switcher/product-switcher-content.component.ts:** Previously, we checked if an organization is enabled to determine the organization set to `acOrg`variable. I have updated the logic by removing the `enabled` condition. The admin console product can now be included in the product switcher for deactivated organizations.
- **apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts:** Switched the `orgFilter` to use the helper function `canAccessOrgAdmin`.

## Screenshots
### PM-6584
***Before***

https://github.com/bitwarden/clients/assets/13024008/573f77d0-9182-4db3-8472-89773fcb90d9

***After***

https://github.com/bitwarden/clients/assets/13024008/5b6faa69-c79d-4bf4-9d9b-e8cae7d8617b

### PM-6632
***Before***

https://github.com/bitwarden/clients/assets/13024008/cfc4af2c-d8cd-4cd7-b6b3-8ad65903c3d0

***After***

https://github.com/bitwarden/clients/assets/13024008/01f9ee1c-9d38-4844-824c-9ed152833e40





<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.c

om/contributing/accessibility/)
