### PR TITLE
[AC-2328] Add a Bulk OrganizationUsersController.GetResetPasswordDetails endpoint

### DIFF
--- a/libs/common/src/admin-console/abstractions/organization-user/organization-user.service.ts
+++ b/libs/common/src/admin-console/abstractions/organization-user/organization-user.service.ts
@@ -67,6 +67,16 @@ export abstract class OrganizationUserService {
   ): Promise<OrganizationUserResetPasswordDetailsResponse>;
 
   /**
+   * Retrieve reset password details for many organization users
+   * @param organizationId - Identifier for the organization
+   * @param ids - A list of organization user identifiers
+   */
+  abstract getManyOrganizationUserResetPasswordDetails(
+    organizationId: string,
+    ids: string[],
+  ): Promise<ListResponse<OrganizationUserResetPasswordDetailsResponse>>;
+
+  /**
    * Create new organization user invite(s) for the specified organization
    * @param organizationId - Identifier for the organization
    * @param request - New user invitation request details

--- a/libs/common/src/admin-console/abstractions/organization-user/responses/organization-user.response.ts
+++ b/libs/common/src/admin-console/abstractions/organization-user/responses/organization-user.response.ts
@@ -70,6 +70,7 @@ export class OrganizationUserDetailsResponse extends OrganizationUserResponse {
 }
 
 export class OrganizationUserResetPasswordDetailsResponse extends BaseResponse {
+  organizationUserId: string;
   kdf: KdfType;
   kdfIterations: number;
   kdfMemory?: number;
@@ -79,6 +80,7 @@ export class OrganizationUserResetPasswordDetailsResponse extends BaseResponse {
 
   constructor(response: any) {
     super(response);
+    this.organizationUserId = this.getResponseProperty("OrganizationUserId");
     this.kdf = this.getResponseProperty("Kdf");
     this.kdfIterations = this.getResponseProperty("KdfIterations");
     this.kdfMemory = this.getResponseProperty("KdfMemory");

--- a/libs/common/src/admin-console/services/organization-user/organization-user.service.implementation.ts
+++ b/libs/common/src/admin-console/services/organization-user/organization-user.service.implementation.ts
@@ -98,6 +98,20 @@ export class OrganizationUserServiceImplementation implements OrganizationUserSe
     return new OrganizationUserResetPasswordDetailsResponse(r);
   }
 
+  async getManyOrganizationUserResetPasswordDetails(
+    organizationId: string,
+    ids: string[],
+  ): Promise<ListResponse<OrganizationUserResetPasswordDetailsResponse>> {
+    const r = await this.apiService.send(
+      "POST",
+      "/organizations/" + organizationId + "/users/reset-password-details",
+      new OrganizationUserBulkRequest(ids),
+      true,
+      true,
+    );
+    return new ListResponse(r, OrganizationUserResetPasswordDetailsResponse);
+  }
+
   postOrganizationUserInvite(
     organizationId: string,
     request: OrganizationUserInviteRequest,


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The current endpoint requires multiple database calls, this new endpoint gets all data using one new stored procedure.



## Code changes
[Server PR](https://github.com/bitwarden/server/pull/4079)

- **libs/common/src/admin-console/abstractions/organization-user/organization-user.service.ts:** Abstract API method
- **libs/common/src/admin-console/abstractions/organization-user/responses/organization-user.response.ts:** Add `OrganizationUserId` property for result mapping
- **libs/common/src/admin-console/services/organization-user/organization-user.service.implementation.ts:** API method implementation

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
