### PR TITLE
[PM-7603] Fix individual vault export not appearing on Event Logs

### DIFF
--- a/libs/common/src/services/event/event-collection.service.ts
+++ b/libs/common/src/services/event/event-collection.service.ts
@@ -36,7 +36,7 @@ export class EventCollectionService implements EventCollectionServiceAbstraction
     const userId = await firstValueFrom(this.stateProvider.activeUserId$);
     const eventStore = this.stateProvider.getUser(userId, EVENT_COLLECTION);
 
-    if (!(await this.shouldUpdate(cipherId, organizationId))) {
+    if (!(await this.shouldUpdate(cipherId, organizationId, eventType))) {
       return;
     }
 
@@ -87,7 +87,7 @@ export class EventCollectionService implements EventCollectionServiceAbstraction
     }
 
     // Individual vault export doesn't need cipher id or organization id.
-    if (eventType != EventType.User_ClientExportedVault) {
+    if (eventType == EventType.User_ClientExportedVault) {
       return true;
     }
 

--- a/libs/common/src/services/event/event-collection.service.ts
+++ b/libs/common/src/services/event/event-collection.service.ts
@@ -64,6 +64,7 @@ export class EventCollectionService implements EventCollectionServiceAbstraction
   private async shouldUpdate(
     cipherId: string = null,
     organizationId: string = null,
+    eventType: EventType = null,
   ): Promise<boolean> {
     const orgIds$ = this.organizationService.organizations$.pipe(
       map((orgs) => orgs?.filter((o) => o.useEvents)?.map((x) => x.id) ?? []),
@@ -83,6 +84,11 @@ export class EventCollectionService implements EventCollectionServiceAbstraction
     // User must have organizations assigned to them
     if (orgIds == null || orgIds.length == 0) {
       return false;
+    }
+
+    // Individual vault export doesn't need cipher id or organization id.
+    if (eventType != EventType.User_ClientExportedVault) {
+      return true;
     }
 
     // If the cipher is null there must be an organization id provided


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Individual vault export event was not showing on organization event logs. `EventCollectionService` only updated events when they had a cipher id or a organization id. 
Individual vault export has neither so it was not being added. Added an if exception for this event type.

## Code changes
- **event-collection.service.ts:** Added an if validation that allows `User_ClientExportedVault` to be updated even not having `organizationid` and `cipherid`


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
