### PR TITLE
[BEEEP] Hide linux tray icon setting on environments without tray icon

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -266,70 +266,72 @@
               </button>
             </h2>
             <ng-container *ngIf="showAppPreferences">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="enableTray">
-                    <input
-                      id="enableTray"
-                      type="checkbox"
-                      aria-describedby="enableTrayHelp"
-                      formControlName="enableTray"
-                      (change)="saveTray()"
-                    />
-                    {{ enableTrayText }}
-                  </label>
+              <ng-container *ngIf="isTrayAvailable">
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableTray">
+                      <input
+                        id="enableTray"
+                        type="checkbox"
+                        aria-describedby="enableTrayHelp"
+                        formControlName="enableTray"
+                        (change)="saveTray()"
+                      />
+                      {{ enableTrayText }}
+                    </label>
+                  </div>
+                  <small id="enableTrayHelp" class="help-block">{{ enableTrayDescText }}</small>
                 </div>
-                <small id="enableTrayHelp" class="help-block">{{ enableTrayDescText }}</small>
-              </div>
-              <div class="form-group" *ngIf="showMinToTray">
-                <div class="checkbox">
-                  <label for="enableMinToTray">
-                    <input
-                      id="enableMinToTray"
-                      type="checkbox"
-                      aria-describedby="enableMinToTrayHelp"
-                      formControlName="enableMinToTray"
-                      (change)="saveMinToTray()"
-                    />
-                    {{ enableMinToTrayText }}
-                  </label>
+                <div class="form-group" *ngIf="showMinToTray">
+                  <div class="checkbox">
+                    <label for="enableMinToTray">
+                      <input
+                        id="enableMinToTray"
+                        type="checkbox"
+                        aria-describedby="enableMinToTrayHelp"
+                        formControlName="enableMinToTray"
+                        (change)="saveMinToTray()"
+                      />
+                      {{ enableMinToTrayText }}
+                    </label>
+                  </div>
+                  <small id="enableMinToTrayHelp" class="help-block">{{
+                    enableMinToTrayDescText
+                  }}</small>
                 </div>
-                <small id="enableMinToTrayHelp" class="help-block">{{
-                  enableMinToTrayDescText
-                }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="enableCloseToTray">
-                    <input
-                      id="enableCloseToTray"
-                      type="checkbox"
-                      aria-describedby="enableCloseToTrayHelp"
-                      formControlName="enableCloseToTray"
-                      (change)="saveCloseToTray()"
-                    />
-                    {{ enableCloseToTrayText }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableCloseToTray">
+                      <input
+                        id="enableCloseToTray"
+                        type="checkbox"
+                        aria-describedby="enableCloseToTrayHelp"
+                        formControlName="enableCloseToTray"
+                        (change)="saveCloseToTray()"
+                      />
+                      {{ enableCloseToTrayText }}
+                    </label>
+                  </div>
+                  <small id="enableCloseToTrayHelp" class="help-block">{{
+                    enableCloseToTrayDescText
+                  }}</small>
                 </div>
-                <small id="enableCloseToTrayHelp" class="help-block">{{
-                  enableCloseToTrayDescText
-                }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="startToTray">
-                    <input
-                      id="startToTray"
-                      type="checkbox"
-                      aria-describedby="startToTrayHelp"
-                      formControlName="startToTray"
-                      (change)="saveStartToTray()"
-                    />
-                    {{ startToTrayText }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="startToTray">
+                      <input
+                        id="startToTray"
+                        type="checkbox"
+                        aria-describedby="startToTrayHelp"
+                        formControlName="startToTray"
+                        (change)="saveStartToTray()"
+                      />
+                      {{ startToTrayText }}
+                    </label>
+                  </div>
+                  <small id="startToTrayHelp" class="help-block">{{ startToTrayDescText }}</small>
                 </div>
-                <small id="startToTrayHelp" class="help-block">{{ startToTrayDescText }}</small>
-              </div>
+              </ng-container>
               <div class="form-group">
                 <div class="checkbox">
                   <label for="openAtLogin">

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -45,6 +45,7 @@ export class SettingsComponent implements OnInit {
   // For use in template
   protected readonly VaultTimeoutAction = VaultTimeoutAction;
 
+  isTrayAvailable = true;
   showMinToTray = false;
   vaultTimeoutOptions: VaultTimeoutOption[];
   localeOptions: any[];
@@ -215,6 +216,7 @@ export class SettingsComponent implements OnInit {
   }
 
   async ngOnInit() {
+    this.isTrayAvailable = await ipc.platform.tray.isTrayAvailable();
     this.userHasMasterPassword = await this.userVerificationService.hasMasterPassword();
 
     this.isWindows = (await this.platformUtilsService.getDevice()) === DeviceType.WindowsDesktop;

--- a/apps/desktop/src/main/tray.main.ts
+++ b/apps/desktop/src/main/tray.main.ts
@@ -1,6 +1,14 @@
 import * as path from "path";
 
-import { app, BrowserWindow, Menu, MenuItemConstructorOptions, nativeImage, Tray } from "electron";
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  Menu,
+  MenuItemConstructorOptions,
+  nativeImage,
+  Tray,
+} from "electron";
 import { firstValueFrom } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -59,6 +67,10 @@ export class TrayMain {
     if (await firstValueFrom(this.desktopSettingsService.trayEnabled$)) {
       this.showTray();
     }
+
+    ipcMain.handle("tray.isTrayAvailable", async (event) => {
+      return this.isTrayAvailable();
+    });
   }
 
   setupWindowListeners(win: BrowserWindow) {
@@ -194,5 +206,9 @@ export class TrayMain {
     if (this.windowMain.win != null) {
       this.windowMain.win.close();
     }
+  }
+
+  private isTrayAvailable() {
+    return this.tray != null;
   }
 }

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -59,6 +59,10 @@ const clipboard = {
   write: (message: ClipboardWriteMessage) => ipcRenderer.invoke("clipboard.write", message),
 };
 
+const tray = {
+  isTrayAvailable: (): Promise<boolean> => ipcRenderer.invoke("tray.isTrayAvailable"),
+};
+
 const nativeMessaging = {
   sendReply: (message: EncryptedMessageResponse | UnencryptedMessageResponse) => {
     ipcRenderer.send("nativeMessagingReply", message);
@@ -148,6 +152,7 @@ export default {
   passwords,
   biometric,
   clipboard,
+  tray,
   nativeMessaging,
   crypto,
 };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Some environments (gnome) don't have a tray available. This is caught by https://github.com/bitwarden/clients/pull/9265, and the tray actions are ignored. Since the tray settings have no effect on these environments, the settings should be hidden. This PR checks if the tray is available, and if not, hides the tray related settings in the settings menu.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
