### PR TITLE
[PM-8994] Load vault data when coming from another user that was viewing an org

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/services/abstractions/vault-filter.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/services/abstractions/vault-filter.service.ts
@@ -32,4 +32,5 @@ export abstract class VaultFilterService {
   ) => Observable<TreeNode<CipherTypeFilter>>;
   // TODO: Remove this from org vault when collection admin service adopts state management
   reloadCollections?: (collections: CollectionAdminView[]) => void;
+  clearOrganizationFilter: () => void;
 }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
@@ -103,6 +103,10 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     return this._organizationFilter;
   }
 
+  clearOrganizationFilter() {
+    this._organizationFilter.next(null);
+  }
+
   setOrganizationFilter(organization: Organization) {
     if (organization?.id != "AllVaults") {
       this._organizationFilter.next(organization);

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -394,6 +394,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
     this.destroy$.next();
     this.destroy$.complete();
+    this.vaultFilterService.clearOrganizationFilter();
   }
 
   async onVaultItemsEvent(event: VaultItemEvent) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8994](https://bitwarden.atlassian.net/browse/PM-8994)

## 📔 Objective

Log in with a user and navigate to a organization in the individual vault.
Log out from that user
Log into another user
Vault items should load properly

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/8302660/9d7f0b1a-92f2-483b-9888-d955355f4af9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8994]: https://bitwarden.atlassian.net/browse/PM-8994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ