### PR TITLE
[PM-5951] Remove org invite state

### DIFF
--- a/apps/web/src/app/auth/accept-organization.component.ts
+++ b/apps/web/src/app/auth/accept-organization.component.ts
@@ -80,9 +80,8 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
         : this.i18nService.t("inviteAcceptedDesc"),
       { timeout: 10000 },
     );
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.router.navigate(["/vault"]);
+
+    await this.router.navigate(["/vault"]);
   }
 
   async unauthedHandler(qParams: Params): Promise<void> {
@@ -198,21 +197,16 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
 
     // if user exists, send user to login
     if (orgUserHasExistingUser) {
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.router.navigate(["/login"], {
+      await this.router.navigate(["/login"], {
         queryParams: { email: qParams.email },
       });
       return;
     }
 
-    // no user exists; so either sign in via SSO and JIT provision one or simply register.
-
     if (orgSsoIdentifier) {
       // We only send sso org identifier if the org has SSO enabled and the SSO policy required.
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.router.navigate(["/sso"], {
+      // Will JIT provision the user.
+      await this.router.navigate(["/sso"], {
         queryParams: { email: qParams.email, identifier: orgSsoIdentifier },
       });
       return;
@@ -220,9 +214,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
 
     // if SSO is disabled OR if sso is enabled but the SSO login required policy is not enabled
     // then send user to create account
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.router.navigate(["/register"], {
+    await this.router.navigate(["/register"], {
       queryParams: { email: qParams.email, fromOrgInvite: true },
     });
     return;

--- a/apps/web/src/app/auth/emergency-access/accept/accept-emergency.component.ts
+++ b/apps/web/src/app/auth/emergency-access/accept/accept-emergency.component.ts
@@ -1,9 +1,9 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 
 import { BaseAcceptComponent } from "../../../common/base.accept.component";
 import { SharedModule } from "../../../shared";
@@ -27,10 +27,10 @@ export class AcceptEmergencyComponent extends BaseAcceptComponent {
     platformUtilsService: PlatformUtilsService,
     i18nService: I18nService,
     route: ActivatedRoute,
-    stateService: StateService,
+    authService: AuthService,
     private emergencyAccessService: EmergencyAccessService,
   ) {
-    super(router, platformUtilsService, i18nService, route, stateService);
+    super(router, platformUtilsService, i18nService, route, authService);
   }
 
   async authedHandler(qParams: Params): Promise<void> {

--- a/apps/web/src/app/auth/set-password.component.ts
+++ b/apps/web/src/app/auth/set-password.component.ts
@@ -1,9 +1,26 @@
-import { Component } from "@angular/core";
+import { Component, inject } from "@angular/core";
 
 import { SetPasswordComponent as BaseSetPasswordComponent } from "@bitwarden/angular/auth/components/set-password.component";
+import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { MasterKey, UserKey } from "@bitwarden/common/types/key";
+
+import { RouterService } from "../core";
 
 @Component({
   selector: "app-set-password",
   templateUrl: "set-password.component.html",
 })
-export class SetPasswordComponent extends BaseSetPasswordComponent {}
+export class SetPasswordComponent extends BaseSetPasswordComponent {
+  routerService = inject(RouterService);
+
+  protected override async onSetPasswordSuccess(
+    masterKey: MasterKey,
+    userKey: [UserKey, EncString],
+    keyPair: [string, EncString],
+  ): Promise<void> {
+    await super.onSetPasswordSuccess(masterKey, userKey, keyPair);
+    // SSO JIT accepts org invites when setting their MP, meaning
+    // we can clear the deep linked url for accepting it.
+    await this.routerService.getAndClearLoginRedirectUrl();
+  }
+}

--- a/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
+++ b/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
@@ -36,12 +36,14 @@ describe("TrialInitiationComponent", () => {
   let stateServiceMock: MockProxy<StateService>;
   let policyApiServiceMock: MockProxy<PolicyApiServiceAbstraction>;
   let policyServiceMock: MockProxy<PolicyService>;
+  let routerServiceMock: MockProxy<RouterService>;
 
   beforeEach(() => {
     // only define services directly that we want to mock return values in this component
     stateServiceMock = mock<StateService>();
     policyApiServiceMock = mock<PolicyApiServiceAbstraction>();
     policyServiceMock = mock<PolicyService>();
+    routerServiceMock = mock<RouterService>();
 
     // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -81,7 +83,7 @@ describe("TrialInitiationComponent", () => {
         },
         {
           provide: RouterService,
-          useValue: mock<RouterService>(),
+          useValue: routerServiceMock,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Allows child components to be ignored (such as register component)
@@ -100,8 +102,8 @@ describe("TrialInitiationComponent", () => {
 
   // These tests demonstrate mocking service calls
   describe("onInit() enforcedPolicyOptions", () => {
-    it("should not set enforcedPolicyOptions if state service returns no invite", async () => {
-      stateServiceMock.getOrganizationInvitation.mockReturnValueOnce(null);
+    it("should not set enforcedPolicyOptions if there isn't an org invite in deep linked url", async () => {
+      routerServiceMock.getLoginRedirectUrlQueryParams.mockResolvedValueOnce(null);
       // Need to recreate component with new service mock
       fixture = TestBed.createComponent(TrialInitiationComponent);
       component = fixture.componentInstance;
@@ -109,16 +111,14 @@ describe("TrialInitiationComponent", () => {
 
       expect(component.enforcedPolicyOptions).toBe(undefined);
     });
-    it("should set enforcedPolicyOptions if state service returns an invite", async () => {
+    it("should set enforcedPolicyOptions if the deep linked url has an org invite", async () => {
       // Set up service method mocks
-      stateServiceMock.getOrganizationInvitation.mockReturnValueOnce(
-        Promise.resolve({
-          organizationId: testOrgId,
-          token: "token",
-          email: "testEmail",
-          organizationUserId: "123",
-        }),
-      );
+      routerServiceMock.getLoginRedirectUrlQueryParams.mockResolvedValueOnce({
+        organizationId: testOrgId,
+        token: "token",
+        email: "testEmail",
+        organizationUserId: "123",
+      });
       policyApiServiceMock.getPoliciesByToken.mockReturnValueOnce(
         Promise.resolve({
           data: [

--- a/apps/web/src/app/auth/update-password.component.ts
+++ b/apps/web/src/app/auth/update-password.component.ts
@@ -14,6 +14,8 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
 import { DialogService } from "@bitwarden/components";
 
+import { RouterService } from "../core";
+
 @Component({
   selector: "app-update-password",
   templateUrl: "update-password.component.html",
@@ -32,6 +34,7 @@ export class UpdatePasswordComponent extends BaseUpdatePasswordComponent {
     stateService: StateService,
     userVerificationService: UserVerificationService,
     dialogService: DialogService,
+    private routerService: RouterService,
   ) {
     super(
       router,
@@ -47,5 +50,12 @@ export class UpdatePasswordComponent extends BaseUpdatePasswordComponent {
       logService,
       dialogService,
     );
+  }
+
+  override async cancel() {
+    // clearing the login redirect url so that the user
+    // does not join the organization if they cancel
+    await this.routerService.getAndClearLoginRedirectUrl();
+    await super.cancel();
   }
 }

--- a/apps/web/src/app/common/base.accept.component.ts
+++ b/apps/web/src/app/common/base.accept.component.ts
@@ -1,11 +1,12 @@
 import { Directive, OnInit } from "@angular/core";
 import { ActivatedRoute, Params, Router } from "@angular/router";
-import { Subject } from "rxjs";
+import { Subject, firstValueFrom } from "rxjs";
 import { first, switchMap, takeUntil } from "rxjs/operators";
 
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 
 @Directive()
 export abstract class BaseAcceptComponent implements OnInit {
@@ -25,7 +26,7 @@ export abstract class BaseAcceptComponent implements OnInit {
     protected platformUtilService: PlatformUtilsService,
     protected i18nService: I18nService,
     protected route: ActivatedRoute,
-    protected stateService: StateService,
+    protected authService: AuthService,
   ) {}
 
   abstract authedHandler(qParams: Params): Promise<void>;
@@ -41,10 +42,10 @@ export abstract class BaseAcceptComponent implements OnInit {
           );
           let errorMessage: string = null;
           if (!error) {
-            this.authed = await this.stateService.getIsAuthenticated();
             this.email = qParams.email;
 
-            if (this.authed) {
+            const status = await firstValueFrom(this.authService.activeAccountStatus$);
+            if (status !== AuthenticationStatus.LoggedOut) {
               try {
                 await this.authedHandler(qParams);
               } catch (e) {

--- a/apps/web/src/app/core/router.service.ts
+++ b/apps/web/src/app/core/router.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { Title } from "@angular/platform-browser";
-import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
+import { ActivatedRoute, NavigationEnd, Params, Router } from "@angular/router";
 import { filter, firstValueFrom } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -92,7 +92,7 @@ export class RouterService {
   /**
    * Fetch and clear persisted LoginRedirectUrl if present in state
    */
-  async getAndClearLoginRedirectUrl(): Promise<string> | undefined {
+  async getAndClearLoginRedirectUrl(): Promise<string | undefined> {
     const persistedPreLoginUrl = await firstValueFrom(this.deepLinkRedirectUrlState.state$);
 
     if (!Utils.isNullOrEmpty(persistedPreLoginUrl)) {
@@ -101,5 +101,18 @@ export class RouterService {
     }
 
     return;
+  }
+
+  /**
+   * Returns the query parameters of the persisted LoginRedirectUrl if present in state.
+   * Useful for authentication actions that require knowledge of the deep linked URL.
+   */
+  async getLoginRedirectUrlQueryParams(): Promise<Params | undefined> {
+    const persistedPreLoginUrl = await firstValueFrom(this.deepLinkRedirectUrlState.state$);
+    if (Utils.isNullOrEmpty(persistedPreLoginUrl)) {
+      return;
+    }
+    const url = this.router.parseUrl(persistedPreLoginUrl);
+    return url?.queryParams;
   }
 }

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/accept-provider.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/accept-provider.component.ts
@@ -3,9 +3,9 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { ProviderUserAcceptRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-user-accept.request";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { BaseAcceptComponent } from "@bitwarden/web-vault/app/common/base.accept.component";
 
 @Component({
@@ -23,11 +23,11 @@ export class AcceptProviderComponent extends BaseAcceptComponent {
     router: Router,
     i18nService: I18nService,
     route: ActivatedRoute,
-    stateService: StateService,
+    authService: AuthService,
     private apiService: ApiService,
     platformUtilService: PlatformUtilsService,
   ) {
-    super(router, platformUtilService, i18nService, route, stateService);
+    super(router, platformUtilService, i18nService, route, authService);
   }
 
   async authedHandler(qParams: Params) {

--- a/libs/angular/src/auth/components/register.component.ts
+++ b/libs/angular/src/auth/components/register.component.ts
@@ -78,6 +78,10 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
 
   protected captchaBypassToken: string = null;
 
+  // allows for extending classes to modify the register request before sending
+  // currently used by web to add organization invitation details
+  protected modifyRegisterRequest: (request: RegisterRequest) => Promise<void>;
+
   constructor(
     protected formValidationErrorService: FormValidationErrorsService,
     protected formBuilder: UntypedFormBuilder,
@@ -293,10 +297,8 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
       kdfConfig.parallelism,
     );
     request.keys = new KeysRequest(keys[0], keys[1].encryptedString);
-    const orgInvite = await this.stateService.getOrganizationInvitation();
-    if (orgInvite != null && orgInvite.token != null && orgInvite.organizationUserId != null) {
-      request.token = orgInvite.token;
-      request.organizationUserId = orgInvite.organizationUserId;
+    if (this.modifyRegisterRequest) {
+      await this.modifyRegisterRequest(request);
     }
     return request;
   }

--- a/libs/angular/src/auth/components/update-password.component.ts
+++ b/libs/angular/src/auth/components/update-password.component.ts
@@ -63,10 +63,7 @@ export class UpdatePasswordComponent extends BaseChangePasswordComponent {
   }
 
   async cancel() {
-    await this.stateService.setOrganizationInvitation(null);
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.router.navigate(["/vault"]);
+    await this.router.navigate(["/vault"]);
   }
 
   async setupSubmitActions(): Promise<boolean> {

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -182,8 +182,6 @@ export abstract class StateService<T extends Account = Account> {
   ) => Promise<void>;
   getMinimizeOnCopyToClipboard: (options?: StorageOptions) => Promise<boolean>;
   setMinimizeOnCopyToClipboard: (value: boolean, options?: StorageOptions) => Promise<void>;
-  getOrganizationInvitation: (options?: StorageOptions) => Promise<any>;
-  setOrganizationInvitation: (value: any, options?: StorageOptions) => Promise<void>;
   getPasswordGenerationOptions: (options?: StorageOptions) => Promise<PasswordGeneratorOptions>;
   setPasswordGenerationOptions: (
     value: PasswordGeneratorOptions,

--- a/libs/common/src/platform/models/domain/global-state.ts
+++ b/libs/common/src/platform/models/domain/global-state.ts
@@ -1,5 +1,4 @@
 export class GlobalState {
-  organizationInvitation?: any;
   vaultTimeout?: number;
   vaultTimeoutAction?: string;
   enableBrowserIntegration?: boolean;

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -895,23 +895,6 @@ export class StateService<
     );
   }
 
-  async getOrganizationInvitation(options?: StorageOptions): Promise<any> {
-    return (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultInMemoryOptions()))
-    )?.organizationInvitation;
-  }
-
-  async setOrganizationInvitation(value: any, options?: StorageOptions): Promise<void> {
-    const globals = await this.getGlobals(
-      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
-    );
-    globals.organizationInvitation = value;
-    await this.saveGlobals(
-      globals,
-      this.reconcileOptions(options, await this.defaultInMemoryOptions()),
-    );
-  }
-
   async getPasswordGenerationOptions(options?: StorageOptions): Promise<PasswordGeneratorOptions> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The original issue (SSO users getting routed back to "join org" screen after authenticating) was caused due to the `OrganizationInvite` state using memory instead of disk.

We needed to also migrate `OrganizationInvites` to state providers, but there wasn't a great place to put them. Rather than doing that I removed the state altogether and the flow now uses the `DeepLinkedUrl` state. I don't think this is the greatest way of handling organization invites, but a good stopgap solution for now.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Should be straightforward changes, but two things to note:
1. The `accept-invite` flow previously used the `OrganizationInvite` state to know whether authenticated users had been sent through the login flow to check their MP against the orgs MP policy. Since we didn't have that option anymore, I added a query param to the deep link so we know the MP has been checked.
2. SSO JIT flows actually accept invites once they set their password. So for that flow in particular, I clear the deep link so we don't try to accept the invite twice. This way, passwordless users should still be sent to the `AcceptOrganizationComponent`

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/24985544/06cb5346-b61b-4977-b28a-1d7c04ebcaed


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
