### PR TITLE
Fix Premium Badge Storybook

### DIFF
--- a/apps/web/src/app/vault/components/premium-badge.stories.ts
+++ b/apps/web/src/app/vault/components/premium-badge.stories.ts
@@ -1,6 +1,8 @@
 import { Meta, moduleMetadata, Story } from "@storybook/angular";
+import { of } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { BadgeModule, I18nMockService } from "@bitwarden/components";
@@ -32,6 +34,12 @@ export default {
           provide: MessagingService,
           useFactory: () => {
             return new MockMessagingService();
+          },
+        },
+        {
+          provide: BillingAccountProfileStateService,
+          useValue: {
+            hasPremiumFromAnySource$: of(false),
           },
         },
       ],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8133 introduced `BillingAccountProfileStateService` as a dependency for `NotPremiumDirective` which was not supplied in the Premium Badge storybook module. This PR addresses that.

## Code changes

Add a mock implementation of `BillingAccountProfileStateService`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
