### PR TITLE
[CL-236] Card component

### DIFF
--- a/libs/components/src/card/card.component.ts
+++ b/libs/components/src/card/card.component.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+
+@Component({
+  selector: "bit-card",
+  standalone: true,
+  imports: [CommonModule],
+  template: `<ng-content></ng-content>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class:
+      "tw-box-border tw-block tw-bg-background tw-text-main tw-border-solid tw-border-b tw-border-0 tw-border-b-secondary-300 tw-rounded-lg tw-py-4 tw-px-3",
+  },
+})
+export class CardComponent {}

--- a/libs/components/src/card/card.stories.ts
+++ b/libs/components/src/card/card.stories.ts
@@ -52,15 +52,8 @@ export const WithinSections: Story = {
           </bit-section>
 
           <bit-section>
+            <h2 bitTypography="h5">Bar</h2>
             <bit-card>
-                <h2 bitTypography="h5">Bar</h2>
-                <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
-            </bit-card>
-          </bit-section>
-
-          <bit-section>
-            <bit-card>
-                <h2 bitTypography="h5">Bar</h2>
                 <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
             </bit-card>
           </bit-section>

--- a/libs/components/src/card/card.stories.ts
+++ b/libs/components/src/card/card.stories.ts
@@ -1,0 +1,69 @@
+import { Meta, StoryObj, componentWrapperDecorator, moduleMetadata } from "@storybook/angular";
+
+import { SectionComponent } from "../section";
+import { TypographyModule } from "../typography";
+
+import { CardComponent } from "./card.component";
+
+export default {
+  title: "Component Library/Card",
+  component: CardComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [TypographyModule, SectionComponent],
+    }),
+    componentWrapperDecorator(
+      (story) => `<div class="tw-bg-background-alt tw-p-10 tw-text-main">${story}</div>`,
+    ),
+  ],
+} as Meta;
+
+type Story = StoryObj<CardComponent>;
+
+/** Cards are presentational containers. */
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+        <bit-card>
+            <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
+        </bit-card>
+    `,
+  }),
+};
+
+/** Cards are often paired with [Sections](/docs/component-library-section--docs). */
+export const WithinSections: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+          <bit-section>
+            <h2 bitTypography="h5">Bar</h2>
+            <bit-card>
+                <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
+            </bit-card>
+          </bit-section>
+
+          <bit-section>
+            <h2 bitTypography="h5">Bar</h2>
+            <bit-card>
+                <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
+            </bit-card>
+          </bit-section>
+
+          <bit-section>
+            <bit-card>
+                <h2 bitTypography="h5">Bar</h2>
+                <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
+            </bit-card>
+          </bit-section>
+
+          <bit-section>
+            <bit-card>
+                <h2 bitTypography="h5">Bar</h2>
+                <p bitTypography="body1" class="!tw-mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vitae congue risus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc elementum odio nibh, eget pellentesque sem ornare vitae. Etiam vel ante et velit fringilla egestas a sed sem. Fusce molestie nisl et nisi accumsan dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed eu risus ex. </p>
+            </bit-card>
+          </bit-section>
+      `,
+  }),
+};

--- a/libs/components/src/card/index.ts
+++ b/libs/components/src/card/index.ts
@@ -1,0 +1,1 @@
+export * from "./card.component";

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -7,6 +7,7 @@ export * from "./breadcrumbs";
 export * from "./button";
 export { ButtonType } from "./shared/button-like.abstraction";
 export * from "./callout";
+export * from "./card";
 export * from "./checkbox";
 export * from "./color-password";
 export * from "./container";

--- a/libs/components/src/section/section.component.ts
+++ b/libs/components/src/section/section.component.ts
@@ -6,7 +6,7 @@ import { Component } from "@angular/core";
   standalone: true,
   imports: [CommonModule],
   template: `
-    <section class="tw-mb-12">
+    <section class="tw-mb-6 md:tw-mb-12">
       <ng-content></ng-content>
     </section>
   `,

--- a/libs/components/src/section/section.stories.ts
+++ b/libs/components/src/section/section.stories.ts
@@ -17,7 +17,7 @@ export default {
 
 type Story = StoryObj<SectionComponent>;
 
-/** Sections are simple containers that apply a bottom margin. They often contain a heading. */
+/** Sections are simple containers that apply a responsive bottom margin. They often contain a heading. */
 export const Default: Story = {
   render: (args) => ({
     props: args,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds a card component to the CL

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/card** Add card component and stories
- **libs/components/src/section** Adjust section bottom margin to be `24px` on small screens, otherwise `48px` (what it is today). My thinking/assumptions:
1. this enables many of the card UIs on the extension
2. we are unlikely to want 48px spaced sections on small screens in general (otherwise we would be using them in the extension).
3. we are fine with this flowing through to the web vault 

## Screenshots

See Storybook for more

![image](https://github.com/bitwarden/clients/assets/17113462/50d25e78-ddf3-4f6f-b4ea-b2699c2ba0e9)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
