### PR TITLE
PM-7745 - SSO Login Strategy - Attempt to fix TDE decryption "no private key" error

### DIFF
--- a/libs/auth/src/common/login-strategies/sso-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.ts
@@ -244,7 +244,7 @@ export class SsoLoginStrategy extends LoginStrategy {
 
       // Only try to set user key with device key if admin approval request was not successful
       if (!hasUserKey) {
-        await this.trySetUserKeyWithDeviceKey(tokenResponse);
+        await this.trySetUserKeyWithDeviceKey(tokenResponse, userId);
       }
     } else if (
       masterKeyEncryptedUserKey != null &&
@@ -312,10 +312,11 @@ export class SsoLoginStrategy extends LoginStrategy {
     }
   }
 
-  private async trySetUserKeyWithDeviceKey(tokenResponse: IdentityTokenResponse): Promise<void> {
+  private async trySetUserKeyWithDeviceKey(
+    tokenResponse: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     const trustedDeviceOption = tokenResponse.userDecryptionOptions?.trustedDeviceOption;
-
-    const userId = (await this.stateService.getUserId()) as UserId;
 
     const deviceKey = await this.deviceTrustService.getDeviceKey(userId);
     const encDevicePrivateKey = trustedDeviceOption?.encryptedPrivateKey;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Try to resolve [PM-7745](https://bitwarden.atlassian.net/browse/PM-7745) where the vault sometimes fails to decrypt with a `No private key` error.  We can't reproduce this locally, but I suspect that the `UserId` isn’t coming back from the `StateService` or it’s getting an incorrect one. That would then result in a null `devicePrivateKey`  in the `DeviceTrustService.decryptUserKeyWithDeviceKey(…)` which would then call `await this.cryptoService.rsaDecrypt(encryptedUserKey.encryptedString,  devicePrivateKey)`  which would throw the `No private key` error.

I suspect that I introduced the issue here: https://github.com/bitwarden/clients/pull/7882/files#diff-874e570f3547ce8f7fd1941c7ac3180fa157307e40052ba983dd20be417660fdR303

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/auth/src/common/login-strategies/sso-login.strategy.ts:** `trySetUserKeyWithDeviceKey` should use the `UserId` from the `IdTokenResponse` instead of relying on `StateService`

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-7745]: https://bitwarden.atlassian.net/browse/PM-7745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ