### PR TITLE
[PM-7088] Only initialize user decryption options if present on response obj

### DIFF
--- a/libs/auth/src/common/models/domain/user-decryption-options.ts
+++ b/libs/auth/src/common/models/domain/user-decryption-options.ts
@@ -15,11 +15,14 @@ export class KeyConnectorUserDecryptionOption {
   /**
    * Initializes a new instance of the KeyConnectorUserDecryptionOption from a response object.
    * @param response The key connector user decryption option response object.
-   * @returns A new instance of the KeyConnectorUserDecryptionOption. Will initialize even if the response is nullish.
+   * @returns A new instance of the KeyConnectorUserDecryptionOption or undefined if `response` is nullish.
    */
   static fromResponse(
     response: KeyConnectorUserDecryptionOptionResponse,
-  ): KeyConnectorUserDecryptionOption {
+  ): KeyConnectorUserDecryptionOption | undefined {
+    if (response == null) {
+      return undefined;
+    }
     const options = new KeyConnectorUserDecryptionOption();
     options.keyConnectorUrl = response?.keyConnectorUrl ?? null;
     return options;
@@ -28,11 +31,14 @@ export class KeyConnectorUserDecryptionOption {
   /**
    * Initializes a new instance of a KeyConnectorUserDecryptionOption from a JSON object.
    * @param obj JSON object to deserialize.
-   * @returns A new instance of the KeyConnectorUserDecryptionOption. Will initialize even if the JSON object is nullish.
+   * @returns A new instance of the KeyConnectorUserDecryptionOption or undefined if `obj` is nullish.
    */
   static fromJSON(
     obj: Jsonify<KeyConnectorUserDecryptionOption>,
-  ): KeyConnectorUserDecryptionOption {
+  ): KeyConnectorUserDecryptionOption | undefined {
+    if (obj == null) {
+      return undefined;
+    }
     return Object.assign(new KeyConnectorUserDecryptionOption(), obj);
   }
 }
@@ -52,11 +58,14 @@ export class TrustedDeviceUserDecryptionOption {
   /**
    * Initializes a new instance of the TrustedDeviceUserDecryptionOption from a response object.
    * @param response The trusted device user decryption option response object.
-   * @returns A new instance of the TrustedDeviceUserDecryptionOption. Will initialize even if the response is nullish.
+   * @returns A new instance of the TrustedDeviceUserDecryptionOption or undefined if `response` is nullish.
    */
   static fromResponse(
     response: TrustedDeviceUserDecryptionOptionResponse,
-  ): TrustedDeviceUserDecryptionOption {
+  ): TrustedDeviceUserDecryptionOption | undefined {
+    if (response == null) {
+      return undefined;
+    }
     const options = new TrustedDeviceUserDecryptionOption();
     options.hasAdminApproval = response?.hasAdminApproval ?? false;
     options.hasLoginApprovingDevice = response?.hasLoginApprovingDevice ?? false;
@@ -67,11 +76,14 @@ export class TrustedDeviceUserDecryptionOption {
   /**
    * Initializes a new instance of the TrustedDeviceUserDecryptionOption from a JSON object.
    * @param obj JSON object to deserialize.
-   * @returns A new instance of the TrustedDeviceUserDecryptionOption. Will initialize even if the JSON object is nullish.
+   * @returns A new instance of the TrustedDeviceUserDecryptionOption or undefined if `obj` is nullish.
    */
   static fromJSON(
     obj: Jsonify<TrustedDeviceUserDecryptionOption>,
-  ): TrustedDeviceUserDecryptionOption {
+  ): TrustedDeviceUserDecryptionOption | undefined {
+    if (obj == null) {
+      return undefined;
+    }
     return Object.assign(new TrustedDeviceUserDecryptionOption(), obj);
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As part of the user decryption options service, I decided to always initialize a `TrustedDeviceOption` and `KeyConnectorOptions` to prevent possible null references. This broke regular SSO login since existence of the `TrustedDeviceOption` was used to determine if trusted device was available for login and where to navigate. Since we don't store the keys themselves, this has been reverted to the original behavior.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
