### PR TITLE
[AC-2436] Fix flashing unassigned items banner

### DIFF
--- a/libs/angular/src/services/unassigned-items-banner.service.spec.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.spec.ts
@@ -1,5 +1,5 @@
 import { MockProxy, mock } from "jest-mock-extended";
-import { firstValueFrom, take } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -37,7 +37,7 @@ describe("UnassignedItemsBanner", () => {
     expect(apiService.getShowUnassignedCiphersBanner).not.toHaveBeenCalled();
   });
 
-  it("fetches from server if local state has not been set yet", (done) => {
+  it("fetches from server if local state has not been set yet", async () => {
     apiService.getShowUnassignedCiphersBanner.mockResolvedValue(true);
 
     const showBanner = stateProvider.activeUser.getFake(SHOW_BANNER_KEY);
@@ -45,18 +45,7 @@ describe("UnassignedItemsBanner", () => {
 
     const sut = sutFactory();
 
-    let count = 1;
-    sut.showBanner$.pipe(take(2)).subscribe((val) => {
-      if (count == 1) {
-        // Should continue to hide the banner while we wait for the server response
-        expect(val).toBe(false);
-        count++;
-      } else {
-        // Then use the server response
-        expect(val).toBe(true);
-        expect(apiService.getShowUnassignedCiphersBanner).toHaveBeenCalledTimes(1);
-        done();
-      }
-    });
+    expect(await firstValueFrom(sut.showBanner$)).toBe(true);
+    expect(apiService.getShowUnassignedCiphersBanner).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/angular/src/services/unassigned-items-banner.service.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.ts
@@ -25,6 +25,7 @@ export class UnassignedItemsBannerService {
 
   showBanner$ = this._showBanner.state$.pipe(
     concatMap(async (showBannerState) => {
+      // null indicates that the user has not seen or dismissed the banner yet - get the flag from server
       if (showBannerState == null) {
         const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
         await this._showBanner.update(() => showBannerResponse);

--- a/libs/angular/src/services/unassigned-items-banner.service.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.ts
@@ -25,16 +25,13 @@ export class UnassignedItemsBannerService {
 
   showBanner$ = this._showBanner.state$.pipe(
     concatMap(async (showBannerState) => {
-      let result = showBannerState;
-
-      // null indicates that the user has not seen or dismissed the banner yet - get the flag from server
-      if (result == null) {
+      if (showBannerState == null) {
         const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
         await this._showBanner.update(() => showBannerResponse);
-        result = showBannerResponse;
+        return showBannerResponse;
       }
 
-      return result;
+      return showBannerState;
     }),
   );
 

--- a/libs/angular/src/services/unassigned-items-banner.service.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.ts
@@ -24,15 +24,17 @@ export class UnassignedItemsBannerService {
   private _showBanner = this.stateProvider.getActive(SHOW_BANNER_KEY);
 
   showBanner$ = this._showBanner.state$.pipe(
-    concatMap(async (showBanner) => {
+    concatMap(async (showBannerState) => {
+      let result = showBannerState;
+
       // null indicates that the user has not seen or dismissed the banner yet - get the flag from server
-      if (showBanner == null) {
+      if (result == null) {
         const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
         await this._showBanner.update(() => showBannerResponse);
-        return false; // don't show anything yet, the call to update() will trigger another run and use the stored value
+        result = showBannerResponse;
       }
 
-      return showBanner;
+      return result;
     }),
   );
 

--- a/libs/angular/src/services/unassigned-items-banner.service.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { EMPTY, concatMap } from "rxjs";
+import { concatMap } from "rxjs";
 
 import {
   StateProvider,
@@ -29,7 +29,7 @@ export class UnassignedItemsBannerService {
       if (showBanner == null) {
         const showBannerResponse = await this.apiService.getShowUnassignedCiphersBanner();
         await this._showBanner.update(() => showBannerResponse);
-        return EMPTY; // complete the inner observable without emitting any value; the update on the previous line will trigger another run
+        return false; // don't show anything yet, the call to update() will trigger another run and use the stored value
       }
 
       return showBanner;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

QA reported the unassigned items banner appearing for a brief moment for users who should not see it. Fix.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

I thought returning `EMPTY` on the callback's initial run would not emit any value. However, it seems to have emitted a non-falsey value which caused the banner to briefly appear until the server value could be loaded from state.

We could return `false` instead if we wanted, but I simplified it further and just returned the server value early (after updating state). That way the observable will always emit the correct value (from a business logic perspective) the first time.

This will need to be cherry-picked into:
* rc
* hotfix-rc-browser
* hotfix-rc-web

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
