### PR TITLE
[CL-232] exclude bit-dialog from global extension header styles

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -169,7 +169,7 @@ cdk-virtual-scroll-viewport::-webkit-scrollbar-thumb,
   }
 }
 
-header:not(bit-callout header) {
+header:not(bit-callout header, bit-dialog header) {
   height: 44px;
   display: flex;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The extension contains global CSS that targets `header` elements. This was unintentionally overriding the styles of the `header` within the template of `bit-dialog`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/base.scss:** Exclude `bit-dialog` from CSS selector.

## Screenshots

Before:
<img width="405" alt="Screenshot 2024-03-21 at 10 32 53 PM" src="https://github.com/bitwarden/clients/assets/17113462/8e7e9079-f2f4-4770-8f5f-3d9753e0c039">

After:
<img width="405" alt="Screenshot 2024-03-21 at 10 32 14 PM" src="https://github.com/bitwarden/clients/assets/17113462/73335f83-eb4d-41a5-b022-6e982fb2ccf3">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
