### PR TITLE
[PM-8335] Show autofill suggestion when no autofill login items present

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -4,23 +4,6 @@
   [title]="'autofillSuggestions' | i18n"
   [showRefresh]="showRefresh"
   (onRefresh)="refreshCurrentTab()"
+  [description]="(showEmptyAutofillTip$ | async) ? ('autofillSuggestionsTip' | i18n) : null"
   showAutofillButton
 ></app-vault-list-items-container>
-<ng-container *ngIf="showEmptyAutofillTip$ | async">
-  <bit-section>
-    <popup-section-header [title]="'autofillSuggestions' | i18n">
-      <button
-        *ngIf="showRefresh"
-        bitIconButton="bwi-refresh"
-        size="small"
-        slot="title-suffix"
-        type="button"
-        [appA11yTitle]="'refresh' | i18n"
-        (click)="refreshCurrentTab()"
-      ></button>
-    </popup-section-header>
-    <span class="tw-text-muted tw-px-1" bitTypography="body2">{{
-      "autofillSuggestionsTip" | i18n
-    }}</span>
-  </bit-section>
-</ng-container>

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
@@ -3,6 +3,7 @@ import { Component } from "@angular/core";
 import { combineLatest, map, Observable } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { IconButtonModule, SectionComponent, TypographyModule } from "@bitwarden/components";
 
 import BrowserPopupUtils from "../../../../../platform/popup/browser-popup-utils";
@@ -41,7 +42,7 @@ export class AutofillVaultListItemsComponent {
 
   /**
    * Observable that determines whether the empty autofill tip should be shown.
-   * The tip is shown when there are no ciphers to autofill, no filter is applied, and autofill is allowed in
+   * The tip is shown when there are no login ciphers to autofill, no filter is applied, and autofill is allowed in
    * the current context (e.g. not in a popout).
    * @protected
    */
@@ -50,7 +51,10 @@ export class AutofillVaultListItemsComponent {
     this.autofillCiphers$,
     this.vaultPopupItemsService.autofillAllowed$,
   ]).pipe(
-    map(([hasFilter, ciphers, canAutoFill]) => !hasFilter && canAutoFill && ciphers.length === 0),
+    map(
+      ([hasFilter, ciphers, canAutoFill]) =>
+        !hasFilter && canAutoFill && ciphers.filter((c) => c.type == CipherType.Login).length === 0,
+    ),
   );
 
   constructor(private vaultPopupItemsService: VaultPopupItemsService) {

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -1,6 +1,6 @@
-<bit-section *ngIf="ciphers?.length > 0">
+<bit-section *ngIf="ciphers?.length > 0 || description">
   <popup-section-header [title]="title">
-    <span bitTypography="body2" slot="end">{{ ciphers.length }}</span>
+    <span bitTypography="body2" slot="end" *ngIf="ciphers.length">{{ ciphers.length }}</span>
     <button
       *ngIf="showRefresh"
       bitIconButton="bwi-refresh"
@@ -11,6 +11,9 @@
       [appA11yTitle]="'refresh' | i18n"
     ></button>
   </popup-section-header>
+  <div *ngIf="description" class="tw-text-muted tw-px-1 tw-mb-2" bitTypography="body2">
+    {{ description }}
+  </div>
   <bit-item-group>
     <bit-item *ngFor="let cipher of ciphers">
       <a

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -51,6 +51,13 @@ export class VaultListItemsContainerComponent {
   title: string;
 
   /**
+   * Optional description for the vault list item section. Will be shown below the title even when
+   * no ciphers are available.
+   */
+  @Input()
+  description: string;
+
+  /**
    * Option to show a refresh button in the section header.
    */
   @Input({ transform: booleanAttribute })


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8335](https://bitwarden.atlassian.net/browse/PM-8335)

## 📔 Objective

Update the vault list items container to have an optional `description`. This `description` will always be shown beneath the section title when available. The autofill list item section component will now use the `description` to show the autofill suggestion tip when no login ciphers are present (even if CC/Identities are shown).

## 📸 Screenshots

<img width="382" alt="image" src="https://github.com/bitwarden/clients/assets/8764515/734e7ab3-ff53-41ce-b507-ce6317e193b1">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
