### PR TITLE
[PM-8314] [WIP] hide sso button

### DIFF
--- a/apps/browser/src/auth/popup/login.component.ts
+++ b/apps/browser/src/auth/popup/login.component.ts
@@ -10,6 +10,7 @@ import {
   LoginEmailServiceAbstraction,
   RegisterRouteService,
 } from "@bitwarden/auth/common";
+import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
@@ -20,6 +21,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
@@ -53,6 +55,8 @@ export class LoginComponent extends BaseLoginComponent {
     ssoLoginService: SsoLoginServiceAbstraction,
     webAuthnLoginService: WebAuthnLoginServiceAbstraction,
     registerRouteService: RegisterRouteService,
+    orgDomainApiService: OrgDomainApiServiceAbstraction,
+    validationService: ValidationService,
   ) {
     super(
       devicesApiService,
@@ -74,6 +78,8 @@ export class LoginComponent extends BaseLoginComponent {
       ssoLoginService,
       webAuthnLoginService,
       registerRouteService,
+      orgDomainApiService,
+      validationService,
     );
     super.onSuccessfulLogin = async () => {
       await syncService.fullSync(true);

--- a/apps/desktop/src/auth/login/login.component.ts
+++ b/apps/desktop/src/auth/login/login.component.ts
@@ -11,6 +11,7 @@ import {
   LoginEmailServiceAbstraction,
   RegisterRouteService,
 } from "@bitwarden/auth/common";
+import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
@@ -23,6 +24,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 
@@ -73,6 +75,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     ssoLoginService: SsoLoginServiceAbstraction,
     webAuthnLoginService: WebAuthnLoginServiceAbstraction,
     registerRouteService: RegisterRouteService,
+    orgDomainApiService: OrgDomainApiServiceAbstraction,
+    validationService: ValidationService,
   ) {
     super(
       devicesApiService,
@@ -94,6 +98,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
       ssoLoginService,
       webAuthnLoginService,
       registerRouteService,
+      orgDomainApiService,
+      validationService,
     );
     super.onSuccessfulLogin = () => {
       return syncService.fullSync(true);

--- a/apps/web/src/app/auth/login/login.component.html
+++ b/apps/web/src/app/auth/login/login.component.html
@@ -48,12 +48,12 @@
 
     <p class="tw-m-0 tw-text-sm">
       {{ "newAroundHere" | i18n }}
-      <!-- Two notes:  
-           (1) We check the value and validity of email so we don't send an invalid email to autofill 
+      <!-- Two notes:
+           (1) We check the value and validity of email so we don't send an invalid email to autofill
            on load of register for both enter and mouse based navigation
-           (2) We use mousedown to trigger navigation so that the onBlur form validation does not fire 
-           and move the create account link down the page on click which causes the user to miss actually 
-           clicking on the link. Mousedown fires before onBlur. 
+           (2) We use mousedown to trigger navigation so that the onBlur form validation does not fire
+           and move the create account link down the page on click which causes the user to miss actually
+           clicking on the link. Mousedown fires before onBlur.
       -->
       <a
         [routerLink]="registerRoute$ | async"
@@ -102,7 +102,7 @@
       </button>
     </div>
 
-    <div class="tw-mb-3">
+    <div class="tw-mb-3" *ngIf="showSSO">
       <a
         routerLink="/sso"
         [queryParams]="{ email: formGroup.value.email }"

--- a/apps/web/src/app/auth/login/login.component.ts
+++ b/apps/web/src/app/auth/login/login.component.ts
@@ -11,6 +11,7 @@ import {
   LoginEmailServiceAbstraction,
   RegisterRouteService,
 } from "@bitwarden/auth/common";
+import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyData } from "@bitwarden/common/admin-console/models/data/policy.data";
@@ -26,6 +27,7 @@ import { EnvironmentService } from "@bitwarden/common/platform/abstractions/envi
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 
@@ -69,6 +71,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit {
     ssoLoginService: SsoLoginServiceAbstraction,
     webAuthnLoginService: WebAuthnLoginServiceAbstraction,
     registerRouteService: RegisterRouteService,
+    orgDomainApiService: OrgDomainApiServiceAbstraction,
+    validationService: ValidationService,
   ) {
     super(
       devicesApiService,
@@ -90,6 +94,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit {
       ssoLoginService,
       webAuthnLoginService,
       registerRouteService,
+      orgDomainApiService,
+      validationService,
     );
     this.onSuccessfulLoginNavigate = this.goAfterLogIn;
     this.showPasswordless = flagEnabled("showPasswordless");

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,14 @@
         "@bitwarden/vault-export-core": "file:../tools/export/vault-export/vault-export-core"
       }
     },
+    "libs/importer/node_modules/@bitwarden/vault-export-core": {
+      "version": "0.0.0",
+      "resolved": "file:libs/tools/export/vault-export/vault-export-core",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@bitwarden/common": "file:../../../../common"
+      }
+    },
     "libs/node": {
       "name": "@bitwarden/node",
       "version": "0.0.0",
@@ -310,6 +318,7 @@
     "libs/tools/export/vault-export/vault-export-core": {
       "name": "@bitwarden/vault-export-core",
       "version": "0.0.0",
+      "extraneous": true,
       "license": "GPL-3.0",
       "dependencies": {
         "@bitwarden/common": "file:../../../../common"
@@ -4412,10 +4421,6 @@
     },
     "node_modules/@bitwarden/vault": {
       "resolved": "libs/vault",
-      "link": true
-    },
-    "node_modules/@bitwarden/vault-export-core": {
-      "resolved": "libs/tools/export/vault-export/vault-export-core",
       "link": true
     },
     "node_modules/@bitwarden/web-vault": {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ x] Other
```

## Objective

Toggle the SSO button visibility.

## Code changes

The idea is to call the `/api/organizations/domain/sso/details` endpoint earlier and toggle the SSO button visibility depending on the `ssoAvailable` value.

Since this is just a WIP to test the idea just made a quick modification of the web client.
This could be expended to allow to hide the password field if the SSO login is [required](https://bitwarden.com/help/policies/#require-single-sign-on-authentication).

And lastly I'm sorry if this proposition does not really make sense in specific flow (I'm not testing with the official server).
Have a nice day :).