### PR TITLE
[PM-6825] Fix app icon styling in Browser

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -458,3 +458,14 @@ html.force_redraw {
 .rounded-circle {
   border-radius: 50% !important;
 }
+
+/* override for vault icon in browser (pre extension refresh) */
+app-vault-icon:not(app-vault-list-items-container app-vault-icon) > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  float: left;
+  height: 36px;
+  width: 34px;
+  margin-left: -5px;
+}

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
@@ -39,10 +39,12 @@
       <app-vault-list-items-container
         [title]="'favorites' | i18n"
         [ciphers]="favoriteCiphers$ | async"
+        id="favorites"
       ></app-vault-list-items-container>
       <app-vault-list-items-container
         [title]="'allItems' | i18n"
         [ciphers]="remainingCiphers$ | async"
+        id="allItems"
       ></app-vault-list-items-container>
     </ng-container>
   </ng-container>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Changes in #9199 inadvertently broke the spacing in the current browser vault list app icons. This PR re-adds the previous style in the form of a temporary addition to `styles.css` for browser (similar to what we had to do for Desktop). 

Also adds some list Ids to the vault list items containers for QA test automation.

## Screenshots

<img width="372" alt="image" src="https://github.com/bitwarden/clients/assets/8764515/01bb5daa-4dba-46a4-8b8e-a71d78488479">

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
