### PR TITLE
[PM-8003] process reload only when cancelled

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -38,6 +38,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { SystemService } from "@bitwarden/common/platform/abstractions/system.service";
 import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
+import { CANCELLED_PROCESS_RELOAD } from "@bitwarden/common/platform/messaging";
 import { clearCaches } from "@bitwarden/common/platform/misc/sequentialize";
 import { StateEventRunnerService } from "@bitwarden/common/platform/state";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/common/tools/generator/password";
@@ -248,9 +249,11 @@ export class AppComponent implements OnInit, OnDestroy {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.systemService.startProcessReload(this.authService);
             break;
-          case "cancelProcessReload":
-            this.systemService.cancelProcessReload();
+          case "cancelProcessReload": {
+            const cancelled = this.systemService.cancelProcessReload();
+            this.messagingService.send(CANCELLED_PROCESS_RELOAD, { cancelled });
             break;
+          }
           case "reloadProcess":
             ipc.platform.reloadProcess();
             break;

--- a/apps/desktop/src/platform/utils/from-ipc-main-messaging.ts
+++ b/apps/desktop/src/platform/utils/from-ipc-main-messaging.ts
@@ -1,0 +1,26 @@
+import { ipcMain } from "electron";
+import { fromEventPattern, share } from "rxjs";
+
+import { Message } from "@bitwarden/common/platform/messaging";
+import { tagAsExternal } from "@bitwarden/common/platform/messaging/internal";
+
+type Handler = (message: Message<object>) => void;
+type EventHandler = (event: Electron.IpcMainEvent, message: Message<object>) => void;
+const handlers = new Map<Handler, EventHandler>();
+
+export const fromIpcMainMessaging = () => {
+  return fromEventPattern<Message<object>>(
+    (handler) => ipcMain.addListener("messagingService", eventHandlerFor(handler)),
+    (handler) => ipcMain.removeListener("messagingService", eventHandlerFor(handler)),
+  ).pipe(tagAsExternal, share());
+};
+
+function eventHandlerFor<T extends Message<object>>(handler: (message: T) => void) {
+  const eventHandler = (_event: Electron.IpcMainEvent, message: T) => {
+    if (message.command) {
+      handler(message);
+    }
+  };
+  handlers.set(handler, eventHandler);
+  return eventHandler;
+}

--- a/libs/common/src/platform/abstractions/system.service.ts
+++ b/libs/common/src/platform/abstractions/system.service.ts
@@ -2,7 +2,11 @@ import { AuthService } from "../../auth/abstractions/auth.service";
 
 export abstract class SystemService {
   abstract startProcessReload(authService: AuthService): Promise<void>;
-  abstract cancelProcessReload(): void;
+  /**
+   * Cancels the process reload interval
+   * @returns {boolean} - Returns true if the reload interval was cancelled, false otherwise
+   */
+  abstract cancelProcessReload(): boolean;
   abstract clearClipboard(clipboardValue: string, timeoutMs?: number): Promise<void>;
   abstract clearPendingClipboard(): Promise<any>;
 }

--- a/libs/common/src/platform/messaging/commands.ts
+++ b/libs/common/src/platform/messaging/commands.ts
@@ -1,0 +1,10 @@
+import { CommandDefinition } from "./types";
+
+/** Command to cancel process realod */
+export const CANCEL_PROCESS_RELOAD = new CommandDefinition<Record<string, never>>(
+  "cancelProcessReload",
+);
+/** Response to `CANCEL_PROCESS_RELOAD` indicating whether process reload was cancelled */
+export const CANCELLED_PROCESS_RELOAD = new CommandDefinition<{ cancelled: boolean }>(
+  "cancelledProcessReload",
+);

--- a/libs/common/src/platform/messaging/index.ts
+++ b/libs/common/src/platform/messaging/index.ts
@@ -2,3 +2,4 @@ export { MessageListener } from "./message.listener";
 export { MessageSender } from "./message.sender";
 export { Message, CommandDefinition } from "./types";
 export { isExternalMessage } from "./helpers";
+export * from "./commands";

--- a/libs/common/src/platform/services/system.service.ts
+++ b/libs/common/src/platform/services/system.service.ts
@@ -107,11 +107,13 @@ export class SystemService implements SystemServiceAbstraction {
     }
   }
 
-  cancelProcessReload(): void {
+  cancelProcessReload(): boolean {
     if (this.reloadInterval != null) {
       clearInterval(this.reloadInterval);
       this.reloadInterval = null;
+      return true;
     }
+    return false;
   }
 
   async clearClipboard(clipboardValue: string, timeoutMs: number = null): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Browser biometric unlocks had a cycle with Desktop where because of process reload on failed biometric unlocks, the desktop forgets native messaging shared keys.

This allows for restarting process reload only if it was actually cancelled.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
