### PR TITLE
[AC-2447] Owner/Admin Can Remove Last Accessible Collection From Item

### DIFF
--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -220,7 +220,10 @@ export abstract class ApiService {
   putMoveCiphers: (request: CipherBulkMoveRequest) => Promise<any>;
   putShareCipher: (id: string, request: CipherShareRequest) => Promise<CipherResponse>;
   putShareCiphers: (request: CipherBulkShareRequest) => Promise<any>;
-  putCipherCollections: (id: string, request: CipherCollectionsRequest) => Promise<CipherResponse>;
+  putCipherCollections: (
+    id: string,
+    request: CipherCollectionsRequest,
+  ) => Promise<CipherResponse | null>;
   putCipherCollectionsAdmin: (id: string, request: CipherCollectionsRequest) => Promise<any>;
   postPurgeCiphers: (request: SecretVerificationRequest, organizationId?: string) => Promise<any>;
   putDeleteCipher: (id: string) => Promise<any>;

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -569,8 +569,13 @@ export class ApiService implements ApiServiceAbstraction {
     id: string,
     request: CipherCollectionsRequest,
   ): Promise<CipherResponse> {
-    const response = await this.send("PUT", "/ciphers/" + id + "/collections", request, true, true);
-    return new CipherResponse(response);
+    // If the put request results in the user losing access to that cipher we will return null
+    try {
+      const response = await this.send("PUT", `/ciphers/${id}/collections`, request, true, true);
+      return new CipherResponse(response);
+    } catch (e) {
+      return null;
+    }
   }
 
   putCipherCollectionsAdmin(id: string, request: CipherCollectionsRequest): Promise<any> {

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -684,7 +684,8 @@ export class CipherService implements CipherServiceAbstraction {
   async saveCollectionsWithServer(cipher: Cipher): Promise<any> {
     const request = new CipherCollectionsRequest(cipher.collectionIds);
     const response = await this.apiService.putCipherCollections(cipher.id, request);
-    const data = new CipherData(response);
+    // The response will return null if the user can no longer access the cipher after the PUT request.
+    const data = response != null ? new CipherData(response) : cipher.toCipherData();
     await this.upsert(data);
   }
 


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When an owner/admin removes the last collections they have any access to from an item they were receiving an error.
Updated the `cipherService` and `apiService` to address a null response from the `putCipherCollections` call

## Code changes

* `api.service` - `putCipherCollections` now has a try catch that will return `null` if the response is an error
* `cipher.service` - if the response is null call `upsert` with the cipher data passed into the method

## Screen Recording

https://github.com/bitwarden/clients/assets/8302660/03a40f43-0840-46a3-9dcb-f9bc307d151a

