### PR TITLE
 [PM-8004] [AC-2603] [AC-2616] [AC-2621] [AC-2622] Unmanaged collection fixes

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -30,12 +30,7 @@
   >
     <span class="tw-truncate tw-mr-1">{{ collection.name }}</span>
     <div>
-      <span
-        *ngIf="collection.addAccess && collection.id !== Unassigned"
-        bitBadge
-        variant="warning"
-        >{{ "addAccess" | i18n }}</span
-      >
+      <span *ngIf="showAddAccess" bitBadge variant="warning">{{ "addAccess" | i18n }}</span>
     </div>
   </button>
 </td>

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -57,6 +57,10 @@ export class VaultCollectionRowComponent {
   }
 
   get showAddAccess() {
+    if (!this.flexibleCollectionsV1Enabled) {
+      return false;
+    }
+
     if (this.collection.id == Unassigned) {
       return false;
     }

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -56,6 +56,24 @@ export class VaultCollectionRowComponent {
     return this.organizations.find((o) => o.id === this.collection.organizationId);
   }
 
+  get showAddAccess() {
+    if (this.collection.id == Unassigned) {
+      return false;
+    }
+
+    // Only show AddAccess when viewing the Org vault (implied by CollectionAdminView)
+    if (this.collection instanceof CollectionAdminView) {
+      // Only show AddAccess if unmanaged and allowAdminAccessToAllCollectionItems is disabled
+      return (
+        !this.organization.allowAdminAccessToAllCollectionItems &&
+        this.collection.unmanaged &&
+        this.organization.canEditUnmanagedCollections()
+      );
+    }
+
+    return false;
+  }
+
   get permissionText() {
     if (
       this.collection.id == Unassigned &&

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -1,7 +1,6 @@
 import { SelectionModel } from "@angular/cdk/collections";
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
-import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
@@ -106,27 +105,6 @@ export class VaultItemsComponent {
 
     const organization = this.allOrganizations.find((o) => o.id === collection.organizationId);
 
-    if (this.flexibleCollectionsV1Enabled) {
-      //Custom user without edit access should not see the Edit option unless that user has "Can Manage" access to a collection
-      if (
-        !collection.manage &&
-        organization?.type === OrganizationUserType.Custom &&
-        !organization?.permissions.editAnyCollection
-      ) {
-        return false;
-      }
-      //Owner/Admin and Custom Users with Edit can see Edit and Access of Orphaned Collections
-      if (
-        collection.addAccess &&
-        collection.id !== Unassigned &&
-        ((organization?.type === OrganizationUserType.Custom &&
-          organization?.permissions.editAnyCollection) ||
-          organization.isAdmin ||
-          organization.isOwner)
-      ) {
-        return true;
-      }
-    }
     return collection.canEdit(organization, this.flexibleCollectionsV1Enabled);
   }
 
@@ -137,31 +115,6 @@ export class VaultItemsComponent {
     }
 
     const organization = this.allOrganizations.find((o) => o.id === collection.organizationId);
-
-    if (this.flexibleCollectionsV1Enabled) {
-      //Custom user with only edit access should not see the Delete button for orphaned collections
-      if (
-        collection.addAccess &&
-        organization?.type === OrganizationUserType.Custom &&
-        !organization?.permissions.deleteAnyCollection &&
-        organization?.permissions.editAnyCollection
-      ) {
-        return false;
-      }
-
-      // Owner/Admin with no access to a collection will not see Delete
-      if (
-        !collection.assigned &&
-        !collection.addAccess &&
-        (organization.isAdmin || organization.isOwner) &&
-        !(
-          organization?.type === OrganizationUserType.Custom &&
-          organization?.permissions.deleteAnyCollection
-        )
-      ) {
-        return false;
-      }
-    }
 
     return collection.canDelete(organization, this.flexibleCollectionsV1Enabled);
   }

--- a/apps/web/src/app/vault/core/collection-admin.service.ts
+++ b/apps/web/src/app/vault/core/collection-admin.service.ts
@@ -127,6 +127,7 @@ export class CollectionAdminService {
         view.readOnly = c.readOnly;
         view.hidePasswords = c.hidePasswords;
         view.manage = c.manage;
+        view.unmanaged = c.unmanaged;
       }
 
       return view;

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -9,7 +9,12 @@ import { Unassigned } from "../../individual-vault/vault-filter/shared/models/ro
 export class CollectionAdminView extends CollectionView {
   groups: CollectionAccessSelectionView[] = [];
   users: CollectionAccessSelectionView[] = [];
-  addAccess: boolean;
+
+  /**
+   * Flag indicating the collection has no active user or group assigned to it with CanManage permissions
+   * In this case, the collection can be managed by admins/owners or custom users with appropriate permissions
+   */
+  unmanaged: boolean;
 
   /**
    * Flag indicating the user has been explicitly assigned to this Collection

--- a/apps/web/src/app/vault/core/views/collection-admin.view.ts
+++ b/apps/web/src/app/vault/core/views/collection-admin.view.ts
@@ -67,7 +67,7 @@ export class CollectionAdminView extends CollectionView {
       !flexibleCollectionsV1Enabled || org.allowAdminAccessToAllCollectionItems;
 
     return (
-      (org.permissions.manageUsers && (allowAdminAccessToAllCollectionItems || this.unmanaged)) ||
+      (org.permissions.manageUsers && allowAdminAccessToAllCollectionItems) ||
       this.canEdit(org, flexibleCollectionsV1Enabled)
     );
   }
@@ -80,7 +80,7 @@ export class CollectionAdminView extends CollectionView {
       !flexibleCollectionsV1Enabled || org.allowAdminAccessToAllCollectionItems;
 
     return (
-      (org.permissions.manageGroups && (allowAdminAccessToAllCollectionItems || this.unmanaged)) ||
+      (org.permissions.manageGroups && allowAdminAccessToAllCollectionItems) ||
       this.canEdit(org, flexibleCollectionsV1Enabled)
     );
   }

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -38,7 +38,6 @@ import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
 import { OrganizationUserUserDetailsResponse } from "@bitwarden/common/admin-console/abstractions/organization-user/responses";
-import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { EventType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -433,13 +432,13 @@ export class VaultComponent implements OnInit, OnDestroy {
         this.showAddAccessToggle = false;
         let collectionsToReturn = [];
         if (filter.collectionId === undefined || filter.collectionId === All) {
-          collectionsToReturn = await this.addAccessCollectionsMap(collections);
+          collectionsToReturn = collections.map((c) => c.node);
         } else {
           const selectedCollection = ServiceUtils.getTreeNodeObjectFromList(
             collections,
             filter.collectionId,
           );
-          collectionsToReturn = await this.addAccessCollectionsMap(selectedCollection?.children);
+          collectionsToReturn = selectedCollection?.children.map((c) => c.node) ?? [];
         }
 
         if (await this.searchService.isSearchable(searchText)) {
@@ -451,8 +450,14 @@ export class VaultComponent implements OnInit, OnDestroy {
           );
         }
 
+        // Add access toggle is only shown if allowAdminAccessToAllCollectionItems is false and there are unmanaged collections the user can edit
+        this.showAddAccessToggle =
+          !this.organization.allowAdminAccessToAllCollectionItems &&
+          this.organization.canEditUnmanagedCollections() &&
+          collectionsToReturn.some((c) => c.unmanaged);
+
         if (addAccessStatus === 1 && this.showAddAccessToggle) {
-          collectionsToReturn = collectionsToReturn.filter((c: any) => c.addAccess);
+          collectionsToReturn = collectionsToReturn.filter((c) => c.unmanaged);
         }
         return collectionsToReturn;
       }),
@@ -663,57 +668,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       );
   }
 
-  // Update the list of collections to see if any collection is orphaned
-  // and will receive the addAccess badge / be filterable by the user
-  async addAccessCollectionsMap(collections: TreeNode<CollectionAdminView>[]) {
-    let mappedCollections;
-    const { type, allowAdminAccessToAllCollectionItems, permissions } = this.organization;
-
-    const canEditCiphersCheck =
-      this._flexibleCollectionsV1FlagEnabled &&
-      !this.organization.canEditAllCiphers(
-        this._flexibleCollectionsV1FlagEnabled,
-        this.restrictProviderAccessEnabled,
-      );
-
-    // This custom type check will show addAccess badge for
-    // Custom users with canEdit access AND owner/admin manage access setting is OFF
-    const customUserCheck =
-      this._flexibleCollectionsV1FlagEnabled &&
-      !allowAdminAccessToAllCollectionItems &&
-      type === OrganizationUserType.Custom &&
-      permissions.editAnyCollection;
-
-    // If Custom user has Delete Only access they will not see Add Access toggle
-    const customUserOnlyDelete =
-      this.flexibleCollectionsV1Enabled &&
-      type === OrganizationUserType.Custom &&
-      permissions.deleteAnyCollection &&
-      !permissions.editAnyCollection;
-
-    if (!customUserOnlyDelete && (canEditCiphersCheck || customUserCheck)) {
-      mappedCollections = collections.map((c: TreeNode<CollectionAdminView>) => {
-        const groupsCanManage = c.node.groupsCanManage();
-        const usersCanManage = c.node.usersCanManage(this.orgRevokedUsers);
-        if (
-          groupsCanManage.length === 0 &&
-          usersCanManage.length === 0 &&
-          c.node.id !== Unassigned
-        ) {
-          c.node.addAccess = true;
-          this.showAddAccessToggle = true;
-        } else {
-          c.node.addAccess = false;
-        }
-        return c.node;
-      });
-    } else {
-      mappedCollections = collections.map((c: TreeNode<CollectionAdminView>) => c.node);
-    }
-    return mappedCollections;
-  }
-
-  addAccessToggle(e: any) {
+  addAccessToggle(e: AddAccessStatusType) {
     this.addAccessStatus$.next(e);
   }
 
@@ -758,9 +713,17 @@ export class VaultComponent implements OnInit, OnDestroy {
       } else if (event.type === "copyField") {
         await this.copy(event.item, event.field);
       } else if (event.type === "editCollection") {
-        await this.editCollection(event.item, CollectionDialogTabType.Info, event.readonly);
+        await this.editCollection(
+          event.item as CollectionAdminView,
+          CollectionDialogTabType.Info,
+          event.readonly,
+        );
       } else if (event.type === "viewCollectionAccess") {
-        await this.editCollection(event.item, CollectionDialogTabType.Access, event.readonly);
+        await this.editCollection(
+          event.item as CollectionAdminView,
+          CollectionDialogTabType.Access,
+          event.readonly,
+        );
       } else if (event.type === "bulkEditCollectionAccess") {
         await this.bulkEditCollectionAccess(event.items, this.organization);
       } else if (event.type === "assignToCollections") {
@@ -1273,7 +1236,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async editCollection(
-    c: CollectionView,
+    c: CollectionAdminView,
     tab: CollectionDialogTabType,
     readonly: boolean,
   ): Promise<void> {
@@ -1283,7 +1246,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         organizationId: this.organization?.id,
         initialTab: tab,
         readonly: readonly,
-        isAddAccessCollection: c.addAccess,
+        isAddAccessCollection: c.unmanaged,
         limitNestedCollections: !this.organization.canEditAnyCollection(
           this.flexibleCollectionsV1Enabled,
         ),

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -452,6 +452,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
         // Add access toggle is only shown if allowAdminAccessToAllCollectionItems is false and there are unmanaged collections the user can edit
         this.showAddAccessToggle =
+          this.flexibleCollectionsV1Enabled &&
           !this.organization.allowAdminAccessToAllCollectionItems &&
           this.organization.canEditUnmanagedCollections() &&
           collectionsToReturn.some((c) => c.unmanaged);

--- a/apps/web/src/app/vault/utils/collection-utils.ts
+++ b/apps/web/src/app/vault/utils/collection-utils.ts
@@ -44,6 +44,7 @@ function cloneCollection(
     cloned.groups = [...collection.groups];
     cloned.users = [...collection.users];
     cloned.assigned = collection.assigned;
+    cloned.unmanaged = collection.unmanaged;
   } else {
     cloned = new CollectionView();
   }

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -203,6 +203,11 @@ export class Organization {
     );
   }
 
+  canEditUnmanagedCollections() {
+    // Any admin or custom user with editAnyCollection permission can edit unmanaged collections
+    return this.isAdmin || this.permissions.editAnyCollection;
+  }
+
   canEditUnassignedCiphers(restrictProviderAccessFlagEnabled: boolean) {
     if (this.isProviderUser) {
       return !restrictProviderAccessFlagEnabled;

--- a/libs/common/src/vault/models/domain/collection.spec.ts
+++ b/libs/common/src/vault/models/domain/collection.spec.ts
@@ -61,7 +61,6 @@ describe("Collection", () => {
     const view = await collection.decrypt();
 
     expect(view).toEqual({
-      addAccess: false,
       externalId: "extId",
       hidePasswords: false,
       id: "id",

--- a/libs/common/src/vault/models/response/collection.response.ts
+++ b/libs/common/src/vault/models/response/collection.response.ts
@@ -42,10 +42,12 @@ export class CollectionDetailsResponse extends CollectionResponse {
 export class CollectionAccessDetailsResponse extends CollectionDetailsResponse {
   groups: SelectionReadOnlyResponse[] = [];
   users: SelectionReadOnlyResponse[] = [];
+  unmanaged: boolean;
 
   constructor(response: any) {
     super(response);
     this.assigned = this.getResponseProperty("Assigned") || false;
+    this.unmanaged = this.getResponseProperty("Unmanaged") || false;
 
     const groups = this.getResponseProperty("Groups");
     if (groups != null) {

--- a/libs/common/src/vault/models/view/collection.view.ts
+++ b/libs/common/src/vault/models/view/collection.view.ts
@@ -17,7 +17,6 @@ export class CollectionView implements View, ITreeNodeObject {
   readOnly: boolean = null;
   hidePasswords: boolean = null;
   manage: boolean = null;
-  addAccess: boolean = false;
   assigned: boolean = null;
 
   constructor(c?: Collection | CollectionAccessDetailsResponse) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Orphaned/Unmanaged collections broke many assumptions in our permission getters and required complicated client side logic to determine if a user has the ability to manage the orphaned collection. We decided to move that logic into the serverside sproc in https://github.com/bitwarden/server/pull/4108 in the form of an `Unmanaged` property on the collection.

This PR utilizes the new `Unmanaged` property in the `CollectionAdminView` permission getters (`canEdit`, `canEditUserAccess`, etc..) to avoid the need to calculate in multiple places. Now that its in the getters, this PR also removes/updates the repeated logic that was implemented for the "AddAccess" badge story.

## Code changes

### `CollectionAdminView`

- Add the `Unmanaged` property
- Remove helpers that were used to determine if a collection was unmanaged client-side.
- Update other helpers that depend on `Unmanaged` to take it into consideration appropriately.

### `org-vault/vault.component.ts`

- Remove the logic that was used to calculate the `AddAccess` property on collections
  -  This is replaced with the new `Unmanaged` property
- Cleanup the `CollectionAdminView` types to make it more clear what's available in the org vault.

### `domain/organization.ts`

- Add helper to determine if the user has access to edit `Unmanaged` collections
  - Limited to admins/owners, providers, and custom users with edit any collection

### `vault-items/vault-items.component.ts`

- Remove now redundant logic for collection permissions and only rely on the permission getters

### `vault-items/vault-collection-row.component.ts`

- Since the logic to determine if `AddAccess` was removed from the `CollectionView` I had to re-add it at the component level. Fortunately, it's able to re-use the existing helpers/flags.

### Service, Models, Responses, everything else

- Add the `Unmanaged` property to all the relevant models/responses

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
