### PR TITLE
[PM-7546] Assign `CipherData` to Record

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -785,7 +785,7 @@ export class CipherService implements CipherServiceAbstraction {
   async upsert(cipher: CipherData | CipherData[]): Promise<any> {
     const ciphers = cipher instanceof CipherData ? [cipher] : cipher;
     await this.updateEncryptedCipherState((current) => {
-      ciphers.forEach((c) => current[c.id as CipherId]);
+      ciphers.forEach((c) => (current[c.id as CipherId] = c));
       return current;
     });
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When building the new ciphers array, we need to assign the new value to the record at the specified indexer. This was previously done before the `CipherService` migration here: 

https://github.com/bitwarden/clients/blob/ceffa2064213ce2ffbcbe69853e6285391bfffa0/libs/common/src/vault/services/cipher.service.ts#L743-L745

Without this, the foreach was just indexing into the record but doing nothing with it. This resulted in the record being the exact same as it was when it was passed in, making it seem that no new ciphers were added and the ciphers were only retrievable from forcing it to come from the server.


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
