### PR TITLE
Prefer UserKeyDefinitions for `getUser` state

### DIFF
--- a/libs/common/src/tools/state/buffered-state.spec.ts
+++ b/libs/common/src/tools/state/buffered-state.spec.ts
@@ -6,7 +6,7 @@ import {
   awaitAsync,
   trackEmissions,
 } from "../../../spec";
-import { GENERATOR_DISK, KeyDefinition } from "../../platform/state";
+import { GENERATOR_DISK, UserKeyDefinition } from "../../platform/state";
 import { UserId } from "../../types/guid";
 
 import { BufferedKeyDefinition } from "./buffered-key-definition";
@@ -16,8 +16,9 @@ const SomeUser = "SomeUser" as UserId;
 const accountService = mockAccountServiceWith(SomeUser);
 type SomeType = { foo: boolean; bar: boolean };
 
-const SOME_KEY = new KeyDefinition<SomeType>(GENERATOR_DISK, "fooBar", {
+const SOME_KEY = new UserKeyDefinition<SomeType>(GENERATOR_DISK, "fooBar", {
   deserializer: (jsonValue) => jsonValue as SomeType,
+  clearOn: [],
 });
 const BUFFER_KEY = new BufferedKeyDefinition<SomeType>(GENERATOR_DISK, "fooBar_buffer", {
   deserializer: (jsonValue) => jsonValue as SomeType,


### PR DESCRIPTION
## 🎟️ Tracking

pre work for #8669

## 📔 Objective

Currently KeyDefinitions and UserKeyDefinitions are interchangeable, but internally BufferedState already uses UserKeyDefinitions and extends UserKeyDefinitionOptions, so testing with that class makes more sense.

Additionally, #8669 is lined up to separate KeyDefinitions as global-only state and UserKeyDefinitions as user-scoped state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
