### PR TITLE
[PM-7216] Bugfix - Fix notification bar content script using old server config state storage

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/notification.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/notification.background.ts
@@ -1,4 +1,5 @@
 import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
+import { ServerConfig } from "@bitwarden/common/platform/abstractions/config/server-config";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 
 import { NotificationQueueMessageTypes } from "../../enums/notification-queue-message-type.enum";
@@ -113,6 +114,7 @@ type NotificationBackgroundExtensionMessageHandlers = {
   bgGetEnableChangedPasswordPrompt: () => Promise<boolean>;
   bgGetEnableAddedLoginPrompt: () => Promise<boolean>;
   bgGetExcludedDomains: () => Promise<NeverDomains>;
+  bgGetActiveUserServerConfig: () => Promise<ServerConfig>;
   getWebVaultUrlForNotification: () => Promise<string>;
 };
 

--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -6,6 +6,7 @@ import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authenticatio
 import { AuthService } from "@bitwarden/common/auth/services/auth.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { UserNotificationSettingsService } from "@bitwarden/common/autofill/services/user-notification-settings.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SelfHostedEnvironment } from "@bitwarden/common/platform/services/default-environment.service";
@@ -54,6 +55,7 @@ describe("NotificationBackground", () => {
   const environmentService = mock<EnvironmentService>();
   const logService = mock<LogService>();
   const themeStateService = mock<ThemeStateService>();
+  const configService = mock<ConfigService>();
 
   beforeEach(() => {
     notificationBackground = new NotificationBackground(
@@ -68,6 +70,7 @@ describe("NotificationBackground", () => {
       environmentService,
       logService,
       themeStateService,
+      configService,
     );
   });
 

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -8,6 +8,8 @@ import { NOTIFICATION_BAR_LIFESPAN_MS } from "@bitwarden/common/autofill/constan
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { UserNotificationSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/user-notification-settings.service";
 import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { ServerConfig } from "@bitwarden/common/platform/abstractions/config/server-config";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -64,6 +66,7 @@ export default class NotificationBackground {
     bgGetEnableChangedPasswordPrompt: () => this.getEnableChangedPasswordPrompt(),
     bgGetEnableAddedLoginPrompt: () => this.getEnableAddedLoginPrompt(),
     bgGetExcludedDomains: () => this.getExcludedDomains(),
+    bgGetActiveUserServerConfig: () => this.getActiveUserServerConfig(),
     getWebVaultUrlForNotification: () => this.getWebVaultUrl(),
   };
 
@@ -79,6 +82,7 @@ export default class NotificationBackground {
     private environmentService: EnvironmentService,
     private logService: LogService,
     private themeStateService: ThemeStateService,
+    private configService: ConfigService,
   ) {}
 
   async init() {
@@ -110,6 +114,13 @@ export default class NotificationBackground {
    */
   async getExcludedDomains(): Promise<NeverDomains> {
     return await firstValueFrom(this.domainSettingsService.neverDomains$);
+  }
+
+  /**
+   * Gets the active user server config from the config service.
+   */
+  async getActiveUserServerConfig(): Promise<ServerConfig> {
+    return await firstValueFrom(this.configService.serverConfig$);
   }
 
   /**

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -908,6 +908,7 @@ export default class MainBackground {
       this.environmentService,
       this.logService,
       themeStateService,
+      this.configService,
     );
     this.overlayBackground = new OverlayBackground(
       this.cipherService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix

## Objective

Looks like things broke with the state updates in https://github.com/bitwarden/clients/pull/8325

![Screenshot 2024-04-04 at 11 32 50 AM](https://github.com/bitwarden/clients/assets/1556494/26e43518-016a-4f20-8f41-2c5364a615b3)

![Screenshot 2024-04-04 at 11 30 58 AM](https://github.com/bitwarden/clients/assets/1556494/38edf08d-551b-43b3-bbd6-50422eddddf4)

The notification bar content script is still looking in the old state location for the server config

These changes add messaging to the notification bar background in order to get the server config values from the new state service location.