### PR TITLE
[AC-2484] Fix build error caused by canEditUnassignedCiphers

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -35,6 +35,7 @@ export class VaultCollectionRowComponent {
   @Input() groups: GroupView[];
   @Input() showPermissionsColumn: boolean;
   @Input() flexibleCollectionsV1Enabled: boolean;
+  @Input() restrictProviderAccess: boolean;
 
   @Output() onEvent = new EventEmitter<VaultItemEvent>();
 
@@ -56,7 +57,10 @@ export class VaultCollectionRowComponent {
   }
 
   get permissionText() {
-    if (this.collection.id == Unassigned && this.organization?.canEditUnassignedCiphers()) {
+    if (
+      this.collection.id == Unassigned &&
+      this.organization?.canEditUnassignedCiphers(this.restrictProviderAccess)
+    ) {
       return this.i18nService.t("canEdit");
     }
     if ((this.collection as CollectionAdminView).assigned) {

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -97,6 +97,7 @@
           [canEditCollection]="canEditCollection(item.collection)"
           [canViewCollectionInfo]="canViewCollectionInfo(item.collection)"
           [flexibleCollectionsV1Enabled]="flexibleCollectionsV1Enabled"
+          [restrictProviderAccess]="restrictProviderAccess"
           [checked]="selection.isSelected(item)"
           (checkedToggled)="selection.toggle(item)"
           (onEvent)="event($event)"

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -48,6 +48,7 @@ export class VaultItemsComponent {
   @Input({ required: true }) flexibleCollectionsV1Enabled = false;
   @Input() addAccessStatus: number;
   @Input() addAccessToggle: boolean;
+  @Input() restrictProviderAccess: boolean;
 
   private _ciphers?: CipherView[] = [];
   @Input() get ciphers(): CipherView[] {

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -71,6 +71,7 @@
       [flexibleCollectionsV1Enabled]="flexibleCollectionsV1Enabled"
       [addAccessStatus]="addAccessStatus$ | async"
       [addAccessToggle]="showAddAccessToggle"
+      [restrictProviderAccess]="restrictProviderAccessEnabled"
     >
     </app-vault-items>
     <ng-container *ngIf="!flexibleCollectionsV1Enabled">


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
#8858 was merged without updating from `main` first, which means that a call to `organization.canEditUnassignedCiphers` was missing a required parameter. This broke `main`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Pass the `restrict-provider-access` feature flag value from the org vault -> `VaultItemsComponent` -> `VaultCollectionRowComponent` -> into the method call.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
