### PR TITLE
[PM-6826] Pass along the filtered vault in new item dropdown

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -12,16 +12,12 @@ import { ButtonModule, NoItemsModule, MenuModule } from "@bitwarden/components";
   standalone: true,
   imports: [NoItemsModule, JslibModule, CommonModule, ButtonModule, RouterLink, MenuModule],
 })
-export class NewItemDropdownV2Component implements OnInit, OnDestroy {
+export class NewItemDropdownV2Component {
   @Input() selectedVaultId: string;
 
   cipherType = CipherType;
 
   constructor(private router: Router) {}
-
-  ngOnInit(): void {}
-
-  ngOnDestroy(): void {}
 
   newItemNavigate(type: CipherType) {
     const selectedVault = this.selectedVaultId;

--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -1,10 +1,16 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { ButtonModule, NoItemsModule, MenuModule } from "@bitwarden/components";
+
+import {
+  MY_VAULT_ID,
+  VaultPopupListFiltersService,
+} from "../../../services/vault-popup-list-filters.service";
 
 @Component({
   selector: "app-new-item-dropdown",
@@ -13,16 +19,29 @@ import { ButtonModule, NoItemsModule, MenuModule } from "@bitwarden/components";
   imports: [NoItemsModule, JslibModule, CommonModule, ButtonModule, RouterLink, MenuModule],
 })
 export class NewItemDropdownV2Component implements OnInit, OnDestroy {
+  private selectedVaultId: string | null | undefined = null;
+
   cipherType = CipherType;
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    vaultPopupListFiltersService: VaultPopupListFiltersService,
+  ) {
+    vaultPopupListFiltersService.filters$.pipe(takeUntilDestroyed()).subscribe((filters) => {
+      this.selectedVaultId =
+        filters.organization?.id !== MY_VAULT_ID ? filters.organization?.id : null;
+    });
+  }
 
   ngOnInit(): void {}
 
   ngOnDestroy(): void {}
 
-  // TODO PM-6826: add selectedVault query param
   newItemNavigate(type: CipherType) {
-    void this.router.navigate(["/add-cipher"], { queryParams: { type: type, isNew: true } });
+    const selectedVault = this.selectedVaultId;
+
+    void this.router.navigate(["/add-cipher"], {
+      queryParams: { type: type, isNew: true, selectedVault },
+    });
   }
 }

--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -1,16 +1,10 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Component, Input, OnDestroy, OnInit } from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { ButtonModule, NoItemsModule, MenuModule } from "@bitwarden/components";
-
-import {
-  MY_VAULT_ID,
-  VaultPopupListFiltersService,
-} from "../../../services/vault-popup-list-filters.service";
 
 @Component({
   selector: "app-new-item-dropdown",
@@ -19,19 +13,11 @@ import {
   imports: [NoItemsModule, JslibModule, CommonModule, ButtonModule, RouterLink, MenuModule],
 })
 export class NewItemDropdownV2Component implements OnInit, OnDestroy {
-  private selectedVaultId: string | null | undefined = null;
+  @Input() selectedVaultId: string;
 
   cipherType = CipherType;
 
-  constructor(
-    private router: Router,
-    vaultPopupListFiltersService: VaultPopupListFiltersService,
-  ) {
-    vaultPopupListFiltersService.filters$.pipe(takeUntilDestroyed()).subscribe((filters) => {
-      this.selectedVaultId =
-        filters.organization?.id !== MY_VAULT_ID ? filters.organization?.id : null;
-    });
-  }
+  constructor(private router: Router) {}
 
   ngOnInit(): void {}
 

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
@@ -1,7 +1,7 @@
 <popup-page>
   <popup-header slot="header" [pageTitle]="'vault' | i18n">
     <ng-container slot="end">
-      <app-new-item-dropdown></app-new-item-dropdown>
+      <app-new-item-dropdown [selectedVaultId]="selectedVaultId$ | async"></app-new-item-dropdown>
 
       <app-pop-out></app-pop-out>
       <app-current-account></app-current-account>

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
@@ -1,7 +1,7 @@
 <popup-page>
   <popup-header slot="header" [pageTitle]="'vault' | i18n">
     <ng-container slot="end">
-      <app-new-item-dropdown [selectedVaultId]="selectedVaultId$ | async"></app-new-item-dropdown>
+      <app-new-item-dropdown [selectedVaultId]="selectedVaultId"></app-new-item-dropdown>
 
       <app-pop-out></app-pop-out>
       <app-current-account></app-current-account>
@@ -15,7 +15,10 @@
     <bit-no-items [icon]="vaultIcon">
       <ng-container slot="title">{{ "yourVaultIsEmpty" | i18n }}</ng-container>
       <ng-container slot="description">{{ "autofillSuggestionsTip" | i18n }}</ng-container>
-      <app-new-item-dropdown slot="button"></app-new-item-dropdown>
+      <app-new-item-dropdown
+        slot="button"
+        [selectedVaultId]="selectedVaultId"
+      ></app-new-item-dropdown>
     </bit-no-items>
   </div>
 

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { Router, RouterLink } from "@angular/router";
+import { RouterLink } from "@angular/router";
 import { combineLatest } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -59,10 +59,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
 
   protected VaultStateEnum = VaultState;
 
-  constructor(
-    private vaultPopupItemsService: VaultPopupItemsService,
-    private router: Router,
-  ) {
+  constructor(private vaultPopupItemsService: VaultPopupItemsService) {
     combineLatest([
       this.vaultPopupItemsService.emptyVault$,
       this.vaultPopupItemsService.noFilteredResults$,

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
@@ -55,10 +55,8 @@ export class VaultV2Component {
   protected favoriteCiphers$ = this.vaultPopupItemsService.favoriteCiphers$;
   protected remainingCiphers$ = this.vaultPopupItemsService.remainingCiphers$;
 
-  protected selectedVaultId$ = this.vaultPopupListFiltersService.filters$.pipe(
-    filter((filters) => filters.organization?.id !== MY_VAULT_ID),
-    map((filters) => filters.organization?.id),
-  );
+  /** The `id` of the filtered organization */
+  protected selectedVaultId: string | null = null;
 
   /** Visual state of the vault */
   protected vaultState: VaultState | null = null;
@@ -94,6 +92,16 @@ export class VaultV2Component {
           default:
             this.vaultState = null;
         }
+      });
+
+    this.vaultPopupListFiltersService.filters$
+      .pipe(
+        takeUntilDestroyed(),
+        filter((filters) => filters.organization?.id !== MY_VAULT_ID),
+        map((filters) => filters.organization?.id ?? null),
+      )
+      .subscribe((organizationId) => {
+        this.selectedVaultId = organizationId;
       });
   }
 }

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterLink } from "@angular/router";
 import { combineLatest, filter, map } from "rxjs";
@@ -49,7 +49,7 @@ enum VaultState {
     NewItemDropdownV2Component,
   ],
 })
-export class VaultV2Component implements OnInit, OnDestroy {
+export class VaultV2Component {
   cipherType = CipherType;
 
   protected favoriteCiphers$ = this.vaultPopupItemsService.favoriteCiphers$;
@@ -96,8 +96,4 @@ export class VaultV2Component implements OnInit, OnDestroy {
         }
       });
   }
-
-  ngOnInit(): void {}
-
-  ngOnDestroy(): void {}
 }

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterLink } from "@angular/router";
-import { combineLatest } from "rxjs";
+import { combineLatest, filter, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -13,6 +13,10 @@ import { PopOutComponent } from "../../../../platform/popup/components/pop-out.c
 import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
 import { VaultPopupItemsService } from "../../services/vault-popup-items.service";
+import {
+  MY_VAULT_ID,
+  VaultPopupListFiltersService,
+} from "../../services/vault-popup-list-filters.service";
 import { AutofillVaultListItemsComponent, VaultListItemsContainerComponent } from "../vault-v2";
 import { NewItemDropdownV2Component } from "../vault-v2/new-item-dropdown/new-item-dropdown-v2.component";
 import { VaultListFiltersComponent } from "../vault-v2/vault-list-filters/vault-list-filters.component";
@@ -47,8 +51,14 @@ enum VaultState {
 })
 export class VaultV2Component implements OnInit, OnDestroy {
   cipherType = CipherType;
+
   protected favoriteCiphers$ = this.vaultPopupItemsService.favoriteCiphers$;
   protected remainingCiphers$ = this.vaultPopupItemsService.remainingCiphers$;
+
+  protected selectedVaultId$ = this.vaultPopupListFiltersService.filters$.pipe(
+    filter((filters) => filters.organization?.id !== MY_VAULT_ID),
+    map((filters) => filters.organization?.id),
+  );
 
   /** Visual state of the vault */
   protected vaultState: VaultState | null = null;
@@ -59,7 +69,10 @@ export class VaultV2Component implements OnInit, OnDestroy {
 
   protected VaultStateEnum = VaultState;
 
-  constructor(private vaultPopupItemsService: VaultPopupItemsService) {
+  constructor(
+    private vaultPopupItemsService: VaultPopupItemsService,
+    private vaultPopupListFiltersService: VaultPopupListFiltersService,
+  ) {
     combineLatest([
       this.vaultPopupItemsService.emptyVault$,
       this.vaultPopupItemsService.noFilteredResults$,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-6826](https://bitwarden.atlassian.net/browse/PM-6826)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a user is filtering by an organization and selects a new item, pass along the `id` of the organization to the add/edit component.

- I believe this is the only location. It was the only TODO 😄 
- The existing logic doesn't appear to filter out `MyVault` if it is selected but I don't believe that would be needed by the Add/Edit component because it would be the same scenario as if an organization wasn't selected all. Is that accuate?

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-6826]: https://bitwarden.atlassian.net/browse/PM-6826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ