### PR TITLE
[AC-2443] Update unassigned items banner text for self-hosted

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3008,5 +3008,8 @@
   },
   "unassignedItemsBanner": {
     "message": "Notice: Unassigned organization items are no longer visible in the All Vaults view and only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
+  },
+  "unassignedItemsBannerSelfHost": {
+    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in the All Vaults view and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.html
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.html
@@ -39,12 +39,13 @@
     <app-callout
       *ngIf="
         (unassignedItemsBannerEnabled$ | async) &&
-        (unassignedItemsBannerService.showBanner$ | async)
+        (unassignedItemsBannerService.showBanner$ | async) &&
+        (unassignedItemsBannerService.bannerText$ | async)
       "
       type="info"
     >
       <p>
-        {{ "unassignedItemsBanner" | i18n }}
+        {{ unassignedItemsBannerService.bannerText$ | async | i18n }}
         <a
           href="https://bitwarden.com/help/unassigned-vault-items-moved-to-admin-console"
           bitLink

--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -2,10 +2,12 @@
   class="-tw-m-6 tw-flex tw-flex-col tw-pb-6"
   (onClose)="unassignedItemsBannerService.hideBanner()"
   *ngIf="
-    (unassignedItemsBannerEnabled$ | async) && (unassignedItemsBannerService.showBanner$ | async)
+    (unassignedItemsBannerEnabled$ | async) &&
+    (unassignedItemsBannerService.showBanner$ | async) &&
+    (unassignedItemsBannerService.bannerText$ | async)
   "
 >
-  {{ "unassignedItemsBanner" | i18n }}
+  {{ unassignedItemsBannerService.bannerText$ | async | i18n }}
   <a
     href="https://bitwarden.com/help/unassigned-vault-items-moved-to-admin-console"
     bitLink

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7902,5 +7902,8 @@
   },
   "unassignedItemsBanner": {
     "message": "Notice: Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
+  },
+  "unassignedItemsBannerSelfHost": {
+    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in your All Vaults view across devices and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7904,6 +7904,6 @@
     "message": "Notice: Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   },
   "unassignedItemsBannerSelfHost": {
-    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in the All Vaults view and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
+    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in your All Vaults view across devices and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7904,6 +7904,6 @@
     "message": "Notice: Unassigned organization items are no longer visible in your All Vaults view across devices and are now only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   },
   "unassignedItemsBannerSelfHost": {
-    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in your All Vaults view across devices and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
+    "message": "Notice: On May 2, 2024, unassigned organization items will no longer be visible in the All Vaults view and will only be accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible."
   }
 }

--- a/libs/angular/src/services/unassigned-items-banner.service.spec.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.spec.ts
@@ -1,5 +1,5 @@
 import { MockProxy, mock } from "jest-mock-extended";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -21,6 +21,7 @@ describe("UnassignedItemsBanner", () => {
     stateProvider = new FakeStateProvider(fakeAccountService);
     apiService = mock();
     environmentService = mock();
+    environmentService.environment$ = of(null);
   });
 
   it("shows the banner if showBanner local state is true", async () => {

--- a/libs/angular/src/services/unassigned-items-banner.service.spec.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.spec.ts
@@ -1,6 +1,7 @@
 import { MockProxy, mock } from "jest-mock-extended";
 import { firstValueFrom } from "rxjs";
 
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
 
@@ -10,13 +11,16 @@ import { SHOW_BANNER_KEY, UnassignedItemsBannerService } from "./unassigned-item
 describe("UnassignedItemsBanner", () => {
   let stateProvider: FakeStateProvider;
   let apiService: MockProxy<UnassignedItemsBannerApiService>;
+  let environmentService: MockProxy<EnvironmentService>;
 
-  const sutFactory = () => new UnassignedItemsBannerService(stateProvider, apiService);
+  const sutFactory = () =>
+    new UnassignedItemsBannerService(stateProvider, apiService, environmentService);
 
   beforeEach(() => {
     const fakeAccountService = mockAccountServiceWith("userId" as UserId);
     stateProvider = new FakeStateProvider(fakeAccountService);
     apiService = mock();
+    environmentService = mock();
   });
 
   it("shows the banner if showBanner local state is true", async () => {

--- a/libs/angular/src/services/unassigned-items-banner.service.ts
+++ b/libs/angular/src/services/unassigned-items-banner.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from "@angular/core";
-import { concatMap } from "rxjs";
+import { concatMap, map } from "rxjs";
 
+import {
+  EnvironmentService,
+  Region,
+} from "@bitwarden/common/platform/abstractions/environment.service";
 import {
   StateProvider,
   UNASSIGNED_ITEMS_BANNER_DISK,
@@ -36,9 +40,18 @@ export class UnassignedItemsBannerService {
     }),
   );
 
+  bannerText$ = this.environmentService.environment$.pipe(
+    map((e) =>
+      e?.getRegion() == Region.SelfHosted
+        ? "unassignedItemsBannerSelfHost"
+        : "unassignedItemsBanner",
+    ),
+  );
+
   constructor(
     private stateProvider: StateProvider,
     private apiService: UnassignedItemsBannerApiService,
+    private environmentService: EnvironmentService,
   ) {}
 
   async hideBanner() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Show the unassigned items banner in advance of the self-hosted flexible collections release, to give self-hosted users advance warning of the change.

Client-side, this really just means changing the text to use future tense instead.

Server-side, see https://github.com/bitwarden/server/pull/3978.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![Screenshot 2024-04-12 at 11 49 16 AM](https://github.com/bitwarden/clients/assets/31796059/48aba652-9db4-4765-99c1-f9082b02ebfc)

![Screenshot 2024-04-12 at 11 49 32 AM](https://github.com/bitwarden/clients/assets/31796059/65ee8b46-bb66-40bc-9774-89fe0a3f6582)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
