### PR TITLE
[AC-2403] Hide grace period note when in self-serve trial

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
@@ -42,7 +42,10 @@
             : subscription.expirationWithGracePeriod
           ) | date: "mediumDate"
         }}
-        <div *ngIf="subscription.hasSeparateGracePeriod" class="tw-text-muted">
+        <div
+          *ngIf="subscription.hasSeparateGracePeriod && !subscription.isInTrial"
+          class="tw-text-muted"
+        >
           {{
             "selfHostGracePeriodHelp"
               | i18n: (subscription.expirationWithGracePeriod | date: "mediumDate")

--- a/libs/common/src/billing/models/view/self-hosted-organization-subscription.view.ts
+++ b/libs/common/src/billing/models/view/self-hosted-organization-subscription.view.ts
@@ -58,4 +58,16 @@ export class SelfHostedOrganizationSubscriptionView implements View {
   get isExpiredAndOutsideGracePeriod() {
     return this.hasExpiration && this.expirationWithGracePeriod < new Date();
   }
+
+  /**
+   * In the case of a trial, where there is no grace period, the expirationWithGracePeriod and expirationWithoutGracePeriod will
+   * be exactly the same. This can be used to hide the grace period note.
+   */
+  get isInTrial() {
+    return (
+      this.expirationWithGracePeriod &&
+      this.expirationWithoutGracePeriod &&
+      this.expirationWithGracePeriod.getTime() === this.expirationWithoutGracePeriod.getTime()
+    );
+  }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Subscriptions in self-serve trials do not have a grace period. We need to hide the grace period note when this is the case. This can be identified when the expiration and expiration with grace period are exactly the same. 
