### PR TITLE
[DRAFT] [CL-293] Experiment with enabling bitAction on ItemContentComponent

### DIFF
--- a/apps/browser/src/vault/popup/settings/vault-settings-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/vault-settings-v2.component.html
@@ -25,10 +25,21 @@
       </a>
     </bit-item>
     <bit-item>
-      <button type="button" bit-item-content (click)="sync()">
+      <button
+        type="button"
+        bit-item-content
+        [disabled]="syncButton.disabled"
+        #syncButton
+        [bitAction]="sync"
+      >
         {{ "syncVaultNow" | i18n }}
         <span slot="secondary">{{ lastSync }}</span>
-        <i slot="end" class="bwi bwi-refresh" aria-hidden="true"></i>
+        <i
+          slot="end"
+          [ngClass]="syncButton.loading ? 'bwi-spinner' : 'bwi-refresh'"
+          class="bwi"
+          aria-hidden="true"
+        ></i>
       </button>
     </bit-item>
   </bit-item-group>

--- a/apps/browser/src/vault/popup/settings/vault-settings-v2.component.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings-v2.component.ts
@@ -5,7 +5,7 @@ import { Router, RouterModule } from "@angular/router";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { ItemModule, ToastOptions, ToastService } from "@bitwarden/components";
+import { AsyncActionsModule, ItemModule, ToastOptions, ToastService } from "@bitwarden/components";
 
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../platform/popup/browser-popup-utils";
@@ -26,6 +26,7 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
     PopupHeaderComponent,
     PopOutComponent,
     ItemModule,
+    AsyncActionsModule,
   ],
 })
 export class VaultSettingsV2Component implements OnInit {
@@ -49,7 +50,7 @@ export class VaultSettingsV2Component implements OnInit {
     }
   }
 
-  async sync() {
+  sync = async () => {
     let toastConfig: ToastOptions;
     const success = await this.syncService.fullSync(true);
     if (success) {
@@ -63,7 +64,7 @@ export class VaultSettingsV2Component implements OnInit {
       toastConfig = { variant: "error", title: "", message: this.i18nService.t("syncingFailed") };
     }
     this.toastService.showToast(toastConfig);
-  }
+  };
 
   private async setLastSync() {
     const last = await this.syncService.getLastSync();

--- a/libs/components/src/item/item-content.component.ts
+++ b/libs/components/src/item/item-content.component.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 
+import { ButtonLikeAbstraction, ButtonType } from "../shared/button-like.abstraction";
+
 @Component({
   selector: "bit-item-content, [bit-item-content]",
   standalone: true,
@@ -11,5 +13,15 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
       "fvw-target tw-outline-none tw-text-main hover:tw-text-main hover:tw-no-underline tw-text-base tw-py-2 tw-px-4 tw-bg-transparent tw-w-full tw-border-none tw-flex tw-gap-4 tw-items-center tw-justify-between",
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: ButtonLikeAbstraction,
+      useExisting: ItemContentComponent,
+    },
+  ],
 })
-export class ItemContentComponent {}
+export class ItemContentComponent implements ButtonLikeAbstraction {
+  loading: boolean;
+  disabled: boolean;
+  setButtonType: (value: ButtonType) => void = () => {};
+}


### PR DESCRIPTION
The sync button on the vault-settings-v2 page (behind a extension UI refresh feature flag), currently does not disable or show a loading indicator when pressed

Originally brought up by Ryan, which would make test-automation easier

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The sync button on the vault-settings-v2 page (behind a extension UI refresh feature flag), currently does not disable or show a loading indicator when pressed

Originally brought up by Ryan, which would make test-automation easier

This is a little experiment that @willmartian and I were working on: How to enable the bitAction on ItemContentComponent. As a follow-up the ItemContentComponent, currently does not have any disabled styles.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **libs/components/src/item/item-content.component.ts:** Extended the ItemContentComponent to implement the ButtonLikeAbstraction which is needed for bitAction to work
- **apps/browser/src/vault/popup/settings/vault-settings-v2.component.ts:** Import AsyncActionsModule, migrate sync method to arrow function
- **apps/browser/src/vault/popup/settings/vault-settings-v2.component.html:**Use bitAction and show loading spinner when clicked

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->

https://github.com/bitwarden/clients/assets/2670567/5842f541-17fa-49fa-b34c-f78d2a81fbd2


https://github.com/bitwarden/clients/assets/2670567/fcce13dc-974c-4a34-b552-d115016937e2



## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
