### PR TITLE
Auth/pm 7672/Update token service to return new token from state

### DIFF
--- a/libs/common/src/auth/abstractions/token.service.ts
+++ b/libs/common/src/auth/abstractions/token.service.ts
@@ -24,7 +24,7 @@ export abstract class TokenService {
    * @param refreshToken The optional refresh token to set. Note: this is undefined when using the CLI Login Via API Key flow
    * @param clientIdClientSecret The API Key Client ID and Client Secret to set.
    *
-   * @returns A SetTokensResult containing the tokens that were set.
+   * @returns A promise that resolves with the SetTokensResult containing the tokens that were set.
    */
   setTokens: (
     accessToken: string,

--- a/libs/common/src/auth/abstractions/token.service.ts
+++ b/libs/common/src/auth/abstractions/token.service.ts
@@ -3,6 +3,7 @@ import { Observable } from "rxjs";
 import { VaultTimeoutAction } from "../../enums/vault-timeout-action.enum";
 import { UserId } from "../../types/guid";
 import { VaultTimeout } from "../../types/vault-timeout.type";
+import { SetTokensResult } from "../models/domain/set-tokens-result";
 import { DecodedAccessToken } from "../services/token.service";
 
 export abstract class TokenService {
@@ -23,7 +24,7 @@ export abstract class TokenService {
    * @param refreshToken The optional refresh token to set. Note: this is undefined when using the CLI Login Via API Key flow
    * @param clientIdClientSecret The API Key Client ID and Client Secret to set.
    *
-   * @returns A promise that resolves when the tokens have been set.
+   * @returns A SetTokensResult containing the tokens that were set.
    */
   setTokens: (
     accessToken: string,
@@ -31,7 +32,7 @@ export abstract class TokenService {
     vaultTimeout: VaultTimeout,
     refreshToken?: string,
     clientIdClientSecret?: [string, string],
-  ) => Promise<void>;
+  ) => Promise<SetTokensResult>;
 
   /**
    * Clears the access token, refresh token, API Key Client ID, and API Key Client Secret out of memory, disk, and secure storage if supported.
@@ -47,13 +48,13 @@ export abstract class TokenService {
    * @param accessToken The access token to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.
-   * @returns A promise that resolves when the access token has been set.
+   * @returns A promise that resolves with the access token that has been set.
    */
   setAccessToken: (
     accessToken: string,
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
-  ) => Promise<void>;
+  ) => Promise<string>;
 
   // TODO: revisit having this public clear method approach once the state service is fully deprecated.
   /**
@@ -86,14 +87,14 @@ export abstract class TokenService {
    * @param clientId The API Key Client ID to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.
-   * @returns A promise that resolves when the API Key Client ID has been set.
+   * @returns A promise that resolves with the API Key Client ID that has been set.
    */
   setClientId: (
     clientId: string,
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId?: UserId,
-  ) => Promise<void>;
+  ) => Promise<string>;
 
   /**
    * Gets the API Key Client ID for the active user.
@@ -106,14 +107,14 @@ export abstract class TokenService {
    * @param clientSecret The API Key Client Secret to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.
-   * @returns A promise that resolves when the API Key Client Secret has been set.
+   * @returns A promise that resolves with the client secret that has been set.
    */
   setClientSecret: (
     clientSecret: string,
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId?: UserId,
-  ) => Promise<void>;
+  ) => Promise<string>;
 
   /**
    * Gets the API Key Client Secret for the active user.

--- a/libs/common/src/auth/models/domain/set-tokens-result.ts
+++ b/libs/common/src/auth/models/domain/set-tokens-result.ts
@@ -1,0 +1,5 @@
+export class SetTokensResult {
+  accessToken: string;
+  refreshToken?: string;
+  clientIdSecretPair?: [string, string];
+}

--- a/libs/common/src/auth/models/domain/set-tokens-result.ts
+++ b/libs/common/src/auth/models/domain/set-tokens-result.ts
@@ -1,4 +1,9 @@
 export class SetTokensResult {
+  constructor(accessToken: string, refreshToken?: string, clientIdSecretPair?: [string, string]) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.clientIdSecretPair = clientIdSecretPair;
+  }
   accessToken: string;
   refreshToken?: string;
   clientIdSecretPair?: [string, string];

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -15,6 +15,7 @@ import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypt
 import { CsprngArray } from "../../types/csprng";
 import { UserId } from "../../types/guid";
 import { VaultTimeout, VaultTimeoutStringType } from "../../types/vault-timeout.type";
+import { SetTokensResult } from "../models/domain/set-tokens-result";
 
 import { ACCOUNT_ACTIVE_ACCOUNT_ID } from "./account.service";
 import {
@@ -2432,11 +2433,9 @@ describe("TokenService", () => {
         userIdFromAccessToken,
       );
 
-      expect(result).toStrictEqual({
-        accessToken: accessTokenJwt,
-        refreshToken: refreshToken,
-        clientIdSecretPair: [clientId, clientSecret],
-      });
+      expect(result).toStrictEqual(
+        new SetTokensResult(accessTokenJwt, refreshToken, [clientId, clientSecret]),
+      );
     });
 
     it("does not try to set client id and client secret when they are not passed in", async () => {
@@ -2477,10 +2476,7 @@ describe("TokenService", () => {
       expect(tokenService.setClientId).not.toHaveBeenCalled();
       expect(tokenService.setClientSecret).not.toHaveBeenCalled();
 
-      expect(result).toStrictEqual({
-        accessToken: accessTokenJwt,
-        refreshToken: refreshToken,
-      });
+      expect(result).toStrictEqual(new SetTokensResult(accessTokenJwt, refreshToken));
     });
 
     it("throws an error when the access token is invalid", async () => {
@@ -2574,9 +2570,7 @@ describe("TokenService", () => {
 
       // Assert
       expect((tokenService as any).setRefreshToken).not.toHaveBeenCalled();
-      expect(result).toStrictEqual({
-        accessToken: accessTokenJwt,
-      });
+      expect(result).toStrictEqual(new SetTokensResult(accessTokenJwt));
     });
   });
 

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -2565,10 +2565,18 @@ describe("TokenService", () => {
       (tokenService as any).setRefreshToken = jest.fn();
 
       // Act
-      await tokenService.setTokens(accessTokenJwt, vaultTimeoutAction, vaultTimeout, refreshToken);
+      const result = await tokenService.setTokens(
+        accessTokenJwt,
+        vaultTimeoutAction,
+        vaultTimeout,
+        refreshToken,
+      );
 
       // Assert
       expect((tokenService as any).setRefreshToken).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        accessToken: accessTokenJwt,
+      });
     });
   });
 

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -182,14 +182,14 @@ export class TokenService implements TokenServiceAbstraction {
       throw new Error("User id not found. Cannot set tokens.");
     }
 
-    const newTokens = new SetTokensResult();
-
-    newTokens.accessToken = await this._setAccessToken(
+    const newAccessToken = await this._setAccessToken(
       accessToken,
       vaultTimeoutAction,
       vaultTimeout,
       userId,
     );
+
+    const newTokens = new SetTokensResult(newAccessToken);
 
     if (refreshToken) {
       newTokens.refreshToken = await this.setRefreshToken(

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -21,6 +21,7 @@ import {
 import { UserId } from "../../types/guid";
 import { VaultTimeout, VaultTimeoutStringType } from "../../types/vault-timeout.type";
 import { TokenService as TokenServiceAbstraction } from "../abstractions/token.service";
+import { SetTokensResult } from "../models/domain/set-tokens-result";
 
 import { ACCOUNT_ACTIVE_ACCOUNT_ID } from "./account.service";
 import {
@@ -160,7 +161,7 @@ export class TokenService implements TokenServiceAbstraction {
     vaultTimeout: VaultTimeout,
     refreshToken?: string,
     clientIdClientSecret?: [string, string],
-  ): Promise<void> {
+  ): Promise<SetTokensResult> {
     if (!accessToken) {
       throw new Error("Access token is required.");
     }
@@ -181,16 +182,40 @@ export class TokenService implements TokenServiceAbstraction {
       throw new Error("User id not found. Cannot set tokens.");
     }
 
-    await this._setAccessToken(accessToken, vaultTimeoutAction, vaultTimeout, userId);
+    const newTokens = new SetTokensResult();
+
+    newTokens.accessToken = await this._setAccessToken(
+      accessToken,
+      vaultTimeoutAction,
+      vaultTimeout,
+      userId,
+    );
 
     if (refreshToken) {
-      await this.setRefreshToken(refreshToken, vaultTimeoutAction, vaultTimeout, userId);
+      newTokens.refreshToken = await this.setRefreshToken(
+        refreshToken,
+        vaultTimeoutAction,
+        vaultTimeout,
+        userId,
+      );
     }
 
     if (clientIdClientSecret != null) {
-      await this.setClientId(clientIdClientSecret[0], vaultTimeoutAction, vaultTimeout, userId);
-      await this.setClientSecret(clientIdClientSecret[1], vaultTimeoutAction, vaultTimeout, userId);
+      const clientId = await this.setClientId(
+        clientIdClientSecret[0],
+        vaultTimeoutAction,
+        vaultTimeout,
+        userId,
+      );
+      const clientSecret = await this.setClientSecret(
+        clientIdClientSecret[1],
+        vaultTimeoutAction,
+        vaultTimeout,
+        userId,
+      );
+      newTokens.clientIdSecretPair = [clientId, clientSecret];
     }
+    return newTokens;
   }
 
   private async getAccessTokenKey(userId: UserId): Promise<AccessTokenKey | null> {
@@ -289,7 +314,7 @@ export class TokenService implements TokenServiceAbstraction {
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId: UserId,
-  ): Promise<void> {
+  ): Promise<string> {
     const storageLocation = await this.determineStorageLocation(
       vaultTimeoutAction,
       vaultTimeout,
@@ -302,6 +327,8 @@ export class TokenService implements TokenServiceAbstraction {
         // store the access token directly. Instead, we encrypt with accessTokenKey and store that
         // in secure storage.
 
+        let decryptedAccessToken: string = null;
+
         try {
           const encryptedAccessToken: EncString = await this.encryptAccessToken(
             accessToken,
@@ -312,6 +339,10 @@ export class TokenService implements TokenServiceAbstraction {
           await this.singleUserStateProvider
             .get(userId, ACCESS_TOKEN_DISK)
             .update((_) => encryptedAccessToken.encryptedString);
+
+          // If we've successfully stored the encrypted access token to disk, we can return the decrypted access token
+          // so that the caller can use it immediately.
+          decryptedAccessToken = accessToken;
 
           // TODO: PM-6408
           // 2024-02-20: Remove access token from memory so that we migrate to encrypt the access token over time.
@@ -324,25 +355,23 @@ export class TokenService implements TokenServiceAbstraction {
           );
 
           // Fall back to disk storage for unecrypted access token
-          await this.singleUserStateProvider
+          decryptedAccessToken = await this.singleUserStateProvider
             .get(userId, ACCESS_TOKEN_DISK)
             .update((_) => accessToken);
         }
 
-        return;
+        return decryptedAccessToken;
       }
       case TokenStorageLocation.Disk:
         // Access token stored on disk unencrypted as platform does not support secure storage
-        await this.singleUserStateProvider
+        return await this.singleUserStateProvider
           .get(userId, ACCESS_TOKEN_DISK)
           .update((_) => accessToken);
-        return;
       case TokenStorageLocation.Memory:
         // Access token stored in memory due to vault timeout settings
-        await this.singleUserStateProvider
+        return await this.singleUserStateProvider
           .get(userId, ACCESS_TOKEN_MEMORY)
           .update((_) => accessToken);
-        return;
     }
   }
 
@@ -350,7 +379,7 @@ export class TokenService implements TokenServiceAbstraction {
     accessToken: string,
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
-  ): Promise<void> {
+  ): Promise<string> {
     if (!accessToken) {
       throw new Error("Access token is required.");
     }
@@ -370,7 +399,7 @@ export class TokenService implements TokenServiceAbstraction {
       throw new Error("Vault Timeout Action is required.");
     }
 
-    await this._setAccessToken(accessToken, vaultTimeoutAction, vaultTimeout, userId);
+    return await this._setAccessToken(accessToken, vaultTimeoutAction, vaultTimeout, userId);
   }
 
   async clearAccessToken(userId?: UserId): Promise<void> {
@@ -486,7 +515,7 @@ export class TokenService implements TokenServiceAbstraction {
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId: UserId,
-  ): Promise<void> {
+  ): Promise<string> {
     // If we don't have a user id, we can't save the value
     if (!userId) {
       throw new Error("User id not found. Cannot save refresh token.");
@@ -509,6 +538,8 @@ export class TokenService implements TokenServiceAbstraction {
 
     switch (storageLocation) {
       case TokenStorageLocation.SecureStorage: {
+        let decryptedRefreshToken: string = null;
+
         try {
           await this.saveStringToSecureStorage(
             userId,
@@ -530,6 +561,10 @@ export class TokenService implements TokenServiceAbstraction {
             throw new Error("Refresh token failed to save to secure storage.");
           }
 
+          // If we've successfully stored the encrypted refresh token, we can return the decrypted refresh token
+          // so that the caller can use it immediately.
+          decryptedRefreshToken = refreshToken;
+
           // TODO: PM-6408
           // 2024-02-20: Remove refresh token from memory and disk so that we migrate to secure storage over time.
           // Remove these 2 calls to remove the refresh token from memory and disk after 3 months.
@@ -544,24 +579,22 @@ export class TokenService implements TokenServiceAbstraction {
           );
 
           // Fall back to disk storage for refresh token
-          await this.singleUserStateProvider
+          decryptedRefreshToken = await this.singleUserStateProvider
             .get(userId, REFRESH_TOKEN_DISK)
             .update((_) => refreshToken);
         }
 
-        return;
+        return decryptedRefreshToken;
       }
       case TokenStorageLocation.Disk:
-        await this.singleUserStateProvider
+        return await this.singleUserStateProvider
           .get(userId, REFRESH_TOKEN_DISK)
           .update((_) => refreshToken);
-        return;
 
       case TokenStorageLocation.Memory:
-        await this.singleUserStateProvider
+        return await this.singleUserStateProvider
           .get(userId, REFRESH_TOKEN_MEMORY)
           .update((_) => refreshToken);
-        return;
     }
   }
 
@@ -644,7 +677,7 @@ export class TokenService implements TokenServiceAbstraction {
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId?: UserId,
-  ): Promise<void> {
+  ): Promise<string> {
     userId ??= await firstValueFrom(this.activeUserIdGlobalState.state$);
 
     // If we don't have a user id, we can't save the value
@@ -668,11 +701,11 @@ export class TokenService implements TokenServiceAbstraction {
     );
 
     if (storageLocation === TokenStorageLocation.Disk) {
-      await this.singleUserStateProvider
+      return await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_ID_DISK)
         .update((_) => clientId);
     } else if (storageLocation === TokenStorageLocation.Memory) {
-      await this.singleUserStateProvider
+      return await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_ID_MEMORY)
         .update((_) => clientId);
     }
@@ -721,7 +754,7 @@ export class TokenService implements TokenServiceAbstraction {
     vaultTimeoutAction: VaultTimeoutAction,
     vaultTimeout: VaultTimeout,
     userId?: UserId,
-  ): Promise<void> {
+  ): Promise<string> {
     userId ??= await firstValueFrom(this.activeUserIdGlobalState.state$);
 
     if (!userId) {
@@ -744,11 +777,11 @@ export class TokenService implements TokenServiceAbstraction {
     );
 
     if (storageLocation === TokenStorageLocation.Disk) {
-      await this.singleUserStateProvider
+      return await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_SECRET_DISK)
         .update((_) => clientSecret);
     } else if (storageLocation === TokenStorageLocation.Memory) {
-      await this.singleUserStateProvider
+      return await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_SECRET_MEMORY)
         .update((_) => clientSecret);
     }

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1769,13 +1769,13 @@ export class ApiService implements ApiServiceAbstraction {
         this.vaultTimeoutSettingsService.getVaultTimeoutByUserId$(userId),
       );
 
-      await this.tokenService.setTokens(
+      const refreshedTokens = await this.tokenService.setTokens(
         tokenResponse.accessToken,
         vaultTimeoutAction as VaultTimeoutAction,
         vaultTimeout,
         tokenResponse.refreshToken,
       );
-      return tokenResponse.accessToken;
+      return refreshedTokens.accessToken;
     } else {
       const error = await this.handleError(response, true, true);
       return Promise.reject(error);
@@ -1810,12 +1810,12 @@ export class ApiService implements ApiServiceAbstraction {
       this.vaultTimeoutSettingsService.getVaultTimeoutByUserId$(userId),
     );
 
-    await this.tokenService.setAccessToken(
+    const refreshedToken = await this.tokenService.setAccessToken(
       response.accessToken,
       vaultTimeoutAction as VaultTimeoutAction,
       vaultTimeout,
     );
-    return response.accessToken;
+    return refreshedToken;
   }
 
   async send(

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -247,9 +247,9 @@ export class ApiService implements ApiServiceAbstraction {
     return Promise.reject(new ErrorResponse(responseJson, response.status, true));
   }
 
-  async refreshIdentityToken(): Promise<string> {
+  async refreshIdentityToken(): Promise<any> {
     try {
-      return await this.refreshToken();
+      await this.refreshToken();
     } catch (e) {
       this.logService.error("Error refreshing access token: ", e);
       throw e;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-7672

## 📔 Objective

We identified the opportunity for a race condition in the `ApiService` in the manner in which it refreshed the access token and immediately read the value from state (via an observable).  This has the potential for not resolving to the new state value.

Instead, we have changed the methods on the `TokenService` to return the new value from the state update.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
