### PR TITLE
[PM-8480] Rename ambiguous Jest testing method

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -22,7 +22,7 @@ import { NotificationQueueMessageType } from "../enums/notification-queue-messag
 import { FormData } from "../services/abstractions/autofill.service";
 import AutofillService from "../services/autofill.service";
 import { createAutofillPageDetailsMock, createChromeTabMock } from "../spec/autofill-mocks";
-import { flushPromises, sendExtensionRuntimeMessage } from "../spec/testing-utils";
+import { flushPromises, sendMockExtensionMessage } from "../spec/testing-utils";
 
 import {
   AddChangePasswordQueueMessage,
@@ -143,7 +143,7 @@ describe("NotificationBackground", () => {
       const message: NotificationBackgroundExtensionMessage = { command: "unknown" };
       jest.spyOn(notificationBackground as any, "handleSaveCipherMessage");
 
-      sendExtensionRuntimeMessage(message);
+      sendMockExtensionMessage(message);
 
       expect(notificationBackground["handleSaveCipherMessage"]).not.toHaveBeenCalled();
     });
@@ -159,7 +159,7 @@ describe("NotificationBackground", () => {
         };
         jest.spyOn(BrowserApi, "tabSendMessageData").mockImplementation();
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(BrowserApi.tabSendMessageData).toHaveBeenCalledWith(
@@ -178,7 +178,7 @@ describe("NotificationBackground", () => {
         };
         jest.spyOn(notificationBackground as any, "handleSaveCipherMessage").mockImplementation();
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(notificationBackground["handleSaveCipherMessage"]).toHaveBeenCalledWith(
@@ -198,7 +198,7 @@ describe("NotificationBackground", () => {
         jest.spyOn(notificationBackground as any, "getFolderData");
         (firstValueFrom as jest.Mock).mockResolvedValueOnce(folderViews);
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(notificationBackground["getFolderData"]).toHaveBeenCalled();
@@ -214,7 +214,7 @@ describe("NotificationBackground", () => {
         };
         jest.spyOn(BrowserApi, "tabSendMessageData").mockImplementation();
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(BrowserApi.tabSendMessageData).toHaveBeenCalledWith(
@@ -233,7 +233,7 @@ describe("NotificationBackground", () => {
         };
         jest.spyOn(BrowserApi, "tabSendMessageData").mockImplementation();
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(BrowserApi.tabSendMessageData).toHaveBeenCalledWith(
@@ -281,7 +281,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.LoggedOut);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -296,7 +296,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -312,7 +312,7 @@ describe("NotificationBackground", () => {
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
         getEnableAddedLoginPromptSpy.mockReturnValueOnce(false);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -331,7 +331,7 @@ describe("NotificationBackground", () => {
         getEnableAddedLoginPromptSpy.mockReturnValueOnce(false);
         getAllDecryptedForUrlSpy.mockResolvedValueOnce([]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -353,7 +353,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "test", password: "oldPassword" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -375,7 +375,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "test", password: "password" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -391,7 +391,7 @@ describe("NotificationBackground", () => {
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
         getEnableAddedLoginPromptSpy.mockReturnValueOnce(true);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -411,7 +411,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "anotherTestUsername", password: "password" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -431,7 +431,7 @@ describe("NotificationBackground", () => {
           }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(pushChangePasswordToQueueSpy).toHaveBeenCalledWith(
@@ -467,7 +467,7 @@ describe("NotificationBackground", () => {
           data: { newPassword: "newPassword", currentPassword: "currentPassword", url: "" },
         };
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(pushChangePasswordToQueueSpy).not.toHaveBeenCalled();
@@ -484,7 +484,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -511,7 +511,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "test", password: "password" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -534,7 +534,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "test2", password: "password" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -559,7 +559,7 @@ describe("NotificationBackground", () => {
           }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(pushChangePasswordToQueueSpy).toHaveBeenCalledWith(
@@ -584,7 +584,7 @@ describe("NotificationBackground", () => {
           mock<CipherView>({ login: { username: "test2", password: "password" } }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -608,7 +608,7 @@ describe("NotificationBackground", () => {
           }),
         ]);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(pushChangePasswordToQueueSpy).toHaveBeenCalledWith(
@@ -644,7 +644,7 @@ describe("NotificationBackground", () => {
           thirdQueueMessage,
         ];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(removeTabFromNotificationQueueSpy).toHaveBeenCalledWith(tab);
@@ -677,7 +677,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -744,7 +744,7 @@ describe("NotificationBackground", () => {
             }),
           ];
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updatePasswordSpy).not.toHaveBeenCalled();
@@ -767,7 +767,7 @@ describe("NotificationBackground", () => {
             }),
           ];
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updatePasswordSpy).not.toHaveBeenCalled();
@@ -791,7 +791,7 @@ describe("NotificationBackground", () => {
             }),
           ];
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           expect(updatePasswordSpy).not.toHaveBeenCalled();
           expect(editItemSpy).not.toHaveBeenCalled();
           expect(createWithServerSpy).not.toHaveBeenCalled();
@@ -815,7 +815,7 @@ describe("NotificationBackground", () => {
           const cipherView = mock<CipherView>();
           getDecryptedCipherByIdSpy.mockResolvedValueOnce(cipherView);
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(editItemSpy).not.toHaveBeenCalled();
@@ -854,7 +854,7 @@ describe("NotificationBackground", () => {
           });
           getAllDecryptedForUrlSpy.mockResolvedValueOnce([cipherView]);
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updatePasswordSpy).toHaveBeenCalledWith(
@@ -887,7 +887,7 @@ describe("NotificationBackground", () => {
           setAddEditCipherInfoSpy.mockResolvedValue(undefined);
           openAddEditVaultItemPopoutSpy.mockResolvedValue(undefined);
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updatePasswordSpy).toHaveBeenCalledWith(
@@ -937,7 +937,7 @@ describe("NotificationBackground", () => {
           convertAddLoginQueueMessageToCipherViewSpy.mockReturnValueOnce(cipherView);
           editItemSpy.mockResolvedValueOnce(undefined);
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updatePasswordSpy).not.toHaveBeenCalled();
@@ -976,7 +976,7 @@ describe("NotificationBackground", () => {
           convertAddLoginQueueMessageToCipherViewSpy.mockReturnValueOnce(cipherView);
           editItemSpy.mockResolvedValueOnce(undefined);
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(convertAddLoginQueueMessageToCipherViewSpy).toHaveBeenCalledWith(
@@ -1019,7 +1019,7 @@ describe("NotificationBackground", () => {
             throw new Error(errorMessage);
           });
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(cipherEncryptSpy).toHaveBeenCalledWith(cipherView);
@@ -1058,7 +1058,7 @@ describe("NotificationBackground", () => {
             throw new Error(errorMessage);
           });
 
-          sendExtensionRuntimeMessage(message, sender);
+          sendMockExtensionMessage(message, sender);
           await flushPromises();
 
           expect(updateWithServerSpy).toThrow(errorMessage);
@@ -1093,7 +1093,7 @@ describe("NotificationBackground", () => {
           }),
         ];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).not.toHaveBeenCalled();
@@ -1107,7 +1107,7 @@ describe("NotificationBackground", () => {
           mock<AddUnlockVaultQueueMessage>({ type: NotificationQueueMessageType.UnlockVault, tab }),
         ];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).not.toHaveBeenCalled();
@@ -1125,7 +1125,7 @@ describe("NotificationBackground", () => {
           }),
         ];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).not.toHaveBeenCalled();
@@ -1149,7 +1149,7 @@ describe("NotificationBackground", () => {
         jest.spyOn(cipherService, "saveNeverDomain").mockImplementation();
         jest.spyOn(BrowserApi, "tabSendMessageData").mockImplementation();
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).toHaveBeenCalledWith(tab, "closeNotificationBar");
@@ -1171,7 +1171,7 @@ describe("NotificationBackground", () => {
           sender: "not-notificationBar",
         };
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).not.toHaveBeenCalled();
@@ -1188,7 +1188,7 @@ describe("NotificationBackground", () => {
         const formData = [mock<FormData>()];
         jest.spyOn(autofillService, "getFormsWithPasswordFields").mockReturnValueOnce(formData);
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
@@ -1222,7 +1222,7 @@ describe("NotificationBackground", () => {
           data: { skipNotification: true },
         };
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).not.toHaveBeenCalled();
@@ -1237,7 +1237,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.LoggedOut);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -1253,7 +1253,7 @@ describe("NotificationBackground", () => {
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
         notificationBackground["notificationQueue"] = [mock<AddLoginQueueMessage>()];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(pushUnlockVaultToQueueSpy).not.toHaveBeenCalled();
@@ -1267,7 +1267,7 @@ describe("NotificationBackground", () => {
         };
         getAuthStatusSpy.mockResolvedValueOnce(AuthenticationStatus.Locked);
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(pushUnlockVaultToQueueSpy).toHaveBeenCalledWith("example.com", sender.tab);
@@ -1292,7 +1292,7 @@ describe("NotificationBackground", () => {
         };
         notificationBackground["notificationQueue"] = [];
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(doNotificationQueueCheckSpy).not.toHaveBeenCalled();
@@ -1309,7 +1309,7 @@ describe("NotificationBackground", () => {
           mock<AddLoginQueueMessage>({ tab: createChromeTabMock({ id: 2 }) }),
         ];
 
-        sendExtensionRuntimeMessage(message, sender);
+        sendMockExtensionMessage(message, sender);
         await flushPromises();
 
         expect(doNotificationQueueCheckSpy).toHaveBeenCalledWith(tab);
@@ -1325,7 +1325,7 @@ describe("NotificationBackground", () => {
         ];
         getTabFromCurrentWindowSpy.mockResolvedValueOnce(currenTab);
 
-        sendExtensionRuntimeMessage(message, mock<chrome.runtime.MessageSender>({ tab: null }));
+        sendMockExtensionMessage(message, mock<chrome.runtime.MessageSender>({ tab: null }));
         await flushPromises();
 
         expect(getTabFromCurrentWindowSpy).toHaveBeenCalledWith();
@@ -1340,7 +1340,7 @@ describe("NotificationBackground", () => {
         };
         const openUnlockWindowSpy = jest.spyOn(notificationBackground as any, "openUnlockPopout");
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(openUnlockWindowSpy).toHaveBeenCalled();
@@ -1363,7 +1363,7 @@ describe("NotificationBackground", () => {
           .spyOn(environmentService as any, "environment$", "get")
           .mockReturnValue(new BehaviorSubject(env).asObservable());
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(environmentServiceSpy).toHaveBeenCalled();

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -43,7 +43,7 @@ import {
   createPageDetailMock,
   createPortSpyMock,
 } from "../spec/autofill-mocks";
-import { flushPromises, sendExtensionRuntimeMessage, sendPortMessage } from "../spec/testing-utils";
+import { flushPromises, sendMockExtensionMessage, sendPortMessage } from "../spec/testing-utils";
 import {
   AutofillOverlayElement,
   AutofillOverlayPort,
@@ -550,7 +550,7 @@ describe("OverlayBackground", () => {
           jest.spyOn(BrowserApi, "getTabFromCurrentWindowId").mockResolvedValueOnce(sender.tab);
           jest.spyOn(BrowserApi, "tabSendMessageData").mockImplementation();
 
-          sendExtensionRuntimeMessage({ command: "openAutofillOverlay" });
+          sendMockExtensionMessage({ command: "openAutofillOverlay" });
           await flushPromises();
 
           expect(BrowserApi.tabSendMessageData).toHaveBeenCalledWith(
@@ -576,9 +576,9 @@ describe("OverlayBackground", () => {
           overlayBackground["expiredPorts"] = [port1, port2];
           const sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 } });
           const focusedFieldData = createFocusedFieldDataMock({ tabId: 2 });
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             {
               command: "autofillOverlayElementClosed",
               overlayElement: AutofillOverlayElement.Button,
@@ -591,7 +591,7 @@ describe("OverlayBackground", () => {
         });
 
         it("disconnects the button element port", () => {
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "autofillOverlayElementClosed",
             overlayElement: AutofillOverlayElement.Button,
           });
@@ -601,7 +601,7 @@ describe("OverlayBackground", () => {
         });
 
         it("disconnects the list element port", () => {
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "autofillOverlayElementClosed",
             overlayElement: AutofillOverlayElement.List,
           });
@@ -622,7 +622,7 @@ describe("OverlayBackground", () => {
         });
 
         it("will not open the add edit popout window if the message does not have a login cipher provided", () => {
-          sendExtensionRuntimeMessage({ command: "autofillOverlayAddNewVaultItem" }, sender);
+          sendMockExtensionMessage({ command: "autofillOverlayAddNewVaultItem" }, sender);
 
           expect(overlayBackground["cipherService"].setAddEditCipherInfo).not.toHaveBeenCalled();
           expect(overlayBackground["openAddEditVaultItemPopout"]).not.toHaveBeenCalled();
@@ -631,7 +631,7 @@ describe("OverlayBackground", () => {
         it("will open the add edit popout window after creating a new cipher", async () => {
           jest.spyOn(BrowserApi, "sendMessage");
 
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             {
               command: "autofillOverlayAddNewVaultItem",
               login: {
@@ -661,7 +661,7 @@ describe("OverlayBackground", () => {
         });
 
         it("will set the overlayVisibility property", async () => {
-          sendExtensionRuntimeMessage({ command: "getAutofillOverlayVisibility" });
+          sendMockExtensionMessage({ command: "getAutofillOverlayVisibility" });
           await flushPromises();
 
           expect(await overlayBackground["getOverlayVisibility"]()).toBe(
@@ -672,7 +672,7 @@ describe("OverlayBackground", () => {
         it("returns the overlayVisibility property", async () => {
           const sendMessageSpy = jest.fn();
 
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             { command: "getAutofillOverlayVisibility" },
             undefined,
             sendMessageSpy,
@@ -689,7 +689,7 @@ describe("OverlayBackground", () => {
         });
 
         it("will check if the overlay list is focused if the list port is open", () => {
-          sendExtensionRuntimeMessage({ command: "checkAutofillOverlayFocused" });
+          sendMockExtensionMessage({ command: "checkAutofillOverlayFocused" });
 
           expect(listPortSpy.postMessage).toHaveBeenCalledWith({
             command: "checkAutofillOverlayListFocused",
@@ -702,7 +702,7 @@ describe("OverlayBackground", () => {
         it("will check if the overlay button is focused if the list port is not open", () => {
           overlayBackground["overlayListPort"] = undefined;
 
-          sendExtensionRuntimeMessage({ command: "checkAutofillOverlayFocused" });
+          sendMockExtensionMessage({ command: "checkAutofillOverlayFocused" });
 
           expect(buttonPortSpy.postMessage).toHaveBeenCalledWith({
             command: "checkAutofillOverlayButtonFocused",
@@ -717,7 +717,7 @@ describe("OverlayBackground", () => {
         it("will send a `focusOverlayList` message to the overlay list port", async () => {
           await initOverlayElementPorts({ initList: true, initButton: false });
 
-          sendExtensionRuntimeMessage({ command: "focusAutofillOverlayList" });
+          sendMockExtensionMessage({ command: "focusAutofillOverlayList" });
 
           expect(listPortSpy.postMessage).toHaveBeenCalledWith({ command: "focusOverlayList" });
         });
@@ -737,7 +737,7 @@ describe("OverlayBackground", () => {
         });
 
         it("ignores updating the position if the overlay element type is not provided", () => {
-          sendExtensionRuntimeMessage({ command: "updateAutofillOverlayPosition" });
+          sendMockExtensionMessage({ command: "updateAutofillOverlayPosition" });
 
           expect(listPortSpy.postMessage).not.toHaveBeenCalledWith({
             command: "updateIframePosition",
@@ -752,9 +752,9 @@ describe("OverlayBackground", () => {
         it("skips updating the position if the most recently focused field is different than the message sender", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 } });
           const focusedFieldData = createFocusedFieldDataMock({ tabId: 2 });
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage({ command: "updateAutofillOverlayPosition" }, sender);
+          sendMockExtensionMessage({ command: "updateAutofillOverlayPosition" }, sender);
 
           expect(listPortSpy.postMessage).not.toHaveBeenCalledWith({
             command: "updateIframePosition",
@@ -768,9 +768,9 @@ describe("OverlayBackground", () => {
 
         it("updates the overlay button's position", () => {
           const focusedFieldData = createFocusedFieldDataMock();
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayPosition",
             overlayElement: AutofillOverlayElement.Button,
           });
@@ -785,9 +785,9 @@ describe("OverlayBackground", () => {
           const focusedFieldData = createFocusedFieldDataMock({
             focusedFieldRects: { top: 1, left: 2, height: 35, width: 4 },
           });
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayPosition",
             overlayElement: AutofillOverlayElement.Button,
           });
@@ -802,9 +802,9 @@ describe("OverlayBackground", () => {
           const focusedFieldData = createFocusedFieldDataMock({
             focusedFieldRects: { top: 1, left: 2, height: 50, width: 4 },
           });
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayPosition",
             overlayElement: AutofillOverlayElement.Button,
           });
@@ -819,9 +819,9 @@ describe("OverlayBackground", () => {
           const focusedFieldData = createFocusedFieldDataMock({
             focusedFieldStyles: { paddingRight: "20px", paddingLeft: "6px" },
           });
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayPosition",
             overlayElement: AutofillOverlayElement.Button,
           });
@@ -835,13 +835,13 @@ describe("OverlayBackground", () => {
         it("will post a message to the overlay list facilitating an update of the list's position", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 } });
           const focusedFieldData = createFocusedFieldDataMock();
-          sendExtensionRuntimeMessage({ command: "updateFocusedFieldData", focusedFieldData });
+          sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData });
 
           overlayBackground["updateOverlayPosition"](
             { overlayElement: AutofillOverlayElement.List },
             sender,
           );
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayPosition",
             overlayElement: AutofillOverlayElement.List,
           });
@@ -863,7 +863,7 @@ describe("OverlayBackground", () => {
             command: "updateAutofillOverlayHidden",
           };
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(buttonPortSpy.postMessage).not.toHaveBeenCalledWith(message);
           expect(listPortSpy.postMessage).not.toHaveBeenCalledWith(message);
@@ -872,7 +872,7 @@ describe("OverlayBackground", () => {
         it("posts a message to the overlay button and list with the display value", () => {
           const message = { command: "updateAutofillOverlayHidden", display: "none" };
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(overlayBackground["overlayButtonPort"].postMessage).toHaveBeenCalledWith({
             command: "updateOverlayHidden",
@@ -903,7 +903,7 @@ describe("OverlayBackground", () => {
         });
 
         it("stores the page details provided by the message by the tab id of the sender", () => {
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             { command: "collectPageDetailsResponse", details: pageDetails1 },
             sender,
           );
@@ -924,7 +924,7 @@ describe("OverlayBackground", () => {
             [sender.frameId, { frameId: sender.frameId, tab: sender.tab, details: pageDetails1 }],
           ]);
 
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             { command: "collectPageDetailsResponse", details: pageDetails2 },
             secondFrameSender,
           );
@@ -967,7 +967,7 @@ describe("OverlayBackground", () => {
             },
           };
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
           await flushPromises();
 
           expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -984,7 +984,7 @@ describe("OverlayBackground", () => {
           };
           jest.spyOn(BrowserApi, "getTabFromCurrentWindowId").mockResolvedValueOnce(sender.tab);
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
           await flushPromises();
 
           expect(getAuthStatusSpy).toHaveBeenCalled();
@@ -1007,7 +1007,7 @@ describe("OverlayBackground", () => {
           };
           jest.spyOn(overlayBackground as any, "updateOverlayCiphers").mockImplementation();
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(overlayBackground["updateOverlayCiphers"]).toHaveBeenCalled();
         });
@@ -1020,7 +1020,7 @@ describe("OverlayBackground", () => {
           };
           jest.spyOn(overlayBackground as any, "updateOverlayCiphers").mockImplementation();
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(overlayBackground["updateOverlayCiphers"]).toHaveBeenCalled();
         });

--- a/apps/browser/src/autofill/content/autofill-init.spec.ts
+++ b/apps/browser/src/autofill/content/autofill-init.spec.ts
@@ -9,7 +9,7 @@ import AutofillOverlayContentService from "../services/autofill-overlay-content.
 import {
   flushPromises,
   mockQuerySelectorAllDefinedCall,
-  sendExtensionRuntimeMessage,
+  sendMockExtensionMessage,
 } from "../spec/testing-utils";
 import { RedirectFocusDirection } from "../utils/autofill-overlay.enum";
 
@@ -174,7 +174,7 @@ describe("AutofillInit", () => {
             .spyOn(autofillInit["collectAutofillContentService"], "getPageDetails")
             .mockResolvedValue(pageDetails);
 
-          sendExtensionRuntimeMessage(message, sender, sendResponse);
+          sendMockExtensionMessage(message, sender, sendResponse);
           await flushPromises();
 
           expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
@@ -200,7 +200,7 @@ describe("AutofillInit", () => {
             .spyOn(autofillInit["collectAutofillContentService"], "getPageDetails")
             .mockResolvedValue(pageDetails);
 
-          sendExtensionRuntimeMessage(
+          sendMockExtensionMessage(
             { command: "collectPageDetailsImmediately" },
             sender,
             sendResponse,
@@ -233,7 +233,7 @@ describe("AutofillInit", () => {
             pageDetailsUrl: "https://a-different-url.com",
           };
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
           await flushPromises();
 
           expect(autofillInit["insertAutofillContentService"].fillForm).not.toHaveBeenCalledWith(
@@ -242,7 +242,7 @@ describe("AutofillInit", () => {
         });
 
         it("calls the InsertAutofillContentService to fill the form", async () => {
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "fillForm",
             fillScript,
             pageDetailsUrl: window.location.href,
@@ -256,7 +256,7 @@ describe("AutofillInit", () => {
 
         it("removes the overlay when filling the form", async () => {
           const blurAndRemoveOverlaySpy = jest.spyOn(autofillInit as any, "blurAndRemoveOverlay");
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "fillForm",
             fillScript,
             pageDetailsUrl: window.location.href,
@@ -273,7 +273,7 @@ describe("AutofillInit", () => {
             .spyOn(autofillInit["autofillOverlayContentService"], "focusMostRecentOverlayField")
             .mockImplementation();
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "fillForm",
             fillScript,
             pageDetailsUrl: window.location.href,
@@ -297,7 +297,7 @@ describe("AutofillInit", () => {
             .spyOn(newAutofillInit["insertAutofillContentService"], "fillForm")
             .mockImplementation();
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "fillForm",
             fillScript,
             pageDetailsUrl: window.location.href,
@@ -333,13 +333,13 @@ describe("AutofillInit", () => {
           const newAutofillInit = new AutofillInit(undefined);
           newAutofillInit.init();
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
         });
 
         it("opens the autofill overlay", () => {
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(
             autofillInit["autofillOverlayContentService"].openAutofillOverlay,
@@ -362,7 +362,7 @@ describe("AutofillInit", () => {
           newAutofillInit.init();
           jest.spyOn(newAutofillInit as any, "removeAutofillOverlay");
 
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "closeAutofillOverlay",
             data: { forceCloseOverlay: false },
           });
@@ -371,7 +371,7 @@ describe("AutofillInit", () => {
         });
 
         it("removes the autofill overlay if the message flags a forced closure", () => {
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "closeAutofillOverlay",
             data: { forceCloseOverlay: true },
           });
@@ -384,7 +384,7 @@ describe("AutofillInit", () => {
         it("ignores the message if a field is currently focused", () => {
           autofillInit["autofillOverlayContentService"].isFieldCurrentlyFocused = true;
 
-          sendExtensionRuntimeMessage({ command: "closeAutofillOverlay" });
+          sendMockExtensionMessage({ command: "closeAutofillOverlay" });
 
           expect(
             autofillInit["autofillOverlayContentService"].removeAutofillOverlayList,
@@ -397,7 +397,7 @@ describe("AutofillInit", () => {
         it("removes the autofill overlay list if the overlay is currently filling", () => {
           autofillInit["autofillOverlayContentService"].isCurrentlyFilling = true;
 
-          sendExtensionRuntimeMessage({ command: "closeAutofillOverlay" });
+          sendMockExtensionMessage({ command: "closeAutofillOverlay" });
 
           expect(
             autofillInit["autofillOverlayContentService"].removeAutofillOverlayList,
@@ -408,7 +408,7 @@ describe("AutofillInit", () => {
         });
 
         it("removes the entire overlay if the overlay is not currently filling", () => {
-          sendExtensionRuntimeMessage({ command: "closeAutofillOverlay" });
+          sendMockExtensionMessage({ command: "closeAutofillOverlay" });
 
           expect(
             autofillInit["autofillOverlayContentService"].removeAutofillOverlayList,
@@ -424,13 +424,13 @@ describe("AutofillInit", () => {
           const newAutofillInit = new AutofillInit(undefined);
           newAutofillInit.init();
 
-          sendExtensionRuntimeMessage({ command: "addNewVaultItemFromOverlay" });
+          sendMockExtensionMessage({ command: "addNewVaultItemFromOverlay" });
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
         });
 
         it("will add a new vault item", () => {
-          sendExtensionRuntimeMessage({ command: "addNewVaultItemFromOverlay" });
+          sendMockExtensionMessage({ command: "addNewVaultItemFromOverlay" });
 
           expect(autofillInit["autofillOverlayContentService"].addNewVaultItem).toHaveBeenCalled();
         });
@@ -448,13 +448,13 @@ describe("AutofillInit", () => {
           const newAutofillInit = new AutofillInit(undefined);
           newAutofillInit.init();
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
         });
 
         it("redirects the overlay focus", () => {
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(
             autofillInit["autofillOverlayContentService"].redirectOverlayFocusOut,
@@ -474,13 +474,13 @@ describe("AutofillInit", () => {
           const newAutofillInit = new AutofillInit(undefined);
           newAutofillInit.init();
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
         });
 
         it("updates whether the overlay ciphers are populated", () => {
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(autofillInit["autofillOverlayContentService"].isOverlayCiphersPopulated).toEqual(
             message.data.isOverlayCiphersPopulated,
@@ -494,7 +494,7 @@ describe("AutofillInit", () => {
           newAutofillInit.init();
           jest.spyOn(newAutofillInit as any, "removeAutofillOverlay");
 
-          sendExtensionRuntimeMessage({ command: "bgUnlockPopoutOpened" });
+          sendMockExtensionMessage({ command: "bgUnlockPopoutOpened" });
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
           expect(newAutofillInit["removeAutofillOverlay"]).not.toHaveBeenCalled();
@@ -504,7 +504,7 @@ describe("AutofillInit", () => {
           jest.spyOn(autofillInit["autofillOverlayContentService"], "blurMostRecentOverlayField");
           jest.spyOn(autofillInit as any, "removeAutofillOverlay");
 
-          sendExtensionRuntimeMessage({ command: "bgUnlockPopoutOpened" });
+          sendMockExtensionMessage({ command: "bgUnlockPopoutOpened" });
 
           expect(
             autofillInit["autofillOverlayContentService"].blurMostRecentOverlayField,
@@ -519,7 +519,7 @@ describe("AutofillInit", () => {
           newAutofillInit.init();
           jest.spyOn(newAutofillInit as any, "removeAutofillOverlay");
 
-          sendExtensionRuntimeMessage({ command: "bgVaultItemRepromptPopoutOpened" });
+          sendMockExtensionMessage({ command: "bgVaultItemRepromptPopoutOpened" });
 
           expect(newAutofillInit["autofillOverlayContentService"]).toBe(undefined);
           expect(newAutofillInit["removeAutofillOverlay"]).not.toHaveBeenCalled();
@@ -529,7 +529,7 @@ describe("AutofillInit", () => {
           jest.spyOn(autofillInit["autofillOverlayContentService"], "blurMostRecentOverlayField");
           jest.spyOn(autofillInit as any, "removeAutofillOverlay");
 
-          sendExtensionRuntimeMessage({ command: "bgVaultItemRepromptPopoutOpened" });
+          sendMockExtensionMessage({ command: "bgVaultItemRepromptPopoutOpened" });
 
           expect(
             autofillInit["autofillOverlayContentService"].blurMostRecentOverlayField,
@@ -545,7 +545,7 @@ describe("AutofillInit", () => {
         });
 
         it("skips attempting to update the overlay visibility if the autofillOverlayVisibility data value is not present", () => {
-          sendExtensionRuntimeMessage({
+          sendMockExtensionMessage({
             command: "updateAutofillOverlayVisibility",
             data: {},
           });
@@ -563,7 +563,7 @@ describe("AutofillInit", () => {
             },
           };
 
-          sendExtensionRuntimeMessage(message);
+          sendMockExtensionMessage(message);
 
           expect(autofillInit["autofillOverlayContentService"].autofillOverlayVisibility).toEqual(
             message.data.autofillOverlayVisibility,

--- a/apps/browser/src/autofill/content/content-message-handler.spec.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.spec.ts
@@ -2,7 +2,7 @@ import { mock } from "jest-mock-extended";
 
 import { VaultOnboardingMessages } from "@bitwarden/common/vault/enums/vault-onboarding.enum";
 
-import { postWindowMessage, sendExtensionRuntimeMessage } from "../spec/testing-utils";
+import { postWindowMessage, sendMockExtensionMessage } from "../spec/testing-utils";
 
 describe("ContentMessageHandler", () => {
   const sendMessageSpy = jest.spyOn(chrome.runtime, "sendMessage");
@@ -92,13 +92,13 @@ describe("ContentMessageHandler", () => {
 
   describe("handled extension messages", () => {
     it("ignores the message to the extension background if it is not present in the forwardCommands list", () => {
-      sendExtensionRuntimeMessage({ command: "someOtherCommand" });
+      sendMockExtensionMessage({ command: "someOtherCommand" });
 
       expect(sendMessageSpy).not.toHaveBeenCalled();
     });
 
     it("forwards the message to the extension background if it is present in the forwardCommands list", () => {
-      sendExtensionRuntimeMessage({ command: "bgUnlockPopoutOpened" });
+      sendMockExtensionMessage({ command: "bgUnlockPopoutOpened" });
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(sendMessageSpy).toHaveBeenCalledWith({ command: "bgUnlockPopoutOpened" });

--- a/apps/browser/src/autofill/spec/testing-utils.ts
+++ b/apps/browser/src/autofill/spec/testing-utils.ts
@@ -15,7 +15,7 @@ function postWindowMessage(data: any, origin = "https://localhost/", source = wi
   globalThis.dispatchEvent(new MessageEvent("message", { data, origin, source }));
 }
 
-function sendExtensionRuntimeMessage(
+function sendMockExtensionMessage(
   message: any,
   sender?: chrome.runtime.MessageSender,
   sendResponse?: CallableFunction,
@@ -130,7 +130,7 @@ export {
   triggerTestFailure,
   flushPromises,
   postWindowMessage,
-  sendExtensionRuntimeMessage,
+  sendMockExtensionMessage,
   triggerRuntimeOnConnectEvent,
   sendPortMessage,
   triggerPortOnDisconnectEvent,

--- a/apps/browser/src/platform/offscreen-document/offscreen-document.spec.ts
+++ b/apps/browser/src/platform/offscreen-document/offscreen-document.spec.ts
@@ -1,4 +1,4 @@
-import { flushPromises, sendExtensionRuntimeMessage } from "../../autofill/spec/testing-utils";
+import { flushPromises, sendMockExtensionMessage } from "../../autofill/spec/testing-utils";
 import { BrowserApi } from "../browser/browser-api";
 import BrowserClipboardService from "../services/browser-clipboard.service";
 
@@ -21,7 +21,7 @@ describe("OffscreenDocument", () => {
 
   describe("extension message handlers", () => {
     it("ignores messages that do not have a handler registered with the corresponding command", () => {
-      sendExtensionRuntimeMessage({ command: "notAValidCommand" });
+      sendMockExtensionMessage({ command: "notAValidCommand" });
 
       expect(browserClipboardServiceCopySpy).not.toHaveBeenCalled();
       expect(browserClipboardServiceReadSpy).not.toHaveBeenCalled();
@@ -31,7 +31,7 @@ describe("OffscreenDocument", () => {
       const error = new Error("test error");
       browserClipboardServiceCopySpy.mockRejectedValueOnce(new Error("test error"));
 
-      sendExtensionRuntimeMessage({ command: "offscreenCopyToClipboard", text: "test" });
+      sendMockExtensionMessage({ command: "offscreenCopyToClipboard", text: "test" });
       await flushPromises();
 
       expect(browserClipboardServiceCopySpy).toHaveBeenCalled();
@@ -45,7 +45,7 @@ describe("OffscreenDocument", () => {
       it("copies the message text", async () => {
         const text = "test";
 
-        sendExtensionRuntimeMessage({ command: "offscreenCopyToClipboard", text });
+        sendMockExtensionMessage({ command: "offscreenCopyToClipboard", text });
         await flushPromises();
 
         expect(browserClipboardServiceCopySpy).toHaveBeenCalledWith(window, text);
@@ -54,7 +54,7 @@ describe("OffscreenDocument", () => {
 
     describe("handleOffscreenReadFromClipboard", () => {
       it("reads the value from the clipboard service", async () => {
-        sendExtensionRuntimeMessage({ command: "offscreenReadFromClipboard" });
+        sendMockExtensionMessage({ command: "offscreenReadFromClipboard" });
         await flushPromises();
 
         expect(browserClipboardServiceReadSpy).toHaveBeenCalledWith(window);

--- a/apps/browser/src/vault/fido2/background/fido2.background.spec.ts
+++ b/apps/browser/src/vault/fido2/background/fido2.background.spec.ts
@@ -12,7 +12,7 @@ import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault
 import { createPortSpyMock } from "../../../autofill/spec/autofill-mocks";
 import {
   flushPromises,
-  sendExtensionRuntimeMessage,
+  sendMockExtensionMessage,
   triggerPortOnDisconnectEvent,
   triggerRuntimeOnConnectEvent,
 } from "../../../autofill/spec/testing-utils";
@@ -263,7 +263,7 @@ describe("Fido2Background", () => {
     it("ignores messages that do not have a handler associated with a command within the message", () => {
       const message = mock<Fido2ExtensionMessage>({ command: "nonexistentCommand" });
 
-      sendExtensionRuntimeMessage(message);
+      sendMockExtensionMessage(message);
 
       expect(abortManagerMock.abort).not.toHaveBeenCalled();
     });
@@ -274,7 +274,7 @@ describe("Fido2Background", () => {
       const sendResponse = jest.fn();
       fido2ClientService.createCredential.mockRejectedValue(new Error("error"));
 
-      sendExtensionRuntimeMessage(message, sender, sendResponse);
+      sendMockExtensionMessage(message, sender, sendResponse);
       await flushPromises();
 
       expect(sendResponse).toHaveBeenCalledWith({ error: { message: "error" } });
@@ -287,7 +287,7 @@ describe("Fido2Background", () => {
           abortedRequestId: "123",
         });
 
-        sendExtensionRuntimeMessage(message);
+        sendMockExtensionMessage(message);
         await flushPromises();
 
         expect(abortManagerMock.abort).toHaveBeenCalledWith(message.abortedRequestId);
@@ -302,7 +302,7 @@ describe("Fido2Background", () => {
           data: mock<CreateCredentialParams>(),
         });
 
-        sendExtensionRuntimeMessage(message, senderMock);
+        sendMockExtensionMessage(message, senderMock);
         await flushPromises();
 
         expect(fido2ClientService.createCredential).toHaveBeenCalledWith(
@@ -323,7 +323,7 @@ describe("Fido2Background", () => {
           data: mock<AssertCredentialParams>(),
         });
 
-        sendExtensionRuntimeMessage(message, senderMock);
+        sendMockExtensionMessage(message, senderMock);
         await flushPromises();
 
         expect(fido2ClientService.assertCredential).toHaveBeenCalledWith(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8480

## 📔 Objective

A testing utility method that sends a mock extension message has a confusing/ambiguous name of `sendExtensionRuntimeMessage`. This needs to be renamed to ensure that our team understands the purpose of that method. I’ll be modifying the method name to `sendMockExtensionMessage`. This change should not affect any logic in production. The change strictly affects testing files.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
