### PR TITLE
Consider Higher `stateVersion` "ready"

### DIFF
--- a/libs/common/src/state-migrations/migrate.ts
+++ b/libs/common/src/state-migrations/migrate.ts
@@ -101,8 +101,12 @@ export async function waitForMigrations(
   const isReady = async () => {
     const version = await currentVersion(storageService, logService);
     // The saved version is what we consider the latest
-    // migrations should be complete
-    return version === CURRENT_VERSION;
+    // migrations should be complete, the state version
+    // shouldn't become larger than `CURRENT_VERSION` in
+    // any normal usage of the application but it is common
+    // enough in dev scenarios where we want to consider that
+    // ready as well and return true in that scenario.
+    return version >= CURRENT_VERSION;
   };
 
   const wait = async (time: number) => {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Developers will often work on a state migration in one branch then context switch to another branch that doesn't have that state migration. Because we don't do migrations in the desktop renderer and instead attempt to wait for their completion it would think the migrations weren't completed before bailing out after waiting 8 seconds. If we consider `stateVersion >= CURRENT_VERSION` it will tell the caller that migrations have completed sooner. The higher state version is unlikely to have any considerable issue for the developer. Both @MGibson1 and @eliykat have reported this happening to them.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
