### PR TITLE
[PS] fix broken local Storybook

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -142,7 +142,15 @@
             "configDir": ".storybook",
             "browserTarget": "components:build",
             "compodoc": true,
-            "compodocArgs": ["-p", "./tsconfig.json", "-e", "json", "-d", "."],
+            "compodocArgs": [
+              "-p",
+              "./tsconfig.json",
+              "-e",
+              "json",
+              "-d",
+              ".",
+              "--disableRoutesGraph"
+            ],
             "port": 6006
           }
         },

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -315,13 +315,13 @@ export default {
         importProvidersFrom(
           RouterModule.forRoot(
             [
-              { path: "", redirectTo: "vault", pathMatch: "full" },
-              { path: "vault", component: MockVaultPageComponent },
-              { path: "generator", component: MockGeneratorPageComponent },
-              { path: "send", component: MockSendPageComponent },
-              { path: "settings", component: MockSettingsPageComponent },
+              { path: "", redirectTo: "tabs/vault", pathMatch: "full" },
+              { path: "tabs/vault", component: MockVaultPageComponent },
+              { path: "tabs/generator", component: MockGeneratorPageComponent },
+              { path: "tabs/send", component: MockSendPageComponent },
+              { path: "tabs/settings", component: MockSettingsPageComponent },
               // in case you are coming from a story that also uses the router
-              { path: "**", redirectTo: "vault" },
+              { path: "**", redirectTo: "tabs/vault" },
             ],
             { useHash: true },
           ),


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

`npm run storybook` is broken after the changes made in https://github.com/bitwarden/clients/pull/9004

Compodoc (a dependency of Storybook) performs static analysis on the Angular code. It fails when parsing [this line](https://github.com/bitwarden/clients/pull/9004/files#diff-2502db9ec554bdfd084c897239c7344e2f693755acd16f1e5986a9141cec2278R327), yielding this error:

```
[10:42:47] Analysing routes definitions and clean them if necessary
Unhandled Rejection at: Promise {
  <rejected> InvalidOperationError: Could not find the node's symbol.

  /Users/shane/Repos/clients/apps/browser/src/popup/app-routing.module.ts:327:6
  > 327 |   ...extensionRefreshSwap(TabsComponent, TabsV2Component, {
      at Object.throwIfNullOrUndefined (/Users/shane/Repos/clients/node_modules/@ts-morph/common/dist/ts-morph-common.js:438:19)
      at CallExpression.getSymbolOrThrow (/Users/shane/Repos/clients/node_modules/ts-morph/dist/ts-morph.js:3079:30)
      at _loop_3 (/Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:6899:22)
      at RouterParserUtil.cleanFileSpreads (/Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:6915:17)
      at AngularDependencies.getSourceFileDecorators (/Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:10088:32)
      at /Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:9880:31
      at Array.map (<anonymous>)
      at AngularDependencies.getDependencies (/Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:9869:21)
      at Application.getDependenciesData (/Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:11669:40)
      at /Users/shane/Repos/clients/node_modules/@compodoc/compodoc/dist/index.js:11475:23
} reason: InvalidOperationError: Could not find the node's symbol.
```

Since we are not using Compodoc directly and are only using it through Storybook, we can disable router graph analysis entirely by passing `--disableRoutesGraph` in the Storybook/Compodoc config. This prevents the bug from occurring and fixes `npm run storybook`.

This does not fix the core issue, which is a bug within Compodoc, possibly this: https://github.com/compodoc/compodoc/issues/525

---

The above PR also introduces diffs to the popup-layout component story. Fixing that is technically unrelated to the above, but is included here anyways. [c697172](https://github.com/bitwarden/clients/pull/9075/commits/c6971725c3d4f99da8829271daecf12b3b84968f)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
