### PR TITLE
[PM-7710] Avoid re-indexing ciphers on current tab component and re-setting null storage values for popup components

### DIFF
--- a/apps/browser/src/tools/popup/services/browser-send-state.service.ts
+++ b/apps/browser/src/tools/popup/services/browser-send-state.service.ts
@@ -46,7 +46,9 @@ export class BrowserSendStateService {
    *  the send component on the browser
    */
   async setBrowserSendComponentState(value: BrowserSendComponentState): Promise<void> {
-    await this.activeUserBrowserSendComponentState.update(() => value);
+    await this.activeUserBrowserSendComponentState.update(() => value, {
+      shouldUpdate: (current) => !(current == null && value == null),
+    });
   }
 
   /** Get the active user's browser component state
@@ -60,6 +62,8 @@ export class BrowserSendStateService {
    *  @param { BrowserComponentState } value set the scroll position and search text for the send component on the browser
    */
   async setBrowserSendTypeComponentState(value: BrowserComponentState): Promise<void> {
-    await this.activeUserBrowserSendTypeComponentState.update(() => value);
+    await this.activeUserBrowserSendTypeComponentState.update(() => value, {
+      shouldUpdate: (current) => !(current == null && value == null),
+    });
   }
 }

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -292,6 +292,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     const ciphers = await this.cipherService.getAllDecryptedForUrl(
       this.url,
       otherTypes.length > 0 ? otherTypes : null,
+      null,
+      false,
     );
 
     this.loginCiphers = [];

--- a/apps/browser/src/vault/services/vault-browser-state.service.ts
+++ b/apps/browser/src/vault/services/vault-browser-state.service.ts
@@ -52,7 +52,9 @@ export class VaultBrowserStateService {
   }
 
   async setBrowserGroupingsComponentState(value: BrowserGroupingsComponentState): Promise<void> {
-    await this.activeUserVaultBrowserGroupingsComponentState.update(() => value);
+    await this.activeUserVaultBrowserGroupingsComponentState.update(() => value, {
+      shouldUpdate: (current) => !(current == null && value == null),
+    });
   }
 
   async getBrowserVaultItemsComponentState(): Promise<BrowserComponentState> {
@@ -60,6 +62,8 @@ export class VaultBrowserStateService {
   }
 
   async setBrowserVaultItemsComponentState(value: BrowserComponentState): Promise<void> {
-    await this.activeUserVaultBrowserComponentState.update(() => value);
+    await this.activeUserVaultBrowserComponentState.update(() => value, {
+      shouldUpdate: (current) => !(current == null && value == null),
+    });
   }
 }

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -33,6 +33,7 @@ export abstract class CipherService {
     url: string,
     includeOtherTypes?: CipherType[],
     defaultMatch?: UriMatchStrategySetting,
+    reindexCiphers?: boolean,
   ) => Promise<CipherView[]>;
   getAllFromApiForOrganization: (organizationId: string) => Promise<CipherView[]>;
   /**

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -437,45 +437,6 @@ export class CipherService implements CipherServiceAbstraction {
     });
   }
 
-  async newGetAllDecryptedForUrl(
-    url: string,
-    includeOtherTypes?: CipherType[],
-    defaultMatch: UriMatchStrategySetting = null,
-    reindexCiphers = true,
-  ): Promise<CipherView[]> {
-    if (url == null && includeOtherTypes == null) {
-      return Promise.resolve([]);
-    }
-
-    const equivalentDomains = await firstValueFrom(
-      this.domainSettingsService.getUrlEquivalentDomains(url),
-    );
-    const ciphers = await this.getDecryptedCiphers();
-    defaultMatch ??= await firstValueFrom(this.domainSettingsService.defaultUriMatchStrategy$);
-
-    return ciphers.filter((cipher) => {
-      const cipherIsLogin = cipher.type === CipherType.Login && cipher.login !== null;
-
-      if (cipher.deletedDate !== null) {
-        return false;
-      }
-
-      if (
-        Array.isArray(includeOtherTypes) &&
-        includeOtherTypes.includes(cipher.type) &&
-        !cipherIsLogin
-      ) {
-        return true;
-      }
-
-      if (cipherIsLogin) {
-        return cipher.login.matchesUri(url, equivalentDomains, defaultMatch);
-      }
-
-      return false;
-    });
-  }
-
   async getAllDecryptedForUrl(
     url: string,
     includeOtherTypes?: CipherType[],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Working to optimize the load times of the current-tab component. The changes in this PR address two concerns, the first involves avoiding re-indexing ciphers when pulling decrypted ciphers for the current tab (as searching is not a concern with this tab, and using the search bar forces the user to the vault tab which triggers the re-index). The second concern addresses whether we should trigger state updates within LocalBackedSessionStorage when a `nullish` state value is attempting to set a `nullish` value in local storage.

## Code changes

- **apps/browser/src/tools/popup/services/browser-send-state.service.ts:** Adding `shouldUpdate` methods that ensure we do not attempt to save a `nullish` value to local storage if the current value is already `nullish`.
- **apps/browser/src/vault/popup/components/vault/current-tab.component.ts:** Updating the call to `cipherService.getAllDecryptedForUrl` to ensure we do not trigger a re-index of the ciphers in storage.
- **apps/browser/src/vault/services/vault-browser-state.service.ts:** Adding `shouldUpdate` methods that ensure we do not attempt to save a `nullish` value to local storage if the current value is already `nullish`.
- **libs/common/src/vault/abstractions/cipher.service.ts:** Adding typing information to the `getAllDecryptedForUrl` method.
- **libs/common/src/vault/services/cipher.service.ts:** Updating the `getAllDecryptedForUrl` method to facilitate conditional re-indexing of cipher data.


