### PR TITLE
[PM-7820] Remove sync messages that seems to not be listened to

### DIFF
--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -221,14 +221,12 @@ export class SyncService implements SyncServiceAbstraction {
           const remoteCipher = await this.apiService.getFullCipherDetails(notification.id);
           if (remoteCipher != null) {
             await this.cipherService.upsert(new CipherData(remoteCipher));
-            this.messagingService.send("syncedUpsertedCipher", { cipherId: notification.id });
             return this.syncCompleted(true);
           }
         }
       } catch (e) {
         if (e != null && e.statusCode === 404 && isEdit) {
           await this.cipherService.delete(notification.id);
-          this.messagingService.send("syncedDeletedCipher", { cipherId: notification.id });
           return this.syncCompleted(true);
         }
       }
@@ -240,7 +238,6 @@ export class SyncService implements SyncServiceAbstraction {
     this.syncStarted();
     if (await this.stateService.getIsAuthenticated()) {
       await this.cipherService.delete(notification.id);
-      this.messagingService.send("syncedDeletedCipher", { cipherId: notification.id });
       return this.syncCompleted(true);
     }
     return this.syncCompleted(false);
@@ -258,7 +255,6 @@ export class SyncService implements SyncServiceAbstraction {
           const remoteSend = await this.sendApiService.getSend(notification.id);
           if (remoteSend != null) {
             await this.sendService.upsert(new SendData(remoteSend));
-            this.messagingService.send("syncedUpsertedSend", { sendId: notification.id });
             return this.syncCompleted(true);
           }
         }
@@ -273,7 +269,6 @@ export class SyncService implements SyncServiceAbstraction {
     this.syncStarted();
     if (await this.stateService.getIsAuthenticated()) {
       await this.sendService.delete(notification.id);
-      this.messagingService.send("syncedDeletedSend", { sendId: notification.id });
       this.syncCompleted(true);
       return true;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When playing with the sync on a fork, I discovered these sync messages that seems to not be listened to. Is it dead code ? If yes, my PR remove these sync messages. If not, I am curious to understand what role they play.

- `"syncedUpsertedCipher"`  see [GitHub search result](https://github.com/search?q=repo%3Abitwarden%2Fclients+syncedUpsertedCipher&type=code)
- `"syncedDeletedCipher"` see [GitHub search result](https://github.com/search?q=repo%3Abitwarden%2Fclients+syncedDeletedCipher&type=code)
- `"syncedUpsertedSend"`
- `"syncedDeletedSend"`

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/vault/services/sync/sync.service.ts:** Remove sync messages that seems to not be listened to

## Before you submit

- ~~Please add **unit tests** where it makes sense to do so (encouraged but not required)~~
- ~~If this change requires a **documentation update** - notify the documentation team~~
- ~~If this change has particular **deployment requirements** - notify the DevOps team~~
- ~~Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)~~
