### PR TITLE
[PM-6606] remove onboarding feature flag

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.html
@@ -1,8 +1,5 @@
 <div
-  *ngIf="
-    isNewAccount && showOnboarding && onboardingTasks$
-      | async as onboardingTasks
-  "
+  *ngIf="isNewAccount && showOnboarding && onboardingTasks$ | async as onboardingTasks"
   class="tw-mb-6"
 >
   <app-onboarding

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.html
@@ -1,6 +1,6 @@
 <div
   *ngIf="
-    isNewAccount && showOnboarding && (showOnboardingAccess$ | async) && onboardingTasks$
+    isNewAccount && showOnboarding && onboardingTasks$
       | async as onboardingTasks
   "
   class="tw-mb-6"

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.spec.ts
@@ -5,7 +5,6 @@ import { Subject, of } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateProvider } from "@bitwarden/common/platform/state";
@@ -21,7 +20,6 @@ describe("VaultOnboardingComponent", () => {
   let mockApiService: Partial<ApiService>;
   let mockPolicyService: MockProxy<PolicyService>;
   let mockI18nService: MockProxy<I18nService>;
-  let mockConfigService: MockProxy<ConfigService>;
   let mockVaultOnboardingService: MockProxy<VaultOnboardingServiceAbstraction>;
   let mockStateProvider: Partial<StateProvider>;
   let setInstallExtLinkSpy: any;
@@ -34,7 +32,6 @@ describe("VaultOnboardingComponent", () => {
     mockApiService = {
       getProfile: jest.fn(),
     };
-    mockConfigService = mock<ConfigService>();
     mockVaultOnboardingService = mock<VaultOnboardingServiceAbstraction>();
     mockStateProvider = {
       getActive: jest.fn().mockReturnValue(
@@ -56,7 +53,6 @@ describe("VaultOnboardingComponent", () => {
         { provide: VaultOnboardingServiceAbstraction, useValue: mockVaultOnboardingService },
         { provide: I18nService, useValue: mockI18nService },
         { provide: ApiService, useValue: mockApiService },
-        { provide: ConfigService, useValue: mockConfigService },
         { provide: StateProvider, useValue: mockStateProvider },
       ],
     }).compileComponents();

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
@@ -16,8 +16,6 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { VaultOnboardingMessages } from "@bitwarden/common/vault/enums/vault-onboarding.enum";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -44,7 +42,6 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
   private destroy$ = new Subject<void>();
   isNewAccount: boolean;
   private readonly onboardingReleaseDate = new Date("2024-04-02");
-  showOnboardingAccess$: Observable<boolean>;
 
   protected currentTasks: VaultOnboardingTasks;
 
@@ -55,14 +52,10 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
     protected platformUtilsService: PlatformUtilsService,
     protected policyService: PolicyService,
     private apiService: ApiService,
-    private configService: ConfigService,
     private vaultOnboardingService: VaultOnboardingServiceAbstraction,
   ) {}
 
   async ngOnInit() {
-    this.showOnboardingAccess$ = await this.configService.getFeatureFlag$(
-      FeatureFlag.VaultOnboarding,
-    );
     this.onboardingTasks$ = this.vaultOnboardingService.vaultOnboardingState$;
     await this.setOnboardingTasks();
     this.setInstallExtLink();

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -7,7 +7,6 @@ export enum FeatureFlag {
   BrowserFilelessImport = "browser-fileless-import",
   ItemShare = "item-share",
   FlexibleCollectionsV1 = "flexible-collections-v-1", // v-1 is intentional
-  VaultOnboarding = "vault-onboarding",
   GeneratorToolsModernization = "generator-tools-modernization",
   FlexibleCollectionsMigration = "flexible-collections-migration",
   ShowPaymentMethodWarningBanners = "show-payment-method-warning-banners",
@@ -34,7 +33,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.BrowserFilelessImport]: FALSE,
   [FeatureFlag.ItemShare]: FALSE,
   [FeatureFlag.FlexibleCollectionsV1]: FALSE,
-  [FeatureFlag.VaultOnboarding]: FALSE,
   [FeatureFlag.GeneratorToolsModernization]: FALSE,
   [FeatureFlag.FlexibleCollectionsMigration]: FALSE,
   [FeatureFlag.ShowPaymentMethodWarningBanners]: FALSE,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
removes the `vault-onboarding` feature flag for the end-user onboarding component since this feature is live

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **vault-onboarding.component.html ** removed `showOnboardingAccess` so that it doesnt check the feature flag value
- **vault-onboarding.component.ts** removing getting feature flag & storing it in variable
- **feature-flag.enum.ts** removes corresponding flag from shared enum
- **vault-onboarding.component.spec.ts** remove `ConfigService` from being mocked in the spec

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
