### PR TITLE
[AC-2763] Allow providers who are also members access to items

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -312,9 +312,14 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.editableCollections$ = this.allCollectionsWithoutUnassigned$.pipe(
       map((collections) => {
         // If restricted, providers can not add items to any collections or edit those items
-        if (this.organization.isProviderUser && this.restrictProviderAccessEnabled) {
+        if (
+          this.organization.isProviderUser &&
+          !this.organization.isMember &&
+          this.restrictProviderAccessEnabled
+        ) {
           return [];
         }
+
         // Users that can edit all ciphers can implicitly add to / edit within any collection
         if (
           this.organization.canEditAllCiphers(
@@ -356,7 +361,11 @@ export class VaultComponent implements OnInit, OnDestroy {
         }
         let ciphers;
 
-        if (organization.isProviderUser && this.restrictProviderAccessEnabled) {
+        if (
+          organization.isProviderUser &&
+          !organization.isMember &&
+          this.restrictProviderAccessEnabled
+        ) {
           return [];
         }
 
@@ -488,7 +497,11 @@ export class VaultComponent implements OnInit, OnDestroy {
       organization$,
     ]).pipe(
       map(([filter, collection, organization]) => {
-        if (organization.isProviderUser && this.restrictProviderAccessEnabled) {
+        if (
+          organization.isProviderUser &&
+          !organization.isMember &&
+          this.restrictProviderAccessEnabled
+        ) {
           return collection != undefined || filter.collectionId === Unassigned;
         }
 

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -195,8 +195,17 @@ export class Organization {
   }
 
   canEditUnassignedCiphers(restrictProviderAccessFlagEnabled: boolean) {
+    // Check if the user is a ProviderUser
     if (this.isProviderUser) {
-      return !restrictProviderAccessFlagEnabled;
+      // If the user is not a member and the restrictProviderAccessFlag is enabled, return false
+      if (!this.isMember && restrictProviderAccessFlagEnabled) {
+        return false;
+      }
+      // If the restrictProviderAccessFlag is not enabled, return true
+      if (!restrictProviderAccessFlagEnabled) {
+        return true;
+      }
+      // The user is both a provider user and a member, they should follow normal member permission logic below
     }
     return this.isAdmin || this.permissions.editAnyCollection;
   }
@@ -210,8 +219,17 @@ export class Organization {
       return this.isAdmin || this.permissions.editAnyCollection;
     }
 
+    // Check if the user is a ProviderUser
     if (this.isProviderUser) {
-      return !restrictProviderAccessFlagEnabled;
+      // If the user is not a member and the restrictProviderAccessFlag is enabled, return false
+      if (!this.isMember && restrictProviderAccessFlagEnabled) {
+        return false;
+      }
+      // If the restrictProviderAccessFlag is not enabled, return true
+      if (!restrictProviderAccessFlagEnabled) {
+        return true;
+      }
+      // The user is both a provider user and a member, they should follow normal member permission logic below
     }
 
     // Post Flexible Collections V1, the allowAdminAccessToAllCollectionItems flag can restrict admins


### PR DESCRIPTION
## 🎟️ Tracking

[AC-2763](https://bitwarden.atlassian.net/browse/AC-2763)

## 📔 Objective

Account for provider users that are also members of a client organization and should still have cipher access to any assigned collections with edit/manage permissions when the `restrict-provider-access` feature flag is active.

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/8764515/267db5ef-4070-4307-8b60-63b9eeeee753

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
