### PR TITLE
[PM-6853] Recreate `getUserStateOrDefault$`

### DIFF
--- a/libs/common/src/admin-console/services/provider.service.spec.ts
+++ b/libs/common/src/admin-console/services/provider.service.spec.ts
@@ -1,5 +1,5 @@
 import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../spec";
-import { FakeActiveUserState } from "../../../spec/fake-state";
+import { FakeActiveUserState, FakeSingleUserState } from "../../../spec/fake-state";
 import { Utils } from "../../platform/misc/utils";
 import { UserId } from "../../types/guid";
 import { ProviderUserStatusType, ProviderUserType } from "../enums";
@@ -77,11 +77,13 @@ describe("ProviderService", () => {
   const fakeUserId = Utils.newGuid() as UserId;
   let fakeAccountService: FakeAccountService;
   let fakeStateProvider: FakeStateProvider;
+  let fakeUserState: FakeSingleUserState<Record<string, ProviderData>>;
   let fakeActiveUserState: FakeActiveUserState<Record<string, ProviderData>>;
 
   beforeEach(async () => {
     fakeAccountService = mockAccountServiceWith(fakeUserId);
     fakeStateProvider = new FakeStateProvider(fakeAccountService);
+    fakeUserState = fakeStateProvider.singleUser.getFake(fakeUserId, PROVIDERS);
     fakeActiveUserState = fakeStateProvider.activeUser.getFake(PROVIDERS);
     providerService = new ProviderService(fakeStateProvider);
   });
@@ -89,7 +91,7 @@ describe("ProviderService", () => {
   describe("getAll()", () => {
     it("Returns an array of all providers stored in state", async () => {
       const mockData: ProviderData[] = buildMockProviders(5);
-      fakeActiveUserState.nextState(arrayToRecord(mockData));
+      fakeUserState.nextState(arrayToRecord(mockData));
       const providers = await providerService.getAll();
       expect(providers).toHaveLength(5);
       expect(providers).toEqual(mockData.map((x) => new Provider(x)));
@@ -97,7 +99,7 @@ describe("ProviderService", () => {
 
     it("Returns an empty array if no providers are found in state", async () => {
       const mockData: ProviderData[] = undefined;
-      fakeActiveUserState.nextState(arrayToRecord(mockData));
+      fakeUserState.nextState(arrayToRecord(mockData));
       const result = await providerService.getAll();
       expect(result).toEqual([]);
     });
@@ -106,7 +108,7 @@ describe("ProviderService", () => {
   describe("get()", () => {
     it("Returns a single provider from state that matches the specified id", async () => {
       const mockData = buildMockProviders(5);
-      fakeActiveUserState.nextState(arrayToRecord(mockData));
+      fakeUserState.nextState(arrayToRecord(mockData));
       const result = await providerService.get(mockData[3].id);
       expect(result).toEqual(new Provider(mockData[3]));
     });
@@ -120,15 +122,12 @@ describe("ProviderService", () => {
   describe("save()", () => {
     it("replaces the entire provider list in state for the active user", async () => {
       const originalData = buildMockProviders(10);
-      fakeActiveUserState.nextState(arrayToRecord(originalData));
+      fakeUserState.nextState(arrayToRecord(originalData));
 
-      const newData = buildMockProviders(10, "newData");
-      await providerService.save(arrayToRecord(newData));
+      const newData = arrayToRecord(buildMockProviders(10, "newData"));
+      await providerService.save(newData);
 
-      const result = await providerService.getAll();
-
-      expect(result).toEqual(newData);
-      expect(result).not.toEqual(originalData);
+      expect(fakeActiveUserState.nextMock).toHaveBeenCalledWith([fakeUserId, newData]);
     });
 
     // This is more or less a test for logouts
@@ -136,9 +135,8 @@ describe("ProviderService", () => {
       const originalData = buildMockProviders(2);
       fakeActiveUserState.nextState(arrayToRecord(originalData));
       await providerService.save(null);
-      const result = await providerService.getAll();
-      expect(result).toEqual([]);
-      expect(result).not.toEqual(originalData);
+
+      expect(fakeActiveUserState.nextMock).toHaveBeenCalledWith([fakeUserId, null]);
     });
   });
 });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We are seeing some problems with providers being retrieved when there is no user active at this time. We've already updated the implementation of `getUserState$` to not throw and instead wait until a user becomes active and we added `getUserStateOrDefault$` which will return a default value when a user isn't active at the time but we want to pick this to `rc` where those changes aren't done yet. I just re-implemented it locally here to keep overall impact low.

https://github.com/bitwarden/clients/blob/087d174194453c9eca6e28ed95facdc5998ab205/libs/common/src/platform/state/implementations/default-state.provider.ts#L44-L54

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
