### PR TITLE
[CL-243] honor initial disabled state in `bitFormButton`

### DIFF
--- a/libs/components/src/async-actions/form-button.directive.ts
+++ b/libs/components/src/async-actions/form-button.directive.ts
@@ -40,7 +40,7 @@ export class BitFormButtonDirective implements OnDestroy {
         if (this.type === "submit") {
           buttonComponent.loading = loading;
         } else {
-          buttonComponent.disabled = loading;
+          buttonComponent.disabled = this.disabled || loading;
         }
       });
 

--- a/libs/components/src/async-actions/form-button.directive.ts
+++ b/libs/components/src/async-actions/form-button.directive.ts
@@ -46,7 +46,7 @@ export class BitFormButtonDirective implements OnDestroy {
 
       submitDirective.disabled$.pipe(takeUntil(this.destroy$)).subscribe((disabled) => {
         if (this.disabled !== false) {
-          buttonComponent.disabled = disabled;
+          buttonComponent.disabled = this.disabled || disabled;
         }
       });
     }

--- a/libs/components/src/async-actions/in-forms.stories.ts
+++ b/libs/components/src/async-actions/in-forms.stories.ts
@@ -33,6 +33,7 @@ const template = `
     <button class="tw-mr-2" type="submit" buttonType="primary" bitButton bitFormButton>Submit</button>
     <button class="tw-mr-2" type="button" buttonType="secondary" bitButton bitFormButton>Cancel</button>
     <button class="tw-mr-2" type="button" buttonType="danger" bitButton bitFormButton [bitAction]="delete">Delete</button>
+    <button class="tw-mr-2" type="button" buttonType="secondary" bitButton bitFormButton [disabled]="true">Disabled</button>
     <button class="tw-mr-2" type="button" buttonType="secondary" bitIconButton="bwi-star" bitFormButton [bitAction]="delete">Delete</button>
   </form>`;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-243

## 📔 Objective

Fix an issue where `bitFormButton` will enabled buttons that were initially disabled.

## 📸 Screenshots

See Storybook


https://github.com/bitwarden/clients/assets/17113462/decd1df0-4b17-421e-b316-2d53387d2d9d



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
