### PR TITLE
[AC-2523] Fix broken members dialog for Manage Users custom permission

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -619,7 +619,7 @@ export class MemberDialogComponent implements OnDestroy {
 }
 
 function mapCollectionToAccessItemView(
-  collection: CollectionView,
+  collection: CollectionAdminView,
   organization: Organization,
   flexibleCollectionsV1Enabled: boolean,
   accessSelection?: CollectionAccessSelectionView,
@@ -631,7 +631,8 @@ function mapCollectionToAccessItemView(
     labelName: collection.name,
     listName: collection.name,
     readonly:
-      group !== undefined || !collection.canEdit(organization, flexibleCollectionsV1Enabled),
+      group !== undefined ||
+      !collection.canEditUserAccess(organization, flexibleCollectionsV1Enabled),
     readonlyPermission: accessSelection ? convertToPermission(accessSelection) : undefined,
     viaGroupName: group?.name,
   };

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -31,6 +31,9 @@ export class CollectionAdminView extends CollectionView {
     this.assigned = response.assigned;
   }
 
+  /**
+   * Whether the current user can edit the collection, including user and group access
+   */
   override canEdit(org: Organization, flexibleCollectionsV1Enabled: boolean): boolean {
     return org?.flexibleCollections
       ? org?.canEditAnyCollection(flexibleCollectionsV1Enabled) || this.manage
@@ -42,5 +45,15 @@ export class CollectionAdminView extends CollectionView {
     return org?.flexibleCollections
       ? org?.canDeleteAnyCollection || (!org?.limitCollectionCreationDeletion && this.manage)
       : org?.canDeleteAnyCollection || (org?.canDeleteAssignedCollections && this.assigned);
+  }
+
+  /**
+   * Whether the user can modify user access to this collection
+   * @param org
+   * @param flexibleCollectionsV1Enabled
+   * @returns
+   */
+  canEditUserAccess(org: Organization, flexibleCollectionsV1Enabled: boolean): boolean {
+    return this.canEdit(org, flexibleCollectionsV1Enabled) || org.canManageUsers;
   }
 }

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -49,9 +49,6 @@ export class CollectionAdminView extends CollectionView {
 
   /**
    * Whether the user can modify user access to this collection
-   * @param org
-   * @param flexibleCollectionsV1Enabled
-   * @returns
    */
   canEditUserAccess(org: Organization, flexibleCollectionsV1Enabled: boolean): boolean {
     return this.canEdit(org, flexibleCollectionsV1Enabled) || org.canManageUsers;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In #8758, I switched the Members modal -> Collection tab over to using the `collection.canEdit` getter to determine user permissions. However, this does not take into account the `Manage Users` custom permission, which is specifically for this tab. 

The result is that a custom user with the `Manage Users` permission is seeing disabled collection rows when editing a member:

![Screenshot 2024-04-29 at 4 30 26 PM](https://github.com/bitwarden/clients/assets/31796059/91024a1c-1afa-46d8-9bb9-44c711b30546)

This is in `rc` for 2024.5.0 so it will need to be cherry-picked. The server-side changes did not make `rc` cut, and are properly feature flagged, so they need a fix but not as urgently.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/vault/core/views/collection-admin.view.ts** - add a new `canEditUserAccess` getter. The current `canEdit` getter indicates they can edit the collection including any access, `canEditUserAccess` only indicates they can manage user access.
- **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts** - use this new getter when evaluating permissions in the member dialog.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
