### PR TITLE
Fix `BiometricStateService.logout`

### DIFF
--- a/libs/common/src/platform/biometrics/biometric-state.service.spec.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.spec.ts
@@ -274,4 +274,60 @@ describe("BiometricStateService", () => {
       );
     });
   });
+
+  describe("logout", () => {
+    it("will not delete prompt cancelled state for user when object is null", async () => {
+      const promptCancelledFake = stateProvider.global.getFake(PROMPT_CANCELLED);
+      promptCancelledFake.stateSubject.next(null);
+
+      await sut.logout(userId);
+
+      // Since the prompt cancelled state is null and therefore doesn't have an entry for this user, it shouldn't be updated
+      expect(promptCancelledFake.nextMock).not.toHaveBeenCalled();
+      expect(
+        stateProvider.singleUser.getFake(userId, ENCRYPTED_CLIENT_KEY_HALF).nextMock,
+      ).toHaveBeenCalledWith(null);
+
+      // NOTE: Exact same state for global and single user? is this supposed to be PROMPT_AUTOMATICALLY
+      expect(
+        stateProvider.singleUser.getFake(userId, PROMPT_CANCELLED).nextMock,
+      ).toHaveBeenCalledWith(null);
+    });
+
+    it("will delete prompt cancelled state for user when user is in record and value is true", async () => {
+      const promptCancelledFake = stateProvider.global.getFake(PROMPT_CANCELLED);
+      promptCancelledFake.stateSubject.next({ [userId]: true });
+
+      await sut.logout(userId);
+
+      // Since the prompt cancelled state is null and therefore doesn't have an entry for this user, it shouldn't be updated
+      expect(promptCancelledFake.nextMock).toHaveBeenCalledWith({});
+      expect(
+        stateProvider.singleUser.getFake(userId, ENCRYPTED_CLIENT_KEY_HALF).nextMock,
+      ).toHaveBeenCalledWith(null);
+
+      // NOTE: Exact same state for global and single user? is this supposed to be PROMPT_AUTOMATICALLY
+      expect(
+        stateProvider.singleUser.getFake(userId, PROMPT_CANCELLED).nextMock,
+      ).toHaveBeenCalledWith(null);
+    });
+
+    it("will leave user value on logout if their prompt cancelled value is false", async () => {
+      const promptCancelledFake = stateProvider.global.getFake(PROMPT_CANCELLED);
+      promptCancelledFake.stateSubject.next({ [userId]: false });
+
+      await sut.logout(userId);
+
+      // Since the prompt cancelled state is null and therefore doesn't have an entry for this user, it shouldn't be updated
+      expect(promptCancelledFake.nextMock).not.toHaveBeenCalled();
+      expect(
+        stateProvider.singleUser.getFake(userId, ENCRYPTED_CLIENT_KEY_HALF).nextMock,
+      ).toHaveBeenCalledWith(null);
+
+      // NOTE: Exact same state for global and single user? is this supposed to be PROMPT_AUTOMATICALLY
+      expect(
+        stateProvider.singleUser.getFake(userId, PROMPT_CANCELLED).nextMock,
+      ).toHaveBeenCalledWith(null);
+    });
+  });
 });

--- a/libs/common/src/platform/biometrics/biometric-state.service.ts
+++ b/libs/common/src/platform/biometrics/biometric-state.service.ts
@@ -215,7 +215,7 @@ export class DefaultBiometricStateService implements BiometricStateService {
         return record;
       },
       {
-        shouldUpdate: (record) => record[userId] == true,
+        shouldUpdate: (record) => record?.[userId] == true,
       },
     );
     await this.stateProvider.getUser(userId, PROMPT_CANCELLED).update(() => null);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a `TypeError` that could happen when checking if we should run the update function. Since this object is able to be null trying to access the object with a user id could cause an error. If we change the `shouldUpdate` to handle for it being null we know for sure it's not null in the `update` call and can just delete it. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
