### PR TITLE
[PM-8295] Fix ImportService DI

### DIFF
--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -16,6 +16,8 @@ import { concat, Observable, Subject, lastValueFrom, combineLatest, firstValueFr
 import { filter, map, takeUntil } from "rxjs/operators";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { safeProvider, SafeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
+import { PinServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import {
   canAccessImport,
@@ -64,6 +66,27 @@ import {
 } from "./dialog";
 import { ImportLastPassComponent } from "./lastpass";
 
+const safeProviders: SafeProvider[] = [
+  safeProvider({
+    provide: ImportApiServiceAbstraction,
+    useClass: ImportApiService,
+    deps: [ApiService],
+  }),
+  safeProvider({
+    provide: ImportServiceAbstraction,
+    useClass: ImportService,
+    deps: [
+      CipherService,
+      FolderService,
+      ImportApiServiceAbstraction,
+      I18nService,
+      CollectionService,
+      CryptoService,
+      PinServiceAbstraction,
+    ],
+  }),
+];
+
 @Component({
   selector: "tools-import",
   templateUrl: "import.component.html",
@@ -81,25 +104,7 @@ import { ImportLastPassComponent } from "./lastpass";
     ImportLastPassComponent,
     RadioButtonModule,
   ],
-  providers: [
-    {
-      provide: ImportApiServiceAbstraction,
-      useClass: ImportApiService,
-      deps: [ApiService],
-    },
-    {
-      provide: ImportServiceAbstraction,
-      useClass: ImportService,
-      deps: [
-        CipherService,
-        FolderService,
-        ImportApiServiceAbstraction,
-        I18nService,
-        CollectionService,
-        CryptoService,
-      ],
-    },
-  ],
+  providers: safeProviders,
 })
 export class ImportComponent implements OnInit, OnDestroy {
   featuredImportOptions: ImportOption[];


### PR DESCRIPTION
Fixes a bug where `PinService` was undefined on the `ImportService` causing the import component to throw an error. Resolved by adding `PinService` to `ImportComponent` and wrapping dependencies in `SafeProvider()` for added safety.

If reviewer wants to also test locally:

1. Log in as an owner of an organization
2. Navigate to Admin Console > Settings >Export
3. Select encrypted json option and password protected option
4. Set a password and export
5. navigate to Import page and try to import the encrypted json file with password set

Or

1. Log in as a user in web vault
2. Navigate to Tools > Export Vault
3. Select encrypted json option and password protected option
4. Set a password and export
5. navigate to Import page and try to import the encrypted json file with password set

**Expected:** Expected to be able to import the file successfully

