### PR TITLE
Revert "[PM-7349] Update snap description with new URL to help docs (#8703)"

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -228,8 +228,7 @@
     "artifactName": "${productName}-${version}-${arch}.${ext}"
   },
   "snap": {
-    "summary": "Bitwarden is a secure and free password manager for all of your devices.",
-    "description": "**Installation**\nBitwarden requires access to the `password-manager-service`. Please enable it through permissions or by running `sudo snap connect bitwarden:password-manager-service` after installation. See https://btwrdn.com/install-snap for details.",
+    "summary": "After installation enable required `password-manager-service` by running `sudo snap connect bitwarden:password-manager-service`.",
     "autoStart": true,
     "base": "core22",
     "confinement": "strict",


### PR DESCRIPTION
This reverts commit e4ebf4aeccb4c214e0b483113d9b9b53cc6f7438.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Reverting the change from #8703 that added a `description` to the snap release.  We received [errors](https://github.com/bitwarden/clients/actions/runs/8971600451/job/24639158142) on the release that indicate issues with the `description` length, despite documentation indicating that there is no limit.

In order to avoid continuing to block the release, this will roll back the change.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
