### PR TITLE
[PM-2155] migrate policy edit component

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.html
@@ -1,49 +1,28 @@
-<div class="modal fade" role="dialog" aria-modal="true" aria-labelledby="policiesEditTitle">
-  <div class="modal-dialog modal-dialog-scrollable" role="document">
-    <form
-      class="modal-content"
-      #form
-      (ngSubmit)="submit()"
-      [appApiAction]="formPromise"
-      ngNativeValidate
-    >
-      <div class="modal-header">
-        <h1 class="modal-title" id="policiesEditTitle">
-          {{ "editPolicy" | i18n }} - {{ policy.name | i18n }}
-        </h1>
-        <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          appA11yTitle="{{ 'close' | i18n }}"
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
+<form [formGroup]="formGroup" [bitSubmit]="submit" [appApiAction]="formPromise">
+  <bit-dialog [loading]="loading">
+    <span bitDialogTitle>{{ "editPolicy" | i18n }} - {{ policy.name | i18n }}</span>
 
-      <div class="modal-body">
-        <div class="modal-body" *ngIf="loading">
-          <i
-            class="bwi bwi-spinner bwi-spin text-muted"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "loading" | i18n }}</span>
-        </div>
-        <div [hidden]="loading">
-          <p>{{ policy.description | i18n }}</p>
-          <ng-template #policyForm></ng-template>
-        </div>
+    <ng-container bitDialogContent>
+      <div *ngIf="loading">
+        <i
+          class="bwi bwi-spinner bwi-spin tw-text-muted"
+          title="{{ 'loading' | i18n }}"
+          aria-hidden="true"
+        ></i>
+        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
       </div>
-      <div class="modal-footer">
-        <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
-          <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-          <span>{{ "save" | i18n }}</span>
-        </button>
-        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-          {{ "cancel" | i18n }}
-        </button>
+      <div [hidden]="loading">
+        <p bitTypography="body1">{{ policy.description | i18n }}</p>
+        <ng-template #policyForm></ng-template>
       </div>
-    </form>
-  </div>
-</div>
+    </ng-container>
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary" bitFormButton type="submit">
+        {{ "save" | i18n }}
+      </button>
+      <button bitButton buttonType="secondary" bitDialogClose type="button">
+        {{ "cancel" | i18n }}
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.ts
@@ -1,33 +1,34 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  ViewChild,
-  ViewContainerRef,
-} from "@angular/core";
+import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
+import { ChangeDetectorRef, Component, Inject, ViewChild, ViewContainerRef } from "@angular/core";
+import { FormBuilder } from "@angular/forms";
 
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { PolicyRequest } from "@bitwarden/common/admin-console/models/request/policy.request";
 import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DialogService } from "@bitwarden/components";
 
 import { BasePolicy, BasePolicyComponent } from "../policies";
 
+export type PolicyEditDialogData = {
+  /** Returns policy abstracts. */
+  policy: BasePolicy;
+  /** Returns a unique organization id  */
+  organizationId: string;
+  /** A map indicating whether each policy type is enabled or disabled. */
+  policiesEnabledMap: Map<PolicyType, boolean>;
+};
+
+export enum PolicyEditDialogResult {
+  Saved = "saved",
+}
 @Component({
   selector: "app-policy-edit",
   templateUrl: "policy-edit.component.html",
 })
 export class PolicyEditComponent {
-  @Input() policy: BasePolicy;
-  @Input() organizationId: string;
-  @Input() policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
-  @Output() onSavedPolicy = new EventEmitter();
-
   @ViewChild("policyForm", { read: ViewContainerRef, static: true })
   policyFormRef: ViewContainerRef;
 
@@ -39,22 +40,29 @@ export class PolicyEditComponent {
   policyComponent: BasePolicyComponent;
 
   private policyResponse: PolicyResponse;
-
+  formGroup = this.formBuilder.group({
+    enabled: [this.enabled],
+  });
   constructor(
+    @Inject(DIALOG_DATA) protected data: PolicyEditDialogData,
     private policyApiService: PolicyApiServiceAbstraction,
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private cdr: ChangeDetectorRef,
-    private logService: LogService,
+    private formBuilder: FormBuilder,
+    private dialogRef: DialogRef<PolicyEditDialogResult>,
   ) {}
+  get policy(): BasePolicy {
+    return this.data.policy;
+  }
 
   async ngAfterViewInit() {
     await this.load();
     this.loading = false;
 
-    this.policyComponent = this.policyFormRef.createComponent(this.policy.component)
+    this.policyComponent = this.policyFormRef.createComponent(this.data.policy.component)
       .instance as BasePolicyComponent;
-    this.policyComponent.policy = this.policy;
+    this.policyComponent.policy = this.data.policy;
     this.policyComponent.policyResponse = this.policyResponse;
 
     this.cdr.detectChanges();
@@ -63,8 +71,8 @@ export class PolicyEditComponent {
   async load() {
     try {
       this.policyResponse = await this.policyApiService.getPolicy(
-        this.organizationId,
-        this.policy.type,
+        this.data.organizationId,
+        this.data.policy.type,
       );
     } catch (e) {
       if (e.statusCode === 404) {
@@ -75,30 +83,29 @@ export class PolicyEditComponent {
     }
   }
 
-  async submit() {
+  submit = async () => {
     let request: PolicyRequest;
     try {
-      request = await this.policyComponent.buildRequest(this.policiesEnabledMap);
+      request = await this.policyComponent.buildRequest(this.data.policiesEnabledMap);
     } catch (e) {
       this.platformUtilsService.showToast("error", null, e.message);
       return;
     }
+    this.formPromise = this.policyApiService.putPolicy(
+      this.data.organizationId,
+      this.data.policy.type,
+      request,
+    );
+    await this.formPromise;
+    this.platformUtilsService.showToast(
+      "success",
+      null,
+      this.i18nService.t("editedPolicyId", this.i18nService.t(this.data.policy.name)),
+    );
+    this.dialogRef.close(PolicyEditDialogResult.Saved);
+  };
 
-    try {
-      this.formPromise = this.policyApiService.putPolicy(
-        this.organizationId,
-        this.policy.type,
-        request,
-      );
-      await this.formPromise;
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("editedPolicyId", this.i18nService.t(this.policy.name)),
-      );
-      this.onSavedPolicy.emit();
-    } catch (e) {
-      this.logService.error(e);
-    }
-  }
+  static open = (dialogService: DialogService, config: DialogConfig<PolicyEditDialogData>) => {
+    return dialogService.open<PolicyEditDialogResult>(PolicyEditComponent, config);
+  };
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Migrate the policy edit component to use the component library.

## Code changes

policy-edit.component.html -  Updated the bootstrap css to use the equivalent components from the Component Library.
policy-edit.component.ts - Updated the modal to dialog service.
policies.component.ts -  Updated the import statement and edit function to call the dialog service.

## Screenshots

https://github.com/bitwarden/clients/assets/156108204/e8e491b2-2b2d-4b56-a5d9-1cd2dce49268



