### PR TITLE
reintroduce policy reduction for multi-org accounts

### DIFF
--- a/libs/common/src/tools/generator/abstractions/generator-strategy.abstraction.ts
+++ b/libs/common/src/tools/generator/abstractions/generator-strategy.abstraction.ts
@@ -1,3 +1,5 @@
+import { Observable } from "rxjs";
+
 import { PolicyType } from "../../../admin-console/enums";
 // FIXME: use index.ts imports once policy abstractions and models
 // implement ADR-0002
@@ -21,13 +23,16 @@ export abstract class GeneratorStrategy<Options, Policy> {
   /** Length of time in milliseconds to cache the evaluator */
   cache_ms: number;
 
-  /** Creates an evaluator from a generator policy.
+  /** Operator function that converts a policy collection observable to a single
+   *   policy evaluator observable.
    * @param policy The policy being evaluated.
    * @returns the policy evaluator. If `policy` is is `null` or `undefined`,
    * then the evaluator defaults to the application's limits.
    * @throws when the policy's type does not match the generator's policy type.
    */
-  evaluator: (policy: AdminPolicy) => PolicyEvaluator<Policy, Options>;
+  toEvaluator: () => (
+    source: Observable<AdminPolicy[]>,
+  ) => Observable<PolicyEvaluator<Policy, Options>>;
 
   /** Generates credentials from the given options.
    * @param options The options used to generate the credentials.

--- a/libs/common/src/tools/generator/default-generator.service.ts
+++ b/libs/common/src/tools/generator/default-generator.service.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, map, share, timer, ReplaySubject, Observable } from "rxjs";
+import { firstValueFrom, share, timer, ReplaySubject, Observable } from "rxjs";
 
 // FIXME: use index.ts imports once policy abstractions and models
 // implement ADR-0002
@@ -44,14 +44,12 @@ export class DefaultGeneratorService<Options, Policy> implements GeneratorServic
   }
 
   private createEvaluator(userId: UserId) {
-    // FIXME: when it becomes possible to get a user-specific policy observable
-    // (`getAll$`) update this code to call it instead of `get$`.
-    const policies$ = this.policy.get$(this.strategy.policy);
+    const evaluator$ = this.policy.getAll$(this.strategy.policy, userId).pipe(
+      // create the evaluator from the policies
+      this.strategy.toEvaluator(),
 
-    // cache evaluator in a replay subject to amortize creation cost
-    // and reduce GC pressure.
-    const evaluator$ = policies$.pipe(
-      map((policy) => this.strategy.evaluator(policy)),
+      // cache evaluator in a replay subject to amortize creation cost
+      // and reduce GC pressure.
       share({
         connector: () => new ReplaySubject(1),
         resetOnRefCountZero: () => timer(this.strategy.cache_ms),

--- a/libs/common/src/tools/generator/passphrase/passphrase-generator-policy.spec.ts
+++ b/libs/common/src/tools/generator/passphrase/passphrase-generator-policy.spec.ts
@@ -1,0 +1,51 @@
+import { PolicyType } from "../../../admin-console/enums";
+// FIXME: use index.ts imports once policy abstractions and models
+// implement ADR-0002
+import { Policy } from "../../../admin-console/models/domain/policy";
+import { PolicyId } from "../../../types/guid";
+
+import { DisabledPassphraseGeneratorPolicy, leastPrivilege } from "./passphrase-generator-policy";
+
+function createPolicy(
+  data: any,
+  type: PolicyType = PolicyType.PasswordGenerator,
+  enabled: boolean = true,
+) {
+  return new Policy({
+    id: "id" as PolicyId,
+    organizationId: "organizationId",
+    data,
+    enabled,
+    type,
+  });
+}
+
+describe("leastPrivilege", () => {
+  it("should return the accumulator when the policy type does not apply", () => {
+    const policy = createPolicy({}, PolicyType.RequireSso);
+
+    const result = leastPrivilege(DisabledPassphraseGeneratorPolicy, policy);
+
+    expect(result).toEqual(DisabledPassphraseGeneratorPolicy);
+  });
+
+  it("should return the accumulator when the policy is not enabled", () => {
+    const policy = createPolicy({}, PolicyType.PasswordGenerator, false);
+
+    const result = leastPrivilege(DisabledPassphraseGeneratorPolicy, policy);
+
+    expect(result).toEqual(DisabledPassphraseGeneratorPolicy);
+  });
+
+  it.each([
+    ["minNumberWords", 10],
+    ["capitalize", true],
+    ["includeNumber", true],
+  ])("should take the %p from the policy", (input, value) => {
+    const policy = createPolicy({ [input]: value });
+
+    const result = leastPrivilege(DisabledPassphraseGeneratorPolicy, policy);
+
+    expect(result).toEqual({ ...DisabledPassphraseGeneratorPolicy, [input]: value });
+  });
+});

--- a/libs/common/src/tools/generator/passphrase/passphrase-generator-policy.ts
+++ b/libs/common/src/tools/generator/passphrase/passphrase-generator-policy.ts
@@ -1,3 +1,8 @@
+import { PolicyType } from "../../../admin-console/enums";
+// FIXME: use index.ts imports once policy abstractions and models
+// implement ADR-0002
+import { Policy } from "../../../admin-console/models/domain/policy";
+
 /** Policy options enforced during passphrase generation. */
 export type PassphraseGeneratorPolicy = {
   minNumberWords: number;
@@ -11,3 +16,24 @@ export const DisabledPassphraseGeneratorPolicy: PassphraseGeneratorPolicy = Obje
   capitalize: false,
   includeNumber: false,
 });
+
+/** Reduces a policy into an accumulator by accepting the most restrictive
+ *  values from each policy.
+ *  @param acc the accumulator
+ *  @param policy the policy to reduce
+ *  @returns the most restrictive values between the policy and accumulator.
+ */
+export function leastPrivilege(
+  acc: PassphraseGeneratorPolicy,
+  policy: Policy,
+): PassphraseGeneratorPolicy {
+  if (policy.type !== PolicyType.PasswordGenerator) {
+    return acc;
+  }
+
+  return {
+    minNumberWords: Math.max(acc.minNumberWords, policy.data.minNumberWords ?? acc.minNumberWords),
+    capitalize: policy.data.capitalize || acc.capitalize,
+    includeNumber: policy.data.includeNumber || acc.includeNumber,
+  };
+}

--- a/libs/common/src/tools/generator/password/password-generator-policy.spec.ts
+++ b/libs/common/src/tools/generator/password/password-generator-policy.spec.ts
@@ -1,0 +1,55 @@
+import { PolicyType } from "../../../admin-console/enums";
+// FIXME: use index.ts imports once policy abstractions and models
+// implement ADR-0002
+import { Policy } from "../../../admin-console/models/domain/policy";
+import { PolicyId } from "../../../types/guid";
+
+import { DisabledPasswordGeneratorPolicy, leastPrivilege } from "./password-generator-policy";
+
+function createPolicy(
+  data: any,
+  type: PolicyType = PolicyType.PasswordGenerator,
+  enabled: boolean = true,
+) {
+  return new Policy({
+    id: "id" as PolicyId,
+    organizationId: "organizationId",
+    data,
+    enabled,
+    type,
+  });
+}
+
+describe("leastPrivilege", () => {
+  it("should return the accumulator when the policy type does not apply", () => {
+    const policy = createPolicy({}, PolicyType.RequireSso);
+
+    const result = leastPrivilege(DisabledPasswordGeneratorPolicy, policy);
+
+    expect(result).toEqual(DisabledPasswordGeneratorPolicy);
+  });
+
+  it("should return the accumulator when the policy is not enabled", () => {
+    const policy = createPolicy({}, PolicyType.PasswordGenerator, false);
+
+    const result = leastPrivilege(DisabledPasswordGeneratorPolicy, policy);
+
+    expect(result).toEqual(DisabledPasswordGeneratorPolicy);
+  });
+
+  it.each([
+    ["minLength", 10, "minLength"],
+    ["useUpper", true, "useUppercase"],
+    ["useLower", true, "useLowercase"],
+    ["useNumbers", true, "useNumbers"],
+    ["minNumbers", 10, "numberCount"],
+    ["useSpecial", true, "useSpecial"],
+    ["minSpecial", 10, "specialCount"],
+  ])("should take the %p from the policy", (input, value, expected) => {
+    const policy = createPolicy({ [input]: value });
+
+    const result = leastPrivilege(DisabledPasswordGeneratorPolicy, policy);
+
+    expect(result).toEqual({ ...DisabledPasswordGeneratorPolicy, [expected]: value });
+  });
+});

--- a/libs/common/src/tools/generator/password/password-generator-policy.ts
+++ b/libs/common/src/tools/generator/password/password-generator-policy.ts
@@ -1,3 +1,8 @@
+import { PolicyType } from "../../../admin-console/enums";
+// FIXME: use index.ts imports once policy abstractions and models
+// implement ADR-0002
+import { Policy } from "../../../admin-console/models/domain/policy";
+
 /** Policy options enforced during password generation. */
 export type PasswordGeneratorPolicy = {
   /** The minimum length of generated passwords.
@@ -48,3 +53,25 @@ export const DisabledPasswordGeneratorPolicy: PasswordGeneratorPolicy = Object.f
   useSpecial: false,
   specialCount: 0,
 });
+
+/** Reduces a policy into an accumulator by accepting the most restrictive
+ *  values from each policy.
+ *  @param acc the accumulator
+ *  @param policy the policy to reduce
+ *  @returns the most restrictive values between the policy and accumulator.
+ */
+export function leastPrivilege(acc: PasswordGeneratorPolicy, policy: Policy) {
+  if (policy.type !== PolicyType.PasswordGenerator || !policy.enabled) {
+    return acc;
+  }
+
+  return {
+    minLength: Math.max(acc.minLength, policy.data.minLength ?? acc.minLength),
+    useUppercase: policy.data.useUpper || acc.useUppercase,
+    useLowercase: policy.data.useLower || acc.useLowercase,
+    useNumbers: policy.data.useNumbers || acc.useNumbers,
+    numberCount: Math.max(acc.numberCount, policy.data.minNumbers ?? acc.numberCount),
+    useSpecial: policy.data.useSpecial || acc.useSpecial,
+    specialCount: Math.max(acc.specialCount, policy.data.minSpecial ?? acc.specialCount),
+  };
+}

--- a/libs/common/src/tools/generator/password/password-generator-strategy.spec.ts
+++ b/libs/common/src/tools/generator/password/password-generator-strategy.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { mock } from "jest-mock-extended";
+import { of, firstValueFrom } from "rxjs";
 
 import { PolicyType } from "../../../admin-console/enums";
 // FIXME: use index.ts imports once policy abstractions and models
@@ -24,17 +25,8 @@ import {
 const SomeUser = "some user" as UserId;
 
 describe("Password generation strategy", () => {
-  describe("evaluator()", () => {
-    it("should throw if the policy type is incorrect", () => {
-      const strategy = new PasswordGeneratorStrategy(null, null);
-      const policy = mock<Policy>({
-        type: PolicyType.DisableSend,
-      });
-
-      expect(() => strategy.evaluator(policy)).toThrow(new RegExp("Mismatched policy type\\. .+"));
-    });
-
-    it("should map to the policy evaluator", () => {
+  describe("toEvaluator()", () => {
+    it("should map to a password policy evaluator", async () => {
       const strategy = new PasswordGeneratorStrategy(null, null);
       const policy = mock<Policy>({
         type: PolicyType.PasswordGenerator,
@@ -49,7 +41,8 @@ describe("Password generation strategy", () => {
         },
       });
 
-      const evaluator = strategy.evaluator(policy);
+      const evaluator$ = of([policy]).pipe(strategy.toEvaluator());
+      const evaluator = await firstValueFrom(evaluator$);
 
       expect(evaluator).toBeInstanceOf(PasswordGeneratorOptionsEvaluator);
       expect(evaluator.policy).toMatchObject({
@@ -63,13 +56,18 @@ describe("Password generation strategy", () => {
       });
     });
 
-    it("should map `null`  to a default policy evaluator", () => {
-      const strategy = new PasswordGeneratorStrategy(null, null);
-      const evaluator = strategy.evaluator(null);
+    it.each([[[]], [null], [undefined]])(
+      "should map `%p` to a disabled password policy evaluator",
+      async (policies) => {
+        const strategy = new PasswordGeneratorStrategy(null, null);
 
-      expect(evaluator).toBeInstanceOf(PasswordGeneratorOptionsEvaluator);
-      expect(evaluator.policy).toMatchObject(DisabledPasswordGeneratorPolicy);
-    });
+        const evaluator$ = of(policies).pipe(strategy.toEvaluator());
+        const evaluator = await firstValueFrom(evaluator$);
+
+        expect(evaluator).toBeInstanceOf(PasswordGeneratorOptionsEvaluator);
+        expect(evaluator.policy).toMatchObject(DisabledPasswordGeneratorPolicy);
+      },
+    );
   });
 
   describe("durableState", () => {

--- a/libs/common/src/tools/generator/reduce-collection.operator.spec.ts
+++ b/libs/common/src/tools/generator/reduce-collection.operator.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * include structuredClone in test environment.
+ * @jest-environment ../../../../shared/test.environment.ts
+ */
+
+import { of, firstValueFrom } from "rxjs";
+
+import { reduceCollection } from "./reduce-collection.operator";
+
+describe("reduceCollection", () => {
+  it.each([[null], [undefined], [[]]])(
+    "should return the default value when the collection is %p",
+    async (value: number[]) => {
+      const reduce = (acc: number, value: number) => acc + value;
+      const source$ = of(value);
+
+      const result$ = source$.pipe(reduceCollection(reduce, 100));
+      const result = await firstValueFrom(result$);
+
+      expect(result).toEqual(100);
+    },
+  );
+
+  it("should reduce the collection to a single value", async () => {
+    const reduce = (acc: number, value: number) => acc + value;
+    const source$ = of([1, 2, 3]);
+
+    const result$ = source$.pipe(reduceCollection(reduce, 0));
+    const result = await firstValueFrom(result$);
+
+    expect(result).toEqual(6);
+  });
+});

--- a/libs/common/src/tools/generator/reduce-collection.operator.ts
+++ b/libs/common/src/tools/generator/reduce-collection.operator.ts
@@ -1,0 +1,20 @@
+import { map, OperatorFunction } from "rxjs";
+
+/**
+ * An observable operator that filters a collection then reduces
+ * it to a single output, returning a default if all items are ignored.
+ * @param reduce The reduce function to apply to the filtered collection. The
+ *  first argument is the accumulator, and the second is the current item. The
+ *  return value is the new accumulator.
+ * @param defaultValue The default value to return if the collection is empty and
+ *   the initial value of the accumulator.
+ */
+export function reduceCollection<Item, Accumulator>(
+  reduce: (acc: Accumulator, value: Item) => Accumulator,
+  defaultValue: Accumulator,
+): OperatorFunction<Item[], Accumulator> {
+  return map((values: Item[]) => {
+    const reduced = (values ?? []).reduce(reduce, structuredClone(defaultValue));
+    return reduced;
+  });
+}

--- a/libs/common/src/tools/generator/username/catchall-generator-strategy.spec.ts
+++ b/libs/common/src/tools/generator/username/catchall-generator-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import { of, firstValueFrom } from "rxjs";
 
 import { PolicyType } from "../../../admin-console/enums";
 // FIXME: use index.ts imports once policy abstractions and models
@@ -12,39 +13,26 @@ import { CATCHALL_SETTINGS } from "../key-definitions";
 import { CatchallGeneratorStrategy, UsernameGenerationServiceAbstraction } from ".";
 
 const SomeUser = "some user" as UserId;
+const SomePolicy = mock<Policy>({
+  type: PolicyType.PasswordGenerator,
+  data: {
+    minLength: 10,
+  },
+});
 
 describe("Email subaddress list generation strategy", () => {
-  describe("evaluator()", () => {
-    it("should throw if the policy type is incorrect", () => {
-      const strategy = new CatchallGeneratorStrategy(null, null);
-      const policy = mock<Policy>({
-        type: PolicyType.DisableSend,
-      });
+  describe("toEvaluator()", () => {
+    it.each([[[]], [null], [undefined], [[SomePolicy]], [[SomePolicy, SomePolicy]]])(
+      "should map any input (= %p) to the default policy evaluator",
+      async (policies) => {
+        const strategy = new CatchallGeneratorStrategy(null, null);
 
-      expect(() => strategy.evaluator(policy)).toThrow(new RegExp("Mismatched policy type\\. .+"));
-    });
+        const evaluator$ = of(policies).pipe(strategy.toEvaluator());
+        const evaluator = await firstValueFrom(evaluator$);
 
-    it("should map to the policy evaluator", () => {
-      const strategy = new CatchallGeneratorStrategy(null, null);
-      const policy = mock<Policy>({
-        type: PolicyType.PasswordGenerator,
-        data: {
-          minLength: 10,
-        },
-      });
-
-      const evaluator = strategy.evaluator(policy);
-
-      expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
-      expect(evaluator.policy).toMatchObject({});
-    });
-
-    it("should map `null` to a default policy evaluator", () => {
-      const strategy = new CatchallGeneratorStrategy(null, null);
-      const evaluator = strategy.evaluator(null);
-
-      expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
-    });
+        expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
+      },
+    );
   });
 
   describe("durableState", () => {

--- a/libs/common/src/tools/generator/username/catchall-generator-strategy.ts
+++ b/libs/common/src/tools/generator/username/catchall-generator-strategy.ts
@@ -1,5 +1,6 @@
+import { map, pipe } from "rxjs";
+
 import { PolicyType } from "../../../admin-console/enums";
-import { Policy } from "../../../admin-console/models/domain/policy";
 import { StateProvider } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { GeneratorStrategy } from "../abstractions";
@@ -41,18 +42,9 @@ export class CatchallGeneratorStrategy
     return ONE_MINUTE;
   }
 
-  /** {@link GeneratorStrategy.evaluator} */
-  evaluator(policy: Policy) {
-    if (!policy) {
-      return new DefaultPolicyEvaluator<CatchallGenerationOptions>();
-    }
-
-    if (policy.type !== this.policy) {
-      const details = `Expected: ${this.policy}. Received: ${policy.type}`;
-      throw Error("Mismatched policy type. " + details);
-    }
-
-    return new DefaultPolicyEvaluator<CatchallGenerationOptions>();
+  /** {@link GeneratorStrategy.toEvaluator} */
+  toEvaluator() {
+    return pipe(map((_) => new DefaultPolicyEvaluator<CatchallGenerationOptions>()));
   }
 
   /** {@link GeneratorStrategy.generate} */

--- a/libs/common/src/tools/generator/username/eff-username-generator-strategy.ts
+++ b/libs/common/src/tools/generator/username/eff-username-generator-strategy.ts
@@ -1,5 +1,6 @@
+import { map, pipe } from "rxjs";
+
 import { PolicyType } from "../../../admin-console/enums";
-import { Policy } from "../../../admin-console/models/domain/policy";
 import { StateProvider } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { GeneratorStrategy } from "../abstractions";
@@ -41,18 +42,9 @@ export class EffUsernameGeneratorStrategy
     return ONE_MINUTE;
   }
 
-  /** {@link GeneratorStrategy.evaluator} */
-  evaluator(policy: Policy) {
-    if (!policy) {
-      return new DefaultPolicyEvaluator<EffUsernameGenerationOptions>();
-    }
-
-    if (policy.type !== this.policy) {
-      const details = `Expected: ${this.policy}. Received: ${policy.type}`;
-      throw Error("Mismatched policy type. " + details);
-    }
-
-    return new DefaultPolicyEvaluator<EffUsernameGenerationOptions>();
+  /** {@link GeneratorStrategy.toEvaluator} */
+  toEvaluator() {
+    return pipe(map((_) => new DefaultPolicyEvaluator<EffUsernameGenerationOptions>()));
   }
 
   /** {@link GeneratorStrategy.generate} */

--- a/libs/common/src/tools/generator/username/forwarder-generator-strategy.ts
+++ b/libs/common/src/tools/generator/username/forwarder-generator-strategy.ts
@@ -1,5 +1,6 @@
+import { map, pipe } from "rxjs";
+
 import { PolicyType } from "../../../admin-console/enums";
-import { Policy } from "../../../admin-console/models/domain/policy";
 import { CryptoService } from "../../../platform/abstractions/crypto.service";
 import { EncryptService } from "../../../platform/abstractions/encrypt.service";
 import { KeyDefinition, StateProvider } from "../../../platform/state";
@@ -66,8 +67,8 @@ export abstract class ForwarderGeneratorStrategy<
   /** Determine where forwarder configuration is stored  */
   protected abstract readonly key: KeyDefinition<Options>;
 
-  /** {@link GeneratorStrategy.evaluator} */
-  evaluator = (_policy: Policy) => {
-    return new DefaultPolicyEvaluator<Options>();
+  /** {@link GeneratorStrategy.toEvaluator} */
+  toEvaluator = () => {
+    return pipe(map((_) => new DefaultPolicyEvaluator<Options>()));
   };
 }

--- a/libs/common/src/tools/generator/username/subaddress-generator-strategy.spec.ts
+++ b/libs/common/src/tools/generator/username/subaddress-generator-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import { of, firstValueFrom } from "rxjs";
 
 import { PolicyType } from "../../../admin-console/enums";
 // FIXME: use index.ts imports once policy abstractions and models
@@ -12,39 +13,26 @@ import { SUBADDRESS_SETTINGS } from "../key-definitions";
 import { SubaddressGeneratorStrategy, UsernameGenerationServiceAbstraction } from ".";
 
 const SomeUser = "some user" as UserId;
+const SomePolicy = mock<Policy>({
+  type: PolicyType.PasswordGenerator,
+  data: {
+    minLength: 10,
+  },
+});
 
 describe("Email subaddress list generation strategy", () => {
-  describe("evaluator()", () => {
-    it("should throw if the policy type is incorrect", () => {
-      const strategy = new SubaddressGeneratorStrategy(null, null);
-      const policy = mock<Policy>({
-        type: PolicyType.DisableSend,
-      });
+  describe("toEvaluator()", () => {
+    it.each([[[]], [null], [undefined], [[SomePolicy]], [[SomePolicy, SomePolicy]]])(
+      "should map any input (= %p) to the default policy evaluator",
+      async (policies) => {
+        const strategy = new SubaddressGeneratorStrategy(null, null);
 
-      expect(() => strategy.evaluator(policy)).toThrow(new RegExp("Mismatched policy type\\. .+"));
-    });
+        const evaluator$ = of(policies).pipe(strategy.toEvaluator());
+        const evaluator = await firstValueFrom(evaluator$);
 
-    it("should map to the policy evaluator", () => {
-      const strategy = new SubaddressGeneratorStrategy(null, null);
-      const policy = mock<Policy>({
-        type: PolicyType.PasswordGenerator,
-        data: {
-          minLength: 10,
-        },
-      });
-
-      const evaluator = strategy.evaluator(policy);
-
-      expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
-      expect(evaluator.policy).toMatchObject({});
-    });
-
-    it("should map `null` to a default policy evaluator", () => {
-      const strategy = new SubaddressGeneratorStrategy(null, null);
-      const evaluator = strategy.evaluator(null);
-
-      expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
-    });
+        expect(evaluator).toBeInstanceOf(DefaultPolicyEvaluator);
+      },
+    );
   });
 
   describe("durableState", () => {

--- a/libs/common/src/tools/generator/username/subaddress-generator-strategy.ts
+++ b/libs/common/src/tools/generator/username/subaddress-generator-strategy.ts
@@ -1,5 +1,6 @@
+import { map, pipe } from "rxjs";
+
 import { PolicyType } from "../../../admin-console/enums";
-import { Policy } from "../../../admin-console/models/domain/policy";
 import { StateProvider } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { GeneratorStrategy } from "../abstractions";
@@ -41,18 +42,9 @@ export class SubaddressGeneratorStrategy
     return ONE_MINUTE;
   }
 
-  /** {@link GeneratorStrategy.evaluator} */
-  evaluator(policy: Policy) {
-    if (!policy) {
-      return new DefaultPolicyEvaluator<SubaddressGenerationOptions>();
-    }
-
-    if (policy.type !== this.policy) {
-      const details = `Expected: ${this.policy}. Received: ${policy.type}`;
-      throw Error("Mismatched policy type. " + details);
-    }
-
-    return new DefaultPolicyEvaluator<SubaddressGenerationOptions>();
+  /** {@link GeneratorStrategy.toEvaluator} */
+  toEvaluator() {
+    return pipe(map((_) => new DefaultPolicyEvaluator<SubaddressGenerationOptions>()));
   }
 
   /** {@link GeneratorStrategy.generate} */


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

Requested review by `team-admin-console-dev` to continue the conversation we started in #7977.

## Objective

* Use `getAll$` interface to load a user-specific policy.
* Fix bug where an arbitrary multi-org password policy would be applied by the generator. The generator now combines all password policies together.

## Code changes

Policy reducers:
- **libs/common/src/tools/generator/passphrase/passphrase-generator-policy.ts:** reduce multi-org policies into a passphrase-specific policy by combining the most restrictive policies from each organization.
- **libs/common/src/tools/generator/password/password-generator-policy.ts:** reduce multi-org policies into a password-specific policy by combining the most restrictive policies from each organization.
- **libs/common/src/tools/generator/reduce-collection.operator.ts:** an RxJs operator that maps `Observable<T[]>` to `Observable<U>`. It's combined with the reducers to transform an `Observable<Policy[]>` into a strategy-specific observable policy.
- **file:**
- **file:**


Generator strategy adjustments lifting the policy evaluator over a set of policies:
- **libs/common/src/tools/generator/abstractions/generator-strategy.abstraction.ts** - API update
- **libs/common/src/tools/generator/default-generator.service.ts** - use revised generator strategy API
- **libs/common/src/tools/generator/passphrase/passphrase-generator-strategy.ts**
- **libs/common/src/tools/generator/password/password-generator-strategy.ts**
- **file**
- **file**
- **file**
- **file**
- **file**

Unit tests:
- **libs/common/src/tools/generator/default-generator.service.spec.ts**
- **libs/common/src/tools/generator/passphrase/passphrase-generator-policy.spec.ts**
- **libs/common/src/tools/generator/passphrase/passphrase-generator-strategy.spec.ts**
- **libs/common/src/tools/generator/password/password-generator-policy.spec.ts**
- **libs/common/src/tools/generator/password/password-generator-strategy.spec.ts**
- **libs/common/src/tools/generator/reduce-collection.operator.spec.ts**
- **libs/common/src/tools/generator/username/catchall-generator-strategy.spec.ts**
- **file**
- **file**
- **file**
- **file**
- **file**


<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file:**

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
