### PR TITLE
[CL-110] fix code block text color in Storybook (attempt #2)

### DIFF
--- a/libs/components/src/styles.scss
+++ b/libs/components/src/styles.scss
@@ -49,6 +49,6 @@ $card-icons-base: "../../src/billing/images/cards/";
 @import "multi-select/scss/bw.theme.scss";
 
 // Workaround for https://bitwarden.atlassian.net/browse/CL-110
-#storybook-docs pre.prismjs {
+#storybook-docs .sb-anchor pre.prismjs {
   color: white;
 }


### PR DESCRIPTION
## Type of change

- Bug fix

## Objective

See https://github.com/bitwarden/clients/pull/8868 for background.

There are two types of code blocks in storybook:

One is in the normal flow of documentation, which has a light background:

![Screenshot 2024-04-29 at 2 45 27 PM](https://github.com/bitwarden/clients/assets/102181210/6b2018dc-e0ef-43f4-9626-6aaa80829a5b)

The other is accessed by clicking the "Show Code / Hide Code" toggle, which has a dark background.

![Screenshot 2024-04-29 at 2 46 45 PM](https://github.com/bitwarden/clients/assets/102181210/9b5b9ad6-65fb-4eeb-b2c1-d705d2b5613c)

The changes to https://github.com/bitwarden/clients/pull/8868 fixed the code color for a dark background, but broke the color for light background (see image above).

### Solution

The code blocks accessed by "Show Code" all seem to be the child of a parent div with the class `sb-anchor`. This PR adds extra CSS specificity to target only those code blocks when setting the text color to white.

![Screenshot 2024-04-29 at 3 01 38 PM](https://github.com/bitwarden/clients/assets/102181210/d60f3786-ea11-4f04-aa4a-b6b4453c6c1d)