### PR TITLE
[PM-7388] Fix AutofillService dependency reference to TotpService within poppup services module

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -312,7 +312,7 @@ const safeProviders: SafeProvider[] = [
     deps: [
       CipherService,
       AutofillSettingsServiceAbstraction,
-      TotpService,
+      TotpServiceAbstraction,
       EventCollectionServiceAbstraction,
       LogService,
       DomainSettingsService,


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

With the changes for https://github.com/bitwarden/clients/pull/8380 an issue was identified with how the `AutofillService` references the `TotpService` as part of its dependencies. The change in this PR addresses that issue, ensuring we are correctly referencing the `TotpServiceAbstraction` to populate the dependency.

## Code changes

- **apps/browser/src/popup/services/services.module.ts:** Updating the dependency reference for `AutofillService` to reference the `TotpServiceAbstraction` instead of the `TotpService` class implementation
