### PR TITLE
[CL-253] Fix undefined reference to `keyManager` within `menu-trigger-for` directive

### DIFF
--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -88,12 +88,12 @@ export class MenuTriggerForDirective implements OnDestroy {
       }
       this.destroyMenu();
     });
-    this.menu.keyManager.setFirstItemActive();
-    this.keyDownEventsSub =
-      this.menu.keyManager &&
-      this.overlayRef
+    if (this.menu.keyManager) {
+      this.menu.keyManager.setFirstItemActive();
+      this.keyDownEventsSub = this.overlayRef
         .keydownEvents()
         .subscribe((event: KeyboardEvent) => this.menu.keyManager.onKeydown(event));
+    }
   }
 
   private destroyMenu() {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Within the `menu-trigger-for.directive.ts` file, we should be conditionally referencing the `this.menu.keyManager` class. This class is not instantiated in cases where the ARIA role of the MenuComponent is not `'menu'`.

## Code changes

- **libs/components/src/menu/menu-trigger-for.directive.ts:** Wrapping both calls to `this.menu.keyManager` within a conditional that ensures it is a defined value.
