### PR TITLE
[AC-2635] [AC-2636] Add device-approval deny and deny-all commands

### DIFF
--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/deny-all.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/deny-all.command.ts
@@ -1,9 +1,49 @@
+import { firstValueFrom } from "rxjs";
+
 import { Response } from "@bitwarden/cli/models/response";
+import { MessageResponse } from "@bitwarden/cli/models/response/message.response";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
+import { OrganizationAuthRequestService } from "../../../../bit-common/src/admin-console/auth-requests";
 
 export class DenyAllCommand {
-  constructor() {}
+  constructor(
+    private organizationService: OrganizationService,
+    private organizationAuthRequestService: OrganizationAuthRequestService,
+  ) {}
 
   async run(organizationId: string): Promise<Response> {
-    throw new Error("Not implemented");
+    if (organizationId != null) {
+      organizationId = organizationId.toLowerCase();
+    }
+
+    if (!Utils.isGuid(organizationId)) {
+      return Response.badRequest("`" + organizationId + "` is not a GUID.");
+    }
+
+    const organization = await firstValueFrom(this.organizationService.get$(organizationId));
+    if (!organization?.canManageUsersPassword) {
+      return Response.error(
+        "You do not have permission to approve pending device authorization requests.",
+      );
+    }
+
+    try {
+      const pendingRequests =
+        await this.organizationAuthRequestService.listPendingRequests(organizationId);
+      if (pendingRequests.length == 0) {
+        const res = new MessageResponse("No pending device authorization requests to deny.", null);
+        return Response.success(res);
+      }
+
+      await this.organizationAuthRequestService.denyPendingRequests(
+        organizationId,
+        ...pendingRequests.map((r) => r.id),
+      );
+      return Response.success();
+    } catch (e) {
+      return Response.error(e);
+    }
   }
 }

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/deny.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/deny.command.ts
@@ -1,9 +1,46 @@
+import { firstValueFrom } from "rxjs";
+
 import { Response } from "@bitwarden/cli/models/response";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
+import { OrganizationAuthRequestService } from "../../../../bit-common/src/admin-console/auth-requests";
 
 export class DenyCommand {
-  constructor() {}
+  constructor(
+    private organizationService: OrganizationService,
+    private organizationAuthRequestService: OrganizationAuthRequestService,
+  ) {}
 
-  async run(id: string): Promise<Response> {
-    throw new Error("Not implemented");
+  async run(organizationId: string, id: string): Promise<Response> {
+    if (organizationId != null) {
+      organizationId = organizationId.toLowerCase();
+    }
+
+    if (!Utils.isGuid(organizationId)) {
+      return Response.badRequest("`" + organizationId + "` is not a GUID.");
+    }
+
+    if (id != null) {
+      id = id.toLowerCase();
+    }
+
+    if (!Utils.isGuid(id)) {
+      return Response.badRequest("`" + id + "` is not a GUID.");
+    }
+
+    const organization = await firstValueFrom(this.organizationService.get$(organizationId));
+    if (!organization?.canManageUsersPassword) {
+      return Response.error(
+        "You do not have permission to approve pending device authorization requests.",
+      );
+    }
+
+    try {
+      await this.organizationAuthRequestService.denyPendingRequests(organizationId, id);
+      return Response.success();
+    } catch (e) {
+      return Response.error(e);
+    }
   }
 }

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/device-approval.program.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/device-approval.program.ts
@@ -80,14 +80,18 @@ export class DeviceApprovalProgram extends BaseProgram {
 
   private denyCommand(): Command {
     return new Command("deny")
-      .argument("<id>")
+      .argument("<organizationId>", "The id of the organization")
+      .argument("<requestId>", "The id of the request to deny")
       .description("Deny a pending request")
-      .action(async (id: string) => {
+      .action(async (organizationId: string, id: string) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
-        const cmd = new DenyCommand();
-        const response = await cmd.run(id);
+        const cmd = new DenyCommand(
+          this.serviceContainer.organizationService,
+          this.serviceContainer.organizationAuthRequestService,
+        );
+        const response = await cmd.run(organizationId, id);
         this.processResponse(response);
       });
   }
@@ -100,7 +104,10 @@ export class DeviceApprovalProgram extends BaseProgram {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
-        const cmd = new DenyAllCommand();
+        const cmd = new DenyAllCommand(
+          this.serviceContainer.organizationService,
+          this.serviceContainer.organizationAuthRequestService,
+        );
         const response = await cmd.run(organizationId);
         this.processResponse(response);
       });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-1679 and subtasks

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Implement the `deny` and `deny-all` commands for device approvals in the CLI.

This follows the same patterns as the other commands we've done.

Note that I had to add `organizationId` as a parameter to `deny` because our REST api requires it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Deny:

```
Usage: bw device-approval deny [options] <organizationId> <requestId>

Deny a pending request

Arguments:
  organizationId  The id of the organization
  requestId       The id of the request to deny

Options:
  -h, --help      display help for command
```

Deny all:
```
Usage: bw device-approval deny-all [options] <organizationId>

Deny all pending requests for an organization

Options:
  -h, --help  display help for command
```
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
