### PR TITLE
[PM-8142] Trigger cipher decryption on new browser vault tab

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -151,7 +151,10 @@ export class VaultPopupItemsService {
   constructor(
     private cipherService: CipherService,
     private vaultSettingsService: VaultSettingsService,
-  ) {}
+  ) {
+    // Temporary workaround to trigger decrypting all ciphers when the service is created.
+    void this.cipherService.getAllDecrypted();
+  }
 
   /**
    * Re-fetch the current tab to trigger a re-evaluation of the autofill ciphers.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `VaultPopupItemService` depends on the `cipherView$`. However, the `cipherService` currently only populates that observable when a call to `getAllDecrypted()` is called. So this PR adds a call to `getAllDecrypted` in the constructor for the new popup item service. This is a temporary work around to help ensure the new vault tab always attempts to decrypt the ciphers on popup open instead of waiting on another process to call `getAllDecrypted()`. 

Ultimately, the cipher service needs to be refactored so that subscribing to the `cipherViews$` observable will attempt to decrypt ciphers if none are available in the cache.

## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
