### PR TITLE
[PM-7627] [MV3] Do not run fido2 content scripts on browser settings or extension pages

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -12,6 +12,7 @@ import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abs
 import { EventType } from "@bitwarden/common/enums";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EventCollectionService } from "@bitwarden/common/services/event/event-collection.service";
 import {
@@ -74,9 +75,10 @@ describe("AutofillService", () => {
   const logService = mock<LogService>();
   const userVerificationService = mock<UserVerificationService>();
   const billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
+  const platformUtilsService = mock<PlatformUtilsService>();
 
   beforeEach(() => {
-    scriptInjectorService = new BrowserScriptInjectorService();
+    scriptInjectorService = new BrowserScriptInjectorService(platformUtilsService, logService);
     autofillService = new AutofillService(
       cipherService,
       autofillSettingsService,

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -3,7 +3,6 @@ import { firstValueFrom } from "rxjs";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
-import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
@@ -107,17 +106,13 @@ export default class AutofillService implements AutofillServiceInterface {
     frameId = 0,
     triggeringOnPageLoad = true,
   ): Promise<void> {
-    // Autofill settings loaded from state can await the active account state indefinitely if
-    // not guarded by an active account check (e.g. the user is logged in)
+    // Autofill user settings loaded from state can await the active account state indefinitely
+    // if not guarded by an active account check (e.g. the user is logged in)
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
 
-    // These settings are not available until the user logs in
-    let overlayVisibility: InlineMenuVisibilitySetting = AutofillOverlayVisibility.Off;
     let autoFillOnPageLoadIsEnabled = false;
+    const overlayVisibility = await this.getOverlayVisibility();
 
-    if (activeAccount) {
-      overlayVisibility = await this.getOverlayVisibility();
-    }
     const mainAutofillScript = overlayVisibility
       ? "bootstrap-autofill-overlay.js"
       : "bootstrap-autofill.js";
@@ -2087,9 +2082,7 @@ export default class AutofillService implements AutofillServiceInterface {
     for (let index = 0; index < tabs.length; index++) {
       const tab = tabs[index];
       if (tab.url?.startsWith("http")) {
-        // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.injectAutofillScripts(tab, 0, false);
+        void this.injectAutofillScripts(tab, 0, false);
       }
     }
   }

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -808,7 +808,10 @@ export default class MainBackground {
     );
     this.totpService = new TotpService(this.cryptoFunctionService, this.logService);
 
-    this.scriptInjectorService = new BrowserScriptInjectorService();
+    this.scriptInjectorService = new BrowserScriptInjectorService(
+      this.platformUtilsService,
+      this.logService,
+    );
     this.autofillService = new AutofillService(
       this.cipherService,
       this.autofillSettingsService,

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -51,7 +51,6 @@
     "default_popup": "popup/index.html"
   },
   "permissions": [
-    "<all_urls>",
     "tabs",
     "contextMenus",
     "storage",
@@ -63,7 +62,7 @@
     "offscreen"
   ],
   "optional_permissions": ["nativeMessaging", "privacy"],
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": ["https://*/*", "http://*/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
     "sandbox": "sandbox allow-scripts; script-src 'self'"

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -51,6 +51,7 @@
     "default_popup": "popup/index.html"
   },
   "permissions": [
+    "activeTab",
     "tabs",
     "contextMenus",
     "storage",

--- a/apps/browser/src/platform/background/service-factories/browser-script-injector-service.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/browser-script-injector-service.factory.ts
@@ -1,10 +1,20 @@
+import {
+  LogServiceInitOptions,
+  logServiceFactory,
+} from "../../background/service-factories/log-service.factory";
 import { BrowserScriptInjectorService } from "../../services/browser-script-injector.service";
 
 import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import {
+  PlatformUtilsServiceInitOptions,
+  platformUtilsServiceFactory,
+} from "./platform-utils-service.factory";
 
 type BrowserScriptInjectorServiceOptions = FactoryOptions;
 
-export type BrowserScriptInjectorServiceInitOptions = BrowserScriptInjectorServiceOptions;
+export type BrowserScriptInjectorServiceInitOptions = BrowserScriptInjectorServiceOptions &
+  PlatformUtilsServiceInitOptions &
+  LogServiceInitOptions;
 
 export function browserScriptInjectorServiceFactory(
   cache: { browserScriptInjectorService?: BrowserScriptInjectorService } & CachedServices,
@@ -14,6 +24,10 @@ export function browserScriptInjectorServiceFactory(
     cache,
     "browserScriptInjectorService",
     opts,
-    async () => new BrowserScriptInjectorService(),
+    async () =>
+      new BrowserScriptInjectorService(
+        await platformUtilsServiceFactory(cache, opts),
+        await logServiceFactory(cache, opts),
+      ),
   );
 }

--- a/apps/browser/src/platform/services/browser-script-injector.service.spec.ts
+++ b/apps/browser/src/platform/services/browser-script-injector.service.spec.ts
@@ -1,3 +1,8 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
 import { BrowserApi } from "../browser/browser-api";
 
 import {
@@ -20,9 +25,11 @@ describe("ScriptInjectorService", () => {
   let scriptInjectorService: BrowserScriptInjectorService;
   jest.spyOn(BrowserApi, "executeScriptInTab").mockImplementation();
   jest.spyOn(BrowserApi, "isManifestVersion");
+  const platformUtilsService = mock<PlatformUtilsService>();
+  const logService = mock<LogService>();
 
   beforeEach(() => {
-    scriptInjectorService = new BrowserScriptInjectorService();
+    scriptInjectorService = new BrowserScriptInjectorService(platformUtilsService, logService);
   });
 
   describe("inject", () => {

--- a/apps/browser/src/platform/services/browser-script-injector.service.ts
+++ b/apps/browser/src/platform/services/browser-script-injector.service.ts
@@ -37,18 +37,20 @@ export class BrowserScriptInjectorService extends ScriptInjectorService {
         await BrowserApi.executeScriptInTab(tabId, injectionDetails, {
           world: mv3Details?.world ?? "ISOLATED",
         });
-      } catch ({ message }) {
+      } catch (error) {
         // Swallow errors for host permissions, since this is believed to be a Manifest V3 Chrome bug
         // @TODO remove when the bugged behaviour is resolved
         if (
-          message ===
+          error.message !==
           "Cannot access contents of the page. Extension manifest must request permission to access the respective host."
         ) {
-          if (this.platformUtilsService.isDev()) {
-            this.logService.warning(
-              `BrowserApi.executeScriptInTab exception for ${injectDetails.file} in tab ${tabId}: ${message}`,
-            );
-          }
+          throw error;
+        }
+
+        if (this.platformUtilsService.isDev()) {
+          this.logService.warning(
+            `BrowserApi.executeScriptInTab exception for ${injectDetails.file} in tab ${tabId}: ${error.message}`,
+          );
         }
       }
 

--- a/apps/browser/src/platform/services/browser-script-injector.service.ts
+++ b/apps/browser/src/platform/services/browser-script-injector.service.ts
@@ -1,3 +1,6 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
 import { BrowserApi } from "../browser/browser-api";
 
 import {
@@ -7,6 +10,13 @@ import {
 } from "./abstractions/script-injector.service";
 
 export class BrowserScriptInjectorService extends ScriptInjectorService {
+  constructor(
+    private readonly platformUtilsService: PlatformUtilsService,
+    private readonly logService: LogService,
+  ) {
+    super();
+  }
+
   /**
    * Facilitates the injection of a script into a tab context. Will adjust
    * behavior between manifest v2 and v3 based on the passed configuration.
@@ -23,9 +33,24 @@ export class BrowserScriptInjectorService extends ScriptInjectorService {
     const injectionDetails = this.buildInjectionDetails(injectDetails, file);
 
     if (BrowserApi.isManifestVersion(3)) {
-      await BrowserApi.executeScriptInTab(tabId, injectionDetails, {
-        world: mv3Details?.world ?? "ISOLATED",
-      });
+      try {
+        await BrowserApi.executeScriptInTab(tabId, injectionDetails, {
+          world: mv3Details?.world ?? "ISOLATED",
+        });
+      } catch ({ message }) {
+        // Swallow errors for host permissions, since this is believed to be a Manifest V3 Chrome bug
+        // @TODO remove when the bugged behaviour is resolved
+        if (
+          message ===
+          "Cannot access contents of the page. Extension manifest must request permission to access the respective host."
+        ) {
+          if (this.platformUtilsService.isDev()) {
+            this.logService.warning(
+              `BrowserApi.executeScriptInTab exception for ${injectDetails.file} in tab ${tabId}: ${message}`,
+            );
+          }
+        }
+      }
 
       return;
     }

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -312,7 +312,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: ScriptInjectorService,
     useClass: BrowserScriptInjectorService,
-    deps: [],
+    deps: [PlatformUtilsService, LogService],
   }),
   safeProvider({
     provide: KeyConnectorService,

--- a/apps/browser/src/tools/background/fileless-importer.background.spec.ts
+++ b/apps/browser/src/tools/background/fileless-importer.background.spec.ts
@@ -5,6 +5,8 @@ import { PolicyService } from "@bitwarden/common/admin-console/services/policy/p
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { AuthService } from "@bitwarden/common/auth/services/auth.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Importer, ImportResult, ImportServiceAbstraction } from "@bitwarden/importer/core";
 
@@ -38,10 +40,12 @@ describe("FilelessImporterBackground ", () => {
   const notificationBackground = mock<NotificationBackground>();
   const importService = mock<ImportServiceAbstraction>();
   const syncService = mock<SyncService>();
+  const platformUtilsService = mock<PlatformUtilsService>();
+  const logService = mock<LogService>();
   let scriptInjectorService: BrowserScriptInjectorService;
 
   beforeEach(() => {
-    scriptInjectorService = new BrowserScriptInjectorService();
+    scriptInjectorService = new BrowserScriptInjectorService(platformUtilsService, logService);
     filelessImporterBackground = new FilelessImporterBackground(
       configService,
       authService,

--- a/apps/browser/src/vault/fido2/background/fido2.background.ts
+++ b/apps/browser/src/vault/fido2/background/fido2.background.ts
@@ -70,13 +70,13 @@ export class Fido2Background implements Fido2BackgroundInterface {
    */
   async injectFido2ContentScriptsInAllTabs() {
     const tabs = await BrowserApi.tabsQuery({});
+
     for (let index = 0; index < tabs.length; index++) {
       const tab = tabs[index];
-      if (!tab.url?.startsWith("https")) {
-        continue;
-      }
 
-      void this.injectFido2ContentScripts(tab);
+      if (tab.url?.startsWith("https")) {
+        void this.injectFido2ContentScripts(tab);
+      }
     }
   }
 

--- a/apps/browser/src/vault/fido2/content/content-script.ts
+++ b/apps/browser/src/vault/fido2/content/content-script.ts
@@ -15,7 +15,11 @@ import {
 import { MessageWithMetadata, Messenger } from "./messaging/messenger";
 
 (function (globalContext) {
-  if (globalContext.document.contentType !== "text/html") {
+  const shouldExecuteContentScript =
+    globalContext.document.contentType === "text/html" &&
+    globalContext.document.location.protocol === "https:";
+
+  if (!shouldExecuteContentScript) {
     return;
   }
 

--- a/apps/browser/src/vault/fido2/content/page-script-append.mv2.ts
+++ b/apps/browser/src/vault/fido2/content/page-script-append.mv2.ts
@@ -5,11 +5,7 @@
 import { Fido2ContentScript } from "../enums/fido2-content-script.enum";
 
 (function (globalContext) {
-  const shouldExecuteContentScript =
-    globalContext.document.contentType === "text/html" &&
-    globalContext.document.location.protocol === "https:";
-
-  if (!shouldExecuteContentScript) {
+  if (globalContext.document.contentType !== "text/html") {
     return;
   }
 

--- a/apps/browser/src/vault/fido2/content/page-script-append.mv2.ts
+++ b/apps/browser/src/vault/fido2/content/page-script-append.mv2.ts
@@ -5,7 +5,11 @@
 import { Fido2ContentScript } from "../enums/fido2-content-script.enum";
 
 (function (globalContext) {
-  if (globalContext.document.contentType !== "text/html") {
+  const shouldExecuteContentScript =
+    globalContext.document.contentType === "text/html" &&
+    globalContext.document.location.protocol === "https:";
+
+  if (!shouldExecuteContentScript) {
     return;
   }
 

--- a/apps/browser/src/vault/fido2/content/page-script.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.ts
@@ -6,9 +6,14 @@ import { MessageType } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 (function (globalContext) {
-  if (globalContext.document.contentType !== "text/html") {
+  const shouldExecuteContentScript =
+    globalContext.document.contentType === "text/html" &&
+    globalContext.document.location.protocol === "https:";
+
+  if (!shouldExecuteContentScript) {
     return;
   }
+
   const BrowserPublicKeyCredential = globalContext.PublicKeyCredential;
   const BrowserNavigatorCredentials = navigator.credentials;
   const BrowserAuthenticatorAttestationResponse = globalContext.AuthenticatorAttestationResponse;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix
- Tech debt (refactoring, code cleanup, dependency upgrades, etc)

## Objective

The fido2 content script is throwing errors in the extension (clicking on "Errors" from the extensions page).

## Screenshots
| | |
| --- | --- | 
| ![Screenshot 2024-04-25 at 11 31 48 AM](https://github.com/bitwarden/clients/assets/1556494/1f36d457-81f9-48a5-aeb7-5a5134691789) | ![Screenshot 2024-04-25 at 11 31 31 AM](https://github.com/bitwarden/clients/assets/1556494/14ed5f18-2d1c-4198-a2b9-ae42bb39ff95) |

## Code changes

- Extra guarding against content script execution in unintended environments prevents the fido2 content script errors from emitting
- Additionally, address errors emitting (improperly?) from host permissions issues in MV3 and update v3 manifest host permissions for proper "all domains":

![Screenshot 2024-04-25 at 5 18 24 PM](https://github.com/bitwarden/clients/assets/1556494/f7cee58a-ebfe-4b8c-bfd4-8932cb82fbcf)
| | |
| --- | --- |
| ![Screenshot 2024-04-25 at 2 19 02 PM](https://github.com/bitwarden/clients/assets/1556494/94f99318-14eb-4fb6-b6aa-a9f2b5beda7d) | ![Screenshot 2024-04-25 at 2 19 21 PM](https://github.com/bitwarden/clients/assets/1556494/8756fd13-0bfa-405f-9be1-88e6e87c01bf) |
