### PR TITLE
[PM-8285] Resolve app id race

### DIFF
--- a/libs/common/spec/observable-tracker.ts
+++ b/libs/common/spec/observable-tracker.ts
@@ -1,10 +1,11 @@
-import { Observable, Subscription, firstValueFrom, throwError, timeout } from "rxjs";
+import { Observable, Subject, Subscription, firstValueFrom, throwError, timeout } from "rxjs";
 
 /** Test class to enable async awaiting of observable emissions */
 export class ObservableTracker<T> {
   private subscription: Subscription;
+  private emissionReceived = new Subject<T>();
   emissions: T[] = [];
-  constructor(private observable: Observable<T>) {
+  constructor(observable: Observable<T>) {
     this.emissions = this.trackEmissions(observable);
   }
 
@@ -21,7 +22,7 @@ export class ObservableTracker<T> {
    */
   async expectEmission(msTimeout = 50): Promise<T> {
     return await firstValueFrom(
-      this.observable.pipe(
+      this.emissionReceived.pipe(
         timeout({
           first: msTimeout,
           with: () => throwError(() => new Error("Timeout exceeded waiting for another emission.")),
@@ -34,39 +35,37 @@ export class ObservableTracker<T> {
    * @param count The number of emissions to wait for
    */
   async pauseUntilReceived(count: number, msTimeout = 50): Promise<T[]> {
-    for (let i = 0; i < count - this.emissions.length; i++) {
+    for (; this.emissions.length < count; ) {
       await this.expectEmission(msTimeout);
     }
     return this.emissions;
   }
 
-  private trackEmissions<T>(observable: Observable<T>): T[] {
+  private trackEmissions(observable: Observable<T>): T[] {
     const emissions: T[] = [];
     this.subscription = observable.subscribe((value) => {
-      switch (value) {
-        case undefined:
-        case null:
-          emissions.push(value);
-          return;
-        default:
-          // process by type
-          break;
+      if (value == null) {
+        this.emissionReceived.next(null);
+        return;
       }
 
       switch (typeof value) {
         case "string":
         case "number":
         case "boolean":
-          emissions.push(value);
+          this.emissionReceived.next(value);
           break;
         case "symbol":
           // Cheating types to make symbols work at all
-          emissions.push(value.toString() as T);
+          this.emissionReceived.next(value as T);
           break;
         default: {
-          emissions.push(clone(value));
+          this.emissionReceived.next(clone(value));
         }
       }
+    });
+    this.emissionReceived.subscribe((value) => {
+      emissions.push(value);
     });
     return emissions;
   }

--- a/libs/common/spec/observable-tracker.ts
+++ b/libs/common/spec/observable-tracker.ts
@@ -35,7 +35,7 @@ export class ObservableTracker<T> {
    * @param count The number of emissions to wait for
    */
   async pauseUntilReceived(count: number, msTimeout = 50): Promise<T[]> {
-    for (; this.emissions.length < count; ) {
+    while (this.emissions.length < count) {
       await this.expectEmission(msTimeout);
     }
     return this.emissions;

--- a/libs/common/src/platform/services/app-id.service.spec.ts
+++ b/libs/common/src/platform/services/app-id.service.spec.ts
@@ -1,4 +1,4 @@
-import { FakeGlobalState, FakeGlobalStateProvider } from "../../../spec";
+import { FakeGlobalState, FakeGlobalStateProvider, ObservableTracker } from "../../../spec";
 import { Utils } from "../misc/utils";
 
 import { ANONYMOUS_APP_ID_KEY, APP_ID_KEY, AppIdService } from "./app-id.service";
@@ -55,6 +55,16 @@ describe("AppIdService", () => {
 
       expect(appIdState.nextMock).toHaveBeenCalledWith(appId);
     });
+
+    it("emits only once when creating a new appId", async () => {
+      appIdState.stateSubject.next(null);
+
+      const tracker = new ObservableTracker(sut.appId$);
+      const appId = await sut.getAppId();
+
+      expect(tracker.emissions).toEqual([appId]);
+      await expect(tracker.pauseUntilReceived(2, 50)).rejects.toThrow("Timeout exceeded");
+    });
   });
 
   describe("getAnonymousAppId", () => {
@@ -95,5 +105,15 @@ describe("AppIdService", () => {
         expect(anonymousAppIdState.nextMock).toHaveBeenCalledWith(appId);
       },
     );
+
+    it("emits only once when creating a new anonymousAppId", async () => {
+      anonymousAppIdState.stateSubject.next(null);
+
+      const tracker = new ObservableTracker(sut.anonymousAppId$);
+      const appId = await sut.getAnonymousAppId();
+
+      expect(tracker.emissions).toEqual([appId]);
+      await expect(tracker.pauseUntilReceived(2, 50)).rejects.toThrow("Timeout exceeded");
+    });
   });
 });

--- a/libs/common/src/platform/services/app-id.service.spec.ts
+++ b/libs/common/src/platform/services/app-id.service.spec.ts
@@ -1,20 +1,23 @@
-import { FakeGlobalStateProvider } from "../../../spec";
+import { FakeGlobalState, FakeGlobalStateProvider } from "../../../spec";
 import { Utils } from "../misc/utils";
 
 import { ANONYMOUS_APP_ID_KEY, APP_ID_KEY, AppIdService } from "./app-id.service";
 
 describe("AppIdService", () => {
-  const globalStateProvider = new FakeGlobalStateProvider();
-  const appIdState = globalStateProvider.getFake(APP_ID_KEY);
-  const anonymousAppIdState = globalStateProvider.getFake(ANONYMOUS_APP_ID_KEY);
+  let globalStateProvider: FakeGlobalStateProvider;
+  let appIdState: FakeGlobalState<string>;
+  let anonymousAppIdState: FakeGlobalState<string>;
   let sut: AppIdService;
 
   beforeEach(() => {
+    globalStateProvider = new FakeGlobalStateProvider();
+    appIdState = globalStateProvider.getFake(APP_ID_KEY);
+    anonymousAppIdState = globalStateProvider.getFake(ANONYMOUS_APP_ID_KEY);
     sut = new AppIdService(globalStateProvider);
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
   describe("getAppId", () => {
@@ -26,19 +29,18 @@ describe("AppIdService", () => {
       expect(appId).toBe("existingAppId");
     });
 
-    it.each([null, undefined])(
-      "uses the util function to create a new id when it AppId does not exist",
-      async (value) => {
-        appIdState.stateSubject.next(value);
-        const spy = jest.spyOn(Utils, "newGuid");
+    it("creates a new appId only once", async () => {
+      appIdState.stateSubject.next(null);
 
-        await sut.getAppId();
+      const appIds: string[] = [];
+      const promises = [async () => appIds.push(await sut.getAppId())];
+      promises.push(async () => appIds.push(await sut.getAppId()));
+      await Promise.all(promises);
 
-        expect(spy).toHaveBeenCalledTimes(1);
-      },
-    );
+      expect(appIds[0]).toBe(appIds[1]);
+    });
 
-    it.each([null, undefined])("returns a new appId when it does not exist", async (value) => {
+    it.each([null, undefined])("returns a new appId when %s", async (value) => {
       appIdState.stateSubject.next(value);
 
       const appId = await sut.getAppId();
@@ -46,16 +48,13 @@ describe("AppIdService", () => {
       expect(appId).toMatch(Utils.guidRegex);
     });
 
-    it.each([null, undefined])(
-      "stores the new guid when it an existing one is not found",
-      async (value) => {
-        appIdState.stateSubject.next(value);
+    it.each([null, undefined])("stores the new guid when %s", async (value) => {
+      appIdState.stateSubject.next(value);
 
-        const appId = await sut.getAppId();
+      const appId = await sut.getAppId();
 
-        expect(appIdState.nextMock).toHaveBeenCalledWith(appId);
-      },
-    );
+      expect(appIdState.nextMock).toHaveBeenCalledWith(appId);
+    });
   });
 
   describe("getAnonymousAppId", () => {
@@ -67,17 +66,16 @@ describe("AppIdService", () => {
       expect(appId).toBe("existingAppId");
     });
 
-    it.each([null, undefined])(
-      "uses the util function to create a new id when it AppId does not exist",
-      async (value) => {
-        anonymousAppIdState.stateSubject.next(value);
-        const spy = jest.spyOn(Utils, "newGuid");
+    it("creates a new anonymousAppId only once", async () => {
+      anonymousAppIdState.stateSubject.next(null);
 
-        await sut.getAnonymousAppId();
+      const appIds: string[] = [];
+      const promises = [async () => appIds.push(await sut.getAnonymousAppId())];
+      promises.push(async () => appIds.push(await sut.getAnonymousAppId()));
+      await Promise.all(promises);
 
-        expect(spy).toHaveBeenCalledTimes(1);
-      },
-    );
+      expect(appIds[0]).toBe(appIds[1]);
+    });
 
     it.each([null, undefined])("returns a new appId when it does not exist", async (value) => {
       anonymousAppIdState.stateSubject.next(value);

--- a/libs/common/src/platform/services/app-id.service.ts
+++ b/libs/common/src/platform/services/app-id.service.ts
@@ -1,4 +1,4 @@
-import { Observable, distinctUntilChanged, firstValueFrom, switchMap } from "rxjs";
+import { Observable, concatMap, distinctUntilChanged, firstValueFrom, share } from "rxjs";
 
 import { AppIdService as AppIdServiceAbstraction } from "../abstractions/app-id.service";
 import { Utils } from "../misc/utils";
@@ -15,14 +15,11 @@ export class AppIdService implements AppIdServiceAbstraction {
   appId$: Observable<string>;
   anonymousAppId$: Observable<string>;
 
-  private updatingAppId = false;
-  private updatingAnonymousAppId = false;
-
   constructor(globalStateProvider: GlobalStateProvider) {
     const appIdState = globalStateProvider.get(APP_ID_KEY);
     const anonymousAppIdState = globalStateProvider.get(ANONYMOUS_APP_ID_KEY);
     this.appId$ = appIdState.state$.pipe(
-      switchMap(async (appId) => {
+      concatMap(async (appId) => {
         if (!appId) {
           return await appIdState.update(() => Utils.newGuid(), {
             shouldUpdate: (v) => v == null,
@@ -31,9 +28,10 @@ export class AppIdService implements AppIdServiceAbstraction {
         return appId;
       }),
       distinctUntilChanged(),
+      share(),
     );
     this.anonymousAppId$ = anonymousAppIdState.state$.pipe(
-      switchMap(async (appId) => {
+      concatMap(async (appId) => {
         if (!appId) {
           return await anonymousAppIdState.update(() => Utils.newGuid(), {
             shouldUpdate: (v) => v == null,
@@ -42,6 +40,7 @@ export class AppIdService implements AppIdServiceAbstraction {
         return appId;
       }),
       distinctUntilChanged(),
+      share(),
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8285

## 📔 Objective

Resolves a race condition when retrieving app ids where quickly subscribing multiple times would trigger the update function multiple times.

This could not be resolved by converting to a hot observable because of context sharing in the browser. Instead, I'm just using a switchmap and should update to determine what the valid appId is and filtering duplicates due to the switch map.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
