### PR TITLE
[AC-2602] Fix groups modal not loading for providers

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
@@ -273,12 +273,13 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
 
           // If the current user is not already in the group and cannot add themselves, remove them from the list
           if (restrictGroupAccess) {
-            const organizationUserId = this.members.find((m) => m.userId === activeAccount.id).id;
+            // organizationUserId may be null if accessing via a provider
+            const organizationUserId = this.members.find((m) => m.userId === activeAccount.id)?.id;
             const isAlreadyInGroup = this.groupForm.value.members.some(
               (m) => m.id === organizationUserId,
             );
 
-            if (!isAlreadyInGroup) {
+            if (organizationUserId != null && !isAlreadyInGroup) {
               this.members = this.members.filter((m) => m.id !== organizationUserId);
             }
           }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix a bug where the edit group modal wasn't loading for a provider when "allow admin access to all collections" was off.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

When this setting is off, a user cannot add themselves to a group. The code that does this assumes that the user is a member of the org, which is not true for a provider, so it was throwing a null error.

Add in a null check and explanatory comment. If the user is not a member of the org, there is nothing to remove from the list.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
