### PR TITLE
[PM-7215] User with Can View permission can remove passkey or delete URIs from UI, though it isn't saved

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -144,6 +144,7 @@
                   appStopClick
                   (click)="removePasskey()"
                   appA11yTitle="{{ 'removePasskey' | i18n }}"
+                  *ngIf="!(!cipher.edit && editMode)"
                 >
                   <i class="bwi bwi-fw bwi-minus-circle bwi-lg" aria-hidden="true"></i>
                 </button>
@@ -542,6 +543,7 @@
           >
             <button
               type="button"
+              *ngIf="!(!cipher.edit && editMode)"
               appStopClick
               (click)="removeUri(u)"
               appA11yTitle="{{ 'remove' | i18n }}"
@@ -558,6 +560,7 @@
                 [hidden]="$any(u).showUriOptionsInput === true"
                 placeholder="{{ 'ex' | i18n }} https://google.com"
                 inputmode="url"
+                [readonly]="!cipher.edit && editMode"
                 appInputVerbatim
               />
               <label for="loginUriMatch{{ i }}" class="sr-only">
@@ -607,6 +610,7 @@
                 appA11yTitle="{{ 'toggleOptions' | i18n }}"
                 (click)="toggleUriOptions(u)"
                 [attr.aria-pressed]="$any(u).showOptions === true"
+                [disabled]="!cipher.edit && editMode"
               >
                 <i class="bwi bwi-fw bwi-lg bwi-cog" aria-hidden="true"></i>
               </button>

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -127,7 +127,7 @@
                 appStopClick
                 (click)="removePasskey()"
                 appA11yTitle="{{ 'removePasskey' | i18n }}"
-                [disabled]="!cipher.edit && editMode"
+                *ngIf="!(!cipher.edit && editMode)"
               >
                 <i class="bwi bwi-fw bwi-minus-circle bwi-lg" aria-hidden="true"></i>
               </button>
@@ -488,7 +488,7 @@
                 appStopClick
                 (click)="removeUri(u)"
                 appA11yTitle="{{ 'remove' | i18n }}"
-                [disabled]="!cipher.edit && editMode"
+                *ngIf="!(!cipher.edit && editMode)"
               >
                 <i class="bwi bwi-minus-circle bwi-lg" aria-hidden="true"></i>
               </button>
@@ -500,6 +500,7 @@
                   name="Login.Uris[{{ i }}].Uri"
                   [(ngModel)]="u.uri"
                   placeholder="{{ 'ex' | i18n }} https://google.com"
+                  [readonly]="!cipher.edit && editMode"
                   appInputVerbatim
                 />
                 <label for="loginUriMatch{{ i }}" class="sr-only">
@@ -533,6 +534,7 @@
                       ($any(u).showOptions == null && u.match == null)
                     )
                   "
+                  [disabled]="!cipher.edit && editMode"
                 >
                   <i class="bwi bwi-lg bwi-cog" aria-hidden="true"></i>
                 </button>

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.html
@@ -217,7 +217,7 @@
                     class="tw-items-center tw-border-none tw-bg-transparent tw-text-danger tw-ml-3"
                     appA11yTitle="{{ 'removePasskey' | i18n }}"
                     (click)="removePasskey()"
-                    *ngIf="!cipher.isDeleted && !viewOnly && !(!cipher.edit && editMode)"
+                    *ngIf="!cipher.isDeleted && !viewOnly"
                   >
                     <i class="bwi bwi-lg bwi-minus-circle"></i>
                   </button>
@@ -405,7 +405,7 @@
                     class="btn btn-link text-danger ml-2"
                     (click)="removeUri(u)"
                     appA11yTitle="{{ 'remove' | i18n }}"
-                    *ngIf="!cipher.isDeleted && !viewOnly && !(!cipher.edit && editMode)"
+                    *ngIf="!cipher.isDeleted && !viewOnly"
                   >
                     <i class="bwi bwi-minus-circle bwi-lg" aria-hidden="true"></i>
                   </button>

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.html
@@ -217,7 +217,7 @@
                     class="tw-items-center tw-border-none tw-bg-transparent tw-text-danger tw-ml-3"
                     appA11yTitle="{{ 'removePasskey' | i18n }}"
                     (click)="removePasskey()"
-                    *ngIf="!cipher.isDeleted && !viewOnly"
+                    *ngIf="!cipher.isDeleted && !viewOnly && !(!cipher.edit && editMode)"
                   >
                     <i class="bwi bwi-lg bwi-minus-circle"></i>
                   </button>
@@ -405,7 +405,7 @@
                     class="btn btn-link text-danger ml-2"
                     (click)="removeUri(u)"
                     appA11yTitle="{{ 'remove' | i18n }}"
-                    *ngIf="!cipher.isDeleted && !viewOnly"
+                    *ngIf="!cipher.isDeleted && !viewOnly && !(!cipher.edit && editMode)"
                   >
                     <i class="bwi bwi-minus-circle bwi-lg" aria-hidden="true"></i>
                   </button>

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.ts
@@ -93,6 +93,7 @@ export class AddEditComponent extends BaseAddEditComponent implements OnInit, On
   async ngOnInit() {
     await super.ngOnInit();
     await this.load();
+    this.viewOnly = !this.cipher.edit && this.editMode;
     // remove when all the title for all clients are updated to New Item
     if (this.cloneMode || !this.editMode) {
       this.title = this.i18nService.t("newItem");


### PR DESCRIPTION
## 🎟️ Tracking
[PM-7215](https://bitwarden.atlassian.net/browse/PM-7215)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This PR aims to ensure that the remove button doesn't appear when a user with only view access tries to edit an item.
<!-- Describe what the purpose of this PR is, for example, what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before
<img width="600" alt="Screenshot 2024-06-12 at 10 52 45 AM" src="https://github.com/bitwarden/clients/assets/13024008/1672fe3b-f98b-4b7d-90d3-aa64873f043f">
<img width="600" alt="Screenshot 2024-06-12 at 10 53 32 AM" src="https://github.com/bitwarden/clients/assets/13024008/552ebf6c-852f-4708-9f9b-cf6c9ed44bd3">

### After
<img width="600" alt="Screenshot 2024-06-12 at 10 43 25 AM" src="https://github.com/bitwarden/clients/assets/13024008/744f9ae6-12f2-4d53-91e0-859fe4b03592">

<img width="600" alt="Screenshot 2024-06-12 at 10 44 02 AM" src="https://github.com/bitwarden/clients/assets/13024008/c11e37c0-d663-46fd-9a1b-377688be8d48">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-7215]: https://bitwarden.atlassian.net/browse/PM-7215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ