### PR TITLE
Secrets Manager `UserKeyDefinition` Migration

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/sm-onboarding-tasks.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/sm-onboarding-tasks.service.ts
@@ -3,16 +3,21 @@ import { Observable, map } from "rxjs";
 
 import {
   ActiveUserState,
-  KeyDefinition,
   SM_ONBOARDING_DISK,
   StateProvider,
+  UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 
 export type SMOnboardingTasks = Record<string, Record<string, boolean>>;
 
-const SM_ONBOARDING_TASKS_KEY = new KeyDefinition<SMOnboardingTasks>(SM_ONBOARDING_DISK, "tasks", {
-  deserializer: (b) => b,
-});
+const SM_ONBOARDING_TASKS_KEY = new UserKeyDefinition<SMOnboardingTasks>(
+  SM_ONBOARDING_DISK,
+  "tasks",
+  {
+    deserializer: (b) => b,
+    clearOn: [], // Used to track tasks completed by a user, we don't want to reshow if they've locked or logged out and came back to the app
+  },
+);
 
 @Injectable({
   providedIn: "root",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Platform has decided we want to push up our timeline of deprecating the usage of `KeyDefinition` for user based state. [`UserKeyDefinition`](https://add-state-provider-framework.contributing-docs.pages.dev/architecture/deep-dives/state/#key-definition-options) is relatively new but it requires implementers to define the lifecycle of your data by implementing the `clearOn` property. Before this change, there was an implicit conversion from `KeyDefinition` -> `UserKeyDefinition` and would default the `clearOn` property to an empty array, which meant that data was never cleared during lock or logout. We'd rather each implemented explicitly declare `[]` themselves and take ownership of the lifecycle of their data. 

So in this PR you should review the addition of the `clearOn` property on your state, if it has `[]`, you can know that it is functionally equivalent but that doesn't mean it is _right_. Please think about if your data should be deleted when a user locks the vault or logs out. If I added a value to the `clearOn` array then I have made a behavioral change to your code, please ensure that I have done so correctly and the comment I have made is accurate and summarizes the decision well.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
