### PR TITLE
Ps/test macos 12 runner

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build CLI ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-22.04, macos-12]
     runs-on: ${{ matrix.os }}
     needs:
       - setup

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -444,7 +444,10 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
+    runs-on: macos-11
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -602,7 +605,10 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
+    runs-on: macos-11
     needs:
       - browser-build
       - macos-build
@@ -808,7 +814,10 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
+    runs-on: macos-11
     needs:
       - browser-build
       - macos-build
@@ -1006,7 +1015,10 @@ jobs:
   macos-package-dev:
     name: MacOS Package Dev Release Asset
     if: false  # We need to look into how code signing works for dev
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
+    runs-on: macos-11
     needs:
       - browser-build
       - macos-build

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -444,10 +444,10 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
-    runs-on: macos-11
+    runs-on: macos-12
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -605,10 +605,10 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - browser-build
       - macos-build
@@ -814,10 +814,10 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - browser-build
       - macos-build
@@ -1015,10 +1015,10 @@ jobs:
   macos-package-dev:
     name: MacOS Package Dev Release Asset
     if: false  # We need to look into how code signing works for dev
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - browser-build
       - macos-build

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -393,7 +393,10 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
+    runs-on: macos-11
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.release-version }}
@@ -522,7 +525,10 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules  
+    runs-on: macos-11
     needs:
       - setup
       - macos-build
@@ -732,7 +738,10 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    runs-on: macos-13
+    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # as the newer versions will case the native modules to be incompatible with older macOS systems
+    # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules    
+    runs-on: macos-11
     needs:
       - setup
       - macos-build

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -393,10 +393,10 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules
-    runs-on: macos-11
+    runs-on: macos-12
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.release-version }}
@@ -525,10 +525,10 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules  
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - setup
       - macos-build
@@ -738,10 +738,10 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    # Note, this workflow is running on macOS 11 to maintain compatibility with macOS 10.15 Catalina, 
+    # Note, this workflow is running on macOS 12 to maintain compatibility with macOS 10.15 Catalina, 
     # as the newer versions will case the native modules to be incompatible with older macOS systems
     # This version should stay pinned until we drop support for macOS 10.15, or we drop the native modules    
-    runs-on: macos-11
+    runs-on: macos-12
     needs:
       - setup
       - macos-build


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
MacOS 11 builders are deprecated and will be removed soon, so let's see if the macOS 12 builders also work with catalina