### PR TITLE
[PM-9250] Move send icons to @bitwarden/send-ui

### DIFF
--- a/apps/web/src/app/tools/send/access.component.ts
+++ b/apps/web/src/app/tools/send/access.component.ts
@@ -18,10 +18,10 @@ import { SendAccessView } from "@bitwarden/common/tools/send/models/view/send-ac
 import { SEND_KDF_ITERATIONS } from "@bitwarden/common/tools/send/send-kdf";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { NoItemsModule, ToastService } from "@bitwarden/components";
+import { ExpiredSendIcon } from "@bitwarden/send-ui";
 
 import { SharedModule } from "../../shared";
 
-import { ExpiredSend } from "./icons/expired-send.icon";
 import { SendAccessFileComponent } from "./send-access-file.component";
 import { SendAccessPasswordComponent } from "./send-access-password.component";
 import { SendAccessTextComponent } from "./send-access-text.component";
@@ -51,7 +51,7 @@ export class AccessComponent implements OnInit {
   protected hideEmail = false;
   protected decKey: SymmetricCryptoKey;
   protected accessRequest: SendAccessRequest;
-  protected expiredSendIcon = ExpiredSend;
+  protected expiredSendIcon = ExpiredSendIcon;
 
   protected formGroup = this.formBuilder.group({});
 

--- a/apps/web/src/app/tools/send/send.component.ts
+++ b/apps/web/src/app/tools/send/send.component.ts
@@ -19,12 +19,12 @@ import {
   TableDataSource,
   ToastService,
 } from "@bitwarden/components";
+import { NoSendsIcon } from "@bitwarden/send-ui";
 
 import { HeaderModule } from "../../layouts/header/header.module";
 import { SharedModule } from "../../shared";
 
 import { AddEditComponent } from "./add-edit.component";
-import { NoSend } from "./icons/no-send.icon";
 
 const BroadcasterSubscriptionId = "SendComponent";
 
@@ -37,7 +37,7 @@ const BroadcasterSubscriptionId = "SendComponent";
 export class SendComponent extends BaseSendComponent {
   @ViewChild("sendAddEdit", { read: ViewContainerRef, static: true })
   sendAddEditModalRef: ViewContainerRef;
-  noItemIcon = NoSend;
+  noItemIcon = NoSendsIcon;
 
   override set filteredSends(filteredSends: SendView[]) {
     super.filteredSends = filteredSends;

--- a/libs/tools/send/send-ui/package.json
+++ b/libs/tools/send/send-ui/package.json
@@ -18,6 +18,7 @@
     "build:watch": "npm run clean && tsc -watch"
   },
   "dependencies": {
-    "@bitwarden/common": "file:../../../common"
+    "@bitwarden/common": "file:../../../common",
+    "@bitwarden/components": "file:../../../components"
   }
 }

--- a/libs/tools/send/send-ui/src/icons/expired-send.icon.ts
+++ b/libs/tools/send/send-ui/src/icons/expired-send.icon.ts
@@ -1,6 +1,6 @@
 import { svgIcon } from "@bitwarden/components";
 
-export const ExpiredSend = svgIcon`
+export const ExpiredSendIcon = svgIcon`
     <svg xmlns="http://www.w3.org/2000/svg" width="130" height="130" fill="none">
         <path class="tw-fill-secondary-600" fill-rule="evenodd" d="M22.75 29.695c0-4.991 4.074-9.037 9.1-9.037h14.3v2.582h-14.3c-3.59 0-6.5 2.89-6.5 6.455v68.428h-2.6V29.696Zm75.4 76.175V68.428h2.6v37.442c0 4.991-4.074 9.038-9.1 9.038h-53.3v-2.582h53.3c3.59 0 6.5-2.891 6.5-6.456Z" clip-rule="evenodd"/>
         <path class="tw-fill-secondary-600" fill-rule="evenodd" d="M43.55 37.441c0-17.113 13.969-30.986 31.2-30.986s31.2 13.873 31.2 30.986c0 17.114-13.969 30.987-31.2 30.987s-31.2-13.873-31.2-30.986Zm31.2-33.568c-18.667 0-33.8 15.03-33.8 33.569S56.083 71.01 74.75 71.01c18.668 0 33.8-15.03 33.8-33.569S93.418 3.873 74.75 3.873Z" clip-rule="evenodd"/>

--- a/libs/tools/send/send-ui/src/icons/index.ts
+++ b/libs/tools/send/send-ui/src/icons/index.ts
@@ -1,0 +1,2 @@
+export { NoSendsIcon } from "./no-send.icon";
+export { ExpiredSendIcon } from "./expired-send.icon";

--- a/libs/tools/send/send-ui/src/icons/no-send.icon.ts
+++ b/libs/tools/send/send-ui/src/icons/no-send.icon.ts
@@ -1,6 +1,6 @@
 import { svgIcon } from "@bitwarden/components";
 
-export const NoSend = svgIcon`
+export const NoSendsIcon = svgIcon`
   <svg xmlns="http://www.w3.org/2000/svg" width="120" height="125" fill="none">
     <path class="tw-stroke-secondary-600" stroke-width="3" d="M13.425 11.994H5.99a4.311 4.311 0 0 0-4.311 4.312v62.09a4.311 4.311 0 0 0 4.311 4.311h40.09"/>
     <path class="tw-stroke-secondary-600" stroke-width="3" d="M66.27 75.142h-49.9a3.234 3.234 0 0 1-3.233-3.234V9.818a3.234 3.234 0 0 1 3.234-3.233h35.764a3.233 3.233 0 0 1 2.293.953l14.134 14.216c.602.605.94 1.425.94 2.28v47.874a3.233 3.233 0 0 1-3.233 3.234Z"/>

--- a/libs/tools/send/send-ui/src/index.ts
+++ b/libs/tools/send/send-ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./icons";


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-9250

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Preparing to re-use the existing icons on other clients (namely browser for the extension UI refresh)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
