### PR TITLE
[PM-4406] fix select overlay visibility when popup is zoomed

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -17,6 +17,8 @@ body {
 body {
   width: 375px !important;
   height: 600px !important;
+  position: relative;
+  min-height: 100vh;
   overflow: hidden;
   color: $text-color;
   background-color: $background-color;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR fixes select overlays not being visible when the popup window is zoomed beyond 100%.

This was caused by the positioning strategy of `ng-select`, which requires the body have `positive: relative`. 


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/popup/scss/base.scss:** Add `positive: relative` to `body`. This causes another bug (0 height content, see recording), which is remedied by adding a min width.

## Screenshots


https://github.com/bitwarden/clients/assets/17113462/1eafc6b8-2a50-4e0e-b3f8-337fee43d556



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
