### PR TITLE
Prefer UserKeyDefinition for user-scoped data

### DIFF
--- a/apps/browser/src/tools/popup/services/key-definitions.ts
+++ b/apps/browser/src/tools/popup/services/key-definitions.ts
@@ -1,23 +1,25 @@
 import { Jsonify } from "type-fest";
 
-import { BROWSER_SEND_MEMORY, KeyDefinition } from "@bitwarden/common/platform/state";
+import { BROWSER_SEND_MEMORY, UserKeyDefinition } from "@bitwarden/common/platform/state";
 
 import { BrowserComponentState } from "../../../models/browserComponentState";
 import { BrowserSendComponentState } from "../../../models/browserSendComponentState";
 
-export const BROWSER_SEND_COMPONENT = new KeyDefinition<BrowserSendComponentState>(
+export const BROWSER_SEND_COMPONENT = new UserKeyDefinition<BrowserSendComponentState>(
   BROWSER_SEND_MEMORY,
   "browser_send_component",
   {
     deserializer: (obj: Jsonify<BrowserSendComponentState>) =>
       BrowserSendComponentState.fromJSON(obj),
+    clearOn: ["logout", "lock"],
   },
 );
 
-export const BROWSER_SEND_TYPE_COMPONENT = new KeyDefinition<BrowserComponentState>(
+export const BROWSER_SEND_TYPE_COMPONENT = new UserKeyDefinition<BrowserComponentState>(
   BROWSER_SEND_MEMORY,
   "browser_send_type_component",
   {
     deserializer: (obj: Jsonify<BrowserComponentState>) => BrowserComponentState.fromJSON(obj),
+    clearOn: ["logout", "lock"],
   },
 );


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

UserKeyDefinitions are purpose built for storing user data and offer the ability to ensure cleanup on user status events.

This PR moves tools code that uses user-scoped state to UserKeyDefinitions.

Please be sure that each clearOn definition aligns with expectations. My gut says that component data isn't relevant past a lock, but I'm not very familiar on the usage of this data.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
