### PR TITLE
Prefer prefetching keys

### DIFF
--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -5,6 +5,7 @@ import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 
 import { EncryptionType } from "../src/platform/enums";
 import { Utils } from "../src/platform/misc/utils";
+import { SymmetricCryptoKey } from "../src/platform/models/domain/symmetric-crypto-key";
 
 function newGuid() {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -43,6 +44,10 @@ export function makeStaticByteArray(length: number, start = 0) {
     arr[i] = start + i;
   }
   return arr;
+}
+
+export function makeSymmetricCryptoKey<T extends SymmetricCryptoKey>(length: 32 | 64 = 64) {
+  return new SymmetricCryptoKey(makeStaticByteArray(length)) as T;
 }
 
 /**

--- a/libs/common/src/vault/models/domain/collection.spec.ts
+++ b/libs/common/src/vault/models/domain/collection.spec.ts
@@ -1,5 +1,6 @@
-import { mockEnc } from "../../../../spec";
+import { makeSymmetricCryptoKey, mockEnc } from "../../../../spec";
 import { CollectionId, OrganizationId } from "../../../types/guid";
+import { OrgKey } from "../../../types/key";
 import { CollectionData } from "../data/collection.data";
 
 import { Collection } from "./collection";
@@ -51,14 +52,16 @@ describe("Collection", () => {
   it("Decrypt", async () => {
     const collection = new Collection();
     collection.id = "id";
-    collection.organizationId = "orgId";
+    collection.organizationId = "orgId" as OrganizationId;
     collection.name = mockEnc("encName");
     collection.externalId = "extId";
     collection.readOnly = false;
     collection.hidePasswords = false;
     collection.manage = true;
 
-    const view = await collection.decrypt();
+    const key = makeSymmetricCryptoKey<OrgKey>();
+
+    const view = await collection.decrypt(key);
 
     expect(view).toEqual({
       addAccess: false,

--- a/libs/common/src/vault/models/domain/collection.ts
+++ b/libs/common/src/vault/models/domain/collection.ts
@@ -1,5 +1,6 @@
 import Domain from "../../../platform/models/domain/domain-base";
 import { EncString } from "../../../platform/models/domain/enc-string";
+import { OrgKey } from "../../../types/key";
 import { CollectionData } from "../data/collection.data";
 import { CollectionView } from "../view/collection.view";
 
@@ -34,13 +35,14 @@ export class Collection extends Domain {
     );
   }
 
-  decrypt(): Promise<CollectionView> {
+  decrypt(orgKey: OrgKey): Promise<CollectionView> {
     return this.decryptObj(
       new CollectionView(this),
       {
         name: null,
       },
       this.organizationId,
+      orgKey,
     );
   }
 }

--- a/libs/common/src/vault/services/collection.service.ts
+++ b/libs/common/src/vault/services/collection.service.ts
@@ -12,7 +12,7 @@ import {
   DeriveDefinition,
   DerivedState,
 } from "../../platform/state";
-import { CollectionId, UserId } from "../../types/guid";
+import { CollectionId, OrganizationId, UserId } from "../../types/guid";
 import { CollectionService as CollectionServiceAbstraction } from "../../vault/abstractions/collection.service";
 import { CollectionData } from "../models/data/collection.data";
 import { Collection } from "../models/domain/collection";
@@ -108,9 +108,16 @@ export class CollectionService implements CollectionServiceAbstraction {
       return [];
     }
     const decCollections: CollectionView[] = [];
+
+    const organizationKeys = await firstValueFrom(this.cryptoService.activeUserOrgKeys$);
+
     const promises: Promise<any>[] = [];
     collections.forEach((collection) => {
-      promises.push(collection.decrypt().then((c) => decCollections.push(c)));
+      promises.push(
+        collection
+          .decrypt(organizationKeys[collection.organizationId as OrganizationId])
+          .then((c) => decCollections.push(c)),
+      );
     });
     await Promise.all(promises);
     return decCollections.sort(Utils.getSortFunction(this.i18nService, "name"));

--- a/libs/importer/src/importers/bitwarden/bitwarden-json-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-json-importer.ts
@@ -1,3 +1,5 @@
+import { firstValueFrom } from "rxjs";
+
 import { PinServiceAbstraction } from "@bitwarden/auth/common";
 import {
   CipherWithIdExport,
@@ -7,6 +9,7 @@ import {
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
@@ -194,7 +197,9 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
       if (data.encrypted) {
         const collection = CollectionWithIdExport.toDomain(c);
         collection.organizationId = this.organizationId;
-        collectionView = await collection.decrypt();
+        collectionView = await firstValueFrom(this.cryptoService.activeUserOrgKeys$).then(
+          (orgKeys) => collection.decrypt(orgKeys[c.organizationId as OrganizationId]),
+        );
       } else {
         collectionView = CollectionWithIdExport.toView(c);
         collectionView.organizationId = null;


### PR DESCRIPTION
magical black-box key retrieval is slow, due to needing to repeatedly resolve (and potentially decrypt) keys. Doing the work up front is both more explicit and much faster.

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The collection service was using auto-magical key resolutions to decrypt collections, which is slow due to repeated retrieval and potentially needing to redecrypt the custody chain for the user’s keys many times.

That particular user is laggy in the tab and vault views, likely for similar reasons.


This slowness was revealed through testing upgrade paths rather than just identifying it from fresh installs. What doesn’t make sense is why the upgrade path reveals these issues. There may be something deeper here that this fix patches over by better practices in key handling.

## Code changes

There are only two real changes here, and then bubbled through updates to comply with these changes

1. The collection domain now requires an `OrgKey` to its `decrypt` method.
2. Using opaque typed OrganizationIds

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
