### PR TITLE
Use `UserKeyDefinition` for user-scoped data

### DIFF
--- a/libs/common/src/platform/services/key-state/user-key.state.ts
+++ b/libs/common/src/platform/services/key-state/user-key.state.ts
@@ -3,18 +3,17 @@ import { CryptoFunctionService } from "../../abstractions/crypto-function.servic
 import { EncryptService } from "../../abstractions/encrypt.service";
 import { EncString, EncryptedString } from "../../models/domain/enc-string";
 import { SymmetricCryptoKey } from "../../models/domain/symmetric-crypto-key";
-import {
-  KeyDefinition,
-  CRYPTO_DISK,
-  DeriveDefinition,
-  CRYPTO_MEMORY,
-  UserKeyDefinition,
-} from "../../state";
+import { CRYPTO_DISK, DeriveDefinition, CRYPTO_MEMORY, UserKeyDefinition } from "../../state";
 import { CryptoService } from "../crypto.service";
 
-export const USER_EVER_HAD_USER_KEY = new KeyDefinition<boolean>(CRYPTO_DISK, "everHadUserKey", {
-  deserializer: (obj) => obj,
-});
+export const USER_EVER_HAD_USER_KEY = new UserKeyDefinition<boolean>(
+  CRYPTO_DISK,
+  "everHadUserKey",
+  {
+    deserializer: (obj) => obj,
+    clearOn: ["logout"],
+  },
+);
 
 export const USER_ENCRYPTED_PRIVATE_KEY = new UserKeyDefinition<EncryptedString>(
   CRYPTO_DISK,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

I had missed the ever had user key boolean as user-scoped in #8584. This PR moves that value to be cleared on logout.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
