### PR TITLE
[AC-2601] Hide Vault filters for providers when flag enabled

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -12,7 +12,7 @@
 ></app-org-vault-header>
 
 <div class="row">
-  <div class="col-3" *ngIf="!organization?.isProviderUser">
+  <div class="col-3" *ngIf="!hideVaultFilters">
     <div class="groupings">
       <div class="content">
         <div class="inner-content">
@@ -26,7 +26,7 @@
       </div>
     </div>
   </div>
-  <div [class]="organization?.isProviderUser ? 'col-12' : 'col-9'">
+  <div [class]="hideVaultFilters ? 'col-12' : 'col-9'">
     <bit-toggle-group
       *ngIf="showAddAccessToggle && activeFilter.selectedCollectionNode"
       [selected]="addAccessStatus$ | async"

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -166,6 +166,10 @@ export class VaultComponent implements OnInit, OnDestroy {
     return this._restrictProviderAccessFlagEnabled && this.flexibleCollectionsV1Enabled;
   }
 
+  protected get hideVaultFilters(): boolean {
+    return this.restrictProviderAccessEnabled && this.organization?.isProviderUser;
+  }
+
   private searchText$ = new Subject<string>();
   private refresh$ = new BehaviorSubject<void>(null);
   private destroy$ = new Subject<void>();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#8265 added functionality to hide the Vault filter section for providers that was not properly hidden behind the `restrict-provider-access` feature flag. This PR ensures the section is only hidden when the flag is enabled.

## Code changes

Add a `hideVaultFilters` getter that takes the feature flag into consideration.

## Screenshots

### Flag OFF
![image](https://github.com/bitwarden/clients/assets/8764515/090e0966-1f26-4123-89bf-e654937cf4be)

### Flag ON
![image](https://github.com/bitwarden/clients/assets/8764515/c8ab78c3-ac1b-4fda-bc57-d9271b3727f5)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
