### PR TITLE
[PM-1210] Provider invite/edit member text

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/people.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/people.component.html
@@ -2,7 +2,7 @@
   <bit-search class="tw-grow" [(ngModel)]="searchText" [placeholder]="'search' | i18n"></bit-search>
   <button type="button" bitButton buttonType="primary" (click)="invite()">
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-    {{ "inviteUsers" | i18n }}
+    {{ "inviteMember" | i18n }}
   </button>
 </app-header>
 

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/user-add-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/user-add-edit.component.ts
@@ -46,7 +46,7 @@ export class UserAddEditComponent implements OnInit {
 
     if (this.editMode) {
       this.editMode = true;
-      this.title = this.i18nService.t("editUser");
+      this.title = this.i18nService.t("editMember");
       try {
         const user = await this.apiService.getProviderUser(this.providerId, this.providerUserId);
         this.type = user.type;
@@ -54,7 +54,7 @@ export class UserAddEditComponent implements OnInit {
         this.logService.error(e);
       }
     } else {
-      this.title = this.i18nService.t("inviteUser");
+      this.title = this.i18nService.t("inviteMember");
     }
 
     this.loading = false;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

> Provider portal was missing/using incorrect text for the `invite member` button and dialog


## Code changes

- **.../providers/manage/people.component.html**: Changed `inviteUsers` to `inviteMember` to align with `Admin Console` flow
- **.../providers/manage/user-add-edit.component.ts**: Updated both `invite` and `edit` strings to use the `member` verbiage that also aligns with `Admin Console` flow


## Screenshots

![Screenshot 2024-05-22 at 12 53 17 PM](https://github.com/bitwarden/clients/assets/26154748/2a5fae75-59b5-4717-a9d7-aa03383b3ef8)
![Screenshot 2024-05-22 at 12 53 32 PM](https://github.com/bitwarden/clients/assets/26154748/30ea8a36-81dc-4061-a2b0-c103497f139f)


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
