### PR TITLE
Create New Method for Setting Avatar Color from Sync

### DIFF
--- a/libs/common/src/auth/abstractions/avatar.service.ts
+++ b/libs/common/src/auth/abstractions/avatar.service.ts
@@ -16,6 +16,17 @@ export abstract class AvatarService {
    */
   abstract setAvatarColor(color: string): Promise<void>;
   /**
+   * Sets the avatar color for the given user, meant to be used via sync.
+   *
+   * @remarks This is meant to be used for getting an updated avatar color from
+   *          the sync endpoint. If the user is changing their avatar color
+   *          on device, you should instead call {@link setAvatarColor}.
+   *
+   * @param userId The user id for the user to set the avatar color for
+   * @param color The color to set the avatar color to
+   */
+  abstract setSyncAvatarColor(userId: UserId, color: string): Promise<void>;
+  /**
    * Gets the avatar color of the specified user.
    *
    * @remarks This is most useful for account switching where we show an

--- a/libs/common/src/auth/services/avatar.service.ts
+++ b/libs/common/src/auth/services/avatar.service.ts
@@ -27,6 +27,10 @@ export class AvatarService implements AvatarServiceAbstraction {
     await this.stateProvider.setUserState(AVATAR_COLOR, avatarColor);
   }
 
+  async setSyncAvatarColor(userId: UserId, color: string): Promise<void> {
+    await this.stateProvider.getUser(userId, AVATAR_COLOR).update(() => color);
+  }
+
   getUserAvatarColor$(userId: UserId): Observable<string | null> {
     return this.stateProvider.getUser(userId, AVATAR_COLOR).state$;
   }

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -29,6 +29,7 @@ import { SendData } from "../../../tools/send/models/data/send.data";
 import { SendResponse } from "../../../tools/send/models/response/send.response";
 import { SendApiService } from "../../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../../tools/send/services/send.service.abstraction";
+import { UserId } from "../../../types/guid";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "../../../vault/abstractions/folder/folder-api.service.abstraction";
 import { InternalFolderService } from "../../../vault/abstractions/folder/folder.service.abstraction";
@@ -313,7 +314,7 @@ export class SyncService implements SyncServiceAbstraction {
     await this.cryptoService.setPrivateKey(response.privateKey);
     await this.cryptoService.setProviderKeys(response.providers);
     await this.cryptoService.setOrgKeys(response.organizations, response.providerOrganizations);
-    await this.avatarService.setAvatarColor(response.avatarColor);
+    await this.avatarService.setSyncAvatarColor(response.id as UserId, response.avatarColor);
     await this.stateService.setSecurityStamp(response.securityStamp);
     await this.stateService.setEmailVerified(response.emailVerified);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We are currently seeing a loop where we get this value from sync and that causes us to update the avatar color on the server which then updates the revision date causing for a sync to happen the next time some requests it without forcing. The method that sets the avatar color from sync shouldn't go and update the server since it already got it from there. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
