### PR TITLE
[AC-2420] Hide SM checkbox on member invite when org is on SM Standalone

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -371,7 +371,7 @@
               </div>
             </ng-template>
           </ng-container>
-          <ng-container *ngIf="organization.useSecretsManager">
+          <ng-container *ngIf="organization.useSecretsManager && !isOnSecretsManagerStandalone">
             <h3 class="mt-4">
               {{ "secretsManager" | i18n }}
               <a

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -62,6 +62,7 @@ export interface MemberDialogParams {
   organizationUserId: string;
   allOrganizationUserEmails: string[];
   usesKeyConnector: boolean;
+  isOnSecretsManagerStandalone: boolean;
   initialTab?: MemberDialogTab;
   numConfirmedMembers: number;
 }
@@ -87,6 +88,7 @@ export class MemberDialogComponent implements OnDestroy {
   organizationUserType = OrganizationUserType;
   PermissionMode = PermissionMode;
   showNoMasterPasswordWarning = false;
+  isOnSecretsManagerStandalone: boolean;
 
   protected organization$: Observable<Organization>;
   protected collectionAccessItems: AccessItemView[] = [];
@@ -159,6 +161,7 @@ export class MemberDialogComponent implements OnDestroy {
     this.editMode = this.params.organizationUserId != null;
     this.tabIndex = this.params.initialTab ?? MemberDialogTab.Role;
     this.title = this.i18nService.t(this.editMode ? "editMember" : "inviteMember");
+    this.isOnSecretsManagerStandalone = this.params.isOnSecretsManagerStandalone;
 
     const groups$ = this.organization$.pipe(
       switchMap((organization) =>
@@ -411,7 +414,9 @@ export class MemberDialogComponent implements OnDestroy {
       ? null
       : this.formGroup.value.groups.map((m) => m.id);
 
-    userView.accessSecretsManager = this.formGroup.value.accessSecretsManager;
+    userView.accessSecretsManager = this.isOnSecretsManagerStandalone
+      ? true
+      : this.formGroup.value.accessSecretsManager;
 
     if (this.editMode) {
       await this.userService.save(userView);

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-client-organization-subscription.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-client-organization-subscription.component.ts
@@ -3,7 +3,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 
 import { ProviderOrganizationOrganizationDetailsResponse } from "@bitwarden/common/admin-console/models/response/provider/provider-organization.response";
 import { BillingApiServiceAbstraction as BillingApiService } from "@bitwarden/common/billing/abstractions/billilng-api.service.abstraction";
-import { ProviderSubscriptionUpdateRequest } from "@bitwarden/common/billing/models/request/provider-subscription-update.request";
+import { ProviderOrganizationUpdateRequest } from "@bitwarden/common/billing/models/request/provider-organization-update.request";
 import { Plans } from "@bitwarden/common/billing/models/response/provider-subscription-response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -45,7 +45,7 @@ export class ManageClientOrganizationSubscriptionComponent implements OnInit {
 
   async ngOnInit() {
     try {
-      const response = await this.billingApiService.getProviderClientSubscriptions(this.providerId);
+      const response = await this.billingApiService.getProviderSubscription(this.providerId);
       this.AdditionalSeatPurchased = this.getPurchasedSeatsByPlan(this.planName, response.plans);
       const seatMinimum = this.getProviderSeatMinimumByPlan(this.planName, response.plans);
       const assignedByPlan = this.getAssignedByPlan(this.planName, response.plans);
@@ -69,10 +69,10 @@ export class ManageClientOrganizationSubscriptionComponent implements OnInit {
       return;
     }
 
-    const request = new ProviderSubscriptionUpdateRequest();
+    const request = new ProviderOrganizationUpdateRequest();
     request.assignedSeats = assignedSeats;
 
-    await this.billingApiService.putProviderClientSubscriptions(
+    await this.billingApiService.updateProviderOrganization(
       this.providerId,
       this.providerOrganizationId,
       request,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1019,6 +1019,7 @@ const safeProviders: SafeProvider[] = [
     provide: OrganizationBillingServiceAbstraction,
     useClass: OrganizationBillingService,
     deps: [
+      BillingApiServiceAbstraction,
       CryptoServiceAbstraction,
       EncryptService,
       I18nServiceAbstraction,

--- a/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
@@ -1,5 +1,6 @@
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
 import { OrganizationBillingStatusResponse } from "../../billing/models/response/organization-billing-status.response";
+import { OrganizationSubscriptionResponse } from "../../billing/models/response/organization-subscription.response";
 import { ProviderOrganizationUpdateRequest } from "../models/request/provider-organization-update.request";
 import { ProviderSubscriptionResponse } from "../models/response/provider-subscription-response";
 
@@ -12,6 +13,10 @@ export abstract class BillingApiServiceAbstraction {
   cancelPremiumUserSubscription: (request: SubscriptionCancellationRequest) => Promise<void>;
 
   getBillingStatus: (id: string) => Promise<OrganizationBillingStatusResponse>;
+
+  getOrganizationSubscription: (
+    organizationId: string,
+  ) => Promise<OrganizationSubscriptionResponse>;
 
   getProviderSubscription: (providerId: string) => Promise<ProviderSubscriptionResponse>;
 

--- a/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
@@ -1,6 +1,6 @@
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
 import { OrganizationBillingStatusResponse } from "../../billing/models/response/organization-billing-status.response";
-import { ProviderSubscriptionUpdateRequest } from "../models/request/provider-subscription-update.request";
+import { ProviderOrganizationUpdateRequest } from "../models/request/provider-organization-update.request";
 import { ProviderSubscriptionResponse } from "../models/response/provider-subscription-response";
 
 export abstract class BillingApiServiceAbstraction {
@@ -8,12 +8,16 @@ export abstract class BillingApiServiceAbstraction {
     organizationId: string,
     request: SubscriptionCancellationRequest,
   ) => Promise<void>;
+
   cancelPremiumUserSubscription: (request: SubscriptionCancellationRequest) => Promise<void>;
+
   getBillingStatus: (id: string) => Promise<OrganizationBillingStatusResponse>;
-  getProviderClientSubscriptions: (providerId: string) => Promise<ProviderSubscriptionResponse>;
-  putProviderClientSubscriptions: (
+
+  getProviderSubscription: (providerId: string) => Promise<ProviderSubscriptionResponse>;
+
+  updateProviderOrganization: (
     providerId: string,
     organizationId: string,
-    request: ProviderSubscriptionUpdateRequest,
+    request: ProviderOrganizationUpdateRequest,
   ) => Promise<any>;
 }

--- a/libs/common/src/billing/abstractions/organization-billing.service.ts
+++ b/libs/common/src/billing/abstractions/organization-billing.service.ts
@@ -41,6 +41,8 @@ export type SubscriptionInformation = {
 };
 
 export abstract class OrganizationBillingServiceAbstraction {
+  isOnSecretsManagerStandalone: (organizationId: string) => Promise<boolean>;
+
   purchaseSubscription: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;
 
   startFree: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;

--- a/libs/common/src/billing/models/request/provider-organization-update.request.ts
+++ b/libs/common/src/billing/models/request/provider-organization-update.request.ts
@@ -1,0 +1,3 @@
+export class ProviderOrganizationUpdateRequest {
+  assignedSeats: number;
+}

--- a/libs/common/src/billing/models/request/provider-subscription-update.request.ts
+++ b/libs/common/src/billing/models/request/provider-subscription-update.request.ts
@@ -1,3 +1,0 @@
-export class ProviderSubscriptionUpdateRequest {
-  assignedSeats: number;
-}

--- a/libs/common/src/billing/services/billing-api.service.ts
+++ b/libs/common/src/billing/services/billing-api.service.ts
@@ -2,7 +2,7 @@ import { ApiService } from "../../abstractions/api.service";
 import { BillingApiServiceAbstraction } from "../../billing/abstractions/billilng-api.service.abstraction";
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
 import { OrganizationBillingStatusResponse } from "../../billing/models/response/organization-billing-status.response";
-import { ProviderSubscriptionUpdateRequest } from "../models/request/provider-subscription-update.request";
+import { ProviderOrganizationUpdateRequest } from "../models/request/provider-organization-update.request";
 import { ProviderSubscriptionResponse } from "../models/response/provider-subscription-response";
 
 export class BillingApiService implements BillingApiServiceAbstraction {
@@ -37,7 +37,7 @@ export class BillingApiService implements BillingApiServiceAbstraction {
     return new OrganizationBillingStatusResponse(r);
   }
 
-  async getProviderClientSubscriptions(providerId: string): Promise<ProviderSubscriptionResponse> {
+  async getProviderSubscription(providerId: string): Promise<ProviderSubscriptionResponse> {
     const r = await this.apiService.send(
       "GET",
       "/providers/" + providerId + "/billing/subscription",
@@ -48,10 +48,10 @@ export class BillingApiService implements BillingApiServiceAbstraction {
     return new ProviderSubscriptionResponse(r);
   }
 
-  async putProviderClientSubscriptions(
+  async updateProviderOrganization(
     providerId: string,
     organizationId: string,
-    request: ProviderSubscriptionUpdateRequest,
+    request: ProviderOrganizationUpdateRequest,
   ): Promise<any> {
     return await this.apiService.send(
       "PUT",

--- a/libs/common/src/billing/services/billing-api.service.ts
+++ b/libs/common/src/billing/services/billing-api.service.ts
@@ -2,6 +2,7 @@ import { ApiService } from "../../abstractions/api.service";
 import { BillingApiServiceAbstraction } from "../../billing/abstractions/billilng-api.service.abstraction";
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
 import { OrganizationBillingStatusResponse } from "../../billing/models/response/organization-billing-status.response";
+import { OrganizationSubscriptionResponse } from "../../billing/models/response/organization-subscription.response";
 import { ProviderOrganizationUpdateRequest } from "../models/request/provider-organization-update.request";
 import { ProviderSubscriptionResponse } from "../models/response/provider-subscription-response";
 
@@ -35,6 +36,19 @@ export class BillingApiService implements BillingApiServiceAbstraction {
     );
 
     return new OrganizationBillingStatusResponse(r);
+  }
+
+  async getOrganizationSubscription(
+    organizationId: string,
+  ): Promise<OrganizationSubscriptionResponse> {
+    const r = await this.apiService.send(
+      "GET",
+      "/organizations/" + organizationId + "/subscription",
+      null,
+      true,
+      true,
+    );
+    return new OrganizationSubscriptionResponse(r);
   }
 
   async getProviderSubscription(providerId: string): Promise<ProviderSubscriptionResponse> {

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -7,6 +7,7 @@ import { EncryptService } from "../../platform/abstractions/encrypt.service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
 import { EncString } from "../../platform/models/domain/enc-string";
 import { OrgKey } from "../../types/key";
+import { BillingApiServiceAbstraction as BillingApiService } from "../abstractions/billilng-api.service.abstraction";
 import {
   OrganizationBillingServiceAbstraction,
   OrganizationInformation,
@@ -25,11 +26,25 @@ interface OrganizationKeys {
 
 export class OrganizationBillingService implements OrganizationBillingServiceAbstraction {
   constructor(
+    private billingApiService: BillingApiService,
     private cryptoService: CryptoService,
     private encryptService: EncryptService,
     private i18nService: I18nService,
     private organizationApiService: OrganizationApiService,
   ) {}
+
+  async isOnSecretsManagerStandalone(organizationId: string): Promise<boolean> {
+    const response = await this.billingApiService.getOrganizationSubscription(organizationId);
+    if (response.customerDiscount?.id === "sm-standalone") {
+      const productIds = response.subscription.items.map((item) => item.productId);
+      return (
+        response.customerDiscount?.appliesTo.filter((appliesToProductId) =>
+          productIds.includes(appliesToProductId),
+        ).length > 0
+      );
+    }
+    return false;
+  }
 
   async purchaseSubscription(subscription: SubscriptionInformation): Promise<OrganizationResponse> {
     const request = new OrganizationCreateRequest();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR updates the `people.component` to check if the current organization is on SM Standalone. If it is, when the user tries to invite a new member, it hides the option to give the invited member access to SM and defaults it to `true`. This enforces a rule that SM standalone orgs cannot invite PM only members. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->


https://github.com/bitwarden/clients/assets/144709477/75eb6d20-12fc-4624-9fe9-ef91c1995e61



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
