### PR TITLE
[PM-7660] Master Password Re-Prompt from Autofill Not Working

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1105,20 +1105,22 @@ export default class MainBackground {
     await (this.eventUploadService as EventUploadService).init(true);
     this.twoFactorService.init();
 
-    if (!this.popupOnlyContext) {
-      await this.vaultTimeoutService.init(true);
-      this.fido2Background.init();
-      await this.runtimeBackground.init();
-      await this.notificationBackground.init();
-      this.filelessImporterBackground.init();
-      await this.commandsBackground.init();
-      await this.overlayBackground.init();
-      await this.tabsBackground.init();
-      this.contextMenusBackground?.init();
-      await this.idleBackground.init();
-      if (BrowserApi.isManifestVersion(2)) {
-        await this.webRequestBackground.init();
-      }
+    if (this.popupOnlyContext) {
+      return;
+    }
+
+    await this.vaultTimeoutService.init(true);
+    this.fido2Background.init();
+    await this.runtimeBackground.init();
+    await this.notificationBackground.init();
+    this.filelessImporterBackground.init();
+    await this.commandsBackground.init();
+    await this.overlayBackground.init();
+    await this.tabsBackground.init();
+    this.contextMenusBackground?.init();
+    await this.idleBackground.init();
+    if (BrowserApi.isManifestVersion(2)) {
+      await this.webRequestBackground.init();
     }
 
     if (this.platformUtilsService.isFirefox() && !this.isPrivateMode) {


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

A bug has been encountered with the master password reprompt workflow when attempting to autofill a vault item from keyboard shortcut or context menu. This issue seems to be occurring due to a follow up load event that is triggering in the view component.

This follow up load event is triggering due to a message that is sent to the component of syncCompleted. This shouldn’t be occurring, and is happening due to the re-instantiation of MainBackground within the popup vault. Guarding against that event will be necessary.

## Code changes

- **apps/browser/src/background/main.background.ts:** Guarding against calling a fullSync within `MainBackground` when it is initialized in the popup.
