### PR TITLE
Tell `PROVIDERS` to clear its own state on logout

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1131,7 +1131,6 @@ export default class MainBackground {
       this.vaultTimeoutSettingsService.clear(userId),
       this.vaultFilterService.clear(),
       this.biometricStateService.logout(userId),
-      this.providerService.save(null, userId),
       /* We intentionally do not clear:
        *  - autofillSettingsService
        *  - badgeSettingsService

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -697,7 +697,6 @@ export class Main {
       this.collectionService.clear(userId as UserId),
       this.policyService.clear(userId as UserId),
       this.passwordGenerationService.clear(),
-      this.providerService.save(null, userId as UserId),
     ]);
 
     await this.stateEventRunnerService.handleEvent("logout", userId as UserId);

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -585,7 +585,6 @@ export class AppComponent implements OnInit, OnDestroy {
       await this.vaultTimeoutSettingsService.clear(userBeingLoggedOut);
       await this.policyService.clear(userBeingLoggedOut);
       await this.biometricStateService.logout(userBeingLoggedOut as UserId);
-      await this.providerService.save(null, userBeingLoggedOut as UserId);
 
       await this.stateEventRunnerService.handleEvent("logout", userBeingLoggedOut as UserId);
 

--- a/libs/common/src/admin-console/services/provider.service.ts
+++ b/libs/common/src/admin-console/services/provider.service.ts
@@ -1,13 +1,14 @@
 import { Observable, map, firstValueFrom, of, switchMap, take } from "rxjs";
 
-import { KeyDefinition, PROVIDERS_DISK, StateProvider } from "../../platform/state";
+import { UserKeyDefinition, PROVIDERS_DISK, StateProvider } from "../../platform/state";
 import { UserId } from "../../types/guid";
 import { ProviderService as ProviderServiceAbstraction } from "../abstractions/provider.service";
 import { ProviderData } from "../models/data/provider.data";
 import { Provider } from "../models/domain/provider";
 
-export const PROVIDERS = KeyDefinition.record<ProviderData>(PROVIDERS_DISK, "providers", {
+export const PROVIDERS = UserKeyDefinition.record<ProviderData>(PROVIDERS_DISK, "providers", {
   deserializer: (obj: ProviderData) => obj,
+  clearOn: ["logout"],
 });
 
 function mapToSingleProvider(providerId: string) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

These changes swap the `PROVIDERS` `KeyDefinition` to a `UserKeyDefinition`. The difference is that `UserKeyDefinition` comes with some baked in functionality for clearing state on lock or logout.

Using this new type lets us remove boilerplate lines from the centralized `logOut` methods in each application that clear state. 