### PR TITLE
[PM-7907] Encourage The Use of UserId in CryptoService

### DIFF
--- a/libs/angular/src/auth/components/set-password.component.ts
+++ b/libs/angular/src/auth/components/set-password.component.ts
@@ -244,7 +244,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     await this.userDecryptionOptionsService.setUserDecryptionOptions(userDecryptionOpts);
     await this.kdfConfigService.setKdfConfig(this.userId, this.kdfConfig);
     await this.masterPasswordService.setMasterKey(masterKey, this.userId);
-    await this.cryptoService.setUserKey(userKey[0]);
+    await this.cryptoService.setUserKey(userKey[0], this.userId);
 
     // Set private key only for new JIT provisioned users in MP encryption orgs
     // Existing TDE users will have private key set on sync or on login
@@ -253,7 +253,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
       this.forceSetPasswordReason !=
         ForceSetPasswordReason.TdeUserWithoutPasswordHasPasswordResetPermission
     ) {
-      await this.cryptoService.setPrivateKey(keyPair[1].encryptedString);
+      await this.cryptoService.setPrivateKey(keyPair[1].encryptedString, this.userId);
     }
 
     const localMasterKeyHash = await this.cryptoService.hashMasterKey(

--- a/libs/auth/src/common/login-strategies/auth-request-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/auth-request-login.strategy.spec.ts
@@ -140,7 +140,7 @@ describe("AuthRequestLoginStrategy", () => {
     expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(tokenResponse.key);
     expect(cryptoService.setUserKey).toHaveBeenCalledWith(userKey);
     expect(deviceTrustService.trustDeviceIfRequired).toHaveBeenCalled();
-    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey);
+    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey, mockUserId);
   });
 
   it("sets keys after a successful authentication when only userKey provided in login credentials", async () => {
@@ -164,7 +164,7 @@ describe("AuthRequestLoginStrategy", () => {
     // setMasterKeyEncryptedUserKey, setUserKey, and setPrivateKey should still be called
     expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(tokenResponse.key);
     expect(cryptoService.setUserKey).toHaveBeenCalledWith(decUserKey);
-    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey);
+    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey, mockUserId);
 
     // trustDeviceIfRequired should be called
     expect(deviceTrustService.trustDeviceIfRequired).not.toHaveBeenCalled();

--- a/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
@@ -163,9 +163,13 @@ export class AuthRequestLoginStrategy extends LoginStrategy {
     }
   }
 
-  protected override async setPrivateKey(response: IdentityTokenResponse): Promise<void> {
+  protected override async setPrivateKey(
+    response: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     await this.cryptoService.setPrivateKey(
-      response.privateKey ?? (await this.createKeyPairForOldAccount()),
+      response.privateKey ?? (await this.createKeyPairForOldAccount(userId)),
+      userId,
     );
   }
 

--- a/libs/auth/src/common/login-strategies/login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/login.strategy.ts
@@ -251,7 +251,7 @@ export abstract class LoginStrategy {
 
     await this.setMasterKey(response);
     await this.setUserKey(response, userId);
-    await this.setPrivateKey(response);
+    await this.setPrivateKey(response, userId);
 
     this.messagingService.send("loggedIn");
 
@@ -261,7 +261,7 @@ export abstract class LoginStrategy {
   // The keys comes from different sources depending on the login strategy
   protected abstract setMasterKey(response: IdentityTokenResponse): Promise<void>;
   protected abstract setUserKey(response: IdentityTokenResponse, userId: UserId): Promise<void>;
-  protected abstract setPrivateKey(response: IdentityTokenResponse): Promise<void>;
+  protected abstract setPrivateKey(response: IdentityTokenResponse, userId: UserId): Promise<void>;
 
   // Old accounts used master key for encryption. We are forcing migrations but only need to
   // check on password logins
@@ -269,9 +269,10 @@ export abstract class LoginStrategy {
     return false;
   }
 
-  protected async createKeyPairForOldAccount() {
+  protected async createKeyPairForOldAccount(userId: UserId) {
     try {
-      const [publicKey, privateKey] = await this.cryptoService.makeKeyPair();
+      const userKey = await this.cryptoService.getUserKeyWithLegacySupport(userId);
+      const [publicKey, privateKey] = await this.cryptoService.makeKeyPair(userKey);
       await this.apiService.postAccountKeys(new KeysRequest(publicKey, privateKey.encryptedString));
       return privateKey.encryptedString;
     } catch (e) {

--- a/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
@@ -175,7 +175,7 @@ describe("PasswordLoginStrategy", () => {
     );
     expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(tokenResponse.key);
     expect(cryptoService.setUserKey).toHaveBeenCalledWith(userKey);
-    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey);
+    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey, userId);
   });
 
   it("does not force the user to update their master password when there are no requirements", async () => {

--- a/libs/auth/src/common/login-strategies/password-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.ts
@@ -228,9 +228,13 @@ export class PasswordLoginStrategy extends LoginStrategy {
     }
   }
 
-  protected override async setPrivateKey(response: IdentityTokenResponse): Promise<void> {
+  protected override async setPrivateKey(
+    response: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     await this.cryptoService.setPrivateKey(
-      response.privateKey ?? (await this.createKeyPairForOldAccount()),
+      response.privateKey ?? (await this.createKeyPairForOldAccount(userId)),
+      userId,
     );
   }
 

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.ts
@@ -354,12 +354,16 @@ export class SsoLoginStrategy extends LoginStrategy {
     await this.cryptoService.setUserKey(userKey);
   }
 
-  protected override async setPrivateKey(tokenResponse: IdentityTokenResponse): Promise<void> {
+  protected override async setPrivateKey(
+    tokenResponse: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     const newSsoUser = tokenResponse.key == null;
 
     if (!newSsoUser) {
       await this.cryptoService.setPrivateKey(
-        tokenResponse.privateKey ?? (await this.createKeyPairForOldAccount()),
+        tokenResponse.privateKey ?? (await this.createKeyPairForOldAccount(userId)),
+        userId,
       );
     }
   }

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
@@ -159,7 +159,7 @@ describe("UserApiLoginStrategy", () => {
     await apiLogInStrategy.logIn(credentials);
 
     expect(cryptoService.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(tokenResponse.key);
-    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey);
+    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(tokenResponse.privateKey, userId);
   });
 
   it("gets and sets the master key if Key Connector is enabled", async () => {

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
@@ -117,9 +117,13 @@ export class UserApiLoginStrategy extends LoginStrategy {
     }
   }
 
-  protected override async setPrivateKey(response: IdentityTokenResponse): Promise<void> {
+  protected override async setPrivateKey(
+    response: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     await this.cryptoService.setPrivateKey(
-      response.privateKey ?? (await this.createKeyPairForOldAccount()),
+      response.privateKey ?? (await this.createKeyPairForOldAccount(userId)),
+      userId,
     );
   }
 

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
@@ -221,7 +221,7 @@ describe("WebAuthnLoginStrategy", () => {
       mockPrfPrivateKey,
     );
     expect(cryptoService.setUserKey).toHaveBeenCalledWith(mockUserKey);
-    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(idTokenResponse.privateKey);
+    expect(cryptoService.setPrivateKey).toHaveBeenCalledWith(idTokenResponse.privateKey, userId);
 
     // Master key and private key should not be set
     expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
@@ -139,9 +139,13 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
     }
   }
 
-  protected override async setPrivateKey(response: IdentityTokenResponse): Promise<void> {
+  protected override async setPrivateKey(
+    response: IdentityTokenResponse,
+    userId: UserId,
+  ): Promise<void> {
     await this.cryptoService.setPrivateKey(
-      response.privateKey ?? (await this.createKeyPairForOldAccount()),
+      response.privateKey ?? (await this.createKeyPairForOldAccount(userId)),
+      userId,
     );
   }
 

--- a/libs/common/src/auth/services/key-connector.service.ts
+++ b/libs/common/src/auth/services/key-connector.service.ts
@@ -152,7 +152,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     await this.cryptoService.setUserKey(userKey[0]);
     await this.cryptoService.setMasterKeyEncryptedUserKey(userKey[1].encryptedString);
 
-    const [pubKey, privKey] = await this.cryptoService.makeKeyPair();
+    const [pubKey, privKey] = await this.cryptoService.makeKeyPair(userKey[0]);
 
     try {
       const keyConnectorUrl =

--- a/libs/common/src/models/response/profile.response.ts
+++ b/libs/common/src/models/response/profile.response.ts
@@ -1,11 +1,12 @@
 import { ProfileOrganizationResponse } from "../../admin-console/models/response/profile-organization.response";
 import { ProfileProviderOrganizationResponse } from "../../admin-console/models/response/profile-provider-organization.response";
 import { ProfileProviderResponse } from "../../admin-console/models/response/profile-provider.response";
+import { UserId } from "../../types/guid";
 
 import { BaseResponse } from "./base.response";
 
 export class ProfileResponse extends BaseResponse {
-  id: string;
+  id: UserId;
   name: string;
   email: string;
   emailVerified: boolean;

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -35,7 +35,6 @@ import { SendData } from "../../../tools/send/models/data/send.data";
 import { SendResponse } from "../../../tools/send/models/response/send.response";
 import { SendApiService } from "../../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../../tools/send/services/send.service.abstraction";
-import { UserId } from "../../../types/guid";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "../../../vault/abstractions/folder/folder-api.service.abstraction";
 import { InternalFolderService } from "../../../vault/abstractions/folder/folder.service.abstraction";
@@ -311,7 +310,7 @@ export class SyncService implements SyncServiceAbstraction {
   }
 
   private async syncProfile(response: ProfileResponse) {
-    const stamp = await this.tokenService.getSecurityStamp(response.id as UserId);
+    const stamp = await this.tokenService.getSecurityStamp(response.id);
     if (stamp != null && stamp !== response.securityStamp) {
       if (this.logoutCallback != null) {
         await this.logoutCallback(true);
@@ -321,15 +320,16 @@ export class SyncService implements SyncServiceAbstraction {
     }
 
     await this.cryptoService.setMasterKeyEncryptedUserKey(response.key);
-    await this.cryptoService.setPrivateKey(response.privateKey);
-    await this.cryptoService.setProviderKeys(response.providers);
-    await this.cryptoService.setOrgKeys(response.organizations, response.providerOrganizations);
-    await this.avatarService.setSyncAvatarColor(response.id as UserId, response.avatarColor);
-    await this.tokenService.setSecurityStamp(response.securityStamp, response.id as UserId);
-    await this.accountService.setAccountEmailVerified(
-      response.id as UserId,
-      response.emailVerified,
+    await this.cryptoService.setPrivateKey(response.privateKey, response.id);
+    await this.cryptoService.setProviderKeys(response.providers, response.id);
+    await this.cryptoService.setOrgKeys(
+      response.organizations,
+      response.providerOrganizations,
+      response.id,
     );
+    await this.avatarService.setSyncAvatarColor(response.id, response.avatarColor);
+    await this.tokenService.setSecurityStamp(response.securityStamp, response.id);
+    await this.accountService.setAccountEmailVerified(response.id, response.emailVerified);
 
     await this.billingAccountProfileStateService.setHasPremium(
       response.premiumPersonally,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Various tech debt things where `CryptoService` should highly encourage the use of `UserId`, especially for mutations. Many of these uses are in either `SyncService` where the user id is easily available and during the login process where it can be made available with minor changes. 

This also makes the `SymmetricCryptoKey` parameter required in `makeKeyPair`, it updates the two call sites that weren't passing it in with either a `UserKey` that was already in context, and was very recently set or I called the method that `makeKeyPair` used to call for them.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
