### PR TITLE
[PM-7610] [MV3] Guard overlay visibility and autofill on page load settings from awaiting indefinitely when there is no active account

### DIFF
--- a/apps/browser/src/autofill/background/service_factories/autofill-service.factory.ts
+++ b/apps/browser/src/autofill/background/service_factories/autofill-service.factory.ts
@@ -1,4 +1,8 @@
 import {
+  accountServiceFactory,
+  AccountServiceInitOptions,
+} from "../../../auth/background/service-factories/account-service.factory";
+import {
   UserVerificationServiceInitOptions,
   userVerificationServiceFactory,
 } from "../../../auth/background/service-factories/user-verification-service.factory";
@@ -50,7 +54,8 @@ export type AutoFillServiceInitOptions = AutoFillServiceOptions &
   LogServiceInitOptions &
   UserVerificationServiceInitOptions &
   DomainSettingsServiceInitOptions &
-  BrowserScriptInjectorServiceInitOptions;
+  BrowserScriptInjectorServiceInitOptions &
+  AccountServiceInitOptions;
 
 export function autofillServiceFactory(
   cache: { autofillService?: AbstractAutoFillService } & CachedServices,
@@ -71,6 +76,7 @@ export function autofillServiceFactory(
         await userVerificationServiceFactory(cache, opts),
         await billingAccountProfileStateServiceFactory(cache, opts),
         await browserScriptInjectorServiceFactory(cache, opts),
+        await accountServiceFactory(cache, opts),
       ),
   );
 }

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -87,6 +87,7 @@ describe("AutofillService", () => {
       userVerificationService,
       billingAccountProfileStateService,
       scriptInjectorService,
+      accountService,
     );
 
     domainSettingsService = new DefaultDomainSettingsService(fakeStateProvider);

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -3,6 +3,7 @@ import { firstValueFrom } from "rxjs";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
@@ -111,7 +112,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
 
     // These settings are not available until the user logs in
-    let overlayVisibility = 0;
+    let overlayVisibility: InlineMenuVisibilitySetting = AutofillOverlayVisibility.Off;
     let autoFillOnPageLoadIsEnabled = false;
 
     if (activeAccount) {
@@ -223,7 +224,7 @@ export default class AutofillService implements AutofillServiceInterface {
    * Gets the overlay's visibility setting from the autofill settings service.
    */
   async getOverlayVisibility(): Promise<InlineMenuVisibilitySetting> {
-    return (await firstValueFrom(this.autofillSettingsService.inlineMenuVisibility$)) || 0;
+    return await firstValueFrom(this.autofillSettingsService.inlineMenuVisibility$);
   }
 
   /**
@@ -237,7 +238,7 @@ export default class AutofillService implements AutofillServiceInterface {
    * Gets the autofill on page load setting from the autofill settings service.
    */
   async getAutofillOnPageLoad(): Promise<boolean> {
-    return (await firstValueFrom(this.autofillSettingsService.autofillOnPageLoad$)) || false;
+    return await firstValueFrom(this.autofillSettingsService.autofillOnPageLoad$);
   }
 
   /**

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -29,6 +29,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/services/policy/p
 import { ProviderService } from "@bitwarden/common/admin-console/services/provider.service";
 import { AccountService as AccountServiceAbstraction } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AvatarService as AvatarServiceAbstraction } from "@bitwarden/common/auth/abstractions/avatar.service";
 import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
@@ -135,7 +136,6 @@ import { EventUploadService } from "@bitwarden/common/services/event/event-uploa
 import { NotificationsService } from "@bitwarden/common/services/notifications.service";
 import { SearchService } from "@bitwarden/common/services/search.service";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/services/vault-timeout/vault-timeout-settings.service";
-import { AvatarService as AvatarServiceAbstraction } from "@bitwarden/common/src/auth/abstractions/avatar.service";
 import {
   PasswordGenerationService,
   PasswordGenerationServiceAbstraction,
@@ -806,6 +806,7 @@ export default class MainBackground {
       this.userVerificationService,
       this.billingAccountProfileStateService,
       this.scriptInjectorService,
+      this.accountService,
     );
     this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
 

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -314,6 +314,7 @@ const safeProviders: SafeProvider[] = [
       UserVerificationService,
       BillingAccountProfileStateService,
       ScriptInjectorService,
+      AccountServiceAbstraction,
     ],
   }),
   safeProvider({


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- Bug fix
- Tech debt (refactoring, code cleanup, dependency upgrades, etc)
```

## Objective

If no user is logged in, some autofill settings (in user state as `inlineMenuVisibility` and `autofillOnPageLoad`) which are used for pre-login autofill script injections will await an active account indefinitely. This PR adds active account checks to guard against this case.