### PR TITLE
Translation settings should be persisted on web

### DIFF
--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -112,7 +112,7 @@ export const DESKTOP_SETTINGS_DISK = new StateDefinition("desktopSettings", "dis
 export const ENVIRONMENT_DISK = new StateDefinition("environment", "disk");
 export const ENVIRONMENT_MEMORY = new StateDefinition("environment", "memory");
 export const THEMING_DISK = new StateDefinition("theming", "disk", { web: "disk-local" });
-export const TRANSLATION_DISK = new StateDefinition("translation", "disk");
+export const TRANSLATION_DISK = new StateDefinition("translation", "disk", { web: "disk-local" });
 
 // Secrets Manager
 


### PR DESCRIPTION

## 🎟️ Tracking

https://bitwarden.atlassian.net/issues/PM-7098
resolves #8507

## 📔 Objective

Translation locale should have been persisted in web in #8122, but was mistakenly left in session.

Unfortunately we cannot migrate this data from session, as it is lost on tab closed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
