### PR TITLE
[AC-2487] [AC-2486] Changes to restricted access view

### DIFF
--- a/apps/web/src/app/vault/org-vault/collection-access-restricted.component.ts
+++ b/apps/web/src/app/vault/org-vault/collection-access-restricted.component.ts
@@ -16,13 +16,24 @@ const icon = svgIcon`<svg xmlns="http://www.w3.org/2000/svg" width="120" height=
   template: `<bit-no-items [icon]="icon" class="tw-mt-2 tw-block">
     <span slot="title" class="tw-mt-4 tw-block">{{ "collectionAccessRestricted" | i18n }}</span>
     <button
+      *ngIf="canEditCollection"
       slot="button"
       bitButton
-      (click)="viewCollectionClicked.emit()"
+      (click)="viewCollectionClicked.emit({ readonly: false })"
       buttonType="secondary"
       type="button"
     >
-      <i aria-hidden="true" class="bwi bwi-pencil-square"></i> {{ buttonText | i18n }}
+      <i aria-hidden="true" class="bwi bwi-pencil-square"></i> {{ "editCollection" | i18n }}
+    </button>
+    <button
+      *ngIf="!canEditCollection && canViewCollectionInfo"
+      slot="button"
+      bitButton
+      (click)="viewCollectionClicked.emit({ readonly: true })"
+      buttonType="secondary"
+      type="button"
+    >
+      <i aria-hidden="true" class="bwi bwi-pencil-square"></i> {{ "viewCollection" | i18n }}
     </button>
   </bit-no-items>`,
 })
@@ -30,10 +41,7 @@ export class CollectionAccessRestrictedComponent {
   protected icon = icon;
 
   @Input() canEditCollection = false;
+  @Input() canViewCollectionInfo = false;
 
-  @Output() viewCollectionClicked = new EventEmitter<void>();
-
-  get buttonText() {
-    return this.canEditCollection ? "editCollection" : "viewCollection";
-  }
+  @Output() viewCollectionClicked = new EventEmitter<{ readonly: boolean }>();
 }

--- a/apps/web/src/app/vault/org-vault/collection-access-restricted.component.ts
+++ b/apps/web/src/app/vault/org-vault/collection-access-restricted.component.ts
@@ -3,6 +3,7 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { ButtonModule, NoItemsModule, svgIcon } from "@bitwarden/components";
 
 import { SharedModule } from "../../shared";
+import { CollectionDialogTabType } from "../components/collection-dialog";
 
 const icon = svgIcon`<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="10 -10 120 140" fill="none">
   <rect class="tw-stroke-secondary-600" width="134" height="86" x="3" y="31.485" stroke-width="6" rx="11"/>
@@ -19,7 +20,7 @@ const icon = svgIcon`<svg xmlns="http://www.w3.org/2000/svg" width="120" height=
       *ngIf="canEditCollection"
       slot="button"
       bitButton
-      (click)="viewCollectionClicked.emit({ readonly: false })"
+      (click)="viewCollectionClicked.emit({ readonly: false, tab: collectionDialogTabType.Info })"
       buttonType="secondary"
       type="button"
     >
@@ -29,19 +30,23 @@ const icon = svgIcon`<svg xmlns="http://www.w3.org/2000/svg" width="120" height=
       *ngIf="!canEditCollection && canViewCollectionInfo"
       slot="button"
       bitButton
-      (click)="viewCollectionClicked.emit({ readonly: true })"
+      (click)="viewCollectionClicked.emit({ readonly: true, tab: collectionDialogTabType.Access })"
       buttonType="secondary"
       type="button"
     >
-      <i aria-hidden="true" class="bwi bwi-pencil-square"></i> {{ "viewCollection" | i18n }}
+      <i aria-hidden="true" class="bwi bwi-users"></i> {{ "viewAccess" | i18n }}
     </button>
   </bit-no-items>`,
 })
 export class CollectionAccessRestrictedComponent {
   protected icon = icon;
+  protected collectionDialogTabType = CollectionDialogTabType;
 
   @Input() canEditCollection = false;
   @Input() canViewCollectionInfo = false;
 
-  @Output() viewCollectionClicked = new EventEmitter<{ readonly: boolean }>();
+  @Output() viewCollectionClicked = new EventEmitter<{
+    readonly: boolean;
+    tab: CollectionDialogTabType;
+  }>();
 }

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -120,7 +120,7 @@
         "
         [canViewCollectionInfo]="selectedCollection.node?.canViewCollectionInfo(organization)"
         (viewCollectionClicked)="
-          editCollection(selectedCollection.node, CollectionDialogTabType.Info, $event.readonly)
+          editCollection(selectedCollection.node, $event.tab, $event.readonly)
         "
       >
       </collection-access-restricted>

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -115,13 +115,12 @@
       </bit-no-items>
       <collection-access-restricted
         *ngIf="showCollectionAccessRestricted"
-        [canEditCollection]="organization.isProviderUser"
+        [canEditCollection]="
+          selectedCollection.node?.canEdit(organization, flexibleCollectionsV1Enabled)
+        "
+        [canViewCollectionInfo]="selectedCollection.node?.canViewCollectionInfo(organization)"
         (viewCollectionClicked)="
-          editCollection(
-            selectedCollection.node,
-            CollectionDialogTabType.Info,
-            !organization.isProviderUser
-          )
+          editCollection(selectedCollection.node, CollectionDialogTabType.Info, $event.readonly)
         "
       >
       </collection-access-restricted>

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -118,7 +118,9 @@
         [canEditCollection]="
           selectedCollection.node?.canEdit(organization, flexibleCollectionsV1Enabled)
         "
-        [canViewCollectionInfo]="selectedCollection.node?.canViewCollectionInfo(organization)"
+        [canViewCollectionInfo]="
+          selectedCollection.node?.canViewCollectionInfo(organization, flexibleCollectionsV1Enabled)
+        "
         (viewCollectionClicked)="
           editCollection(selectedCollection.node, $event.tab, $event.readonly)
         "

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7638,9 +7638,6 @@
   "success": {
     "message": "Success"
   },
-  "viewCollection": {
-    "message": "View collection"
-  },
   "restrictedGroupAccess": {
     "message": "You cannot add yourself to groups."
   },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Stacked on #9116 because that changes an interface used by this PR. This can still be reviewed in the meantime.

In the restricted access view:
* if a user cannot edit the collection (e.g. owner/admin without access to all collections) - the button should say "View access" with the `bwi-users` icon. Clicking it should open the modal in read-only mode on the Access tab.
* if a user can edit the collection (e.g. providers after provider access is restricted) - no change. They still get "Edit collection" with the pencil icon, and it opens the dialog in edit mode.
* if the user can neither edit nor delete the collection (e.g. delete any collection custom users) - hide the button

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/vault/org-vault/collection-access-restricted.component.ts** - split the button into 2 separate HTML elements because they're diverging more than before. Include `readonly` and `CollectionDialogTabType` in the emitted event depending on the desired behavior.
- **apps/web/src/app/vault/org-vault/vault.component.html** - update inputs and outputs. Note that I've swapped `!isProviderUser` for the collectionView getter, it should evaluate to the same result, but uses the abstraction instead.
- **apps/web/src/locales/en/messages.json** - remove text no longer needed.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Owner with restricted access (using collection management settings):
![Screenshot 2024-05-09 at 9 57 20 AM](https://github.com/bitwarden/clients/assets/31796059/051c0dd4-969f-4cc1-8d02-f89e1a614c1c)

Provider with restricted access (using the `restrict-provider-access` feature flag):
![Screenshot 2024-05-10 at 11 36 45 AM](https://github.com/bitwarden/clients/assets/31796059/74fef7f4-b16b-453f-8ccf-3273bde05dc1)

Delete any collection custom user:
![Screenshot 2024-05-10 at 11 34 37 AM](https://github.com/bitwarden/clients/assets/31796059/a8e2fa71-fd86-42e7-9152-efda17d3267f)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
