### PR TITLE
[PM-7024] - BUG - View events for cipher available for users without permission

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -62,7 +62,7 @@
       [showPremiumFeatures]="organization?.useTotp"
       [showBulkMove]="false"
       [showBulkTrashOptions]="filter.type === 'trash'"
-      [useEvents]="organization?.useEvents"
+      [useEvents]="organization?.canAccessEventLogs"
       [showAdminActions]="true"
       (onEvent)="onVaultItemsEvent($event)"
       [showBulkEditCollectionAccess]="organization?.flexibleCollections"


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

> Users that do not have permission to view event logs specific to a cipher were given the menu option within the vault item's row. Hide the menu option when the accessing user does not have permission to view the event logs.


## Code changes

- **apps/web/src/app/vault/org-vault/vault.component.html:** Updated the `useEvents` input to be evaluated based on the `canAccessEventLogs`. This shows the menu for Owners, Admins, Providers, and custom users with the AccessEventLogs permission


## Screenshots

https://github.com/bitwarden/clients/assets/26154748/e7e8d191-e4de-4083-ad3f-bc8c2d350788


## Before you submit

- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
- Ensure that all UI additions follow [WCAG AA requirements](https://contributing.bitwarden.com/contributing/accessibility/)
