### PR TITLE
[AC-2404] Fix subscription page for free org with new statuses enabled

### DIFF
--- a/apps/web/src/app/billing/organizations/subscription-status.component.html
+++ b/apps/web/src/app/billing/organizations/subscription-status.component.html
@@ -14,7 +14,7 @@
   <dl class="tw-grid tw-grid-flow-col tw-grid-rows-2">
     <dt>{{ "billingPlan" | i18n }}</dt>
     <dd>{{ planName }}</dd>
-    <ng-container>
+    <ng-container *ngIf="data.status && data.date">
       <dt>{{ data.status.label }}</dt>
       <dd>
         <span class="tw-capitalize">

--- a/apps/web/src/app/billing/organizations/subscription-status.component.ts
+++ b/apps/web/src/app/billing/organizations/subscription-status.component.ts
@@ -5,11 +5,11 @@ import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/mode
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 type ComponentData = {
-  status: {
+  status?: {
     label: string;
     value: string;
   };
-  date: {
+  date?: {
     label: string;
     value: string;
   };
@@ -44,13 +44,15 @@ export class SubscriptionStatusComponent {
   }
 
   get status(): string {
-    return this.subscription.status != "canceled" && this.subscription.cancelAtEndDate
-      ? "pending_cancellation"
-      : this.subscription.status;
+    return this.subscription
+      ? this.subscription.status != "canceled" && this.subscription.cancelAtEndDate
+        ? "pending_cancellation"
+        : this.subscription.status
+      : "free";
   }
 
   get subscription() {
-    return this.organizationSubscriptionResponse.subscription;
+    return this.organizationSubscriptionResponse?.subscription;
   }
 
   get data(): ComponentData {
@@ -61,6 +63,9 @@ export class SubscriptionStatusComponent {
     const cancellationDateLabel = this.i18nService.t("cancellationDate");
 
     switch (this.status) {
+      case "free": {
+        return {};
+      }
       case "trialing": {
         return {
           status: {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The refactoring completed as part of [AC-1759](https://bitwarden.atlassian.net/browse/AC-1759) did not take into account what happens when the organization is free (doesn't have a Stripe subscription). This PR handles that case.


https://github.com/bitwarden/clients/assets/144709477/865f61d8-d144-4f67-8060-0e6e51faf4cd






[AC-1759]: https://bitwarden.atlassian.net/browse/AC-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ