### PR TITLE
[PM-5938] Prevent vault coruption on key-rotation on desycned vault

### DIFF
--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
@@ -17,6 +17,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { Folder } from "@bitwarden/common/vault/models/domain/folder";
@@ -49,6 +50,7 @@ describe("KeyRotationService", () => {
   let mockStateService: MockProxy<StateService>;
   let mockConfigService: MockProxy<ConfigService>;
   let mockKdfConfigService: MockProxy<KdfConfigService>;
+  let mockSyncService: MockProxy<SyncService>;
 
   const mockUserId = Utils.newGuid() as UserId;
   const mockAccountService: FakeAccountService = mockAccountServiceWith(mockUserId);
@@ -68,6 +70,7 @@ describe("KeyRotationService", () => {
     mockStateService = mock<StateService>();
     mockConfigService = mock<ConfigService>();
     mockKdfConfigService = mock<KdfConfigService>();
+    mockSyncService = mock<SyncService>();
 
     keyRotationService = new UserKeyRotationService(
       mockMasterPasswordService,
@@ -83,6 +86,7 @@ describe("KeyRotationService", () => {
       mockStateService,
       mockAccountService,
       mockKdfConfigService,
+      mockSyncService,
     );
   });
 

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -13,6 +13,7 @@ import { SendService } from "@bitwarden/common/tools/send/services/send.service.
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { CipherWithIdRequest } from "@bitwarden/common/vault/models/request/cipher-with-id.request";
 import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 
@@ -38,6 +39,7 @@ export class UserKeyRotationService {
     private stateService: StateService,
     private accountService: AccountService,
     private kdfConfigService: KdfConfigService,
+    private syncService: SyncService,
   ) {}
 
   /**
@@ -47,6 +49,12 @@ export class UserKeyRotationService {
   async rotateUserKeyAndEncryptedData(masterPassword: string): Promise<void> {
     if (!masterPassword) {
       throw new Error("Invalid master password");
+    }
+
+    if ((await this.syncService.getLastSync()) === null) {
+      throw new Error(
+        "The local vault is de-synced and the keys cannot be rotated. Please log out and log back in to resolve this issue.",
+      );
     }
 
     // Create master key to validate the master password

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -57,6 +57,15 @@ export class UserKeyRotationService {
       );
     }
 
+    if (
+      (await this.cipherService.getAllDecrypted()).length === 0 &&
+      (await this.cipherService.getAll()).length > 0
+    ) {
+      throw new Error(
+        "The local vaults could not be decrypted and the keys cannot be rotated. Please log out and log back in to resolve this issue.",
+      );
+    }
+
     // Create master key to validate the master password
     const masterKey = await this.cryptoService.makeMasterKey(
       masterPassword,

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -57,15 +57,6 @@ export class UserKeyRotationService {
       );
     }
 
-    if (
-      (await this.cipherService.getAllDecrypted()).length === 0 &&
-      (await this.cipherService.getAll()).length > 0
-    ) {
-      throw new Error(
-        "The local vaults could not be decrypted and the keys cannot be rotated. Please log out and log back in to resolve this issue.",
-      );
-    }
-
     // Create master key to validate the master password
     const masterKey = await this.cryptoService.makeMasterKey(
       masterPassword,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds client side guardrails on key rotation to prevent corrupting the vault when
- Sync requests timed out/failed
- Local cipher decryption failed

Reproduction steps for the corruption this prevents are here: #7709
Server side check for ciphers here: https://github.com/bitwarden/server/pull/4098

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
