### PR TITLE
Improve jest performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,12 @@ jobs:
       # Tests in apps/ are typechecked when their app is built, so we just do it here for libs/
       # See https://bitwarden.atlassian.net/browse/EC-497
       - name: Run typechecking
-        run: npm run test:types --coverage
+        run: npm run test:types
 
       - name: Run tests
-        run: npm run test --coverage
+        # maxWorkers is a workaround for a memory leak that crashes tests in CI:
+        # https://github.com/facebook/jest/issues/9430#issuecomment-1149882002
+        run: npm test -- --coverage --maxWorkers=3
 
       - name: Report test results
         uses: dorny/test-reporter@eaa763f6ffc21c7a37837f56cd5f9737f27fc6c8 # v1.8.0

--- a/libs/shared/jest.config.angular.js
+++ b/libs/shared/jest.config.angular.js
@@ -11,10 +11,8 @@ module.exports = {
     ".*.type.spec.ts", // ignore type tests (which are checked at compile time and not run by jest)
   ],
 
-  // Workaround for a memory leak that crashes tests in CI:
-  // https://github.com/facebook/jest/issues/9430#issuecomment-1149882002
-  // Also anecdotally improves performance when run locally
-  maxWorkers: 3,
+  // Improves on-demand performance, for watches prefer 25%, overridable by setting --maxWorkers
+  maxWorkers: "50%",
 
   transform: {
     "^.+\\.(ts|js|mjs|svg)$": [


### PR DESCRIPTION
## 📔 Objective

Improve jest performance and split execution plan for dev vs CI. 

Locally, utilizing resources based on thread availability improves performance vs fixed threading.

<details>
<summary>my hyperfine results</summary>

```
❯ hyperfine 'npm test' 'npm test -- --maxWorkers=50%' 'npm test -- --maxWorkers=25%'
Benchmark 1: npm test
  Time (mean ± σ):     34.298 s ±  0.371 s    [User: 115.773 s, System: 14.455 s]
  Range (min … max):   33.880 s … 34.978 s    10 runs

Benchmark 2: npm test -- --maxWorkers=50%
  Time (mean ± σ):     24.585 s ±  0.504 s    [User: 140.707 s, System: 18.622 s]
  Range (min … max):   23.856 s … 25.460 s    10 runs

Benchmark 3: npm test -- --maxWorkers=25%
  Time (mean ± σ):     34.489 s ±  0.455 s    [User: 116.269 s, System: 14.511 s]
  Range (min … max):   33.835 s … 35.374 s    10 runs

Summary
  npm test -- --maxWorkers=50% ran
    1.40 ± 0.03 times faster than npm test
    1.40 ± 0.03 times faster than npm test -- --maxWorkers=25%
```

</details>

The linked issue for CI crashes has not been closed. Once this is solves, `runInBand` may improves performance in CI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
