### PR TITLE
Add Custom `ErrorHandler`

### DIFF
--- a/libs/angular/src/platform/services/logging-error-handler.ts
+++ b/libs/angular/src/platform/services/logging-error-handler.ts
@@ -1,0 +1,14 @@
+import { ErrorHandler, Injectable } from "@angular/core";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+@Injectable()
+export class LoggingErrorHandler extends ErrorHandler {
+  constructor(private readonly logService: LogService) {
+    super();
+  }
+
+  override handleError(error: any): void {
+    this.logService.error(error);
+  }
+}

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1,4 +1,4 @@
-import { LOCALE_ID, NgModule } from "@angular/core";
+import { ErrorHandler, LOCALE_ID, NgModule } from "@angular/core";
 
 import {
   AuthRequestServiceAbstraction,
@@ -238,6 +238,7 @@ import { UnauthGuard } from "../auth/guards/unauth.guard";
 import { FormValidationErrorsService as FormValidationErrorsServiceAbstraction } from "../platform/abstractions/form-validation-errors.service";
 import { BroadcasterService } from "../platform/services/broadcaster.service";
 import { FormValidationErrorsService } from "../platform/services/form-validation-errors.service";
+import { LoggingErrorHandler } from "../platform/services/logging-error-handler";
 import { AngularThemingService } from "../platform/services/theming/angular-theming.service";
 import { AbstractThemingService } from "../platform/services/theming/theming.service.abstraction";
 import { safeProvider, SafeProvider } from "../platform/utils/safe-provider";
@@ -1068,6 +1069,11 @@ const safeProviders: SafeProvider[] = [
     provide: OrganizationManagementPreferencesService,
     useClass: DefaultOrganizationManagementPreferencesService,
     deps: [StateProvider],
+  }),
+  safeProvider({
+    provide: ErrorHandler,
+    useClass: LoggingErrorHandler,
+    deps: [LogService],
   }),
 ];
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Errors that are uncaught but happen inside of angular like a components `ngOnInit` method are currently handled by the default angular `ErrorHandler` class but since this class just uses `console.error` those errors don't make it to our desktops `app.log` file. With dev tools disabled in non-dev environments this can make debugging issues more difficult. Creating a custom `ErrorHandler` that uses our own `LogService` means in most of our application the error will be put into the console like normal but in desktop it will be in both the console and the `app.log`.

## Alternative Design

I could keep the main `ErrorHandler` for all contexts other than desktop non-dev and use this implementation for desktop production mode. Angulars `ErrorHandler` has a way to unwrap an error into the original one. I can't personally say I have ever noticed `ORIGINAL ERROR` but I could have missed it. @willmartian Are those pretty common and would we be missing out on vital information during development. 

https://github.com/angular/angular/blob/0b450ffa6fbfcba7a9b143ca7d2c56a460006c2e/packages/core/src/error_handler.ts#L43-L59

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
