### PR TITLE
[CL-289] fix text decoration in CL button and item-content

### DIFF
--- a/libs/components/src/button/button.component.ts
+++ b/libs/components/src/button/button.component.ts
@@ -69,6 +69,7 @@ export class ButtonComponent implements ButtonLikeAbstraction {
       "tw-border",
       "tw-border-solid",
       "tw-text-center",
+      "tw-no-underline",
       "hover:tw-no-underline",
       "focus:tw-outline-none",
     ]

--- a/libs/components/src/item/item-content.component.ts
+++ b/libs/components/src/item/item-content.component.ts
@@ -8,7 +8,7 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
   templateUrl: `item-content.component.html`,
   host: {
     class:
-      "fvw-target tw-outline-none tw-text-main hover:tw-text-main hover:tw-no-underline tw-text-base tw-py-2 tw-px-4 tw-bg-transparent tw-w-full tw-border-none tw-flex tw-gap-4 tw-items-center tw-justify-between",
+      "fvw-target tw-outline-none tw-text-main hover:tw-text-main tw-no-underline hover:tw-no-underline tw-text-base tw-py-2 tw-px-4 tw-bg-transparent tw-w-full tw-border-none tw-flex tw-gap-4 tw-items-center tw-justify-between",
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The button and item-content components should not have text decoration when used with an anchor element. This was missed due to certain global styles being present in the web app but not the extension.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

Before:
<img width="674" alt="Screenshot 2024-05-16 at 2 25 44 PM" src="https://github.com/bitwarden/clients/assets/17113462/ca15dcfa-c163-417d-999f-49b2622f0c3a">

After:



https://github.com/bitwarden/clients/assets/17113462/e3e942a9-d60b-468b-b660-5bc548eef087


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
