### PR TITLE
[PM-7765] Support Authorization Header protection in bw serve

### DIFF
--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -479,6 +479,10 @@ export class Program {
       .description("Start a RESTful API webserver.")
       .option("--hostname <hostname>", "The hostname to bind your API webserver to.")
       .option("--port <port>", "The port to run your API webserver on.")
+      .option("--auth-token-env <authTokenEnv>", "The environment variable to use for the auth token. Defaults to BW_SERVE_AUTH_TOKEN if not set.")
+      .option("--auth-token-file <authTokenFile>", "The file to use for the auth token.")
+      .option("--auth-token <authToken>", "The auth token to use for authentication.")
+      .option("--disable-auth", "If set, disables authentication.")
       .option(
         "--disable-origin-protection",
         "If set, allows requests with origin header. Warning, this option exists for backwards compatibility reasons and exposes your environment to known CSRF attacks.",


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This PR adds authentication to the `bw serve` command and enables it by default. The old behaviour can be achieved by calling `bw serve --disable-auth`.

This enhances the security as the caller must authenticate to use the Vault-Management API.

The service can be used with e.g.: 
```bash
node ./build/bw.js serve --auth-token THE_TOKEN &

curl -H "Authorization: Bearer THE_TOKEN" http://localhost:8087/list/object/items
```

## Code changes

The code changes are just on the commandline options, handling these options and an additional authentication interceptor.

