### PR TITLE
[AC-2487] Fix restricted access view not loading for Unassigned

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -117,10 +117,13 @@
       <collection-access-restricted
         *ngIf="showCollectionAccessRestricted"
         [canEditCollection]="
-          selectedCollection.node?.canEdit(organization, flexibleCollectionsV1Enabled)
+          selectedCollection?.node?.canEdit(organization, flexibleCollectionsV1Enabled)
         "
         [canViewCollectionInfo]="
-          selectedCollection.node?.canViewCollectionInfo(organization, flexibleCollectionsV1Enabled)
+          selectedCollection?.node?.canViewCollectionInfo(
+            organization,
+            flexibleCollectionsV1Enabled
+          )
         "
         (viewCollectionClicked)="
           editCollection(selectedCollection.node, $event.tab, $event.readonly)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The Unassigned collection appears to be represented by `selectedCollection = null`. However, I was missing a null check in #9118. This means that the restricted access page fails to load (specifically for providers if provider access is restricted).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Add additional null checks. The Unassigned collection is not a real collection, so you cannot view or edit it, which means that these input values will default to false in this case anyway - as intended.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
