### PR TITLE
[AC-2351] Fix unable to move items to organization in Browser

### DIFF
--- a/libs/angular/src/components/share.component.ts
+++ b/libs/angular/src/components/share.component.ts
@@ -62,6 +62,7 @@ export class ShareComponent implements OnInit, OnDestroy {
     this.organizations$.pipe(takeUntil(this._destroy)).subscribe((orgs) => {
       if (this.organizationId == null && orgs.length > 0) {
         this.organizationId = orgs[0].id;
+        this.filterCollections();
       }
     });
 
@@ -69,8 +70,6 @@ export class ShareComponent implements OnInit, OnDestroy {
     this.cipher = await cipherDomain.decrypt(
       await this.cipherService.getKeyForCipherKeyDecryption(cipherDomain),
     );
-
-    this.filterCollections();
   }
 
   filterCollections() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `share.component.ts` called `filterCollections()` at the end of `load()` which could run before the `organizations$` observable emitted (responsible for setting `this.organizationId`) resulting in an empty list of collections. This PR moves the call to `filterCollections()` into the `organizations$` subscription and is called right after `this.organizationId` is assigned.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/angular/src/components/share.component.ts:** See above.

## Screenshots

https://github.com/bitwarden/clients/assets/8764515/e0f4396f-4e91-4615-8ade-3fe692a38292


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
