### PR TITLE
[PM-7808][PM-7848] UV Preferred/Required, Item has MP reprompt, user without MP incorrectly bypasses UV and When UV = discouraged, cannot save passkey to item using [+] button

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -569,7 +569,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: Fido2UserVerificationService,
     useClass: Fido2UserVerificationService,
-    deps: [PasswordRepromptService, DialogService],
+    deps: [PasswordRepromptService, UserVerificationService, DialogService],
   }),
 ];
 

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -172,8 +172,10 @@ export class AddEditComponent extends BaseAddEditComponent {
     const fido2SessionData = await firstValueFrom(this.fido2PopoutSessionData$);
     const { isFido2Session, sessionId, userVerification, fromLock } = fido2SessionData;
     const inFido2PopoutWindow = BrowserPopupUtils.inPopout(window) && isFido2Session;
+
     if (
       inFido2PopoutWindow &&
+      userVerification &&
       !(await this.fido2UserVerificationService.handleUserVerification(
         userVerification,
         this.cipher,

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -175,7 +175,6 @@ export class AddEditComponent extends BaseAddEditComponent {
 
     if (
       inFido2PopoutWindow &&
-      userVerification &&
       !(await this.fido2UserVerificationService.handleUserVerification(
         userVerification,
         this.cipher,

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.ts
@@ -172,7 +172,6 @@ export class AddEditComponent extends BaseAddEditComponent {
     const fido2SessionData = await firstValueFrom(this.fido2PopoutSessionData$);
     const { isFido2Session, sessionId, userVerification, fromLock } = fido2SessionData;
     const inFido2PopoutWindow = BrowserPopupUtils.inPopout(window) && isFido2Session;
-
     if (
       inFido2PopoutWindow &&
       !(await this.fido2UserVerificationService.handleUserVerification(

--- a/apps/browser/src/vault/services/fido2-user-verification.service.spec.ts
+++ b/apps/browser/src/vault/services/fido2-user-verification.service.spec.ts
@@ -1,0 +1,248 @@
+import { MockProxy, mock } from "jest-mock-extended";
+
+import { UserVerificationDialogComponent } from "@bitwarden/auth/angular";
+import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService } from "@bitwarden/components";
+import { PasswordRepromptService } from "@bitwarden/vault";
+
+import { SetPinComponent } from "./../../auth/popup/components/set-pin.component";
+import { Fido2UserVerificationService } from "./fido2-user-verification.service";
+
+jest.mock("@bitwarden/auth/angular", () => ({
+  UserVerificationDialogComponent: {
+    open: jest.fn().mockResolvedValue({ userAction: "confirm", verificationSuccess: true }),
+  },
+}));
+
+jest.mock("../../auth/popup/components/set-pin.component", () => {
+  return {
+    SetPinComponent: {
+      open: jest.fn(),
+    },
+  };
+});
+
+describe("Fido2UserVerificationService", () => {
+  let fido2UserVerificationService: Fido2UserVerificationService;
+
+  let passwordRepromptService: MockProxy<PasswordRepromptService>;
+  let userVerificationService: MockProxy<UserVerificationService>;
+  let dialogService: MockProxy<DialogService>;
+  let cipher: CipherView;
+
+  beforeEach(() => {
+    passwordRepromptService = mock<PasswordRepromptService>();
+    userVerificationService = mock<UserVerificationService>();
+    dialogService = mock<DialogService>();
+
+    cipher = createCipherView();
+
+    fido2UserVerificationService = new Fido2UserVerificationService(
+      passwordRepromptService,
+      userVerificationService,
+      dialogService,
+    );
+
+    (UserVerificationDialogComponent.open as jest.Mock).mockResolvedValue({
+      userAction: "confirm",
+      verificationSuccess: true,
+    });
+  });
+
+  describe("handleUserVerification", () => {
+    describe("user verification requested is true", () => {
+      it("should return true if user is redirected from lock screen and master password reprompt is not required", async () => {
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          true,
+        );
+        expect(result).toBe(true);
+      });
+
+      it("should call master password reprompt dialog if user is redirected from lock screen, has master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(true);
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          true,
+        );
+
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+        expect(result).toBe(true);
+      });
+
+      it("should call user verification dialog if user is redirected from lock screen, does not have a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          true,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should call user verification dialog if user is not redirected from lock screen, does not have a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          false,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should call master password reprompt dialog if user is not redirected from lock screen, has a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          false,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should call user verification dialog if user is not redirected from lock screen and no master password reprompt is required", async () => {
+        const result = await fido2UserVerificationService.handleUserVerification(
+          true,
+          cipher,
+          false,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should prompt user to set pin if user has no verification method", async () => {
+        (UserVerificationDialogComponent.open as jest.Mock).mockResolvedValue({
+          userAction: "confirm",
+          verificationSuccess: false,
+          noAvailableClientVerificationMethods: true,
+        });
+
+        await fido2UserVerificationService.handleUserVerification(true, cipher, false);
+
+        expect(SetPinComponent.open).toHaveBeenCalledWith(dialogService);
+      });
+    });
+
+    describe("user verification requested is false", () => {
+      it("should return false if user is redirected from lock screen and master password reprompt is not required", async () => {
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          true,
+        );
+        expect(result).toBe(false);
+      });
+
+      it("should return false if user is not redirected from lock screen and master password reprompt is not required", async () => {
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          false,
+        );
+        expect(result).toBe(false);
+      });
+
+      it("should call master password reprompt dialog if user is redirected from lock screen, has master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(true);
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          true,
+        );
+
+        expect(result).toBe(true);
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+      });
+
+      it("should call user verification dialog if user is redirected from lock screen, does not have a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          true,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should call user verification dialog if user is not redirected from lock screen, does not have a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          false,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+
+      it("should call master password reprompt dialog if user is not redirected from lock screen, has a master password and master password reprompt is required", async () => {
+        cipher.reprompt = CipherRepromptType.Password;
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+        const result = await fido2UserVerificationService.handleUserVerification(
+          false,
+          cipher,
+          false,
+        );
+
+        expect(UserVerificationDialogComponent.open).toHaveBeenCalledWith(dialogService, {
+          clientSideOnlyVerification: true,
+        });
+        expect(result).toBe(true);
+      });
+    });
+  });
+});
+
+function createCipherView() {
+  const cipher = new CipherView();
+  cipher.id = Utils.newGuid();
+  cipher.type = CipherType.Login;
+  cipher.reprompt = CipherRepromptType.None;
+  return cipher;
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This PR fixes two issues:
1. If a user without a MP is a part of an organization, and there’s an item in that organization’s vault with MP reprompt enabled, when the user attempts to create or retrieve a passkey from that item, they are not given the verification prompt.
2. When UV = discouraged, cannot save passkey to item using + button
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/vault/services/fido2-user-verification.service.ts:** Added logic to check if a user has a master password and use that to determine the user verification prompt to render if an item has master password re-prompt enabled.
- **apps/browser/src/vault/services/fido2-user-verification.service.spec.ts:** Added unit tests for basic user verification scenarios.

## Screenshots

https://github.com/bitwarden/clients/assets/13024008/220ab03b-3a76-4f63-845e-434aaef6caaa

https://github.com/bitwarden/clients/assets/13024008/17dea281-ff71-45f8-8a58-eeac25444a6e



<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
