### PR TITLE
Use account service for account enumeration.

### DIFF
--- a/apps/browser/src/platform/services/default-browser-state.service.ts
+++ b/apps/browser/src/platform/services/default-browser-state.service.ts
@@ -1,5 +1,3 @@
-import { BehaviorSubject } from "rxjs";
-
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -15,21 +13,13 @@ import { MigrationRunner } from "@bitwarden/common/platform/services/migration-r
 import { StateService as BaseStateService } from "@bitwarden/common/platform/services/state.service";
 
 import { Account } from "../../models/account";
-import { browserSession, sessionSync } from "../decorators/session-sync-observable";
 
 import { BrowserStateService } from "./abstractions/browser-state.service";
 
-@browserSession
 export class DefaultBrowserStateService
   extends BaseStateService<GlobalState, Account>
   implements BrowserStateService
 {
-  @sessionSync({
-    initializer: Account.fromJSON as any, // TODO: Remove this any when all any types are removed from Account
-    initializeAs: "record",
-  })
-  protected accountsSubject: BehaviorSubject<{ [userId: string]: Account }>;
-
   protected accountDeserializer = Account.fromJSON;
 
   constructor(

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -218,8 +218,10 @@ export class AppComponent implements OnInit, OnDestroy {
             await this.vaultTimeoutService.lock(message.userId);
             break;
           case "lockAllVaults": {
-            const currentUser = await this.stateService.getUserId();
-            const accounts = await firstValueFrom(this.stateService.accounts$);
+            const currentUser = await firstValueFrom(
+              this.accountService.activeAccount$.pipe(map((a) => a.id)),
+            );
+            const accounts = await firstValueFrom(this.accountService.accounts$);
             await this.vaultTimeoutService.lock(currentUser);
             for (const account of Object.keys(accounts)) {
               if (account === currentUser) {
@@ -690,7 +692,7 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   private async checkForSystemTimeout(timeout: number): Promise<void> {
-    const accounts = await firstValueFrom(this.stateService.accounts$);
+    const accounts = await firstValueFrom(this.accountService.accounts$);
     for (const userId in accounts) {
       if (userId == null) {
         continue;

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -221,7 +221,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: EncryptedMessageHandlerService,
     deps: [
-      StateServiceAbstraction,
+      AccountServiceAbstraction,
       AuthServiceAbstraction,
       CipherServiceAbstraction,
       PolicyServiceAbstraction,

--- a/libs/common/src/platform/abstractions/state.service.ts
+++ b/libs/common/src/platform/abstractions/state.service.ts
@@ -1,5 +1,3 @@
-import { Observable } from "rxjs";
-
 import { BiometricKey } from "../../auth/types/biometric-key";
 import { GeneratorOptions } from "../../tools/generator/generator-options";
 import { GeneratedPasswordHistory, PasswordGeneratorOptions } from "../../tools/generator/password";
@@ -24,8 +22,6 @@ export type InitOptions = {
 };
 
 export abstract class StateService<T extends Account = Account> {
-  accounts$: Observable<{ [userId: string]: T }>;
-
   addAccount: (account: T) => Promise<void>;
   clearDecryptedData: (userId: UserId) => Promise<void>;
   clean: (options?: StorageOptions) => Promise<void>;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Remove accounts subject from state service. Use account service as the source for known user ids.

## Code changes

- **state service**: remove account subject
- **app component / encrypted message handler **: use account service for userId enumeration
- **native messaging handler**: one case of account enumeration, but mostly awaits and fixes for showing the fingerprint of the requested user rather than whichever happens to be active at the time of the request.

To come is a PR removing session sync, since this was the last usage.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
