### PR TITLE
Fix and test hasUserKey implementation

### DIFF
--- a/libs/common/spec/fake-state-provider.ts
+++ b/libs/common/spec/fake-state-provider.ts
@@ -119,7 +119,7 @@ export class FakeActiveUserStateProvider implements ActiveUserStateProvider {
   states: Map<string, FakeActiveUserState<unknown>> = new Map();
 
   constructor(public accountService: FakeAccountService) {
-    this.activeUserId$ = accountService.activeAccountSubject.asObservable().pipe(map((a) => a.id));
+    this.activeUserId$ = accountService.activeAccountSubject.asObservable().pipe(map((a) => a?.id));
   }
 
   get<T>(keyDefinition: KeyDefinition<T> | UserKeyDefinition<T>): ActiveUserState<T> {

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -4,7 +4,7 @@ import { ProfileOrganizationResponse } from "../../admin-console/models/response
 import { ProfileProviderOrganizationResponse } from "../../admin-console/models/response/profile-provider-organization.response";
 import { ProfileProviderResponse } from "../../admin-console/models/response/profile-provider.response";
 import { KdfConfig } from "../../auth/models/domain/kdf-config";
-import { OrganizationId, ProviderId } from "../../types/guid";
+import { OrganizationId, ProviderId, UserId } from "../../types/guid";
 import { UserKey, MasterKey, OrgKey, ProviderKey, PinKey, CipherKey } from "../../types/key";
 import { KeySuffixOptions, KdfType, HashPurpose } from "../enums";
 import { EncArrayBuffer } from "../models/domain/enc-array-buffer";
@@ -62,12 +62,15 @@ export abstract class CryptoService {
   getUserKeyFromStorage: (keySuffix: KeySuffixOptions, userId?: string) => Promise<UserKey>;
 
   /**
+   * Determines whether the user key is available for the given user.
+   * @param userId The desired user. If not provided, the active user will be used. If no active user exists, the method will return false.
    * @returns True if the user key is available
    */
-  hasUserKey: () => Promise<boolean>;
+  hasUserKey: (userId?: UserId) => Promise<boolean>;
   /**
-   * @param userId The desired user
-   * @returns True if the user key is set in memory
+   * Determines whether the user key is available for the given user in memory.
+   * @param userId The desired user. If not provided, the active user will be used. If no active user exists, the method will return false.
+   * @returns True if the user key is available
    */
   hasUserKeyInMemory: (userId?: string) => Promise<boolean>;
   /**

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -202,13 +202,23 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
   }
 
-  async hasUserKey(): Promise<boolean> {
+  async hasUserKey(userId?: UserId): Promise<boolean> {
+    userId ??= await firstValueFrom(this.stateProvider.activeUserId$);
+    if (userId == null) {
+      return false;
+    }
     return (
-      (await this.hasUserKeyInMemory()) || (await this.hasUserKeyStored(KeySuffixOptions.Auto))
+      (await this.hasUserKeyInMemory(userId)) ||
+      (await this.hasUserKeyStored(KeySuffixOptions.Auto, userId))
     );
   }
 
   async hasUserKeyInMemory(userId?: UserId): Promise<boolean> {
+    userId ??= await firstValueFrom(this.stateProvider.activeUserId$);
+    if (userId == null) {
+      return false;
+    }
+
     return (await firstValueFrom(this.stateProvider.getUserState$(USER_KEY, userId))) != null;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

It's possible to test user key presence without an active user due to things like guard services. This hardens crypto service against these kind of usages.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
