### PR TITLE
Only Run Migrations in True Background

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -993,7 +993,8 @@ export default class MainBackground {
   async bootstrap() {
     this.containerService.attachToGlobal(self);
 
-    await this.stateService.init();
+    // Only the "true" background should run migrations
+    await this.stateService.init({ runMigrations: !this.popupOnlyContext });
 
     await this.vaultTimeoutService.init(true);
     await (this.i18nService as I18nService).init();

--- a/apps/browser/src/popup/services/init.service.ts
+++ b/apps/browser/src/popup/services/init.service.ts
@@ -23,7 +23,7 @@ export class InitService {
 
   init() {
     return async () => {
-      await this.stateService.init();
+      await this.stateService.init({ runMigrations: false }); // Browser background is responsible for migrations
       await this.i18nService.init();
 
       if (!BrowserPopupUtils.inPopup(window)) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Attempt to run migrations less often, the actual migration would still only have been ran once in each context but it would _attempt_ to run it more often and it would do this by checking the state version and running each migrations `shouldUpdate` method, they would all likely return false from that but it's still work we don't need to do.

| Context | Branch | MV2 | MV3 |
| ------ | --- | --- | --- |
| Background | `main` | 1 | 1 |
| Foreground | `main` | 1 | 2 |
| Background | `run-migrations-less-often` | 1 | 1 (per SW instantiation) |
| Foreground | `run-migrations-less-often` | 0 | 0 |

We could still improve browser even more by just running migrations inside of a `chrome.runtime.onInstalled` but that is for another time.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
