### PR TITLE
[PM-7747] add timeout to safari sendMessageWithResponse

### DIFF
--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -163,20 +163,9 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
    * the view is open.
    */
   async isViewOpen(): Promise<boolean> {
-    // chrome.runtime.sendMessage does not timeout on safari and will hang, so we
-    // need to add our own timeout of 1 second
     if (this.isSafari()) {
-      // timeout that returns false if the popup does not respond
-      const timeout = new Promise((resolve) => setTimeout(() => resolve(false), 1000));
-      try {
-        const result = await Promise.race([
-          BrowserApi.sendMessageWithResponse("checkVaultPopupHeartbeat"),
-          timeout,
-        ]);
-        return Boolean(result);
-      } catch (e) {
-        return false;
-      }
+      // Query views on safari since chrome.runtime.sendMessage does not timeout and will hang.
+      return BrowserApi.isPopupOpen();
     }
     return Boolean(await BrowserApi.sendMessageWithResponse("checkVaultPopupHeartbeat"));
   }

--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -163,6 +163,21 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
    * the view is open.
    */
   async isViewOpen(): Promise<boolean> {
+    // chrome.runtime.sendMessage does not timeout on safari and will hang, so we
+    // need to add our own timeout of 1 second
+    if (this.isSafari()) {
+      // timeout that returns false if the popup does not respond
+      const timeout = new Promise((resolve) => setTimeout(() => resolve(false), 1000));
+      try {
+        const result = await Promise.race([
+          BrowserApi.sendMessageWithResponse("checkVaultPopupHeartbeat"),
+          timeout,
+        ]);
+        return Boolean(result);
+      } catch (e) {
+        return false;
+      }
+    }
     return Boolean(await BrowserApi.sendMessageWithResponse("checkVaultPopupHeartbeat"));
   }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`chrome.runtime.sendMessage` on safari doesn't have a timeout for a response. We are using the lack of a response to determine whether the popup is open or not.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
