### PR TITLE
[CL-250] Update badge styles for extension refresh

### DIFF
--- a/libs/components/src/badge/badge.directive.ts
+++ b/libs/components/src/badge/badge.directive.ts
@@ -5,21 +5,25 @@ import { FocusableElement } from "../shared/focusable-element";
 export type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info";
 
 const styles: Record<BadgeVariant, string[]> = {
-  primary: ["tw-bg-primary-600"],
-  secondary: ["tw-bg-text-muted"],
-  success: ["tw-bg-success-600"],
-  danger: ["tw-bg-danger-600"],
-  warning: ["tw-bg-warning-600"],
-  info: ["tw-bg-info-600"],
+  primary: ["tw-bg-primary-100", "tw-border-primary-700", "!tw-text-primary-700"],
+  secondary: ["tw-bg-secondary-100", "tw-border-secondary-700", "!tw-text-secondary-700"],
+  success: ["tw-bg-success-100", "tw-border-success-700", "!tw-text-success-700"],
+  danger: ["tw-bg-danger-100", "tw-border-danger-700", "!tw-text-danger-700"],
+  warning: ["tw-bg-warning-100", "tw-border-warning-700", "!tw-text-warning-700"],
+  info: ["tw-bg-info-100", "tw-border-info-700", "!tw-text-info-700"],
 };
 
 const hoverStyles: Record<BadgeVariant, string[]> = {
-  primary: ["hover:tw-bg-primary-700"],
-  secondary: ["hover:tw-bg-secondary-700"],
-  success: ["hover:tw-bg-success-700"],
-  danger: ["hover:tw-bg-danger-700"],
-  warning: ["hover:tw-bg-warning-700"],
-  info: ["hover:tw-bg-info-700"],
+  primary: ["hover:tw-bg-primary-600", "hover:tw-border-primary-600", "hover:!tw-text-contrast"],
+  secondary: [
+    "hover:tw-bg-secondary-600",
+    "hover:tw-border-secondary-600",
+    "hover:!tw-text-contrast",
+  ],
+  success: ["hover:tw-bg-success-600", "hover:tw-border-success-600", "hover:!tw-text-contrast"],
+  danger: ["hover:tw-bg-danger-600", "hover:tw-border-danger-600", "hover:!tw-text-contrast"],
+  warning: ["hover:tw-bg-warning-600", "hover:tw-border-warning-600", "hover:!tw-text-black"],
+  info: ["hover:tw-bg-info-600", "hover:tw-border-info-600", "hover:!tw-text-black"],
 };
 
 @Directive({
@@ -30,22 +34,28 @@ export class BadgeDirective implements FocusableElement {
   @HostBinding("class") get classList() {
     return [
       "tw-inline-block",
-      "tw-py-0.5",
-      "tw-px-1.5",
-      "tw-font-bold",
+      "tw-py-1",
+      "tw-px-2",
       "tw-text-center",
       "tw-align-text-top",
-      "!tw-text-contrast",
-      "tw-rounded",
-      "tw-border-none",
+      "tw-rounded-full",
+      "tw-border-[0.5px]",
+      "tw-border-solid",
       "tw-box-border",
       "tw-whitespace-nowrap",
       "tw-text-xs",
       "hover:tw-no-underline",
       "focus-visible:tw-outline-none",
-      "focus-visible:tw-ring",
+      "focus-visible:tw-ring-2",
       "focus-visible:tw-ring-offset-2",
-      "focus-visible:tw-ring-primary-700",
+      "focus-visible:tw-ring-primary-500",
+      "disabled:tw-bg-secondary-300",
+      "disabled:hover:tw-bg-secondary-300",
+      "disabled:tw-border-secondary-300",
+      "disabled:hover:tw-border-secondary-300",
+      "disabled:!tw-text-muted",
+      "disabled:hover:!tw-text-muted",
+      "disabled:tw-cursor-not-allowed",
     ]
       .concat(styles[this.variant])
       .concat(this.hasHoverEffects ? hoverStyles[this.variant] : [])

--- a/libs/components/src/badge/badge.directive.ts
+++ b/libs/components/src/badge/badge.directive.ts
@@ -36,6 +36,7 @@ export class BadgeDirective implements FocusableElement {
       "tw-inline-block",
       "tw-py-1",
       "tw-px-2",
+      "tw-font-medium",
       "tw-text-center",
       "tw-align-text-top",
       "tw-rounded-full",

--- a/libs/components/src/badge/badge.mdx
+++ b/libs/components/src/badge/badge.mdx
@@ -6,11 +6,16 @@ import * as stories from "./badge.stories";
 
 # Badge
 
-The Badge directive can be used on a `<span>` (non clickable events), or an `<a>` or `<button>` tag
-for interactive events. The Focus and Hover states only apply to badges used for interactive events.
+Badges are primarily used as labels, counters, and small buttons.
 
 Typically Badges are only used with text set to `text-xs`. If additional sizes are needed, the
 component configurations may be reviewed and adjusted.
+
+The Badge directive can be used on a `<span>` (non clickable events), or an `<a>` or `<button>` tag
+for interactive events. The Focus and Hover states only apply to badges used for interactive events.
+The `disabled` state only applies to buttons.
+
+The story below uses the `<button>` element to demonstrate all the possible states.
 
 <Primary />
 <Controls />

--- a/libs/components/src/badge/badge.stories.ts
+++ b/libs/components/src/badge/badge.stories.ts
@@ -26,6 +26,41 @@ export default {
 
 type Story = StoryObj<BadgeDirective>;
 
+export const Variants: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <button class="tw-mx-1" bitBadge variant="primary" [truncate]="truncate">Primary</button>
+      <button class="tw-mx-1" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
+      <button class="tw-mx-1" bitBadge variant="success" [truncate]="truncate">Success</button>
+      <button class="tw-mx-1" bitBadge variant="danger" [truncate]="truncate">Danger</button>
+      <button class="tw-mx-1" bitBadge variant="warning" [truncate]="truncate">Warning</button>
+      <button class="tw-mx-1" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <br/><br/>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="primary" [truncate]="truncate">Primary</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="success" [truncate]="truncate">Success</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="danger" [truncate]="truncate">Danger</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="warning" [truncate]="truncate">Warning</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <br/><br/>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="primary" [truncate]="truncate">Primary</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="success" [truncate]="truncate">Success</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="danger" [truncate]="truncate">Danger</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="warning" [truncate]="truncate">Warning</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <br/><br/>
+      <button disabled class="tw-mx-1" bitBadge variant="primary" [truncate]="truncate">Primary</button>
+      <button disabled class="tw-mx-1" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
+      <button disabled class="tw-mx-1" bitBadge variant="success" [truncate]="truncate">Success</button>
+      <button disabled class="tw-mx-1" bitBadge variant="danger" [truncate]="truncate">Danger</button>
+      <button disabled class="tw-mx-1" bitBadge variant="warning" [truncate]="truncate">Warning</button>
+      <button disabled class="tw-mx-1" bitBadge variant="info" [truncate]="truncate">Info</button>
+    `,
+  }),
+};
+
 export const Primary: Story = {
   render: (args) => ({
     props: args,

--- a/libs/components/src/badge/badge.stories.ts
+++ b/libs/components/src/badge/badge.stories.ts
@@ -29,7 +29,8 @@ type Story = StoryObj<BadgeDirective>;
 export const Variants: Story = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
+      <span class="tw-text-main tw-mx-1">Default</span>
       <button class="tw-mx-1" bitBadge variant="primary" [truncate]="truncate">Primary</button>
       <button class="tw-mx-1" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
       <button class="tw-mx-1" bitBadge variant="success" [truncate]="truncate">Success</button>
@@ -37,6 +38,7 @@ export const Variants: Story = {
       <button class="tw-mx-1" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1" bitBadge variant="info" [truncate]="truncate">Info</button>
       <br/><br/>
+      <span class="tw-text-main tw-mx-1">Hover</span>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="primary" [truncate]="truncate">Primary</button>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="success" [truncate]="truncate">Success</button>
@@ -44,6 +46,7 @@ export const Variants: Story = {
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="info" [truncate]="truncate">Info</button>
       <br/><br/>
+      <span class="tw-text-main tw-mx-1">Focus Visible</span>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="primary" [truncate]="truncate">Primary</button>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="success" [truncate]="truncate">Success</button>
@@ -51,6 +54,7 @@ export const Variants: Story = {
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="info" [truncate]="truncate">Info</button>
       <br/><br/>
+      <span class="tw-text-main tw-mx-1">Disabled</span>
       <button disabled class="tw-mx-1" bitBadge variant="primary" [truncate]="truncate">Primary</button>
       <button disabled class="tw-mx-1" bitBadge variant="secondary" [truncate]="truncate">Secondary</button>
       <button disabled class="tw-mx-1" bitBadge variant="success" [truncate]="truncate">Success</button>
@@ -64,7 +68,7 @@ export const Variants: Story = {
 export const Primary: Story = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
       <span class="tw-text-main">Span </span><span bitBadge [variant]="variant" [truncate]="truncate">Badge containing lengthy text</span>
       <br><br>
       <span class="tw-text-main">Link </span><a href="#" bitBadge [variant]="variant" [truncate]="truncate">Badge</a>

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -80,18 +80,34 @@ module.exports = {
       headers: rgba("--color-text-headers"),
       alt2: rgba("--color-text-alt2"),
       code: rgba("--color-text-code"),
-      success: rgba("--color-success-600"),
+      black: colors.black,
+      success: {
+        DEFAULT: rgba("--color-success-600"),
+        600: rgba("--color-success-600"),
+        700: rgba("--color-success-700"),
+      },
       danger: {
         DEFAULT: rgba("--color-danger-600"),
         600: rgba("--color-danger-600"),
         700: rgba("--color-danger-700"),
       },
-      warning: rgba("--color-warning-600"),
-      info: rgba("--color-info-600"),
+      warning: {
+        DEFAULT: rgba("--color-warning-600"),
+        600: rgba("--color-warning-600"),
+        700: rgba("--color-warning-700"),
+      },
+      info: {
+        DEFAULT: rgba("--color-info-600"),
+        600: rgba("--color-info-600"),
+        700: rgba("--color-info-700"),
+      },
       primary: {
         300: rgba("--color-primary-300"),
         600: rgba("--color-primary-600"),
         700: rgba("--color-primary-700"),
+      },
+      secondary: {
+        700: rgba("--color-secondary-700"),
       },
     },
     ringOffsetColor: ({ theme }) => ({


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-250](https://bitwarden.atlassian.net/browse/CL-250)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the styles of the `badge` component according to the new designs for the extension refresh. This also involved adding some more text color options in the tailwind config. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Check the Storybook Publish action and the `badge` stories.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-250]: https://bitwarden.atlassian.net/browse/CL-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ