### PR TITLE
Correct and test changeover point for userId source in storage migration

### DIFF
--- a/libs/common/src/state-migrations/migration-helper.spec.ts
+++ b/libs/common/src/state-migrations/migration-helper.spec.ts
@@ -235,6 +235,11 @@ export function mockMigrationHelper(
     helper.setToUser(userId, keyDefinition, value),
   );
   mockHelper.getAccounts.mockImplementation(() => helper.getAccounts());
+  mockHelper.getKnownUserIds.mockImplementation(() => helper.getKnownUserIds());
+  mockHelper.removeFromGlobal.mockImplementation((keyDefinition) =>
+    helper.removeFromGlobal(keyDefinition),
+  );
+  mockHelper.remove.mockImplementation((key) => helper.remove(key));
 
   mockHelper.type = helper.type;
 

--- a/libs/common/src/state-migrations/migration-helper.ts
+++ b/libs/common/src/state-migrations/migration-helper.ts
@@ -175,8 +175,8 @@ export class MigrationHelper {
    * Helper method to read known users ids.
    */
   async getKnownUserIds(): Promise<string[]> {
-    if (this.currentVersion < 61) {
-      return knownAccountUserIdsBuilderPre61(this.storageService);
+    if (this.currentVersion < 60) {
+      return knownAccountUserIdsBuilderPre60(this.storageService);
     } else {
       return knownAccountUserIdsBuilder(this.storageService);
     }
@@ -245,7 +245,7 @@ function globalKeyBuilderPre9(): string {
   throw Error("No key builder should be used for versions prior to 9.");
 }
 
-async function knownAccountUserIdsBuilderPre61(
+async function knownAccountUserIdsBuilderPre60(
   storageService: AbstractStorageService,
 ): Promise<string[]> {
   return (await storageService.get<string[]>("authenticatedAccounts")) ?? [];

--- a/libs/common/src/state-migrations/migrations/60-known-accounts.spec.ts
+++ b/libs/common/src/state-migrations/migrations/60-known-accounts.spec.ts
@@ -51,17 +51,13 @@ const rollbackJson = () => {
     },
     global_account_accounts: {
       user1: {
-        profile: {
-          email: "user1",
-          name: "User 1",
-          emailVerified: true,
-        },
+        email: "user1",
+        name: "User 1",
+        emailVerified: true,
       },
       user2: {
-        profile: {
-          email: "",
-          emailVerified: false,
-        },
+        email: "",
+        emailVerified: false,
       },
     },
     global_account_activeAccountId: "user1",

--- a/libs/common/src/state-migrations/migrations/60-known-accounts.ts
+++ b/libs/common/src/state-migrations/migrations/60-known-accounts.ts
@@ -38,8 +38,8 @@ export class KnownAccountsMigrator extends Migrator<59, 60> {
   }
   async rollback(helper: MigrationHelper): Promise<void> {
     // authenticated account are removed, but the accounts record also contains logged out accounts. Best we can do is to add them all back
-    const accounts = (await helper.getFromGlobal<Record<string, unknown>>(ACCOUNT_ACCOUNTS)) ?? {};
-    await helper.set("authenticatedAccounts", Object.keys(accounts));
+    const userIds = (await helper.getKnownUserIds()) ?? {};
+    await helper.set("authenticatedAccounts", userIds);
     await helper.removeFromGlobal(ACCOUNT_ACCOUNTS);
 
     // Active Account Id


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8893 changes the source of truth of known userIds in storage, but made a mistake on the changeover point in state version for that change. This corrects that error, and updates the migration to both use the helper function and test that it works correctly.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
