### PR TITLE
Ps/pm-8003/handle-dekstop-invalidated-message-encryption

### DIFF
--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -167,6 +167,11 @@ export class NativeMessagingBackground {
               cancelButtonText: null,
               type: "danger",
             });
+
+            if (this.resolver) {
+              this.resolver(message);
+            }
+
             break;
           case "verifyFingerprint": {
             if (this.sharedSecret == null) {


### PR DESCRIPTION
Handling of this error is to require the user to retry, so the promise needs to resolve.

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Desktop is capable of providing biometrically locked user keys while it itself is locked. However, process reloads are common in this state and this breaks the shared encryption key for native messaging. This PR implements better handling of this state (`"invalidateEncryption"` response) by recognizing this is an end-of-message-chain event and resolving any awaited responses as failures.


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
