### PR TITLE
[PM-6789] add legacy user key state

### DIFF
--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
@@ -28,7 +28,6 @@ import {
   mockAccountServiceWith,
 } from "../../../../../../libs/common/spec/fake-account-service";
 import { OrganizationUserResetPasswordService } from "../../admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service";
-import { StateService } from "../../core";
 import { EmergencyAccessService } from "../emergency-access";
 
 import { UserKeyRotationApiService } from "./user-key-rotation-api.service";
@@ -46,7 +45,6 @@ describe("KeyRotationService", () => {
   let mockDeviceTrustService: MockProxy<DeviceTrustServiceAbstraction>;
   let mockCryptoService: MockProxy<CryptoService>;
   let mockEncryptService: MockProxy<EncryptService>;
-  let mockStateService: MockProxy<StateService>;
   let mockConfigService: MockProxy<ConfigService>;
   let mockKdfConfigService: MockProxy<KdfConfigService>;
 
@@ -65,7 +63,6 @@ describe("KeyRotationService", () => {
     mockDeviceTrustService = mock<DeviceTrustServiceAbstraction>();
     mockCryptoService = mock<CryptoService>();
     mockEncryptService = mock<EncryptService>();
-    mockStateService = mock<StateService>();
     mockConfigService = mock<ConfigService>();
     mockKdfConfigService = mock<KdfConfigService>();
 
@@ -80,7 +77,6 @@ describe("KeyRotationService", () => {
       mockDeviceTrustService,
       mockCryptoService,
       mockEncryptService,
-      mockStateService,
       mockAccountService,
       mockKdfConfigService,
     );

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -7,7 +7,6 @@ import { KdfConfigService } from "@bitwarden/common/auth/abstractions/kdf-config
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/auth/abstractions/master-password.service.abstraction";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { EncryptedString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -35,7 +34,6 @@ export class UserKeyRotationService {
     private deviceTrustService: DeviceTrustServiceAbstraction,
     private cryptoService: CryptoService,
     private encryptService: EncryptService,
-    private stateService: StateService,
     private accountService: AccountService,
     private kdfConfigService: KdfConfigService,
   ) {}

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -106,12 +106,16 @@ export class CryptoService implements CryptoServiceAbstraction {
     const activeUserKeyWithLegacySupport$ = this.activeUserKey$.pipe(
       combineLatestWith(this.stateProvider.activeUserId$),
       switchMap(async ([userKey, userId]) => {
+        const masterKey = await firstValueFrom(this.masterPasswordService.masterKey$(userId));
+        return [userKey, masterKey, userId];
+      }),
+      switchMap(async ([userKey, masterKey, userId]: [UserKey, MasterKey, UserId]) => {
         if (userKey != null) {
           return userKey;
         }
 
-        if (await this.isLegacyUser(null, userId)) {
-          return await this.getUserKeyWithLegacySupport(userId);
+        if (await this.isLegacyUser(masterKey, userId)) {
+          return masterKey;
         }
       }),
     );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When we migrated private keys to state providers, we didn't account for legacy user keys. Without being able to decrypt the private key using the legacy key (master key) we couldn't migrate the legacy users. This adds a `activeUserKeyWithLegacySupport$` observable to pass in the derived state so it can correctly decrypt the private key.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
