### PR TITLE
[PM-7906] Authenticator aborts passkey creation sometimes

### DIFF
--- a/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/vault/services/fido2/fido2-authenticator.service.ts
@@ -118,7 +118,7 @@ export class Fido2AuthenticatorService implements Fido2AuthenticatorServiceAbstr
       const cipherId = response.cipherId;
       userVerified = response.userVerified;
 
-      if (cipherId === undefined) {
+      if (!cipherId) {
         this.logService?.warning(
           `[Fido2Authenticator] Aborting because user confirmation was not recieved.`,
         );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Address a race condition issue that occurs when the cipher is retrieved before it has fully completed its creation process, leading to errors when adding a passkey item.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
