### PR TITLE
[PM-8017] Force active styles for navigation items

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
@@ -6,6 +6,7 @@
     [text]="product.name"
     [route]="product.appRoute"
     [attr.icon]="product.icon"
+    [forceActiveStyles]="product.isActive"
   >
   </bit-nav-item>
   <ng-container *ngIf="moreProducts$ | async as moreProducts">

--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.spec.ts
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
@@ -134,6 +135,26 @@ describe("NavigationProductSwitcherComponent", () => {
       expect(links[0].textContent).toContain("Organizations");
       expect(links[1].textContent).toContain("AA Product");
       expect(links[2].textContent).toContain("Test Product");
+    });
+
+    it('shows the nav item as active when "isActive" is true', () => {
+      mockProducts$.next({
+        bento: [
+          {
+            name: "Organizations",
+            icon: "bwi-lock",
+            marketingRoute: "https://www.example.com/",
+            isActive: true,
+          },
+        ],
+        other: [],
+      });
+
+      fixture.detectChanges();
+
+      const navItem = fixture.debugElement.query(By.directive(NavItemComponent));
+
+      expect(navItem.componentInstance.forceActiveStyles).toBe(true);
     });
   });
 

--- a/libs/components/src/navigation/nav-item.component.ts
+++ b/libs/components/src/navigation/nav-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, Optional } from "@angular/core";
+import { Component, HostListener, Input, Optional } from "@angular/core";
 import { BehaviorSubject, map } from "rxjs";
 
 import { NavBaseComponent } from "./nav-base.component";
@@ -10,6 +10,9 @@ import { NavGroupComponent } from "./nav-group.component";
   providers: [{ provide: NavBaseComponent, useExisting: NavItemComponent }],
 })
 export class NavItemComponent extends NavBaseComponent {
+  /** Forces active styles to be shown, regardless of the `routerLinkActiveOptions` */
+  @Input() forceActiveStyles? = false;
+
   /**
    * Is `true` if `to` matches the current route
    */
@@ -21,7 +24,7 @@ export class NavItemComponent extends NavBaseComponent {
     }
   }
   protected get showActiveStyles() {
-    return this._isActive && !this.hideActiveStyles;
+    return this.forceActiveStyles || (this._isActive && !this.hideActiveStyles);
   }
 
   /**

--- a/libs/components/src/navigation/nav-item.stories.ts
+++ b/libs/components/src/navigation/nav-item.stories.ts
@@ -101,3 +101,14 @@ export const MultipleItemsWithDivider: Story = {
     `,
   }),
 };
+
+export const ForceActiveStyles: Story = {
+  render: (args: NavItemComponent) => ({
+    props: args,
+    template: `
+      <bit-nav-item text="First Nav" icon="bwi-collection"></bit-nav-item>
+      <bit-nav-item text="Active Nav" icon="bwi-collection" [forceActiveStyles]="true"></bit-nav-item>
+      <bit-nav-item text="Third Nav" icon="bwi-collection"></bit-nav-item>
+    `,
+  }),
+};


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The product switcher shown within the navigation has a requirement that the items be shown as "active" when any route within the specific product is active. The current implementation of the the navigation item uses `routerLinkActiveOptions` to show the active style automatically. 

In this case, that won't work because the link destination and the current path are different.

Adding an Input to force active styles to be shown.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **nav-item.component.ts:**
  - Add `forceActiveStyles` Input that defaults to `false
- **nav-item.stories.ts:**
  - Add stories to show the new attribute
- **navigation-switcher.component.html:** 
   - Pass `isActive` attribute of the product, this is how the current product switcher works in the upper right

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![Screenshot 2024-05-10 at 9 31 15 AM](https://github.com/bitwarden/clients/assets/125900171/78d0b219-3ed2-42a7-ba64-ea0b86d124fd)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
