### PR TITLE
[PM-8436] [PM-8483] Support Asymmetric Mac Encryption Types in EncString

### DIFF
--- a/libs/common/src/platform/models/domain/enc-string.spec.ts
+++ b/libs/common/src/platform/models/domain/enc-string.spec.ts
@@ -55,6 +55,26 @@ describe("EncString", () => {
           encryptionType: 3,
         });
       });
+
+      const cases = [
+        "aXY=|Y3Q=", // AesCbc256_B64 w/out header
+        "aXY=|Y3Q=|cnNhQ3Q=", // AesCbc128_HmacSha256_B64 w/out header
+        "0.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // AesCbc256_B64 with header
+        "1.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // AesCbc128_HmacSha256_B64
+        "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // AesCbc256_HmacSha256_B64
+        "3.QmFzZTY0UGFydA==", // Rsa2048_OaepSha256_B64
+        "4.QmFzZTY0UGFydA==", // Rsa2048_OaepSha1_B64
+        "5.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // Rsa2048_OaepSha256_HmacSha256_B64
+        "6.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // Rsa2048_OaepSha1_HmacSha256_B64
+      ];
+
+      it.each(cases)("can retrieve data bytes for %s", (encryptedString) => {
+        const encString = new EncString(encryptedString);
+
+        const dataBytes = encString.dataBytes;
+        expect(dataBytes).not.toBeNull();
+        expect(dataBytes.length).toBeGreaterThan(0);
+      });
     });
 
     describe("decrypt", () => {

--- a/libs/common/src/platform/models/domain/enc-string.ts
+++ b/libs/common/src/platform/models/domain/enc-string.ts
@@ -97,6 +97,11 @@ export class EncString implements Encrypted {
       case EncryptionType.Rsa2048_OaepSha1_B64:
         this.data = encPieces[0];
         break;
+      case EncryptionType.Rsa2048_OaepSha256_HmacSha256_B64:
+      case EncryptionType.Rsa2048_OaepSha1_HmacSha256_B64:
+        this.data = encPieces[0];
+        this.mac = encPieces[1];
+        break;
       default:
         return;
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-8436
https://bitwarden.atlassian.net/browse/PM-8483

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

A change was made in #9191 to use `EncryptService` instead of `CryptoService` to do the RSA decryption of organization keys. This changes it to parse the string data with `EncString` and take the `.dataBytes` property vs relying on `CryptoService.rsaDecrypt` logic to handle getting the data as bytes. `EncString` didn't have cases for encryption types 5 & 6 so it left the `data` & `mac` properties `undefined`. When those are null, so would `get dataBytes` and that would cause `SubtleCrypto.decrypt` to throw. All we have to do is set the data to the correct piece (I also do `mac` even though it's never actually used). This should fix the decryption of organization keys from ~2018. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
