### PR TITLE
[PM-7565] fix filter icon alignment

### DIFF
--- a/apps/desktop/src/scss/left-nav.scss
+++ b/apps/desktop/src/scss/left-nav.scss
@@ -141,6 +141,8 @@
       color: themed("headingButtonColor");
     }
 
+    margin-right: 0.25rem;
+
     &:hover,
     &:focus {
       @include themify($themes) {

--- a/apps/web/src/scss/vault-filters.scss
+++ b/apps/web/src/scss/vault-filters.scss
@@ -43,6 +43,7 @@
 
   button.toggle-button,
   button.add-button {
+    margin-right: 0.25rem;
     &:hover,
     &:focus {
       @include themify($themes) {
@@ -98,6 +99,7 @@
   }
 
   .toggle-button {
+    margin-right: 0.25rem;
     &:hover,
     &:focus {
       @include themify($themes) {


### PR DESCRIPTION
update styles so that folders and subfolders are correctly aligned in vault filters on web and desktop

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes #8553 

Small styling fix to align icons in vault filters when subfolders are present. Desktop and web.

## Code changes

Added a margin-right style attribute to the "toggle-button" class (folders with subfolders) to match the layout of 
the "filter-button" class (folders without subfolders).


## Screenshots

<img width="156" alt="Screen Shot 2024-04-17 at 1 29 39 PM" src="https://github.com/bitwarden/clients/assets/95505948/2bfb1602-959a-4971-b6c1-9dceb3a748ad">

