### PR TITLE
[PM-7617] Stop CryptoService from using `getBgService`

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -31,6 +31,7 @@ import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/auth/ab
 import { DeviceTrustCryptoServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust-crypto.service.abstraction";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import { KeyConnectorService } from "@bitwarden/common/auth/abstractions/key-connector.service";
+import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/auth/abstractions/master-password.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { TwoFactorService } from "@bitwarden/common/auth/abstractions/two-factor.service";
@@ -55,6 +56,7 @@ import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { KeyGenerationService } from "@bitwarden/common/platform/abstractions/key-generation.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService as BaseStateServiceAbstraction } from "@bitwarden/common/platform/abstractions/state.service";
@@ -63,6 +65,7 @@ import {
   AbstractStorageService,
   ObservableStorageService,
 } from "@bitwarden/common/platform/abstractions/storage.service";
+import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { StateFactory } from "@bitwarden/common/platform/factories/state-factory";
 import { Message, MessageListener, MessageSender } from "@bitwarden/common/platform/messaging";
 // eslint-disable-next-line no-restricted-imports -- Used for dependency injection
@@ -101,6 +104,7 @@ import BrowserPopupUtils from "../../platform/popup/browser-popup-utils";
 import { BrowserFileDownloadService } from "../../platform/popup/services/browser-file-download.service";
 import { BrowserStateService as StateServiceAbstraction } from "../../platform/services/abstractions/browser-state.service";
 import { ScriptInjectorService } from "../../platform/services/abstractions/script-injector.service";
+import { BrowserCryptoService } from "../../platform/services/browser-crypto.service";
 import { BrowserEnvironmentService } from "../../platform/services/browser-environment.service";
 import BrowserLocalStorageService from "../../platform/services/browser-local-storage.service";
 import { BrowserScriptInjectorService } from "../../platform/services/browser-script-injector.service";
@@ -226,12 +230,45 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: CryptoService,
-    useFactory: (encryptService: EncryptService) => {
-      const cryptoService = getBgService<CryptoService>("cryptoService")();
+    useFactory: (
+      masterPasswordService: InternalMasterPasswordServiceAbstraction,
+      keyGenerationService: KeyGenerationService,
+      cryptoFunctionService: CryptoFunctionService,
+      encryptService: EncryptService,
+      platformUtilsService: PlatformUtilsService,
+      logService: LogService,
+      stateService: StateServiceAbstraction,
+      accountService: AccountServiceAbstraction,
+      stateProvider: StateProvider,
+      biometricStateService: BiometricStateService,
+    ) => {
+      const cryptoService = new BrowserCryptoService(
+        masterPasswordService,
+        keyGenerationService,
+        cryptoFunctionService,
+        encryptService,
+        platformUtilsService,
+        logService,
+        stateService,
+        accountService,
+        stateProvider,
+        biometricStateService,
+      );
       new ContainerService(cryptoService, encryptService).attachToGlobal(self);
       return cryptoService;
     },
-    deps: [EncryptService],
+    deps: [
+      InternalMasterPasswordServiceAbstraction,
+      KeyGenerationService,
+      CryptoFunctionService,
+      EncryptService,
+      PlatformUtilsService,
+      LogService,
+      StateServiceAbstraction,
+      AccountServiceAbstraction,
+      StateProvider,
+      BiometricStateService,
+    ],
   }),
   safeProvider({
     provide: TotpServiceAbstraction,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This helps fix unlock with biometric because the crypto service is responsible for prompting for biometrics when the key is requested and since it was getting its instance from the fake background which has the `BackgroundPlatformUtilsService` which wasn't working because parts of the background it was trying to use were gone. Changing this means it gets the `ForegroundPlatformUtilsService` which allows the biometrics to work the way it was intended, through a message to the true background.

`CryptoFunctionService` is already being injected without `getBgService` ([see](https://github.com/bitwarden/clients/compare/ps/pm-7617/fix-biometric-unlock?expand=1#diff-210fa6ef76ade2d9a5dc1a77eefb240c2c0f71e951d00ac6fcdc38e83fe328f8L195-L199)).

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
