### PR TITLE
[AC-2547] Defect - Deleting Provider from Provider Portal should take user to Password Manager Vault page

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/settings/account.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/settings/account.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 
 import { UserVerificationDialogComponent } from "@bitwarden/auth/angular";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -42,6 +42,7 @@ export class AccountComponent {
     private dialogService: DialogService,
     private configService: ConfigService,
     private providerApiService: ProviderApiServiceAbstraction,
+    private router: Router,
   ) {}
 
   async ngOnInit() {
@@ -93,9 +94,8 @@ export class AccountComponent {
       return;
     }
 
-    this.formPromise = this.providerApiService.deleteProvider(this.providerId);
     try {
-      await this.formPromise;
+      await this.providerApiService.deleteProvider(this.providerId);
       this.platformUtilsService.showToast(
         "success",
         this.i18nService.t("providerDeleted"),
@@ -104,7 +104,8 @@ export class AccountComponent {
     } catch (e) {
       this.logService.error(e);
     }
-    this.formPromise = null;
+
+    await this.router.navigate(["/"]);
   }
 
   private async verifyUser(): Promise<boolean> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a Provider Owner/Admin user deletes the Provider from the Provider Portal Settings page, the user currently remains on the My Provider page. The user should be directed to the Password Manager Vaults page - similar to when an Org Admin/Owner deletes an Organization from the Admin Console Org Settings page.

 

Navigate to Provider Portal via product switcher

Go to the Setting page

Click ‘Delete provider’

Enter MP and confirm

Expected Result - Green confirmation banner is displayed confirming provider has been deleted and user is taken to the Password Manager Vaults page

Actual Result - Green confirmation banner is displayed confirming provider has been deleted and user remains on the My Provider page in the Provider Portal

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)

https://github.com/bitwarden/clients/assets/108260115/890a596c-e969-4166-b710-9610190b3e77

