### PR TITLE
[CL-287] Make `app-current-account` a standalone component

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/current-account.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/current-account.component.ts
@@ -1,13 +1,15 @@
-import { Location } from "@angular/common";
+import { CommonModule, Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Observable, combineLatest, switchMap } from "rxjs";
 
+import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UserId } from "@bitwarden/common/types/guid";
+import { AvatarModule } from "@bitwarden/components";
 
 export type CurrentAccount = {
   id: UserId;
@@ -20,6 +22,8 @@ export type CurrentAccount = {
 @Component({
   selector: "app-current-account",
   templateUrl: "current-account.component.html",
+  standalone: true,
+  imports: [CommonModule, JslibModule, AvatarModule],
 })
 export class CurrentAccountComponent {
   currentAccount$: Observable<CurrentAccount>;

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -126,6 +126,7 @@ import "../platform/popup/locales";
     PopupHeaderComponent,
     UserVerificationDialogComponent,
     PopupSectionHeaderComponent,
+    CurrentAccountComponent,
   ],
   declarations: [
     ActionButtonsComponent,
@@ -188,7 +189,6 @@ import "../platform/popup/locales";
     HelpAndFeedbackComponent,
     AutofillComponent,
     EnvironmentSelectorComponent,
-    CurrentAccountComponent,
     AccountSwitcherComponent,
     VaultV2Component,
   ],


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
While trying to implement the new `popup-page` on the [new settings-page](https://github.com/bitwarden/clients/pull/9213), I noticed the `app-current-account` is not standalone yet. This will be needed for any other pages/components that are also standalone.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/account-switching/current-account.component.ts:** Mark the component as standalone and import necessary modules
- **apps/browser/src/popup/app.module.ts:** Remove CurrentAccountComponent from declarations and add it as an import

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
