### PR TITLE
[PM-7687] Fix `reloadPopup` Recursion

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -265,9 +265,6 @@ export default class RuntimeBackground {
         await openTwoFactorAuthPopout(msg);
         break;
       }
-      case "reloadPopup":
-        this.messagingService.send("reloadPopup");
-        break;
       case "emailVerificationRequired":
         this.messagingService.send("showDialog", {
           title: { key: "emailVerificationRequired" },

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -10,7 +10,7 @@ import { SystemService } from "@bitwarden/common/platform/abstractions/system.se
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherType } from "@bitwarden/common/vault/enums";
 
-import { MessageListener } from "../../../../libs/common/src/platform/messaging";
+import { MessageListener, isExternalMessage } from "../../../../libs/common/src/platform/messaging";
 import {
   closeUnlockPopout,
   openSsoAuthResultPopout,
@@ -265,6 +265,11 @@ export default class RuntimeBackground {
         await openTwoFactorAuthPopout(msg);
         break;
       }
+      case "reloadPopup":
+        if (isExternalMessage(msg)) {
+          this.messagingService.send("reloadPopup");
+        }
+        break;
       case "emailVerificationRequired":
         this.messagingService.send("showDialog", {
           title: { key: "emailVerificationRequired" },

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -216,10 +216,6 @@ export class LocalBackedSessionStorageService
       return false;
     }
 
-    if (typeof value1 !== "object" || typeof value2 !== "object") {
-      return value1 === value2;
-    }
-
     if (JSON.stringify(value1) === JSON.stringify(value2)) {
       return true;
     }

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -212,8 +212,8 @@ export class LocalBackedSessionStorageService
       return false;
     }
 
-    if (typeof value1 !== typeof value2) {
-      return false;
+    if (typeof value1 !== "object" || typeof value2 !== "object") {
+      return value1 === value2;
     }
 
     if (JSON.stringify(value1) === JSON.stringify(value2)) {

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -92,9 +92,16 @@ export class LocalBackedSessionStorageService
     // This is for observation purposes only. At some point, we don't want to write to local session storage if the value is the same.
     if (this.platformUtilsService.isDev()) {
       const existingValue = this.cache[key] as T;
-      if (this.compareValues<T>(existingValue, obj)) {
-        this.logService.warning(`Possible unnecessary write to local session storage. Key: ${key}`);
-        this.logService.warning(obj as any);
+      try {
+        if (this.compareValues<T>(existingValue, obj)) {
+          this.logService.warning(
+            `Possible unnecessary write to local session storage. Key: ${key}`,
+          );
+          this.logService.warning(obj as any);
+        }
+      } catch (err) {
+        this.logService.warning(`Error while comparing values for key: ${key}`);
+        this.logService.warning(err);
       }
     }
 
@@ -202,6 +209,10 @@ export class LocalBackedSessionStorageService
     }
 
     if (value1 == null && value2) {
+      return false;
+    }
+
+    if (typeof value1 !== typeof value2) {
       return false;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

With #8709 messages now go to all contexts, an unguarded resending of a message like this is likely to cause recursion. 2FA sends this message on successful completion. This causes a `RangeError: Maximum call stack size exceeded`. If we only guard to care about messages from the external context we avoid having infinite recursion but still allow the message to come from one popup and make it to another popup. 

While debugging this locally I saw failures with comparing the search index. This wouldn't be seen by our testers but it did hamper me while testing this bug so I added a fallback.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
