### PR TITLE
[PM-8623] Show family icon for free orgs in filter chips

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, skipWhile } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { ProductType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
@@ -18,7 +19,7 @@ import { MY_VAULT_ID, VaultPopupListFiltersService } from "./vault-popup-list-fi
 
 describe("VaultPopupListFiltersService", () => {
   let service: VaultPopupListFiltersService;
-  const memberOrganizations$ = new BehaviorSubject<{ name: string; id: string }[]>([]);
+  const memberOrganizations$ = new BehaviorSubject<Organization[]>([]);
   const folderViews$ = new BehaviorSubject([]);
   const cipherViews$ = new BehaviorSubject({});
   const decryptedCollections$ = new BehaviorSubject<CollectionView[]>([]);
@@ -100,7 +101,8 @@ describe("VaultPopupListFiltersService", () => {
     });
 
     it('adds "myVault" to the list of organizations when there are other organizations', (done) => {
-      memberOrganizations$.next([{ name: "bobby's org", id: "1234-3323-23223" }]);
+      const orgs = [{ name: "bobby's org", id: "1234-3323-23223" }] as Organization[];
+      memberOrganizations$.next(orgs);
 
       service.organizations$.subscribe((organizations) => {
         expect(organizations.map((o) => o.label)).toEqual(["myVault", "bobby's org"]);
@@ -109,10 +111,11 @@ describe("VaultPopupListFiltersService", () => {
     });
 
     it("sorts organizations by name", (done) => {
-      memberOrganizations$.next([
+      const orgs = [
         { name: "bobby's org", id: "1234-3323-23223" },
         { name: "alice's org", id: "2223-4343-99888" },
-      ]);
+      ] as Organization[];
+      memberOrganizations$.next(orgs);
 
       service.organizations$.subscribe((organizations) => {
         expect(organizations.map((o) => o.label)).toEqual([
@@ -121,6 +124,65 @@ describe("VaultPopupListFiltersService", () => {
           "bobby's org",
         ]);
         done();
+      });
+    });
+
+    describe("icons", () => {
+      it("sets family icon for family organizations", (done) => {
+        const orgs = [
+          {
+            name: "family org",
+            id: "1234-3323-23223",
+            enabled: true,
+            planProductType: ProductType.Families,
+          },
+        ] as Organization[];
+
+        memberOrganizations$.next(orgs);
+
+        service.organizations$.subscribe((organizations) => {
+          expect(organizations.map((o) => o.icon)).toEqual(["bwi-user", "bwi-family"]);
+          done();
+        });
+      });
+
+      it("sets family icon for free organizations", (done) => {
+        const orgs = [
+          {
+            name: "free org",
+            id: "1234-3323-23223",
+            enabled: true,
+            planProductType: ProductType.Free,
+          },
+        ] as Organization[];
+
+        memberOrganizations$.next(orgs);
+
+        service.organizations$.subscribe((organizations) => {
+          expect(organizations.map((o) => o.icon)).toEqual(["bwi-user", "bwi-family"]);
+          done();
+        });
+      });
+
+      it("sets warning icon for disabled organizations", (done) => {
+        const orgs = [
+          {
+            name: "free org",
+            id: "1234-3323-23223",
+            enabled: false,
+            planProductType: ProductType.Free,
+          },
+        ] as Organization[];
+
+        memberOrganizations$.next(orgs);
+
+        service.organizations$.subscribe((organizations) => {
+          expect(organizations.map((o) => o.icon)).toEqual([
+            "bwi-user",
+            "bwi-exclamation-triangle tw-text-danger",
+          ]);
+          done();
+        });
       });
     });
   });

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -188,8 +188,11 @@ export class VaultPopupListFiltersService {
             if (!org.enabled) {
               // Show a warning icon if the organization is deactivated
               icon = "bwi-exclamation-triangle tw-text-danger";
-            } else if (org.planProductType === ProductType.Families) {
-              // Show a family icon if the organization is a family org
+            } else if (
+              org.planProductType === ProductType.Families ||
+              org.planProductType === ProductType.Free
+            ) {
+              // Show a family icon if the organization is a family or free org
               icon = "bwi-family";
             }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8623](https://bitwarden.atlassian.net/browse/PM-8623)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Free organizations should show the family icon rather than the business icon
  - Add tests for all icon variants 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
|------|-----|
|![Screen Shot 2024-06-06 at 09 19 30 AM](https://github.com/bitwarden/clients/assets/125900171/03e1d211-7a55-4c6c-a35f-cba2112d6761)|![Screen Shot 2024-06-06 at 09 19 13 AM](https://github.com/bitwarden/clients/assets/125900171/ec6a67bd-fcc4-4eea-a9ca-745ffd38e1fc)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8623]: https://bitwarden.atlassian.net/browse/PM-8623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ