### PR TITLE
[CL-290] make popup layout grow to full height

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.mdx
+++ b/apps/browser/src/platform/popup/layout/popup-layout.mdx
@@ -136,3 +136,9 @@ When the browser extension is popped out, the "popout" button should not be pass
 <Canvas>
   <Story of={stories.PoppedOut} />
 </Canvas>
+
+## Centered Content
+
+<Canvas>
+  <Story of={stories.CenteredContent} />
+</Canvas>

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -11,6 +11,7 @@ import {
   I18nMockService,
   IconButtonModule,
   ItemModule,
+  NoItemsModule,
 } from "@bitwarden/components";
 
 import { PopupFooterComponent } from "./popup-footer.component";
@@ -289,6 +290,9 @@ export default {
     moduleMetadata({
       imports: [
         PopupTabNavigationComponent,
+        PopupHeaderComponent,
+        PopupPageComponent,
+        PopupFooterComponent,
         CommonModule,
         RouterModule,
         ExtensionContainerComponent,
@@ -298,6 +302,7 @@ export default {
         MockGeneratorPageComponent,
         MockSettingsPageComponent,
         MockVaultPagePoppedComponent,
+        NoItemsModule,
       ],
       providers: [
         {
@@ -375,6 +380,27 @@ export const PoppedOut: Story = {
       <div class="tw-h-[640px] tw-w-[900px] tw-border tw-border-solid tw-border-secondary-300">
         <mock-vault-page-popped></mock-vault-page-popped>
       </div>
+    `,
+  }),
+};
+
+export const CenteredContent: Story = {
+  render: (args) => ({
+    props: args,
+    template: /* HTML */ `
+      <extension-container>
+        <popup-tab-navigation>
+          <popup-page>
+            <popup-header slot="header" pageTitle="Centered Content"></popup-header>
+            <div class="tw-h-full tw-flex tw-items-center tw-justify-center">
+              <bit-no-items>
+                <ng-container slot="title">Before centering a div</ng-container>
+                <ng-container slot="description">One must first center oneself</ng-container>
+              </bit-no-items>
+            </div>
+          </popup-page>
+        </popup-tab-navigation>
+      </extension-container>
     `,
   }),
 };

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -392,7 +392,7 @@ export const CenteredContent: Story = {
         <popup-tab-navigation>
           <popup-page>
             <popup-header slot="header" pageTitle="Centered Content"></popup-header>
-            <div class="tw-h-full tw-flex tw-items-center tw-justify-center">
+            <div class="tw-h-full tw-flex tw-items-center tw-justify-center tw-text-main">
               <bit-no-items>
                 <ng-container slot="title">Before centering a div</ng-container>
                 <ng-container slot="description">One must first center oneself</ng-container>

--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -1,6 +1,6 @@
 <ng-content select="[slot=header]"></ng-content>
-<main class="tw-bg-background-alt tw-p-3 tw-flex-1 tw-overflow-y-auto">
-  <div class="tw-max-w-screen-sm tw-mx-auto">
+<main class="tw-bg-background-alt tw-p-3 tw-flex-1 tw-overflow-y-auto tw-h-full">
+  <div class="tw-max-w-screen-sm tw-mx-auto tw-h-full">
     <ng-content></ng-content>
   </div>
 </main>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The extension layout component should grow to fill 100% of the available height. Otherwise, devs will be unable to vertically center page content. See: https://github.com/bitwarden/clients/pull/9199#issuecomment-2113504341

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/platform/popup/layout/popup-layout.stories.ts:** Add story
- **apps/browser/src/platform/popup/layout/popup-page.component.html:** propogate `tw-h-full` down element tree

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
