### PR TITLE
[PM-6853] Stop Caching Empty Ciphers List

### DIFF
--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -618,7 +618,7 @@ export class StateService<
   }
 
   async setDecryptedCiphers(value: CipherView[], options?: StorageOptions): Promise<void> {
-    if (value == null || value.length === 0) {
+    if (value != null && value.length === 0) {
       // Don't cache a list of ciphers that might either be wrong or a true empty vault.
       return;
     }

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -618,6 +618,10 @@ export class StateService<
   }
 
   async setDecryptedCiphers(value: CipherView[], options?: StorageOptions): Promise<void> {
+    if (value == null || value.length === 0) {
+      // Don't cache a list of ciphers that might either be wrong or a true empty vault.
+      return;
+    }
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -618,10 +618,6 @@ export class StateService<
   }
 
   async setDecryptedCiphers(value: CipherView[], options?: StorageOptions): Promise<void> {
-    if (value != null && value.length === 0) {
-      // Don't cache a list of ciphers that might either be wrong or a true empty vault.
-      return;
-    }
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultInMemoryOptions()),
     );

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -79,7 +79,12 @@ export class CipherService implements CipherServiceAbstraction {
   }
 
   async setDecryptedCipherCache(value: CipherView[]) {
-    await this.stateService.setDecryptedCiphers(value);
+    // Sometimes we might prematurely decrypt the vault and that will result in no ciphers
+    // if we cache it then we may accidentially return it when it's not right, we'd rather try decryption again.
+    // We still want to set null though, that is the indicator that the cache isn't valid and we should do decryption.
+    if (value == null || value.length !== 0) {
+      await this.stateService.setDecryptedCiphers(value);
+    }
     if (this.searchService != null) {
       if (value == null) {
         this.searchService.clearIndex();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Occasionally we may attempt to cache an empty cipher array and that could have been from an attempt to decrypt the vault a bit to early, this will keep it from making it to the cache and allow for the next time ciphers are requested for it to do the work instead of trusting the cache which might be wrong.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
