### PR TITLE
PM-4878: Add passkey information to items when signing in

### DIFF
--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
@@ -28,7 +28,7 @@
             </ng-container>
           </span>
         </span>
-        <span class="detail" *ngIf="cipher.subName">{{ cipher.subName }}</span>
+        <span class="detail" *ngIf="getSubName(cipher)">{{ getSubName(cipher) }}</span>
         <span class="detail" *ngIf="cipher.subTitle">{{ cipher.subTitle }}</span>
       </div>
     </button>

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.html
@@ -28,6 +28,7 @@
             </ng-container>
           </span>
         </span>
+        <span class="detail" *ngIf="cipher.subName">{{ cipher.subName }}</span>
         <span class="detail" *ngIf="cipher.subTitle">{{ cipher.subTitle }}</span>
       </div>
     </button>

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
@@ -18,7 +18,17 @@ export class Fido2CipherRowComponent {
     this.onSelected.emit(c);
   }
 
-  protected getSubName(c: CipherView): string {
+  protected getSubName(c: CipherView): string | null {
+    const fido2Credentials = c.login?.fido2Credentials;
+    
+    if (!fido2Credentials || fido2Credentials.length === 0) {
+        return null;
+    }
+    
+    const [fido2Credential] = fido2Credentials;
+    
+    return c.name !== fido2Credential.rpId ? fido2Credential.rpId : null;
+}
     if (c.login?.fido2Credentials != null && c.login.fido2Credentials.length > 0) {
       const fido2Credential = c.login.fido2Credentials[0];
       if (c.name != fido2Credential.rpId) {

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
@@ -18,23 +18,21 @@ export class Fido2CipherRowComponent {
     this.onSelected.emit(c);
   }
 
+  /**
+   * Returns a subname for the cipher.
+   * If this has a FIDO2 credential, and the cipher.name is different from the FIDO2 credential's rpId, return the rpId.
+   * @param c Cipher
+   * @returns
+   */
   protected getSubName(c: CipherView): string | null {
     const fido2Credentials = c.login?.fido2Credentials;
-    
+
     if (!fido2Credentials || fido2Credentials.length === 0) {
-        return null;
+      return null;
     }
-    
+
     const [fido2Credential] = fido2Credentials;
-    
+
     return c.name !== fido2Credential.rpId ? fido2Credential.rpId : null;
-}
-    if (c.login?.fido2Credentials != null && c.login.fido2Credentials.length > 0) {
-      const fido2Credential = c.login.fido2Credentials[0];
-      if (c.name != fido2Credential.rpId) {
-        return fido2Credential.rpId;
-      }
-    }
-    return null;
   }
 }

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
@@ -1,10 +1,11 @@
-import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from "@angular/core";
 
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 @Component({
   selector: "app-fido2-cipher-row",
   templateUrl: "fido2-cipher-row.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Fido2CipherRowComponent {
   @Output() onSelected = new EventEmitter<CipherView>();

--- a/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/fido2/fido2-cipher-row.component.ts
@@ -17,4 +17,14 @@ export class Fido2CipherRowComponent {
   protected selectCipher(c: CipherView) {
     this.onSelected.emit(c);
   }
+
+  protected getSubName(c: CipherView): string {
+    if (c.login?.fido2Credentials != null && c.login.fido2Credentials.length > 0) {
+      const fido2Credential = c.login.fido2Credentials[0];
+      if (c.name != fido2Credential.rpId) {
+        return fido2Credential.rpId;
+      }
+    }
+    return null;
+  }
 }

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -86,6 +86,16 @@ export class CipherView implements View, InitializerMetadata {
     return this.item?.subTitle;
   }
 
+  get subName(): string {
+    if (this.login?.fido2Credentials != null && this.login.fido2Credentials.length > 0) {
+      const fido2Credential = this.login.fido2Credentials[0];
+      if (this.name != fido2Credential.rpId) {
+        return fido2Credential.rpId;
+      }
+    }
+    return null;
+  }
+
   get hasPasswordHistory(): boolean {
     return this.passwordHistory && this.passwordHistory.length > 0;
   }

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -86,16 +86,6 @@ export class CipherView implements View, InitializerMetadata {
     return this.item?.subTitle;
   }
 
-  get subName(): string {
-    if (this.login?.fido2Credentials != null && this.login.fido2Credentials.length > 0) {
-      const fido2Credential = this.login.fido2Credentials[0];
-      if (this.name != fido2Credential.rpId) {
-        return fido2Credential.rpId;
-      }
-    }
-    return null;
-  }
-
   get hasPasswordHistory(): boolean {
     return this.passwordHistory && this.passwordHistory.length > 0;
   }

--- a/libs/common/src/vault/models/view/login.view.ts
+++ b/libs/common/src/vault/models/view/login.view.ts
@@ -40,6 +40,11 @@ export class LoginView extends ItemView {
   }
 
   get subTitle(): string {
+    // if there's a passkey available, use that as a fallback
+    if (Utils.isNullOrEmpty(this.username) && this.fido2Credentials?.length > 0) {
+      return this.fido2Credentials[0].userName;
+    }
+
     return this.username;
   }
 


### PR DESCRIPTION
- **Added username to subtitle**
- **Added subName to cipher**

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-4878


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

![CleanShot 2024-06-26 at 01 00 39@2x](https://github.com/bitwarden/clients/assets/357283/56801bf9-45d5-48df-9b19-d22753c7527a)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
