### PR TITLE
[PM-6533] Sort organizations by name within product switcher

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.ts
@@ -1,12 +1,13 @@
 import { Component, ViewChild } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
-import { combineLatest, concatMap } from "rxjs";
+import { ActivatedRoute, ParamMap, Router } from "@angular/router";
+import { combineLatest, concatMap, map } from "rxjs";
 
 import {
   canAccessOrgAdmin,
   OrganizationService,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { MenuComponent } from "@bitwarden/components";
 
 type ProductSwitcherItem = {
@@ -48,6 +49,13 @@ export class ProductSwitcherContentComponent {
     this.organizationService.organizations$,
     this.route.paramMap,
   ]).pipe(
+    map(([orgs, paramMap]): [Organization[], ParamMap] => {
+      return [
+        // Sort orgs by name to match the order within the sidebar
+        orgs.sort((a, b) => a.name.localeCompare(b.name)),
+        paramMap,
+      ];
+    }),
     concatMap(async ([orgs, paramMap]) => {
       const routeOrg = orgs.find((o) => o.id === paramMap.get("organizationId"));
       // If the active route org doesn't have access to SM, find the first org that does.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Sort organizations by name in the product switcher, resulting in the organizations being iterated over in the same order they are visually displayed in the filters.
  - Currently when navigating from Password Manager to Admin Console the first organization that can be access is chosen but it isn't necessarily first alphabetically. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **product-switcher-content.component.ts:**
  - Sort organizations by `name` attribute

## Screenshots

|Before|After|
|------|-----|
|Org "aa bb org" is shown first but not selected when navigating to the Admin Console even though admin permissions are available.| Org "aa bb org" is chosen first when navigating to the Admin Console|
|![before](https://github.com/bitwarden/clients/assets/125900171/6703fb47-cf42-476d-b2fd-a0b83bcabdb8)|![after](https://github.com/bitwarden/clients/assets/125900171/ed9623d3-2a28-4307-8895-2e4ab1fec29f)|

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
