### PR TITLE
Fix AnonLayout width bug

### DIFF
--- a/apps/web/src/app/auth/login/login.component.html
+++ b/apps/web/src/app/auth/login/login.component.html
@@ -2,7 +2,6 @@
   [bitSubmit]="submitForm.bind(null, false)"
   [appApiAction]="formPromise"
   [formGroup]="formGroup"
-  class="tw-w-96"
 >
   <ng-container *ngIf="!validatedEmail">
     <div class="tw-mb-3">

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -14,10 +14,10 @@
     <p *ngIf="subtitle" bitTypography="body1">{{ subtitle }}</p>
   </div>
   <div
-    class="tw-mb-auto tw-min-w-full tw-max-w-md tw-mx-auto tw-flex tw-flex-col tw-items-center sm:tw-min-w-[28rem]"
+    class="tw-mb-auto tw-w-full tw-max-w-md tw-mx-auto tw-flex tw-flex-col tw-items-center sm:tw-min-w-[28rem]"
   >
     <div
-      class="tw-rounded-xl tw-mb-9 tw-mx-auto tw-min-w-full sm:tw-bg-background sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
+      class="tw-rounded-xl tw-mb-9 tw-mx-auto tw-w-full sm:tw-bg-background sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
     >
       <ng-content></ng-content>
     </div>


### PR DESCRIPTION
## 📔 Objective

Attempt to fix a bug where anon-layout content is getting stretched due the fact that our `body` element has a min-width of 1010px.

This PR makes it so at least the anon-layout content stays centered. I believe we will eventually remove the body min-width 1010px in the future to make it truly responsive.

## 📘 Storybook

https://62a88a6de5b807fa98886113-lmtdmuingl.chromatic.com/?path=/story/auth-anon-layout--with-primary-content

## 📸 Screencasts

### Before

https://github.com/bitwarden/clients/assets/102181210/806235ea-81fb-4b51-9bc2-2d170174a954

### After

https://github.com/bitwarden/clients/assets/102181210/a13968f5-0a47-48b4-ab6c-00e8a244516a


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
