### PR TITLE
Update Organization and Policy Services to allow the passing of a user id and to prevent hangs waiting on an active user

### DIFF
--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -123,9 +123,9 @@ export abstract class OrganizationService {
   getAll: (userId?: string) => Promise<Organization[]>;
 
   /**
-   * Publishes state for all organizations for the given user id.
+   * Publishes state for all organizations for the given user id or the active user.
    */
-  getAll$: (userId: UserId) => Observable<Organization[]>;
+  getAll$: (userId?: UserId) => Observable<Organization[]>;
 }
 
 /**

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -121,7 +121,11 @@ export abstract class OrganizationService {
   get$: (id: string) => Observable<Organization | undefined>;
   get: (id: string) => Promise<Organization>;
   getAll: (userId?: string) => Promise<Organization[]>;
-  //
+
+  /**
+   * Publishes state for all organizations for the given user id.
+   */
+  getAll$: (userId: UserId) => Observable<Organization[]>;
 }
 
 /**

--- a/libs/common/src/admin-console/services/organization/organization.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization.service.ts
@@ -73,6 +73,10 @@ export class OrganizationService implements InternalOrganizationServiceAbstracti
     return this.organizations$.pipe(mapToSingleOrganization(id));
   }
 
+  getAll$(userId: UserId): Observable<Organization[]> {
+    return this.getOrganizationsFromState$(userId);
+  }
+
   async getAll(userId?: string): Promise<Organization[]> {
     return await firstValueFrom(this.getOrganizationsFromState$(userId as UserId));
   }

--- a/libs/common/src/admin-console/services/organization/organization.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization.service.ts
@@ -73,7 +73,7 @@ export class OrganizationService implements InternalOrganizationServiceAbstracti
     return this.organizations$.pipe(mapToSingleOrganization(id));
   }
 
-  getAll$(userId: UserId): Observable<Organization[]> {
+  getAll$(userId?: UserId): Observable<Organization[]> {
     return this.getOrganizationsFromState$(userId);
   }
 

--- a/libs/common/src/admin-console/services/policy/policy.service.spec.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.spec.ts
@@ -32,7 +32,8 @@ describe("PolicyService", () => {
     organizationService = mock<OrganizationService>();
 
     activeUserState = stateProvider.activeUser.getFake(POLICIES);
-    organizationService.organizations$ = of([
+
+    const organizations$ = of([
       // User
       organization("org1", true, true, OrganizationUserStatusType.Confirmed, false),
       // Owner
@@ -53,6 +54,10 @@ describe("PolicyService", () => {
       // Can manage policies
       organization("org6", true, true, OrganizationUserStatusType.Confirmed, true),
     ]);
+
+    organizationService.organizations$ = organizations$;
+
+    organizationService.getAll$.mockReturnValue(organizations$);
 
     policyService = new PolicyService(stateProvider, organizationService);
   });

--- a/libs/common/src/admin-console/services/policy/policy.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.ts
@@ -51,7 +51,7 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
       map((policies) => policies.filter((p) => p.type === policyType)),
     );
 
-    return combineLatest([filteredPolicies$, this.organizationService.organizations$]).pipe(
+    return combineLatest([filteredPolicies$, this.organizationService.getAll$(userId)]).pipe(
       map(([policies, organizations]) => this.enforcedPolicyFilter(policies, organizations)),
     );
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

- To add a method on the `OrganizationService` which accepts an optional user id and returns an observable of the given or active user's organizations state.
- To then resolve a bug in the `PolicyService` in which the `getAll$(...)` method didn't pass the optional user id into the retrieval of the organizations. This would result in a hang if you called to get policies before there was an active account (a scenario I ran into in #8604) even if you provided a user id. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts:** Add `getAll$`docs
- **libs/common/src/admin-console/services/organization/organization.service.ts:** Add `getAll$` method
- **libs/common/src/admin-console/services/policy/policy.service.ts:** Update `PolicyService.getAll$` to use `OrganizationService.getAll$`
- **libs/common/src/admin-console/services/policy/policy.service.spec.ts:** Update `PolicyService` tests

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
