### PR TITLE
[PM-8311] Add missing RouterModule to the CurrentAccountComponent

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/current-account.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/current-account.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule, Location } from "@angular/common";
 import { Component } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Router, RouterModule } from "@angular/router";
 import { Observable, combineLatest, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -23,7 +23,7 @@ export type CurrentAccount = {
   selector: "app-current-account",
   templateUrl: "current-account.component.html",
   standalone: true,
-  imports: [CommonModule, JslibModule, AvatarModule],
+  imports: [CommonModule, JslibModule, AvatarModule, RouterModule],
 })
 export class CurrentAccountComponent {
   currentAccount$: Observable<CurrentAccount>;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
A regression was found where a user was not able to re-enter the account-switcher after clicking on `Add account`

Originally caused with work done on https://github.com/bitwarden/clients/pull/9215

This should override the need to revert with https://github.com/bitwarden/clients/pull/9291

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **apps/browser/src/auth/popup/account-switching/current-account.component.ts:** Add `RouterModule` to the imports of the standalone `CurrentAccountComponent`

## Screenshots

https://github.com/bitwarden/clients/assets/2670567/6729611c-94f8-4963-9d20-0d9a9f1bb9dc


<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
