### PR TITLE
Remove `StateService` `useAccountCache`

### DIFF
--- a/apps/browser/src/models/account.ts
+++ b/apps/browser/src/models/account.ts
@@ -5,10 +5,6 @@ import {
   AccountSettings as BaseAccountSettings,
 } from "@bitwarden/common/platform/models/domain/account";
 
-import { BrowserComponentState } from "./browserComponentState";
-import { BrowserGroupingsComponentState } from "./browserGroupingsComponentState";
-import { BrowserSendComponentState } from "./browserSendComponentState";
-
 export class AccountSettings extends BaseAccountSettings {
   vaultTimeout = -1; // On Restart
 
@@ -23,10 +19,6 @@ export class AccountSettings extends BaseAccountSettings {
 
 export class Account extends BaseAccount {
   settings?: AccountSettings = new AccountSettings();
-  groupings?: BrowserGroupingsComponentState;
-  send?: BrowserSendComponentState;
-  ciphers?: BrowserComponentState;
-  sendType?: BrowserComponentState;
 
   constructor(init: Partial<Account>) {
     super(init);
@@ -34,10 +26,6 @@ export class Account extends BaseAccount {
       ...new AccountSettings(),
       ...this.settings,
     });
-    this.groupings = init?.groupings ?? new BrowserGroupingsComponentState();
-    this.send = init?.send ?? new BrowserSendComponentState();
-    this.ciphers = init?.ciphers ?? new BrowserComponentState();
-    this.sendType = init?.sendType ?? new BrowserComponentState();
   }
 
   static fromJSON(json: Jsonify<Account>): Account {
@@ -47,10 +35,6 @@ export class Account extends BaseAccount {
 
     return Object.assign(new Account({}), json, super.fromJSON(json), {
       settings: AccountSettings.fromJSON(json.settings),
-      groupings: BrowserGroupingsComponentState.fromJSON(json.groupings),
-      send: BrowserSendComponentState.fromJSON(json.send),
-      ciphers: BrowserComponentState.fromJSON(json.ciphers),
-      sendType: BrowserComponentState.fromJSON(json.sendType),
     });
   }
 }

--- a/apps/browser/src/models/account.ts
+++ b/apps/browser/src/models/account.ts
@@ -5,6 +5,10 @@ import {
   AccountSettings as BaseAccountSettings,
 } from "@bitwarden/common/platform/models/domain/account";
 
+import { BrowserComponentState } from "./browserComponentState";
+import { BrowserGroupingsComponentState } from "./browserGroupingsComponentState";
+import { BrowserSendComponentState } from "./browserSendComponentState";
+
 export class AccountSettings extends BaseAccountSettings {
   vaultTimeout = -1; // On Restart
 
@@ -19,6 +23,10 @@ export class AccountSettings extends BaseAccountSettings {
 
 export class Account extends BaseAccount {
   settings?: AccountSettings = new AccountSettings();
+  groupings?: BrowserGroupingsComponentState;
+  send?: BrowserSendComponentState;
+  ciphers?: BrowserComponentState;
+  sendType?: BrowserComponentState;
 
   constructor(init: Partial<Account>) {
     super(init);
@@ -26,6 +34,10 @@ export class Account extends BaseAccount {
       ...new AccountSettings(),
       ...this.settings,
     });
+    this.groupings = init?.groupings ?? new BrowserGroupingsComponentState();
+    this.send = init?.send ?? new BrowserSendComponentState();
+    this.ciphers = init?.ciphers ?? new BrowserComponentState();
+    this.sendType = init?.sendType ?? new BrowserComponentState();
   }
 
   static fromJSON(json: Jsonify<Account>): Account {
@@ -35,6 +47,10 @@ export class Account extends BaseAccount {
 
     return Object.assign(new Account({}), json, super.fromJSON(json), {
       settings: AccountSettings.fromJSON(json.settings),
+      groupings: BrowserGroupingsComponentState.fromJSON(json.groupings),
+      send: BrowserSendComponentState.fromJSON(json.send),
+      ciphers: BrowserComponentState.fromJSON(json.ciphers),
+      sendType: BrowserComponentState.fromJSON(json.sendType),
     });
   }
 }

--- a/apps/browser/src/platform/background/service-factories/state-service.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/state-service.factory.ts
@@ -30,7 +30,6 @@ import {
 
 type StateServiceFactoryOptions = FactoryOptions & {
   stateServiceOptions: {
-    useAccountCache?: boolean;
     stateFactory: StateFactory<GlobalState, Account>;
   };
 };
@@ -64,7 +63,6 @@ export async function stateServiceFactory(
         await environmentServiceFactory(cache, opts),
         await tokenServiceFactory(cache, opts),
         await migrationRunnerFactory(cache, opts),
-        opts.stateServiceOptions.useAccountCache,
       ),
   );
   // TODO: If we run migration through a chrome installed/updated event we can turn off running migrations

--- a/apps/browser/src/platform/services/browser-state.service.spec.ts
+++ b/apps/browser/src/platform/services/browser-state.service.spec.ts
@@ -27,7 +27,6 @@ describe("Browser State Service", () => {
   let diskStorageService: MockProxy<AbstractStorageService>;
   let logService: MockProxy<LogService>;
   let stateFactory: MockProxy<StateFactory<GlobalState, Account>>;
-  let useAccountCache: boolean;
   let environmentService: MockProxy<EnvironmentService>;
   let tokenService: MockProxy<TokenService>;
   let migrationRunner: MockProxy<MigrationRunner>;
@@ -46,8 +45,6 @@ describe("Browser State Service", () => {
     environmentService = mock();
     tokenService = mock();
     migrationRunner = mock();
-    // turn off account cache for tests
-    useAccountCache = false;
 
     state = new State(new GlobalState());
     state.accounts[userId] = new Account({
@@ -78,7 +75,6 @@ describe("Browser State Service", () => {
         environmentService,
         tokenService,
         migrationRunner,
-        useAccountCache,
       );
     });
 

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -4,7 +4,6 @@ import { Subject, merge } from "rxjs";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
 import {
   SECURE_STORAGE,
-  STATE_SERVICE_USE_CACHE,
   LOCALES_DIRECTORY,
   SYSTEM_LANGUAGE,
   MEMORY_STORAGE,
@@ -205,7 +204,6 @@ const safeProviders: SafeProvider[] = [
       EnvironmentService,
       TokenService,
       MigrationRunner,
-      STATE_SERVICE_USE_CACHE,
     ],
   }),
   safeProvider({

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -205,7 +205,6 @@ export class Main {
       this.environmentService,
       this.tokenService,
       this.migrationRunner,
-      false, // Do not use disk caching because this will get out of sync with the renderer service
     );
 
     this.desktopSettingsService = new DesktopSettingsService(stateProvider);

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -5,7 +5,6 @@ import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/sa
 import {
   SECURE_STORAGE,
   STATE_FACTORY,
-  STATE_SERVICE_USE_CACHE,
   LOCALES_DIRECTORY,
   SYSTEM_LANGUAGE,
   MEMORY_STORAGE,
@@ -77,10 +76,6 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: STATE_FACTORY,
     useValue: new StateFactory(GlobalState, Account),
-  }),
-  safeProvider({
-    provide: STATE_SERVICE_USE_CACHE,
-    useValue: false,
   }),
   safeProvider({
     provide: I18nServiceAbstraction,

--- a/apps/web/src/app/core/state/state.service.ts
+++ b/apps/web/src/app/core/state/state.service.ts
@@ -4,7 +4,6 @@ import {
   MEMORY_STORAGE,
   SECURE_STORAGE,
   STATE_FACTORY,
-  STATE_SERVICE_USE_CACHE,
 } from "@bitwarden/angular/services/injection-tokens";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
@@ -34,7 +33,6 @@ export class StateService extends BaseStateService<GlobalState, Account> {
     environmentService: EnvironmentService,
     tokenService: TokenService,
     migrationRunner: MigrationRunner,
-    @Inject(STATE_SERVICE_USE_CACHE) useAccountCache = true,
   ) {
     super(
       storageService,
@@ -46,7 +44,6 @@ export class StateService extends BaseStateService<GlobalState, Account> {
       environmentService,
       tokenService,
       migrationRunner,
-      useAccountCache,
     );
   }
 

--- a/libs/angular/src/services/injection-tokens.ts
+++ b/libs/angular/src/services/injection-tokens.ts
@@ -36,7 +36,6 @@ export const MEMORY_STORAGE = new SafeInjectionToken<AbstractMemoryStorageServic
 );
 export const SECURE_STORAGE = new SafeInjectionToken<AbstractStorageService>("SECURE_STORAGE");
 export const STATE_FACTORY = new SafeInjectionToken<StateFactory>("STATE_FACTORY");
-export const STATE_SERVICE_USE_CACHE = new SafeInjectionToken<boolean>("STATE_SERVICE_USE_CACHE");
 export const LOGOUT_CALLBACK = new SafeInjectionToken<
   (expired: boolean, userId?: string) => Promise<void>
 >("LOGOUT_CALLBACK");

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -269,7 +269,6 @@ import {
   SafeInjectionToken,
   SECURE_STORAGE,
   STATE_FACTORY,
-  STATE_SERVICE_USE_CACHE,
   SUPPORTS_SECURE_STORAGE,
   SYSTEM_LANGUAGE,
   SYSTEM_THEME_OBSERVABLE,
@@ -312,10 +311,6 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: STATE_FACTORY,
     useValue: new StateFactory(GlobalState, Account),
-  }),
-  safeProvider({
-    provide: STATE_SERVICE_USE_CACHE,
-    useValue: true,
   }),
   safeProvider({
     provide: LOGOUT_CALLBACK,
@@ -690,7 +685,6 @@ const safeProviders: SafeProvider[] = [
       EnvironmentService,
       TokenServiceAbstraction,
       MigrationRunner,
-      STATE_SERVICE_USE_CACHE,
     ],
   }),
   safeProvider({

--- a/libs/common/src/platform/services/state.service.ts
+++ b/libs/common/src/platform/services/state.service.ts
@@ -65,8 +65,6 @@ export class StateService<
   private hasBeenInited = false;
   protected isRecoveredSession = false;
 
-  protected accountDiskCache = new BehaviorSubject<Record<string, TAccount>>({});
-
   // default account serializer, must be overridden by child class
   protected accountDeserializer = Account.fromJSON as (json: Jsonify<TAccount>) => TAccount;
 
@@ -80,7 +78,6 @@ export class StateService<
     protected environmentService: EnvironmentService,
     protected tokenService: TokenService,
     private migrationRunner: MigrationRunner,
-    protected useAccountCache: boolean = true,
   ) {}
 
   async init(initOptions: InitOptions = {}): Promise<void> {
@@ -990,13 +987,6 @@ export class StateService<
       return null;
     }
 
-    if (this.useAccountCache) {
-      const cachedAccount = this.accountDiskCache.value[options.userId];
-      if (cachedAccount != null) {
-        return cachedAccount;
-      }
-    }
-
     const account = options?.useSecureStorage
       ? (await this.secureStorageService.get<TAccount>(options.userId, options)) ??
         (await this.storageService.get<TAccount>(
@@ -1004,8 +994,6 @@ export class StateService<
           this.reconcileOptions(options, { htmlStorageLocation: HtmlStorageLocation.Local }),
         ))
       : await this.storageService.get<TAccount>(options.userId, options);
-
-    this.setDiskCache(options.userId, account);
     return account;
   }
 
@@ -1035,8 +1023,6 @@ export class StateService<
       : this.storageService;
 
     await storageLocation.save(`${options.userId}`, account, options);
-
-    this.deleteDiskCache(options.userId);
   }
 
   protected async saveAccountToMemory(account: TAccount): Promise<void> {
@@ -1236,9 +1222,6 @@ export class StateService<
     await this.updateState(async (state) => {
       userId = userId ?? state.activeUserId;
       delete state.accounts[userId];
-
-      this.deleteDiskCache(userId);
-
       return state;
     });
   }
@@ -1351,20 +1334,6 @@ export class StateService<
 
       return await this.setState(updatedState);
     });
-  }
-
-  private setDiskCache(key: string, value: TAccount, options?: StorageOptions) {
-    if (this.useAccountCache) {
-      this.accountDiskCache.value[key] = value;
-      this.accountDiskCache.next(this.accountDiskCache.value);
-    }
-  }
-
-  protected deleteDiskCache(key: string) {
-    if (this.useAccountCache) {
-      delete this.accountDiskCache.value[key];
-      this.accountDiskCache.next(this.accountDiskCache.value);
-    }
   }
 }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove the `useAccountCache` option from `StateService` and all the code it enabled. In browser, this involved making a message to another context, in some cases that message would return `undefined` and cause problems in MV3. 

The disk cache should largely not be needed since most larger objects has been removed out of state service in favor or state providers. All the items left can be retrieved from disk quite quickly. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
