### PR TITLE
PM-8482 Change KDF Confirmation no longer has browser validation

### DIFF
--- a/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.ts
+++ b/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.ts
@@ -41,6 +41,9 @@ export class ChangeKdfConfirmationComponent {
   }
 
   submit = async () => {
+    if (this.form.value.masterPassword === null) {
+      return;
+    }
     this.loading = true;
     await this.makeKeyAndSaveAsync();
     this.platformUtilsService.showToast(

--- a/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.ts
+++ b/apps/web/src/app/auth/settings/security/change-kdf/change-kdf-confirmation.component.ts
@@ -41,7 +41,7 @@ export class ChangeKdfConfirmationComponent {
   }
 
   submit = async () => {
-    if (this.form.value.masterPassword === null) {
+    if (this.form.invalid) {
       return;
     }
     this.loading = true;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8482

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## 📔 Objective

To make change KDF confirmation component to have a browser validation when master password is empty.

## Code changes

- **change-kdf-confirmation.component.ts:** Added a condition to check whether the master password is empty.

## 📸 Screenshots


https://github.com/bitwarden/clients/assets/162679756/c5c40713-0359-4290-9051-ed3121189fe1


