### PR TITLE
[PM-8333] Autofill refresh button for sidebar popup (Firefox)

### DIFF
--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.component.html
@@ -1,5 +1,5 @@
 <div class="tw-flex tw-justify-between tw-items-end tw-gap-1 tw-px-1 tw-pb-1">
-  <div>
+  <div class="tw-flex tw-items-center tw-gap-1">
     <h2 bitTypography="h6" noMargin class="tw-mb-0 tw-text-headers">
       {{ title }}
     </h2>

--- a/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
+++ b/apps/browser/src/platform/popup/popup-section-header/popup-section-header.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 
 import {
   CardComponent,
@@ -61,6 +61,20 @@ export const TailingIcon: Story = {
   }),
   args: {
     title: "Trailing Icon",
+  },
+};
+
+export const TitleSuffix: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <popup-section-header [title]="title">
+        <button bitIconButton="bwi-refresh" size="small" slot="title-suffix"></button>
+      </popup-section-header>
+    `,
+  }),
+  args: {
+    title: "Title Suffix",
   },
 };
 

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -14,6 +14,7 @@
         bitIconButton="bwi-refresh"
         size="small"
         slot="title-suffix"
+        type="button"
         [appA11yTitle]="'refresh' | i18n"
         (click)="refreshCurrentTab()"
       ></button>

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -2,11 +2,22 @@
   *ngIf="autofillCiphers$ | async as ciphers"
   [ciphers]="ciphers"
   [title]="'autofillSuggestions' | i18n"
+  [showRefresh]="showRefresh"
+  (onRefresh)="refreshCurrentTab()"
   showAutoFill
 ></app-vault-list-items-container>
 <ng-container *ngIf="showEmptyAutofillTip$ | async">
   <bit-section>
-    <popup-section-header [title]="'autofillSuggestions' | i18n"></popup-section-header>
+    <popup-section-header [title]="'autofillSuggestions' | i18n">
+      <button
+        *ngIf="showRefresh"
+        bitIconButton="bwi-refresh"
+        size="small"
+        slot="title-suffix"
+        [appA11yTitle]="'refresh' | i18n"
+        (click)="refreshCurrentTab()"
+      ></button>
+    </popup-section-header>
     <span class="tw-text-muted tw-px-1" bitTypography="body2">{{
       "autofillSuggestionsTip" | i18n
     }}</span>

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
@@ -4,8 +4,9 @@ import { combineLatest, map, Observable } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { SectionComponent, TypographyModule } from "@bitwarden/components";
+import { IconButtonModule, SectionComponent, TypographyModule } from "@bitwarden/components";
 
+import BrowserPopupUtils from "../../../../../platform/popup/browser-popup-utils";
 import { PopupSectionHeaderComponent } from "../../../../../platform/popup/popup-section-header/popup-section-header.component";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import { VaultListItemsContainerComponent } from "../vault-list-items-container/vault-list-items-container.component";
@@ -19,6 +20,7 @@ import { VaultListItemsContainerComponent } from "../vault-list-items-container/
     VaultListItemsContainerComponent,
     JslibModule,
     PopupSectionHeaderComponent,
+    IconButtonModule,
   ],
   selector: "app-autofill-vault-list-items",
   templateUrl: "autofill-vault-list-items.component.html",
@@ -30,6 +32,12 @@ export class AutofillVaultListItemsComponent {
    */
   protected autofillCiphers$: Observable<CipherView[]> =
     this.vaultPopupItemsService.autoFillCiphers$;
+
+  /**
+   * Flag indicating whether the refresh button should be shown. Only shown when the popup is within the FF sidebar.
+   * @protected
+   */
+  protected showRefresh: boolean = BrowserPopupUtils.inSidebar(window);
 
   /**
    * Observable that determines whether the empty autofill tip should be shown.
@@ -47,5 +55,13 @@ export class AutofillVaultListItemsComponent {
 
   constructor(private vaultPopupItemsService: VaultPopupItemsService) {
     // TODO: Migrate logic to show Autofill policy toast PM-8144
+  }
+
+  /**
+   * Refreshes the current tab to re-populate the autofill ciphers.
+   * @protected
+   */
+  protected refreshCurrentTab() {
+    this.vaultPopupItemsService.refreshCurrentTab();
   }
 }

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -4,6 +4,7 @@
     <button
       *ngIf="showRefresh"
       bitIconButton="bwi-refresh"
+      type="button"
       size="small"
       slot="title-suffix"
       (click)="onRefresh.emit()"

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -1,6 +1,14 @@
 <bit-section *ngIf="ciphers?.length > 0">
   <popup-section-header [title]="title">
     <span bitTypography="body2" slot="end">{{ ciphers.length }}</span>
+    <button
+      *ngIf="showRefresh"
+      bitIconButton="bwi-refresh"
+      size="small"
+      slot="title-suffix"
+      (click)="onRefresh.emit()"
+      [appA11yTitle]="'refresh' | i18n"
+    ></button>
   </popup-section-header>
   <bit-item-group>
     <bit-item *ngFor="let cipher of ciphers">

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { booleanAttribute, Component, Input } from "@angular/core";
+import { booleanAttribute, Component, EventEmitter, Input, Output } from "@angular/core";
 import { RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -33,12 +33,33 @@ import { PopupSectionHeaderComponent } from "../../../../../platform/popup/popup
   standalone: true,
 })
 export class VaultListItemsContainerComponent {
+  /**
+   * The list of ciphers to display.
+   */
   @Input()
   ciphers: CipherView[];
 
+  /**
+   * Title for the vault list item section.
+   */
   @Input()
   title: string;
 
+  /**
+   * Option to show a refresh button in the section header.
+   */
+  @Input({ transform: booleanAttribute })
+  showRefresh: boolean;
+
+  /**
+   * Event emitted when the refresh button is clicked.
+   */
+  @Output()
+  onRefresh = new EventEmitter<void>();
+
+  /**
+   * Option to show the autofill button for each item.
+   */
   @Input({ transform: booleanAttribute })
   showAutoFill: boolean;
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add the refresh button for the autofill items section when the popup is in the FF sidebar. Also, this tweaks the popup-section-header to properly align the `title-suffix` slot with the title and adds a corresponding story.

## Code changes

- `popup-section-header.component.html` - Add `tw-flex tw-items-center tw-gap-1` classes to `h1` container.
- `autofill-vault-list-items/autofill-vault-list-items.component.html` - Add logic to show refresh button and call service to refresh the current tab.
- `vault-list-items-container/vault-list-items-container.component.ts` - Add Input/Outputs for showing refresh button.

## Screenshots

Also see new story in storybook.

![image](https://github.com/bitwarden/clients/assets/8764515/6f63efbb-1845-40b2-acca-928d4cbabf54)

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
