### PR TITLE
Auth/PM-5263 - TokenService State provider migration bug fix to avoid persisting tokens in local storage

### DIFF
--- a/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
@@ -116,6 +116,10 @@ function rollbackJSON() {
 
 describe("TokenServiceStateProviderMigrator", () => {
   let helper: MockProxy<MigrationHelper>;
+
+  // TODO: figure out how to do this
+  // helper.type = "web-disk-local";
+
   let sut: TokenServiceStateProviderMigrator;
 
   describe("migrate", () => {

--- a/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
@@ -196,7 +196,7 @@ describe("TokenServiceStateProviderMigrator", () => {
     });
     describe("Local storage", () => {
       beforeEach(() => {
-        Object.defineProperty(helper, "type", { value: "web-disk-local" });
+        helper = mockMigrationHelper(preMigrationJson(), 37, "web-disk-local");
       });
       it("should remove state service data from all accounts that have it", async () => {
         await sut.migrate(helper);

--- a/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.spec.ts
@@ -116,10 +116,6 @@ function rollbackJSON() {
 
 describe("TokenServiceStateProviderMigrator", () => {
   let helper: MockProxy<MigrationHelper>;
-
-  // TODO: figure out how to do this
-  // helper.type = "web-disk-local";
-
   let sut: TokenServiceStateProviderMigrator;
 
   describe("migrate", () => {
@@ -128,65 +124,107 @@ describe("TokenServiceStateProviderMigrator", () => {
       sut = new TokenServiceStateProviderMigrator(37, 38);
     });
 
-    it("should remove state service data from all accounts that have it", async () => {
-      await sut.migrate(helper);
+    describe("Session storage", () => {
+      it("should remove state service data from all accounts that have it", async () => {
+        await sut.migrate(helper);
 
-      expect(helper.set).toHaveBeenCalledWith("user1", {
-        tokens: {
-          otherStuff: "overStuff2",
-        },
-        profile: {
-          email: "user1Email",
-          otherStuff: "overStuff3",
-        },
-        keys: {
-          otherStuff: "overStuff4",
-        },
-        otherStuff: "otherStuff5",
+        expect(helper.set).toHaveBeenCalledWith("user1", {
+          tokens: {
+            otherStuff: "overStuff2",
+          },
+          profile: {
+            email: "user1Email",
+            otherStuff: "overStuff3",
+          },
+          keys: {
+            otherStuff: "overStuff4",
+          },
+          otherStuff: "otherStuff5",
+        });
+
+        expect(helper.set).toHaveBeenCalledTimes(2);
+        expect(helper.set).not.toHaveBeenCalledWith("user2", any());
+        expect(helper.set).not.toHaveBeenCalledWith("user3", any());
       });
 
-      expect(helper.set).toHaveBeenCalledTimes(2);
-      expect(helper.set).not.toHaveBeenCalledWith("user2", any());
-      expect(helper.set).not.toHaveBeenCalledWith("user3", any());
+      it("should migrate data to state providers for defined accounts that have the data", async () => {
+        await sut.migrate(helper);
+
+        // Two factor Token Migration
+        expect(helper.setToGlobal).toHaveBeenLastCalledWith(
+          EMAIL_TWO_FACTOR_TOKEN_RECORD_DISK_LOCAL,
+          {
+            user1Email: "twoFactorToken",
+            user2Email: "twoFactorToken",
+          },
+        );
+        expect(helper.setToGlobal).toHaveBeenCalledTimes(1);
+
+        expect(helper.setToUser).toHaveBeenCalledWith("user1", ACCESS_TOKEN_DISK, "accessToken");
+        expect(helper.setToUser).toHaveBeenCalledWith("user1", REFRESH_TOKEN_DISK, "refreshToken");
+        expect(helper.setToUser).toHaveBeenCalledWith(
+          "user1",
+          API_KEY_CLIENT_ID_DISK,
+          "apiKeyClientId",
+        );
+        expect(helper.setToUser).toHaveBeenCalledWith(
+          "user1",
+          API_KEY_CLIENT_SECRET_DISK,
+          "apiKeyClientSecret",
+        );
+
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user2", ACCESS_TOKEN_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user2", REFRESH_TOKEN_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user2", API_KEY_CLIENT_ID_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith(
+          "user2",
+          API_KEY_CLIENT_SECRET_DISK,
+          any(),
+        );
+
+        // Expect that we didn't migrate anything to user 3
+
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user3", ACCESS_TOKEN_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user3", REFRESH_TOKEN_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith("user3", API_KEY_CLIENT_ID_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalledWith(
+          "user3",
+          API_KEY_CLIENT_SECRET_DISK,
+          any(),
+        );
+      });
     });
+    describe("Local storage", () => {
+      beforeEach(() => {
+        Object.defineProperty(helper, "type", { value: "web-disk-local" });
+      });
+      it("should remove state service data from all accounts that have it", async () => {
+        await sut.migrate(helper);
 
-    it("should migrate data to state providers for defined accounts that have the data", async () => {
-      await sut.migrate(helper);
+        expect(helper.set).toHaveBeenCalledWith("user1", {
+          tokens: {
+            otherStuff: "overStuff2",
+          },
+          profile: {
+            email: "user1Email",
+            otherStuff: "overStuff3",
+          },
+          keys: {
+            otherStuff: "overStuff4",
+          },
+          otherStuff: "otherStuff5",
+        });
 
-      // Two factor Token Migration
-      expect(helper.setToGlobal).toHaveBeenLastCalledWith(
-        EMAIL_TWO_FACTOR_TOKEN_RECORD_DISK_LOCAL,
-        {
-          user1Email: "twoFactorToken",
-          user2Email: "twoFactorToken",
-        },
-      );
-      expect(helper.setToGlobal).toHaveBeenCalledTimes(1);
+        expect(helper.set).toHaveBeenCalledTimes(2);
+        expect(helper.set).not.toHaveBeenCalledWith("user2", any());
+        expect(helper.set).not.toHaveBeenCalledWith("user3", any());
+      });
 
-      expect(helper.setToUser).toHaveBeenCalledWith("user1", ACCESS_TOKEN_DISK, "accessToken");
-      expect(helper.setToUser).toHaveBeenCalledWith("user1", REFRESH_TOKEN_DISK, "refreshToken");
-      expect(helper.setToUser).toHaveBeenCalledWith(
-        "user1",
-        API_KEY_CLIENT_ID_DISK,
-        "apiKeyClientId",
-      );
-      expect(helper.setToUser).toHaveBeenCalledWith(
-        "user1",
-        API_KEY_CLIENT_SECRET_DISK,
-        "apiKeyClientSecret",
-      );
+      it("should not migrate any data to local storage", async () => {
+        await sut.migrate(helper);
 
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user2", ACCESS_TOKEN_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user2", REFRESH_TOKEN_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user2", API_KEY_CLIENT_ID_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user2", API_KEY_CLIENT_SECRET_DISK, any());
-
-      // Expect that we didn't migrate anything to user 3
-
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user3", ACCESS_TOKEN_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user3", REFRESH_TOKEN_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user3", API_KEY_CLIENT_ID_DISK, any());
-      expect(helper.setToUser).not.toHaveBeenCalledWith("user3", API_KEY_CLIENT_SECRET_DISK, any());
+        expect(helper.setToUser).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.ts
+++ b/libs/common/src/state-migrations/migrations/38-migrate-token-svc-to-state-provider.ts
@@ -84,7 +84,10 @@ export class TokenServiceStateProviderMigrator extends Migrator<37, 38> {
 
       if (existingAccessToken != null) {
         // Only migrate data that exists
-        await helper.setToUser(userId, ACCESS_TOKEN_DISK, existingAccessToken);
+        if (helper.type !== "web-disk-local") {
+          // only migrate access token to session storage - never local.
+          await helper.setToUser(userId, ACCESS_TOKEN_DISK, existingAccessToken);
+        }
         delete account.tokens.accessToken;
         updatedAccount = true;
       }
@@ -93,7 +96,10 @@ export class TokenServiceStateProviderMigrator extends Migrator<37, 38> {
       const existingRefreshToken = account?.tokens?.refreshToken;
 
       if (existingRefreshToken != null) {
-        await helper.setToUser(userId, REFRESH_TOKEN_DISK, existingRefreshToken);
+        if (helper.type !== "web-disk-local") {
+          // only migrate refresh token to session storage - never local.
+          await helper.setToUser(userId, REFRESH_TOKEN_DISK, existingRefreshToken);
+        }
         delete account.tokens.refreshToken;
         updatedAccount = true;
       }
@@ -102,7 +108,10 @@ export class TokenServiceStateProviderMigrator extends Migrator<37, 38> {
       const existingApiKeyClientId = account?.profile?.apiKeyClientId;
 
       if (existingApiKeyClientId != null) {
-        await helper.setToUser(userId, API_KEY_CLIENT_ID_DISK, existingApiKeyClientId);
+        if (helper.type !== "web-disk-local") {
+          // only migrate client id to session storage - never local.
+          await helper.setToUser(userId, API_KEY_CLIENT_ID_DISK, existingApiKeyClientId);
+        }
         delete account.profile.apiKeyClientId;
         updatedAccount = true;
       }
@@ -110,7 +119,10 @@ export class TokenServiceStateProviderMigrator extends Migrator<37, 38> {
       // Migrate API key client secret
       const existingApiKeyClientSecret = account?.keys?.apiKeyClientSecret;
       if (existingApiKeyClientSecret != null) {
-        await helper.setToUser(userId, API_KEY_CLIENT_SECRET_DISK, existingApiKeyClientSecret);
+        if (helper.type !== "web-disk-local") {
+          // only migrate client secret to session storage - never local.
+          await helper.setToUser(userId, API_KEY_CLIENT_SECRET_DISK, existingApiKeyClientSecret);
+        }
         delete account.keys.apiKeyClientSecret;
         updatedAccount = true;
       }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```
## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Previous to the TokenService state provider migration (#7975) ( [PM-5263](https://bitwarden.atlassian.net/browse/PM-5263)), access / refresh tokens + client id & secret were improperly being persisted to local storage on account scaffolding. The #7975 changes no longer persist this data for new logins, but the migration was still incorrectly porting over the tokens from the account in local storage to the new state provider location in local storage.  This change utilizes the new migration type to stop the migration of those tokens but only for web local storage. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-5263]: https://bitwarden.atlassian.net/browse/PM-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ