### PR TITLE
[AC-2610] [AC-2613] Fix copy in members and groups dialogs

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -33,7 +33,7 @@
         <bit-tab label="{{ 'members' | i18n }}">
           <p>
             {{ "editGroupMembersDesc" | i18n }}
-            <span *ngIf="restrictGroupAccess$ | async">
+            <span *ngIf="cannotAddSelfToGroup$ | async">
               {{ "restrictedGroupAccessDesc" | i18n }}
             </span>
           </p>
@@ -52,7 +52,7 @@
         <bit-tab label="{{ 'collections' | i18n }}">
           <p>
             {{ "editGroupCollectionsDesc" | i18n }}
-            <span *ngIf="!(allowAdminAccessToAllCollectionItems$ | async)">
+            <span *ngIf="!(canEditAnyCollection$ | async)">
               {{ "restrictedCollectionAssignmentDesc" | i18n }}
             </span>
           </p>

--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -53,7 +53,7 @@
           <p>
             {{ "editGroupCollectionsDesc" | i18n }}
             <span *ngIf="!(allowAdminAccessToAllCollectionItems$ | async)">
-              {{ "editGroupCollectionsRestrictionsDesc" | i18n }}
+              {{ "restrictedCollectionAssignmentDesc" | i18n }}
             </span>
           </p>
           <div *ngIf="!(flexibleCollectionsEnabled$ | async)" class="tw-my-3">

--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
@@ -183,7 +183,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
     shareReplay({ refCount: true, bufferSize: 1 }),
   );
 
-  allowAdminAccessToAllCollectionItems$ = combineLatest([
+  protected allowAdminAccessToAllCollectionItems$ = combineLatest([
     this.organization$,
     this.flexibleCollectionsV1Enabled$,
   ]).pipe(
@@ -196,7 +196,16 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
     }),
   );
 
-  restrictGroupAccess$ = combineLatest([
+  protected canEditAnyCollection$ = combineLatest([
+    this.organization$,
+    this.flexibleCollectionsV1Enabled$,
+  ]).pipe(
+    map(([org, flexibleCollectionsV1Enabled]) =>
+      org.canEditAnyCollection(flexibleCollectionsV1Enabled),
+    ),
+  );
+
+  protected cannotAddSelfToGroup$ = combineLatest([
     this.allowAdminAccessToAllCollectionItems$,
     this.groupDetails$,
   ]).pipe(map(([allowAdminAccess, groupDetails]) => !allowAdminAccess && groupDetails != null));
@@ -229,7 +238,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
       this.orgCollections$,
       this.orgMembers$,
       this.groupDetails$,
-      this.restrictGroupAccess$,
+      this.cannotAddSelfToGroup$,
       this.accountService.activeAccount$,
       this.organization$,
       this.flexibleCollectionsV1Enabled$,

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -426,7 +426,7 @@
           </div>
           <div *ngIf="organization.useGroups && !(restrictEditingSelf$ | async)" class="tw-mb-6">
             {{ "userPermissionOverrideHelperDesc" | i18n }}
-            <span *ngIf="!(allowAdminAccessToAllCollectionItems$ | async)">
+            <span *ngIf="!(canEditAnyCollection$ | async)">
               {{ "restrictedCollectionAssignmentDesc" | i18n }}
             </span>
           </div>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -405,7 +405,7 @@
         <bit-tab *ngIf="organization.useGroups" [label]="'groups' | i18n">
           <div class="tw-mb-6">
             {{
-              (restrictedAccess$ | async)
+              (restrictEditingSelf$ | async)
                 ? ("restrictedGroupAccess" | i18n)
                 : ("groupAccessUserDesc" | i18n)
             }}
@@ -417,15 +417,18 @@
             [selectorLabelText]="'selectGroups' | i18n"
             [emptySelectionText]="'noGroupsAdded' | i18n"
             [flexibleCollectionsEnabled]="organization.flexibleCollections"
-            [hideMultiSelect]="restrictedAccess$ | async"
+            [hideMultiSelect]="restrictEditingSelf$ | async"
           ></bit-access-selector>
         </bit-tab>
         <bit-tab [label]="'collections' | i18n">
-          <div class="tw-mb-6" *ngIf="restrictedAccess$ | async">
-            {{ "restrictedCollectionAccess" | i18n }}
+          <div class="tw-mb-6" *ngIf="restrictEditingSelf$ | async">
+            {{ "cannotAddYourselfToCollections" | i18n }}
           </div>
-          <div *ngIf="organization.useGroups && !(restrictedAccess$ | async)" class="tw-mb-6">
-            {{ "userPermissionOverrideHelper" | i18n }}
+          <div *ngIf="organization.useGroups && !(restrictEditingSelf$ | async)" class="tw-mb-6">
+            {{ "userPermissionOverrideHelperDesc" | i18n }}
+            <span *ngIf="!(allowAdminAccessToAllCollectionItems$ | async)">
+              {{ "restrictedCollectionAssignmentDesc" | i18n }}
+            </span>
           </div>
           <div *ngIf="!organization.flexibleCollections" class="tw-mb-6">
             <bit-form-control>
@@ -454,7 +457,7 @@
             [selectorLabelText]="'selectCollections' | i18n"
             [emptySelectionText]="'noCollectionsAdded' | i18n"
             [flexibleCollectionsEnabled]="organization.flexibleCollections"
-            [hideMultiSelect]="restrictedAccess$ | async"
+            [hideMultiSelect]="restrictEditingSelf$ | async"
           ></bit-access-selector
         ></bit-tab>
       </bit-tab-group>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -107,6 +107,7 @@ export class MemberDialogComponent implements OnDestroy {
 
   protected allowAdminAccessToAllCollectionItems$: Observable<boolean>;
   protected restrictEditingSelf$: Observable<boolean>;
+  protected canEditAnyCollection$: Observable<boolean>;
 
   protected permissionsGroup = this.formBuilder.group({
     manageAssignedCollectionsGroup: this.formBuilder.group<Record<string, boolean>>({
@@ -217,14 +218,25 @@ export class MemberDialogComponent implements OnDestroy {
       }
     });
 
+    const flexibleCollectionsV1Enabled$ = this.configService.getFeatureFlag$(
+      FeatureFlag.FlexibleCollectionsV1,
+    );
+
+    this.canEditAnyCollection$ = combineLatest([
+      this.organization$,
+      flexibleCollectionsV1Enabled$,
+    ]).pipe(
+      map(([org, flexibleCollectionsV1Enabled]) =>
+        org.canEditAnyCollection(flexibleCollectionsV1Enabled),
+      ),
+    );
+
     combineLatest({
       organization: this.organization$,
       collections: this.collectionAdminService.getAll(this.params.organizationId),
       userDetails: userDetails$,
       groups: groups$,
-      flexibleCollectionsV1Enabled: this.configService.getFeatureFlag$(
-        FeatureFlag.FlexibleCollectionsV1,
-      ),
+      flexibleCollectionsV1Enabled: flexibleCollectionsV1Enabled$,
     })
       .pipe(takeUntil(this.destroy$))
       .subscribe(

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -105,7 +105,8 @@ export class MemberDialogComponent implements OnDestroy {
     groups: [[] as AccessItemValue[]],
   });
 
-  protected restrictedAccess$: Observable<boolean>;
+  protected allowAdminAccessToAllCollectionItems$: Observable<boolean>;
+  protected restrictEditingSelf$: Observable<boolean>;
 
   protected permissionsGroup = this.formBuilder.group({
     manageAssignedCollectionsGroup: this.formBuilder.group<Record<string, boolean>>({
@@ -182,29 +183,34 @@ export class MemberDialogComponent implements OnDestroy {
       ? this.userService.get(this.params.organizationId, this.params.organizationUserId)
       : of(null);
 
-    // The orgUser cannot manage their own Group assignments if collection access is restricted
-    // TODO: fix disabled state of access-selector rows so that any controls are hidden
-    this.restrictedAccess$ = combineLatest([
+    this.allowAdminAccessToAllCollectionItems$ = combineLatest([
       this.organization$,
-      userDetails$,
-      this.accountService.activeAccount$,
       this.configService.getFeatureFlag$(FeatureFlag.FlexibleCollectionsV1),
     ]).pipe(
+      map(([organization, flexibleCollectionsV1Enabled]) => {
+        if (!flexibleCollectionsV1Enabled || !organization.flexibleCollections) {
+          return true;
+        }
+
+        return organization.allowAdminAccessToAllCollectionItems;
+      }),
+    );
+
+    // The orgUser cannot manage their own Group assignments if collection access is restricted
+    this.restrictEditingSelf$ = combineLatest([
+      this.allowAdminAccessToAllCollectionItems$,
+      userDetails$,
+      this.accountService.activeAccount$,
+    ]).pipe(
       map(
-        ([organization, userDetails, activeAccount, flexibleCollectionsV1Enabled]) =>
-          // Feature flag conditionals
-          flexibleCollectionsV1Enabled &&
-          organization.flexibleCollections &&
-          // Business logic conditionals
-          userDetails != null &&
-          userDetails.userId == activeAccount.id &&
-          !organization.allowAdminAccessToAllCollectionItems,
+        ([allowAdminAccess, userDetails, activeAccount]) =>
+          !allowAdminAccess && userDetails != null && userDetails.userId == activeAccount.id,
       ),
       shareReplay({ refCount: true, bufferSize: 1 }),
     );
 
-    this.restrictedAccess$.pipe(takeUntil(this.destroy$)).subscribe((restrictedAccess) => {
-      if (restrictedAccess) {
+    this.restrictEditingSelf$.pipe(takeUntil(this.destroy$)).subscribe((restrictEditingSelf) => {
+      if (restrictEditingSelf) {
         this.formGroup.controls.groups.disable();
       } else {
         this.formGroup.controls.groups.enable();
@@ -454,7 +460,7 @@ export class MemberDialogComponent implements OnDestroy {
       .filter((v) => v.type === AccessItemType.Collection)
       .map(convertToSelectionView);
 
-    userView.groups = (await firstValueFrom(this.restrictedAccess$))
+    userView.groups = (await firstValueFrom(this.restrictEditingSelf$))
       ? null
       : this.formGroup.value.groups.map((m) => m.id);
 

--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.html
@@ -105,7 +105,7 @@
             [items]="accessItems"
             [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
             [selectorLabelText]="'selectGroupsAndMembers' | i18n"
-            [selectorHelpText]="'userPermissionOverrideHelper' | i18n"
+            [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
             [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
             [flexibleCollectionsEnabled]="organization.flexibleCollections"
           ></bit-access-selector>

--- a/apps/web/src/app/vault/org-vault/bulk-collections-dialog/bulk-collections-dialog.component.html
+++ b/apps/web/src/app/vault/org-vault/bulk-collections-dialog/bulk-collections-dialog.component.html
@@ -15,7 +15,7 @@
         [items]="accessItems"
         [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
         [selectorLabelText]="'selectGroupsAndMembers' | i18n"
-        [selectorHelpText]="'userPermissionOverrideHelper' | i18n"
+        [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
         [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
         [flexibleCollectionsEnabled]="flexibleCollectionsEnabled$ | async"
       ></bit-access-selector>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6588,7 +6588,7 @@
   "editGroupCollectionsDesc": {
     "message": "Grant access to collections by adding them to this group."
   },
-  "editGroupCollectionsRestrictionsDesc": {
+  "restrictedCollectionAssignmentDesc": {
     "message": "You can only assign collections you manage."
   },
   "accessAllCollectionsDesc": {
@@ -6822,8 +6822,8 @@
   "selectGroups": {
     "message": "Select groups"
   },
-  "userPermissionOverrideHelper": {
-    "message": "Permissions set for a member will replace permissions set by that member's group"
+  "userPermissionOverrideHelperDesc": {
+    "message": "Permissions set for a member will replace permissions set by that member's group."
   },
   "noMembersOrGroupsAdded": {
     "message": "No members or groups added"
@@ -7749,7 +7749,7 @@
   "restrictedGroupAccess": {
     "message": "You cannot add yourself to groups."
   },
-  "restrictedCollectionAccess": {
+  "cannotAddYourselfToCollections": {
     "message": "You cannot add yourself to collections."
   },
   "assign": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When `Allow owners and admins to manage all collections` is off, the members modal -> collection tab was missing additional copy: `You can only assign collections you manage.`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts** - rename `restrictedAccess$` to `restrictEditingSelf$` to be more specific. Separate out the collection management setting to its own observable, `allowAdminAccessToAllCollectionItems$`, so that we can use it to display this missing copy (which only depends on the setting, not on editing yourself).
- everything else is basically name updates - e.g. we already had this copy in `messages.json` but its i18n string was `editGroupCollectionsRestrictionsDesc`, which isn't accurate now that we're using it in the members dialog. Also bumped the string for `userPermissionOverrideHelper` because I added a `.` at the end.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->


https://github.com/bitwarden/clients/assets/31796059/5653c02f-4c25-4175-b157-782c216008a1


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
