### PR TITLE
[AC-2350] - FIX - Separate domain verification steps

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
@@ -26,7 +26,7 @@
         <bit-hint>{{ "domainNameInputHint" | i18n }}</bit-hint>
       </bit-form-field>
 
-      <bit-form-field>
+      <bit-form-field *ngIf="data?.orgDomain">
         <bit-label>{{ "dnsTxtRecord" | i18n }}</bit-label>
         <input bitInput formControlName="txt" />
         <bit-hint>{{ "dnsTxtRecordInputHint" | i18n }}</bit-hint>
@@ -42,7 +42,7 @@
       </bit-form-field>
 
       <bit-callout
-        *ngIf="!data?.orgDomain?.verifiedDate"
+        *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate"
         type="info"
         title="{{ 'automaticDomainVerification' | i18n }}"
       >
@@ -51,7 +51,10 @@
     </div>
     <ng-container bitDialogFooter>
       <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span *ngIf="!data?.orgDomain?.verifiedDate">{{ "verifyDomain" | i18n }}</span>
+        <span *ngIf="!data?.orgDomain">{{ "next" | i18n }}</span>
+        <span *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate">{{
+          "verifyDomain" | i18n
+        }}</span>
         <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reverifyDomain" | i18n }}</span>
       </button>
       <button bitButton buttonType="secondary" (click)="dialogRef.close()" type="button">

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
@@ -13,7 +13,6 @@ import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from "@bitw
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { DialogService } from "@bitwarden/components";
 
 import { domainNameValidator } from "./validators/domain-name.validator";
@@ -90,17 +89,6 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
       // Edit
       this.domainForm.patchValue(this.data.orgDomain);
       this.domainForm.disable();
-    } else {
-      // Add
-
-      // Figuring out the proper length of our DNS TXT Record value was fun.
-      // DNS-Based Service Discovery RFC: https://www.ietf.org/rfc/rfc6763.txt; see section 6.1
-      // Google uses 43 chars for their TXT record value: https://support.google.com/a/answer/2716802
-      // So, chose a magic # of 33 bytes to achieve at least that once converted to base 64 (47 char length).
-      const generatedTxt = `bw=${Utils.fromBufferToB64(
-        await this.cryptoFunctionService.randomBytes(33),
-      )}`;
-      this.txtCtrl.setValue(generatedTxt);
     }
 
     this.setupFormListeners();
@@ -121,6 +109,7 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
   // End Form methods
 
   // Async Form Actions
+  // Creates a new domain record. The DNS TXT Record will be generated server-side and returned in the response.
   saveDomain = async (): Promise<void> => {
     if (this.domainForm.invalid) {
       this.platformUtilsService.showToast("error", null, this.i18nService.t("domainFormInvalid"));
@@ -130,14 +119,14 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
     this.domainNameCtrl.disable();
 
     const request: OrganizationDomainRequest = new OrganizationDomainRequest(
-      this.txtCtrl.value,
       this.domainNameCtrl.value,
     );
 
     try {
       this.data.orgDomain = await this.orgDomainApiService.post(this.data.organizationId, request);
+      // Patch the DNS TXT Record that was generated server-side
+      this.domainForm.controls.txt.patchValue(this.data.orgDomain.txt);
       this.platformUtilsService.showToast("success", null, this.i18nService.t("domainSaved"));
-      await this.verifyDomain();
     } catch (e) {
       this.handleDomainSaveError(e);
     }

--- a/libs/common/src/admin-console/services/organization-domain/requests/organization-domain.request.ts
+++ b/libs/common/src/admin-console/services/organization-domain/requests/organization-domain.request.ts
@@ -1,9 +1,7 @@
 export class OrganizationDomainRequest {
-  txt: string;
   domainName: string;
 
-  constructor(txt: string, domainName: string) {
-    this.txt = txt;
+  constructor(domainName: string) {
     this.domainName = domainName;
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

> Adjust the domain verification dialog to separate the save/verify domain steps. Generate the DNS TXT record server-side in order to increase security from potential client-side manipulation.


## Code changes

- **...domain-add-edit-dialog.component.html**: Visually separated the save/verify steps. Introduced a `Next` button before allowing verification while also hiding items specific to the `verify` step, until necessary.
- **...domain-add-edit-dialog.component.ts**: Removed client-side DNS TXT record generation. Removed chaining to the `verify` step as the user will not yet have had a chance to upload the generated record to their DNS provider.
- **...organization-domain.request.ts**: Removed the `txt`object property. 


## Screenshots

![Screenshot 2024-03-28 at 4 16 07 PM](https://github.com/bitwarden/clients/assets/26154748/1d13d2d0-ad0f-4361-8b50-6bb6dcdf9086)
![Screenshot 2024-03-28 at 4 16 32 PM](https://github.com/bitwarden/clients/assets/26154748/1003677f-d4ed-4aaa-98d3-a2fbfb56f220)

https://github.com/bitwarden/clients/assets/26154748/fda88e65-c021-4741-87fa-152517d86744





## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
