### PR TITLE
[PM-3050] Add sync on unlock, logout when account is deleted

### DIFF
--- a/apps/browser/src/auth/popup/lock.component.ts
+++ b/apps/browser/src/auth/popup/lock.component.ts
@@ -25,6 +25,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 
 import { BiometricErrors, BiometricErrorTypes } from "../../models/biometricErrors";
@@ -68,6 +69,7 @@ export class LockComponent extends BaseLockComponent {
     biometricStateService: BiometricStateService,
     accountService: AccountService,
     kdfConfigService: KdfConfigService,
+    syncService: SyncService,
   ) {
     super(
       masterPasswordService,
@@ -94,6 +96,7 @@ export class LockComponent extends BaseLockComponent {
       accountService,
       authService,
       kdfConfigService,
+      syncService,
     );
     this.successRoute = "/tabs/current";
     this.isInitialLockScreen = (window as any).previousPopupUrl == null;

--- a/apps/desktop/src/auth/lock.component.spec.ts
+++ b/apps/desktop/src/auth/lock.component.spec.ts
@@ -32,6 +32,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { UserId } from "@bitwarden/common/types/guid";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 
 import { LockComponent } from "./lock.component";
@@ -173,6 +174,10 @@ describe("LockComponent", () => {
         {
           provide: KdfConfigService,
           useValue: mock<KdfConfigService>(),
+        },
+        {
+          provide: SyncService,
+          useValue: mock<SyncService>(),
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/apps/desktop/src/auth/lock.component.ts
+++ b/apps/desktop/src/auth/lock.component.ts
@@ -26,6 +26,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { BiometricStateService } from "@bitwarden/common/platform/biometrics/biometric-state.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 
 const BroadcasterSubscriptionId = "LockComponent";
@@ -67,6 +68,7 @@ export class LockComponent extends BaseLockComponent {
     accountService: AccountService,
     authService: AuthService,
     kdfConfigService: KdfConfigService,
+    syncService: SyncService,
   ) {
     super(
       masterPasswordService,
@@ -93,6 +95,7 @@ export class LockComponent extends BaseLockComponent {
       accountService,
       authService,
       kdfConfigService,
+      syncService,
     );
   }
 

--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -33,6 +33,7 @@ import { HashPurpose, KeySuffixOptions } from "@bitwarden/common/platform/enums"
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 
 @Directive()
@@ -85,6 +86,7 @@ export class LockComponent implements OnInit, OnDestroy {
     protected accountService: AccountService,
     protected authService: AuthService,
     protected kdfConfigService: KdfConfigService,
+    protected syncService: SyncService,
   ) {}
 
   async ngOnInit() {
@@ -317,6 +319,9 @@ export class LockComponent implements OnInit, OnDestroy {
         this.logService.error(e);
       }
     }
+
+    // Vault can be de-synced since notifications get ignored while locked. Need to check whether sync is required using the sync service.
+    await this.syncService.fullSync(false);
 
     if (this.onSuccessfulSubmit != null) {
       await this.onSuccessfulSubmit();

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -145,6 +145,13 @@ export class SyncService extends CoreSyncService {
     }
 
     const response = await this.apiService.getAccountRevisionDate();
+    if (response < 0) {
+      // account was deleted, log out now
+      if (this.logoutCallback != null) {
+        await this.logoutCallback(false);
+      }
+    }
+
     if (new Date(response) <= lastSync) {
       return false;
     }

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -146,13 +146,8 @@ export class SyncService extends CoreSyncService {
 
     const response = await this.apiService.getAccountRevisionDate();
     if (response < 0 && this.logoutCallback) {
-          // Account was deleted, log out now
-          await this.logoutCallback(false);
-    }
-      // account was deleted, log out now
-      if (this.logoutCallback != null) {
-        await this.logoutCallback(false);
-      }
+      // Account was deleted, log out now
+      await this.logoutCallback(false);
     }
 
     if (new Date(response) <= lastSync) {

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -145,7 +145,10 @@ export class SyncService extends CoreSyncService {
     }
 
     const response = await this.apiService.getAccountRevisionDate();
-    if (response < 0) {
+    if (response < 0 && this.logoutCallback) {
+          // Account was deleted, log out now
+          await this.logoutCallback(false);
+    }
       // account was deleted, log out now
       if (this.logoutCallback != null) {
         await this.logoutCallback(false);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Notifications for logout or account changes are only processed while an account is unlocked. This means that if an account change occurs while locked, or the account gets deleted while locked, the client (browser/desktop) does not know about this, even after unlocking. This leads to items being desynced, and if the account was deleted, the client is in a broken state.

This PR fixes that, by, upon unlock checking if a full sync is required. Since fullSync checks the account revision timestamp, the "expensive" full sync only happens when needed, and thus prevents a desynced state. Further, the account revision timestamp is negative if (and only if) the account was deleted. In this case we log the client out. (We might want to change this on the server side to give a proper error noting that the account does not exist).

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
