### PR TITLE
[PM-7878] PopupSectionHeader component

### DIFF
--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
@@ -1,0 +1,8 @@
+<div class="tw-flex tw-justify-between tw-items-end tw-gap-1 tw-px-1 tw-pb-1">
+  <div class="tw-text-headers">
+    <ng-content select="[slot=title]"></ng-content>
+  </div>
+  <div class="tw-text-muted has-[button]:-tw-mb-1.5">
+    <ng-content select="[slot=end]"></ng-content>
+  </div>
+</div>

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
@@ -5,7 +5,7 @@
     </h2>
     <ng-content select="[slot=title-suffix]"></ng-content>
   </div>
-  <div class="tw-text-muted has-[button]:-tw-mb-1.5">
+  <div class="tw-text-muted has-[button]:-tw-mb-1">
     <ng-content select="[slot=end]"></ng-content>
   </div>
 </div>

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
@@ -1,6 +1,9 @@
 <div class="tw-flex tw-justify-between tw-items-end tw-gap-1 tw-px-1 tw-pb-1">
-  <div class="tw-text-headers">
-    <ng-content select="[slot=title]"></ng-content>
+  <div>
+    <h2 bitTypography="h6" noMargin class="tw-mb-0 tw-text-headers">
+      {{ title }}
+    </h2>
+    <ng-content select="[slot=title-suffix]"></ng-content>
   </div>
   <div class="tw-text-muted has-[button]:-tw-mb-1.5">
     <ng-content select="[slot=end]"></ng-content>

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.ts
@@ -1,8 +1,13 @@
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
+
+import { TypographyModule } from "@bitwarden/components";
 
 @Component({
   standalone: true,
   selector: "popup-section-header",
   templateUrl: "./popup-section-header.component.html",
+  imports: [TypographyModule],
 })
-export class PopupSectionHeaderComponent {}
+export class PopupSectionHeaderComponent {
+  @Input() title: string;
+}

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.ts
@@ -1,0 +1,8 @@
+import { Component } from "@angular/core";
+
+@Component({
+  standalone: true,
+  selector: "popup-section-header",
+  templateUrl: "./popup-section-header.component.html",
+})
+export class PopupSectionHeaderComponent {}

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
@@ -55,7 +55,7 @@ export const TailingIcon: Story = {
     props: args,
     template: `
       <popup-section-header [title]="title">
-        <button bitIconButton="bwi-star" slot="end"></button>
+        <button bitIconButton="bwi-star" size="small" slot="end"></button>
       </popup-section-header>
     `,
   }),
@@ -70,7 +70,7 @@ export const WithSections: Story = {
       <div class="tw-bg-background-alt tw-p-2">
         <bit-section>
           <popup-section-header title="Section 1">
-            <button bitIconButton="bwi-star" slot="end">1</button>
+            <button bitIconButton="bwi-star" size="small" slot="end"></button>
           </popup-section-header>
           <bit-card>
             <h3 bitTypography="h3">Card 1 Content</h3>
@@ -78,7 +78,7 @@ export const WithSections: Story = {
         </bit-section>
         <bit-section>
           <popup-section-header title="Section 2">
-            <button bitIconButton="bwi-star" slot="end">2</button>
+            <button bitIconButton="bwi-star" size="small" slot="end"></button>
           </popup-section-header>
           <bit-card>
             <h3 bitTypography="h3">Card 2 Content</h3>

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
@@ -1,9 +1,11 @@
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
-import { CardComponent } from "../../../../../../libs/components/src/card";
-import { IconButtonModule } from "../../../../../../libs/components/src/icon-button";
-import { SectionComponent } from "../../../../../../libs/components/src/section";
-import { TypographyModule } from "../../../../../../libs/components/src/typography";
+import {
+  CardComponent,
+  IconButtonModule,
+  SectionComponent,
+  TypographyModule,
+} from "@bitwarden/components";
 
 import { PopupSectionHeaderComponent } from "./popup-section-header.component";
 

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
@@ -1,0 +1,90 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+
+import { CardComponent } from "../../../../../../libs/components/src/card";
+import { IconButtonModule } from "../../../../../../libs/components/src/icon-button";
+import { SectionComponent } from "../../../../../../libs/components/src/section";
+import { TypographyModule } from "../../../../../../libs/components/src/typography";
+
+import { PopupSectionHeaderComponent } from "./popup-section-header.component";
+
+export default {
+  title: "Browser/Popup Section Header",
+  component: PopupSectionHeaderComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [TypographyModule, IconButtonModule, SectionComponent, CardComponent],
+    }),
+  ],
+} as Meta<PopupSectionHeaderComponent>;
+
+type Story = StoryObj<PopupSectionHeaderComponent>;
+
+export const OnlyTitle: Story = {
+  render: () => ({
+    template: `
+      <popup-section-header>
+        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
+          Only Title
+        </h2>
+      </popup-section-header>
+    `,
+  }),
+};
+
+export const TrailingText: Story = {
+  render: () => ({
+    template: `
+      <popup-section-header>
+        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
+          Trailing Text
+        </h2>
+        <span bitTypography="body2" slot="end">13</span>
+      </popup-section-header>
+    `,
+  }),
+};
+
+export const TailingIcon: Story = {
+  render: () => ({
+    template: `
+      <popup-section-header>
+        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
+          Trailing Icon
+        </h2>
+        <button bitIconButton="bwi-star" slot="end"></button>
+      </popup-section-header>
+    `,
+  }),
+};
+
+export const WithSections: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <div class="tw-bg-background-alt tw-p-2">
+        <bit-section>
+          <popup-section-header>
+            <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
+              Section 1
+            </h2>
+            <button bitIconButton="bwi-star" slot="end">1</button>
+          </popup-section-header>
+          <bit-card>
+            <h3 bitTypography="h3">Card 1 Content</h3>
+          </bit-card>
+        </bit-section>
+        <bit-section>
+          <popup-section-header>
+            <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
+              Section 2
+            </h2>
+            <button bitIconButton="bwi-star" slot="end">2</button>
+          </popup-section-header>
+          <bit-card>
+            <h3 bitTypography="h3">Card 2 Content</h3>
+          </bit-card>
+        </bit-section>
+      </div>
+    `,
+  }),
+};

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
@@ -12,9 +12,12 @@ import { PopupSectionHeaderComponent } from "./popup-section-header.component";
 export default {
   title: "Browser/Popup Section Header",
   component: PopupSectionHeaderComponent,
+  args: {
+    title: "Title",
+  },
   decorators: [
     moduleMetadata({
-      imports: [TypographyModule, IconButtonModule, SectionComponent, CardComponent],
+      imports: [SectionComponent, CardComponent, TypographyModule, IconButtonModule],
     }),
   ],
 } as Meta<PopupSectionHeaderComponent>;
@@ -22,53 +25,51 @@ export default {
 type Story = StoryObj<PopupSectionHeaderComponent>;
 
 export const OnlyTitle: Story = {
-  render: () => ({
+  render: (args) => ({
+    props: args,
     template: `
-      <popup-section-header>
-        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
-          Only Title
-        </h2>
-      </popup-section-header>
+      <popup-section-header [title]="title"></popup-section-header>
     `,
   }),
+  args: {
+    title: "Only Title",
+  },
 };
 
 export const TrailingText: Story = {
-  render: () => ({
+  render: (args) => ({
+    props: args,
     template: `
-      <popup-section-header>
-        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
-          Trailing Text
-        </h2>
+      <popup-section-header [title]="title">
         <span bitTypography="body2" slot="end">13</span>
       </popup-section-header>
     `,
   }),
+  args: {
+    title: "Trailing Text",
+  },
 };
 
 export const TailingIcon: Story = {
-  render: () => ({
+  render: (args) => ({
+    props: args,
     template: `
-      <popup-section-header>
-        <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
-          Trailing Icon
-        </h2>
+      <popup-section-header [title]="title">
         <button bitIconButton="bwi-star" slot="end"></button>
       </popup-section-header>
     `,
   }),
+  args: {
+    title: "Trailing Icon",
+  },
 };
 
 export const WithSections: Story = {
-  render: (args) => ({
-    props: args,
+  render: () => ({
     template: `
       <div class="tw-bg-background-alt tw-p-2">
         <bit-section>
-          <popup-section-header>
-            <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
-              Section 1
-            </h2>
+          <popup-section-header title="Section 1">
             <button bitIconButton="bwi-star" slot="end">1</button>
           </popup-section-header>
           <bit-card>
@@ -76,10 +77,7 @@ export const WithSections: Story = {
           </bit-card>
         </bit-section>
         <bit-section>
-          <popup-section-header>
-            <h2 bitTypography="h6" noMargin class="tw-mb-0" slot="title">
-              Section 2
-            </h2>
+          <popup-section-header title="Section 2">
             <button bitIconButton="bwi-star" slot="end">2</button>
           </popup-section-header>
           <bit-card>

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -195,4 +195,4 @@ import "../platform/popup/locales";
   providers: [CurrencyPipe, DatePipe],
   bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -46,6 +46,7 @@ import { PopupFooterComponent } from "../platform/popup/layout/popup-footer.comp
 import { PopupHeaderComponent } from "../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../platform/popup/layout/popup-page.component";
 import { PopupTabNavigationComponent } from "../platform/popup/layout/popup-tab-navigation.component";
+import { PopupSectionHeaderComponent } from "../platform/popup/popup-section-header/popup-section-header.component";
 import { FilePopoutCalloutComponent } from "../tools/popup/components/file-popout-callout.component";
 import { GeneratorComponent } from "../tools/popup/generator/generator.component";
 import { PasswordGeneratorHistoryComponent } from "../tools/popup/generator/password-generator-history.component";
@@ -123,6 +124,7 @@ import "../platform/popup/locales";
     PopupFooterComponent,
     PopupHeaderComponent,
     UserVerificationDialogComponent,
+    PopupSectionHeaderComponent,
   ],
   declarations: [
     ActionButtonsComponent,
@@ -193,4 +195,4 @@ import "../platform/popup/locales";
   providers: [CurrencyPipe, DatePipe],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule { }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds a new PopupSectionHeader component to be used within the browser extension refresh 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **popup-section-header.*** 
  - Implementation of heading component & associated stories
  - I followed the implementation pretty closely that is in [PM-7878](https://bitwarden.atlassian.net/browse/PM-7878).
    - With the each title slot having to implement `noMargin class="tw-mb-0"` would this be better off as an input rather than a slot?

## Screenshots

![Screen Shot 2024-05-09 at 15 16 46 PM](https://github.com/bitwarden/clients/assets/125900171/5620babe-dac3-4711-bcfb-400351d1c66a)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-7878]: https://bitwarden.atlassian.net/browse/PM-7878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ