### PR TITLE
Update AnonLayout BG Colors

### DIFF
--- a/apps/web/src/app/auth/anon-layout-wrapper.component.ts
+++ b/apps/web/src/app/auth/anon-layout-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 
 import { AnonLayoutComponent } from "@bitwarden/auth/angular";
@@ -10,7 +10,7 @@ import { Icon } from "@bitwarden/components";
   templateUrl: "anon-layout-wrapper.component.html",
   imports: [AnonLayoutComponent, RouterModule],
 })
-export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
+export class AnonLayoutWrapperComponent {
   protected pageTitle: string;
   protected pageSubtitle: string;
   protected pageIcon: Icon;
@@ -22,13 +22,5 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.pageTitle = this.i18nService.t(this.route.snapshot.firstChild.data["pageTitle"]);
     this.pageSubtitle = this.i18nService.t(this.route.snapshot.firstChild.data["pageSubtitle"]);
     this.pageIcon = this.route.snapshot.firstChild.data["pageIcon"]; // don't translate
-  }
-
-  ngOnInit() {
-    document.body.classList.add("layout_frontend");
-  }
-
-  ngOnDestroy() {
-    document.body.classList.remove("layout_frontend");
   }
 }

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -1,5 +1,5 @@
 <main
-  class="tw-flex tw-min-h-screen tw-w-full tw-mx-auto tw-flex-col tw-gap-9 tw-px-4 tw-pb-4 tw-pt-14 tw-text-main"
+  class="tw-flex tw-min-h-screen tw-w-full tw-mx-auto tw-flex-col tw-gap-9 tw-bg-background-alt tw-px-4 tw-pb-4 tw-pt-14 tw-text-main"
 >
   <div class="tw-text-center">
     <div class="tw-px-8">
@@ -15,7 +15,7 @@
   </div>
   <div class="tw-mb-auto tw-mx-auto tw-flex tw-flex-col tw-items-center">
     <div
-      class="tw-rounded-xl tw-mb-9 tw-mx-auto sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
+      class="tw-rounded-xl tw-bg-background tw-mb-9 tw-mx-auto sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
     >
       <ng-content></ng-content>
     </div>

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -15,7 +15,7 @@
   </div>
   <div class="tw-mb-auto tw-mx-auto tw-flex tw-flex-col tw-items-center">
     <div
-      class="tw-rounded-xl tw-bg-background tw-mb-9 tw-mx-auto sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
+      class="tw-rounded-xl tw-mb-9 tw-mx-auto sm:tw-bg-background sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
     >
       <ng-content></ng-content>
     </div>


### PR DESCRIPTION
# Changes

- Makes the AnonLayout page background `tw-bg-background-alt`
- Makes the AnonLayout primary content area `tw-bg-background`
- Removes `layout_frontend` class from body element

# Storybook Preview

https://62a88a6de5b807fa98886113-uyskarvklc.chromatic.com/?path=/docs/documentation-introduction--docs

# Screenshots

![Screenshot 2024-05-14 at 12 13 22 PM](https://github.com/bitwarden/clients/assets/102181210/25b45891-d6e6-42ba-b98d-a8b734e8dfc3)

![Screenshot 2024-05-14 at 12 14 18 PM](https://github.com/bitwarden/clients/assets/102181210/f9706de0-e975-4384-9e0e-cbd512614c05)