### PR TITLE
[PM-8587] Update icons for folder & collection filters

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
@@ -169,6 +169,13 @@ describe("VaultPopupListFiltersService", () => {
         expect(collections.map((c) => c.label)).toEqual(["Test collection 2"]);
       });
     });
+
+    it("sets collection icon", (done) => {
+      service.collections$.subscribe((collections) => {
+        expect(collections.every(({ icon }) => icon === "bwi-collection")).toBeTruthy();
+        done();
+      });
+    });
   });
 
   describe("folders$", () => {
@@ -206,6 +213,22 @@ describe("VaultPopupListFiltersService", () => {
 
       service.folders$.subscribe((folders) => {
         expect(folders.map((f) => f.label)).toEqual(["Folder 1", "Folder 2"]);
+        done();
+      });
+    });
+
+    it("sets folder icon", (done) => {
+      service.filterForm.patchValue({
+        organization: { id: MY_VAULT_ID } as Organization,
+      });
+
+      folderViews$.next([
+        { id: "1234", name: "Folder 1" },
+        { id: "2345", name: "Folder 2" },
+      ]);
+
+      service.folders$.subscribe((folders) => {
+        expect(folders.every(({ icon }) => icon === "bwi-folder")).toBeTruthy();
         done();
       });
     });

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -206,7 +206,7 @@ export class VaultPopupListFiltersService {
   /**
    * Folder array structured to be directly passed to `ChipSelectComponent`
    */
-  folders$: Observable<ChipSelectOption<string>[]> = combineLatest([
+  folders$: Observable<ChipSelectOption<FolderView>[]> = combineLatest([
     this.filters$.pipe(
       distinctUntilChanged(
         (previousFilter, currentFilter) =>
@@ -258,13 +258,15 @@ export class VaultPopupListFiltersService {
         nestedList: nestedFolders,
       });
     }),
-    map((folders) => folders.nestedList.map(this.convertToChipSelectOption.bind(this))),
+    map((folders) =>
+      folders.nestedList.map((f) => this.convertToChipSelectOption(f, "bwi-folder")),
+    ),
   );
 
   /**
    * Collection array structured to be directly passed to `ChipSelectComponent`
    */
-  collections$: Observable<ChipSelectOption<string>[]> = combineLatest([
+  collections$: Observable<ChipSelectOption<CollectionView>[]> = combineLatest([
     this.filters$.pipe(
       distinctUntilChanged(
         (previousFilter, currentFilter) =>
@@ -292,7 +294,9 @@ export class VaultPopupListFiltersService {
         nestedList: nestedCollections,
       });
     }),
-    map((collections) => collections.nestedList.map(this.convertToChipSelectOption.bind(this))),
+    map((collections) =>
+      collections.nestedList.map((c) => this.convertToChipSelectOption(c, "bwi-collection")),
+    ),
   );
 
   /**
@@ -300,13 +304,14 @@ export class VaultPopupListFiltersService {
    */
   private convertToChipSelectOption<T extends ITreeNodeObject>(
     item: TreeNode<T>,
+    icon: string,
   ): ChipSelectOption<T> {
     return {
       value: item.node,
       label: item.node.name,
-      icon: "bwi-folder", // Organization & Folder icons are the same
+      icon,
       children: item.children
-        ? item.children.map(this.convertToChipSelectOption.bind(this))
+        ? item.children.map((i) => this.convertToChipSelectOption(i, icon))
         : undefined,
     };
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8587](https://bitwarden.atlassian.net/browse/PM-8587)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Swap icons for collections in the extension filters. 🤦 I'm not sure what designs I was looking at before.

## 📸 Screenshots

|Folder -> `bwi-folder`|Collection -> `bwi-collection`|
|----------------------|------------------------------|
|![Screen Shot 2024-06-04 at 16 03 33 PM](https://github.com/bitwarden/clients/assets/125900171/39288e8c-ff6e-46cb-8ed5-5726484f2bab)|![Screen Shot 2024-06-04 at 16 03 51 PM](https://github.com/bitwarden/clients/assets/125900171/d77c87cc-c8a6-4f1f-b64b-c7d13c2836aa)|

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8587]: https://bitwarden.atlassian.net/browse/PM-8587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ