### PR TITLE
[PM-8379] Vault Popup Loading State Preliminary Work

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -379,6 +379,54 @@ describe("VaultPopupItemsService", () => {
     });
   });
 
+  describe("loading$", () => {
+    let tracked: ObservableTracker<boolean>;
+    let trackedCiphers: ObservableTracker<any>;
+    beforeEach(() => {
+      // Start tracking loading$ emissions
+      tracked = new ObservableTracker(service.loading$);
+
+      // Track remainingCiphers$ to make cipher observables active
+      trackedCiphers = new ObservableTracker(service.remainingCiphers$);
+    });
+
+    it("should initialize with true first", async () => {
+      expect(tracked.emissions[0]).toBe(true);
+    });
+
+    it("should emit false once ciphers are available", async () => {
+      expect(tracked.emissions.length).toBe(2);
+      expect(tracked.emissions[0]).toBe(true);
+      expect(tracked.emissions[1]).toBe(false);
+    });
+
+    it("should cycle when cipherService.ciphers$ emits", async () => {
+      // Restart tracking
+      tracked = new ObservableTracker(service.loading$);
+      (cipherServiceMock.ciphers$ as BehaviorSubject<any>).next(null);
+
+      await trackedCiphers.pauseUntilReceived(2);
+
+      expect(tracked.emissions.length).toBe(3);
+      expect(tracked.emissions[0]).toBe(false);
+      expect(tracked.emissions[1]).toBe(true);
+      expect(tracked.emissions[2]).toBe(false);
+    });
+
+    it("should cycle when filters are applied", async () => {
+      // Restart tracking
+      tracked = new ObservableTracker(service.loading$);
+      service.applyFilter("test");
+
+      await trackedCiphers.pauseUntilReceived(2);
+
+      expect(tracked.emissions.length).toBe(3);
+      expect(tracked.emissions[0]).toBe(false);
+      expect(tracked.emissions[1]).toBe(true);
+      expect(tracked.emissions[2]).toBe(false);
+    });
+  });
+
   describe("applyFilter", () => {
     it("should call search Service with the new search term", (done) => {
       const searchText = "Hello";

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable, NgZone } from "@angular/core";
 import {
   BehaviorSubject,
   combineLatest,
+  distinctUntilChanged,
   distinctUntilKeyChanged,
   from,
   map,
@@ -12,6 +13,8 @@ import {
   startWith,
   Subject,
   switchMap,
+  tap,
+  withLatestFrom,
 } from "rxjs";
 
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
@@ -40,6 +43,13 @@ import { MY_VAULT_ID, VaultPopupListFiltersService } from "./vault-popup-list-fi
 export class VaultPopupItemsService {
   private _refreshCurrentTab$ = new Subject<void>();
   private _searchText$ = new BehaviorSubject<string>("");
+
+  /**
+   * Subject that emits whenever new ciphers are being processed/filtered.
+   * @private
+   */
+  private _ciphersLoading$ = new Subject<void>();
+
   latestSearchText$: Observable<string> = this._searchText$.asObservable();
 
   /**
@@ -84,6 +94,7 @@ export class VaultPopupItemsService {
     this.cipherService.localData$,
   ).pipe(
     runInsideAngular(inject(NgZone)), // Workaround to ensure cipher$ state provider emissions are run inside Angular
+    tap(() => this._ciphersLoading$.next()),
     switchMap(() => Utils.asyncToObservable(() => this.cipherService.getAllDecrypted())),
     switchMap((ciphers) =>
       combineLatest([
@@ -112,6 +123,7 @@ export class VaultPopupItemsService {
     this._searchText$,
     this.vaultPopupListFiltersService.filterFunction$,
   ]).pipe(
+    tap(() => this._ciphersLoading$.next()),
     map(([ciphers, searchText, filterFunction]): [CipherView[], string] => [
       filterFunction(ciphers),
       searchText,
@@ -148,10 +160,8 @@ export class VaultPopupItemsService {
    * List of favorite ciphers that are not currently suggested for autofill.
    * Ciphers are sorted by last used date, then by name.
    */
-  favoriteCiphers$: Observable<PopupCipherView[]> = combineLatest([
-    this.autoFillCiphers$,
-    this._filteredCipherList$,
-  ]).pipe(
+  favoriteCiphers$: Observable<PopupCipherView[]> = this.autoFillCiphers$.pipe(
+    withLatestFrom(this._filteredCipherList$),
     map(([autoFillCiphers, ciphers]) =>
       ciphers.filter((cipher) => cipher.favorite && !autoFillCiphers.includes(cipher)),
     ),
@@ -165,12 +175,9 @@ export class VaultPopupItemsService {
    * List of all remaining ciphers that are not currently suggested for autofill or marked as favorite.
    * Ciphers are sorted by name.
    */
-  remainingCiphers$: Observable<PopupCipherView[]> = combineLatest([
-    this.autoFillCiphers$,
-    this.favoriteCiphers$,
-    this._filteredCipherList$,
-  ]).pipe(
-    map(([autoFillCiphers, favoriteCiphers, ciphers]) =>
+  remainingCiphers$: Observable<PopupCipherView[]> = this.favoriteCiphers$.pipe(
+    withLatestFrom(this._filteredCipherList$, this.autoFillCiphers$),
+    map(([favoriteCiphers, ciphers, autoFillCiphers]) =>
       ciphers.filter(
         (cipher) => !autoFillCiphers.includes(cipher) && !favoriteCiphers.includes(cipher),
       ),
@@ -178,6 +185,14 @@ export class VaultPopupItemsService {
     map((ciphers) => ciphers.sort(this.cipherService.getLocaleSortingFunction())),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
+
+  /**
+   * Observable that indicates whether the service is currently loading ciphers.
+   */
+  loading$: Observable<boolean> = merge(
+    this._ciphersLoading$.pipe(map(() => true)),
+    this.remainingCiphers$.pipe(map(() => false)),
+  ).pipe(startWith(true), distinctUntilChanged(), shareReplay({ refCount: false, bufferSize: 1 }));
 
   /**
    * Observable that indicates whether a filter is currently applied to the ciphers.

--- a/libs/common/spec/observable-tracker.ts
+++ b/libs/common/spec/observable-tracker.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject, Subscription, firstValueFrom, throwError, timeout } from "rxjs";
+import { firstValueFrom, Observable, Subject, Subscription, throwError, timeout } from "rxjs";
 
 /** Test class to enable async awaiting of observable emissions */
 export class ObservableTracker<T> {
@@ -43,6 +43,9 @@ export class ObservableTracker<T> {
 
   private trackEmissions(observable: Observable<T>): T[] {
     const emissions: T[] = [];
+    this.emissionReceived.subscribe((value) => {
+      emissions.push(value);
+    });
     this.subscription = observable.subscribe((value) => {
       if (value == null) {
         this.emissionReceived.next(null);
@@ -64,9 +67,7 @@ export class ObservableTracker<T> {
         }
       }
     });
-    this.emissionReceived.subscribe((value) => {
-      emissions.push(value);
-    });
+
     return emissions;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8379](https://bitwarden.atlassian.net/browse/PM-8379)

## 📔 Objective

Refactor the vault popup item service to reduce redundant emissions and add a `loading$` observable that will be used to show a loading spinner once [CL-285](https://bitwarden.atlassian.net/browse/CL-285) is complete. 

## 📸 Screenshots

No UI changes yet.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8379]: https://bitwarden.atlassian.net/browse/PM-8379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-285]: https://bitwarden.atlassian.net/browse/CL-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ