### PR TITLE
Delay return of State Provider Update until `state$` is up to date

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -467,7 +467,10 @@ export default class MainBackground {
       this.largeObjectMemoryStorageForStateProviders,
     );
 
-    this.globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    this.globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      this.logService,
+    );
 
     const stateEventRegistrarService = new StateEventRegistrarService(
       this.globalStateProvider,
@@ -491,6 +494,7 @@ export default class MainBackground {
     this.singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      this.logService,
     );
     this.accountService = new AccountServiceImplementation(
       this.messagingService,

--- a/apps/browser/src/platform/background/service-factories/global-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/global-state-provider.factory.ts
@@ -21,6 +21,7 @@ export async function globalStateProviderFactory(
     cache,
     "globalStateProvider",
     opts,
-    async () => new DefaultGlobalStateProvider(await storageServiceProviderFactory(cache, opts)),
+    async () =>
+      new DefaultGlobalStateProvider(await storageServiceProviderFactory(cache, opts), null),
   );
 }

--- a/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
+++ b/apps/browser/src/platform/background/service-factories/single-user-state-provider.factory.ts
@@ -30,6 +30,7 @@ export async function singleUserStateProviderFactory(
       new DefaultSingleUserStateProvider(
         await storageServiceProviderFactory(cache, opts),
         await stateEventRegistrarServiceFactory(cache, opts),
+        null,
       ),
   );
 }

--- a/apps/cli/src/service-container.ts
+++ b/apps/cli/src/service-container.ts
@@ -283,7 +283,10 @@ export class ServiceContainer {
       this.memoryStorageForStateProviders,
     );
 
-    this.globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    this.globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      this.logService,
+    );
 
     const stateEventRegistrarService = new StateEventRegistrarService(
       this.globalStateProvider,
@@ -300,6 +303,7 @@ export class ServiceContainer {
     this.singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      this.logService,
     );
 
     this.messagingService = MessageSender.EMPTY;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -129,7 +129,10 @@ export class Main {
       this.storageService,
       this.memoryStorageForStateProviders,
     );
-    const globalStateProvider = new DefaultGlobalStateProvider(storageServiceProvider);
+    const globalStateProvider = new DefaultGlobalStateProvider(
+      storageServiceProvider,
+      this.logService,
+    );
 
     this.i18nService = new I18nMainService("en", "./locales/", globalStateProvider);
 
@@ -147,6 +150,7 @@ export class Main {
     const singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      this.logService,
     );
 
     const activeUserStateProvider = new DefaultActiveUserStateProvider(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1047,7 +1047,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: GlobalStateProvider,
     useClass: DefaultGlobalStateProvider,
-    deps: [StorageServiceProvider],
+    deps: [StorageServiceProvider, LogService],
   }),
   safeProvider({
     provide: ActiveUserStateProvider,
@@ -1057,7 +1057,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: SingleUserStateProvider,
     useClass: DefaultSingleUserStateProvider,
-    deps: [StorageServiceProvider, StateEventRegistrarService],
+    deps: [StorageServiceProvider, StateEventRegistrarService, LogService],
   }),
   safeProvider({
     provide: DerivedStateProvider,

--- a/libs/common/spec/fake-storage.service.ts
+++ b/libs/common/spec/fake-storage.service.ts
@@ -10,7 +10,8 @@ import { StorageOptions } from "../src/platform/models/domain/storage-options";
 
 export class FakeStorageService implements AbstractStorageService, ObservableStorageService {
   private store: Record<string, unknown>;
-  private updatesSubject = new Subject<StorageUpdate>();
+  // eslint-disable-next-line rxjs/no-exposed-subjects -- test class
+  updatesSubject = new Subject<StorageUpdate>();
   private _valuesRequireDeserialization = false;
 
   /**

--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -10,6 +10,7 @@ import { awaitAsync, trackEmissions } from "../../../../spec";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { AccountInfo } from "../../../auth/abstractions/account.service";
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { StateDefinition } from "../state-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
@@ -43,6 +44,7 @@ const testKeyDefinition = new UserKeyDefinition<TestState>(testStateDefinition, 
 
 describe("DefaultActiveUserState", () => {
   let diskStorageService: FakeStorageService;
+  const logService = mock<LogService>();
   const storageServiceProvider = mock<StorageServiceProvider>();
   const stateEventRegistrarService = mock<StateEventRegistrarService>();
   let activeAccountSubject: BehaviorSubject<{ id: UserId } & AccountInfo>;
@@ -58,6 +60,7 @@ describe("DefaultActiveUserState", () => {
     singleUserStateProvider = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      logService,
     );
 
     activeAccountSubject = new BehaviorSubject<{ id: UserId } & AccountInfo>(undefined);

--- a/libs/common/src/platform/state/implementations/default-global-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.provider.ts
@@ -1,3 +1,4 @@
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { GlobalState } from "../global-state";
 import { GlobalStateProvider } from "../global-state.provider";
@@ -8,7 +9,10 @@ import { DefaultGlobalState } from "./default-global-state";
 export class DefaultGlobalStateProvider implements GlobalStateProvider {
   private globalStateCache: Record<string, GlobalState<unknown>> = {};
 
-  constructor(private storageServiceProvider: StorageServiceProvider) {}
+  constructor(
+    private storageServiceProvider: StorageServiceProvider,
+    private logService: LogService,
+  ) {}
 
   get<T>(keyDefinition: KeyDefinition<T>): GlobalState<T> {
     const [location, storageService] = this.storageServiceProvider.get(
@@ -23,7 +27,11 @@ export class DefaultGlobalStateProvider implements GlobalStateProvider {
       return existingGlobalState as DefaultGlobalState<T>;
     }
 
-    const newGlobalState = new DefaultGlobalState<T>(keyDefinition, storageService);
+    const newGlobalState = new DefaultGlobalState<T>(
+      keyDefinition,
+      storageService,
+      this.logService,
+    );
 
     this.globalStateCache[cacheKey] = newGlobalState;
     return newGlobalState;

--- a/libs/common/src/platform/state/implementations/default-global-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.spec.ts
@@ -3,11 +3,13 @@
  * @jest-environment ../shared/test.environment.ts
  */
 
+import { mock } from "jest-mock-extended";
 import { firstValueFrom, of } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { trackEmissions, awaitAsync } from "../../../../spec";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
+import { LogService } from "../../abstractions/log.service";
 import { KeyDefinition, globalKeyBuilder } from "../key-definition";
 import { StateDefinition } from "../state-definition";
 
@@ -38,11 +40,12 @@ const globalKey = globalKeyBuilder(testKeyDefinition);
 describe("DefaultGlobalState", () => {
   let diskStorageService: FakeStorageService;
   let globalState: DefaultGlobalState<TestState>;
+  const logService = mock<LogService>();
   const newData = { date: new Date() };
 
   beforeEach(() => {
     diskStorageService = new FakeStorageService();
-    globalState = new DefaultGlobalState(testKeyDefinition, diskStorageService);
+    globalState = new DefaultGlobalState(testKeyDefinition, diskStorageService, logService);
   });
 
   afterEach(() => {

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -1,3 +1,4 @@
+import { LogService } from "../../abstractions/log.service";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -14,7 +15,8 @@ export class DefaultGlobalState<T>
   constructor(
     keyDefinition: KeyDefinition<T>,
     chosenLocation: AbstractStorageService & ObservableStorageService,
+    logService: LogService,
   ) {
-    super(globalKeyBuilder(keyDefinition), chosenLocation, keyDefinition);
+    super(globalKeyBuilder(keyDefinition), chosenLocation, keyDefinition, logService);
   }
 }

--- a/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
@@ -1,4 +1,5 @@
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { KeyDefinition } from "../key-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
@@ -14,6 +15,7 @@ export class DefaultSingleUserStateProvider implements SingleUserStateProvider {
   constructor(
     private readonly storageServiceProvider: StorageServiceProvider,
     private readonly stateEventRegistrarService: StateEventRegistrarService,
+    private readonly logService: LogService,
   ) {}
 
   get<T>(
@@ -40,6 +42,7 @@ export class DefaultSingleUserStateProvider implements SingleUserStateProvider {
       keyDefinition,
       storageService,
       this.stateEventRegistrarService,
+      this.logService,
     );
     this.cache[cacheKey] = newUserState;
     return newUserState;

--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -10,6 +10,7 @@ import { Jsonify } from "type-fest";
 import { trackEmissions, awaitAsync } from "../../../../spec";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import { Utils } from "../../misc/utils";
 import { StateDefinition } from "../state-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
@@ -45,6 +46,7 @@ describe("DefaultSingleUserState", () => {
   let diskStorageService: FakeStorageService;
   let userState: DefaultSingleUserState<TestState>;
   const stateEventRegistrarService = mock<StateEventRegistrarService>();
+  const logService = mock<LogService>();
   const newData = { date: new Date() };
 
   beforeEach(() => {
@@ -54,6 +56,7 @@ describe("DefaultSingleUserState", () => {
       testKeyDefinition,
       diskStorageService,
       stateEventRegistrarService,
+      logService,
     );
   });
 

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,6 +1,7 @@
 import { Observable, combineLatest, of } from "rxjs";
 
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import {
   AbstractStorageService,
   ObservableStorageService,
@@ -22,8 +23,9 @@ export class DefaultSingleUserState<T>
     keyDefinition: UserKeyDefinition<T>,
     chosenLocation: AbstractStorageService & ObservableStorageService,
     private stateEventRegistrarService: StateEventRegistrarService,
+    logService: LogService,
   ) {
-    super(keyDefinition.buildKey(userId), chosenLocation, keyDefinition);
+    super(keyDefinition.buildKey(userId), chosenLocation, keyDefinition, logService);
     this.combinedState$ = combineLatest([of(userId), this.state$]);
   }
 

--- a/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
+++ b/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "jest-mock-extended";
 import { mockAccountServiceWith } from "../../../../spec/fake-account-service";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { UserId } from "../../../types/guid";
+import { LogService } from "../../abstractions/log.service";
 import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { KeyDefinition } from "../key-definition";
 import { StateDefinition } from "../state-definition";
@@ -18,6 +19,7 @@ import { DefaultSingleUserStateProvider } from "./default-single-user-state.prov
 describe("Specific State Providers", () => {
   const storageServiceProvider = mock<StorageServiceProvider>();
   const stateEventRegistrarService = mock<StateEventRegistrarService>();
+  const logService = mock<LogService>();
 
   let singleSut: DefaultSingleUserStateProvider;
   let activeSut: DefaultActiveUserStateProvider;
@@ -33,9 +35,10 @@ describe("Specific State Providers", () => {
     singleSut = new DefaultSingleUserStateProvider(
       storageServiceProvider,
       stateEventRegistrarService,
+      logService,
     );
     activeSut = new DefaultActiveUserStateProvider(mockAccountServiceWith(null), singleSut);
-    globalSut = new DefaultGlobalStateProvider(storageServiceProvider);
+    globalSut = new DefaultGlobalStateProvider(storageServiceProvider, logService);
   });
 
   const fakeDiskStateDefinition = new StateDefinition("fake", "disk");

--- a/libs/common/src/platform/state/implementations/state-base.spec.ts
+++ b/libs/common/src/platform/state/implementations/state-base.spec.ts
@@ -1,0 +1,60 @@
+import { mock } from "jest-mock-extended";
+
+import { FakeStorageService, ObservableTracker } from "../../../../spec";
+import { StorageKey } from "../../../types/state";
+import { LogService } from "../../abstractions/log.service";
+import { KeyDefinition } from "../key-definition";
+import { StateDefinition } from "../state-definition";
+
+import { StateBase } from "./state-base";
+
+class TestStateBase extends StateBase<string, KeyDefinition<string>> {}
+
+describe("StateBase", () => {
+  const storageKey = "key" as StorageKey;
+  const stateDefinition = new StateDefinition("fake", "disk");
+  const keyDefinition = new KeyDefinition<string>(stateDefinition, "fake", {
+    deserializer: (value) => value,
+  });
+  const logService = mock<LogService>();
+
+  let storageService: FakeStorageService;
+  let sut: TestStateBase;
+
+  beforeEach(() => {
+    storageService = new FakeStorageService();
+    sut = new TestStateBase(storageKey, storageService, keyDefinition, logService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("awaits update until `state$` matches", async () => {
+    storageService.save = jest.fn().mockImplementation(
+      (key: string, obj: any) =>
+        new Promise<void>((resolve) => {
+          storageService.internalStore[key] = obj;
+          resolve();
+        }),
+    );
+
+    const updatePromise = sut.update(() => "new value");
+
+    await expect(promiseState(updatePromise)).resolves.toBe("pending");
+
+    const tracker = new ObservableTracker(sut.state$);
+    storageService.updatesSubject.next({ key: storageKey, updateType: "save" });
+    await tracker.expectEmission();
+
+    await expect(promiseState(updatePromise)).resolves.toBe("fulfilled");
+  });
+});
+
+function promiseState(p: Promise<any>) {
+  const t = {};
+  return Promise.race([p, t]).then(
+    (v) => (v === t ? "pending" : "fulfilled"),
+    () => "rejected",
+  );
+}

--- a/libs/common/src/platform/state/implementations/state-base.ts
+++ b/libs/common/src/platform/state/implementations/state-base.ts
@@ -27,6 +27,7 @@ import { getStoredValue } from "./util";
 // The parts of a KeyDefinition this class cares about to make it work
 type KeyDefinitionRequirements<T> = {
   deserializer: (jsonState: Jsonify<T>) => T;
+  equalityComparer: (a: T, b: T) => boolean;
   cleanupDelayMs: number;
 };
 
@@ -77,7 +78,7 @@ export abstract class StateBase<T, KeyDef extends KeyDefinitionRequirements<T>> 
       const newState = await this.updatePromise;
       await firstValueFrom(
         this.state$.pipe(
-          filter((s) => JSON.stringify(s) === JSON.stringify(newState)),
+          filter((s) => this.keyDefinition.equalityComparer(s, newState)),
           mergeWith(
             timer(50).pipe(tap(() => this.logService.warning("emitting anyway", this.key))),
           ),


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The state providers framework has the challenge of attempting to create observable data with async interfaces. One of the known eccentricities with this is that the `update` method can return before the `state$` observable emits. As such, it's a bad idea to: 

```typescript
await state.update(() => false);
const expectUpdated = await firstValueFrom(state.state$);
```

For this reason, we return the current value from the `update` method. However, closing this gap would be quite nice. This PR adds equality comparison to Definitions, defaulting to JSON equality, and uses it to determine when `state$` has picked up a newly saved value.

For safety, I've added a timer that reverts to the old behavior, but in practice I haven't seen this fallback hit.

We've also discussed using this technique to limit IO to the storage service. I had trouble implementing this cleanly, however. There seem to be cases where you don't need to update storage, but you DO need to emit a new value to `state$`. This might be the exact same race discussed above, but I felt we need more research into the root cause of this. It would be nice to not only reduce IO ops, but also to reduce emits from `state$`, given that they are potentially a trigger for a lot of work.

## Code changes

Most of these changes are wiring changes to get a log service available to state base.

- **state-base**: track whether the state was saved and wait for `state$` to emit it.
- **key definition / user definition**: 
  - add `equalityComparer` to options
  - default to JSON comparison
  - add array and record equality comparisons

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
