### PR TITLE
[AC-2488] Use new endpoint to determine SM standalone for organization

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/people.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/people.component.ts
@@ -37,7 +37,7 @@ import {
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
-import { OrganizationBillingServiceAbstraction as OrganizationBillingService } from "@bitwarden/common/billing/abstractions/organization-billing.service";
+import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billilng-api.service.abstraction";
 import { ProductType } from "@bitwarden/common/enums";
 import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
@@ -121,7 +121,7 @@ export class PeopleComponent extends BasePeopleComponent<OrganizationUserView> {
     private groupService: GroupService,
     private collectionService: CollectionService,
     organizationManagementPreferencesService: OrganizationManagementPreferencesService,
-    private organizationBillingService: OrganizationBillingService,
+    private billingApiService: BillingApiServiceAbstraction,
   ) {
     super(
       apiService,
@@ -190,10 +190,11 @@ export class PeopleComponent extends BasePeopleComponent<OrganizationUserView> {
             .find((p) => p.organizationId === this.organization.id);
           this.orgResetPasswordPolicyEnabled = resetPasswordPolicy?.enabled;
 
-          this.orgIsOnSecretsManagerStandalone =
-            await this.organizationBillingService.isOnSecretsManagerStandalone(
-              this.organization.id,
-            );
+          const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+            this.organization.id,
+          );
+
+          this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
 
           await this.load();
 

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1063,7 +1063,6 @@ const safeProviders: SafeProvider[] = [
     useClass: OrganizationBillingService,
     deps: [
       ApiServiceAbstraction,
-      BillingApiServiceAbstraction,
       CryptoServiceAbstraction,
       EncryptService,
       I18nServiceAbstraction,

--- a/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/billilng-api.service.abstraction.ts
@@ -1,4 +1,5 @@
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
+import { OrganizationBillingMetadataResponse } from "../../billing/models/response/organization-billing-metadata.response";
 import { OrganizationBillingStatusResponse } from "../../billing/models/response/organization-billing-status.response";
 import { OrganizationSubscriptionResponse } from "../../billing/models/response/organization-subscription.response";
 import { PlanResponse } from "../../billing/models/response/plan.response";
@@ -12,13 +13,15 @@ export abstract class BillingApiServiceAbstraction {
     organizationId: string,
     request: SubscriptionCancellationRequest,
   ) => Promise<void>;
-
   cancelPremiumUserSubscription: (request: SubscriptionCancellationRequest) => Promise<void>;
   createClientOrganization: (
     providerId: string,
     request: CreateClientOrganizationRequest,
   ) => Promise<void>;
   getBillingStatus: (id: string) => Promise<OrganizationBillingStatusResponse>;
+  getOrganizationBillingMetadata: (
+    organizationId: string,
+  ) => Promise<OrganizationBillingMetadataResponse>;
   getOrganizationSubscription: (
     organizationId: string,
   ) => Promise<OrganizationSubscriptionResponse>;

--- a/libs/common/src/billing/abstractions/organization-billing.service.ts
+++ b/libs/common/src/billing/abstractions/organization-billing.service.ts
@@ -41,8 +41,6 @@ export type SubscriptionInformation = {
 };
 
 export abstract class OrganizationBillingServiceAbstraction {
-  isOnSecretsManagerStandalone: (organizationId: string) => Promise<boolean>;
-
   purchaseSubscription: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;
 
   startFree: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;

--- a/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
+++ b/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
@@ -1,0 +1,10 @@
+import { BaseResponse } from "../../../models/response/base.response";
+
+export class OrganizationBillingMetadataResponse extends BaseResponse {
+  isOnSecretsManagerStandalone: boolean;
+
+  constructor(response: any) {
+    super(response);
+    this.isOnSecretsManagerStandalone = this.getResponseProperty("IsOnSecretsManagerStandalone");
+  }
+}

--- a/libs/common/src/billing/services/billing-api.service.ts
+++ b/libs/common/src/billing/services/billing-api.service.ts
@@ -1,3 +1,5 @@
+import { OrganizationBillingMetadataResponse } from "@bitwarden/common/billing/models/response/organization-billing-metadata.response";
+
 import { ApiService } from "../../abstractions/api.service";
 import { BillingApiServiceAbstraction } from "../../billing/abstractions/billilng-api.service.abstraction";
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
@@ -51,6 +53,20 @@ export class BillingApiService implements BillingApiServiceAbstraction {
       true,
     );
     return new OrganizationBillingStatusResponse(r);
+  }
+
+  async getOrganizationBillingMetadata(
+    organizationId: string,
+  ): Promise<OrganizationBillingMetadataResponse> {
+    const r = await this.apiService.send(
+      "GET",
+      "/organizations/" + organizationId + "/billing/metadata",
+      null,
+      true,
+      true,
+    );
+
+    return new OrganizationBillingMetadataResponse(r);
   }
 
   async getOrganizationSubscription(

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -9,7 +9,6 @@ import { I18nService } from "../../platform/abstractions/i18n.service";
 import { EncString } from "../../platform/models/domain/enc-string";
 import { OrgKey } from "../../types/key";
 import { SyncService } from "../../vault/abstractions/sync/sync.service.abstraction";
-import { BillingApiServiceAbstraction as BillingApiService } from "../abstractions/billilng-api.service.abstraction";
 import {
   OrganizationBillingServiceAbstraction,
   OrganizationInformation,
@@ -29,26 +28,12 @@ interface OrganizationKeys {
 export class OrganizationBillingService implements OrganizationBillingServiceAbstraction {
   constructor(
     private apiService: ApiService,
-    private billingApiService: BillingApiService,
     private cryptoService: CryptoService,
     private encryptService: EncryptService,
     private i18nService: I18nService,
     private organizationApiService: OrganizationApiService,
     private syncService: SyncService,
   ) {}
-
-  async isOnSecretsManagerStandalone(organizationId: string): Promise<boolean> {
-    const response = await this.billingApiService.getOrganizationSubscription(organizationId);
-    if (response.customerDiscount?.id === "sm-standalone") {
-      const productIds = response.subscription.items.map((item) => item.productId);
-      return (
-        response.customerDiscount?.appliesTo.filter((appliesToProductId) =>
-          productIds.includes(appliesToProductId),
-        ).length > 0
-      );
-    }
-    return false;
-  }
 
   async purchaseSubscription(subscription: SubscriptionInformation): Promise<OrganizationResponse> {
     const request = new OrganizationCreateRequest();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In one of my previous changes, I added an API invocation to the `people.component` on the Web Vault that gets the organization's subscription. However, this endpoint is permission protected, which broke the `people.component` for anyone that wasn't an owner. 

That invocation was just being used to determine whether the organization was using SM Standalone. Instead, I created a new endpoint that doesn't do any unnecessary permissions check and just returns the data required by the component. I then used that endpoint in the `people.component` instead.

`server`: https://github.com/bitwarden/server/pull/4014

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/server/assets/144709477/9dccf62f-f234-4f53-82c0-8a285f8649cf
