### PR TITLE
[PM-5085] InputPasswordComponent Updates (email verification)

### DIFF
--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <auth-password-callout
-    *ngIf="masterPasswordPolicy"
-    [policy]="masterPasswordPolicy"
+    *ngIf="masterPasswordPolicyOptions"
+    [policy]="masterPasswordPolicyOptions"
   ></auth-password-callout>
 
   <div class="tw-mb-6">

--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -3,17 +3,12 @@ import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
-import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
-import {
-  DEFAULT_KDF_CONFIG,
-  PBKDF2KdfConfig,
-} from "@bitwarden/common/auth/models/domain/kdf-config";
+import { DEFAULT_KDF_CONFIG } from "@bitwarden/common/auth/models/domain/kdf-config";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { MasterKey } from "@bitwarden/common/types/key";
 import {
   AsyncActionsModule,
   ButtonModule,
@@ -29,12 +24,7 @@ import { InputsFieldMatch } from "../../../../angular/src/auth/validators/inputs
 import { SharedModule } from "../../../../components/src/shared";
 import { PasswordCalloutComponent } from "../password-callout/password-callout.component";
 
-export interface PasswordInputResult {
-  masterKey: MasterKey;
-  masterKeyHash: string;
-  kdfConfig: PBKDF2KdfConfig;
-  hint: string;
-}
+import { PasswordInputResult } from "./password-input-result";
 
 @Component({
   standalone: true,
@@ -58,14 +48,13 @@ export class InputPasswordComponent implements OnInit {
 
   @Input({ required: true }) email: string;
   @Input() protected buttonText: string;
-  @Input() private orgId: string;
+  @Input() masterPasswordPolicyOptions: MasterPasswordPolicyOptions | null = null;
 
   private minHintLength = 0;
   protected maxHintLength = 50;
 
   protected minPasswordLength = Utils.minimumPasswordLength;
   protected minPasswordMsg = "";
-  protected masterPasswordPolicy: MasterPasswordPolicyOptions;
   protected passwordStrengthResult: any;
   protected showErrorSummary = false;
   protected showPassword = false;
@@ -106,18 +95,16 @@ export class InputPasswordComponent implements OnInit {
     private i18nService: I18nService,
     private policyService: PolicyService,
     private toastService: ToastService,
-    private policyApiService: PolicyApiServiceAbstraction,
   ) {}
 
   async ngOnInit() {
-    this.masterPasswordPolicy = await this.policyApiService.getMasterPasswordPolicyOptsForOrgUser(
-      this.orgId,
-    );
-
-    if (this.masterPasswordPolicy != null && this.masterPasswordPolicy.minLength > 0) {
+    if (
+      this.masterPasswordPolicyOptions != null &&
+      this.masterPasswordPolicyOptions.minLength > 0
+    ) {
       this.minPasswordMsg = this.i18nService.t(
         "characterMinimum",
-        this.masterPasswordPolicy.minLength,
+        this.masterPasswordPolicyOptions.minLength,
       );
     } else {
       this.minPasswordMsg = this.i18nService.t("characterMinimum", this.minPasswordLength);
@@ -157,11 +144,11 @@ export class InputPasswordComponent implements OnInit {
 
     // Check if password meets org policy requirements
     if (
-      this.masterPasswordPolicy != null &&
+      this.masterPasswordPolicyOptions != null &&
       !this.policyService.evaluateMasterPassword(
         this.passwordStrengthResult.score,
         password,
-        this.masterPasswordPolicy,
+        this.masterPasswordPolicyOptions,
       )
     ) {
       this.toastService.showToast({

--- a/libs/auth/src/angular/input-password/input-password.mdx
+++ b/libs/auth/src/angular/input-password/input-password.mdx
@@ -22,8 +22,8 @@ the parent component to act on those values as needed.
   `InputPasswordComponent` can create a master key.
 - `buttonText` (optional) - an `i18n` translated string that can be used as button text (default
   text is "Set master password").
-- `orgId` (optional) - used to retreive and enforce the master password policy requirements for an
-  org.
+- `masterPasswordPolicyOptions` (optional) - used to display and enforce master password policy
+  requirements.
 
 <br />
 

--- a/libs/auth/src/angular/input-password/password-input-result.ts
+++ b/libs/auth/src/angular/input-password/password-input-result.ts
@@ -1,0 +1,9 @@
+import { PBKDF2KdfConfig } from "@bitwarden/common/auth/models/domain/kdf-config";
+import { MasterKey } from "@bitwarden/common/types/key";
+
+export interface PasswordInputResult {
+  masterKey: MasterKey;
+  masterKeyHash: string;
+  kdfConfig: PBKDF2KdfConfig;
+  hint: string;
+}


### PR DESCRIPTION
## 📔 Objective

Changes the `orgId` input `masterPasswordPolicyOptions` and updates Storybook stories and docs.

## 📸 Storybook

https://62a88a6de5b807fa98886113-ffshafpbwp.chromatic.com/?path=/docs/auth-input-password--docs

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
