### PR TITLE
[AC-2762] Use --organizationid flag for device-approval commands

### DIFF
--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/device-approval.program.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/device-approval.program.ts
@@ -11,6 +11,10 @@ import { DenyAllCommand } from "./deny-all.command";
 import { DenyCommand } from "./deny.command";
 import { ListCommand } from "./list.command";
 
+type Options = {
+  organizationid: string;
+};
+
 export class DeviceApprovalProgram extends BaseProgram {
   constructor(protected serviceContainer: ServiceContainer) {
     super(serviceContainer);
@@ -33,8 +37,8 @@ export class DeviceApprovalProgram extends BaseProgram {
   private listCommand(): Command {
     return new Command("list")
       .description("List all pending requests for an organization")
-      .argument("<organizationId>")
-      .action(async (organizationId: string) => {
+      .requiredOption("--organizationid <organizationid>", "The organization id (required)")
+      .action(async (options: Options) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
@@ -42,17 +46,18 @@ export class DeviceApprovalProgram extends BaseProgram {
           this.serviceContainer.organizationAuthRequestService,
           this.serviceContainer.organizationService,
         );
-        const response = await cmd.run(organizationId);
+
+        const response = await cmd.run(options.organizationid);
         this.processResponse(response);
       });
   }
 
   private approveCommand(): Command {
     return new Command("approve")
-      .argument("<organizationId>", "The id of the organization")
       .argument("<requestId>", "The id of the request to approve")
+      .requiredOption("--organizationid <organizationid>", "The organization id (required)")
       .description("Approve a pending request")
-      .action(async (organizationId: string, id: string) => {
+      .action(async (id: string, options: Options) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
@@ -60,7 +65,7 @@ export class DeviceApprovalProgram extends BaseProgram {
           this.serviceContainer.organizationService,
           this.serviceContainer.organizationAuthRequestService,
         );
-        const response = await cmd.run(organizationId, id);
+        const response = await cmd.run(options.organizationid, id);
         this.processResponse(response);
       });
   }
@@ -68,8 +73,8 @@ export class DeviceApprovalProgram extends BaseProgram {
   private approveAllCommand(): Command {
     return new Command("approve-all")
       .description("Approve all pending requests for an organization")
-      .argument("<organizationId>")
-      .action(async (organizationId: string) => {
+      .requiredOption("--organizationid <organizationid>", "The organization id (required)")
+      .action(async (options: Options) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
@@ -77,17 +82,17 @@ export class DeviceApprovalProgram extends BaseProgram {
           this.serviceContainer.organizationAuthRequestService,
           this.serviceContainer.organizationService,
         );
-        const response = await cmd.run(organizationId);
+        const response = await cmd.run(options.organizationid);
         this.processResponse(response);
       });
   }
 
   private denyCommand(): Command {
     return new Command("deny")
-      .argument("<organizationId>", "The id of the organization")
       .argument("<requestId>", "The id of the request to deny")
+      .requiredOption("--organizationid <organizationid>", "The organization id (required)")
       .description("Deny a pending request")
-      .action(async (organizationId: string, id: string) => {
+      .action(async (id: string, options: Options) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
@@ -95,7 +100,7 @@ export class DeviceApprovalProgram extends BaseProgram {
           this.serviceContainer.organizationService,
           this.serviceContainer.organizationAuthRequestService,
         );
-        const response = await cmd.run(organizationId, id);
+        const response = await cmd.run(options.organizationid, id);
         this.processResponse(response);
       });
   }
@@ -103,8 +108,8 @@ export class DeviceApprovalProgram extends BaseProgram {
   private denyAllCommand(): Command {
     return new Command("deny-all")
       .description("Deny all pending requests for an organization")
-      .argument("<organizationId>")
-      .action(async (organizationId: string) => {
+      .requiredOption("--organizationid <organizationid>", "The organization id (required)")
+      .action(async (options: Options) => {
         await this.exitIfFeatureFlagDisabled(FeatureFlag.BulkDeviceApproval);
         await this.exitIfLocked();
 
@@ -112,7 +117,7 @@ export class DeviceApprovalProgram extends BaseProgram {
           this.serviceContainer.organizationService,
           this.serviceContainer.organizationAuthRequestService,
         );
-        const response = await cmd.run(organizationId);
+        const response = await cmd.run(options.organizationid);
         this.processResponse(response);
       });
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2762
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When writing the device approval commands, we used positional parameters for all input values. However, our other commands use a flag for the organization id: `--organizationid`. We got feedback from our integration team that these commands should be consistent, so this PR implements the option flag for the organization id instead of an argument.

A couple of notes on implementation:
1. elsewhere we use `.option` to define options, however commander also provides `.requiredOption` which automatically checks for missing/empty option values and returns an error in that case. That's what I've used here.
2. other commands normalize the casing of option names: [example](https://github.com/bitwarden/clients/blob/main/apps/cli/src/admin-console/commands/confirm.command.ts#L69-L75). However, commander itself is case sensitive, so if you define `.option("--organizationid")` and try to invoke the command with `--organizationId`, commander will give you an error about an unknown option. For this reason I didn't bother normalizing it as that code will never run unless you've already matched the defined case.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Updated output of `bw device-approval --help`:

```
Usage: bw device-approval [options] [command]

Manage device approvals

Options:
  -h, --help                     display help for command

Commands:
  list [options]                 List all pending requests for an organization
  approve [options] <requestId>  Approve a pending request
  approve-all [options]          Approve all pending requests for an
                                 organization
  deny [options] <requestId>     Deny a pending request
  deny-all [options]             Deny all pending requests for an organization
  help [command]                 display help for command
```

Updated help output of `approve-all` (for example):

```
Usage: bw device-approval approve-all [options]

Approve all pending requests for an organization

Options:
  --organizationid <organizationid>  The organization id (required)
  -h, --help                         display help for command
```

And for `approve`:

```
Usage: bw device-approval approve [options] <requestId>

Approve a pending request

Arguments:
  requestId                          The id of the request to approve

Options:
  --organizationid <organizationid>  The organization id (required)
  -h, --help                         display help for command
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
