### PR TITLE
[PM-6740] Fix default value for autoCopyTotp

### DIFF
--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -42,7 +42,7 @@ const AUTOFILL_ON_PAGE_LOAD_POLICY_TOAST_HAS_DISPLAYED = new KeyDefinition(
 );
 
 const AUTO_COPY_TOTP = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
-  deserializer: (value: boolean) => value ?? false,
+  deserializer: (value: boolean) => value ?? true,
 });
 
 const INLINE_MENU_VISIBILITY = new KeyDefinition(
@@ -144,7 +144,7 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     );
 
     this.autoCopyTotpState = this.stateProvider.getActive(AUTO_COPY_TOTP);
-    this.autoCopyTotp$ = this.autoCopyTotpState.state$.pipe(map((x) => x ?? false));
+    this.autoCopyTotp$ = this.autoCopyTotpState.state$.pipe(map((x) => x ?? true));
 
     this.inlineMenuVisibilityState = this.stateProvider.getGlobal(INLINE_MENU_VISIBILITY);
     this.inlineMenuVisibility$ = this.inlineMenuVisibilityState.state$.pipe(


### PR DESCRIPTION
## Type of change

- Bug fix

## Objective

If the user has never explicitly/manually set the "Copy TOTP automatically" option, we don't have a stored setting for it. When this is the case, we defer to the default setting value. In this case it's "false" when it should be "true".

The issue should go away if the user sets the setting, but if they don't (or if they reinstall the extension or otherwise clear state), it will remain at the default value (off).

## Code changes

`autoCopyTotp` originates from `disableAutoTotpCopy` in the old state service (before https://github.com/bitwarden/clients/pull/7767):

![Screenshot 2024-03-11 at 9 59 07 AM](https://github.com/bitwarden/clients/assets/1556494/2e15e079-cd7c-4a95-8fdc-560668a4cbbe)

in that work, call sites and state migration logic were inverted to allow the setting to drop the "disable" prefix, but the default value for the setting was left at "false" when it should have been updated to "true" (the original behaviour -> autofill _should_ copy the totp by default)
