### PR TITLE
[CL-110] fix code block text color in Storybook

### DIFF
--- a/libs/components/src/styles.scss
+++ b/libs/components/src/styles.scss
@@ -47,3 +47,8 @@ $card-icons-base: "../../src/billing/images/cards/";
 @import "bootstrap/scss/_print";
 
 @import "multi-select/scss/bw.theme.scss";
+
+// Workaround for https://bitwarden.atlassian.net/browse/CL-110
+#storybook-docs pre.prismjs {
+  color: white;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The Storybook code block is rendering dark text on a dark background due to global Bootstrap styles that are injected into the page. This PR overrides that CSS and colors the text white.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/styles.scss:** add color override

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Before fix:
![image](https://github.com/bitwarden/clients/assets/17113462/72bb8b6c-efa9-46f5-82dd-567ee9c7e40d)


After fix:
![image](https://github.com/bitwarden/clients/assets/17113462/768f130c-ec79-4e01-8859-795c79a62b35)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
