### PR TITLE
[PM-7165] Removing clientSideOnlyVerification from Web ExportComponent

### DIFF
--- a/apps/web/src/app/tools/vault-export/export.component.ts
+++ b/apps/web/src/app/tools/vault-export/export.component.ts
@@ -95,7 +95,6 @@ export class ExportComponent extends BaseExportComponent {
     }
 
     const result = await UserVerificationDialogComponent.open(this.dialogService, {
-      clientSideOnlyVerification: true,
       title: "confirmVaultExport",
       bodyText: confirmDescription,
       confirmButtonOptions: {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Export from TDE accounts should ask for an email code verification and not a PIN

## Code changes

- **web/export.component.ts:** Removed the set to `clientSideOnlyVerification` on the UserVerificationDialog as it was preventing the use of OTP.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
