### PR TITLE
[PM-5187] Fix no automatic two-fa mail & double mail on popout being sent

### DIFF
--- a/apps/browser/src/auth/popup/two-factor.component.ts
+++ b/apps/browser/src/auth/popup/two-factor.component.ts
@@ -147,8 +147,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         BrowserPopupUtils.openCurrentPagePopout(window);
+        return;
       }
     }
+
+    await this.init();
 
     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
     this.route.queryParams.pipe(first()).subscribe(async (qParams) => {

--- a/apps/desktop/src/auth/two-factor.component.ts
+++ b/apps/desktop/src/auth/two-factor.component.ts
@@ -99,6 +99,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     };
   }
 
+  async ngOnInit(): Promise<void> {
+    await super.ngOnInit();
+    await this.init();
+  }
+
   async anotherMethod() {
     const [modal, childComponent] = await this.modalService.openViewRef(
       TwoFactorOptionsComponent,

--- a/libs/angular/src/auth/components/two-factor.component.ts
+++ b/libs/angular/src/auth/components/two-factor.component.ts
@@ -148,7 +148,6 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
     this.selectedProviderType = await this.twoFactorService.getDefaultProvider(
       this.webAuthnSupported,
     );
-    await this.init();
   }
 
   ngOnDestroy(): void {
@@ -216,9 +215,7 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
         break;
       case TwoFactorProviderType.Email:
         this.twoFactorEmail = providerData.Email;
-        if ((await this.twoFactorService.getProviders()).size > 1) {
-          await this.sendEmail(false);
-        }
+        await this.sendEmail(false);
         break;
       default:
         break;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5187

## 📔 Objective

Fixes double two-fa mail being sent on popout, by only calling the base twofa component's init function after the dialog asking whether to popout, has been closed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
