### PR TITLE
[AC-2304] added User Status check to revoke-restore and remove components

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from "@angular/core";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
+import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { BulkUserDetails } from "./bulk-status.component";
@@ -14,7 +15,9 @@ export class BulkRemoveComponent {
   @Input() organizationId: string;
   @Input() set users(value: BulkUserDetails[]) {
     this._users = value;
-    this.showNoMasterPasswordWarning = this._users.some((u) => u.hasMasterPassword === false);
+    this.showNoMasterPasswordWarning = this._users.some(
+      (u) => u.status > OrganizationUserStatusType.Invited && u.hasMasterPassword === false,
+    );
   }
 
   get users(): BulkUserDetails[] {

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.ts
@@ -2,6 +2,7 @@ import { DIALOG_DATA } from "@angular/cdk/dialog";
 import { Component, Inject } from "@angular/core";
 
 import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
+import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService } from "@bitwarden/components";
 
@@ -37,7 +38,9 @@ export class BulkRestoreRevokeComponent {
     this.isRevoking = data.isRevoking;
     this.organizationId = data.organizationId;
     this.users = data.users;
-    this.showNoMasterPasswordWarning = this.users.some((u) => u.hasMasterPassword === false);
+    this.showNoMasterPasswordWarning = this.users.some(
+      (u) => u.status > OrganizationUserStatusType.Invited && u.hasMasterPassword === false,
+    );
   }
 
   get bulkTitle() {


### PR DESCRIPTION
## Type of change
```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
currently, when revoking or removing users in orgs that are not using SSO w/ Trusted Devices, or Key Connector, they are given the details column with a warning stating "user does not have a master password" for invited users. While that is technically correct, the users do not need to be warned about this.

## Code changes

- apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove.component.ts
- apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.ts
changes for both files were the same. added a check to verify the User Status is greater than 0 in addition to the existing HasMasterPassword check

## Screenshots
Before:
![Screenshot 2024-03-14 at 10 29 50 AM](https://github.com/bitwarden/clients/assets/81774843/360fa4d1-3f34-48a0-a1ee-c5f5a2c0357b)

After:
![Screenshot 2024-03-15 at 8 42 11 AM](https://github.com/bitwarden/clients/assets/81774843/85cc07ce-92fe-40bd-9593-2151b97ae83c)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
