### PR TITLE
[PM-7907] No more optional `privateKey`

### DIFF
--- a/libs/common/src/admin-console/models/domain/encrypted-organization-key.ts
+++ b/libs/common/src/admin-console/models/domain/encrypted-organization-key.ts
@@ -25,7 +25,13 @@ export class EncryptedOrganizationKey implements BaseEncryptedOrganizationKey {
   constructor(private key: string) {}
 
   async decrypt(cryptoService: CryptoService) {
-    const decValue = await cryptoService.rsaDecrypt(this.key);
+    const activeUserPrivateKey = await cryptoService.getPrivateKey();
+
+    if (activeUserPrivateKey == null) {
+      throw new Error("Active user does not have a private key, cannot decrypt organization key.");
+    }
+
+    const decValue = await cryptoService.rsaDecrypt(this.key, activeUserPrivateKey);
     return new SymmetricCryptoKey(decValue) as OrgKey;
   }
 

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -319,7 +319,7 @@ export abstract class CryptoService {
    * @param privateKeyValue The private key to use for decryption
    * @returns The decrypted value
    */
-  abstract rsaDecrypt(encValue: string, privateKeyValue: Uint8Array): Promise<Uint8Array>;
+  abstract rsaDecrypt(encValue: string, privateKey: Uint8Array): Promise<Uint8Array>;
   abstract randomNumber(min: number, max: number): Promise<number>;
   /**
    * Generates a new cipher key

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -312,14 +312,14 @@ export abstract class CryptoService {
    * @param publicKey The public key to use for encryption, if not provided, the user's public key will be used
    * @returns The encrypted data
    */
-  abstract rsaEncrypt(data: Uint8Array, publicKey?: Uint8Array): Promise<EncString>;
+  abstract rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString>;
   /**
    * Decrypts a value using RSA.
    * @param encValue The encrypted value to decrypt
    * @param privateKeyValue The private key to use for decryption
    * @returns The decrypted value
    */
-  abstract rsaDecrypt(encValue: string, privateKeyValue?: Uint8Array): Promise<Uint8Array>;
+  abstract rsaDecrypt(encValue: string, privateKeyValue: Uint8Array): Promise<Uint8Array>;
   abstract randomNumber(min: number, max: number): Promise<number>;
   /**
    * Generates a new cipher key

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -311,13 +311,15 @@ export abstract class CryptoService {
    * @param data The data to encrypt
    * @param publicKey The public key to use for encryption, if not provided, the user's public key will be used
    * @returns The encrypted data
+   * @throws If the given publicKey is a null-ish value.
    */
   abstract rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString>;
   /**
    * Decrypts a value using RSA.
    * @param encValue The encrypted value to decrypt
-   * @param privateKeyValue The private key to use for decryption
+   * @param privateKey The private key to use for decryption
    * @returns The decrypted value
+   * @throws If the given privateKey is a null-ish value.
    */
   abstract rsaDecrypt(encValue: string, privateKey: Uint8Array): Promise<Uint8Array>;
   abstract randomNumber(min: number, max: number): Promise<number>;

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -621,19 +621,20 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, null, userId);
   }
 
-  async rsaEncrypt(data: Uint8Array, publicKey?: Uint8Array): Promise<EncString> {
+  async rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString> {
     if (publicKey == null) {
-      publicKey = await this.getPublicKey();
-    }
-    if (publicKey == null) {
-      throw new Error("Public key unavailable.");
+      throw new Error("'publicKey' is a required parameter and must be non-null");
     }
 
     const encBytes = await this.cryptoFunctionService.rsaEncrypt(data, publicKey, "sha1");
     return new EncString(EncryptionType.Rsa2048_OaepSha1_B64, Utils.fromBufferToB64(encBytes));
   }
 
-  async rsaDecrypt(encValue: string, privateKeyValue?: Uint8Array): Promise<Uint8Array> {
+  async rsaDecrypt(encValue: string, privateKey: Uint8Array): Promise<Uint8Array> {
+    if (privateKey == null) {
+      throw new Error("'privateKey' is a required parameter and must be non-null");
+    }
+
     const headerPieces = encValue.split(".");
     let encType: EncryptionType = null;
     let encPieces: string[];
@@ -665,10 +666,6 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     const data = Utils.fromB64ToArray(encPieces[0]);
-    const privateKey = privateKeyValue ?? (await this.getPrivateKey());
-    if (privateKey == null) {
-      throw new Error("No private key.");
-    }
 
     let alg: "sha1" | "sha256" = "sha1";
     switch (encType) {

--- a/libs/common/src/platform/services/key-state/org-keys.state.spec.ts
+++ b/libs/common/src/platform/services/key-state/org-keys.state.spec.ts
@@ -65,6 +65,10 @@ describe("derived decrypted org keys", () => {
       "org-id-2": new SymmetricCryptoKey(makeStaticByteArray(64, 2)) as OrgKey,
     };
 
+    const userPrivateKey = makeStaticByteArray(64, 3);
+
+    cryptoService.getPrivateKey.mockResolvedValue(userPrivateKey);
+
     // TODO: How to not have to mock these decryptions. They are internal concerns of EncryptedOrganizationKey
     cryptoService.rsaDecrypt.mockResolvedValueOnce(decryptedOrgKeys["org-id-1"].key);
     cryptoService.rsaDecrypt.mockResolvedValueOnce(decryptedOrgKeys["org-id-2"].key);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The goal here is to update the requirements of `CryptoService` `rsa{Encrypt|Decrypt}` to disallow the optional private/public key parameters. Before, if someone didn't use the parameter OR passed in `null`/`undefined` we would retrieve the private key/public key of the user for them. If we couldn't retrieve that key we would throw an exception saying `No private key`. Instead if we require this parameter we reduce developer error where they might try to decrypt something that wasn't encrypted with the users key and instead was encrypted with another key. We can also change their call sites to doing the validation that the key exists for themselves and we can throw more specific errors. 

No one was actually not passing in a second parameter of `rsaEncrypt` already but that doesn't mean they couldn't have been passing in `null`-ish values. I looked through all uses and can't see a use where their usage would have resulted in a possible `null` and where the key we would have retrieved for them would have been correct. 

https://github.com/search?q=repo%3Abitwarden%2Fclients+cryptoService.rsaEncrypt&type=code

There were two uses of `rsaDecrypt` that didn't define a private key parameter, I updated both those uses to retrieve the value that we would have done for them and guard that possibly being null with their own, more descriptive error. Other things could have been passing in `null` but looking at those uses it either seems very unlikely or using the key we would have gotten would have caused issues.

https://github.com/search?q=repo%3Abitwarden%2Fclients+cryptoService.rsaDecrypt&type=code

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
