### PR TITLE
[PM-5363] PinService Migration Fix

### DIFF
--- a/libs/auth/src/common/services/pin/pin.service.implementation.ts
+++ b/libs/auth/src/common/services/pin/pin.service.implementation.ts
@@ -387,9 +387,10 @@ export class PinService implements PinServiceAbstraction {
     );
 
     const encUserKey = await this.stateService.getEncryptedCryptoSymmetricKey({ userId: userId });
+
     const userKey = await this.masterPasswordService.decryptUserKeyWithMasterKey(
       masterKey,
-      new EncString(encUserKey),
+      encUserKey ? new EncString(encUserKey) : undefined,
     );
 
     const pinKeyEncryptedUserKey = await this.createPinKeyEncryptedUserKey(pin, userKey, userId);


### PR DESCRIPTION
Fixes a part of the `decryptAndMigrateOldPinKeyEncryptedMasterKey()` method where `undefined` was getting wrapped in `new EncString(undefined)` and passed into `masterPasswordService.decryptUserKeyWithMasterKey()`, resulting in an error.

![Screenshot 2024-05-10 at 3 51 50 PM](https://github.com/bitwarden/clients/assets/102181210/740e171d-6315-4581-9857-1b437a2be474)