### PR TITLE
[PM-6645] Fix Admin Console access logic when an organization is suspended 

### DIFF
--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -37,6 +37,10 @@ export function canAccessBillingTab(org: Organization): boolean {
 }
 
 export function canAccessOrgAdmin(org: Organization): boolean {
+  // Admin console can only be accessed by Owners for disabled organizations
+  if (!org.enabled && !org.isOwner) {
+    return false;
+  }
   return (
     canAccessMembersTab(org) ||
     canAccessGroupsTab(org) ||


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The product switcher would default to the first organization a user had admin access to. If that default organization was disabled and the user is not an Owner they would be denied access to the admin console and redirected back to the Vault with no other means of getting to the admin console for other organizations they may be a part of. 

This PR updates the `canAccessOrgAdmin` helper to take suspended organizations into considerations and now returns `false` if the organization is suspended and the user is not an Owner. This prevents the product switcher AC icon from defaulting to suspended org for users that do not have access.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

#### `admin-console/abstractions/organization/organization.service.abstraction.ts`
Add an early exit in case an org is suspended (not enabled) and the user is not an Owner.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
