### PR TITLE
[PM-7370] Remove usage of `BrowserMessagingPrivateModeBackgroundService` and `MultithreadEncryptService` from manifest v3

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -361,9 +361,10 @@ export default class MainBackground {
     const logoutCallback = async (expired: boolean, userId?: UserId) =>
       await this.logout(expired, userId);
 
-    this.messagingService = this.popupOnlyContext
-      ? new BrowserMessagingPrivateModeBackgroundService()
-      : new BrowserMessagingService();
+    this.messagingService =
+      this.isPrivateMode && BrowserApi.isManifestVersion(2)
+        ? new BrowserMessagingPrivateModeBackgroundService()
+        : new BrowserMessagingService();
     this.logService = new ConsoleLogService(false);
     this.cryptoFunctionService = new WebCryptoFunctionService(self);
     this.keyGenerationService = new KeyGenerationService(this.cryptoFunctionService);
@@ -405,13 +406,14 @@ export default class MainBackground {
       storageServiceProvider,
     );
 
-    this.encryptService = flagEnabled("multithreadDecryption")
-      ? new MultithreadEncryptServiceImplementation(
-          this.cryptoFunctionService,
-          this.logService,
-          true,
-        )
-      : new EncryptServiceImplementation(this.cryptoFunctionService, this.logService, true);
+    this.encryptService =
+      flagEnabled("multithreadDecryption") && BrowserApi.isManifestVersion(2)
+        ? new MultithreadEncryptServiceImplementation(
+            this.cryptoFunctionService,
+            this.logService,
+            true,
+          )
+        : new EncryptServiceImplementation(this.cryptoFunctionService, this.logService, true);
 
     this.singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
@@ -550,10 +552,13 @@ export default class MainBackground {
     const backgroundMessagingService = new (class extends MessagingServiceAbstraction {
       // AuthService should send the messages to the background not popup.
       send = (subscriber: string, arg: any = {}) => {
+        if (BrowserApi.isManifestVersion(3)) {
+          that.messagingService.send(subscriber, arg);
+          return;
+        }
+
         const message = Object.assign({}, { command: subscriber }, arg);
-        // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        that.runtimeBackground.processMessage(message, that as any);
+        void that.runtimeBackground.processMessage(message, that as any);
       };
     })();
 

--- a/apps/browser/src/platform/decorators/session-sync-observable/session-syncer.ts
+++ b/apps/browser/src/platform/decorators/session-sync-observable/session-syncer.ts
@@ -93,6 +93,10 @@ export class SessionSyncer {
   }
 
   async update(serializedValue: any) {
+    if (!serializedValue) {
+      return;
+    }
+
     const unBuiltValue = JSON.parse(serializedValue);
     if (!BrowserApi.isManifestVersion(3) && BrowserApi.isBackgroundPage(self)) {
       await this.memoryStorageService.save(this.metaData.sessionKey, serializedValue);
@@ -104,6 +108,10 @@ export class SessionSyncer {
   }
 
   private async updateSession(value: any) {
+    if (!value) {
+      return;
+    }
+
     const serializedValue = JSON.stringify(value);
     if (BrowserApi.isManifestVersion(3) || BrowserApi.isBackgroundPage(self)) {
       await this.memoryStorageService.save(this.metaData.sessionKey, serializedValue);

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -62,6 +62,7 @@ import { StateService as BaseStateServiceAbstraction } from "@bitwarden/common/p
 import {
   AbstractMemoryStorageService,
   AbstractStorageService,
+  ObservableStorageService,
 } from "@bitwarden/common/platform/abstractions/storage.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { GlobalState } from "@bitwarden/common/platform/models/domain/global-state";
@@ -159,7 +160,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: MessagingService,
     useFactory: () => {
-      return needsBackgroundInit
+      return needsBackgroundInit && BrowserApi.isManifestVersion(2)
         ? new BrowserMessagingPrivateModePopupService()
         : new BrowserMessagingService();
     },
@@ -387,7 +388,15 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: OBSERVABLE_MEMORY_STORAGE,
-    useClass: ForegroundMemoryStorageService,
+    useFactory: () => {
+      if (BrowserApi.isManifestVersion(2)) {
+        return new ForegroundMemoryStorageService();
+      }
+
+      return getBgService<AbstractStorageService & ObservableStorageService>(
+        "memoryStorageForStateProviders",
+      )();
+    },
     deps: [],
   }),
   safeProvider({


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The changes in this PR add mv3 specific logic that removes usage of the `BrowserMessagingPrivateModeBackgroundService` and `MultithreadEncryptService` within manifest v3. 

`BrowserMessagingPrivateModeBackgroundService` is a service class that will be removed with the rollout of manifest v3. The work done without our state providers should facilitate a way to handle messaging in a more effective manner, and this class's purpose will be defunct with those changes.

`MultithreadEncryptService` cannot be used within the background service worker. As a result, we need to remove usage of it to ensure the extension does not trigger an error when attempting to use the class within the background script.

The behavior has been adjusted to ensure that manifest v2 hasn't been affected. 

## Code changes

- **apps/browser/src/background/main.background.ts:** Guarding against usage of the `BrowserMessagingPrivateModeBackgroundService` and `MultithreadEncryptService` within the background script
- **apps/browser/src/platform/decorators/session-sync-observable/session-syncer.ts:** Ensuring that `SessionSyncer` doesn't attempt to parse `undefined` values.
- **apps/browser/src/popup/services/services.module.ts:** Guarding against usage of the `BrowserMessagingPrivateModeBackgroundService` within mv3 and setting up the `OBSERVABLE_MEMORY_STORAGE` to use the `LocalBackedSessionStorage` class from `MainBackground` when running the popup in mv3.