### PR TITLE
[AC-2431] New collection dialog bug

### DIFF
--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts
@@ -101,7 +101,12 @@ export const getPermissionList = (flexibleCollectionsEnabled: boolean): Permissi
  * for the dropdown in the AccessSelectorComponent
  * @param value
  */
-export const convertToPermission = (value: CollectionAccessSelectionView) => {
+export const convertToPermission = (
+  value: CollectionAccessSelectionView | undefined,
+): CollectionPermission | undefined => {
+  if (value == null) {
+    return undefined;
+  }
   if (value.manage) {
     return CollectionPermission.Manage;
   } else if (value.readOnly) {

--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -29,9 +29,9 @@ import { CollectionView } from "@bitwarden/common/vault/models/view/collection.v
 import { BitValidators, DialogService } from "@bitwarden/components";
 
 import {
+  CollectionAccessSelectionView,
   GroupService,
   GroupView,
-  CollectionAccessSelectionView,
 } from "../../../admin-console/organizations/core";
 import { PermissionMode } from "../../../admin-console/organizations/shared/components/access-selector/access-selector.component";
 import {
@@ -432,7 +432,10 @@ function mapGroupToAccessItemView(group: GroupView, collectionId: string): Acces
     labelName: group.name,
     accessAllItems: group.accessAll,
     readonly: group.accessAll,
-    readonlyPermission: convertToPermission(group.collections.find((gc) => gc.id == collectionId)),
+    readonlyPermission:
+      collectionId != null
+        ? convertToPermission(group.collections.find((gc) => gc.id == collectionId))
+        : undefined,
   };
 }
 
@@ -456,9 +459,12 @@ function mapUserToAccessItemView(
     status: user.status,
     accessAllItems: user.accessAll,
     readonly: user.accessAll,
-    readonlyPermission: convertToPermission(
-      new CollectionAccessSelectionView(user.collections.find((uc) => uc.id == collectionId)),
-    ),
+    readonlyPermission:
+      collectionId != null
+        ? convertToPermission(
+            new CollectionAccessSelectionView(user.collections.find((uc) => uc.id == collectionId)),
+          )
+        : undefined,
   };
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8335 introduced some new helpers to handle the new readonly mode for the collection dialog. Unfortunately, the helpers will throw an exception when creating a new collection. This PR adds some null checks to help avoid that.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **access-selector/access-selector.models.ts:** Update `convertToPermission` to handle undefined/null values and return appropriately
- **collection-dialog.component.ts:** Only attempt to find a collection for the group/user if the collectionId is present (we're editing an existing collection).

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
