### PR TITLE
[PM-8197] Do not allow browser biometric for locked account

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1714,6 +1714,12 @@
   "biometricsNotSupportedDesc": {
     "message": "Browser biometrics is not supported on this device."
   },
+  "biometricsNotUnlockedTitle": {
+    "message": "User locked or logged out"
+  },
+  "biometricsNotUnlockedDesc": {
+    "message": "Please unlock this user in the desktop application and try again."
+  },
   "biometricsFailedTitle": {
     "message": "Biometrics failed"
   },

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -321,6 +321,15 @@ export class NativeMessagingBackground {
             type: "danger",
           });
           break;
+        } else if (message.response === "not unlocked") {
+          this.messagingService.send("showDialog", {
+            title: { key: "biometricsNotUnlockedTitle" },
+            content: { key: "biometricsNotUnlockedDesc" },
+            acceptButtonText: { key: "ok" },
+            cancelButtonText: null,
+            type: "danger",
+          });
+          break;
         } else if (message.response === "canceled") {
           break;
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#9023 allowed reading of any user to be requested through browser IPC requests. However, this neglects that the user key will then necessarily be loaded into memory without being protected by process reload.

Process reload is the means by which we protect user keys in memory. once an account locks, it triggers a process reload (assuming no other accounts are unlocked), that frees renderer memory.

However, if the user is not unlocked, it is not protected by the process reload, so we may keep user keys in memory.

## Screenshots

<details>
<summary>Displayed when the requested user to unlock is not logged in or is locked on the desktop client</summary>
<img width="418" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/850f4f1b-7291-4ae7-a1f1-c713b486b4a5">
</details>

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
