### PR TITLE
Auth/PM-8358 - User Verification dialog & form input fix for empty submit displaying wrong error

### DIFF
--- a/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
+++ b/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
@@ -197,8 +197,8 @@ export class UserVerificationFormInputComponent implements ControlValueAccessor,
       }
     }
 
-    // Don't bother executing secret changes if biometrics verification is active.
-    if (this.activeClientVerificationOption === ActiveClientVerificationOption.Biometrics) {
+    // Executing secret changes for all non biometrics verification. Biometrics doesn't have a user entered secret.
+    if (this.activeClientVerificationOption !== ActiveClientVerificationOption.Biometrics) {
       this.processSecretChanges(this.secret.value);
     }
 

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -140,6 +140,10 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
    * @param verification User-supplied verification data (OTP, MP, PIN, or biometrics)
    */
   async verifyUser(verification: Verification): Promise<boolean> {
+    if (verification == null) {
+      throw new Error("Verification is required.");
+    }
+
     const [userId, email] = await firstValueFrom(
       this.accountService.activeAccount$.pipe(map((a) => [a?.id, a?.email])),
     );


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8358](https://bitwarden.atlassian.net/browse/PM-8358).  

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve displaying an incorrect error if the user verification dialog is opened with the "server" (default) flow with a MP and immediately submitted with an empty secret.  
![image](https://github.com/bitwarden/clients/assets/116684653/b44b70e5-3ace-4124-a603-23d11a6c3a96)


## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![image](https://github.com/bitwarden/clients/assets/116684653/fe5bb4ff-5012-4267-ba4b-43b09a417fc1)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8358]: https://bitwarden.atlassian.net/browse/PM-8358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ