### PR TITLE
PM-5501 - VaultTimeoutSettingsSvc State Provider Migration - Small bugfixes

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -254,7 +254,7 @@ export class AccountSecurityComponent implements OnInit {
   }
 
   async saveVaultTimeout(previousValue: VaultTimeout, newValue: VaultTimeout) {
-    if (newValue == null) {
+    if (newValue == VaultTimeoutStringType.Never) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "warning" },
         content: { key: "neverLockWarning" },
@@ -289,7 +289,7 @@ export class AccountSecurityComponent implements OnInit {
       newValue,
       vaultTimeoutAction,
     );
-    if (newValue == null) {
+    if (newValue == VaultTimeoutStringType.Never) {
       this.messagingService.send("bgReseedStorage");
     }
   }

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -254,7 +254,7 @@ export class AccountSecurityComponent implements OnInit {
   }
 
   async saveVaultTimeout(previousValue: VaultTimeout, newValue: VaultTimeout) {
-    if (newValue == VaultTimeoutStringType.Never) {
+    if (newValue === VaultTimeoutStringType.Never) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "warning" },
         content: { key: "neverLockWarning" },
@@ -289,7 +289,7 @@ export class AccountSecurityComponent implements OnInit {
       newValue,
       vaultTimeoutAction,
     );
-    if (newValue == VaultTimeoutStringType.Never) {
+    if (newValue === VaultTimeoutStringType.Never) {
       this.messagingService.send("bgReseedStorage");
     }
   }

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -371,7 +371,7 @@ export class SettingsComponent implements OnInit {
   }
 
   async saveVaultTimeout(newValue: VaultTimeout) {
-    if (newValue == VaultTimeoutStringType.Never) {
+    if (newValue === VaultTimeoutStringType.Never) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "warning" },
         content: { key: "neverLockWarning" },

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -371,7 +371,7 @@ export class SettingsComponent implements OnInit {
   }
 
   async saveVaultTimeout(newValue: VaultTimeout) {
-    if (newValue == null) {
+    if (newValue == VaultTimeoutStringType.Never) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "warning" },
         content: { key: "neverLockWarning" },

--- a/libs/common/src/services/vault-timeout/vault-timeout-settings.service.spec.ts
+++ b/libs/common/src/services/vault-timeout/vault-timeout-settings.service.spec.ts
@@ -313,7 +313,7 @@ describe("VaultTimeoutSettingsService", () => {
       expect(cryptoService.refreshAdditionalKeys).toHaveBeenCalled();
     });
 
-    it("should clear the tokens when the timeout is non-null and the action is log out", async () => {
+    it("should clear the tokens when the timeout is not never and the action is log out", async () => {
       // Arrange
       const action = VaultTimeoutAction.LogOut;
       const timeout = 30;
@@ -323,6 +323,18 @@ describe("VaultTimeoutSettingsService", () => {
 
       // Assert
       expect(tokenService.clearTokens).toHaveBeenCalled();
+    });
+
+    it("should not clear the tokens when the timeout is never and the action is log out", async () => {
+      // Arrange
+      const action = VaultTimeoutAction.LogOut;
+      const timeout = VaultTimeoutStringType.Never;
+
+      // Act
+      await vaultTimeoutSettingsService.setVaultTimeoutOptions(mockUserId, timeout, action);
+
+      // Assert
+      expect(tokenService.clearTokens).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/common/src/services/vault-timeout/vault-timeout-settings.service.ts
+++ b/libs/common/src/services/vault-timeout/vault-timeout-settings.service.ts
@@ -30,7 +30,7 @@ import { LogService } from "../../platform/abstractions/log.service";
 import { BiometricStateService } from "../../platform/biometrics/biometric-state.service";
 import { StateProvider } from "../../platform/state";
 import { UserId } from "../../types/guid";
-import { VaultTimeout } from "../../types/vault-timeout.type";
+import { VaultTimeout, VaultTimeoutStringType } from "../../types/vault-timeout.type";
 
 import { VAULT_TIMEOUT, VAULT_TIMEOUT_ACTION } from "./vault-timeout-settings.state";
 
@@ -74,7 +74,7 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
 
     await this.setVaultTimeout(userId, timeout);
 
-    if (timeout != null && action === VaultTimeoutAction.LogOut) {
+    if (timeout != VaultTimeoutStringType.Never && action === VaultTimeoutAction.LogOut) {
       // if we have a vault timeout and the action is log out, reset tokens
       // as the tokens were stored on disk and now should be stored in memory
       await this.tokenService.clearTokens();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
1. To fix the `VaultTimeoutSettingsService.setVaultTimeoutOptions` method condition which needed to use `never` instead of null which I missed in #8604
2. To fix the fact that the never lock warning dialog wasn't properly shown to users on browser or desktop anymore

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/services/vault-timeout/vault-timeout-settings.service.ts:** Replace a null check with a check for the `VaultTimeoutStringType.Never`
- **libs/common/src/services/vault-timeout/vault-timeout-settings.service.spec.ts** Test the fix to ensure it can't happen again
- **apps/browser/src/auth/popup/settings/account-security.component.ts:** Fix browser never lock warning not showing up
- **apps/desktop/src/app/accounts/settings.component.ts:** Fix desktop never lock warning not showing up

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
