### PR TITLE
[SM-1298] uppercase SM bit-dialog titles

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
     <ng-container bitDialogTitle>
-      <span>{{ title | i18n }}</span>
+      <span>{{ title | i18n | uppercase }}</span>
       <span class="tw-text-sm tw-normal-case tw-text-muted">
         <ng-container *ngIf="data.projects.length == 1">
           {{ data.projects[0].name }}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
-    <span bitDialogTitle>{{ title | i18n }}</span>
+    <span bitDialogTitle>{{ title | i18n | uppercase }}</span>
     <span bitDialogContent>
       <div *ngIf="loading" class="tw-text-center">
         <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="large">
-    <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
+    <ng-container bitDialogTitle>{{ title | i18n | uppercase }}</ng-container>
     <div bitDialogContent class="tw-relative">
       <div
         *ngIf="showSpinner"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
     <ng-container bitDialogTitle>
-      <span>{{ "newAccessToken" | i18n }}</span>
+      <span>{{ "newAccessToken" | i18n | uppercase }}</span>
       <span class="tw-text-sm tw-normal-case tw-text-muted">
         {{ data.serviceAccountView.name }}
       </span>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -1,6 +1,6 @@
 <bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    <span>{{ "newAccessToken" | i18n }}</span>
+    <span>{{ "newAccessToken" | i18n | uppercase }}</span>
     <span class="tw-text-sm tw-normal-case tw-text-muted">
       {{ data.subTitle }}
     </span>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
     <ng-container bitDialogTitle>
-      <span>{{ title }}</span>
+      <span>{{ title | uppercase }}</span>
       <span class="tw-text-sm tw-normal-case tw-text-muted">
         <ng-container *ngIf="data.serviceAccounts.length == 1">
           {{ data.serviceAccounts[0].name }}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
+    <ng-container bitDialogTitle>{{ title | i18n | uppercase }}</ng-container>
     <div bitDialogContent>
       <div *ngIf="loading" class="tw-text-center">
         <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-confirmation-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-confirmation-dialog.component.html
@@ -1,6 +1,6 @@
 <bit-dialog>
   <ng-container bitDialogTitle>
-    {{ data.title | i18n }}
+    {{ data.title | i18n | uppercase }}
   </ng-container>
 
   <div bitDialogContent>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-status-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/dialogs/bulk-status-dialog.component.html
@@ -1,6 +1,6 @@
 <bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    <span>{{ data.title | i18n }}</span>
+    <span>{{ data.title | i18n | uppercase }}</span>
     <span class="tw-text-sm tw-normal-case tw-text-muted">
       {{ data.details.length }}
       {{ data.subTitle | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/SM-1298

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The purpose of this PR is to uppercase titles for Secrets Manager bit-dialogs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Before
![delete projects before](https://github.com/bitwarden/clients/assets/43214426/7953a5ff-822c-4022-9b3a-dddc40db07ce)

### After

![delete projects after](https://github.com/bitwarden/clients/assets/43214426/464bb38d-346f-4b69-a3a6-2f39ddecc7e4)


### Before

![delete project before](https://github.com/bitwarden/clients/assets/43214426/0586ee5d-d62f-429d-8c30-4a563cf8fa52)


### After

![delete project after](https://github.com/bitwarden/clients/assets/43214426/b35151e5-0a19-47fa-ac37-698fc1b14e94)


### Before

![new secret before](https://github.com/bitwarden/clients/assets/43214426/0cf5bede-675f-4ce9-b8b5-362242bcfb43)


### After

![new secret after](https://github.com/bitwarden/clients/assets/43214426/2ff1cec2-f365-4fea-8c3d-fb6662c67148)

### Before
![edit secret before](https://github.com/bitwarden/clients/assets/43214426/0a32cb1b-4f64-48e2-9348-6926a06c8d3d)


### After
![edit secret after](https://github.com/bitwarden/clients/assets/43214426/4cd9a7b7-383c-4ad4-af54-2f6e7764eac7)


### Before
![new access token before](https://github.com/bitwarden/clients/assets/43214426/f38d0dfd-6e08-46e5-bd34-442288982da4)


### After
![new access token after](https://github.com/bitwarden/clients/assets/43214426/e090b607-6c24-4253-8cb3-b3c2a6b61336)


### Before
![delete machine account before](https://github.com/bitwarden/clients/assets/43214426/43abed1b-af87-4789-8ea6-1da93bf844c5)

### After
![delete machine account after](https://github.com/bitwarden/clients/assets/43214426/47496984-49df-49b3-ae6e-ee568363a102)


### Before
![delete machine accounts before](https://github.com/bitwarden/clients/assets/43214426/1afd4282-dacd-4268-8aa0-96571f0e9944)

### After
![delete machine accounts after](https://github.com/bitwarden/clients/assets/43214426/1d4c6ae3-a0b3-4d99-8a76-b29743165873)


### Before
![new machine account before](https://github.com/bitwarden/clients/assets/43214426/70349eb9-b301-4db9-860c-d4a50a7651b1)

### After
![new machine account after](https://github.com/bitwarden/clients/assets/43214426/94a4a745-bbdb-4314-900d-1858beea2f30)


### Before
![edit machine account before](https://github.com/bitwarden/clients/assets/43214426/8a6b4433-a7af-43ed-a207-5002f13bccae)

### After
![edit machine account after](https://github.com/bitwarden/clients/assets/43214426/2b7c12a5-9a8e-4dbb-9fdb-2e0a0479b93e)

### Before
![bulk status before](https://github.com/bitwarden/clients/assets/43214426/790685ce-098d-465c-8081-7f7fad18811b)

### After
![bulk status after](https://github.com/bitwarden/clients/assets/43214426/4289b04c-1e3c-4173-9cbe-846fe44a36fa)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
