### PR TITLE
Use encrypt service in node env secure storage

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -272,7 +272,7 @@ export class Main {
     this.secureStorageService = new NodeEnvSecureStorageService(
       this.storageService,
       this.logService,
-      () => this.cryptoService,
+      this.encryptService,
     );
 
     this.memoryStorageService = new MemoryStorageService();

--- a/apps/cli/src/platform/services/node-env-secure-storage.service.ts
+++ b/apps/cli/src/platform/services/node-env-secure-storage.service.ts
@@ -1,6 +1,6 @@
 import { throwError } from "rxjs";
 
-import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
+import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -11,7 +11,7 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
   constructor(
     private storageService: AbstractStorageService,
     private logService: LogService,
-    private cryptoService: () => CryptoService,
+    private encryptService: EncryptService,
   ) {}
 
   get valuesRequireDeserialization(): boolean {
@@ -59,7 +59,7 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
     if (sessionKey == null) {
       throw new Error("No session key available.");
     }
-    const encValue = await this.cryptoService().encryptToBytes(
+    const encValue = await this.encryptService.encryptToBytes(
       Utils.fromB64ToArray(plainValue),
       sessionKey,
     );
@@ -78,7 +78,7 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
       }
 
       const encBuf = EncArrayBuffer.fromB64(encValue);
-      const decValue = await this.cryptoService().decryptFromBytes(encBuf, sessionKey);
+      const decValue = await this.encryptService.decryptToBytes(encBuf, sessionKey);
       if (decValue == null) {
         this.logService.info("Failed to decrypt.");
         return null;

--- a/libs/common/src/platform/abstractions/encrypt.service.ts
+++ b/libs/common/src/platform/abstractions/encrypt.service.ts
@@ -7,10 +7,7 @@ import { SymmetricCryptoKey } from "../models/domain/symmetric-crypto-key";
 
 export abstract class EncryptService {
   abstract encrypt(plainValue: string | Uint8Array, key: SymmetricCryptoKey): Promise<EncString>;
-  abstract encryptToBytes(
-    plainValue: Uint8Array,
-    key?: SymmetricCryptoKey,
-  ): Promise<EncArrayBuffer>;
+  abstract encryptToBytes(plainValue: Uint8Array, key: SymmetricCryptoKey): Promise<EncArrayBuffer>;
   abstract decryptToUtf8(encString: EncString, key: SymmetricCryptoKey): Promise<string>;
   abstract decryptToBytes(encThing: Encrypted, key: SymmetricCryptoKey): Promise<Uint8Array>;
   abstract rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString>;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Was looking through some code and noticed the `() => CryptoService` smell of avoiding circular dependencies. The methods it was using on `CryptoService` were deprecated anyways in favor of using your own key and calling `EncryptService`. Since this uses a special key and not the user key this will work just fine for us. 

I also noticed that the abstract class of `EncryptService` technically allowed an optional key but it shouldn't. The implementation doesn't expect it to be optional and will throw if a null-ish value is passed in. No one appeared to be using the optional version of it anyways. 

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
