### PR TITLE
Auth/PM-5501 - VaultTimeoutSettingsSvc State Provider Migration - Cleanup desktop orphaned data

### DIFF
--- a/libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.spec.ts
+++ b/libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.spec.ts
@@ -13,6 +13,10 @@ import {
 // Represents data in state service pre-migration
 function preMigrationJson() {
   return {
+    // desktop only global data format
+    "global.vaultTimeout": -1,
+    "global.vaultTimeoutAction": "lock",
+
     global: {
       vaultTimeout: 30,
       vaultTimeoutAction: "lock",
@@ -266,6 +270,10 @@ describe("VaultTimeoutSettingsServiceStateProviderMigrator", () => {
         // no longer has vault timeout data
         otherStuff: "otherStuff",
       });
+
+      // Expect we removed desktop specially formatted global data
+      expect(helper.remove).toHaveBeenCalledWith("global\\.vaultTimeout");
+      expect(helper.remove).toHaveBeenCalledWith("global\\.vaultTimeoutAction");
 
       // User data
       expect(helper.set).toHaveBeenCalledWith("user1", {

--- a/libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.ts
+++ b/libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.ts
@@ -122,10 +122,15 @@ export class VaultTimeoutSettingsServiceStateProviderMigrator extends Migrator<6
 
     await Promise.all([...accounts.map(({ userId, account }) => migrateAccount(userId, account))]);
 
-    // Delete global data
+    // Delete global data (works for browser extension and web; CLI doesn't have these as global settings).
     delete globalData?.vaultTimeout;
     delete globalData?.vaultTimeoutAction;
     await helper.set("global", globalData);
+
+    // Remove desktop only settings. These aren't found by the above global key removal b/c of
+    // the different storage key format. This removal does not cause any issues on migrating for other clients.
+    await helper.remove("global\\.vaultTimeout");
+    await helper.remove("global\\.vaultTimeoutAction");
   }
 
   async rollback(helper: MigrationHelper): Promise<void> {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[PM-5501](https://bitwarden.atlassian.net/browse/PM-5501)
To remove the global vault timeout data **on desktop** as it is no longer referenced or used. It was stored in a different key format which meant that the migration which successfully deleted the global data on other clients didn't work on desktop. 

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.ts:** Remove desktop formatted global values
- **libs/common/src/state-migrations/migrations/62-migrate-vault-timeout-settings-svc-to-state-provider.spec.ts** Test change

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)


[PM-5501]: https://bitwarden.atlassian.net/browse/PM-5501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ