### PR TITLE
Use global state for biometric prompt cancel storage

### DIFF
--- a/libs/common/src/platform/biometrics/biometric-state.service.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.ts
@@ -1,4 +1,4 @@
-import { Observable, firstValueFrom, map } from "rxjs";
+import { Observable, firstValueFrom, map, combineLatest } from "rxjs";
 
 import { UserId } from "../../types/guid";
 import { EncryptedString, EncString } from "../models/domain/enc-string";
@@ -107,7 +107,7 @@ export class DefaultBiometricStateService implements BiometricStateService {
   private requirePasswordOnStartState: ActiveUserState<boolean>;
   private encryptedClientKeyHalfState: ActiveUserState<EncryptedString | undefined>;
   private dismissedRequirePasswordOnStartCalloutState: ActiveUserState<boolean>;
-  private promptCancelledState: ActiveUserState<boolean>;
+  private promptCancelledState: GlobalState<Record<UserId, boolean>>;
   private promptAutomaticallyState: ActiveUserState<boolean>;
   private fingerprintValidatedState: GlobalState<boolean>;
   biometricUnlockEnabled$: Observable<boolean>;
@@ -138,8 +138,15 @@ export class DefaultBiometricStateService implements BiometricStateService {
     this.dismissedRequirePasswordOnStartCallout$ =
       this.dismissedRequirePasswordOnStartCalloutState.state$.pipe(map(Boolean));
 
-    this.promptCancelledState = this.stateProvider.getActive(PROMPT_CANCELLED);
-    this.promptCancelled$ = this.promptCancelledState.state$.pipe(map(Boolean));
+    this.promptCancelledState = this.stateProvider.getGlobal(PROMPT_CANCELLED);
+    this.promptCancelled$ = combineLatest([
+      this.stateProvider.activeUserId$,
+      this.promptCancelledState.state$,
+    ]).pipe(
+      map(([userId, record]) => {
+        return record?.[userId] ?? false;
+      }),
+    );
     this.promptAutomaticallyState = this.stateProvider.getActive(PROMPT_AUTOMATICALLY);
     this.promptAutomatically$ = this.promptAutomaticallyState.state$.pipe(map(Boolean));
 
@@ -202,6 +209,15 @@ export class DefaultBiometricStateService implements BiometricStateService {
 
   async logout(userId: UserId): Promise<void> {
     await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => null);
+    await this.promptCancelledState.update(
+      (record) => {
+        delete record[userId];
+        return record;
+      },
+      {
+        shouldUpdate: (record) => record[userId] == true,
+      },
+    );
     await this.stateProvider.getUser(userId, PROMPT_CANCELLED).update(() => null);
     // Persist auto prompt setting through logout
     // Persist dismissed require password on start callout through logout
@@ -212,7 +228,16 @@ export class DefaultBiometricStateService implements BiometricStateService {
   }
 
   async setPromptCancelled(): Promise<void> {
-    await this.promptCancelledState.update(() => true);
+    await this.promptCancelledState.update(
+      (record, userId) => {
+        record ??= {};
+        record[userId] = true;
+        return record;
+      },
+      {
+        combineLatestWith: this.stateProvider.activeUserId$,
+      },
+    );
   }
 
   async resetPromptCancelled(): Promise<void> {

--- a/libs/common/src/platform/biometrics/biometric.state.spec.ts
+++ b/libs/common/src/platform/biometrics/biometric.state.spec.ts
@@ -14,7 +14,7 @@ import {
 describe.each([
   [ENCRYPTED_CLIENT_KEY_HALF, "encryptedClientKeyHalf"],
   [DISMISSED_REQUIRE_PASSWORD_ON_START_CALLOUT, true],
-  [PROMPT_CANCELLED, true],
+  [PROMPT_CANCELLED, { userId1: true, userId2: false }],
   [PROMPT_AUTOMATICALLY, true],
   [REQUIRE_PASSWORD_ON_START, true],
   [BIOMETRIC_UNLOCK_ENABLED, true],

--- a/libs/common/src/platform/biometrics/biometric.state.ts
+++ b/libs/common/src/platform/biometrics/biometric.state.ts
@@ -1,3 +1,4 @@
+import { UserId } from "../../types/guid";
 import { EncryptedString } from "../models/domain/enc-string";
 import { KeyDefinition, BIOMETRIC_SETTINGS_DISK } from "../state";
 
@@ -56,7 +57,7 @@ export const DISMISSED_REQUIRE_PASSWORD_ON_START_CALLOUT = new KeyDefinition<boo
  * Stores whether the user has elected to cancel the biometric prompt. This is stored on disk due to process-reload
  * wiping memory state. We don't want to prompt the user again if they've elected to cancel.
  */
-export const PROMPT_CANCELLED = new KeyDefinition<boolean>(
+export const PROMPT_CANCELLED = KeyDefinition.record<boolean, UserId>(
   BIOMETRIC_SETTINGS_DISK,
   "promptCancelled",
   {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We clear prompt cancelled data on application close, because this is only relevant to a given session. However, this was erroring due to context differences in background. Desktop background does not have active user information.

Also, we want to delete _all_ prompt cancel data, not just that for the active user. Storing on global and manipulating observables emit only active user data achieves this without needing any user information in the background.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
