### PR TITLE
[PM-8447] Autofill On Load Causes Decryption to Hang After Browser Startup

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -872,6 +872,7 @@ export default class MainBackground {
       this.billingAccountProfileStateService,
       this.scriptInjectorService,
       this.accountService,
+      this.authService,
     );
     this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
 

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -341,6 +341,7 @@ const safeProviders: SafeProvider[] = [
       BillingAccountProfileStateService,
       ScriptInjectorService,
       AccountServiceAbstraction,
+      AuthService,
     ],
   }),
   safeProvider({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8447
Resolves https://github.com/bitwarden/clients/issues/9369

## 📔 Objective

An issue was identified in mv3 where injection of the autofill on load script shortly after the browser has initialized can cause the decryption process for ciphers to hang. To resolve this, we are avoiding injection of the autofill on load content script in cases where the user's account is locked. While we have guards in place to avoid triggering autofill on load in a locked state, this now further guards the behavior and ensures that we do not attempt to trigger a decryption of ciphers in a state where organization keys are not present in the state of the extension.

## 📸 Demo of the issue

https://github.com/bitwarden/clients/assets/16629865/7e6af46f-9c92-4871-8d05-c75bb8b7a7c9


## 📸 Demo of the fix


https://github.com/bitwarden/clients/assets/16629865/a0e11372-858f-4526-9470-2163aa673449



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
