### PR TITLE
[PM-6734] Show the correct host when using multiple accounts

### DIFF
--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -346,7 +346,8 @@ export class LockComponent implements OnInit, OnDestroy {
         !this.platformUtilsService.supportsSecureStorage());
     this.email = await this.stateService.getEmail();
 
-    this.webVaultHostname = await this.environmentService.getHost();
+    const userId = await this.stateService.getUserId();
+    this.webVaultHostname = await this.environmentService.getHost(userId);
   }
 
   /**


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix an issue where either the wrong host or no host may be displayed when logged in to multiple accounts on multiple accounts across multiple self-hosted instances/bitwarden.com servers.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **lock.component.ts:** Pass `userId` for `environmentService.getHost`.

## Screenshots
![screenshot2](https://github.com/bitwarden/clients/assets/47195730/213c1cf2-0632-42d8-a551-662f1061078e)

![screenshot4](https://github.com/bitwarden/clients/assets/47195730/e7e18666-89d8-437f-8be2-fe21bf8f1100)

