### PR TITLE
[AC-2558] Provider Admin still sees manage billing options - not the provided image

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -256,7 +256,7 @@
     </ng-container>
   </ng-container>
 </bit-container>
-<bit-container *ngIf="IsProviderManaged">
+<bit-container *ngIf="isProviderManaged">
   <div
     class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-pt-24 tw-text-center tw-font-bold"
   >

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -5,6 +5,7 @@ import { concatMap, firstValueFrom, lastValueFrom, Observable, Subject, takeUnti
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
 import { OrganizationApiKeyType, ProviderType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { PlanType } from "@bitwarden/common/billing/enums";
@@ -69,6 +70,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     private route: ActivatedRoute,
     private dialogService: DialogService,
     private configService: ConfigService,
+    private providerService: ProviderApiServiceAbstraction,
   ) {}
 
   async ngOnInit() {
@@ -106,13 +108,13 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     this.loading = true;
     this.locale = await firstValueFrom(this.i18nService.locale$);
     this.userOrg = await this.organizationService.get(this.organizationId);
-    const enableConsolidatedBilling = await firstValueFrom(this.enableConsolidatedBilling$);
-    this.IsProviderManaged =
-      this.userOrg.hasProvider &&
-      this.userOrg.providerType == ProviderType.Msp &&
-      enableConsolidatedBilling
-        ? true
-        : false;
+    if (this.userOrg.hasProvider) {
+      const provider = await this.providerService.getProvider(this.userOrg.providerId);
+      const enableConsolidatedBilling = await firstValueFrom(this.enableConsolidatedBilling$);
+      this.IsProviderManaged =
+        provider.type == ProviderType.Msp && enableConsolidatedBilling ? true : false;
+    }
+
     if (this.userOrg.canViewSubscription) {
       this.sub = await this.organizationApiService.getSubscription(this.organizationId);
       this.lineItems = this.sub?.subscription?.items;

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -50,7 +50,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   locale: string;
   showUpdatedSubscriptionStatusSection$: Observable<boolean>;
   manageBillingFromProviderPortal = ManageBilling;
-  IsProviderManaged = false;
+  isProviderManaged = false;
 
   protected readonly teamsStarter = ProductType.TeamsStarter;
 
@@ -111,8 +111,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     if (this.userOrg.hasProvider) {
       const provider = await this.providerService.getProvider(this.userOrg.providerId);
       const enableConsolidatedBilling = await firstValueFrom(this.enableConsolidatedBilling$);
-      this.IsProviderManaged =
-        provider.type == ProviderType.Msp && enableConsolidatedBilling ? true : false;
+      this.isProviderManaged = provider.type == ProviderType.Msp && enableConsolidatedBilling;
     }
 
     if (this.userOrg.canViewSubscription) {

--- a/libs/common/src/admin-console/models/response/provider/provider.response.ts
+++ b/libs/common/src/admin-console/models/response/provider/provider.response.ts
@@ -1,4 +1,5 @@
 import { BaseResponse } from "../../../../models/response/base.response";
+import { ProviderType } from "../../../enums";
 
 export class ProviderResponse extends BaseResponse {
   id: string;
@@ -6,6 +7,7 @@ export class ProviderResponse extends BaseResponse {
   businessName: string;
   billingEmail: string;
   creationDate: Date;
+  type: ProviderType;
 
   constructor(response: any) {
     super(response);
@@ -14,5 +16,6 @@ export class ProviderResponse extends BaseResponse {
     this.businessName = this.getResponseProperty("BusinessName");
     this.billingEmail = this.getResponseProperty("BillingEmail");
     this.creationDate = this.getResponseProperty("CreationDate");
+    this.type = this.getResponseProperty("Type");
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a provider admin accesses the Org Billing Subscription page through the Admin Console, rather than the Provider Portal, the user is still able to see Manage Billing Subscription 

They should instead see the [design outlined here](https://www.figma.com/proto/m8eMk6yeKfOq4AUuyp70ih/Consolidated-Billing?page-id=698%3A10060&type=design&node-id=873-6419&viewport=-339%2C-3810%2C0.71&t=yF61N9Za3qW0lHMW-1&scaling=min-zoom&starting-point-node-id=913%3A20780)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
