### PR TITLE
Ps/pm-8197/clean-up-desktop-biometric-ipc

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -411,7 +411,8 @@ export class AppComponent implements OnInit, OnDestroy {
                 this.masterPasswordService.forceSetPasswordReason$(message.userId),
               )) != ForceSetPasswordReason.None;
             if (locked) {
-              this.messagingService.send("locked", { userId: message.userId });
+              this.modalService.closeAll();
+              await this.router.navigate(["lock"]);
             } else if (forcedPasswordReset) {
               // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
               // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -174,7 +174,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     userId ??= await firstValueFrom(this.stateProvider.activeUserId$);
     masterKey ??= await firstValueFrom(this.masterPasswordService.masterKey$(userId));
 
-    return await this.validateUserKey(masterKey as unknown as UserKey);
+    return await this.validateUserKey(masterKey as unknown as UserKey, userId);
   }
 
   // TODO: legacy support for user key is no longer needed since we require users to migrate on login
@@ -195,7 +195,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   async getUserKeyFromStorage(keySuffix: KeySuffixOptions, userId?: UserId): Promise<UserKey> {
     const userKey = await this.getKeyFromStorage(keySuffix, userId);
     if (userKey) {
-      if (!(await this.validateUserKey(userKey))) {
+      if (!(await this.validateUserKey(userKey, userId))) {
         this.logService.warning("Invalid key, throwing away stored keys");
         await this.clearAllStoredUserKeys(userId);
       }
@@ -663,13 +663,15 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   // ---HELPERS---
-  protected async validateUserKey(key: UserKey): Promise<boolean> {
+  protected async validateUserKey(key: UserKey, userId: UserId): Promise<boolean> {
     if (!key) {
       return false;
     }
 
     try {
-      const encPrivateKey = await firstValueFrom(this.activeUserEncryptedPrivateKeyState.state$);
+      const encPrivateKey = await firstValueFrom(
+        this.stateProvider.getUserState$(USER_ENCRYPTED_PRIVATE_KEY, userId),
+      );
       if (encPrivateKey == null) {
         return false;
       }

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -193,6 +193,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   async getUserKeyFromStorage(keySuffix: KeySuffixOptions, userId?: UserId): Promise<UserKey> {
+    userId ??= await firstValueFrom(this.stateProvider.activeUserId$);
     const userKey = await this.getKeyFromStorage(keySuffix, userId);
     if (userKey) {
       if (!(await this.validateUserKey(userKey, userId))) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Removes two bugs
1. Browser -> Desktop biometrics integration can occasionally remove desktop biometric keys upon successful login. This was occuring due to migration code triggering a failed validation of the current user if the requested biometric key was for a non-active user.
2. Desktop was triggering a process reload due to messaging `"locked"` when account switching to a locked account. this isn't necessary since the account isn't newly locked, we just have to navigate to the lock screen and close modals.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
