### PR TITLE
[PM-8156] Bugfix - Defer badge and menu state updates

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -196,8 +196,6 @@ export default class RuntimeBackground {
         }
 
         await this.notificationsService.updateConnection(msg.command === "loggedIn");
-        await this.main.refreshBadge();
-        await this.main.refreshMenu(false);
         this.systemService.cancelProcessReload();
 
         if (item) {
@@ -209,6 +207,13 @@ export default class RuntimeBackground {
             item,
           );
         }
+
+        // @TODO these need to happen last to avoid blocking `tabSendMessageData` above
+        // The underlying cause exists within `cipherService.getAllDecrypted` via
+        // `getAllDecryptedForUrl` and is anticipated to be refactored
+        await this.main.refreshBadge();
+        await this.main.refreshMenu(false);
+
         break;
       }
       case "addToLockedVaultPendingNotifications":


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix

## Objective

Resolve a scenario whereby a user whose account is locked logs into a form and attempts to save the entered credentials via the Bitwarden notification bar. They will be prompted to unlock their vault and upon successfully unlocking via the pop up window, will be left in a state where the notification bar does not dismiss, nor is the cipher saved.

## Code changes

`refreshBadge` appears to be blocking subsequent block calls from executing. The underlying cause has been traced to `cipherService.getAllDecrypted` (via `getAllDecryptedForUrl`), but for the short term, moving `refreshBadge` (and `refreshMenu`, which makes the same call) resolves these UX issues while we examine how to proceed in the long-term.

## Notes

- This fix also [requires the `multithreadDecryption` feature flag to be off](https://github.com/bitwarden/clients/pull/9221/files#diff-4b8a4df786a048d7e74dae64191d365c17cb40f625a545a7408ceb5ce5f1d7f9R482-R489)

## Screenshots

**Bug Demo**

https://github.com/bitwarden/clients/assets/1556494/8acfbed6-96f4-4c4a-a908-0365adab1c22

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
