### PR TITLE
Tell `POLICIES` to clear its own state on logout

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1126,7 +1126,6 @@ export default class MainBackground {
       this.cipherService.clear(userId),
       this.folderService.clear(userId),
       this.collectionService.clear(userId),
-      this.policyService.clear(userId),
       this.passwordGenerationService.clear(userId),
       this.vaultTimeoutSettingsService.clear(userId),
       this.vaultFilterService.clear(),

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -695,7 +695,6 @@ export class Main {
       this.cipherService.clear(userId),
       this.folderService.clear(userId),
       this.collectionService.clear(userId as UserId),
-      this.policyService.clear(userId as UserId),
       this.passwordGenerationService.clear(),
       this.providerService.save(null, userId as UserId),
     ]);

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -583,7 +583,6 @@ export class AppComponent implements OnInit, OnDestroy {
       await this.collectionService.clear(userBeingLoggedOut);
       await this.passwordGenerationService.clear(userBeingLoggedOut);
       await this.vaultTimeoutSettingsService.clear(userBeingLoggedOut);
-      await this.policyService.clear(userBeingLoggedOut);
       await this.biometricStateService.logout(userBeingLoggedOut as UserId);
       await this.providerService.save(null, userBeingLoggedOut as UserId);
 

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -274,7 +274,6 @@ export class AppComponent implements OnDestroy, OnInit {
       this.cipherService.clear(userId),
       this.folderService.clear(userId),
       this.collectionService.clear(userId),
-      this.policyService.clear(userId),
       this.passwordGenerationService.clear(),
       this.biometricStateService.logout(userId as UserId),
       this.paymentMethodWarningService.clear(),

--- a/libs/common/src/admin-console/abstractions/policy/policy.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/policy/policy.service.abstraction.ts
@@ -78,5 +78,4 @@ export abstract class PolicyService {
 export abstract class InternalPolicyService extends PolicyService {
   upsert: (policy: PolicyData) => Promise<void>;
   replace: (policies: { [id: string]: PolicyData }) => Promise<void>;
-  clear: (userId?: string) => Promise<void>;
 }

--- a/libs/common/src/admin-console/services/policy/policy.service.spec.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.spec.ts
@@ -102,66 +102,6 @@ describe("PolicyService", () => {
     ]);
   });
 
-  describe("clear", () => {
-    beforeEach(() => {
-      activeUserState.nextState(
-        arrayToRecord([
-          policyData("1", "test-organization", PolicyType.MaximumVaultTimeout, true, {
-            minutes: 14,
-          }),
-        ]),
-      );
-    });
-
-    it("clears state for the active user", async () => {
-      await policyService.clear();
-
-      expect(await firstValueFrom(policyService.policies$)).toEqual([]);
-      expect(await firstValueFrom(activeUserState.state$)).toEqual(null);
-      expect(stateProvider.activeUser.getFake(POLICIES).nextMock).toHaveBeenCalledWith([
-        "userId",
-        null,
-      ]);
-    });
-
-    it("clears state for an inactive user", async () => {
-      const inactiveUserId = "someOtherUserId" as UserId;
-      const inactiveUserState = stateProvider.singleUser.getFake(inactiveUserId, POLICIES);
-      inactiveUserState.nextState(
-        arrayToRecord([
-          policyData("10", "another-test-organization", PolicyType.PersonalOwnership, true),
-        ]),
-      );
-
-      await policyService.clear(inactiveUserId);
-
-      // Active user is not affected
-      const expectedActiveUserPolicy: Partial<Policy> = {
-        id: "1" as PolicyId,
-        organizationId: "test-organization",
-        type: PolicyType.MaximumVaultTimeout,
-        enabled: true,
-        data: { minutes: 14 },
-      };
-      expect(await firstValueFrom(policyService.policies$)).toEqual([expectedActiveUserPolicy]);
-      expect(await firstValueFrom(activeUserState.state$)).toEqual({
-        "1": expectedActiveUserPolicy,
-      });
-      expect(stateProvider.activeUser.getFake(POLICIES).nextMock).not.toHaveBeenCalled();
-
-      // Non-active user is cleared
-      expect(
-        await firstValueFrom(
-          policyService.getAll$(PolicyType.PersonalOwnership, "someOtherUserId" as UserId),
-        ),
-      ).toEqual([]);
-      expect(await firstValueFrom(inactiveUserState.state$)).toEqual(null);
-      expect(
-        stateProvider.singleUser.getFake("someOtherUserId" as UserId, POLICIES).nextMock,
-      ).toHaveBeenCalledWith(null);
-    });
-  });
-
   describe("masterPasswordPolicyOptions", () => {
     it("returns default policy options", async () => {
       const data: any = {

--- a/libs/common/src/admin-console/services/policy/policy.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.ts
@@ -1,6 +1,6 @@
 import { combineLatest, firstValueFrom, map, Observable, of } from "rxjs";
 
-import { KeyDefinition, POLICIES_DISK, StateProvider } from "../../../platform/state";
+import { UserKeyDefinition, POLICIES_DISK, StateProvider } from "../../../platform/state";
 import { PolicyId, UserId } from "../../../types/guid";
 import { OrganizationService } from "../../abstractions/organization/organization.service.abstraction";
 import { InternalPolicyService as InternalPolicyServiceAbstraction } from "../../abstractions/policy/policy.service.abstraction";
@@ -14,8 +14,9 @@ import { ResetPasswordPolicyOptions } from "../../models/domain/reset-password-p
 const policyRecordToArray = (policiesMap: { [id: string]: PolicyData }) =>
   Object.values(policiesMap || {}).map((f) => new Policy(f));
 
-export const POLICIES = KeyDefinition.record<PolicyData, PolicyId>(POLICIES_DISK, "policies", {
+export const POLICIES = UserKeyDefinition.record<PolicyData, PolicyId>(POLICIES_DISK, "policies", {
   deserializer: (policyData) => policyData,
+  clearOn: ["logout"],
 });
 
 export class PolicyService implements InternalPolicyServiceAbstraction {
@@ -220,10 +221,6 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
 
   async replace(policies: { [id: string]: PolicyData }): Promise<void> {
     await this.activeUserPolicyState.update(() => policies);
-  }
-
-  async clear(userId?: UserId): Promise<void> {
-    await this.stateProvider.setUserState(POLICIES, null, userId);
   }
 
   /**


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

These changes swap the `POLICIES` `KeyDefinition` to a `UserKeyDefinition`. The difference is that UserKeyDefinition comes with some baked in functionality for clearing state on lock or logout.

Using this new type lets us remove boilerplate lines from the centralized logOut methods in each application that clear state.