### PR TITLE
[PM-8159] [PM-8158] [PM-8156] Swallow multiple offscreen document errors

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -396,7 +396,7 @@ export default class MainBackground {
       ),
     );
 
-    this.offscreenDocumentService = new DefaultOffscreenDocumentService();
+    this.offscreenDocumentService = new DefaultOffscreenDocumentService(this.logService);
 
     this.platformUtilsService = new BackgroundPlatformUtilsService(
       this.messagingService,

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -377,7 +377,8 @@ export default class MainBackground {
     const logoutCallback = async (expired: boolean, userId?: UserId) =>
       await this.logout(expired, userId);
 
-    this.logService = new ConsoleLogService(false);
+    const isDev = process.env.ENV === "development";
+    this.logService = new ConsoleLogService(isDev);
     this.cryptoFunctionService = new WebCryptoFunctionService(self);
     this.keyGenerationService = new KeyGenerationService(this.cryptoFunctionService);
     this.storageService = new BrowserLocalStorageService();

--- a/apps/browser/src/platform/offscreen-document/offscreen-document.service.spec.ts
+++ b/apps/browser/src/platform/offscreen-document/offscreen-document.service.spec.ts
@@ -1,3 +1,7 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
 import { DefaultOffscreenDocumentService } from "./offscreen-document.service";
 
 class TestCase {
@@ -21,6 +25,7 @@ describe.each([
   new TestCase("synchronous callback", () => 42),
   new TestCase("asynchronous callback", () => Promise.resolve(42)),
 ])("DefaultOffscreenDocumentService %s", (testCase) => {
+  const logService = mock<LogService>();
   let sut: DefaultOffscreenDocumentService;
   const reasons = [chrome.offscreen.Reason.TESTING];
   const justification = "justification is testing";
@@ -37,7 +42,7 @@ describe.each([
     callback = testCase.callback;
     chrome.offscreen = api;
 
-    sut = new DefaultOffscreenDocumentService();
+    sut = new DefaultOffscreenDocumentService(logService);
   });
 
   afterEach(() => {

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -195,9 +195,11 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: LogService,
-    useFactory: (platformUtilsService: PlatformUtilsService) =>
-      new ConsoleLogService(platformUtilsService.isDev()),
-    deps: [PlatformUtilsService],
+    useFactory: () => {
+      const isDev = process.env.ENV === "development";
+      return new ConsoleLogService(isDev);
+    },
+    deps: [],
   }),
   safeProvider({
     provide: EnvironmentService,

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -286,7 +286,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: OffscreenDocumentService,
     useClass: DefaultOffscreenDocumentService,
-    deps: [],
+    deps: [LogService],
   }),
   safeProvider({
     provide: PlatformUtilsService,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The API has race issues with determining if an offscreen document exists (https://groups.google.com/a/chromium.org/g/chromium-extensions/c/s2Wp55bjySE/m/SnjJu1MdAAAJ). However, there are no negative effects of attempting to open multiple other than this throw.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
