### PR TITLE
[PM-6789] rc version legacy migration fix

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.spec.ts
@@ -13,6 +13,7 @@ import { EncryptionType, KdfType } from "@bitwarden/common/platform/enums";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
+import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey, OrgKey, MasterKey } from "@bitwarden/common/types/key";
 
 import { OrganizationUserResetPasswordService } from "./organization-user-reset-password.service";
@@ -157,7 +158,7 @@ describe("OrganizationUserResetPasswordService", () => {
     });
   });
 
-  describe("getRotatedKeys", () => {
+  describe("getRotatedData", () => {
     beforeEach(() => {
       organizationService.getAll.mockResolvedValue([
         createOrganization("1", "org1"),
@@ -175,11 +176,23 @@ describe("OrganizationUserResetPasswordService", () => {
     });
 
     it("should return all re-encrypted account recovery keys", async () => {
-      const result = await sut.getRotatedKeys(
+      const result = await sut.getRotatedData(
         new SymmetricCryptoKey(new Uint8Array(64)) as UserKey,
+        new SymmetricCryptoKey(new Uint8Array(64)) as UserKey,
+        "mockUserId" as UserId,
       );
 
       expect(result).toHaveLength(2);
+    });
+
+    it("throws if the new user key is null", async () => {
+      await expect(
+        sut.getRotatedData(
+          new SymmetricCryptoKey(new Uint8Array(64)) as UserKey,
+          null,
+          "mockUserId" as UserId,
+        ),
+      ).rejects.toThrow("New user key is required for rotation.");
     });
   });
 });

--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 
+import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
@@ -19,12 +20,15 @@ import { KdfType } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncryptedString, EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 
 @Injectable({
   providedIn: "root",
 })
-export class OrganizationUserResetPasswordService {
+export class OrganizationUserResetPasswordService
+  implements UserKeyRotationDataProviderAbstraction<OrganizationUserResetPasswordWithIdRequest>
+{
   constructor(
     private cryptoService: CryptoService,
     private encryptService: EncryptService,
@@ -129,11 +133,16 @@ export class OrganizationUserResetPasswordService {
 
   /**
    * Returns existing account recovery keys re-encrypted with the new user key.
+   * @param originalUserKey the original user key
    * @param newUserKey the new user key
+   * @param userId the user id
    * @throws Error if new user key is null
+   * @returns a list of account recovery keys that have been re-encrypted with the new user key
    */
-  async getRotatedKeys(
+  async getRotatedData(
+    originalUserKey: UserKey,
     newUserKey: UserKey,
+    userId: UserId,
   ): Promise<OrganizationUserResetPasswordWithIdRequest[] | null> {
     if (newUserKey == null) {
       throw new Error("New user key is required for rotation.");

--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 
-import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+import { UserKeyRotationDataProvider } from "@bitwarden/auth/common";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { OrganizationUserService } from "@bitwarden/common/admin-console/abstractions/organization-user/organization-user.service";
@@ -27,7 +27,7 @@ import { UserKey } from "@bitwarden/common/types/key";
   providedIn: "root",
 })
 export class OrganizationUserResetPasswordService
-  implements UserKeyRotationDataProviderAbstraction<OrganizationUserResetPasswordWithIdRequest>
+  implements UserKeyRotationDataProvider<OrganizationUserResetPasswordWithIdRequest>
 {
   constructor(
     private cryptoService: CryptoService,

--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 
-import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+import { UserKeyRotationDataProvider } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyData } from "@bitwarden/common/admin-console/models/data/policy.data";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
@@ -38,7 +38,7 @@ import { EmergencyAccessApiService } from "./emergency-access-api.service";
 
 @Injectable()
 export class EmergencyAccessService
-  implements UserKeyRotationDataProviderAbstraction<EmergencyAccessWithIdRequest>
+  implements UserKeyRotationDataProvider<EmergencyAccessWithIdRequest>
 {
   constructor(
     private emergencyAccessApiService: EmergencyAccessApiService,

--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 
+import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyData } from "@bitwarden/common/admin-console/models/data/policy.data";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
@@ -15,6 +16,7 @@ import { KdfType } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncryptedString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -35,7 +37,9 @@ import {
 import { EmergencyAccessApiService } from "./emergency-access-api.service";
 
 @Injectable()
-export class EmergencyAccessService {
+export class EmergencyAccessService
+  implements UserKeyRotationDataProviderAbstraction<EmergencyAccessWithIdRequest>
+{
   constructor(
     private emergencyAccessApiService: EmergencyAccessApiService,
     private apiService: ApiService,
@@ -286,9 +290,21 @@ export class EmergencyAccessService {
   /**
    * Returns existing emergency access keys re-encrypted with new user key.
    * Intended for grantor.
+   * @param originalUserKey the original user key
    * @param newUserKey the new user key
+   * @param userId the user id
+   * @throws Error if newUserKey is nullish
+   * @returns an array of re-encrypted emergency access requests or an empty array if there are no requests
    */
-  async getRotatedKeys(newUserKey: UserKey): Promise<EmergencyAccessWithIdRequest[]> {
+  async getRotatedData(
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ): Promise<EmergencyAccessWithIdRequest[]> {
+    if (newUserKey == null) {
+      throw new Error("New user key is required for rotation.");
+    }
+
     const requests: EmergencyAccessWithIdRequest[] = [];
     const existingEmergencyAccess =
       await this.emergencyAccessApiService.getEmergencyAccessTrusted();

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
@@ -1,36 +1,28 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+import { OrganizationUserResetPasswordWithIdRequest } from "@bitwarden/common/admin-console/abstractions/organization-user/requests";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust.service.abstraction";
 import { KdfConfigService } from "@bitwarden/common/auth/abstractions/kdf-config.service";
 import { FakeMasterPasswordService } from "@bitwarden/common/auth/services/master-password/fake-master-password.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
-import { EncryptionType } from "@bitwarden/common/platform/enums";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
-import { Send } from "@bitwarden/common/tools/send/models/domain/send";
+import { SendWithIdRequest } from "@bitwarden/common/tools/send/models/request/send-with-id.request";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { UserId } from "@bitwarden/common/types/guid";
-import { UserKey } from "@bitwarden/common/types/key";
+import { UserKey, UserPrivateKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
-import { Folder } from "@bitwarden/common/vault/models/domain/folder";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherWithIdRequest } from "@bitwarden/common/vault/models/request/cipher-with-id.request";
+import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 
-import {
-  FakeAccountService,
-  mockAccountServiceWith,
-} from "../../../../../../libs/common/spec/fake-account-service";
 import { OrganizationUserResetPasswordService } from "../../admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service";
-import { StateService } from "../../core";
 import { EmergencyAccessService } from "../emergency-access";
+import { EmergencyAccessWithIdRequest } from "../emergency-access/request/emergency-access-update.request";
 
 import { UserKeyRotationApiService } from "./user-key-rotation-api.service";
 import { UserKeyRotationService } from "./user-key-rotation.service";
@@ -47,14 +39,17 @@ describe("KeyRotationService", () => {
   let mockDeviceTrustService: MockProxy<DeviceTrustServiceAbstraction>;
   let mockCryptoService: MockProxy<CryptoService>;
   let mockEncryptService: MockProxy<EncryptService>;
-  let mockStateService: MockProxy<StateService>;
   let mockConfigService: MockProxy<ConfigService>;
   let mockKdfConfigService: MockProxy<KdfConfigService>;
   let mockSyncService: MockProxy<SyncService>;
-
-  const mockUserId = Utils.newGuid() as UserId;
-  const mockAccountService: FakeAccountService = mockAccountServiceWith(mockUserId);
   let mockMasterPasswordService: FakeMasterPasswordService = new FakeMasterPasswordService();
+
+  const mockUser = {
+    id: "mockUserId" as UserId,
+    email: "mockEmail",
+    emailVerified: true,
+    name: "mockName",
+  };
 
   beforeAll(() => {
     mockMasterPasswordService = new FakeMasterPasswordService();
@@ -67,7 +62,6 @@ describe("KeyRotationService", () => {
     mockDeviceTrustService = mock<DeviceTrustServiceAbstraction>();
     mockCryptoService = mock<CryptoService>();
     mockEncryptService = mock<EncryptService>();
-    mockStateService = mock<StateService>();
     mockConfigService = mock<ConfigService>();
     mockKdfConfigService = mock<KdfConfigService>();
     mockSyncService = mock<SyncService>();
@@ -83,8 +77,6 @@ describe("KeyRotationService", () => {
       mockDeviceTrustService,
       mockCryptoService,
       mockEncryptService,
-      mockStateService,
-      mockAccountService,
       mockKdfConfigService,
       mockSyncService,
     );
@@ -94,86 +86,77 @@ describe("KeyRotationService", () => {
     jest.clearAllMocks();
   });
 
-  it("instantiates", () => {
-    expect(keyRotationService).not.toBeFalsy();
-  });
-
   describe("rotateUserKeyAndEncryptedData", () => {
-    let folderViews: BehaviorSubject<FolderView[]>;
-    let sends: BehaviorSubject<Send[]>;
+    let privateKey: BehaviorSubject<UserPrivateKey>;
 
-    beforeAll(() => {
+    beforeEach(() => {
       mockCryptoService.makeMasterKey.mockResolvedValue("mockMasterKey" as any);
       mockCryptoService.makeUserKey.mockResolvedValue([
         new SymmetricCryptoKey(new Uint8Array(64)) as UserKey,
         {
-          encryptedString: "mockEncryptedUserKey",
+          encryptedString: "mockNewUserKey",
         } as any,
       ]);
       mockCryptoService.hashMasterKey.mockResolvedValue("mockMasterPasswordHash");
       mockConfigService.getFeatureFlag.mockResolvedValue(true);
 
-      // Mock private key
-      mockCryptoService.getPrivateKey.mockResolvedValue("MockPrivateKey" as any);
-
-      // Mock ciphers
-      const mockCiphers = [createMockCipher("1", "Cipher 1"), createMockCipher("2", "Cipher 2")];
-      mockCipherService.getAllDecrypted.mockResolvedValue(mockCiphers);
-
-      // Mock folders
-      const mockFolders = [createMockFolder("1", "Folder 1"), createMockFolder("2", "Folder 2")];
-      folderViews = new BehaviorSubject<FolderView[]>(mockFolders);
-      mockFolderService.folderViews$ = folderViews;
-
-      // Mock sends
-      const mockSends = [createMockSend("1", "Send 1"), createMockSend("2", "Send 2")];
-      sends = new BehaviorSubject<Send[]>(mockSends);
-      mockSendService.sends$ = sends;
-
-      // Mock encryption methods
       mockEncryptService.encrypt.mockResolvedValue({
         encryptedString: "mockEncryptedData",
       } as any);
 
-      mockFolderService.encrypt.mockImplementation((folder, userKey) => {
-        const encryptedFolder = new Folder();
-        encryptedFolder.id = folder.id;
-        encryptedFolder.name = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
-          "Encrypted: " + folder.name,
-        );
-        return Promise.resolve(encryptedFolder);
-      });
+      // Mock user key
+      mockCryptoService.userKey$.mockReturnValue(new BehaviorSubject("mockOriginalUserKey" as any));
 
-      mockCipherService.encrypt.mockImplementation((cipher, userKey) => {
-        const encryptedCipher = new Cipher();
-        encryptedCipher.id = cipher.id;
-        encryptedCipher.name = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
-          "Encrypted: " + cipher.name,
-        );
-        return Promise.resolve(encryptedCipher);
-      });
+      // Mock private key
+      privateKey = new BehaviorSubject("mockPrivateKey" as any);
+      mockCryptoService.userPrivateKeyWithLegacySupport$.mockReturnValue(privateKey);
+
+      // Mock ciphers
+      const mockCiphers = [createMockCipher("1", "Cipher 1"), createMockCipher("2", "Cipher 2")];
+      mockCipherService.getRotatedData.mockResolvedValue(mockCiphers);
+
+      // Mock folders
+      const mockFolders = [createMockFolder("1", "Folder 1"), createMockFolder("2", "Folder 2")];
+      mockFolderService.getRotatedData.mockResolvedValue(mockFolders);
+
+      // Mock sends
+      const mockSends = [createMockSend("1", "Send 1"), createMockSend("2", "Send 2")];
+      mockSendService.getRotatedData.mockResolvedValue(mockSends);
+
+      // Mock emergency access
+      const emergencyAccess = [createMockEmergencyAccess("13")];
+      mockEmergencyAccessService.getRotatedData.mockResolvedValue(emergencyAccess);
+
+      // Mock reset password
+      const resetPassword = [createMockResetPassword("12")];
+      mockResetPasswordService.getRotatedData.mockResolvedValue(resetPassword);
     });
 
     it("rotates the user key and encrypted data", async () => {
-      await keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword");
+      await keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser);
 
       expect(mockApiService.postUserKeyUpdate).toHaveBeenCalled();
       const arg = mockApiService.postUserKeyUpdate.mock.calls[0][0];
+      expect(arg.key).toBe("mockNewUserKey");
+      expect(arg.privateKey).toBe("mockEncryptedData");
       expect(arg.ciphers.length).toBe(2);
       expect(arg.folders.length).toBe(2);
+      expect(arg.sends.length).toBe(2);
+      expect(arg.emergencyAccessKeys.length).toBe(1);
+      expect(arg.resetPasswordKeys.length).toBe(1);
     });
 
     it("throws if master password provided is falsey", async () => {
-      await expect(keyRotationService.rotateUserKeyAndEncryptedData("")).rejects.toThrow();
+      await expect(
+        keyRotationService.rotateUserKeyAndEncryptedData("", mockUser),
+      ).rejects.toThrow();
     });
 
     it("throws if master key creation fails", async () => {
       mockCryptoService.makeMasterKey.mockResolvedValueOnce(null);
 
       await expect(
-        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword"),
+        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser),
       ).rejects.toThrow();
     });
 
@@ -181,16 +164,24 @@ describe("KeyRotationService", () => {
       mockCryptoService.makeUserKey.mockResolvedValueOnce([null, null]);
 
       await expect(
-        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword"),
+        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser),
+      ).rejects.toThrow();
+    });
+
+    it("throws if no private key is found", async () => {
+      privateKey.next(null);
+
+      await expect(
+        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser),
       ).rejects.toThrow();
     });
 
     it("saves the master key in state after creation", async () => {
-      await keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword");
+      await keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser);
 
       expect(mockMasterPasswordService.mock.setMasterKey).toHaveBeenCalledWith(
         "mockMasterKey" as any,
-        mockUserId,
+        mockUser.id,
       );
     });
 
@@ -198,30 +189,45 @@ describe("KeyRotationService", () => {
       mockApiService.postUserKeyUpdate.mockRejectedValueOnce(new Error("mockError"));
 
       await expect(
-        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword"),
+        keyRotationService.rotateUserKeyAndEncryptedData("mockMasterPassword", mockUser),
       ).rejects.toThrow();
     });
   });
 });
 
-function createMockFolder(id: string, name: string): FolderView {
-  const folder = new FolderView();
-  folder.id = id;
-  folder.name = name;
-  return folder;
+function createMockFolder(id: string, name: string): FolderWithIdRequest {
+  return {
+    id: id,
+    name: name,
+  } as FolderWithIdRequest;
 }
 
-function createMockCipher(id: string, name: string): CipherView {
-  const cipher = new CipherView();
-  cipher.id = id;
-  cipher.name = name;
-  cipher.type = CipherType.Login;
-  return cipher;
+function createMockCipher(id: string, name: string): CipherWithIdRequest {
+  return {
+    id: id,
+    name: name,
+    type: CipherType.Login,
+  } as CipherWithIdRequest;
 }
 
-function createMockSend(id: string, name: string): Send {
-  const send = new Send();
-  send.id = id;
-  send.name = new EncString(EncryptionType.AesCbc256_HmacSha256_B64, name);
-  return send;
+function createMockSend(id: string, name: string): SendWithIdRequest {
+  return {
+    id: id,
+    name: name,
+  } as SendWithIdRequest;
+}
+
+function createMockEmergencyAccess(id: string): EmergencyAccessWithIdRequest {
+  return {
+    id: id,
+    type: 0,
+    waitTimeDays: 5,
+  } as EmergencyAccessWithIdRequest;
+}
+
+function createMockResetPassword(id: string): OrganizationUserResetPasswordWithIdRequest {
+  return {
+    organizationId: id,
+    resetPasswordKey: "mockResetPasswordKey",
+  } as OrganizationUserResetPasswordWithIdRequest;
 }

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -1,21 +1,19 @@
 import { Injectable } from "@angular/core";
-import { firstValueFrom, map } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AccountInfo } from "@bitwarden/common/auth/abstractions/account.service";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust.service.abstraction";
 import { KdfConfigService } from "@bitwarden/common/auth/abstractions/kdf-config.service";
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/auth/abstractions/master-password.service.abstraction";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { EncryptedString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
+import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { CipherWithIdRequest } from "@bitwarden/common/vault/models/request/cipher-with-id.request";
-import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 
 import { OrganizationUserResetPasswordService } from "../../admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service";
 import { EmergencyAccessService } from "../emergency-access";
@@ -36,8 +34,6 @@ export class UserKeyRotationService {
     private deviceTrustService: DeviceTrustServiceAbstraction,
     private cryptoService: CryptoService,
     private encryptService: EncryptService,
-    private stateService: StateService,
-    private accountService: AccountService,
     private kdfConfigService: KdfConfigService,
     private syncService: SyncService,
   ) {}
@@ -46,7 +42,10 @@ export class UserKeyRotationService {
    * Creates a new user key and re-encrypts all required data with the it.
    * @param masterPassword current master password (used for validation)
    */
-  async rotateUserKeyAndEncryptedData(masterPassword: string): Promise<void> {
+  async rotateUserKeyAndEncryptedData(
+    masterPassword: string,
+    user: { id: UserId } & AccountInfo,
+  ): Promise<void> {
     if (!masterPassword) {
       throw new Error("Invalid master password");
     }
@@ -60,7 +59,7 @@ export class UserKeyRotationService {
     // Create master key to validate the master password
     const masterKey = await this.cryptoService.makeMasterKey(
       masterPassword,
-      await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.email))),
+      user.email,
       await this.kdfConfigService.getKdfConfig(),
     );
 
@@ -69,8 +68,7 @@ export class UserKeyRotationService {
     }
 
     // Set master key again in case it was lost (could be lost on refresh)
-    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
-    await this.masterPasswordService.setMasterKey(masterKey, userId);
+    await this.masterPasswordService.setMasterKey(masterKey, user.id);
     const [newUserKey, newEncUserKey] = await this.cryptoService.makeUserKey(masterKey);
 
     if (!newUserKey || !newEncUserKey) {
@@ -87,57 +85,77 @@ export class UserKeyRotationService {
     const masterPasswordHash = await this.cryptoService.hashMasterKey(masterPassword, masterKey);
     request.masterPasswordHash = masterPasswordHash;
 
+    // Get original user key
+    // Note: We distribute the legacy key, but not all domains actually use it. If any of those
+    // domains break their legacy support it will break the migration process for legacy users.
+    const originalUserKey = await this.cryptoService.getUserKeyWithLegacySupport(user.id);
+
     // Add re-encrypted data
-    request.privateKey = await this.encryptPrivateKey(newUserKey);
-    request.ciphers = await this.encryptCiphers(newUserKey);
-    request.folders = await this.encryptFolders(newUserKey);
-    request.sends = await this.sendService.getRotatedKeys(newUserKey);
-    request.emergencyAccessKeys = await this.emergencyAccessService.getRotatedKeys(newUserKey);
-    request.resetPasswordKeys = await this.resetPasswordService.getRotatedKeys(newUserKey);
+    request.privateKey = await this.encryptPrivateKey(newUserKey, user.id);
+
+    const rotatedCiphers = await this.cipherService.getRotatedData(
+      originalUserKey,
+      newUserKey,
+      user.id,
+    );
+    if (rotatedCiphers != null) {
+      request.ciphers = rotatedCiphers;
+    }
+
+    const rotatedFolders = await this.folderService.getRotatedData(
+      originalUserKey,
+      newUserKey,
+      user.id,
+    );
+    if (rotatedFolders != null) {
+      request.folders = rotatedFolders;
+    }
+
+    const rotatedSends = await this.sendService.getRotatedData(
+      originalUserKey,
+      newUserKey,
+      user.id,
+    );
+    if (rotatedSends != null) {
+      request.sends = rotatedSends;
+    }
+
+    const rotatedEmergencyAccessKeys = await this.emergencyAccessService.getRotatedData(
+      originalUserKey,
+      newUserKey,
+      user.id,
+    );
+    if (rotatedEmergencyAccessKeys != null) {
+      request.emergencyAccessKeys = rotatedEmergencyAccessKeys;
+    }
+
+    // Note: Reset password keys request model has user verification
+    // properties, but the rotation endpoint uses its own MP hash.
+    const rotatedResetPasswordKeys = await this.resetPasswordService.getRotatedData(
+      originalUserKey,
+      newUserKey,
+      user.id,
+    );
+    if (rotatedResetPasswordKeys != null) {
+      request.resetPasswordKeys = rotatedResetPasswordKeys;
+    }
 
     await this.apiService.postUserKeyUpdate(request);
 
-    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
-    await this.deviceTrustService.rotateDevicesTrust(
-      activeAccount.id,
-      newUserKey,
-      masterPasswordHash,
-    );
+    // TODO: Add device trust rotation support to the user key rotation endpoint
+    await this.deviceTrustService.rotateDevicesTrust(user.id, newUserKey, masterPasswordHash);
   }
 
-  private async encryptPrivateKey(newUserKey: UserKey): Promise<EncryptedString | null> {
-    const privateKey = await this.cryptoService.getPrivateKey();
+  private async encryptPrivateKey(
+    newUserKey: UserKey,
+    userId: UserId,
+  ): Promise<EncryptedString | null> {
+    const privateKey = await firstValueFrom(
+      this.cryptoService.userPrivateKeyWithLegacySupport$(userId),
+    );
     if (!privateKey) {
-      return;
+      throw new Error("No private key found for user key rotation");
     }
     return (await this.encryptService.encrypt(privateKey, newUserKey)).encryptedString;
-  }
-
-  private async encryptCiphers(newUserKey: UserKey): Promise<CipherWithIdRequest[]> {
-    const ciphers = await this.cipherService.getAllDecrypted();
-    if (!ciphers) {
-      // Must return an empty array for backwards compatibility
-      return [];
-    }
-    return await Promise.all(
-      ciphers.map(async (cipher) => {
-        const encryptedCipher = await this.cipherService.encrypt(cipher, newUserKey);
-        return new CipherWithIdRequest(encryptedCipher);
-      }),
-    );
-  }
-
-  private async encryptFolders(newUserKey: UserKey): Promise<FolderWithIdRequest[]> {
-    const folders = await firstValueFrom(this.folderService.folderViews$);
-    if (!folders) {
-      // Must return an empty array for backwards compatibility
-      return [];
-    }
-    return await Promise.all(
-      folders.map(async (folder) => {
-        const encryptedFolder = await this.folderService.encrypt(folder, newUserKey);
-        return new FolderWithIdRequest(encryptedFolder);
-      }),
-    );
   }
 }

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -142,7 +142,7 @@ export class UserKeyRotationService {
 
     await this.apiService.postUserKeyUpdate(request);
 
-    // TODO: Add device trust rotation support to the user key rotation endpoint
+    // TODO PM-2199: Add device trust rotation support to the user key rotation endpoint
     await this.deviceTrustService.rotateDevicesTrust(user.id, newUserKey, masterPasswordHash);
   }
 

--- a/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.ts
+++ b/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.ts
@@ -1,6 +1,8 @@
 import { Component } from "@angular/core";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -25,6 +27,7 @@ export class MigrateFromLegacyEncryptionComponent {
   });
 
   constructor(
+    private accountService: AccountService,
     private keyRotationService: UserKeyRotationService,
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
@@ -41,7 +44,9 @@ export class MigrateFromLegacyEncryptionComponent {
       return;
     }
 
-    const hasUserKey = await this.cryptoService.hasUserKey();
+    const activeUser = await firstValueFrom(this.accountService.activeAccount$);
+
+    const hasUserKey = await this.cryptoService.hasUserKey(activeUser.id);
     if (hasUserKey) {
       this.messagingService.send("logout");
       throw new Error("User key already exists, cannot migrate legacy encryption.");
@@ -52,7 +57,7 @@ export class MigrateFromLegacyEncryptionComponent {
     try {
       await this.syncService.fullSync(false, true);
 
-      await this.keyRotationService.rotateUserKeyAndEncryptedData(masterPassword);
+      await this.keyRotationService.rotateUserKeyAndEncryptedData(masterPassword, activeUser);
 
       this.platformUtilsService.showToast(
         "success",

--- a/apps/web/src/app/auth/settings/change-password.component.ts
+++ b/apps/web/src/app/auth/settings/change-password.component.ts
@@ -220,6 +220,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
   }
 
   private async updateKey() {
-    await this.keyRotationService.rotateUserKeyAndEncryptedData(this.masterPassword);
+    const user = await firstValueFrom(this.accountService.activeAccount$);
+    await this.keyRotationService.rotateUserKeyAndEncryptedData(this.masterPassword, user);
   }
 }

--- a/libs/auth/src/common/abstractions/index.ts
+++ b/libs/auth/src/common/abstractions/index.ts
@@ -3,3 +3,4 @@ export * from "./login-email.service";
 export * from "./login-strategy.service";
 export * from "./user-decryption-options.service.abstraction";
 export * from "./auth-request.service.abstraction";
+export * from "./user-key-rotation-data-provider.abstraction";

--- a/libs/auth/src/common/abstractions/user-key-rotation-data-provider.abstraction.ts
+++ b/libs/auth/src/common/abstractions/user-key-rotation-data-provider.abstraction.ts
@@ -2,18 +2,22 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 
 /**
- * Implemented by domains encrypted by the user key to support key rotations
- * @typeparam T A request model that contains re-encrypted data, must have an id property
+ * Constructs key rotation requests for data encryption by the user key.
+ * @typeparam TRequest A request model that contains re-encrypted data, must have an id property
  */
-export interface UserKeyRotationDataProviderAbstraction<
-  T extends { id: string } | { organizationId: string },
+export interface UserKeyRotationDataProvider<
+  TRequest extends { id: string } | { organizationId: string },
 > {
   /**
-   * Implemented by each domain to provide re-encrypted data for the user key rotation process
+   * Provides re-encrypted data for the user key rotation process
    * @param originalUserKey The original user key, useful for decrypting data
    * @param newUserKey The new user key to use for re-encryption
    * @param userId The owner of the data, useful for fetching data
    * @returns A list of data that has been re-encrypted with the new user key
    */
-  getRotatedData(originalUserKey: UserKey, newUserKey: UserKey, userId: UserId): Promise<T[]>;
+  getRotatedData(
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ): Promise<TRequest[]>;
 }

--- a/libs/auth/src/common/abstractions/user-key-rotation-data-provider.abstraction.ts
+++ b/libs/auth/src/common/abstractions/user-key-rotation-data-provider.abstraction.ts
@@ -1,0 +1,19 @@
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+
+/**
+ * Implemented by domains encrypted by the user key to support key rotations
+ * @typeparam T A request model that contains re-encrypted data, must have an id property
+ */
+export interface UserKeyRotationDataProviderAbstraction<
+  T extends { id: string } | { organizationId: string },
+> {
+  /**
+   * Implemented by each domain to provide re-encrypted data for the user key rotation process
+   * @param originalUserKey The original user key, useful for decrypting data
+   * @param newUserKey The new user key to use for re-encryption
+   * @param userId The owner of the data, useful for fetching data
+   * @returns A list of data that has been re-encrypted with the new user key
+   */
+  getRotatedData(originalUserKey: UserKey, newUserKey: UserKey, userId: UserId): Promise<T[]>;
+}

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -270,6 +270,15 @@ export abstract class CryptoService {
   abstract userPrivateKey$(userId: UserId): Observable<UserPrivateKey>;
 
   /**
+   * Gets an observable stream of the given users decrypted private key with legacy support,
+   * will emit null if the user doesn't have a UserKey to decrypt the encrypted private key
+   * or null if the user doesn't have an encrypted private key at all.
+   *
+   * @param userId The user id of the user to get the data for.
+   */
+  abstract userPrivateKeyWithLegacySupport$(userId: UserId): Observable<UserPrivateKey>;
+
+  /**
    * Generates a fingerprint phrase for the user based on their public key
    * @param fingerprintMaterial Fingerprint material
    * @param publicKey The user's public key

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -929,6 +929,10 @@ export class CryptoService implements CryptoServiceAbstraction {
     return this.userPrivateKeyHelper$(userId, false).pipe(map((keys) => keys?.userPrivateKey));
   }
 
+  userPrivateKeyWithLegacySupport$(userId: UserId): Observable<UserPrivateKey> {
+    return this.userPrivateKeyHelper$(userId, true).pipe(map((keys) => keys?.userPrivateKey));
+  }
+
   private userPrivateKeyHelper$(userId: UserId, legacySupport: boolean) {
     const userKey$ = legacySupport ? this.userKeyWithLegacySupport$(userId) : this.userKey$(userId);
     return userKey$.pipe(
@@ -1010,7 +1014,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   orgKeys$(userId: UserId) {
-    return this.cipherDecryptionKeys$(userId).pipe(map((keys) => keys?.orgKeys));
+    return this.cipherDecryptionKeys$(userId, true).pipe(map((keys) => keys?.orgKeys));
   }
 
   cipherDecryptionKeys$(

--- a/libs/common/src/tools/send/services/send.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send.service.abstraction.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+import { UserKeyRotationDataProvider } from "@bitwarden/auth/common";
 
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
@@ -11,9 +11,7 @@ import { Send } from "../models/domain/send";
 import { SendWithIdRequest } from "../models/request/send-with-id.request";
 import { SendView } from "../models/view/send.view";
 
-export abstract class SendService
-  implements UserKeyRotationDataProviderAbstraction<SendWithIdRequest>
-{
+export abstract class SendService implements UserKeyRotationDataProvider<SendWithIdRequest> {
   sends$: Observable<Send[]>;
   sendViews$: Observable<SendView[]>;
 

--- a/libs/common/src/tools/send/services/send.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send.service.abstraction.ts
@@ -1,14 +1,19 @@
 import { Observable } from "rxjs";
 
+import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
+import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";
 import { SendWithIdRequest } from "../models/request/send-with-id.request";
 import { SendView } from "../models/view/send.view";
 
-export abstract class SendService {
+export abstract class SendService
+  implements UserKeyRotationDataProviderAbstraction<SendWithIdRequest>
+{
   sends$: Observable<Send[]>;
   sendViews$: Observable<SendView[]>;
 
@@ -31,7 +36,11 @@ export abstract class SendService {
    * @throws Error if the new user key is null or undefined
    * @returns A list of user sends that have been re-encrypted with the new user key
    */
-  getRotatedKeys: (newUserKey: UserKey) => Promise<SendWithIdRequest[]>;
+  getRotatedData: (
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ) => Promise<SendWithIdRequest[]>;
   /**
    * @deprecated Do not call this, use the sends$ observable collection
    */

--- a/libs/common/src/tools/send/services/send.service.spec.ts
+++ b/libs/common/src/tools/send/services/send.service.spec.ts
@@ -400,8 +400,11 @@ describe("SendService", () => {
     expect(sends[0]).toMatchObject(testSendViewData("1", "Test Send"));
   });
 
-  describe("getRotatedKeys", () => {
+  describe("getRotatedData", () => {
+    const originalUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
+    const newUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
     let encryptedKey: EncString;
+
     beforeEach(() => {
       encryptService.decryptToBytes.mockResolvedValue(new Uint8Array(32));
       encryptedKey = new EncString("Re-encrypted Send Key");
@@ -409,27 +412,19 @@ describe("SendService", () => {
     });
 
     it("returns re-encrypted user sends", async () => {
-      const newUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
-      const result = await sendService.getRotatedKeys(newUserKey);
+      const result = await sendService.getRotatedData(originalUserKey, newUserKey, mockUserId);
 
       expect(result).toMatchObject([{ id: "1", key: "Re-encrypted Send Key" }]);
     });
 
-    it("returns null if there are no sends", async () => {
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      sendService.replace(null);
-
-      await awaitAsync();
-
-      const newUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
-      const result = await sendService.getRotatedKeys(newUserKey);
-
-      expect(result).toEqual([]);
+    it("throws if the original user key is null", async () => {
+      await expect(sendService.getRotatedData(null, newUserKey, mockUserId)).rejects.toThrow(
+        "Original user key is required for rotation.",
+      );
     });
 
     it("throws if the new user key is null", async () => {
-      await expect(sendService.getRotatedKeys(null)).rejects.toThrowError(
+      await expect(sendService.getRotatedData(originalUserKey, null, mockUserId)).rejects.toThrow(
         "New user key is required for rotation.",
       );
     });

--- a/libs/common/src/tools/send/services/send.service.spec.ts
+++ b/libs/common/src/tools/send/services/send.service.spec.ts
@@ -417,6 +417,19 @@ describe("SendService", () => {
       expect(result).toMatchObject([{ id: "1", key: "Re-encrypted Send Key" }]);
     });
 
+    it("returns empty array if there are no sends", async () => {
+      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      sendService.replace(null);
+
+      await awaitAsync();
+
+      const newUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
+      const result = await sendService.getRotatedData(originalUserKey, newUserKey, mockUserId);
+
+      expect(result).toEqual([]);
+    });
+
     it("throws if the original user key is null", async () => {
       await expect(sendService.getRotatedData(null, newUserKey, mockUserId)).rejects.toThrow(
         "Original user key is required for rotation.",

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -9,6 +9,7 @@ import { Utils } from "../../../platform/misc/utils";
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { EncString } from "../../../platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
+import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { SendType } from "../enums/send-type";
 import { SendData } from "../models/data/send.data";
@@ -258,12 +259,17 @@ export class SendService implements InternalSendServiceAbstraction {
     await this.stateProvider.setEncryptedSends(sends);
   }
 
-  async getRotatedKeys(newUserKey: UserKey): Promise<SendWithIdRequest[]> {
+  async getRotatedData(
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ): Promise<SendWithIdRequest[]> {
     if (newUserKey == null) {
       throw new Error("New user key is required for rotation.");
     }
-
-    const originalUserKey = await this.cryptoService.getUserKey();
+    if (originalUserKey == null) {
+      throw new Error("Original user key is required for rotation.");
+    }
 
     const req = await firstValueFrom(
       this.sends$.pipe(

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+import { UserKeyRotationDataProvider } from "@bitwarden/auth/common";
 import { LocalData } from "@bitwarden/common/vault/models/data/local.data";
 
 import { UriMatchStrategySetting } from "../../models/domain/domain-service";
@@ -16,9 +16,7 @@ import { CipherView } from "../models/view/cipher.view";
 import { FieldView } from "../models/view/field.view";
 import { AddEditCipherInfo } from "../types/add-edit-cipher-info";
 
-export abstract class CipherService
-  implements UserKeyRotationDataProviderAbstraction<CipherWithIdRequest>
-{
+export abstract class CipherService implements UserKeyRotationDataProvider<CipherWithIdRequest> {
   cipherViews$: Observable<Record<CipherId, CipherView>>;
   ciphers$: Observable<Record<CipherId, CipherData>>;
   localData$: Observable<Record<CipherId, LocalData>>;

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -1,19 +1,24 @@
 import { Observable } from "rxjs";
 
+import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
 import { LocalData } from "@bitwarden/common/vault/models/data/local.data";
 
 import { UriMatchStrategySetting } from "../../models/domain/domain-service";
 import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
-import { CipherId, CollectionId, OrganizationId } from "../../types/guid";
+import { CipherId, CollectionId, OrganizationId, UserId } from "../../types/guid";
+import { UserKey } from "../../types/key";
 import { CipherType } from "../enums/cipher-type";
 import { CipherData } from "../models/data/cipher.data";
 import { Cipher } from "../models/domain/cipher";
 import { Field } from "../models/domain/field";
+import { CipherWithIdRequest } from "../models/request/cipher-with-id.request";
 import { CipherView } from "../models/view/cipher.view";
 import { FieldView } from "../models/view/field.view";
 import { AddEditCipherInfo } from "../types/add-edit-cipher-info";
 
-export abstract class CipherService {
+export abstract class CipherService
+  implements UserKeyRotationDataProviderAbstraction<CipherWithIdRequest>
+{
   cipherViews$: Observable<Record<CipherId, CipherView>>;
   ciphers$: Observable<Record<CipherId, CipherData>>;
   localData$: Observable<Record<CipherId, LocalData>>;
@@ -146,4 +151,17 @@ export abstract class CipherService {
   restoreManyWithServer: (ids: string[], orgId?: string) => Promise<void>;
   getKeyForCipherKeyDecryption: (cipher: Cipher) => Promise<any>;
   setAddEditCipherInfo: (value: AddEditCipherInfo) => Promise<void>;
+  /**
+   * Returns user ciphers re-encrypted with the new user key.
+   * @param originalUserKey the original user key
+   * @param newUserKey the new user key
+   * @param userId the user id
+   * @throws Error if new user key is null
+   * @returns a list of user ciphers that have been re-encrypted with the new user key
+   */
+  getRotatedData: (
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ) => Promise<CipherWithIdRequest[]>;
 }

--- a/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
@@ -1,11 +1,18 @@
 import { Observable } from "rxjs";
 
+import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
+import { UserId } from "../../../types/guid";
+import { UserKey } from "../../../types/key";
 import { FolderData } from "../../models/data/folder.data";
 import { Folder } from "../../models/domain/folder";
+import { FolderWithIdRequest } from "../../models/request/folder-with-id.request";
 import { FolderView } from "../../models/view/folder.view";
 
-export abstract class FolderService {
+export abstract class FolderService
+  implements UserKeyRotationDataProviderAbstraction<FolderWithIdRequest>
+{
   folders$: Observable<Folder[]>;
   folderViews$: Observable<FolderView[]>;
 
@@ -22,6 +29,19 @@ export abstract class FolderService {
    */
   getAllDecryptedFromState: () => Promise<FolderView[]>;
   decryptFolders: (folders: Folder[]) => Promise<FolderView[]>;
+  /**
+   * Returns user folders re-encrypted with the new user key.
+   * @param originalUserKey the original user key
+   * @param newUserKey the new user key
+   * @param userId the user id
+   * @throws Error if new user key is null
+   * @returns a list of user folders that have been re-encrypted with the new user key
+   */
+  getRotatedData: (
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ) => Promise<FolderWithIdRequest[]>;
 }
 
 export abstract class InternalFolderService extends FolderService {

--- a/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder.service.abstraction.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { UserKeyRotationDataProviderAbstraction } from "@bitwarden/auth/common";
+import { UserKeyRotationDataProvider } from "@bitwarden/auth/common";
 
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
@@ -10,9 +10,7 @@ import { Folder } from "../../models/domain/folder";
 import { FolderWithIdRequest } from "../../models/request/folder-with-id.request";
 import { FolderView } from "../../models/view/folder.view";
 
-export abstract class FolderService
-  implements UserKeyRotationDataProviderAbstraction<FolderWithIdRequest>
-{
+export abstract class FolderService implements UserKeyRotationDataProvider<FolderWithIdRequest> {
   folders$: Observable<Folder[]>;
   folderViews$: Observable<FolderView[]>;
 

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -56,6 +56,7 @@ import { CipherCollectionsRequest } from "../models/request/cipher-collections.r
 import { CipherCreateRequest } from "../models/request/cipher-create.request";
 import { CipherPartialRequest } from "../models/request/cipher-partial.request";
 import { CipherShareRequest } from "../models/request/cipher-share.request";
+import { CipherWithIdRequest } from "../models/request/cipher-with-id.request";
 import { CipherRequest } from "../models/request/cipher.request";
 import { CipherResponse } from "../models/response/cipher.response";
 import { AttachmentView } from "../models/view/attachment.view";
@@ -1166,6 +1167,34 @@ export class CipherService implements CipherServiceAbstraction {
     await this.addEditCipherInfoState.update(() => value, {
       shouldUpdate: (current) => !(current == null && value == null),
     });
+  }
+
+  async getRotatedData(
+    originalUserKey: UserKey,
+    newUserKey: UserKey,
+    userId: UserId,
+  ): Promise<CipherWithIdRequest[]> {
+    if (originalUserKey == null) {
+      throw new Error("Original user key is required to rotate ciphers");
+    }
+    if (newUserKey == null) {
+      throw new Error("New user key is required to rotate ciphers");
+    }
+
+    let encryptedCiphers: CipherWithIdRequest[] = [];
+
+    const ciphers = await this.getAllDecrypted();
+    if (!ciphers || ciphers.length === 0) {
+      return encryptedCiphers;
+    }
+    encryptedCiphers = await Promise.all(
+      ciphers.map(async (cipher) => {
+        const encryptedCipher = await this.encrypt(cipher, newUserKey, originalUserKey);
+        return new CipherWithIdRequest(encryptedCipher);
+      }),
+    );
+
+    return encryptedCiphers;
   }
 
   // Helpers

--- a/libs/common/src/vault/services/folder/folder.service.spec.ts
+++ b/libs/common/src/vault/services/folder/folder.service.spec.ts
@@ -178,6 +178,29 @@ describe("Folder Service", () => {
     // });
   });
 
+  describe("getRotatedData", () => {
+    const originalUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
+    const newUserKey = new SymmetricCryptoKey(new Uint8Array(32)) as UserKey;
+    let encryptedKey: EncString;
+
+    beforeEach(() => {
+      encryptedKey = new EncString("Re-encrypted Folder");
+      cryptoService.encrypt.mockResolvedValue(encryptedKey);
+    });
+
+    it("returns re-encrypted user folders", async () => {
+      const result = await folderService.getRotatedData(originalUserKey, newUserKey, mockUserId);
+
+      expect(result[0]).toMatchObject({ id: "1", name: "Re-encrypted Folder" });
+    });
+
+    it("throws if the new user key is null", async () => {
+      await expect(folderService.getRotatedData(originalUserKey, null, mockUserId)).rejects.toThrow(
+        "New user key is required for rotation.",
+      );
+    });
+  });
+
   function folderData(id: string, name: string) {
     const data = new FolderData({} as any);
     data.id = id;


### PR DESCRIPTION
Copied from #9498, we unfortunately had key rotation changes that were merged immediately after `rc` was cut. This is a blocker for our release, so I have created a branch off the original work and rebased it on `rc`, without the new key rotation changes.

Everything should be the exact same as #9498, before commit 20b5edca6dfe7a20729b9f782b52805f02777d9a. Which means everything was previously pre-approved (even though I may not be able to prove it 😞).

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-6789
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes legacy user migration by using the legacy key for private key re-encryption.

I took the chance to finish distributing key rotation logic to each domain using an interface.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/clients/assets/24985544/48c0d98f-4625-4de5-8f6e-7f634f2568ea

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
