### PR TITLE
[PM-7345] apply password generator policy categorically

### DIFF
--- a/libs/common/src/admin-console/services/policy/policy.service.spec.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.spec.ts
@@ -50,6 +50,8 @@ describe("PolicyService", () => {
       organization("org4", true, true, OrganizationUserStatusType.Confirmed, false),
       // Another User
       organization("org5", true, true, OrganizationUserStatusType.Confirmed, false),
+      // Can manage policies
+      organization("org6", true, true, OrganizationUserStatusType.Confirmed, true),
     ]);
 
     policyService = new PolicyService(stateProvider, organizationService);
@@ -252,6 +254,22 @@ describe("PolicyService", () => {
       );
 
       expect(result).toBeNull();
+    });
+
+    it.each([
+      ["owners", "org2"],
+      ["administrators", "org6"],
+    ])("returns the password generator policy for %s", async (_, organization) => {
+      activeUserState.nextState(
+        arrayToRecord([
+          policyData("policy1", "org1", PolicyType.ActivateAutofill, false),
+          policyData("policy2", organization, PolicyType.PasswordGenerator, true),
+        ]),
+      );
+
+      const result = await firstValueFrom(policyService.get$(PolicyType.PasswordGenerator));
+
+      expect(result).toBeTruthy();
     });
 
     it("does not return policies for organizations that do not use policies", async () => {

--- a/libs/common/src/admin-console/services/policy/policy.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.ts
@@ -232,6 +232,9 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
       case PolicyType.MaximumVaultTimeout:
         // Max Vault Timeout applies to everyone except owners
         return organization.isOwner;
+      case PolicyType.PasswordGenerator:
+        // password generation policy applies to everyone
+        return false;
       default:
         return organization.canManagePolicies;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This fixes a regression for password generator policy. The policy should always apply to all users, including to owners and policy administrators.

## Code changes

- **libs/common/src/admin-console/services/policy/policy.service.ts:** categorically apply password generation policy
- **libs/common/src/admin-console/services/policy/policy.service.spec.ts:** test that the policy is returned for owners and policy administrators
