### PR TITLE
[DEVOPS-1917] - Display Web deployed commit in GH summary

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -230,6 +230,17 @@ jobs:
           url: https://github.com/bitwarden/clients/actions/runs/${{ github.run_id }}
           AZURE_KV_CI_SERVICE_PRINCIPAL: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
 
+  update-summary:
+    name: Display commit
+    needs: artifact-check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Display commit SHA
+        run: |
+          REPO_URL="https://github.com/bitwarden/clients/commit"
+          COMMIT_SHA="${{ needs.artifact-check.outputs.artifact-build-commit }}"
+          echo ":steam_locomotive: View [commit]($REPO_URL/$COMMIT_SHA)" >> $GITHUB_STEP_SUMMARY
+
   azure-deploy:
     name: Deploy Web Vault to ${{ inputs.environment }} Storage Account
     needs:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add a commit value as a URL, allowing QA engineers to jump from the GitHub workflow summary to the deployed commit.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/deploy-web.yml:** Add a step to display a URL in the GH summary, pointing to the deployed commit.

## Screenshots
<img width="1405" alt="image" src="https://github.com/bitwarden/clients/assets/77340197/5487b021-7e45-4549-aa73-a0f0cd2f1104">

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
