### PR TITLE
[PM-6696] Collections not loading when adding item

### DIFF
--- a/apps/desktop/src/vault/app/vault/add-edit.component.ts
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.ts
@@ -75,6 +75,7 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
 
   async ngOnInit() {
     await super.ngOnInit();
+    await this.load();
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
       this.ngZone.run(() => {
         switch (message.command) {

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -592,7 +592,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
       this.writeableCollections.forEach((c) => ((c as any).checked = false));
     }
     if (this.cipher.organizationId != null) {
-      this.collections = this.writeableCollections.filter(
+      this.collections = this.writeableCollections?.filter(
         (c) => c.organizationId === this.cipher.organizationId,
       );
       const org = await this.organizationService.get(this.cipher.organizationId);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Currently, when creating an item under an organization, collections are not loaded, and because of this, the item cannot be saved. The objective of this ticket is to ensure collections load when displaying the form when adding a new item.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

The collections were loaded in ngOnInit, which is not executed until after the first ngOnChanges call. As a result, when ngOnChanges needed the collections immediately (such as when adding a new item), they were unavailable. 

To fix this bug, I ensure collections are always loaded before they are needed.



## Screenshots

https://github.com/bitwarden/clients/assets/13024008/9b615c38-e212-44d5-9909-ad6819160fd7


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
