### PR TITLE
Bandaid Folders Not Emitting

### DIFF
--- a/apps/browser/src/platform/state/foreground-derived-state.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.ts
@@ -56,7 +56,7 @@ export class ForegroundDerivedState<TTo> implements DerivedState<TTo> {
 
         return await this.getStoredValue();
       }),
-      filter((s) => s.derived),
+      filter((s) => s?.derived === true), // A "remove" storage update will return us null
       map((s) => s.value),
     );
 

--- a/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-filter.component.ts
@@ -1,15 +1,13 @@
 import { Location } from "@angular/common";
 import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
-import { BehaviorSubject, Subject, firstValueFrom, from, of } from "rxjs";
-import { first, switchMap, takeUntil, timeout } from "rxjs/operators";
+import { BehaviorSubject, Subject, firstValueFrom, from } from "rxjs";
+import { first, switchMap, takeUntil } from "rxjs/operators";
 
-import { DynamicTreeNode } from "@bitwarden/angular/vault/vault-filter/models/dynamic-tree-node.model";
 import { VaultFilter } from "@bitwarden/angular/vault/vault-filter/models/vault-filter.model";
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -97,7 +95,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     private location: Location,
     private vaultFilterService: VaultFilterService,
     private vaultBrowserStateService: VaultBrowserStateService,
-    private logService: LogService,
   ) {
     this.noFolderListSize = 100;
   }
@@ -220,19 +217,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
 
   async loadFolders() {
     const allFolders = await firstValueFrom(
-      this.vaultFilterService.buildNestedFolders(this.selectedOrganization).pipe(
-        timeout({
-          first: 1_000,
-          with: () => {
-            this.logService.warning("Folders were not available, returning no folders.");
-            // TEMP: This is a fix for derived state sometimes not emitting a value when it's expected
-            // this replaces a never loading vault with a vault that displays with no folders.
-            // this isn't ideal but folders will attempt to load again when navigating away from this
-            // component and coming back to it.
-            return of(new DynamicTreeNode<FolderView>({}));
-          },
-        }),
-      ),
+      this.vaultFilterService.buildNestedFolders(this.selectedOrganization),
     );
     this.folders = allFolders.fullList;
     this.nestedFolders = allFolders.nestedList;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Add a bandaid for derived folders not emitting at least once, we (platform) are going to keep looking into making this work better but for now this makes the experience of folders not emitting much better for users in MV3. 

I also encountered an issue occasionally in derived state where we were getting `"remove"` updates and returning `null` from the `switchMap` but were just calling `s.derived` on the value, which was causing some errors.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
