### PR TITLE
[PM-8591] Initialize subscription after setting initial values

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -10,6 +10,7 @@ import {
   map,
   Observable,
   pairwise,
+  startWith,
   Subject,
   switchMap,
   takeUntil,
@@ -150,8 +151,25 @@ export class AccountSecurityComponent implements OnInit {
       timeout = VaultTimeoutStringType.OnRestart;
     }
 
+    const initialValues = {
+      vaultTimeout: timeout,
+      vaultTimeoutAction: await firstValueFrom(
+        this.vaultTimeoutSettingsService.getVaultTimeoutActionByUserId$(activeAccount.id),
+      ),
+      pin: await this.pinService.isPinSet(activeAccount.id),
+      biometric: await this.vaultTimeoutSettingsService.isBiometricLockSet(),
+      enableAutoBiometricsPrompt: await firstValueFrom(
+        this.biometricStateService.promptAutomatically$,
+      ),
+    };
+    this.form.patchValue(initialValues, { emitEvent: false });
+
+    this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
+    this.showChangeMasterPass = await this.userVerificationService.hasMasterPassword();
+
     this.form.controls.vaultTimeout.valueChanges
       .pipe(
+        startWith(initialValues.vaultTimeout), // emit to init pairwise
         pairwise(),
         concatMap(async ([previousValue, newValue]) => {
           await this.saveVaultTimeout(previousValue, newValue);
@@ -162,6 +180,7 @@ export class AccountSecurityComponent implements OnInit {
 
     this.form.controls.vaultTimeoutAction.valueChanges
       .pipe(
+        startWith(initialValues.vaultTimeoutAction), // emit to init pairwise
         pairwise(),
         concatMap(async ([previousValue, newValue]) => {
           await this.saveVaultTimeoutAction(previousValue, newValue);
@@ -169,24 +188,6 @@ export class AccountSecurityComponent implements OnInit {
         takeUntil(this.destroy$),
       )
       .subscribe();
-
-    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
-
-    const initialValues = {
-      vaultTimeout: timeout,
-      vaultTimeoutAction: await firstValueFrom(
-        this.vaultTimeoutSettingsService.getVaultTimeoutActionByUserId$(activeAccount.id),
-      ),
-      pin: await this.pinService.isPinSet(userId),
-      biometric: await this.vaultTimeoutSettingsService.isBiometricLockSet(),
-      enableAutoBiometricsPrompt: await firstValueFrom(
-        this.biometricStateService.promptAutomatically$,
-      ),
-    };
-    this.form.patchValue(initialValues); // Emit event to initialize `pairwise` operator
-
-    this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
-    this.showChangeMasterPass = await this.userVerificationService.hasMasterPassword();
 
     this.form.controls.pin.valueChanges
       .pipe(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8591
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix never lock popup showing every time you navigate to settings on browser. The issue here was duplicate firings of the `valueChanges` observable on initialization of our subscription. By using `startWith` instead of relying on an emission from a `patchValue`, we don't kick off a double emission: One from the `patchValue` and one from the `app-vault-timeout-input` component.
## 📸 Screenshots


https://github.com/bitwarden/clients/assets/24985544/9a8a0c60-34ce-4bc7-96de-6d3064d15c6f



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
