### PR TITLE
Use User Key Definitions for user-scoped data

### DIFF
--- a/apps/browser/src/vault/services/vault-browser-state.service.ts
+++ b/apps/browser/src/vault/services/vault-browser-state.service.ts
@@ -3,28 +3,31 @@ import { Jsonify } from "type-fest";
 
 import {
   ActiveUserState,
-  KeyDefinition,
   StateProvider,
+  UserKeyDefinition,
   VAULT_BROWSER_MEMORY,
 } from "@bitwarden/common/platform/state";
 
 import { BrowserComponentState } from "../../models/browserComponentState";
 import { BrowserGroupingsComponentState } from "../../models/browserGroupingsComponentState";
 
-export const VAULT_BROWSER_GROUPINGS_COMPONENT = new KeyDefinition<BrowserGroupingsComponentState>(
-  VAULT_BROWSER_MEMORY,
-  "vault_browser_groupings_component",
-  {
-    deserializer: (obj: Jsonify<BrowserGroupingsComponentState>) =>
-      BrowserGroupingsComponentState.fromJSON(obj),
-  },
-);
+export const VAULT_BROWSER_GROUPINGS_COMPONENT =
+  new UserKeyDefinition<BrowserGroupingsComponentState>(
+    VAULT_BROWSER_MEMORY,
+    "vault_browser_groupings_component",
+    {
+      deserializer: (obj: Jsonify<BrowserGroupingsComponentState>) =>
+        BrowserGroupingsComponentState.fromJSON(obj),
+      clearOn: ["logout", "lock"],
+    },
+  );
 
-export const VAULT_BROWSER_COMPONENT = new KeyDefinition<BrowserComponentState>(
+export const VAULT_BROWSER_COMPONENT = new UserKeyDefinition<BrowserComponentState>(
   VAULT_BROWSER_MEMORY,
   "vault_browser_component",
   {
     deserializer: (obj: Jsonify<BrowserComponentState>) => BrowserComponentState.fromJSON(obj),
+    clearOn: ["logout", "lock"],
   },
 );
 

--- a/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
@@ -11,9 +11,9 @@ import { KdfType, PBKDF2_ITERATIONS } from "@bitwarden/common/platform/enums";
 import {
   StateProvider,
   ActiveUserState,
-  KeyDefinition,
   PREMIUM_BANNER_DISK_LOCAL,
   BANNERS_DISMISSED_DISK,
+  UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 
@@ -33,19 +33,21 @@ type PremiumBannerReprompt = {
 /** Banners that will be re-shown on a new session */
 type SessionBanners = Omit<VisibleVaultBanner, VisibleVaultBanner.Premium>;
 
-export const PREMIUM_BANNER_REPROMPT_KEY = new KeyDefinition<PremiumBannerReprompt>(
+export const PREMIUM_BANNER_REPROMPT_KEY = new UserKeyDefinition<PremiumBannerReprompt>(
   PREMIUM_BANNER_DISK_LOCAL,
   "bannerReprompt",
   {
     deserializer: (bannerReprompt) => bannerReprompt,
+    clearOn: [], // Do not clear user tutorials
   },
 );
 
-export const BANNERS_DISMISSED_DISK_KEY = new KeyDefinition<SessionBanners[]>(
+export const BANNERS_DISMISSED_DISK_KEY = new UserKeyDefinition<SessionBanners[]>(
   BANNERS_DISMISSED_DISK,
   "bannersDismissed",
   {
     deserializer: (bannersDismissed) => bannersDismissed,
+    clearOn: [], // Do not clear user tutorials
   },
 );
 

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/services/vault-onboarding.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/services/vault-onboarding.service.ts
@@ -3,8 +3,8 @@ import { Observable } from "rxjs";
 
 import {
   ActiveUserState,
-  KeyDefinition,
   StateProvider,
+  UserKeyDefinition,
   VAULT_ONBOARDING,
 } from "@bitwarden/common/platform/state";
 
@@ -16,9 +16,14 @@ export type VaultOnboardingTasks = {
   installExtension: boolean;
 };
 
-const VAULT_ONBOARDING_KEY = new KeyDefinition<VaultOnboardingTasks>(VAULT_ONBOARDING, "tasks", {
-  deserializer: (jsonData) => jsonData,
-});
+const VAULT_ONBOARDING_KEY = new UserKeyDefinition<VaultOnboardingTasks>(
+  VAULT_ONBOARDING,
+  "tasks",
+  {
+    deserializer: (jsonData) => jsonData,
+    clearOn: [], // do not clear tutorials
+  },
+);
 
 @Injectable()
 export class VaultOnboardingService implements VaultOnboardingServiceAbstraction {

--- a/libs/common/src/vault/services/collection.service.ts
+++ b/libs/common/src/vault/services/collection.service.ts
@@ -6,11 +6,11 @@ import { I18nService } from "../../platform/abstractions/i18n.service";
 import { Utils } from "../../platform/misc/utils";
 import {
   ActiveUserState,
-  KeyDefinition,
   StateProvider,
   COLLECTION_DATA,
   DeriveDefinition,
   DerivedState,
+  UserKeyDefinition,
 } from "../../platform/state";
 import { CollectionId, OrganizationId, UserId } from "../../types/guid";
 import { CollectionService as CollectionServiceAbstraction } from "../../vault/abstractions/collection.service";
@@ -20,11 +20,12 @@ import { TreeNode } from "../models/domain/tree-node";
 import { CollectionView } from "../models/view/collection.view";
 import { ServiceUtils } from "../service-utils";
 
-const ENCRYPTED_COLLECTION_DATA_KEY = KeyDefinition.record<CollectionData, CollectionId>(
+const ENCRYPTED_COLLECTION_DATA_KEY = UserKeyDefinition.record<CollectionData, CollectionId>(
   COLLECTION_DATA,
   "collections",
   {
     deserializer: (jsonData: Jsonify<CollectionData>) => CollectionData.fromJSON(jsonData),
+    clearOn: ["logout"],
   },
 );
 

--- a/libs/common/src/vault/services/key-state/ciphers.state.ts
+++ b/libs/common/src/vault/services/key-state/ciphers.state.ts
@@ -4,7 +4,7 @@ import {
   CIPHERS_DISK,
   CIPHERS_DISK_LOCAL,
   CIPHERS_MEMORY,
-  KeyDefinition,
+  UserKeyDefinition,
 } from "../../../platform/state";
 import { CipherId } from "../../../types/guid";
 import { CipherData } from "../../models/data/cipher.data";
@@ -12,27 +12,30 @@ import { LocalData } from "../../models/data/local.data";
 import { CipherView } from "../../models/view/cipher.view";
 import { AddEditCipherInfo } from "../../types/add-edit-cipher-info";
 
-export const ENCRYPTED_CIPHERS = KeyDefinition.record<CipherData>(CIPHERS_DISK, "ciphers", {
+export const ENCRYPTED_CIPHERS = UserKeyDefinition.record<CipherData>(CIPHERS_DISK, "ciphers", {
   deserializer: (obj: Jsonify<CipherData>) => CipherData.fromJSON(obj),
+  clearOn: ["logout"],
 });
 
-export const DECRYPTED_CIPHERS = KeyDefinition.record<CipherView>(
+export const DECRYPTED_CIPHERS = UserKeyDefinition.record<CipherView>(
   CIPHERS_MEMORY,
   "decryptedCiphers",
   {
     deserializer: (cipher: Jsonify<CipherView>) => CipherView.fromJSON(cipher),
+    clearOn: ["logout", "lock"],
   },
 );
 
-export const LOCAL_DATA_KEY = new KeyDefinition<Record<CipherId, LocalData>>(
+export const LOCAL_DATA_KEY = new UserKeyDefinition<Record<CipherId, LocalData>>(
   CIPHERS_DISK_LOCAL,
   "localData",
   {
     deserializer: (localData) => localData,
+    clearOn: ["logout"],
   },
 );
 
-export const ADD_EDIT_CIPHER_INFO_KEY = new KeyDefinition<AddEditCipherInfo>(
+export const ADD_EDIT_CIPHER_INFO_KEY = new UserKeyDefinition<AddEditCipherInfo>(
   CIPHERS_MEMORY,
   "addEditCipherInfo",
   {
@@ -48,5 +51,6 @@ export const ADD_EDIT_CIPHER_INFO_KEY = new KeyDefinition<AddEditCipherInfo>(
 
       return { cipher, collectionIds: addEditCipherInfo.collectionIds };
     },
+    clearOn: ["logout", "lock"],
   },
 );

--- a/libs/common/src/vault/services/key-state/collapsed-groupings.state.ts
+++ b/libs/common/src/vault/services/key-state/collapsed-groupings.state.ts
@@ -1,9 +1,10 @@
-import { KeyDefinition, VAULT_FILTER_DISK } from "../../../platform/state";
+import { UserKeyDefinition, VAULT_FILTER_DISK } from "../../../platform/state";
 
-export const COLLAPSED_GROUPINGS = KeyDefinition.array<string>(
+export const COLLAPSED_GROUPINGS = UserKeyDefinition.array<string>(
   VAULT_FILTER_DISK,
   "collapsedGroupings",
   {
     deserializer: (obj) => obj,
+    clearOn: ["logout", "lock"],
   },
 );

--- a/libs/common/src/vault/services/key-state/folder.state.ts
+++ b/libs/common/src/vault/services/key-state/folder.state.ts
@@ -1,15 +1,20 @@
 import { Jsonify } from "type-fest";
 
 import { CryptoService } from "../../../platform/abstractions/crypto.service";
-import { DeriveDefinition, FOLDER_DISK, KeyDefinition } from "../../../platform/state";
+import { DeriveDefinition, FOLDER_DISK, UserKeyDefinition } from "../../../platform/state";
 import { FolderService } from "../../abstractions/folder/folder.service.abstraction";
 import { FolderData } from "../../models/data/folder.data";
 import { Folder } from "../../models/domain/folder";
 import { FolderView } from "../../models/view/folder.view";
 
-export const FOLDER_ENCRYPTED_FOLDERS = KeyDefinition.record<FolderData>(FOLDER_DISK, "folders", {
-  deserializer: (obj: Jsonify<FolderData>) => FolderData.fromJSON(obj),
-});
+export const FOLDER_ENCRYPTED_FOLDERS = UserKeyDefinition.record<FolderData>(
+  FOLDER_DISK,
+  "folders",
+  {
+    deserializer: (obj: Jsonify<FolderData>) => FolderData.fromJSON(obj),
+    clearOn: ["logout"],
+  },
+);
 
 export const FOLDER_DECRYPTED_FOLDERS = DeriveDefinition.from<
   Record<string, FolderData>,

--- a/libs/common/src/vault/services/key-state/vault-settings.state.ts
+++ b/libs/common/src/vault/services/key-state/vault-settings.state.ts
@@ -1,4 +1,4 @@
-import { VAULT_SETTINGS_DISK, KeyDefinition } from "../../../platform/state";
+import { VAULT_SETTINGS_DISK, KeyDefinition, UserKeyDefinition } from "../../../platform/state";
 
 export const USER_ENABLE_PASSKEYS = new KeyDefinition<boolean>(
   VAULT_SETTINGS_DISK,
@@ -8,16 +8,20 @@ export const USER_ENABLE_PASSKEYS = new KeyDefinition<boolean>(
   },
 );
 
-export const SHOW_CARDS_CURRENT_TAB = new KeyDefinition<boolean>(
+export const SHOW_CARDS_CURRENT_TAB = new UserKeyDefinition<boolean>(
   VAULT_SETTINGS_DISK,
   "showCardsCurrentTab",
   {
     deserializer: (obj) => obj,
+    clearOn: [], // do not clear user settings
   },
 );
 
-export const SHOW_IDENTITIES_CURRENT_TAB = new KeyDefinition<boolean>(
+export const SHOW_IDENTITIES_CURRENT_TAB = new UserKeyDefinition<boolean>(
   VAULT_SETTINGS_DISK,
   "showIdentitiesCurrentTab",
-  { deserializer: (obj) => obj },
+  {
+    deserializer: (obj) => obj,
+    clearOn: [], // do not clear user settings
+  },
 );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

UserKeyDefinitions are purpose built for storing user data and offer the ability to ensure cleanup on user status events.

This PR moves vault code that uses user-scoped state to UserKeyDefinitions.

Please be sure that each `clearOn` definition aligns with expectations. Particularly the component ones are just educated guesses on my part.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
