### PR TITLE
[PM-7292] Fix viewing/editing unassigned ciphers for admins

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -213,7 +213,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       switchMap(async ([organization]) => {
         this.organization = organization;
 
-        if (!organization.canUseAdminCollections(this.flexibleCollectionsV1Enabled)) {
+        if (!organization.canEditAnyCollection(this.flexibleCollectionsV1Enabled)) {
           await this.syncService.fullSync(false);
         }
 
@@ -407,7 +407,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     ]).pipe(
       map(([filter, collection, organization]) => {
         return (
-          (filter.collectionId === Unassigned && !organization.canEditUnassignedCiphers) ||
+          (filter.collectionId === Unassigned && !organization.canEditUnassignedCiphers()) ||
           (!organization.canEditAllCiphers(this.flexibleCollectionsV1Enabled) &&
             collection != undefined &&
             !collection.node.assigned)
@@ -453,12 +453,11 @@ export class VaultComponent implements OnInit, OnDestroy {
       map(([filter, collection, organization]) => {
         return (
           // Filtering by unassigned, show message if not admin
-          (filter.collectionId === Unassigned &&
-            !organization.canUseAdminCollections(this.flexibleCollectionsV1Enabled)) ||
+          (filter.collectionId === Unassigned && !organization.canEditUnassignedCiphers()) ||
           // Filtering by a collection, so show message if user is not assigned
           (collection != undefined &&
             !collection.node.assigned &&
-            !organization.canUseAdminCollections(this.flexibleCollectionsV1Enabled))
+            !organization.canEditAnyCollection(this.flexibleCollectionsV1Enabled))
         );
       }),
       shareReplay({ refCount: true, bufferSize: 1 }),
@@ -481,7 +480,7 @@ export class VaultComponent implements OnInit, OnDestroy {
               (await firstValueFrom(allCipherMap$))[cipherId] != undefined;
           } else {
             canEditCipher =
-              organization.canUseAdminCollections(this.flexibleCollectionsV1Enabled) ||
+              organization.canEditAnyCollection(this.flexibleCollectionsV1Enabled) ||
               (await this.cipherService.get(cipherId)) != null;
           }
 

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -407,8 +407,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     ]).pipe(
       map(([filter, collection, organization]) => {
         return (
-          (filter.collectionId === Unassigned &&
-            !organization.canUseAdminCollections(this.flexibleCollectionsV1Enabled)) ||
+          (filter.collectionId === Unassigned && !organization.canEditUnassignedCiphers) ||
           (!organization.canEditAllCiphers(this.flexibleCollectionsV1Enabled) &&
             collection != undefined &&
             !collection.node.assigned)

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -662,7 +662,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
 
     // if a cipher is unassigned we want to check if they are an admin or have permission to edit any collection
     if (!cipher.collectionIds) {
-      orgAdmin = this.organization?.canEditAllCiphers(this.flexibleCollectionsV1Enabled);
+      orgAdmin = this.organization?.canEditUnassignedCiphers();
     }
 
     return this.cipher.id == null

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -207,6 +207,11 @@ export class Organization {
     return this.canEditAnyCollection(flexibleCollectionsV1Enabled);
   }
 
+  canEditUnassignedCiphers() {
+    // TODO: Update this to exclude Providers if provider access is restricted in AC-1707
+    return this.isAdmin || this.permissions.editAnyCollection;
+  }
+
   canEditAllCiphers(flexibleCollectionsV1Enabled: boolean) {
     // Before Flexible Collections, any admin or anyone with editAnyCollection permission could edit all ciphers
     if (!this.flexibleCollections || !flexibleCollectionsV1Enabled) {

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -203,10 +203,6 @@ export class Organization {
     );
   }
 
-  canUseAdminCollections(flexibleCollectionsV1Enabled: boolean) {
-    return this.canEditAnyCollection(flexibleCollectionsV1Enabled);
-  }
-
   canEditUnassignedCiphers() {
     // TODO: Update this to exclude Providers if provider access is restricted in AC-1707
     return this.isAdmin || this.permissions.editAnyCollection;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We recently made a change to use the `canEditAnyCollection` helper to determine if a user can edit unassigned ciphers. This no longer works because `canEditAnyCollection` will start to return false in V1 FC when admins are restricted. So we need a separate helper to determine if the user can access unassigned ciphers (any admin/owner or custom user with `editAnyCollection` permission) 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **organization.ts:**
  - Add a new `canEditUnassignedCiphers()` helper 
  - Remove the redundant and ambiguous `canUseAdminCollections()` helper that was just a wrapper around `canEditAnyCollection()` and was adding unnecessary noise to our permissions.

- **vault.component.ts:**
  - Use `canEditUnassignedCiphers` where appropriate
  - Replace uses of `canUseAdminCollections()` with `canEditAnyCollection()`

- **add-edit.component.ts:**
  - Use `canEditUnassignedCiphers` helper instead of `canEditAnyCollection()`


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
