### PR TITLE
[Fix] Storybook: product navigation errors

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
@@ -48,7 +48,7 @@ class MockProviderService implements Partial<ProviderService> {
 
 class MockSyncService implements Partial<SyncService> {
   async getLastSync() {
-    return await Promise.resolve(new Date());
+    return Promise.resolve(new Date());
   }
 }
 

--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
@@ -9,6 +9,7 @@ import { ProviderService } from "@bitwarden/common/admin-console/abstractions/pr
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Provider } from "@bitwarden/common/admin-console/models/domain/provider";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { LayoutComponent, NavigationModule } from "@bitwarden/components";
 import { I18nMockService } from "@bitwarden/components/src/utils/i18n-mock.service";
 
@@ -42,6 +43,12 @@ class MockProviderService implements Partial<ProviderService> {
   @Input()
   set mockProviders(providers: Provider[]) {
     MockProviderService._providers.next(providers);
+  }
+}
+
+class MockSyncService implements Partial<SyncService> {
+  async getLastSync() {
+    return await Promise.resolve(new Date());
   }
 }
 
@@ -80,6 +87,7 @@ export default {
       providers: [
         { provide: OrganizationService, useClass: MockOrganizationService },
         { provide: ProviderService, useClass: MockProviderService },
+        { provide: MockSyncService, useClass: MockSyncService },
         ProductSwitcherService,
         {
           provide: I18nPipe,

--- a/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
@@ -48,7 +48,7 @@ class MockProviderService implements Partial<ProviderService> {
 
 class MockSyncService implements Partial<SyncService> {
   async getLastSync() {
-    return await Promise.resolve(new Date());
+    return Promise.resolve(new Date());
   }
 }
 

--- a/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
@@ -9,6 +9,7 @@ import { ProviderService } from "@bitwarden/common/admin-console/abstractions/pr
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Provider } from "@bitwarden/common/admin-console/models/domain/provider";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { IconButtonModule, LinkModule, MenuModule } from "@bitwarden/components";
 import { I18nMockService } from "@bitwarden/components/src/utils/i18n-mock.service";
 
@@ -45,6 +46,12 @@ class MockProviderService implements Partial<ProviderService> {
   }
 }
 
+class MockSyncService implements Partial<SyncService> {
+  async getLastSync() {
+    return await Promise.resolve(new Date());
+  }
+}
+
 @Component({
   selector: "story-layout",
   template: `<ng-content></ng-content>`,
@@ -75,6 +82,7 @@ export default {
         MockOrganizationService,
         { provide: ProviderService, useClass: MockProviderService },
         MockProviderService,
+        { provide: SyncService, useClass: MockSyncService },
         ProductSwitcherService,
         {
           provide: I18nService,


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
During https://github.com/bitwarden/clients/pull/9587, I added the `SyncService` to the underlying `ProductSwitcherService` but missed adding mocks for it to the corresponding storybook stories. Thus resulting in rendering errors.

## 📸 Screenshots

|Product Switcher|Navigation Product Switcher|
|-|-|
|![Screen Shot 2024-06-14 at 13 56 46 PM](https://github.com/bitwarden/clients/assets/125900171/95fb5a3a-bde8-47e8-ab5d-f59a1ad47913)|![Screen Shot 2024-06-14 at 13 56 40 PM](https://github.com/bitwarden/clients/assets/125900171/75f7fdad-9aa6-4301-9854-96030d510b0f)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
