### PR TITLE
[PM-9047] Fix - Updated to correct filename

### DIFF
--- a/apps/desktop/desktop_native/index.js
+++ b/apps/desktop/desktop_native/index.js
@@ -165,11 +165,11 @@ switch (platform) {
         break
       case 'arm64':
         localFileExisted = existsSync(
-          join(__dirname, 'desktop_native.linux-arm64-musl.node')
+          join(__dirname, 'desktop_native.linux-arm64-gnu.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./desktop_native.linux-arm64-musl.node')
+            nativeBinding = require('./desktop_native.linux-arm64-gnu.node')
           } else {
             nativeBinding = require('@bitwarden/desktop-native-linux-arm64-musl')
           }


### PR DESCRIPTION
## 🎟️ Tracking

#9735 

## 📔 Objective

Was trying to build bitwarden binary for aarch64 on asahi however threw an error -> due to different file name. However don't know if that's the correct way to do it. PR's up for review, let me know about it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
