### PR TITLE
[PM-7368] Fix issues with invalid locale for appx

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -203,7 +203,7 @@
       "si",
       "sk",
       "sl",
-      "sr",
+      "sr-cyrl",
       "sv",
       "te",
       "th",


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Even though the `sr` language tag appears to be [supported by Microsoft](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/supported-languages?pivots=store-installer-msix), the APPX app will fail to install with it, so we need to swap it to a more specific one, in this case `sr-cyrl` as we're using the Cyrillic characters.

Note that this change only affects the application metadata that is used in the Microsoft Store, and doesn't change anything for the app translations.

I've tested this locally with some unsigned builds and with this change the appx can be installed, opened and the Serbian localization used without problems.

Fixes #8653 
