### PR TITLE
Reintroduce null object remove rerouting

### DIFF
--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -78,6 +78,11 @@ export default abstract class AbstractChromeStorageService
   async save(key: string, obj: any): Promise<void> {
     obj = objToStore(obj);
 
+    if (obj == null) {
+      // Safari does not support set of null values
+      return this.remove(key);
+    }
+
     const keyedObj = { [key]: obj };
     return new Promise<void>((resolve) => {
       this.chromeStorageApi.set(keyedObj, () => {

--- a/apps/browser/src/platform/services/abstractions/chrome-storage-api.service.spec.ts
+++ b/apps/browser/src/platform/services/abstractions/chrome-storage-api.service.spec.ts
@@ -62,6 +62,17 @@ describe("ChromeStorageApiService", () => {
         expect.any(Function),
       );
     });
+
+    it("removes the key when the value is null", async () => {
+      const removeMock = chrome.storage.local.remove as jest.Mock;
+      removeMock.mockImplementation((key, callback) => {
+        delete store[key];
+        callback();
+      });
+      const key = "key";
+      await service.save(key, null);
+      expect(removeMock).toHaveBeenCalledWith(key, expect.any(Function));
+    });
   });
 
   describe("get", () => {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8621 moved all locally stored objects to json serialized data, but reintroduced a bug in safari refusing to set null values. This corrects that issue.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
