### PR TITLE
[AC-2803] Make provider discount dynamic in provider portal for Consolidated Billing

### DIFF
--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.html
@@ -7,7 +7,9 @@
       <p>{{ "createNewClientToManageAsProvider" | i18n }}</p>
       <div class="tw-mb-3">
         <span class="tw-text-lg tw-pr-1">{{ "selectAPlan" | i18n }}</span>
-        <span bitBadge variant="success">{{ "thirtyFivePercentDiscount" | i18n }}</span>
+        <span *ngIf="this.discountPercentage" bitBadge variant="success">{{
+          "providerDiscount" | i18n: this.discountPercentage
+        }}</span>
       </div>
       <ng-container>
         <div class="tw-grid tw-grid-flow-col tw-grid-cols-2 tw-gap-4 tw-mb-4">

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.ts
@@ -42,6 +42,7 @@ type PlanCard = {
   templateUrl: "./create-client-dialog.component.html",
 })
 export class CreateClientDialogComponent implements OnInit {
+  protected discountPercentage: number;
   protected formGroup = new FormGroup({
     clientOwnerEmail: new FormControl<string>("", [Validators.required, Validators.email]),
     organizationName: new FormControl<string>("", [Validators.required]),
@@ -96,27 +97,31 @@ export class CreateClientDialogComponent implements OnInit {
   }
 
   async ngOnInit(): Promise<void> {
-    const subscription = await this.billingApiService.getProviderSubscription(
+    const response = await this.billingApiService.getProviderSubscription(
       this.dialogParams.providerId,
     );
-    this.providerPlans = subscription?.plans ?? [];
+
+    this.providerPlans = response?.plans ?? [];
 
     const teamsPlan = this.dialogParams.plans.find((plan) => plan.type === PlanType.TeamsMonthly);
     const enterprisePlan = this.dialogParams.plans.find(
       (plan) => plan.type === PlanType.EnterpriseMonthly,
     );
 
+    this.discountPercentage = response.discountPercentage;
+    const discountFactor = this.discountPercentage ? (100 - this.discountPercentage) / 100 : 1;
+
     this.planCards = [
       {
         name: this.i18nService.t("planNameTeams"),
-        cost: teamsPlan.PasswordManager.providerPortalSeatPrice * 0.65, // 35% off for MSPs,
+        cost: teamsPlan.PasswordManager.providerPortalSeatPrice * discountFactor,
         type: teamsPlan.type,
         plan: teamsPlan,
         selected: true,
       },
       {
         name: this.i18nService.t("planNameEnterprise"),
-        cost: enterprisePlan.PasswordManager.providerPortalSeatPrice * 0.65, // 35% off for MSPs,
+        cost: enterprisePlan.PasswordManager.providerPortalSeatPrice * discountFactor,
         type: enterprisePlan.type,
         plan: enterprisePlan,
         selected: false,

--- a/bitwarden_license/bit-web/src/app/billing/providers/subscription/provider-subscription.component.html
+++ b/bitwarden_license/bit-web/src/app/billing/providers/subscription/provider-subscription.component.html
@@ -37,7 +37,7 @@
                 {{ ((100 - subscription.discountPercentage) / 100) * i.cost | currency: "$" }} /{{
                   "month" | i18n
                 }}
-                <div>
+                <div *ngIf="subscription.discountPercentage">
                   <bit-hint class="tw-text-sm tw-line-through">
                     {{ i.cost | currency: "$" }} /{{ "month" | i18n }}
                   </bit-hint>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2803

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the Provider Portal to dynamically display or hide the UI elements related to a provider's subscription discount based on whether one exists or not. Previously, some of this was hard-coded as we always expected the guaranteed 35% discount.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/clients/assets/144709477/55895b34-480d-4000-8326-0fa5e84d44e1



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
