### PR TITLE
[PM-8869] Fix broken autofill cache invalidation features on Safari

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -21,6 +21,7 @@ import {
   nodeIsFormElement,
   nodeIsInputElement,
   sendExtensionMessage,
+  requestIdleCallbackPolyfill,
 } from "../utils";
 
 import { AutofillOverlayContentService } from "./abstractions/autofill-overlay-content.service";
@@ -1057,7 +1058,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
     }
 
     if (!this.mutationsQueue.length) {
-      globalThis.requestIdleCallback(this.processMutations, { timeout: 500 });
+      requestIdleCallbackPolyfill(this.processMutations, { timeout: 500 });
     }
     this.mutationsQueue.push(mutations);
   };
@@ -1194,7 +1195,7 @@ class CollectAutofillContentService implements CollectAutofillContentServiceInte
         continue;
       }
 
-      globalThis.requestIdleCallback(
+      requestIdleCallbackPolyfill(
         // We are setting this item to a -1 index because we do not know its position in the DOM.
         // This value should be updated with the next call to collect page details.
         () => void this.buildAutofillFieldItem(node as ElementWithOpId<FormFieldElement>, -1),

--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -1,6 +1,12 @@
 import { AutofillPort } from "../enums/autofill-port.enums";
 import { FillableFormFieldElement, FormFieldElement } from "../types";
 
+/**
+ * Polyfills the requestIdleCallback API with a setTimeout fallback.
+ *
+ * @param callback - The callback function to run when the browser is idle.
+ * @param options - The options to pass to the requestIdleCallback function.
+ */
 export function requestIdleCallbackPolyfill(callback: () => void, options?: Record<string, any>) {
   if ("requestIdleCallback" in globalThis) {
     return globalThis.requestIdleCallback(() => callback(), options);

--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -1,6 +1,14 @@
 import { AutofillPort } from "../enums/autofill-port.enums";
 import { FillableFormFieldElement, FormFieldElement } from "../types";
 
+export function requestIdleCallbackPolyfill(callback: () => void, options?: Record<string, any>) {
+  if ("requestIdleCallback" in globalThis) {
+    return globalThis.requestIdleCallback(() => callback(), options);
+  }
+
+  return globalThis.setTimeout(() => callback(), 1);
+}
+
 /**
  * Generates a random string of characters that formatted as a custom element name.
  */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8869

## 📔 Objective

A regression was encountered within Safari that breaks cache re-validation of autofill page details. This is due to a performance improvement that was implemented for Firefox which uses the window.requestIdleCallback API.

That API is not available in Safari in any manner, and as a result any calls made in collection of page details breaks. To resolve this, we need to fallback to a setTimeout method when the API is not available, allowing us to mimic in some manner the behavior of requestIdleCallback

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
