### PR TITLE
Move update warnings to state provider

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -437,8 +437,6 @@ export default class MainBackground {
         sessionKey,
         this.storageService,
         new EncryptServiceImplementation(this.cryptoFunctionService, this.logService, false),
-        this.platformUtilsService,
-        this.logService,
       );
     };
 
@@ -459,7 +457,11 @@ export default class MainBackground {
       this.largeObjectMemoryStorageForStateProviders,
     );
 
-    this.globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    this.globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      this.platformUtilsService,
+      this.logService,
+    );
 
     const stateEventRegistrarService = new StateEventRegistrarService(
       this.globalStateProvider,
@@ -483,6 +485,8 @@ export default class MainBackground {
     this.singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      this.platformUtilsService,
+      this.logService,
     );
     this.accountService = new AccountServiceImplementation(
       this.messagingService,

--- a/apps/browser/src/platform/background/service-factories/global-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/global-state-provider.factory.ts
@@ -3,6 +3,11 @@ import { GlobalStateProvider } from "@bitwarden/common/platform/state";
 import { DefaultGlobalStateProvider } from "@bitwarden/common/platform/state/implementations/default-global-state.provider";
 
 import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
+import {
+  PlatformUtilsServiceInitOptions,
+  platformUtilsServiceFactory,
+} from "./platform-utils-service.factory";
 import {
   StorageServiceProviderInitOptions,
   storageServiceProviderFactory,
@@ -11,7 +16,9 @@ import {
 type GlobalStateProviderFactoryOptions = FactoryOptions;
 
 export type GlobalStateProviderInitOptions = GlobalStateProviderFactoryOptions &
-  StorageServiceProviderInitOptions;
+  StorageServiceProviderInitOptions &
+  PlatformUtilsServiceInitOptions &
+  LogServiceInitOptions;
 
 export async function globalStateProviderFactory(
   cache: { globalStateProvider?: GlobalStateProvider } & CachedServices,
@@ -21,6 +28,11 @@ export async function globalStateProviderFactory(
     cache,
     "globalStateProvider",
     opts,
-    async () => new DefaultGlobalStateProvider(await storageServiceProviderFactory(cache, opts)),
+    async () =>
+      new DefaultGlobalStateProvider(
+        await storageServiceProviderFactory(cache, opts),
+        await platformUtilsServiceFactory(cache, opts),
+        await logServiceFactory(cache, opts),
+      ),
   );
 }

--- a/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
@@ -3,6 +3,11 @@ import { SingleUserStateProvider } from "@bitwarden/common/platform/state";
 import { DefaultSingleUserStateProvider } from "@bitwarden/common/platform/state/implementations/default-single-user-state.provider";
 
 import { CachedServices, FactoryOptions, factory } from "./factory-options";
+import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
+import {
+  PlatformUtilsServiceInitOptions,
+  platformUtilsServiceFactory,
+} from "./platform-utils-service.factory";
 import {
   StateEventRegistrarServiceInitOptions,
   stateEventRegistrarServiceFactory,
@@ -16,7 +21,9 @@ type SingleUserStateProviderFactoryOptions = FactoryOptions;
 
 export type SingleUserStateProviderInitOptions = SingleUserStateProviderFactoryOptions &
   StorageServiceProviderInitOptions &
-  StateEventRegistrarServiceInitOptions;
+  StateEventRegistrarServiceInitOptions &
+  PlatformUtilsServiceInitOptions &
+  LogServiceInitOptions;
 
 export async function singleUserStateProviderFactory(
   cache: { singleUserStateProvider?: SingleUserStateProvider } & CachedServices,
@@ -30,6 +37,8 @@ export async function singleUserStateProviderFactory(
       new DefaultSingleUserStateProvider(
         await storageServiceProviderFactory(cache, opts),
         await stateEventRegistrarServiceFactory(cache, opts),
+        await platformUtilsServiceFactory(cache, opts),
+        await logServiceFactory(cache, opts),
       ),
   );
 }

--- a/apps/browser/src/platform/background/service-factories/storage-service.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/storage-service.factory.ts
@@ -19,11 +19,6 @@ import {
   KeyGenerationServiceInitOptions,
   keyGenerationServiceFactory,
 } from "./key-generation-service.factory";
-import { LogServiceInitOptions, logServiceFactory } from "./log-service.factory";
-import {
-  PlatformUtilsServiceInitOptions,
-  platformUtilsServiceFactory,
-} from "./platform-utils-service.factory";
 
 export type DiskStorageServiceInitOptions = FactoryOptions;
 export type SecureStorageServiceInitOptions = FactoryOptions;
@@ -32,9 +27,7 @@ export type MemoryStorageServiceInitOptions = FactoryOptions &
   EncryptServiceInitOptions &
   KeyGenerationServiceInitOptions &
   DiskStorageServiceInitOptions &
-  SessionStorageServiceInitOptions &
-  LogServiceInitOptions &
-  PlatformUtilsServiceInitOptions;
+  SessionStorageServiceInitOptions;
 
 export function diskStorageServiceFactory(
   cache: { diskStorageService?: AbstractStorageService } & CachedServices,
@@ -87,8 +80,6 @@ export function memoryStorageServiceFactory(
         }),
         await diskStorageServiceFactory(cache, opts),
         await encryptServiceFactory(cache, opts),
-        await platformUtilsServiceFactory(cache, opts),
-        await logServiceFactory(cache, opts),
       );
     }
     return new MemoryStorageService();

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.spec.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.spec.ts
@@ -1,8 +1,6 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Lazy } from "@bitwarden/common/platform/misc/lazy";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
@@ -16,23 +14,17 @@ describe("LocalBackedSessionStorage", () => {
   );
   let localStorage: FakeStorageService;
   let encryptService: MockProxy<EncryptService>;
-  let platformUtilsService: MockProxy<PlatformUtilsService>;
-  let logService: MockProxy<LogService>;
 
   let sut: LocalBackedSessionStorageService;
 
   beforeEach(() => {
     localStorage = new FakeStorageService();
     encryptService = mock<EncryptService>();
-    platformUtilsService = mock<PlatformUtilsService>();
-    logService = mock<LogService>();
 
     sut = new LocalBackedSessionStorageService(
       new Lazy(async () => sessionKey),
       localStorage,
       encryptService,
-      platformUtilsService,
-      logService,
     );
   });
 
@@ -138,20 +130,6 @@ describe("LocalBackedSessionStorage", () => {
     const encString = makeEncString("encrypted");
     beforeEach(() => {
       encryptService.encrypt.mockResolvedValue(encString);
-    });
-
-    it("logs a warning when saving the same value twice and in a dev environment", async () => {
-      platformUtilsService.isDev.mockReturnValue(true);
-      sut["cache"]["test"] = "cached";
-      await sut.save("test", "cached");
-      expect(logService.warning).toHaveBeenCalled();
-    });
-
-    it("does not log when saving the same value twice and not in a dev environment", async () => {
-      platformUtilsService.isDev.mockReturnValue(false);
-      sut["cache"]["test"] = "cached";
-      await sut.save("test", "cached");
-      expect(logService.warning).not.toHaveBeenCalled();
     });
 
     it("removes the key when saving a null value", async () => {

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -277,7 +277,11 @@ export class Main {
       this.memoryStorageForStateProviders,
     );
 
-    this.globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    this.globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      this.platformUtilsService,
+      this.logService,
+    );
 
     const stateEventRegistrarService = new StateEventRegistrarService(
       this.globalStateProvider,
@@ -294,6 +298,8 @@ export class Main {
     this.singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      this.platformUtilsService,
+      this.logService,
     );
 
     this.messagingService = MessageSender.EMPTY;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -53,7 +53,7 @@ import { ElectronStorageService } from "./platform/services/electron-storage.ser
 import { I18nMainService } from "./platform/services/i18n.main.service";
 import { IllegalSecureStorageService } from "./platform/services/illegal-secure-storage.service";
 import { ElectronMainMessagingService } from "./services/electron-main-messaging.service";
-import { isMacAppStore } from "./utils";
+import { isDev, isMacAppStore } from "./utils";
 
 export class Main {
   logService: ElectronLogMainService;
@@ -128,7 +128,11 @@ export class Main {
       this.storageService,
       this.memoryStorageForStateProviders,
     );
-    const globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    const globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      { isDev: isDev },
+      this.logService,
+    );
 
     this.i18nService = new I18nMainService("en", "./locales/", globalStateProvider);
 
@@ -146,6 +150,8 @@ export class Main {
     const singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      { isDev: isDev },
+      this.logService,
     );
 
     const activeUserStateProvider = new DefaultActiveUserStateProvider(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1031,7 +1031,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: GlobalStateProvider,
     useClass: DefaultGlobalStateProvider,
-    deps: [StorageServiceProvider],
+    deps: [StorageServiceProvider, PlatformUtilsServiceAbstraction, LogService],
   }),
   safeProvider({
     provide: ActiveUserStateProvider,
@@ -1041,7 +1041,12 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: SingleUserStateProvider,
     useClass: DefaultSingleUserStateProvider,
-    deps: [StorageServiceProvider, StateEventRegistrarService],
+    deps: [
+      StorageServiceProvider,
+      StateEventRegistrarService,
+      PlatformUtilsServiceAbstraction,
+      LogService,
+    ],
   }),
   safeProvider({
     provide: DerivedStateProvider,

--- a/libs/common/src/platform/state/implementations/default-global-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.provider.ts
@@ -1,3 +1,4 @@
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { GlobalState } from "../global-state";
 import { GlobalStateProvider } from "../global-state.provider";
@@ -8,7 +9,11 @@ import { DefaultGlobalState } from "./default-global-state";
 export class DefaultGlobalStateProvider implements GlobalStateProvider {
   private globalStateCache: Record<string, GlobalState<unknown>> = {};
 
-  constructor(private storageServiceProvider: StorageServiceProvider) {}
+  constructor(
+    private storageServiceProvider: StorageServiceProvider,
+    private isDev: { isDev(): boolean },
+    private logService: LogService,
+  ) {}
 
   get<T>(keyDefinition: KeyDefinition<T>): GlobalState<T> {
     const [location, storageService] = this.storageServiceProvider.get(
@@ -23,7 +28,12 @@ export class DefaultGlobalStateProvider implements GlobalStateProvider {
       return existingGlobalState as DefaultGlobalState<T>;
     }
 
-    const newGlobalState = new DefaultGlobalState<T>(keyDefinition, storageService);
+    const newGlobalState = new DefaultGlobalState<T>(
+      keyDefinition,
+      storageService,
+      this.isDev.isDev(),
+      this.logService,
+    );
 
     this.globalStateCache[cacheKey] = newGlobalState;
     return newGlobalState;

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -1,3 +1,4 @@
+import { LogService } from "../../abstractions/log.service";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -14,7 +15,9 @@ export class DefaultGlobalState<T>
   constructor(
     keyDefinition: KeyDefinition<T>,
     chosenLocation: AbstractStorageService & ObservableStorageService,
+    isDev: boolean,
+    logService: LogService,
   ) {
-    super(globalKeyBuilder(keyDefinition), chosenLocation, keyDefinition);
+    super(globalKeyBuilder(keyDefinition), chosenLocation, keyDefinition, isDev, logService);
   }
 }

--- a/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
@@ -1,4 +1,5 @@
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { KeyDefinition } from "../key-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
@@ -14,6 +15,8 @@ export class DefaultSingleUserStateProvider implements SingleUserStateProvider {
   constructor(
     private readonly storageServiceProvider: StorageServiceProvider,
     private readonly stateEventRegistrarService: StateEventRegistrarService,
+    private readonly isDev: { isDev(): boolean },
+    private readonly logService: LogService,
   ) {}
 
   get<T>(
@@ -40,6 +43,8 @@ export class DefaultSingleUserStateProvider implements SingleUserStateProvider {
       keyDefinition,
       storageService,
       this.stateEventRegistrarService,
+      this.isDev.isDev(),
+      this.logService,
     );
     this.cache[cacheKey] = newUserState;
     return newUserState;

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,6 +1,7 @@
 import { Observable, combineLatest, of } from "rxjs";
 
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -22,8 +23,10 @@ export class DefaultSingleUserState<T>
     keyDefinition: UserKeyDefinition<T>,
     chosenLocation: AbstractStorageService & ObservableStorageService,
     private stateEventRegistrarService: StateEventRegistrarService,
+    isDev: boolean,
+    logService: LogService,
   ) {
-    super(keyDefinition.buildKey(userId), chosenLocation, keyDefinition);
+    super(keyDefinition.buildKey(userId), chosenLocation, keyDefinition, isDev, logService);
     this.combinedState$ = combineLatest([of(userId), this.state$]);
   }
 

--- a/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
+++ b/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
@@ -3,6 +3,8 @@ import { mock } from "jest-mock-extended";
 import { mockAccountServiceWith } from "../../../../spec/fake-account-service";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
+import { PlatformUtilsService } from "../../abstractions/platform-utils.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { KeyDefinition } from "../key-definition";
 import { StateDefinition } from "../state-definition";
@@ -18,6 +20,8 @@ import { DefaultSingleUserStateProvider } from "./default-single-user-state.prov
 describe("Specific State Providers", () => {
   const storageServiceProvider = mock<StorageServiceProvider>();
   const stateEventRegistrarService = mock<StateEventRegistrarService>();
+  const platformUtilsService = mock<PlatformUtilsService>();
+  const logService = mock<LogService>();
 
   let singleSut: DefaultSingleUserStateProvider;
   let activeSut: DefaultActiveUserStateProvider;
@@ -30,12 +34,20 @@ describe("Specific State Providers", () => {
       return [location, new FakeStorageService()];
     });
 
+    platformUtilsService.isDev.mockReturnValue(false);
+
     singleSut = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      platformUtilsService,
+      logService,
     );
     activeSut = new DefaultActiveUserStateProvider(mockAccountServiceWith(null), singleSut);
-    globalSut = new DefaultGlobalStateProvider(storageServiceProvider);
+    globalSut = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      platformUtilsService,
+      logService,
+    );
   });
 
   const fakeDiskStateDefinition = new StateDefinition("fake", "disk");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Unnecessary change detection had been added to local backed session storage as an attempt at observability on expensive writes that may not have been needed. However, a lot of work is done whenever state is updated, and the state-base offers the perfect, central location to test whether a change should have been blocked by `shoulUpdate`.

This moves our value equivalence tests to state-base, locks it behind a dev environment, and logs warnings whenever any state provider-maintained value was updated, but shouldn't have been.

This is an observability PR for dev environments and has no impact on production code. PRs to follow for found offenders from this work.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
