### PR TITLE
Update CLI storefronts to use bitwarden licensed artifacts

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Package Chocolatey
         shell: pwsh
-        if: ${{ matrix.license_type.prefix }} == 'oss'
+        if: ${{ matrix.license_type.prefix }} == 'bit'
         run: |
           Copy-Item -Path stores/chocolatey -Destination dist/chocolatey -Recurse
           Copy-Item dist/${{ matrix.license_type.prefix }}/windows/bw.exe -Destination dist/chocolatey/tools
@@ -282,7 +282,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Chocolatey asset
-        if: matrix.license_type.prefix == 'oss'
+        if: matrix.license_type.prefix == 'bit'
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
@@ -290,7 +290,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload NPM Build Directory asset
-        if: matrix.license_type.prefix == 'oss'
+        if: matrix.license_type.prefix == 'bit'
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
@@ -320,13 +320,13 @@ jobs:
       - name: Get bw linux cli
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
-          name: bw-oss-linux-${{ env._PACKAGE_VERSION }}.zip
+          name: bw-bit-linux-${{ env._PACKAGE_VERSION }}.zip
           path: apps/cli/dist/snap
 
       - name: Rename snap artifact
         run: |
           cd dist/snap
-          mv bw-oss-linux-${{ env._PACKAGE_VERSION }}.zip bw-linux-${{ env._PACKAGE_VERSION }}.zip
+          mv bw-bit-linux-${{ env._PACKAGE_VERSION }}.zip bw-linux-${{ env._PACKAGE_VERSION }}.zip
 
       - name: Setup Snap Package
         run: |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/bitwarden/clients"
   },
-  "license": "GPL-3.0-only",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "scripts": {
     "clean": "rimraf dist",
     "build:oss": "webpack",

--- a/apps/cli/stores/snap/snapcraft.yaml
+++ b/apps/cli/stores/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: bw
 version: __version__
 summary: Bitwarden CLI - A secure and free password manager for all of your devices.
+license: Proprietary
 description: |
   Bitwarden, Inc. is the parent company of 8bit Solutions LLC.
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2811

## 📔 Objective

Due to recent enhancements to the CLI being backed by the Bitwarden License
Agreement we need to update storefronts so that they point to the correct
licenses and artifacts.

### Important Notes For Release

The Snap store update in this work may be problematic and will need to be
monitored on release. The GUI setting indicating the use of a GPL license may
override the newly added configuration setting in snapcraft.yaml that
indicates the project uses a proprietary license. We should monitor the snap
store upon release and manually update the license to "Proprietary" in the
Snap Store website if it doesn't take from the changed configuration file.
This will require admin access to the Bitwarden snap package.

### Implementation Details

There are two major steps to this: updating the build job to bundle the
correct artifacts for store consumption, and updating store configuration to
indicate a change in licensing.

#### 1. Publish Bitwarden licensed artifacts to 3rd party storefronts

Currently the build job bundles GPL licensed artifacts to later be released
on storefronts. This needs to be updated to publish Bitwarden licensed
artifacts. This can be done by changing a few simple conditionals in the
[build job](https://github.com/bitwarden/clients/blob/14ebcea889e40c239feb58d267053e237bd9d8b5/.github/workflows/build-cli.yml#L239-L246). The release job just grabs whatever is in these prepared
folders from the build job, and so it does not need to be updated. Likewise
we don't need to change any asset names expected by stores, because they have
not changed.

#### 2. Update the license applied to 3rd party storefronts

3rd party storefronts need to be updated to reflect the new license we are
publishing the CLI under. The Bitwarden CLI is published on Chocolatey, NPM,
and Snap. Each storefront has a slightly different means for being updated.

##### 2a. Update the license applied in Chocolatey

The license posted to Chocolatey is sent alongside the build artifact itself.
[It actually already uses the correct license!](https://chocolatey.org/packages/bitwarden-cli). **We do not need to make any
changes to licensing in Chocolatey.**

##### 2b. Update the license applied in NPM

The license the NPM store uses is declared in package.json. See [these docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license)
[from npm](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license) for details. We need to update the [license key](https://github.com/bitwarden/clients/blob/9ec01422dfe7136e177aee2d224c41dc734e3384/apps/cli/package.json#L18) in the CLI's
package.json to indicate that the package is published under a special
license.

##### 2c. Update the license applied in Snap

We might be able to update the snap package license via configuration in
snapcraft.yaml. There is a key for it documented [here](https://snapcraft.io/docs/snapcraft-top-level-metadata#heading--license). 

However, we don't currently have the license configured this way and it
appears the snap store license is set from the GUI. 

The potential fields for the snap store are listed [here](https://github.com/snapcore/snapd/blob/master/spdx/licenses.go). We,
unfortunately, need to use the "Proprietary" option even though our license is
mixed and mostly GPL.

We should try and specify the value in the configuration, but we will need
BRE to monitor the Snap store upon release to make sure the new value takes.
If it does not appear to take BRE will need to update the value manually in
the Snap store website. This will require admin access to the Bitwarden
package on snap. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
