### PR TITLE
[PM-8857] fix passphrase missing number

### DIFF
--- a/libs/common/src/tools/generator/passphrase/passphrase-generator-strategy.ts
+++ b/libs/common/src/tools/generator/passphrase/passphrase-generator-strategy.ts
@@ -51,7 +51,7 @@ export class PassphraseGeneratorStrategy
     // select which word gets the number, if any
     let luckyNumber = -1;
     if (o.includeNumber) {
-      luckyNumber = await this.randomizer.uniform(0, o.numWords);
+      luckyNumber = await this.randomizer.uniform(0, o.numWords - 1);
     }
 
     // generate the passphrase

--- a/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
@@ -47,7 +47,7 @@ export class PassphraseGeneratorStrategy
     // select which word gets the number, if any
     let luckyNumber = -1;
     if (o.includeNumber) {
-      luckyNumber = await this.randomizer.uniform(0, o.numWords);
+      luckyNumber = await this.randomizer.uniform(0, o.numWords - 1);
     }
 
     // generate the passphrase


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8857

## 📔 Objective

The uniform distribution produces inclusive random numbers on its tail end, but is being used in an exclusive for loop. This caused the algorithm to occasionally skip appending a number to one of the words in the passphrase.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
