### PR TITLE
[PM-6983] Disable hardware acceleration for bad GPUs

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -323,12 +323,13 @@ export class Main {
       this.logService.warning("Hardware acceleration is disabled");
       app.disableHardwareAcceleration();
     } else if (isMacAppStore()) {
-      // We disable hardware acceleration on Mac App Store builds with amd switchable GPUs due to:
+      // We disable hardware acceleration on Mac App Store builds for iMacs with amd switchable GPUs due to:
       // https://github.com/electron/electron/issues/41346
       const gpuInfo: any = await app.getGPUInfo("basic");
       const badGpu = gpuInfo?.auxAttributes?.amdSwitchable ?? false;
+      const isImac = gpuInfo?.machineModelName == "iMac";
 
-      if (badGpu) {
+      if (isImac && badGpu) {
         this.logService.warning(
           "Bad GPU detected, hardware acceleration is disabled for compatibility",
         );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -45,6 +45,7 @@ import { ElectronStateService } from "./platform/services/electron-state.service
 import { ElectronStorageService } from "./platform/services/electron-storage.service";
 import { I18nMainService } from "./platform/services/i18n.main.service";
 import { ElectronMainMessagingService } from "./services/electron-main-messaging.service";
+import { isMacAppStore } from "./utils";
 
 export class Main {
   logService: ElectronLogMainService;
@@ -321,6 +322,18 @@ export class Main {
     if (!hardwareAcceleration) {
       this.logService.warning("Hardware acceleration is disabled");
       app.disableHardwareAcceleration();
+    } else if (isMacAppStore()) {
+      // We disable hardware acceleration on Mac App Store builds with amd switchable GPUs due to:
+      // https://github.com/electron/electron/issues/41346
+      const gpuInfo: any = await app.getGPUInfo("basic");
+      const badGpu = gpuInfo?.auxAttributes?.amdSwitchable ?? false;
+
+      if (badGpu) {
+        this.logService.warning(
+          "Bad GPU detected, hardware acceleration is disabled for compatibility",
+        );
+        app.disableHardwareAcceleration();
+      }
     }
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Force hardware acceleration to be disabled for machines with AMD switchable graphics due to https://github.com/bitwarden/clients/issues/8003.

This relies on https://www.electronjs.org/docs/latest/api/app#appgetgpuinfoinfotype, an alternative implementation could use `deviceId` but hopefully `amdSwitchable` is slightly more generic and catches more devices.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
