### PR TITLE
Separate browser foreground and background memory space

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -18,6 +18,7 @@ import {
 } from "@bitwarden/angular/services/injection-tokens";
 import { JslibServicesModule } from "@bitwarden/angular/services/jslib-services.module";
 import { AuthRequestServiceAbstraction, PinServiceAbstraction } from "@bitwarden/auth/common";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { EventCollectionService as EventCollectionServiceAbstraction } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
@@ -178,8 +179,15 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: AuthServiceAbstraction,
-    useFactory: getBgService<AuthService>("authService"),
-    deps: [],
+    useClass: AuthService,
+    deps: [
+      AccountServiceAbstraction,
+      MessageSender,
+      CryptoService,
+      ApiService,
+      StateServiceAbstraction,
+      TokenService,
+    ],
   }),
   safeProvider({
     provide: SsoLoginServiceAbstraction,

--- a/libs/common/src/auth/services/auth.service.ts
+++ b/libs/common/src/auth/services/auth.service.ts
@@ -11,8 +11,8 @@ import {
 
 import { ApiService } from "../../abstractions/api.service";
 import { CryptoService } from "../../platform/abstractions/crypto.service";
-import { MessagingService } from "../../platform/abstractions/messaging.service";
 import { StateService } from "../../platform/abstractions/state.service";
+import { MessageSender } from "../../platform/messaging";
 import { Utils } from "../../platform/misc/utils";
 import { UserId } from "../../types/guid";
 import { AccountService } from "../abstractions/account.service";
@@ -26,7 +26,7 @@ export class AuthService implements AuthServiceAbstraction {
 
   constructor(
     protected accountService: AccountService,
-    protected messagingService: MessagingService,
+    protected messageSender: MessageSender,
     protected cryptoService: CryptoService,
     protected apiService: ApiService,
     protected stateService: StateService,
@@ -95,6 +95,6 @@ export class AuthService implements AuthServiceAbstraction {
 
   logOut(callback: () => void) {
     callback();
-    this.messagingService.send("loggedOut");
+    this.messageSender.send("loggedOut");
   }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Removes memory sharing for AuthService in browser. This was causing dead object in firefox following #9019 and #9229.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
