### PR TITLE
[PM-7387] Hide Master Password tab for users without MP

### DIFF
--- a/apps/web/src/app/auth/settings/security/security.component.html
+++ b/apps/web/src/app/auth/settings/security/security.component.html
@@ -1,6 +1,8 @@
 <app-header>
   <bit-tab-nav-bar slot="tabs">
-    <bit-tab-link route="change-password">{{ "masterPassword" | i18n }}</bit-tab-link>
+    <ng-container *ngIf="showChangePassword">
+      <bit-tab-link route="change-password">{{ "masterPassword" | i18n }}</bit-tab-link>
+    </ng-container>
     <bit-tab-link route="two-factor">{{ "twoStepLogin" | i18n }}</bit-tab-link>
     <bit-tab-link route="security-keys">{{ "keys" | i18n }}</bit-tab-link>
   </bit-tab-nav-bar>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-7387

## 📔 Objective

With the Vertical Vault refresh, we lost the check on the presence of a master password on the user's account to show/hide the "Master Password" tab.  This PR adds it back.

## 📸 Screenshots

![image](https://github.com/bitwarden/clients/assets/106564991/466cab63-2b07-4c60-af3f-6854e1f1c0c0)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
