### PR TITLE
Fix migrated state service data

### DIFF
--- a/libs/common/src/state-migrations/migrations/57-move-cipher-service-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/57-move-cipher-service-to-state-provider.spec.ts
@@ -26,11 +26,13 @@ function exampleJSON() {
           },
         },
         ciphers: {
-          "cipher-id-10": {
-            id: "cipher-id-10",
-          },
-          "cipher-id-11": {
-            id: "cipher-id-11",
+          encrypted: {
+            "cipher-id-10": {
+              id: "cipher-id-10",
+            },
+            "cipher-id-11": {
+              id: "cipher-id-11",
+            },
           },
         },
       },
@@ -150,11 +152,13 @@ describe("CipherServiceMigrator", () => {
             },
           },
           ciphers: {
-            "cipher-id-10": {
-              id: "cipher-id-10",
-            },
-            "cipher-id-11": {
-              id: "cipher-id-11",
+            encrypted: {
+              "cipher-id-10": {
+                id: "cipher-id-10",
+              },
+              "cipher-id-11": {
+                id: "cipher-id-11",
+              },
             },
           },
         },

--- a/libs/common/src/state-migrations/migrations/57-move-cipher-service-to-state-provider.ts
+++ b/libs/common/src/state-migrations/migrations/57-move-cipher-service-to-state-provider.ts
@@ -4,7 +4,9 @@ import { Migrator } from "../migrator";
 type ExpectedAccountType = {
   data: {
     localData?: unknown;
-    ciphers?: unknown;
+    ciphers?: {
+      encrypted: unknown;
+    };
   };
 };
 
@@ -37,7 +39,7 @@ export class CipherServiceMigrator extends Migrator<56, 57> {
       }
 
       //Migrate ciphers
-      const ciphers = account?.data?.ciphers;
+      const ciphers = account?.data?.ciphers?.encrypted;
       if (ciphers != null) {
         await helper.setToUser(userId, CIPHERS_DISK, ciphers);
         delete account.data.ciphers;
@@ -68,7 +70,8 @@ export class CipherServiceMigrator extends Migrator<56, 57> {
       const ciphers = await helper.getFromUser(userId, CIPHERS_DISK);
 
       if (account.data && ciphers != null) {
-        account.data.ciphers = ciphers;
+        account.data.ciphers ||= { encrypted: null };
+        account.data.ciphers.encrypted = ciphers;
         await helper.set(userId, account);
       }
       await helper.setToUser(userId, CIPHERS_DISK, null);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8314 migrated cipher encrypted data from state service to state providers. State service held data in an encrypted pair, with potentially both encrypted and decrypted values. We want the encrypted form for these disk migrations (decrypted would always be empty on disk anyways).

This migration has not yet been released and so does not need to be reverted and reapplied.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
