### PR TITLE
[PM-6404] Add `UserKeyDefinition` to union

### DIFF
--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -25,6 +25,7 @@ import {
   FakeGlobalState,
   FakeSingleUserState,
 } from "./fake-state";
+import { isUserKeyDefinition } from "../src/platform/state/user-key-definition";
 
 export class FakeGlobalStateProvider implements GlobalStateProvider {
   mock = mock<GlobalStateProvider>();
@@ -161,7 +162,11 @@ export class FakeStateProvider implements StateProvider {
     keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>,
     userId?: UserId,
   ): Observable<T> {
-    this.mock.getUserState$(keyDefinition, userId);
+    if (isUserKeyDefinition(keyDefinition)) {
+      this.mock.getUserState$(keyDefinition, userId);
+    } else {
+      this.mock.getUserState$(keyDefinition, userId);
+    }
     if (userId) {
       return this.getUser<T>(userId, keyDefinition).state$;
     }

--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -95,7 +95,10 @@ export class FakeSingleUserStateProvider implements SingleUserStateProvider {
     return result as SingleUserState<T>;
   }
 
-  getFake<T>(userId: UserId, keyDefinition: KeyDefinition<T>): FakeSingleUserState<T> {
+  getFake<T>(
+    userId: UserId,
+    keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>,
+  ): FakeSingleUserState<T> {
     return this.get(userId, keyDefinition) as FakeSingleUserState<T>;
   }
 
@@ -137,7 +140,7 @@ export class FakeActiveUserStateProvider implements ActiveUserStateProvider {
     return result as ActiveUserState<T>;
   }
 
-  getFake<T>(keyDefinition: KeyDefinition<T>): FakeActiveUserState<T> {
+  getFake<T>(keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>): FakeActiveUserState<T> {
     return this.get(keyDefinition) as FakeActiveUserState<T>;
   }
 

--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -157,7 +157,10 @@ export class FakeActiveUserStateProvider implements ActiveUserStateProvider {
 
 export class FakeStateProvider implements StateProvider {
   mock = mock<StateProvider>();
-  getUserState$<T>(keyDefinition: KeyDefinition<T>, userId?: UserId): Observable<T> {
+  getUserState$<T>(
+    keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>,
+    userId?: UserId,
+  ): Observable<T> {
     this.mock.getUserState$(keyDefinition, userId);
     if (userId) {
       return this.getUser<T>(userId, keyDefinition).state$;

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -18,8 +18,22 @@ import { ActiveUserStateProvider, SingleUserStateProvider } from "./user-state.p
  * and {@link GlobalStateProvider}.
  */
 export abstract class StateProvider {
-  /** @see{@link ActiveUserState.activeUserId$} */
+  /** @see{@link ActiveUserStateProvider.activeUserId$} */
   activeUserId$: Observable<UserId | undefined>;
+
+  /**
+   * Gets a state observable for a given key and userId.
+   *
+   * @remarks If userId is falsy the observable returned will point to the currently active user _and not update if the active user changes_.
+   * This is different to how `getActive` works and more similar to `getUser` for whatever user happens to be active at the time of the call.
+   *
+   * @note consider converting your {@link KeyDefinition} to a {@link UserKeyDefinition} for additional features.
+   *
+   * @param keyDefinition - The key definition for the state you want to get.
+   * @param userId - The userId for which you want the state for. If not provided, the state for the currently active user will be returned.
+   */
+  abstract getUserState$<T>(keyDefinition: KeyDefinition<T>, userId?: UserId): Observable<T>;
+
   /**
    * Gets a state observable for a given key and userId.
    *
@@ -29,10 +43,7 @@ export abstract class StateProvider {
    * @param keyDefinition - The key definition for the state you want to get.
    * @param userId - The userId for which you want the state for. If not provided, the state for the currently active user will be returned.
    */
-  getUserState$: <T>(
-    keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>,
-    userId?: UserId,
-  ) => Observable<T>;
+  abstract getUserState$<T>(keyDefinition: UserKeyDefinition<T>, userId?: UserId): Observable<T>;
 
   /**
    * Sets the state for a given key and userId.

--- a/libs/common/src/platform/state/state.provider.ts
+++ b/libs/common/src/platform/state/state.provider.ts
@@ -29,7 +29,10 @@ export abstract class StateProvider {
    * @param keyDefinition - The key definition for the state you want to get.
    * @param userId - The userId for which you want the state for. If not provided, the state for the currently active user will be returned.
    */
-  getUserState$: <T>(keyDefinition: KeyDefinition<T>, userId?: UserId) => Observable<T>;
+  getUserState$: <T>(
+    keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>,
+    userId?: UserId,
+  ) => Observable<T>;
 
   /**
    * Sets the state for a given key and userId.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I forgot to include `UserKeyDefinition` into the union for the methods to return the fakes. This makes it hard to write tests with the new key definition.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
