### PR TITLE
Add setuptools to mac pipeline

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1037,6 +1037,9 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
           node-version: ${{ env._NODE_VERSION }}
 
+      - name: Set up Node-gyp
+        run: python3 -m pip install setuptools
+
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -464,6 +464,9 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
           node-version: ${{ env._NODE_VERSION }}
 
+      - name: Set up Node-gyp
+        run: python3 -m pip install setuptools
+
       - name: Rust
         shell: pwsh
         run: rustup target install aarch64-apple-darwin
@@ -624,6 +627,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
           node-version: ${{ env._NODE_VERSION }}
+
+      - name: Set up Node-gyp
+        run: python3 -m pip install setuptools
 
       - name: Rust
         shell: pwsh
@@ -830,6 +836,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
           node-version: ${{ env._NODE_VERSION }}
+
+      - name: Set up Node-gyp
+        run: python3 -m pip install setuptools
 
       - name: Rust
         shell: pwsh


### PR DESCRIPTION
## 📔 Objective

Fixes missed mac os build runners from #8073. 

Mac runners have progressed above python 3.12, which removed `distutils`. We need to ensure it's installed for node-gyp compilations by installing the setuptools package.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
