### PR TITLE
[PM-7048] Disable relaunch on MAS

### DIFF
--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -240,7 +240,11 @@ export class HelpMenu implements IMenubarMenu {
           await this.desktopSettingsService.setHardwareAcceleration(
             !this.hardwareAccelerationEnabled,
           );
-          app.relaunch();
+          // `app.relaunch` crashes the app on Mac Store builds. Disabling it for now.
+          // https://github.com/electron/electron/issues/41690
+          if (!isMacAppStore()) {
+            app.relaunch();
+          }
           app.exit();
         },
       },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Running `app.relaunch` crashes on mac app store builds. Disabling it for now while we track https://github.com/electron/electron/issues/41690. Unfortunately this means MAS users will have to manually start the app after it quits.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
