### PR TITLE
[PM-6524] Providing import collection service to ImportService

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -162,8 +162,10 @@ import { VaultSettingsService } from "@bitwarden/common/vault/services/vault-set
 import {
   ImportApiService,
   ImportApiServiceAbstraction,
+  ImportCollectionServiceAbstraction,
   ImportService,
   ImportServiceAbstraction,
+  ImportCollectionService,
 } from "@bitwarden/importer/core";
 import {
   IndividualVaultExportService,
@@ -250,6 +252,7 @@ export default class MainBackground {
   authService: AuthServiceAbstraction;
   loginStrategyService: LoginStrategyServiceAbstraction;
   importApiService: ImportApiServiceAbstraction;
+  importCollectionService: ImportCollectionServiceAbstraction;
   importService: ImportServiceAbstraction;
   exportService: VaultExportServiceAbstraction;
   searchService: SearchServiceAbstraction;
@@ -742,6 +745,8 @@ export default class MainBackground {
 
     this.importApiService = new ImportApiService(this.apiService);
 
+    this.importCollectionService = new ImportCollectionService(this.collectionService);
+
     this.importService = new ImportService(
       this.cipherService,
       this.folderService,
@@ -749,6 +754,7 @@ export default class MainBackground {
       this.i18nService,
       this.collectionService,
       this.cryptoService,
+      this.importCollectionService,
     );
 
     this.individualVaultExportService = new IndividualVaultExportService(

--- a/apps/browser/src/tools/background/service_factories/import-collection-service.factory.ts
+++ b/apps/browser/src/tools/background/service_factories/import-collection-service.factory.ts
@@ -1,0 +1,30 @@
+import {
+  ImportCollectionService,
+  ImportCollectionServiceAbstraction,
+} from "../../../../../../libs/importer/src/services";
+import {
+  CachedServices,
+  FactoryOptions,
+  factory,
+} from "../../../platform/background/service-factories/factory-options";
+import {
+  CollectionServiceInitOptions,
+  collectionServiceFactory,
+} from "../../../vault/background/service_factories/collection-service.factory";
+
+export type ImportCollectionServiceInitOptions = FactoryOptions & CollectionServiceInitOptions;
+type ServiceCache = {
+  importCollectionService?: ImportCollectionServiceAbstraction;
+} & CachedServices;
+
+export function importCollectionServiceFactory(
+  cache: ServiceCache,
+  opts: ImportCollectionServiceInitOptions,
+): Promise<ImportCollectionServiceAbstraction> {
+  return factory(
+    cache,
+    "importCollectionService",
+    opts,
+    async () => new ImportCollectionService(await collectionServiceFactory(cache, opts)),
+  );
+}

--- a/apps/browser/src/tools/background/service_factories/import-service.factory.ts
+++ b/apps/browser/src/tools/background/service_factories/import-service.factory.ts
@@ -27,6 +27,10 @@ import {
 } from "../../../vault/background/service_factories/folder-service.factory";
 
 import { importApiServiceFactory, ImportApiServiceInitOptions } from "./import-api-service.factory";
+import {
+  importCollectionServiceFactory,
+  ImportCollectionServiceInitOptions,
+} from "./import-collection-service.factory";
 
 type ImportServiceFactoryOptions = FactoryOptions;
 
@@ -36,7 +40,8 @@ export type ImportServiceInitOptions = ImportServiceFactoryOptions &
   ImportApiServiceInitOptions &
   I18nServiceInitOptions &
   CollectionServiceInitOptions &
-  CryptoServiceInitOptions;
+  CryptoServiceInitOptions &
+  ImportCollectionServiceInitOptions;
 
 export function importServiceFactory(
   cache: {
@@ -56,6 +61,7 @@ export function importServiceFactory(
         await i18nServiceFactory(cache, opts),
         await collectionServiceFactory(cache, opts),
         await cryptoServiceFactory(cache, opts),
+        await importCollectionServiceFactory(cache, opts),
       ),
   );
 }

--- a/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
+++ b/apps/browser/src/tools/popup/settings/import/import-browser.component.ts
@@ -3,8 +3,14 @@ import { Component } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
 import { ImportComponent } from "@bitwarden/importer/ui";
+
+import {
+  ImportCollectionService,
+  ImportCollectionServiceAbstraction,
+} from "../../../../../../../libs/importer/src/services";
 
 @Component({
   templateUrl: "import-browser.component.html",
@@ -17,6 +23,13 @@ import { ImportComponent } from "@bitwarden/importer/ui";
     AsyncActionsModule,
     ButtonModule,
     ImportComponent,
+  ],
+  providers: [
+    {
+      provide: ImportCollectionServiceAbstraction,
+      useClass: ImportCollectionService,
+      deps: [CollectionService],
+    },
   ],
 })
 export class ImportBrowserComponent {

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -108,6 +108,8 @@ import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 import {
   ImportApiService,
   ImportApiServiceAbstraction,
+  ImportCollectionService,
+  ImportCollectionServiceAbstraction,
   ImportService,
   ImportServiceAbstraction,
 } from "@bitwarden/importer/core";
@@ -167,6 +169,7 @@ export class Main {
   containerService: ContainerService;
   auditService: AuditService;
   importService: ImportServiceAbstraction;
+  importCollectionService: ImportCollectionServiceAbstraction;
   importApiService: ImportApiServiceAbstraction;
   exportService: VaultExportServiceAbstraction;
   individualExportService: IndividualVaultExportServiceAbstraction;
@@ -574,6 +577,7 @@ export class Main {
     this.totpService = new TotpService(this.cryptoFunctionService, this.logService);
 
     this.importApiService = new ImportApiService(this.apiService);
+    this.importCollectionService = new ImportCollectionService(this.collectionService);
 
     this.importService = new ImportService(
       this.cipherService,
@@ -582,6 +586,7 @@ export class Main {
       this.i18nService,
       this.collectionService,
       this.cryptoService,
+      this.importCollectionService,
     );
 
     this.individualExportService = new IndividualVaultExportService(

--- a/apps/desktop/src/app/tools/import/import-desktop.component.ts
+++ b/apps/desktop/src/app/tools/import/import-desktop.component.ts
@@ -3,8 +3,14 @@ import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
 import { ImportComponent } from "@bitwarden/importer/ui";
+
+import {
+  ImportCollectionService,
+  ImportCollectionServiceAbstraction,
+} from "../../../../../../libs/importer/src/services";
 
 @Component({
   templateUrl: "import-desktop.component.html",
@@ -16,6 +22,13 @@ import { ImportComponent } from "@bitwarden/importer/ui";
     AsyncActionsModule,
     ButtonModule,
     ImportComponent,
+  ],
+  providers: [
+    {
+      provide: ImportCollectionServiceAbstraction,
+      useClass: ImportCollectionService,
+      deps: [CollectionService],
+    },
   ],
 })
 export class ImportDesktopComponent {

--- a/apps/web/src/app/tools/import/import-collection-admin.service.ts
+++ b/apps/web/src/app/tools/import/import-collection-admin.service.ts
@@ -1,14 +1,12 @@
-import { Injectable } from "@angular/core";
+import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 
 import { ImportCollectionServiceAbstraction } from "../../../../../../libs/importer/src/services/import-collection.service.abstraction";
 import { CollectionAdminService } from "../../vault/core/collection-admin.service";
-import { CollectionAdminView } from "../../vault/core/views/collection-admin.view";
 
-@Injectable()
 export class ImportCollectionAdminService implements ImportCollectionServiceAbstraction {
   constructor(private collectionAdminService: CollectionAdminService) {}
 
-  async getAllAdminCollections(organizationId: string): Promise<CollectionAdminView[]> {
+  async getAllCollections(organizationId: string): Promise<CollectionView[]> {
     return await this.collectionAdminService.getAll(organizationId);
   }
 }

--- a/apps/web/src/app/tools/import/import-web.component.ts
+++ b/apps/web/src/app/tools/import/import-web.component.ts
@@ -1,8 +1,11 @@
 import { Component } from "@angular/core";
 import { Router } from "@angular/router";
 
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import { ImportComponent } from "@bitwarden/importer/ui";
 
+import { ImportCollectionService } from "../../../../../../libs/importer/src/services/import-collection.service";
+import { ImportCollectionServiceAbstraction } from "../../../../../../libs/importer/src/services/import-collection.service.abstraction";
 import { HeaderModule } from "../../layouts/header/header.module";
 import { SharedModule } from "../../shared";
 
@@ -10,6 +13,13 @@ import { SharedModule } from "../../shared";
   templateUrl: "import-web.component.html",
   standalone: true,
   imports: [SharedModule, ImportComponent, HeaderModule],
+  providers: [
+    {
+      provide: ImportCollectionServiceAbstraction,
+      useClass: ImportCollectionService,
+      deps: [CollectionService],
+    },
+  ],
 })
 export class ImportWebComponent {
   protected loading = false;

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -2,11 +2,9 @@ import { CommonModule } from "@angular/common";
 import {
   Component,
   EventEmitter,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   ViewChild,
 } from "@angular/core";
@@ -97,6 +95,7 @@ import { ImportLastPassComponent } from "./lastpass";
         I18nService,
         CollectionService,
         CryptoService,
+        ImportCollectionServiceAbstraction,
       ],
     },
   ],
@@ -183,8 +182,6 @@ export class ImportComponent implements OnInit, OnDestroy {
     protected organizationService: OrganizationService,
     protected collectionService: CollectionService,
     protected formBuilder: FormBuilder,
-    @Inject(ImportCollectionServiceAbstraction)
-    @Optional()
     protected importCollectionService: ImportCollectionServiceAbstraction,
   ) {}
 
@@ -228,7 +225,7 @@ export class ImportComponent implements OnInit, OnDestroy {
 
     this.collections$ = Utils.asyncToObservable(() =>
       this.importCollectionService
-        .getAllAdminCollections(this.organizationId)
+        .getAllCollections(this.organizationId)
         .then((collections) => collections.sort(Utils.getSortFunction(this.i18nService, "name"))),
     );
 
@@ -255,8 +252,8 @@ export class ImportComponent implements OnInit, OnDestroy {
           organizations.find((x) => x.id == this.organizationId)?.flexibleCollections ?? false;
         if (value) {
           this.collections$ = Utils.asyncToObservable(() =>
-            this.collectionService
-              .getAllDecrypted()
+            this.importCollectionService
+              .getAllCollections()
               .then((decryptedCollections) =>
                 decryptedCollections
                   .filter(

--- a/libs/importer/src/services/import-collection.service.abstraction.ts
+++ b/libs/importer/src/services/import-collection.service.abstraction.ts
@@ -1,5 +1,5 @@
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 
 export abstract class ImportCollectionServiceAbstraction {
-  getAllAdminCollections: (organizationId: string) => Promise<CollectionView[]>;
+  getAllCollections: (organizationId?: string) => Promise<CollectionView[]>;
 }

--- a/libs/importer/src/services/import-collection.service.ts
+++ b/libs/importer/src/services/import-collection.service.ts
@@ -1,0 +1,12 @@
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
+import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
+
+import { ImportCollectionServiceAbstraction } from "./import-collection.service.abstraction";
+
+export class ImportCollectionService implements ImportCollectionServiceAbstraction {
+  constructor(private collectionService: CollectionService) {}
+
+  async getAllCollections(): Promise<CollectionView[]> {
+    return await this.collectionService.getAllDecrypted();
+  }
+}

--- a/libs/importer/src/services/import.service.spec.ts
+++ b/libs/importer/src/services/import.service.spec.ts
@@ -14,6 +14,7 @@ import { Importer } from "../importers/importer";
 import { ImportResult } from "../models/import-result";
 
 import { ImportApiServiceAbstraction } from "./import-api.service.abstraction";
+import { ImportCollectionService } from "./import-collection.service";
 import { ImportService } from "./import.service";
 
 describe("ImportService", () => {
@@ -24,6 +25,7 @@ describe("ImportService", () => {
   let i18nService: MockProxy<I18nService>;
   let collectionService: MockProxy<CollectionService>;
   let cryptoService: MockProxy<CryptoService>;
+  let importCollectionService: ImportCollectionService;
 
   beforeEach(() => {
     cipherService = mock<CipherService>();
@@ -32,6 +34,7 @@ describe("ImportService", () => {
     i18nService = mock<I18nService>();
     collectionService = mock<CollectionService>();
     cryptoService = mock<CryptoService>();
+    importCollectionService = new ImportCollectionService(collectionService);
 
     importService = new ImportService(
       cipherService,
@@ -40,6 +43,7 @@ describe("ImportService", () => {
       i18nService,
       collectionService,
       cryptoService,
+      importCollectionService,
     );
   });
 
@@ -174,6 +178,32 @@ describe("ImportService", () => {
       expect(importResult.collections[0].name).toBe(myImportTarget);
       expect(importResult.collections[1].name).toBe(`${myImportTarget}/${mockCollection1.name}`);
       expect(importResult.collections[2].name).toBe(`${myImportTarget}/${mockCollection2.name}`);
+    });
+
+    it("passing importCollectionService calls collectionService", async () => {
+      importService = new ImportService(
+        cipherService,
+        folderService,
+        importApiService,
+        i18nService,
+        collectionService,
+        cryptoService,
+        importCollectionService,
+      );
+
+      collectionService.getAllDecrypted.mockResolvedValue([
+        mockImportTargetCollection,
+        mockCollection1,
+        mockCollection2,
+      ]);
+
+      const myImportTarget = "myImportTarget";
+
+      importResult.collections.push(mockCollection1);
+      importResult.collections.push(mockCollection2);
+
+      await importService["setImportTarget"](importResult, organizationId, myImportTarget);
+      expect(collectionService.getAllDecrypted).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -88,6 +88,8 @@ import { ImportResult } from "../models/import-result";
 import { ImportApiServiceAbstraction } from "../services/import-api.service.abstraction";
 import { ImportServiceAbstraction } from "../services/import.service.abstraction";
 
+import { ImportCollectionServiceAbstraction } from "./import-collection.service.abstraction";
+
 export class ImportService implements ImportServiceAbstraction {
   featuredImportOptions = featuredImportOptions as readonly ImportOption[];
 
@@ -100,6 +102,7 @@ export class ImportService implements ImportServiceAbstraction {
     private i18nService: I18nService,
     private collectionService: CollectionService,
     private cryptoService: CryptoService,
+    private importCollectionService: ImportCollectionServiceAbstraction,
   ) {}
 
   getImportOptions(): ImportOption[] {
@@ -435,7 +438,8 @@ export class ImportService implements ImportServiceAbstraction {
     }
 
     if (organizationId) {
-      const collectionViews: CollectionView[] = await this.collectionService.getAllDecrypted();
+      const collectionViews: CollectionView[] =
+        await this.importCollectionService.getAllCollections(organizationId);
       const targetCollection = collectionViews.find((c) => c.id === importTarget);
 
       const noCollectionRelationShips: [number, number][] = [];

--- a/libs/importer/src/services/index.ts
+++ b/libs/importer/src/services/index.ts
@@ -4,4 +4,5 @@ export { ImportApiService } from "./import-api.service";
 export { ImportServiceAbstraction } from "./import.service.abstraction";
 export { ImportService } from "./import.service";
 
+export { ImportCollectionService } from "./import-collection.service";
 export { ImportCollectionServiceAbstraction } from "./import-collection.service.abstraction";


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`ImportService` is using `CollectionService` and on some cases users are trying to import into collections that are not provided by the `CollectionService`. 
To solve this problem, we are always passing the `ImportCollectionService` that either goes to `AdminCollectionService` web on AdminConsole or to the `CollectionService` when on PasswordManager
## Code changes


- **import.service.ts:** Has a new service that retrieves all the collections user should be able to import into.
- **Import-collection.service.ts:** Service that implements `ImportCollectionServiceAbstraction` and returns all the collections from CollectionService.
- **Import-web.component.ts / bw.ts / import-browser.component.ts / import-desktop.component.t:** Provides `ImportCollectionServiceAbstraction` using `ImportCollectionService`
- **Import-collection-service.factory.ts:** Created factory for the `ImportCollectionService`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
