### PR TITLE
[AC-2436] Show unassigned items banner in web

### DIFF
--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -1,22 +1,7 @@
 <bit-banner
   class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
-  (onClose)="webLayoutMigrationBannerService.hideBanner()"
-  *ngIf="webLayoutMigrationBannerService.showBanner$ | async"
->
-  {{ "newWebApp" | i18n }}
-  <a
-    href="https://bitwarden.com/blog/bitwarden-design-updating-the-navigation-in-the-web-app"
-    bitLink
-    linkType="contrast"
-    target="_blank"
-    rel="noreferrer"
-    >{{ "releaseBlog" | i18n }}</a
-  >
-</bit-banner>
-<bit-banner
-  class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
-  (onClose)="webLayoutMigrationBannerService.hideBanner()"
-  *ngIf="webLayoutMigrationBannerService.showBanner$ | async"
+  (onClose)="webUnassignedItemsBannerService.hideBanner()"
+  *ngIf="webUnassignedItemsBannerService.showBanner$ | async"
 >
   {{ "unassignedItemsBanner" | i18n }}
   <a

--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -1,7 +1,9 @@
 <bit-banner
   class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
   (onClose)="webUnassignedItemsBannerService.hideBanner()"
-  *ngIf="webUnassignedItemsBannerService.showBanner$ | async"
+  *ngIf="
+    (unassignedItemsBannerEnabled$ | async) && (webUnassignedItemsBannerService.showBanner$ | async)
+  "
 >
   {{ "unassignedItemsBanner" | i18n }}
   <a

--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -13,6 +13,21 @@
     >{{ "releaseBlog" | i18n }}</a
   >
 </bit-banner>
+<bit-banner
+  class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
+  (onClose)="webLayoutMigrationBannerService.hideBanner()"
+  *ngIf="webLayoutMigrationBannerService.showBanner$ | async"
+>
+  {{ "unassignedItemsBanner" | i18n }}
+  <a
+    href="https://bitwarden.com/help/unassigned-vault-items-moved-to-admin-console"
+    bitLink
+    linkType="contrast"
+    target="_blank"
+    rel="noreferrer"
+    >{{ "learnMore" | i18n }}</a
+  >
+</bit-banner>
 <header
   *ngIf="routeData$ | async as routeData"
   class="-tw-m-6 tw-mb-3 tw-flex tw-flex-col tw-p-6"

--- a/apps/web/src/app/layouts/header/web-header.component.ts
+++ b/apps/web/src/app/layouts/header/web-header.component.ts
@@ -10,6 +10,7 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { AccountProfile } from "@bitwarden/common/platform/models/domain/account";
 
 import { WebLayoutMigrationBannerService } from "./web-layout-migration-banner.service";
+import { WebUnassignedItemsBannerService } from "./web-unassigned-items-banner.service";
 
 @Component({
   selector: "app-header",
@@ -39,6 +40,7 @@ export class WebHeaderComponent {
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private messagingService: MessagingService,
     protected webLayoutMigrationBannerService: WebLayoutMigrationBannerService,
+    protected webUnassignedItemsBannerService: WebUnassignedItemsBannerService,
   ) {
     this.routeData$ = this.route.data.pipe(
       map((params) => {

--- a/apps/web/src/app/layouts/header/web-header.component.ts
+++ b/apps/web/src/app/layouts/header/web-header.component.ts
@@ -3,7 +3,9 @@ import { ActivatedRoute } from "@angular/router";
 import { combineLatest, map, Observable } from "rxjs";
 
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { VaultTimeoutAction } from "@bitwarden/common/enums/vault-timeout-action.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
@@ -31,6 +33,9 @@ export class WebHeaderComponent {
   protected canLock$: Observable<boolean>;
   protected selfHosted: boolean;
   protected hostname = location.hostname;
+  protected unassignedItemsBannerEnabled$ = this.configService.getFeatureFlag$(
+    FeatureFlag.UnassignedItemsBanner,
+  );
 
   constructor(
     private route: ActivatedRoute,
@@ -39,6 +44,7 @@ export class WebHeaderComponent {
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private messagingService: MessagingService,
     protected webUnassignedItemsBannerService: WebUnassignedItemsBannerService,
+    private configService: ConfigService,
   ) {
     this.routeData$ = this.route.data.pipe(
       map((params) => {

--- a/apps/web/src/app/layouts/header/web-header.component.ts
+++ b/apps/web/src/app/layouts/header/web-header.component.ts
@@ -9,7 +9,6 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { AccountProfile } from "@bitwarden/common/platform/models/domain/account";
 
-import { WebLayoutMigrationBannerService } from "./web-layout-migration-banner.service";
 import { WebUnassignedItemsBannerService } from "./web-unassigned-items-banner.service";
 
 @Component({
@@ -39,7 +38,6 @@ export class WebHeaderComponent {
     private platformUtilsService: PlatformUtilsService,
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private messagingService: MessagingService,
-    protected webLayoutMigrationBannerService: WebLayoutMigrationBannerService,
     protected webUnassignedItemsBannerService: WebUnassignedItemsBannerService,
   ) {
     this.routeData$ = this.route.data.pipe(

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.spec.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.spec.ts
@@ -6,8 +6,7 @@ import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spe
 import { UserId } from "@bitwarden/common/types/guid";
 
 import {
-  DISMISS_BANNER_KEY,
-  HAS_UNASSIGNED_ITEMS,
+  SHOW_BANNER_KEY,
   WebUnassignedItemsBannerService,
 } from "./web-unassigned-items-banner.service";
 
@@ -23,54 +22,35 @@ describe("WebUnassignedItemsBanner", () => {
     apiService = mock();
   });
 
-  describe("given stored values only", () => {
-    it("shows the banner if has unassigned ciphers and has not been dismissed", async () => {
-      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
-      dismissBanner.nextState(undefined);
-      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
-      hasUnassignedItems.nextState(true);
+  it("shows the banner if showBanner local state is true", async () => {
+    const showBanner = stateProvider.activeUser.getFake(SHOW_BANNER_KEY);
+    showBanner.nextState(true);
 
-      const sut = sutFactory();
-      expect(await firstValueFrom(sut.showBanner$)).toBe(true);
-      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
-    });
-
-    it("does not show the banner if does not have unassigned ciphers", async () => {
-      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
-      dismissBanner.nextState(undefined);
-      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
-      hasUnassignedItems.nextState(false);
-
-      const sut = sutFactory();
-      expect(await firstValueFrom(sut.showBanner$)).toBe(false);
-      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
-    });
-
-    it("does not show the banner if it has already been dismissed", async () => {
-      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
-      dismissBanner.nextState(true);
-      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
-      hasUnassignedItems.nextState(true);
-
-      const sut = sutFactory();
-      expect(await firstValueFrom(sut.showBanner$)).toBe(false);
-      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
-    });
+    const sut = sutFactory();
+    expect(await firstValueFrom(sut.showBanner$)).toBe(true);
+    expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
   });
 
-  it("fetches unassigned ciphers value from server", async () => {
+  it("does not show the banner if showBanner local state is false", async () => {
+    const showBanner = stateProvider.activeUser.getFake(SHOW_BANNER_KEY);
+    showBanner.nextState(false);
+
+    const sut = sutFactory();
+    expect(await firstValueFrom(sut.showBanner$)).toBe(false);
+    expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
+  });
+
+  it("fetches from server if local state has not been set yet", async () => {
     apiService.getShowUnassignedCiphersBanner.mockResolvedValue(true);
 
-    const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
-    dismissBanner.nextState(false);
-    const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
-    hasUnassignedItems.nextState(null);
+    const showBanner = stateProvider.activeUser.getFake(SHOW_BANNER_KEY);
+    showBanner.nextState(undefined);
 
     const sut = sutFactory();
     // skip first value so we get the recomputed value after the server call
     expect(await firstValueFrom(sut.showBanner$.pipe(skip(1)))).toBe(true);
     // Expect to have updated local state
-    expect(await firstValueFrom(hasUnassignedItems.state$)).toBe(true);
+    expect(await firstValueFrom(showBanner.state$)).toBe(true);
     expect(apiService.getShowUnassignedCiphersBanner).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.spec.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.spec.ts
@@ -1,0 +1,76 @@
+import { MockProxy, mock } from "jest-mock-extended";
+import { firstValueFrom, skip } from "rxjs";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+
+import {
+  DISMISS_BANNER_KEY,
+  HAS_UNASSIGNED_ITEMS,
+  WebUnassignedItemsBannerService,
+} from "./web-unassigned-items-banner.service";
+
+describe("WebUnassignedItemsBanner", () => {
+  let stateProvider: FakeStateProvider;
+  let apiService: MockProxy<ApiService>;
+
+  const sutFactory = () => new WebUnassignedItemsBannerService(stateProvider, apiService);
+
+  beforeEach(() => {
+    const fakeAccountService = mockAccountServiceWith("userId" as UserId);
+    stateProvider = new FakeStateProvider(fakeAccountService);
+    apiService = mock();
+  });
+
+  describe("given stored values only", () => {
+    it("shows the banner if has unassigned ciphers and has not been dismissed", async () => {
+      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
+      dismissBanner.nextState(undefined);
+      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
+      hasUnassignedItems.nextState(true);
+
+      const sut = sutFactory();
+      expect(await firstValueFrom(sut.showBanner$)).toBe(true);
+      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
+    });
+
+    it("does not show the banner if does not have unassigned ciphers", async () => {
+      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
+      dismissBanner.nextState(undefined);
+      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
+      hasUnassignedItems.nextState(false);
+
+      const sut = sutFactory();
+      expect(await firstValueFrom(sut.showBanner$)).toBe(false);
+      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
+    });
+
+    it("does not show the banner if it has already been dismissed", async () => {
+      const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
+      dismissBanner.nextState(true);
+      const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
+      hasUnassignedItems.nextState(true);
+
+      const sut = sutFactory();
+      expect(await firstValueFrom(sut.showBanner$)).toBe(false);
+      expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
+    });
+  });
+
+  it("fetches unassigned ciphers value from server", async () => {
+    apiService.getShowUnassignedCiphersBanner.mockResolvedValue(true);
+
+    const dismissBanner = stateProvider.activeUser.getFake(DISMISS_BANNER_KEY);
+    dismissBanner.nextState(false);
+    const hasUnassignedItems = stateProvider.activeUser.getFake(HAS_UNASSIGNED_ITEMS);
+    hasUnassignedItems.nextState(null);
+
+    const sut = sutFactory();
+    // skip first value so we get the recomputed value after the server call
+    expect(await firstValueFrom(sut.showBanner$.pipe(skip(1)))).toBe(true);
+    // Expect to have updated local state
+    expect(await firstValueFrom(hasUnassignedItems.state$)).toBe(true);
+    expect(apiService.getShowUnassignedCiphersBanner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -1,40 +1,58 @@
 import { Injectable } from "@angular/core";
-import { combineLatest, map } from "rxjs";
+import { EMPTY, combineLatest, concatMap } from "rxjs";
 
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import {
   GlobalStateProvider,
   KeyDefinition,
   UNASSIGNED_ITEMS_BANNER_DISK,
 } from "@bitwarden/common/platform/state";
 
-const HIDE_BANNER_KEY = new KeyDefinition<boolean>(UNASSIGNED_ITEMS_BANNER_DISK, "hideBanner", {
-  deserializer: (b) => {
-    if (b === null) {
-      return false;
-    }
-    return b;
+const DISMISS_BANNER_KEY = new KeyDefinition<boolean>(
+  UNASSIGNED_ITEMS_BANNER_DISK,
+  "dismissBanner",
+  {
+    deserializer: (b) => {
+      if (b === null) {
+        return false;
+      }
+      return b;
+    },
   },
-});
+);
+
+const SHOW_BANNER_KEY = new KeyDefinition<boolean | null>(
+  UNASSIGNED_ITEMS_BANNER_DISK,
+  "showBanner",
+  {
+    deserializer: (b) => b ?? null,
+  },
+);
 
 /** Displays a banner that tells users how to move their unassigned items into a collection. */
 @Injectable({ providedIn: "root" })
 export class WebUnassignedItemsBannerService {
-  private _hideBannerState = this.globalStateProvider.get(HIDE_BANNER_KEY);
-  private _adminOrganizations = this.organizationService.organizations$.pipe(
-    map((orgs) => orgs.filter((o) => o.isAdmin)),
-  );
+  private _dismissBannerState = this.globalStateProvider.get(DISMISS_BANNER_KEY);
+  private _showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
 
-  showBanner$ = combineLatest([this._hideBannerState.state$, this._adminOrganizations]).pipe(
-    map(([hideBanner, adminOrganizations]) => !hideBanner && adminOrganizations?.length > 1),
+  showBanner$ = combineLatest([this._dismissBannerState.state$, this._showBannerState.state$]).pipe(
+    concatMap(async ([dismissBanner, showBanner]) => {
+      if (!dismissBanner && showBanner == null) {
+        const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
+        await this._showBannerState.update(() => showBannerResponse);
+        return EMPTY; // to test, we could also just emit false and let the value update the next time around
+      }
+
+      return !dismissBanner && showBanner;
+    }),
   );
 
   constructor(
     private globalStateProvider: GlobalStateProvider,
-    private organizationService: OrganizationService,
+    private apiService: ApiService,
   ) {}
 
   async hideBanner() {
-    await this._hideBannerState.update(() => true);
+    await this._dismissBannerState.update(() => true);
   }
 }

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -29,14 +29,14 @@ export const HAS_UNASSIGNED_ITEMS = new UserKeyDefinition<boolean | null>(
 /** Displays a banner that tells users how to move their unassigned items into a collection. */
 @Injectable({ providedIn: "root" })
 export class WebUnassignedItemsBannerService {
-  private _hasUnassignedItems = this.stateProvider.getActive(DISMISS_BANNER_KEY);
-  private _showBanner = this.stateProvider.getActive(HAS_UNASSIGNED_ITEMS);
+  private _dismissBanner = this.stateProvider.getActive(DISMISS_BANNER_KEY);
+  private _hasUnassignedItems = this.stateProvider.getActive(HAS_UNASSIGNED_ITEMS);
 
-  showBanner$ = combineLatest([this._hasUnassignedItems.state$, this._showBanner.state$]).pipe(
+  showBanner$ = combineLatest([this._dismissBanner.state$, this._hasUnassignedItems.state$]).pipe(
     concatMap(async ([dismissBanner, hasUnassignedItems]) => {
       if (!dismissBanner && hasUnassignedItems == null) {
         const hasUnassignedItemsResponse = await this.apiService.getShowUnassignedCiphersBanner();
-        await this._showBanner.update(() => hasUnassignedItemsResponse);
+        await this._hasUnassignedItems.update(() => hasUnassignedItemsResponse);
         return EMPTY; // to test, we could also just emit false and let the value update the next time around
       }
 
@@ -50,6 +50,6 @@ export class WebUnassignedItemsBannerService {
   ) {}
 
   async hideBanner() {
-    await this._hasUnassignedItems.update(() => true);
+    await this._dismissBanner.update(() => true);
   }
 }

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -3,32 +3,34 @@ import { EMPTY, combineLatest, concatMap } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import {
-  GlobalStateProvider,
-  KeyDefinition,
+  StateProvider,
   UNASSIGNED_ITEMS_BANNER_DISK,
+  UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 
-const DISMISS_BANNER_KEY = new KeyDefinition<boolean>(
+const DISMISS_BANNER_KEY = new UserKeyDefinition<boolean>(
   UNASSIGNED_ITEMS_BANNER_DISK,
   "dismissBanner",
   {
     deserializer: (b) => b ?? false,
+    clearOn: ["logout"],
   },
 );
 
-const HAS_UNASSIGNED_ITEMS = new KeyDefinition<boolean | null>(
+const HAS_UNASSIGNED_ITEMS = new UserKeyDefinition<boolean | null>(
   UNASSIGNED_ITEMS_BANNER_DISK,
   "hasUnassignedItems",
   {
     deserializer: (b) => b ?? null,
+    clearOn: ["logout"],
   },
 );
 
 /** Displays a banner that tells users how to move their unassigned items into a collection. */
 @Injectable({ providedIn: "root" })
 export class WebUnassignedItemsBannerService {
-  private _hasUnassignedItems = this.globalStateProvider.get(DISMISS_BANNER_KEY);
-  private _showBanner = this.globalStateProvider.get(HAS_UNASSIGNED_ITEMS);
+  private _hasUnassignedItems = this.stateProvider.getActive(DISMISS_BANNER_KEY);
+  private _showBanner = this.stateProvider.getActive(HAS_UNASSIGNED_ITEMS);
 
   showBanner$ = combineLatest([this._hasUnassignedItems.state$, this._showBanner.state$]).pipe(
     concatMap(async ([dismissBanner, hasUnassignedItems]) => {
@@ -43,7 +45,7 @@ export class WebUnassignedItemsBannerService {
   );
 
   constructor(
-    private globalStateProvider: GlobalStateProvider,
+    private stateProvider: StateProvider,
     private apiService: ApiService,
   ) {}
 

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -13,7 +13,7 @@ export const SHOW_BANNER_KEY = new UserKeyDefinition<boolean>(
   "showBanner",
   {
     deserializer: (b) => b,
-    clearOn: ["logout"],
+    clearOn: [],
   },
 );
 

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -8,7 +8,7 @@ import {
   UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 
-const DISMISS_BANNER_KEY = new UserKeyDefinition<boolean>(
+export const DISMISS_BANNER_KEY = new UserKeyDefinition<boolean>(
   UNASSIGNED_ITEMS_BANNER_DISK,
   "dismissBanner",
   {
@@ -17,7 +17,7 @@ const DISMISS_BANNER_KEY = new UserKeyDefinition<boolean>(
   },
 );
 
-const HAS_UNASSIGNED_ITEMS = new UserKeyDefinition<boolean | null>(
+export const HAS_UNASSIGNED_ITEMS = new UserKeyDefinition<boolean | null>(
   UNASSIGNED_ITEMS_BANNER_DISK,
   "hasUnassignedItems",
   {

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -12,18 +12,13 @@ const DISMISS_BANNER_KEY = new KeyDefinition<boolean>(
   UNASSIGNED_ITEMS_BANNER_DISK,
   "dismissBanner",
   {
-    deserializer: (b) => {
-      if (b === null) {
-        return false;
-      }
-      return b;
-    },
+    deserializer: (b) => b ?? false,
   },
 );
 
-const SHOW_BANNER_KEY = new KeyDefinition<boolean | null>(
+const HAS_UNASSIGNED_ITEMS = new KeyDefinition<boolean | null>(
   UNASSIGNED_ITEMS_BANNER_DISK,
-  "showBanner",
+  "hasUnassignedItems",
   {
     deserializer: (b) => b ?? null,
   },
@@ -32,18 +27,18 @@ const SHOW_BANNER_KEY = new KeyDefinition<boolean | null>(
 /** Displays a banner that tells users how to move their unassigned items into a collection. */
 @Injectable({ providedIn: "root" })
 export class WebUnassignedItemsBannerService {
-  private _dismissBannerState = this.globalStateProvider.get(DISMISS_BANNER_KEY);
-  private _showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
+  private _hasUnassignedItems = this.globalStateProvider.get(DISMISS_BANNER_KEY);
+  private _showBanner = this.globalStateProvider.get(HAS_UNASSIGNED_ITEMS);
 
-  showBanner$ = combineLatest([this._dismissBannerState.state$, this._showBannerState.state$]).pipe(
-    concatMap(async ([dismissBanner, showBanner]) => {
-      if (!dismissBanner && showBanner == null) {
-        const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
-        await this._showBannerState.update(() => showBannerResponse);
+  showBanner$ = combineLatest([this._hasUnassignedItems.state$, this._showBanner.state$]).pipe(
+    concatMap(async ([dismissBanner, hasUnassignedItems]) => {
+      if (!dismissBanner && hasUnassignedItems == null) {
+        const hasUnassignedItemsResponse = await this.apiService.getShowUnassignedCiphersBanner();
+        await this._showBanner.update(() => hasUnassignedItemsResponse);
         return EMPTY; // to test, we could also just emit false and let the value update the next time around
       }
 
-      return !dismissBanner && showBanner;
+      return !dismissBanner && hasUnassignedItems;
     }),
   );
 
@@ -53,6 +48,6 @@ export class WebUnassignedItemsBannerService {
   ) {}
 
   async hideBanner() {
-    await this._dismissBannerState.update(() => true);
+    await this._hasUnassignedItems.update(() => true);
   }
 }

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@angular/core";
+import { combineLatest, map } from "rxjs";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import {
+  GlobalStateProvider,
+  KeyDefinition,
+  UNASSIGNED_ITEMS_BANNER_DISK,
+} from "@bitwarden/common/platform/state";
+
+const SHOW_BANNER_KEY = new KeyDefinition<boolean>(UNASSIGNED_ITEMS_BANNER_DISK, "showBanner", {
+  deserializer: (b) => {
+    if (b === null) {
+      return true;
+    }
+    return b;
+  },
+});
+
+/** Displays a banner that tells users how to move their unassigned items into a collection. */
+@Injectable({ providedIn: "root" })
+export class WebUnassignedItemsBannerService {
+  private _showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
+  private _adminOrganizations = this.organizationService.organizations$.pipe(
+    map((orgs) => orgs.filter((o) => o.isAdmin)),
+  );
+
+  showBanner$ = combineLatest([this._showBannerState.state$, this._adminOrganizations]).pipe(
+    map(([showBanner, adminOrganizations]) => showBanner && adminOrganizations?.length > 1),
+  );
+
+  constructor(
+    private globalStateProvider: GlobalStateProvider,
+    private organizationService: OrganizationService,
+  ) {}
+
+  async hideBanner() {
+    await this._showBannerState.update(() => false);
+  }
+}

--- a/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
+++ b/apps/web/src/app/layouts/header/web-unassigned-items-banner.service.ts
@@ -8,10 +8,10 @@ import {
   UNASSIGNED_ITEMS_BANNER_DISK,
 } from "@bitwarden/common/platform/state";
 
-const SHOW_BANNER_KEY = new KeyDefinition<boolean>(UNASSIGNED_ITEMS_BANNER_DISK, "showBanner", {
+const HIDE_BANNER_KEY = new KeyDefinition<boolean>(UNASSIGNED_ITEMS_BANNER_DISK, "hideBanner", {
   deserializer: (b) => {
     if (b === null) {
-      return true;
+      return false;
     }
     return b;
   },
@@ -20,13 +20,13 @@ const SHOW_BANNER_KEY = new KeyDefinition<boolean>(UNASSIGNED_ITEMS_BANNER_DISK,
 /** Displays a banner that tells users how to move their unassigned items into a collection. */
 @Injectable({ providedIn: "root" })
 export class WebUnassignedItemsBannerService {
-  private _showBannerState = this.globalStateProvider.get(SHOW_BANNER_KEY);
+  private _hideBannerState = this.globalStateProvider.get(HIDE_BANNER_KEY);
   private _adminOrganizations = this.organizationService.organizations$.pipe(
     map((orgs) => orgs.filter((o) => o.isAdmin)),
   );
 
-  showBanner$ = combineLatest([this._showBannerState.state$, this._adminOrganizations]).pipe(
-    map(([showBanner, adminOrganizations]) => showBanner && adminOrganizations?.length > 1),
+  showBanner$ = combineLatest([this._hideBannerState.state$, this._adminOrganizations]).pipe(
+    map(([hideBanner, adminOrganizations]) => !hideBanner && adminOrganizations?.length > 1),
   );
 
   constructor(
@@ -35,6 +35,6 @@ export class WebUnassignedItemsBannerService {
   ) {}
 
   async hideBanner() {
-    await this._showBannerState.update(() => false);
+    await this._hideBannerState.update(() => true);
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7899,5 +7899,8 @@
   },
   "machineAccountAccessUpdated": {
     "message": "Machine account access updated"
+  },
+  "unassignedItemsBanner": {
+    "message": "Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7901,6 +7901,6 @@
     "message": "Machine account access updated"
   },
   "unassignedItemsBanner": {
-    "message": "Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
+    "message": "Notice: Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -207,6 +207,7 @@ export abstract class ApiService {
     emergencyAccessId?: string,
   ) => Promise<AttachmentResponse>;
   getCiphersOrganization: (organizationId: string) => Promise<ListResponse<CipherResponse>>;
+  getShowUnassignedCiphersBanner: () => Promise<boolean>;
   postCipher: (request: CipherRequest) => Promise<CipherResponse>;
   postCipherCreate: (request: CipherCreateRequest) => Promise<CipherResponse>;
   postCipherAdmin: (request: CipherCreateRequest) => Promise<CipherResponse>;

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -9,6 +9,7 @@ export enum FeatureFlag {
   ShowPaymentMethodWarningBanners = "show-payment-method-warning-banners",
   EnableConsolidatedBilling = "enable-consolidated-billing",
   AC1795_UpdatedSubscriptionStatusSection = "AC-1795_updated-subscription-status-section",
+  UnassignedItemsBanner = "unassigned-items-banner",
 }
 
 // Replace this with a type safe lookup of the feature flag values in PM-2282

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -74,6 +74,10 @@ export const NEW_WEB_LAYOUT_BANNER_DISK = new StateDefinition("newWebLayoutBanne
   web: "disk-local",
 });
 
+export const UNASSIGNED_ITEMS_BANNER_DISK = new StateDefinition("unassignedItemsBanner", "disk", {
+  web: "disk-local",
+});
+
 // Platform
 
 export const APPLICATION_ID_DISK = new StateDefinition("applicationId", "disk", {

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -506,6 +506,11 @@ export class ApiService implements ApiServiceAbstraction {
     return new ListResponse(r, CipherResponse);
   }
 
+  async getShowUnassignedCiphersBanner(): Promise<boolean> {
+    const r = await this.send("GET", "/ciphers/unassigned-banner", null, true, true);
+    return r;
+  }
+
   async postCipher(request: CipherRequest): Promise<CipherResponse> {
     const r = await this.send("POST", "/ciphers", request, true, true);
     return new CipherResponse(r);

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -507,7 +507,7 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async getShowUnassignedCiphersBanner(): Promise<boolean> {
-    const r = await this.send("GET", "/ciphers/unassigned-banner", null, true, true);
+    const r = await this.send("GET", "/ciphers/has-unassigned-ciphers", null, true, true);
     return r;
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Show a banner re: unassigned organization items if the user is an admin or owner of an org that has unassigned items.

Server PR: https://github.com/bitwarden/server/pull/3967

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**unassigned-items-banner.service.ts**

This does the main work. It uses a single piece of state, `SHOW_BANNER_KEY`, to manage the banner:
- `null` -> the banner has not been shown to the user yet, check with the server whether we need to display it. This then updates the value which will trigger another run through the subscribe callback
- `true` -> show the banner
- `false` -> do not show the banner (because it has been dismissed or the server indicated it's not required)

Note that this is user state (because its value is computed per user) that is not cleared on logout (because we don't want to show them the banner again later). I'm checking with Platform Team that this is OK, because at the moment we don't have any way of looking this up later to clear it after the user has logged out.

Aside from this, it follows the same approach as `web-layout-migration-banner.service.ts`

**Other changes**
- add tests
- add new state definition
- add api call
- add feature flag (not discussed but seems prudent)

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![Screenshot 2024-04-10 at 3 02 40 PM](https://github.com/bitwarden/clients/assets/31796059/b5534795-37ea-4bba-91e5-f32b756c6c4f)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
