### PR TITLE
Add rust analyzer support for desktop-native

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "**/locales/*[^n]/messages.json": true,
     "**/_locales/[^e]*/messages.json": true,
     "**/_locales/*[^n]/messages.json": true
-  }
+  },
+  "rust-analyzer.linkedProjects": ["apps/desktop/desktop_native/Cargo.toml"]
 }


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
Adds support for rust-analyzer to find the `desktop_native` rust module in VSCode. Otherwise, even if you navigate to the subdirectory and open a rust file, rust-analyzer will fail to load.
