### PR TITLE
[PM-8285] Add clarifying code comments on everHadUserKey

### DIFF
--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -65,8 +65,10 @@ export abstract class CryptoService {
    */
   abstract refreshAdditionalKeys(): Promise<void>;
   /**
-   * Observable value that returns whether or not the currently active user has ever had auser key,
-   * i.e. has ever been unlocked/decrypted. This is key for differentiating between TDE locked and standard locked states.
+   * Observable value that returns whether or not the currently active user has ever had a user key (i.e. has ever been unlocked/decrypted)
+   * in the current session (since last logout). This is key for differentiating between TDE locked and standard locked states.
+   * If a TDE user has not ever had a user key (i.e. `everHadUserKey` is `false`), this means that they need to be directed to the decryption options.
+   * If a TDE user has ever had a user key (i.e. `everHadUserKey` is `true`), this means that they can be directed to the standard locked state.
    */
   abstract everHadUserKey$: Observable<boolean>;
   /**

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -93,7 +93,6 @@ export class CryptoService implements CryptoServiceAbstraction {
     if (key == null) {
       throw new Error("No key provided. Lock the user to clear the key");
     }
-
     // Set userId to ensure we have one for the account status update
     [userId, key] = await this.stateProvider.setUserState(USER_KEY, key, userId);
     await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, true, userId);

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -519,7 +519,6 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.clearProviderKeys(userId);
     await this.clearKeyPair(userId);
     await this.clearPinKeys(userId);
-    await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, null, userId);
   }
 
   async rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString> {

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -89,12 +89,9 @@ export class CryptoService implements CryptoServiceAbstraction {
     );
   }
 
-  async setUserKey(key: UserKey, userId: UserId): Promise<void> {
+  async setUserKey(key: UserKey, userId?: UserId): Promise<void> {
     if (key == null) {
       throw new Error("No key provided. Lock the user to clear the key");
-    }
-    if (userId == null) {
-      throw new Error("No userId provided.");
     }
 
     // Set userId to ensure we have one for the account status update

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -89,10 +89,14 @@ export class CryptoService implements CryptoServiceAbstraction {
     );
   }
 
-  async setUserKey(key: UserKey, userId?: UserId): Promise<void> {
+  async setUserKey(key: UserKey, userId: UserId): Promise<void> {
     if (key == null) {
       throw new Error("No key provided. Lock the user to clear the key");
     }
+    if (userId == null) {
+      throw new Error("No userId provided.");
+    }
+
     // Set userId to ensure we have one for the account status update
     [userId, key] = await this.stateProvider.setUserState(USER_KEY, key, userId);
     await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, true, userId);
@@ -519,6 +523,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.clearProviderKeys(userId);
     await this.clearKeyPair(userId);
     await this.clearPinKeys(userId);
+    await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, null, userId);
   }
 
   async rsaEncrypt(data: Uint8Array, publicKey: Uint8Array): Promise<EncString> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8285

## 📔 Objective

As part of the diagnosis for PM-8285, we have been looking into the `everHadUserKey` state.  There were some questions around how it was used, so I added clarifying code comments.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
