### PR TITLE
[PM-8858] include only 1 digit in passphrase

### DIFF
--- a/libs/common/src/tools/generator/random.ts
+++ b/libs/common/src/tools/generator/random.ts
@@ -21,7 +21,7 @@ export class CryptoServiceRandomizer implements Randomizer {
 
     if (options?.number ?? false) {
       const num = await this.crypto.randomNumber(1, 9);
-      word = word + this.zeroPad(num.toString(), 4);
+      word = word + num.toString();
     }
 
     return word;

--- a/libs/common/src/tools/generator/random.ts
+++ b/libs/common/src/tools/generator/random.ts
@@ -20,7 +20,7 @@ export class CryptoServiceRandomizer implements Randomizer {
     }
 
     if (options?.number ?? false) {
-      const num = await this.crypto.randomNumber(1, 9999);
+      const num = await this.crypto.randomNumber(1, 9);
       word = word + this.zeroPad(num.toString(), 4);
     }
 

--- a/libs/tools/generator/core/src/engine/crypto-service-randomizer.ts
+++ b/libs/tools/generator/core/src/engine/crypto-service-randomizer.ts
@@ -21,7 +21,7 @@ export class CryptoServiceRandomizer implements Randomizer {
 
     if (options?.number ?? false) {
       const num = await this.crypto.randomNumber(1, 9);
-      word = word + this.zeroPad(num.toString(), 4);
+      word = word + num.toString();
     }
 
     return word;

--- a/libs/tools/generator/core/src/engine/crypto-service-randomizer.ts
+++ b/libs/tools/generator/core/src/engine/crypto-service-randomizer.ts
@@ -20,7 +20,7 @@ export class CryptoServiceRandomizer implements Randomizer {
     }
 
     if (options?.number ?? false) {
-      const num = await this.crypto.randomNumber(1, 9999);
+      const num = await this.crypto.randomNumber(1, 9);
       word = word + this.zeroPad(num.toString(), 4);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8858

## 📔 Objective

Append only one digit when generating a passphrase with a number in it.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
