### PR TITLE
[PM-830] Add attribute aria-expanded to Send add-edit options button

### DIFF
--- a/apps/web/src/app/tools/send/add-edit.component.html
+++ b/apps/web/src/app/tools/send/add-edit.component.html
@@ -100,7 +100,7 @@
       </bit-form-control>
       <div class="tw-mt-5 tw-flex" (click)="toggleOptions()">
         <h4 bitTypography="h4" class="tw-mb-0 tw-mr-2">
-          <button type="button" bitLink appStopClick>
+          <button type="button" bitLink appStopClick [attr.aria-expanded]="showOptions">
             <i
               class="bwi"
               aria-hidden="true"


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-830

## 📔 Objective

 Add attribute aria-expanded to Send add-edit options button on Web so that Voice Over announces if it is expanded or collapsed

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
