### PR TITLE
Add beta extension to allowed native messaging hosts

### DIFF
--- a/apps/desktop/src/main/native-messaging.main.ts
+++ b/apps/desktop/src/main/native-messaging.main.ts
@@ -146,6 +146,8 @@ export class NativeMessagingMain {
         allowed_origins: [
           // Chrome extension
           "chrome-extension://nngceckbapebfimnlniiiahkandclblb/",
+          // Chrome beta extension
+          "chrome-extension://hccnnhgbibccigepcmlgppchkpfdophk/",
           // Edge extension
           "chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh/",
           // Opera extension


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds Chrome Mv3 beta extension to the list of allowed native messaging hosts for chrome

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
