### PR TITLE
Use unique port names for derived states

### DIFF
--- a/apps/browser/src/platform/state/foreground-derived-state.provider.ts
+++ b/apps/browser/src/platform/state/foreground-derived-state.provider.ts
@@ -26,7 +26,12 @@ export class ForegroundDerivedStateProvider extends DefaultDerivedStateProvider 
     _dependencies: TDeps,
     storageLocation: [string, AbstractStorageService & ObservableStorageService],
   ): DerivedState<TTo> {
-    const [cacheKey, storageService] = storageLocation;
-    return new ForegroundDerivedState(deriveDefinition, storageService, cacheKey, this.ngZone);
+    const [location, storageService] = storageLocation;
+    return new ForegroundDerivedState(
+      deriveDefinition,
+      storageService,
+      deriveDefinition.buildCacheKey(location),
+      this.ngZone,
+    );
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Fixes a bug introduced in #8844 where port names for derived state are no longer unique to the derived state.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
