### PR TITLE
[CL-302] respect bottom padding in scrollable popup-layout

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -1,6 +1,6 @@
 <ng-content select="[slot=header]"></ng-content>
-<main class="tw-bg-background-alt tw-p-3 tw-flex-1 tw-overflow-y-auto tw-h-full">
-  <div class="tw-max-w-screen-sm tw-mx-auto tw-h-full">
+<main class="tw-bg-background-alt tw-flex-1 tw-overflow-y-auto tw-h-full">
+  <div class="tw-max-w-screen-sm tw-mx-auto tw-p-3 tw-overflow-y-auto tw-h-full">
     <ng-content></ng-content>
   </div>
 </main>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-302

## 📔 Objective

The main content in the popup layout should have visible bottom padding when it is a scroll container. 

## 📸 Screenshots

Before: 

![image](https://github.com/bitwarden/clients/assets/17113462/91fbf0e4-1856-4928-8df7-138d80692459)

After:

<img width="521" alt="image" src="https://github.com/bitwarden/clients/assets/17113462/f043bd8b-37e0-4066-acbe-b41a676a8f7b">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
