### PR TITLE
[PM-7977] Remove unused properties in manifest.v3.json

### DIFF
--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -118,17 +118,6 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "applications": {
-    "gecko": {
-      "id": "{446900e4-71c2-419f-a6a7-df9c091e268b}",
-      "strict_min_version": "91.0"
-    }
-  },
-  "sidebar_action": {
-    "default_title": "Bitwarden",
-    "default_panel": "popup/index.html?uilocation=sidebar",
-    "default_icon": "images/icon19.png"
-  },
   "storage": {
     "managed_schema": "managed_schema.json"
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- Tech debt (refactoring, code cleanup, dependency upgrades, etc)
```

## Objective

These properties in `manifest.v3.json` aren't included in prod builds and Firefox isn't using our manifest.v3.json file either. Removing them should have no impact except to tidy up the extension errors section in Chrome.

![Screenshot 2024-04-30 at 10 36 41 AM](https://github.com/bitwarden/clients/assets/1556494/7a626ccc-9bf0-4727-b148-8e41bd05839b)
![Screenshot 2024-04-30 at 10 36 17 AM](https://github.com/bitwarden/clients/assets/1556494/c9413657-d252-4049-8502-c098b24abb58)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
