### PR TITLE
[PM-7087] Hide bulk assign collections menu item for non-FC orgs

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -91,7 +91,7 @@ export class VaultItemsComponent {
   }
 
   get bulkAssignToCollectionsAllowed() {
-    return this.ciphers.length > 0;
+    return this.showBulkAddToCollections && this.ciphers.length > 0;
   }
 
   protected canEditCollection(collection: CollectionView): boolean {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The bulk assign collection action is not available for organizations that do not have FC enabled and the menu item should be hidden in those cases.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/vault/components/vault-items/vault-items.component.ts:** Use the `showBulkAddToCollections` property to determine if the bulk assign to collections menu option should be rendered. This property is already being set to false for non-FC orgs, it was just mistakenly never used.

## Screenshots
Non-FC Org with missing bulk assign option

<img width="1458" alt="image" src="https://github.com/bitwarden/clients/assets/8764515/66eb16bb-d0f4-47a7-ba82-130c5856aff2">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
