### PR TITLE
[PM-7229] Fix circular dependency in ErrorHandler

### DIFF
--- a/libs/angular/src/platform/services/logging-error-handler.ts
+++ b/libs/angular/src/platform/services/logging-error-handler.ts
@@ -12,7 +12,13 @@ export class LoggingErrorHandler extends ErrorHandler {
   private injector = inject(Injector);
 
   override handleError(error: any): void {
-    const logService = this.injector.get(LogService);
-    logService.error(error);
+  override handleError(error: any): void {
+    try {
+      const logService = this.injector.get(LogService, null);
+      logService.error(error);
+    } catch {
+      super.handleError(error);
+    }
+  }
   }
 }

--- a/libs/angular/src/platform/services/logging-error-handler.ts
+++ b/libs/angular/src/platform/services/logging-error-handler.ts
@@ -12,13 +12,11 @@ export class LoggingErrorHandler extends ErrorHandler {
   private injector = inject(Injector);
 
   override handleError(error: any): void {
-  override handleError(error: any): void {
     try {
       const logService = this.injector.get(LogService, null);
       logService.error(error);
     } catch {
       super.handleError(error);
     }
-  }
   }
 }

--- a/libs/angular/src/platform/services/logging-error-handler.ts
+++ b/libs/angular/src/platform/services/logging-error-handler.ts
@@ -1,14 +1,18 @@
-import { ErrorHandler, Injectable } from "@angular/core";
+import { ErrorHandler, Injectable, Injector, inject } from "@angular/core";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
 @Injectable()
 export class LoggingErrorHandler extends ErrorHandler {
-  constructor(private readonly logService: LogService) {
-    super();
-  }
+  /**
+   * When injecting services into an `ErrorHandler`, we must use the `Injector` manually to avoid circular dependency errors.
+   *
+   * https://stackoverflow.com/a/57115053
+   */
+  private injector = inject(Injector);
 
   override handleError(error: any): void {
-    this.logService.error(error);
+    const logService = this.injector.get(LogService);
+    logService.error(error);
   }
 }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1075,7 +1075,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: ErrorHandler,
     useClass: LoggingErrorHandler,
-    deps: [LogService],
+    deps: [],
   }),
 ];
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The custom `ErrorHandler` recently introduced ([here](https://github.com/bitwarden/clients/pull/8543)) causes a circular dependency error for `APPLICATION_REF`. 

~It is unclear to me why exactly this is happening~, but injecting the dependency with `Injector.get` solves the issue.

edit: This seems to be a known issue. See here: https://medium.com/@amcdnl/global-error-handling-with-angular2-6b992bdfb59c

> There is one problem though, since error handling is really important it needs to be loaded first, thus making it not possible to use dependency injection in the constructor to get other services such as the error handle api service to send the server our error details. As a result, we have to manually call the injector with the service name in the execution of the handleError function

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
