### PR TITLE
[AC-2484] Fix bug where Custom Users with "Delete any collection" permission incorrectly see "Can Edit" permission for Unassigned Collection

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -86,12 +86,7 @@ export class VaultCollectionRowComponent implements OnInit {
   }
 
   get permissionTooltip() {
-    if (
-      this.collection.id == Unassigned &&
-      (this.organization.isAdmin ||
-        (this.flexibleCollectionsV1Enabled &&
-          this.organization.canEditAnyCollection(this._flexibleCollectionsV1FlagEnabled)))
-    ) {
+    if (this.collection.id == Unassigned) {
       return this.i18nService.t("collectionAdminConsoleManaged");
     }
     return "";


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This bug was introduced in https://github.com/bitwarden/clients/pull/8609 because Admin users should see "Can Edit" for the Unassigned Collection.
This PR fixes that by checking if the user is an Admin or (if the V1 feature flag is enabled) by checking if the user can edit any collection.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
