### PR TITLE
[PM-8865] Reset "should trust device" state to null

### DIFF
--- a/libs/common/src/auth/services/device-trust.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust.service.implementation.ts
@@ -102,7 +102,7 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     if (shouldTrustDevice) {
       await this.trustDevice(userId);
       // reset the trust choice
-      await this.setShouldTrustDevice(userId, false);
+      await this.setShouldTrustDevice(userId, null);
     }
   }
 

--- a/libs/common/src/auth/services/device-trust.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust.service.spec.ts
@@ -115,7 +115,7 @@ describe("deviceTrustService", () => {
 
       expect(deviceTrustService.getShouldTrustDevice).toHaveBeenCalledTimes(1);
       expect(deviceTrustService.trustDevice).toHaveBeenCalledTimes(1);
-      expect(deviceTrustService.setShouldTrustDevice).toHaveBeenCalledWith(mockUserId, false);
+      expect(deviceTrustService.setShouldTrustDevice).toHaveBeenCalledWith(mockUserId, null);
     });
 
     it("should not trust device nor reset when getShouldTrustDevice returns false", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8865

## 📔 Objective

If a user somehow loses trust on a device, the "Remember device" checkbox would subsequently default to unchecked.  This was due to resetting to "false" after the trust process was completed previously.

This change re-initializes the state to `null` instead, so that the logic on the component can handle defaulting it to the appropriate value.

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/106564991/60e317be-e6d3-4065-88b8-8807c37511a1

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
