### PR TITLE
[PM-5263, PM-7164] TokenService - Clear all tokens on log out

### DIFF
--- a/libs/common/src/auth/services/token.state.ts
+++ b/libs/common/src/auth/services/token.state.ts
@@ -1,5 +1,9 @@
 import { KeyDefinition, TOKEN_DISK, TOKEN_DISK_LOCAL, TOKEN_MEMORY } from "../../platform/state";
 
+// Note: all tokens / API key information must be cleared on logout.
+// because we are using secure storage, we must manually call to clean up our tokens.
+// See stateService.deAuthenticateAccount for where we call clearTokens(...)
+
 export const ACCESS_TOKEN_DISK = new KeyDefinition<string>(TOKEN_DISK, "accessToken", {
   deserializer: (accessToken) => accessToken,
 });

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -1729,7 +1729,9 @@ export class StateService<
   }
 
   protected async deAuthenticateAccount(userId: string): Promise<void> {
-    await this.tokenService.clearAccessToken(userId as UserId);
+    // We must have a manual call to clear tokens as we can't leverage state provider to clean
+    // up our data as we have secure storage in the mix.
+    await this.tokenService.clearTokens(userId as UserId);
     await this.setLastActive(null, { userId: userId });
     await this.updateState(async (state) => {
       state.authenticatedAccounts = state.authenticatedAccounts.filter((id) => id !== userId);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Finish resolving [PM-5263](https://bitwarden.atlassian.net/browse/PM-5263); fixes bug [PM-7164](https://bitwarden.atlassian.net/browse/PM-7164)

#7975 migrated the state, but we just discovered that we were not properly clearing the refresh token and API key client Id / secret on log out.


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/auth/services/token.state.ts:** Add comments to token state explaining why they aren't user key definitions and why they don't implement `clearOn` 
- **libs/common/src/platform/services/state.service.ts:** `deAuthenticateAccount` should clear all tokens - not just the access token. In the previous state service implementation, the rest of the tokens were cleaned up on logout automatically for us, but we must handle this manually now. 

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-5263]: https://bitwarden.atlassian.net/browse/PM-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-7164]: https://bitwarden.atlassian.net/browse/PM-7164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ