### PR TITLE
[PM-6819] fix update cycle when overwriting state from buffer

### DIFF
--- a/libs/common/src/tools/generator/state/buffered-key-definition.ts
+++ b/libs/common/src/tools/generator/state/buffered-key-definition.ts
@@ -87,9 +87,13 @@ export class BufferedKeyDefinition<Input, Output = Input, Dependency = true> {
   }
 
   /** Checks whether the input type can be converted to the output type.
-   *  @returns `true` if the definition is valid, otherwise `false`.
+   *  @returns `true` if the definition is defined and valid, otherwise `false`.
    */
   isValid(input: Input, dependency: Dependency) {
+    if (input === null) {
+      return Promise.resolve(false);
+    }
+
     const isValid = this.options?.isValid;
     if (isValid) {
       return isValid(input, dependency);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

**Note:** Dependency of #8605, #8606. These branches are the only consumers of `BufferedState`, and QA will occur there.

## Objective

Fix a `BufferedState` bug that causes updates to endlessly loop once an overwrite occurs when wired to `SecretState` in electron. The bug occurs because `SecretState` emissions are ordered before the buffered value is cleared, causing `updateOutput` to repeatedly process the buffered value. 

The solution wires the overwrite logic in parallel with the output logic using `merge`. Emissions from the overwrite stream are ignored, which lets the output stream to control all emissions from `BufferedState.state$`.

This also had a nice side effect of clearing up some double-emissions in the test cases.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/tools/generator/state/buffered-key-definition.ts:** Move null handling into `BufferedKeyDefinition.isValid` to simplify `overwriteOutput`
- **libs/common/src/tools/generator/state/buffered-state.spec.ts** - the unit tests demonstrate the increased consistency
- **libs/common/src/tools/generator/state/buffered-state.ts** - bugfix; label observable streams using variables; increase clarity and consistency of `BufferedState` members
