### PR TITLE
Browser - Add `jest-preset-angular`

### DIFF
--- a/apps/browser/src/autofill/content/autofill-init.spec.ts
+++ b/apps/browser/src/autofill/content/autofill-init.spec.ts
@@ -144,7 +144,7 @@ describe("AutofillInit", () => {
         .mockResolvedValue(pageDetails);
 
       const response = await autofillInit["handleExtensionMessage"](message, sender, sendResponse);
-      await Promise.resolve(response);
+      await flushPromises();
 
       expect(response).toBe(true);
       expect(sendResponse).toHaveBeenCalledWith(pageDetails);

--- a/apps/browser/src/autofill/utils/index.spec.ts
+++ b/apps/browser/src/autofill/utils/index.spec.ts
@@ -37,14 +37,29 @@ describe("generateRandomCustomElementName", () => {
 });
 
 describe("sendExtensionMessage", () => {
-  it("sends a message to the extention", () => {
-    const extensionMessageResponse = sendExtensionMessage("updateAutofillOverlayHidden", {
+  it("sends a message to the extension", async () => {
+    const extensionMessagePromise = sendExtensionMessage("updateAutofillOverlayHidden", {
       display: "none",
     });
-    jest.spyOn(chrome.runtime, "sendMessage");
 
-    expect(chrome.runtime.sendMessage).toHaveBeenCalled();
-    expect(extensionMessageResponse).toEqual(Promise.resolve({}));
+    // Jest doesn't give anyway to select the typed overload of "sendMessage",
+    // a cast is needed to get the correct spy type.
+    const sendMessageSpy = jest.spyOn(chrome.runtime, "sendMessage") as unknown as jest.SpyInstance<
+      void,
+      [message: string, responseCallback: (response: string) => void],
+      unknown
+    >;
+
+    expect(sendMessageSpy).toHaveBeenCalled();
+
+    const [latestCall] = sendMessageSpy.mock.calls;
+    const responseCallback = latestCall[1];
+
+    responseCallback("sendMessageResponse");
+
+    const response = await extensionMessagePromise;
+
+    expect(response).toEqual("sendMessageResponse");
   });
 });
 

--- a/apps/browser/src/vault/fido2/content/page-script.webauthn-supported.spec.ts
+++ b/apps/browser/src/vault/fido2/content/page-script.webauthn-supported.spec.ts
@@ -53,7 +53,9 @@ describe("Fido2 page script with native WebAuthn support", () => {
   const mockCredentialAssertResult = createAssertCredentialResultMock();
   setupMockedWebAuthnSupport();
 
-  require("./page-script");
+  beforeAll(() => {
+    require("./page-script");
+  });
 
   afterEach(() => {
     jest.resetModules();

--- a/apps/browser/test.setup.ts
+++ b/apps/browser/test.setup.ts
@@ -1,3 +1,5 @@
+import "jest-preset-angular/setup-jest";
+
 // Add chrome storage api
 const QUOTA_BYTES = 10;
 const storage = {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
I ran into this issue while adding tests in https://github.com/bitwarden/clients/pull/9365. I'm pulling it into a separate PR to be discussed/reviewed separately and not get lost in my other PR.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add `import "jest-preset-angular/setup-jest";` to `test.setup.ts` in the browser application.
- This is needed for certain Angular/TestBed features. It's also included in other applications `test.setup.ts` file

This caused 3 existing tests to break. Based on from what I can tell, the root cause is now Promises are replaced and integrated with `zone`.
- `autofill-init.spec.ts`
  - Error: `sendResponse` was not being called
  - Fix: use `flushPromises` rather than await a dummy promise 
- `page-script.webauthn-supported.spec.ts`
  - Error:  `require("./page-script");` was being called which runs the script and uses promises outside of the context of a test. Jest threw an error in this case: `Cannot call Promise.then from within a sync test (syncTestZone for jest.describe).`
  - Fix: Move the require into a `beforeAll` 
- `utils/index.spec.ts`
  - Error: `expect(extensionMessageResponse).toEqual(Promise.resolve({}))` was failing due to the comparison is now a `ZoneAwarePromise`
  - Fix: this one was more involved, I personally didn't like that the `expect` was comparing to a generic promise. The test would felt more intentional by testing that the promise resolves with the expected value passed to the callbac.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
