### PR TITLE
[PM-6749] Check MasterPassword in web app during change

### DIFF
--- a/apps/web/src/app/auth/settings/change-password.component.ts
+++ b/apps/web/src/app/auth/settings/change-password.component.ts
@@ -165,7 +165,22 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
     newMasterKey: MasterKey,
     newUserKey: [UserKey, EncString],
   ) {
-    const masterKey = await this.cryptoService.getOrDeriveMasterKey(this.currentMasterPassword);
+    const masterKey = await this.cryptoService.makeMasterKey(
+      this.currentMasterPassword,
+      await this.stateService.getEmail(),
+      await this.kdfConfigService.getKdfConfig(),
+    );
+
+    const userKey = await this.cryptoService.decryptUserKeyWithMasterKey(masterKey);
+    if (userKey == null) {
+      this.platformUtilsService.showToast(
+        "error",
+        null,
+        this.i18nService.t("invalidMasterPassword"),
+      );
+      return;
+    }
+
     const request = new PasswordRequest();
     request.masterPasswordHash = await this.cryptoService.hashMasterKey(
       this.currentMasterPassword,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Check the current master password client side during the change master password logic:
 - Prevent sending new valid key when the user inputted an invalid current master password.
 - Allow for faster feedback since it can be done before spending time computing the hash.

## Code changes

Replace the `getOrDeriveMasterKey` by `makeMasterKey` to ensure that the master key is computed from the user input and not retrieved from the store.
Add `decryptUserKeyWithMasterKey` to short circuit the rest of the logic if the user inputted an invalid current password.


Was playing with the client code and though this could be worth it, no idea if you are interested in such modifications.
Have a nice day :).