### PR TITLE
Autofill `UserKeyDefinition` migration

### DIFF
--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -9,40 +9,46 @@ import {
   GlobalState,
   KeyDefinition,
   StateProvider,
+  UserKeyDefinition,
 } from "../../platform/state";
 import { ClearClipboardDelay, AutofillOverlayVisibility } from "../constants";
 import { ClearClipboardDelaySetting, InlineMenuVisibilitySetting } from "../types";
 
-const AUTOFILL_ON_PAGE_LOAD = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autofillOnPageLoad", {
+const AUTOFILL_ON_PAGE_LOAD = new UserKeyDefinition(AUTOFILL_SETTINGS_DISK, "autofillOnPageLoad", {
   deserializer: (value: boolean) => value ?? false,
+  clearOn: [], // User setting so we don't clear it on lock or logout
 });
 
-const AUTOFILL_ON_PAGE_LOAD_DEFAULT = new KeyDefinition(
+const AUTOFILL_ON_PAGE_LOAD_DEFAULT = new UserKeyDefinition(
   AUTOFILL_SETTINGS_DISK,
   "autofillOnPageLoadDefault",
   {
     deserializer: (value: boolean) => value ?? false,
+    clearOn: [], // User setting so we don't clear it on lock or logout
   },
 );
 
-const AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED = new KeyDefinition(
+const AUTOFILL_ON_PAGE_LOAD_CALLOUT_DISMISSED = new UserKeyDefinition(
   AUTOFILL_SETTINGS_DISK,
   "autofillOnPageLoadCalloutIsDismissed",
   {
     deserializer: (value: boolean) => value ?? false,
+    clearOn: [], // Don't redisplay callout on same device if they've ever dismissed it, so don't clear ever.
   },
 );
 
-const AUTOFILL_ON_PAGE_LOAD_POLICY_TOAST_HAS_DISPLAYED = new KeyDefinition(
+const AUTOFILL_ON_PAGE_LOAD_POLICY_TOAST_HAS_DISPLAYED = new UserKeyDefinition(
   AUTOFILL_SETTINGS_DISK,
   "autofillOnPageLoadPolicyToastHasDisplayed",
   {
     deserializer: (value: boolean) => value ?? false,
+    clearOn: [], // Don't redisplay toast on same device if they've ever dismissed it, so don't clear ever.
   },
 );
 
-const AUTO_COPY_TOTP = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
+const AUTO_COPY_TOTP = new UserKeyDefinition(AUTOFILL_SETTINGS_DISK, "autoCopyTotp", {
   deserializer: (value: boolean) => value ?? true,
+  clearOn: [], // User setting so we don't clear it on lock or logout
 });
 
 const INLINE_MENU_VISIBILITY = new KeyDefinition(
@@ -57,11 +63,12 @@ const ENABLE_CONTEXT_MENU = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "enableCon
   deserializer: (value: boolean) => value ?? true,
 });
 
-const CLEAR_CLIPBOARD_DELAY = new KeyDefinition(
+const CLEAR_CLIPBOARD_DELAY = new UserKeyDefinition(
   AUTOFILL_SETTINGS_DISK_LOCAL,
   "clearClipboardDelay",
   {
     deserializer: (value: ClearClipboardDelaySetting) => value ?? ClearClipboardDelay.Never,
+    clearOn: [], // User setting so we don't clear it on lock or logout
   },
 );
 

--- a/libs/common/src/autofill/services/badge-settings.service.ts
+++ b/libs/common/src/autofill/services/badge-settings.service.ts
@@ -3,12 +3,13 @@ import { map, Observable } from "rxjs";
 import {
   BADGE_SETTINGS_DISK,
   ActiveUserState,
-  KeyDefinition,
   StateProvider,
+  UserKeyDefinition,
 } from "../../platform/state";
 
-const ENABLE_BADGE_COUNTER = new KeyDefinition(BADGE_SETTINGS_DISK, "enableBadgeCounter", {
+const ENABLE_BADGE_COUNTER = new UserKeyDefinition(BADGE_SETTINGS_DISK, "enableBadgeCounter", {
   deserializer: (value: boolean) => value ?? true,
+  clearOn: [], // This is a user setting, we don't clear it on lock or logout
 });
 
 export abstract class BadgeSettingsServiceAbstraction {

--- a/libs/common/src/autofill/services/domain-settings.service.ts
+++ b/libs/common/src/autofill/services/domain-settings.service.ts
@@ -29,11 +29,12 @@ const EQUIVALENT_DOMAINS = new UserKeyDefinition(DOMAIN_SETTINGS_DISK, "equivale
   clearOn: ["logout"],
 });
 
-const DEFAULT_URI_MATCH_STRATEGY = new KeyDefinition(
+const DEFAULT_URI_MATCH_STRATEGY = new UserKeyDefinition(
   DOMAIN_SETTINGS_DISK,
   "defaultUriMatchStrategy",
   {
     deserializer: (value: UriMatchStrategySetting) => value ?? UriMatchStrategy.Domain,
+    clearOn: [], // User setting so it doesn't need to be cleared on lock or logout
   },
 );
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Platform has decided we want to push up our timeline of deprecating the usage of `KeyDefinition` for user based state. [`UserKeyDefinition`](https://add-state-provider-framework.contributing-docs.pages.dev/architecture/deep-dives/state/#key-definition-options) is relatively new but it requires implementers to define the lifecycle of your data by implementing the `clearOn` property. Before this change, there was an implicit conversion from `KeyDefinition` -> `UserKeyDefinition` and would default the `clearOn` property to an empty array, which meant that data was never cleared during lock or logout. We'd rather each implemented explicitly declare `[]` themselves and take ownership of the lifecycle of their data. 

So in this PR you should review the addition of the `clearOn` property on your state, if it has `[]`, you can know that it is functionally equivalent but that doesn't mean it is _right_. Please think about if your data should be deleted when a user locks the vault or logs out. If I added a value to the `clearOn` array then I have made a behavioral change to your code, please ensure that I have done so correctly and the comment I have made is accurate and summarizes the decision well.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
