### PR TITLE
[PM-6967] Replace app-callouts with bit-callouts on desktop

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -30,7 +30,7 @@
               </button>
             </h2>
             <ng-container *ngIf="showSecurity">
-              <app-callout type="info" *ngIf="vaultTimeoutPolicyCallout | async as policy">
+              <bit-callout type="info" *ngIf="vaultTimeoutPolicyCallout | async as policy">
                 <span *ngIf="policy.timeout && policy.action">
                   {{
                     "vaultTimeoutPolicyWithActionInEffect"
@@ -46,7 +46,7 @@
                 <span *ngIf="!policy.timeout && policy.action">
                   {{ "vaultTimeoutActionPolicyInEffect" | i18n: (policy.action | i18n) }}
                 </span>
-              </app-callout>
+              </bit-callout>
               <app-vault-timeout-input
                 [vaultTimeoutOptions]="vaultTimeoutOptions"
                 [formControl]="form.controls.vaultTimeout"

--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { NgModule } from "@angular/core";
 
 import { ColorPasswordCountPipe } from "@bitwarden/angular/pipes/color-password-count.pipe";
 import { ColorPasswordPipe } from "@bitwarden/angular/pipes/color-password.pipe";
-import { DialogModule } from "@bitwarden/components";
+import { DialogModule, CalloutModule } from "@bitwarden/components";
 
 import { AccessibilityCookieComponent } from "../auth/accessibility-cookie.component";
 import { DeleteAccountComponent } from "../auth/delete-account.component";
@@ -59,6 +59,7 @@ import { SendComponent } from "./tools/send/send.component";
     VaultFilterModule,
     LoginModule,
     DialogModule,
+    CalloutModule,
     DeleteAccountComponent,
     UserVerificationComponent,
   ],

--- a/apps/desktop/src/app/tools/export/export.component.html
+++ b/apps/desktop/src/app/tools/export/export.component.html
@@ -2,13 +2,13 @@
   <div class="modal-dialog" role="document">
     <form class="modal-content" #form (ngSubmit)="submit()" [formGroup]="exportForm">
       <div class="modal-body">
-        <app-callout
+        <bit-callout
           type="warning"
           title="{{ 'vaultExportDisabled' | i18n }}"
           *ngIf="disabledByPolicy"
         >
           {{ "personalVaultExportPolicyInEffect" | i18n }}
-        </app-callout>
+        </bit-callout>
         <app-export-scope-callout *ngIf="!disabledByPolicy"></app-export-scope-callout>
         <div class="box">
           <h1 class="box-header" id="exportTitle">

--- a/apps/desktop/src/app/tools/generator.component.html
+++ b/apps/desktop/src/app/tools/generator.component.html
@@ -5,12 +5,12 @@
         <h1 class="modal-title" id="generatorTitle">
           {{ "generator" | i18n }}
         </h1>
-        <app-callout
+        <bit-callout
           type="info"
           *ngIf="enforcedPasswordPolicyOptions?.inEffect() && type === 'password'"
         >
           {{ "passwordGeneratorPolicyInEffect" | i18n }}
-        </app-callout>
+        </bit-callout>
         <div class="generated-block" *ngIf="type === 'password'">
           <div
             class="generated-wrapper"

--- a/apps/desktop/src/app/tools/send/add-edit.component.html
+++ b/apps/desktop/src/app/tools/send/add-edit.component.html
@@ -2,12 +2,12 @@
   <div class="content">
     <div class="inner-content" *ngIf="send">
       <div class="box">
-        <app-callout *ngIf="disableSend">
+        <bit-callout *ngIf="disableSend">
           <span>{{ "sendDisabledWarning" | i18n }}</span>
-        </app-callout>
-        <app-callout type="info" *ngIf="disableHideEmail && !disableSend">
+        </bit-callout>
+        <bit-callout type="info" *ngIf="disableHideEmail && !disableSend">
           {{ "sendOptionsPolicyInEffect" | i18n }}
-        </app-callout>
+        </bit-callout>
       </div>
       <div class="box">
         <h2 class="box-header">

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -2,9 +2,9 @@
   <div class="content">
     <div class="inner-content" *ngIf="cipher">
       <div class="box">
-        <app-callout type="info" *ngIf="allowOwnershipOptions() && !allowPersonal">
+        <bit-callout type="info" *ngIf="allowOwnershipOptions() && !allowPersonal">
           {{ "personalOwnershipPolicyInEffect" | i18n }}
-        </app-callout>
+        </bit-callout>
         <h2 class="box-header">
           {{ title }}
         </h2>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In an partial effort to have a slightly more modern look and feel on the desktop and hopefully getting rid of some our custom css, my goal is to replace the usage of app-callouts with [bit-callouts](https://components.bitwarden.com/?path=/docs/component-library-callout--docs).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **Enable usage of the bit-callout within desktop -** https://github.com/bitwarden/clients/commit/df38b3fefaa19149f7d5960428f5abd71bfe15e8
  -  Adding this should be temporary, with the vision being: All components are standalone and they'd depend/import the CalloutModule themselves if they need it
- **Replace vaultTimeoutPolicy callout in settings -** https://github.com/bitwarden/clients/commit/2e959a0a334c1f0a6228cc44e21252e25031cd16
- **Replace OwnershipPolicy callout in add-edit cipher -** https://github.com/bitwarden/clients/commit/57ee7da43717a23dcd09a372be7f473653282152 
- **Replace vaultExportDisabled policy callout in export -** https://github.com/bitwarden/clients/commit/1961518f64c00454115f42702216629a6855fb5a
- **Replace generator policy callout in generator -** https://github.com/bitwarden/clients/commit/639eb355939dedf37b25cb7f720abb0e07784194
- **Replace policy callouts in add/edit Sends -** https://github.com/bitwarden/clients/commit/e112e01eaad1ec9fd1d4714789c3171e1ed42c73

## Screenshots
### Settings

#### before
![vault-timeout_before](https://github.com/bitwarden/clients/assets/2670567/6341d33d-f3e4-44dd-818c-360bf00fe6e5)

#### after
![vault-timeout_after](https://github.com/bitwarden/clients/assets/2670567/be1a636d-d7e7-4a77-8031-b0fcb6a163fb)

### Vault add/edit cipher

#### before
![cipher-ownership-policy_before](https://github.com/bitwarden/clients/assets/2670567/1f144a7e-4ddb-4c02-b441-4fe4e9bd2cde)

#### after
![cipher-ownership-policy_after](https://github.com/bitwarden/clients/assets/2670567/8e574ea8-00ef-4cd3-8b33-115359020677)

### Disable export policy

#### before
![export_before](https://github.com/bitwarden/clients/assets/2670567/c448bc04-190f-45f0-b1ae-31c57e341737)
#### after
![export_after](https://github.com/bitwarden/clients/assets/2670567/1e27bbf3-6651-4e00-be17-21d50b19150a)

### Generator policy options

#### before
![generator-policy_before](https://github.com/bitwarden/clients/assets/2670567/9b660236-7c81-4f24-ab83-b7c89befdd44)

#### after
![generator-policy_after](https://github.com/bitwarden/clients/assets/2670567/686070ae-6dc9-4079-8603-d652548c1ad1)

### Sends add-edit

#### before
![disable-send_before](https://github.com/bitwarden/clients/assets/2670567/84aeca5b-2bc5-4ca3-92ae-c3f042aa681b)
![send-policy-options_before](https://github.com/bitwarden/clients/assets/2670567/cf240d75-ba01-4cba-926f-575297c37d9d)

#### after
![disable-send_after](https://github.com/bitwarden/clients/assets/2670567/a270288b-67ca-4c3d-a3f3-38d8d0af3b4f)
![send-policy-options_after](https://github.com/bitwarden/clients/assets/2670567/6f188212-3165-485d-a99a-20b5e418bf99)

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
