### PR TITLE
[PM-8624] PersonalOwnershipPolicy check in Vault Filters

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -13,6 +13,8 @@ import {
 
 import { DynamicTreeNode } from "@bitwarden/angular/vault/vault-filter/models/dynamic-tree-node.model";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { ProductType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -88,6 +90,7 @@ export class VaultPopupListFiltersService {
     private i18nService: I18nService,
     private collectionService: CollectionService,
     private formBuilder: FormBuilder,
+    private policyService: PolicyService,
   ) {
     this.filterForm.controls.organization.valueChanges
       .pipe(takeUntilDestroyed())
@@ -167,44 +170,63 @@ export class VaultPopupListFiltersService {
   /**
    * Organization array structured to be directly passed to `ChipSelectComponent`
    */
-  organizations$: Observable<ChipSelectOption<Organization>[]> =
-    this.organizationService.memberOrganizations$.pipe(
-      map((orgs) => orgs.sort(Utils.getSortFunction(this.i18nService, "name"))),
-      map((orgs) => {
-        if (!orgs.length) {
-          return [];
-        }
+  organizations$: Observable<ChipSelectOption<Organization>[]> = combineLatest([
+    this.organizationService.memberOrganizations$,
+    this.policyService.policyAppliesToActiveUser$(PolicyType.PersonalOwnership),
+  ]).pipe(
+    map(([orgs, personalOwnershipApplies]): [Organization[], boolean] => [
+      orgs.sort(Utils.getSortFunction(this.i18nService, "name")),
+      personalOwnershipApplies,
+    ]),
+    map(([orgs, personalOwnershipApplies]) => {
+      // When there are no organizations return an empty array,
+      // resulting in the org filter being hidden
+      if (!orgs.length) {
+        return [];
+      }
 
-        return [
-          // When the user is a member of an organization, make  the "My Vault" option available
-          {
-            value: { id: MY_VAULT_ID } as Organization,
-            label: this.i18nService.t("myVault"),
-            icon: "bwi-user",
-          },
-          ...orgs.map((org) => {
-            let icon = "bwi-business";
+      // When there is only one organization and personal ownership policy applies,
+      // return an empty array, resulting in the org filter being hidden
+      if (orgs.length === 1 && personalOwnershipApplies) {
+        return [];
+      }
 
-            if (!org.enabled) {
-              // Show a warning icon if the organization is deactivated
-              icon = "bwi-exclamation-triangle tw-text-danger";
-            } else if (
-              org.planProductType === ProductType.Families ||
-              org.planProductType === ProductType.Free
-            ) {
-              // Show a family icon if the organization is a family or free org
-              icon = "bwi-family";
-            }
+      const myVaultOrg: ChipSelectOption<Organization>[] = [];
 
-            return {
-              value: org,
-              label: org.name,
-              icon,
-            };
-          }),
-        ];
-      }),
-    );
+      // Only add "My vault" if personal ownership policy does not apply
+      if (!personalOwnershipApplies) {
+        myVaultOrg.push({
+          value: { id: MY_VAULT_ID } as Organization,
+          label: this.i18nService.t("myVault"),
+          icon: "bwi-user",
+        });
+      }
+
+      return [
+        ...myVaultOrg,
+        ...orgs.map((org) => {
+          let icon = "bwi-business";
+
+          if (!org.enabled) {
+            // Show a warning icon if the organization is deactivated
+            icon = "bwi-exclamation-triangle tw-text-danger";
+          } else if (
+            org.planProductType === ProductType.Families ||
+            org.planProductType === ProductType.Free
+          ) {
+            // Show a family icon if the organization is a family or free org
+            icon = "bwi-family";
+          }
+
+          return {
+            value: org,
+            label: org.name,
+            icon,
+          };
+        }),
+      ];
+    }),
+  );
 
   /**
    * Folder array structured to be directly passed to `ChipSelectComponent`


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8624](https://bitwarden.atlassian.net/browse/PM-8624)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add logic to check for `PersonalOwnership` policy when determining to show the "Vaults" filter
From Ticket:
- If the user is only in a single org and that org has the “Remove Individual Vault” policy enabled, then the Vault filter should be hidden
- If the user is in multiple orgs and at least one org has the “Remove Individual Vault” policy enabled, then “My Vault” should not be shown
- If the user is an Owner or an Admin, the above two or are not applicable

### Owner/Admin clarification

The [documentation](https://github.com/bitwarden/clients/blob/b169207b74ee593365a82b1b73c6d0241a21928e/libs/common/src/admin-console/abstractions/policy/policy.service.abstraction.ts#L41-L45) around the `policyAppliesToActiveUser$` method infers that the owner/admin check is included in that logic based on my brief testing that is accurate. But I haven't been able to track down on where the policies are being set in state to validate that.

## 📸 Screenshots

|Account has 1 org and PersonalOwnershipPolicy is active|Account is owner of org with PersonalOwnershipPolicy active|
|-|-|
|![Screen Shot 2024-06-10 at 12 33 31 PM](https://github.com/bitwarden/clients/assets/125900171/75f684e4-4587-4710-a5f5-d63f26ce88de)|![Screen Shot 2024-06-10 at 13 11 33 PM](https://github.com/bitwarden/clients/assets/125900171/acfee612-3af5-4060-94dd-126f59353a99)|

 
## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8624]: https://bitwarden.atlassian.net/browse/PM-8624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ