### PR TITLE
[PM-6969] Use bit-callout within userVerification

### DIFF
--- a/libs/auth/src/angular/user-verification/user-verification-dialog.component.html
+++ b/libs/auth/src/angular/user-verification/user-verification-dialog.component.html
@@ -18,12 +18,12 @@
           {{ dialogOptions.bodyText | i18n }}
         </p>
 
-        <app-callout
+        <bit-callout
           *ngIf="dialogOptions.calloutOptions"
           [type]="dialogOptions.calloutOptions.type"
         >
           {{ dialogOptions.calloutOptions.text | i18n }}
-        </app-callout>
+        </bit-callout>
       </ng-container>
 
       <!-- Shown when client side verification methods picked and no verification methods found -->

--- a/libs/auth/src/angular/user-verification/user-verification-dialog.component.ts
+++ b/libs/auth/src/angular/user-verification/user-verification-dialog.component.ts
@@ -12,6 +12,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import {
   AsyncActionsModule,
   ButtonModule,
+  CalloutModule,
   DialogModule,
   DialogService,
 } from "@bitwarden/components";
@@ -34,6 +35,7 @@ import { UserVerificationFormInputComponent } from "./user-verification-form-inp
     DialogModule,
     AsyncActionsModule,
     UserVerificationFormInputComponent,
+    CalloutModule,
   ],
 })
 export class UserVerificationDialogComponent {

--- a/libs/auth/src/angular/user-verification/user-verification-dialog.types.ts
+++ b/libs/auth/src/angular/user-verification/user-verification-dialog.types.ts
@@ -11,9 +11,9 @@ export type UserVerificationCalloutOptions = {
 
   /**
    * The type of the callout.
-   * Can be "warning", "danger", "error", or "tip".
+   * Can be "warning", "danger", "info", or "success".
    */
-  type: "warning" | "danger" | "error" | "tip";
+  type: "warning" | "danger" | "info" | "success";
 };
 
 /**

--- a/libs/auth/src/angular/user-verification/user-verification-form-input.component.html
+++ b/libs/auth/src/angular/user-verification/user-verification-form-input.component.html
@@ -49,12 +49,12 @@
         </div>
       </div>
 
-      <app-callout type="error" *ngIf="biometricsVerificationFailed">
+      <bit-callout type="danger" *ngIf="biometricsVerificationFailed">
         {{ "couldNotCompleteBiometrics" | i18n }}
         <button bitLink type="button" linkType="primary" (click)="verifyUserViaBiometrics()">
           {{ "tryAgain" | i18n }}
         </button>
-      </app-callout>
+      </bit-callout>
     </ng-container>
 
     <!-- Alternate verification options if user has more than 1 -->

--- a/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
+++ b/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
@@ -20,6 +20,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
   AsyncActionsModule,
   ButtonModule,
+  CalloutModule,
   FormFieldModule,
   IconButtonModule,
   IconModule,
@@ -62,6 +63,7 @@ import { ActiveClientVerificationOption } from "./active-client-verification-opt
     IconModule,
     LinkModule,
     ButtonModule,
+    CalloutModule,
   ],
 })
 // eslint-disable-next-line rxjs-angular/prefer-takeuntil


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The re-worked user-verification component got introduced with https://github.com/bitwarden/clients/pull/7536 but was missing to use the newer [bit-callout](https://components.bitwarden.com/?path=/docs/component-library-callout--docs) instead of the old app-callout. This replaces the usages of the callouts.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/auth/src/angular/user-verification/user-verification-dialog.component.html:** Use `bit-callout` instead of `app-callout`
- **libs/auth/src/angular/user-verification/user-verification-form-input.component.html:** Use `bit-callout` instead of `app-callout` and fixed the calloutType being used
- **libs/auth/src/angular/user-verification/user-verification-dialog.component.ts:** Import CalloutModule and add it as a dependency
- **libs/auth/src/angular/user-verification/user-verification-form-input.component.ts:** Import CalloutModule and add it as a dependency
- **libs/auth/src/angular/user-verification/user-verification-dialog.types.ts:** Fixed the types used to align with the ones within the bit-callout

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
