### PR TITLE
[PM-7986] set user key once we detect session key in CLI

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -686,6 +686,8 @@ export class Main {
       this.organizationExportService,
     );
 
+    this.userAutoUnlockKeyService = new UserAutoUnlockKeyService(this.cryptoService);
+
     this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
     this.program = new Program(this);
     this.vaultProgram = new VaultProgram(this);
@@ -709,8 +711,6 @@ export class Main {
     );
 
     this.providerApiService = new ProviderApiService(this.apiService);
-
-    this.userAutoUnlockKeyService = new UserAutoUnlockKeyService(this.cryptoService);
   }
 
   async run() {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In CLI, we started setting the user key in memory on application init procedurally. This works well when we already have the session key stored as an environment variable, but we forgot about the case when the session key is passed in as a option.

When the program detects the session key, this will immediately attempt to set the user key in memory.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
