### PR TITLE
[Bug Fix] Center secondary content in AnonLayout

### DIFF
--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -13,7 +13,7 @@
     </h1>
     <p *ngIf="subtitle" bitTypography="body1">{{ subtitle }}</p>
   </div>
-  <div class="tw-mb-auto tw-mx-auto tw-grid">
+  <div class="tw-mb-auto tw-mx-auto tw-flex tw-flex-col tw-items-center">
     <div
       class="tw-rounded-xl tw-mb-9 tw-mx-auto sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
     >


### PR DESCRIPTION
# Overview

The secondary content in AnonLayout was slightly off center. This PR centers it.

| [Previous](https://components.bitwarden.com/?path=/story/auth-anon-layout--with-long-content)  | [New](https://62a88a6de5b807fa98886113-mnnctvowfr.chromatic.com/?path=/story/auth-anon-layout--with-long-content) |
| ------------- | ------------- |
| ![Screenshot 2024-05-07 at 4 57 03 PM](https://github.com/bitwarden/clients/assets/102181210/07c364d7-f07d-471e-b864-e0b964185aff) | ![Screenshot 2024-05-07 at 4 59 21 PM](https://github.com/bitwarden/clients/assets/102181210/bf68649f-3764-4923-971a-957b16957df1)  |

# Chromatic Changeset for Review

https://www.chromatic.com/review?appId=62a88a6de5b807fa98886113&number=9079&type=linked&view=activity
