### PR TITLE
[PM-8208] Fix: Product Navigation flash

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/product-switcher.component.html
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.component.html
@@ -4,5 +4,6 @@
   [bitMenuTriggerFor]="content?.menu"
   [buttonType]="buttonType"
   [attr.aria-label]="'switchProducts' | i18n"
+  *ngIf="products$ | async"
 ></button>
 <product-switcher-content #content></product-switcher-content>

--- a/apps/web/src/app/layouts/product-switcher/product-switcher.component.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.component.ts
@@ -1,6 +1,8 @@
 import { AfterViewInit, ChangeDetectorRef, Component, Input } from "@angular/core";
 
 import { IconButtonType } from "@bitwarden/components/src/icon-button/icon-button.component";
+
+import { ProductSwitcherService } from "./shared/product-switcher.service";
 @Component({
   selector: "product-switcher",
   templateUrl: "./product-switcher.component.html",
@@ -21,5 +23,10 @@ export class ProductSwitcherComponent implements AfterViewInit {
     this.changeDetector.detectChanges();
   }
 
-  constructor(private changeDetector: ChangeDetectorRef) {}
+  constructor(
+    private changeDetector: ChangeDetectorRef,
+    private productSwitcherService: ProductSwitcherService,
+  ) {}
+
+  protected readonly products$ = this.productSwitcherService.products$;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8208](https://bitwarden.atlassian.net/browse/PM-8208)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The product navigation switcher can briefly show an incorrect organization of products because a sync hasn't occurred for a user. 

I faced the same issue in #8899 regarding the premium banner flashing when it shouldn't and solved it the same way. There is some code duplication but it doesn't feel like complex logic or an enormous amount of code to centralize this logic. A nice refactor would be to make the `getLastSync` an observable which would remove the need to poll the value. I could attempt that refactor here?

## 📸 Screenshots

|Before: "admin console" takes a tick to load in| After: All product switcher content shows up together|
|-|-|
|<video src="https://github.com/bitwarden/clients/assets/125900171/4d1650da-9271-44c6-bfe9-9f51fc77c40c" />|<video src="https://github.com/bitwarden/clients/assets/125900171/375d09ba-b3a1-42aa-a841-0a8319500cd3" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
