### PR TITLE
[PM-8603] Browser - Sticky Search/Filters

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -1,6 +1,6 @@
 <ng-content select="[slot=header]"></ng-content>
 <main class="tw-bg-background-alt tw-flex-1 tw-overflow-y-auto tw-h-full">
-  <div class="tw-max-w-screen-sm tw-mx-auto tw-p-3 tw-overflow-y-auto tw-h-full">
+  <div class="tw-max-w-screen-sm tw-mx-auto tw-p-3 tw-overflow-y-auto tw-h-full" [id]="id">
     <ng-content></ng-content>
   </div>
 </main>

--- a/apps/browser/src/platform/popup/layout/popup-page.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.ts
@@ -8,4 +8,10 @@ import { Component } from "@angular/core";
     class: "tw-h-full tw-flex tw-flex-col tw-flex-1 tw-overflow-y-auto",
   },
 })
-export class PopupPageComponent {}
+export class PopupPageComponent {
+  static ScrollableContainerId = "scrollable-popup-page";
+
+  get id(): string {
+    return PopupPageComponent.ScrollableContainerId;
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.html
@@ -1,0 +1,7 @@
+<div
+  #stickyElement
+  class="tw-sticky tw-bg-background-alt tw-z-10 -tw-top-3 tw-p-3 -tw-mx-3 -tw-mt-3 tw-border-solid tw-border-0 tw-border-b-[0.5px] tw-border-transparent"
+  [ngClass]="{ 'tw-border-b-secondary-300': !!stuck }"
+>
+  <ng-content></ng-content>
+</div>

--- a/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
+
+import { StickyContainerComponent } from "./sticky-container.component";
+
+describe("StickyContainerComponent", () => {
+  let component: StickyContainerComponent;
+  let fixture: ComponentFixture<StickyContainerComponent>;
+  let getElementByIdSpy: jest.SpyInstance;
+  let scrollContainer: HTMLDivElement;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    scrollContainer = document.createElement("div");
+    getElementByIdSpy = jest.spyOn(document, "getElementById").mockReturnValue(scrollContainer);
+
+    await TestBed.configureTestingModule({
+      imports: [StickyContainerComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StickyContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    jest.runAllTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("gets the element by id `PopupPageComponent.ScrollableContainerId`", () => {
+    expect(getElementByIdSpy).toHaveBeenCalledWith(PopupPageComponent.ScrollableContainerId);
+  });
+
+  it("sets stuck to true when the scroll top is greater than 0", () => {
+    scrollContainer.scrollTop = 1;
+
+    scrollContainer.dispatchEvent(new Event("scroll"));
+
+    expect(component.stuck).toBe(true);
+  });
+
+  it("sets stuck to false when the scroll top is 0", () => {
+    scrollContainer.scrollTop = 0;
+
+    scrollContainer.dispatchEvent(new Event("scroll"));
+
+    expect(component.stuck).toBe(false);
+  });
+});

--- a/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/sticky-container/sticky-container.component.ts
@@ -1,0 +1,46 @@
+import { CommonModule } from "@angular/common";
+import { AfterViewInit, Component, DestroyRef, inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { fromEvent } from "rxjs";
+
+import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
+
+@Component({
+  standalone: true,
+  selector: "app-sticky-container",
+  templateUrl: "./sticky-container.component.html",
+  imports: [CommonModule],
+})
+export class StickyContainerComponent implements AfterViewInit {
+  /** True when the `div` is "stuck" in position */
+  stuck = false;
+
+  destroyRef = inject(DestroyRef);
+
+  ngAfterViewInit(): void {
+    // Use setTimeout to wait a render cycle before subscribing to the scroll event
+    setTimeout(() => {
+      // The window isn't scrollable in this scenario,
+      // so we listen to the scroll event on the `div` itself
+      fromEvent(document.getElementById(PopupPageComponent.ScrollableContainerId), "scroll")
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(this.onScroll.bind(this));
+    });
+  }
+
+  /**
+   * Update `stuck` variable based on scroll position of the container
+   *
+   * Because search/filters are already at the top of the page,
+   * any scroll at all means the container should be "stuck"
+   */
+  private onScroll(e: Event): void {
+    const target = e.target as HTMLElement;
+
+    if (target.scrollTop > 0) {
+      this.stuck = true;
+    } else {
+      this.stuck = false;
+    }
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-filters/vault-list-filters.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-filters/vault-list-filters.component.html
@@ -1,5 +1,5 @@
 <div role="toolbar" [ariaLabel]="'filters' | i18n">
-  <form [formGroup]="filterForm" class="tw-flex tw-flex-wrap tw-gap-2 tw-mb-6 tw-mt-2">
+  <form [formGroup]="filterForm" class="tw-flex tw-flex-wrap tw-gap-2 tw-mt-2">
     <ng-container *ngIf="organizations$ | async as organizations">
       <bit-chip-select
         *ngIf="organizations.length"

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
@@ -20,9 +20,12 @@
   </div>
 
   <ng-container *ngIf="vaultState !== VaultStateEnum.Empty">
-    <app-vault-v2-search> </app-vault-v2-search>
+    <!-- Stick the search/filters to the top of the extension -->
+    <app-sticky-container>
+      <app-vault-v2-search></app-vault-v2-search>
 
-    <app-vault-list-filters></app-vault-list-filters>
+      <app-vault-list-filters></app-vault-list-filters>
+    </app-sticky-container>
     <div
       *ngIf="vaultState === VaultStateEnum.NoResults"
       class="tw-flex tw-flex-col tw-justify-center tw-h-auto tw-pt-12"
@@ -48,7 +51,7 @@
       </div>
     </div>
 
-    <ng-container *ngIf="vaultState === null">
+    <div *ngIf="vaultState === null" class="tw-pt-3">
       <app-autofill-vault-list-items></app-autofill-vault-list-items>
       <app-vault-list-items-container
         [title]="'favorites' | i18n"
@@ -60,6 +63,6 @@
         [ciphers]="remainingCiphers$ | async"
         id="allItems"
       ></app-vault-list-items-container>
-    </ng-container>
+    </div>
   </ng-container>
 </popup-page>

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.ts
@@ -15,6 +15,7 @@ import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page
 import { VaultPopupItemsService } from "../../services/vault-popup-items.service";
 import { AutofillVaultListItemsComponent, VaultListItemsContainerComponent } from "../vault-v2";
 import { NewItemDropdownV2Component } from "../vault-v2/new-item-dropdown/new-item-dropdown-v2.component";
+import { StickyContainerComponent } from "../vault-v2/sticky-container/sticky-container.component";
 import { VaultListFiltersComponent } from "../vault-v2/vault-list-filters/vault-list-filters.component";
 import { VaultV2SearchComponent } from "../vault-v2/vault-search/vault-v2-search.component";
 
@@ -43,6 +44,7 @@ enum VaultState {
     RouterLink,
     VaultV2SearchComponent,
     NewItemDropdownV2Component,
+    StickyContainerComponent,
   ],
 })
 export class VaultV2Component implements OnInit, OnDestroy {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8603](https://bitwarden.atlassian.net/browse/PM-8603)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Make the Search & Filters sticky
  - I switched around some padding/margin to split the spacing between the stuck element and the cipher list components
 
### Bottom border on scroll

- I created the `StickyContainerComponent` to handle the bottom border that should be shown on scroll. I wanted to separate this UI logic from any other business logic so it is a fairly small component.
- I ended up with an _okay_ approach of tying the scrollable container via a static `id` and listening for scroll events. In this case the `window` isn't the element that is scrolled.

#### Other attempts

Showing a border/shadow on scroll isn't necessarily new in my toolbox but this one gave me some trouble.
- I usually manage this with overlapping pseudo elements. For this implementation I would need to know the css `top` value so that border can be "stuck" to the bottom of the search/filters. This was proving difficult because the filters can hide/show so I would have had to consistently check the height of that element. I stopped there, that didn't feel sustainable.
- I also made an attempt at placing overlapping dummy `div`s into the DOM but I was creating dependencies on the negative margin value and once again the `top` value.

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/125900171/2405951e-544a-4f27-84aa-c2fc970611bc


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8603]: https://bitwarden.atlassian.net/browse/PM-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ