### PR TITLE
Observable auth statuses

### DIFF
--- a/libs/common/src/auth/abstractions/auth.service.ts
+++ b/libs/common/src/auth/abstractions/auth.service.ts
@@ -1,10 +1,17 @@
 import { Observable } from "rxjs";
 
+import { UserId } from "../../types/guid";
 import { AuthenticationStatus } from "../enums/authentication-status";
 
 export abstract class AuthService {
   /** Authentication status for the active user */
   abstract activeAccountStatus$: Observable<AuthenticationStatus>;
+  /**
+   * Returns an observable authentication status for the given user id.
+   * @note userId is a required parameter, null values will always return `AuthenticationStatus.LoggedOut`
+   * @param userId The user id to check for an access token.
+   */
+  abstract authStatusFor$(userId: UserId): Observable<AuthenticationStatus>;
   /** @deprecated use {@link activeAccountStatus$} instead */
   abstract getAuthStatus: (userId?: string) => Promise<AuthenticationStatus>;
   abstract logOut: (callback: () => void) => void;

--- a/libs/common/src/auth/abstractions/token.service.ts
+++ b/libs/common/src/auth/abstractions/token.service.ts
@@ -1,8 +1,15 @@
+import { Observable } from "rxjs";
+
 import { VaultTimeoutAction } from "../../enums/vault-timeout-action.enum";
 import { UserId } from "../../types/guid";
 import { DecodedAccessToken } from "../services/token.service";
 
 export abstract class TokenService {
+  /**
+   * Returns an observable that emits a boolean indicating whether the user has an access token.
+   * @param userId The user id to check for an access token.
+   */
+  abstract hasAccessToken$(userId: UserId): Observable<boolean>;
   /**
    * Sets the access token, refresh token, API Key Client ID, and API Key Client Secret in memory or disk
    * based on the given vaultTimeoutAction and vaultTimeout and the derived access token user id.

--- a/libs/common/src/auth/services/auth.service.spec.ts
+++ b/libs/common/src/auth/services/auth.service.spec.ts
@@ -1,13 +1,21 @@
 import { MockProxy, mock } from "jest-mock-extended";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 
-import { FakeAccountService, mockAccountServiceWith } from "../../../spec";
+import {
+  FakeAccountService,
+  makeStaticByteArray,
+  mockAccountServiceWith,
+  trackEmissions,
+} from "../../../spec";
 import { ApiService } from "../../abstractions/api.service";
 import { CryptoService } from "../../platform/abstractions/crypto.service";
 import { MessagingService } from "../../platform/abstractions/messaging.service";
 import { StateService } from "../../platform/abstractions/state.service";
 import { Utils } from "../../platform/misc/utils";
+import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../types/guid";
+import { UserKey } from "../../types/key";
+import { TokenService } from "../abstractions/token.service";
 import { AuthenticationStatus } from "../enums/authentication-status";
 
 import { AuthService } from "./auth.service";
@@ -20,15 +28,18 @@ describe("AuthService", () => {
   let cryptoService: MockProxy<CryptoService>;
   let apiService: MockProxy<ApiService>;
   let stateService: MockProxy<StateService>;
+  let tokenService: MockProxy<TokenService>;
 
   const userId = Utils.newGuid() as UserId;
+  const userKey = new SymmetricCryptoKey(makeStaticByteArray(32) as Uint8Array) as UserKey;
 
   beforeEach(() => {
     accountService = mockAccountServiceWith(userId);
-    messagingService = mock<MessagingService>();
-    cryptoService = mock<CryptoService>();
-    apiService = mock<ApiService>();
-    stateService = mock<StateService>();
+    messagingService = mock();
+    cryptoService = mock();
+    apiService = mock();
+    stateService = mock();
+    tokenService = mock();
 
     sut = new AuthService(
       accountService,
@@ -36,26 +47,115 @@ describe("AuthService", () => {
       cryptoService,
       apiService,
       stateService,
+      tokenService,
     );
   });
 
   describe("activeAccountStatus$", () => {
-    test.each([
-      AuthenticationStatus.LoggedOut,
-      AuthenticationStatus.Locked,
-      AuthenticationStatus.Unlocked,
-    ])(
-      `should emit %p when activeAccount$ emits an account with %p auth status`,
-      async (status) => {
-        accountService.activeAccountSubject.next({
-          id: userId,
-          email: "email",
-          name: "name",
-          status,
-        });
+    const accountInfo = {
+      status: AuthenticationStatus.Unlocked,
+      id: userId,
+      email: "email",
+      name: "name",
+    };
 
-        expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(status);
-      },
-    );
+    beforeEach(() => {
+      accountService.activeAccountSubject.next(accountInfo);
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(undefined));
+    });
+
+    it("emits LoggedOut when there is no active account", async () => {
+      accountService.activeAccountSubject.next(undefined);
+
+      expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(
+        AuthenticationStatus.LoggedOut,
+      );
+    });
+
+    it("emits LoggedOut when there is no access token", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(false));
+
+      expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(
+        AuthenticationStatus.LoggedOut,
+      );
+    });
+
+    it("emits LoggedOut when there is no access token but has a user key", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(false));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(userKey));
+
+      expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(
+        AuthenticationStatus.LoggedOut,
+      );
+    });
+
+    it("emits Locked when there is an access token and no user key", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(undefined));
+
+      expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(AuthenticationStatus.Locked);
+    });
+
+    it("emits Unlocked when there is an access token and user key", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(userKey));
+
+      expect(await firstValueFrom(sut.activeAccountStatus$)).toEqual(AuthenticationStatus.Unlocked);
+    });
+
+    it("follows the current active user", async () => {
+      const accountInfo2 = {
+        status: AuthenticationStatus.Unlocked,
+        id: Utils.newGuid() as UserId,
+        email: "email2",
+        name: "name2",
+      };
+
+      const emissions = trackEmissions(sut.activeAccountStatus$);
+
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(userKey));
+      accountService.activeAccountSubject.next(accountInfo2);
+
+      expect(emissions).toEqual([AuthenticationStatus.Locked, AuthenticationStatus.Unlocked]);
+    });
+  });
+
+  describe("authStatusFor$", () => {
+    beforeEach(() => {
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(undefined));
+    });
+
+    it("emits LoggedOut when userId is null", async () => {
+      expect(await firstValueFrom(sut.authStatusFor$(null))).toEqual(
+        AuthenticationStatus.LoggedOut,
+      );
+    });
+
+    it("emits LoggedOut when there is no access token", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(false));
+
+      expect(await firstValueFrom(sut.authStatusFor$(userId))).toEqual(
+        AuthenticationStatus.LoggedOut,
+      );
+    });
+
+    it("emits Locked when there is an access token and no user key", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(undefined));
+
+      expect(await firstValueFrom(sut.authStatusFor$(userId))).toEqual(AuthenticationStatus.Locked);
+    });
+
+    it("emits Unlocked when there is an access token and user key", async () => {
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
+      cryptoService.getInMemoryUserKeyFor$.mockReturnValue(of(userKey));
+
+      expect(await firstValueFrom(sut.authStatusFor$(userId))).toEqual(
+        AuthenticationStatus.Unlocked,
+      );
+    });
   });
 });

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom } from "rxjs";
+import { Observable, combineLatest, firstValueFrom, map } from "rxjs";
 import { Opaque } from "type-fest";
 
 import { decodeJwtTokenToJson } from "@bitwarden/auth/common";
@@ -133,6 +133,15 @@ export class TokenService implements TokenServiceAbstraction {
     private logService: LogService,
   ) {
     this.initializeState();
+  }
+
+  hasAccessToken$(userId: UserId): Observable<boolean> {
+    // FIXME Once once vault timeout action is observable, we can use it to determine storage location
+    // and avoid the need to check both disk and memory.
+    return combineLatest([
+      this.singleUserStateProvider.get(userId, ACCESS_TOKEN_DISK).state$,
+      this.singleUserStateProvider.get(userId, ACCESS_TOKEN_MEMORY).state$,
+    ]).pipe(map(([disk, memory]) => Boolean(disk || memory)));
   }
 
   // pivoting to an approach where we create a symmetric key we store in secure storage

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -13,6 +13,14 @@ import { SymmetricCryptoKey } from "../models/domain/symmetric-crypto-key";
 
 export abstract class CryptoService {
   abstract activeUserKey$: Observable<UserKey>;
+
+  /**
+   * Returns the an observable key for the given user id.
+   *
+   * @note this observable represents only user keys stored in memory. A null value does not indicate that we cannot load a user key from storage.
+   * @param userId The desired user
+   */
+  abstract getInMemoryUserKeyFor$(userId: UserId): Observable<UserKey>;
   /**
    * Sets the provided user key and stores
    * any other necessary versions (such as auto, biometrics,

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -160,6 +160,10 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.setUserKey(key);
   }
 
+  getInMemoryUserKeyFor$(userId: UserId): Observable<UserKey> {
+    return this.stateProvider.getUserState$(USER_KEY, userId);
+  }
+
   async getUserKey(userId?: UserId): Promise<UserKey> {
     let userKey = await firstValueFrom(this.stateProvider.getUserState$(USER_KEY, userId));
     if (userKey) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We need observable auth statuses, but it's best represented as an ad-hoc calculation of the presence of an access token and user key rather.

This work adds
1. observable access token presence
2. observable user key in memory presence for arbitrary users
3. observable auth status for active and arbitrary users.

## Code changes

- **auth service**:
  - updates active account status observable to ad-hoc calculation based off of sub-observables
  - `authStatusFor$` provides an interface for getting the auth status for arbitrary accounts
- **token service**: Adds observable presence of access token. This works by just checking both possible access token locations, it would be better if we could determine the appropriate storage loction, but that data is not yet observable. This improvement is added as a fixme
 > also, the fact that the content may be encrypted doesn't matter for presence. We're just validating whether we have a token saved or not.
- **crypto service**: Provides outside access to whether or not we have loaded the given user id's user key in memory. There are some differences with the awaitable `getUserKey` due to its auto-loading of the auto key. We don't want to do that here since that's not how the active user key observable works.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
