### PR TITLE
JSONify Items in Cache

### DIFF
--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -21,7 +21,7 @@ export class LocalBackedSessionStorageService
   extends AbstractMemoryStorageService
   implements ObservableStorageService
 {
-  private cache = new Map<string, unknown>();
+  private cache = new Map<string, string>();
   private updatesSubject = new Subject<StorageUpdate>();
 
   private commandName = `localBackedSessionStorage_${this.name}`;
@@ -63,7 +63,7 @@ export class LocalBackedSessionStorageService
 
   async get<T>(key: string, options?: MemoryStorageOptions<T>): Promise<T> {
     if (this.cache.has(key)) {
-      return this.cache.get(key) as T;
+      return JSON.parse(this.cache.get(key)) as T;
     }
 
     return await this.getBypassCache(key, options);
@@ -80,8 +80,8 @@ export class LocalBackedSessionStorageService
       value = options.deserializer(value as Jsonify<T>);
     }
 
-    this.cache.set(key, value);
-    return this.cache.get(key) as T;
+    this.cache.set(key, JSON.stringify(value));
+    return value as T;
   }
 
   async has(key: string): Promise<boolean> {
@@ -93,7 +93,7 @@ export class LocalBackedSessionStorageService
       return await this.remove(key);
     }
 
-    this.cache.set(key, obj);
+    this.cache.set(key, JSON.stringify(obj));
     await this.updateLocalSessionValue(key, obj);
     this.sendUpdate({ key, updateType: "save" });
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Currently `LocalBackedSessionStorage` is returning inconsistently serialized items, if it retrieved the value from cache it will never have been serialized but if it retrieved the item from the disk encrypted data then it will have been serialized. The storage service as a whole dictates that de-serialization is always required though. I noticed the problem with some [send state](https://github.com/bitwarden/clients/blob/9ecf384176c21fb43117a5b324e37f9d218451f0/libs/common/src/tools/send/models/view/send.view.ts#L85) where it believed `key` would be a `string`, because that is what it would be if it had been serialized, but it was instead still a `Uint8Array` which is what it wanted it to become. 

The best course of action is to make sure the item has been serialized before it gets returned, this lets the `deserializer` on the key definition only have one expected shape. 


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
