### PR TITLE
[PM-8311] Bugfix - Revert CL-287 and fix typo

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/current-account.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/current-account.component.ts
@@ -1,15 +1,13 @@
-import { CommonModule, Location } from "@angular/common";
+import { Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Observable, combineLatest, switchMap } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UserId } from "@bitwarden/common/types/guid";
-import { AvatarModule } from "@bitwarden/components";
 
 export type CurrentAccount = {
   id: UserId;
@@ -22,8 +20,6 @@ export type CurrentAccount = {
 @Component({
   selector: "app-current-account",
   templateUrl: "current-account.component.html",
-  standalone: true,
-  imports: [CommonModule, JslibModule, AvatarModule],
 })
 export class CurrentAccountComponent {
   currentAccount$: Observable<CurrentAccount>;

--- a/apps/browser/src/autofill/popup/settings/notifications.component.ts
+++ b/apps/browser/src/autofill/popup/settings/notifications.component.ts
@@ -10,7 +10,7 @@ import { enableAccountSwitching } from "../../../platform/flags";
   selector: "autofill-notification-settings",
   templateUrl: "notifications.component.html",
 })
-export class NotifcationsSettingsComponent implements OnInit {
+export class NotificationsSettingsComponent implements OnInit {
   enableAddLoginNotification = false;
   enableChangedPasswordNotification = false;
   enablePasskeys = true;

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -28,7 +28,7 @@ import { TwoFactorComponent } from "../auth/popup/two-factor.component";
 import { UpdateTempPasswordComponent } from "../auth/popup/update-temp-password.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { ExcludedDomainsComponent } from "../autofill/popup/settings/excluded-domains.component";
-import { NotifcationsSettingsComponent } from "../autofill/popup/settings/notifications.component";
+import { NotificationsSettingsComponent } from "../autofill/popup/settings/notifications.component";
 import { PremiumComponent } from "../billing/popup/settings/premium.component";
 import BrowserPopupUtils from "../platform/popup/browser-popup-utils";
 import { GeneratorComponent } from "../tools/popup/generator/generator.component";
@@ -259,7 +259,7 @@ const routes: Routes = [
   },
   {
     path: "notifications",
-    component: NotifcationsSettingsComponent,
+    component: NotificationsSettingsComponent,
     canActivate: [AuthGuard],
     data: { state: "notifications" },
   },

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -126,7 +126,6 @@ import "../platform/popup/locales";
     PopupHeaderComponent,
     UserVerificationDialogComponent,
     PopupSectionHeaderComponent,
-    CurrentAccountComponent,
   ],
   declarations: [
     ActionButtonsComponent,
@@ -189,6 +188,7 @@ import "../platform/popup/locales";
     HelpAndFeedbackComponent,
     AutofillComponent,
     EnvironmentSelectorComponent,
+    CurrentAccountComponent,
     AccountSwitcherComponent,
     VaultV2Component,
   ],

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -39,7 +39,7 @@ import { TwoFactorComponent } from "../auth/popup/two-factor.component";
 import { UpdateTempPasswordComponent } from "../auth/popup/update-temp-password.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { ExcludedDomainsComponent } from "../autofill/popup/settings/excluded-domains.component";
-import { NotifcationsSettingsComponent } from "../autofill/popup/settings/notifications.component";
+import { NotificationsSettingsComponent } from "../autofill/popup/settings/notifications.component";
 import { PremiumComponent } from "../billing/popup/settings/premium.component";
 import { PopOutComponent } from "../platform/popup/components/pop-out.component";
 import { HeaderComponent } from "../platform/popup/header.component";
@@ -155,7 +155,7 @@ import "../platform/popup/locales";
     LoginViaAuthRequestComponent,
     LoginDecryptionOptionsComponent,
     OptionsComponent,
-    NotifcationsSettingsComponent,
+    NotificationsSettingsComponent,
     AppearanceComponent,
     GeneratorComponent,
     PasswordGeneratorHistoryComponent,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- Bug fix

## Objective

A regression around entering the current account selection when there is no active user was introduced with https://github.com/bitwarden/clients/pull/9215. Since that change was preparatory, this PR reverts it for re-evaluation by the owning team.

Also, fixed a typo.

## Screenshots

**Before**

https://github.com/bitwarden/clients/assets/1556494/317080cc-ec6d-4834-b76f-fd712efe6da1

**After**

https://github.com/bitwarden/clients/assets/1556494/fd9e6a06-862c-4ddd-96fa-179f60f30ca9

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
