### PR TITLE
[AC-2771] [AC-2772] Provider Restriction Fixes

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -69,9 +69,9 @@ export class VaultCollectionRowComponent {
     if (this.collection instanceof CollectionAdminView) {
       // Only show AddAccess if unmanaged and allowAdminAccessToAllCollectionItems is disabled
       return (
-        !this.organization.allowAdminAccessToAllCollectionItems &&
+        !this.organization?.allowAdminAccessToAllCollectionItems &&
         this.collection.unmanaged &&
-        this.organization.canEditUnmanagedCollections()
+        this.organization?.canEditUnmanagedCollections()
       );
     }
 

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -93,7 +93,7 @@
   </ng-container>
 
   <bit-search
-    *ngIf="organization?.isProviderUser"
+    *ngIf="restrictProviderAccessFlag && organization?.isProviderUser && !organization?.isMember"
     class="tw-grow"
     [ngModel]="searchText"
     (ngModelChange)="onSearchTextChanged($event)"

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
@@ -68,7 +68,7 @@ export class VaultHeaderComponent implements OnInit {
   protected organizations$ = this.organizationService.organizations$;
 
   protected flexibleCollectionsV1Enabled = false;
-  private restrictProviderAccessFlag = false;
+  protected restrictProviderAccessFlag = false;
 
   constructor(
     private organizationService: OrganizationService,
@@ -220,7 +220,11 @@ export class VaultHeaderComponent implements OnInit {
   }
 
   get canCreateCipher(): boolean {
-    if (this.organization?.isProviderUser && this.restrictProviderAccessFlag) {
+    if (
+      this.organization?.isProviderUser &&
+      this.restrictProviderAccessFlag &&
+      !this.organization?.isMember
+    ) {
       return false;
     }
     return true;

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -352,6 +352,16 @@ export class VaultComponent implements OnInit, OnDestroy {
         }
         let ciphers;
 
+        // Restricted providers (who are not members) do not have access org cipher endpoint below
+        // Return early to avoid 404 response
+        if (
+          this.restrictProviderAccessEnabled &&
+          !organization.isMember &&
+          organization.isProviderUser
+        ) {
+          return [];
+        }
+
         if (this.flexibleCollectionsV1Enabled) {
           // Flexible collections V1 logic.
           // If the user can edit all ciphers for the organization then fetch them ALL.

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -166,7 +166,11 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   protected get hideVaultFilters(): boolean {
-    return this.restrictProviderAccessEnabled && this.organization?.isProviderUser;
+    return (
+      this.restrictProviderAccessEnabled &&
+      this.organization?.isProviderUser &&
+      !this.organization?.isMember
+    );
   }
 
   private searchText$ = new Subject<string>();


### PR DESCRIPTION
## 🎟️ Tracking

[AC-2771](https://bitwarden.atlassian.net/browse/AC-2771) and [AC-2772](https://bitwarden.atlassian.net/browse/AC-2772)


## 📔 Objective

Fix issue with restricted providers introduced in #9585. It mistakenly assumed the `/assigned` ciphers endpoint would return empty if the provider was not a member. Instead, it throws a 404 error and prevents restricted providers from using the AC vault for the organization. This PR adds the removed check to prevent hitting that endpoint only if the provider is restricted and they are not a member.

It also fixes some missing UI elements for restricted providers that are also members.

## 📸 Screenshots

### Provider who IS a member of the org
Filters are present, new dropdown has new "Item", and header search is hidden
<img width="1424" alt="image" src="https://github.com/bitwarden/clients/assets/8764515/e68b759c-30cb-4e9b-9be3-470ae0b556fa">

### Provider who is NOT a member of the org
Filters are hidden, new collections button only, and header collection search is visible 
<img width="1427" alt="image" src="https://github.com/bitwarden/clients/assets/8764515/c17a8ef9-0e56-41b3-b0dd-06ec6159f27c">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[AC-2771]: https://bitwarden.atlassian.net/browse/AC-2771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AC-2772]: https://bitwarden.atlassian.net/browse/AC-2772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ