### PR TITLE
[PM-9317] fix duo subscriptions and org vs individual duo setup

### DIFF
--- a/apps/web/src/app/auth/settings/two-factor-duo.component.ts
+++ b/apps/web/src/app/auth/settings/two-factor-duo.component.ts
@@ -31,7 +31,7 @@ export class TwoFactorDuoComponent extends TwoFactorBaseComponent {
   override componentName = "app-two-factor-duo";
 
   constructor(
-    @Inject(DIALOG_DATA) protected data: AuthResponse<TwoFactorDuoResponse>,
+    @Inject(DIALOG_DATA) protected data: TwoFactorDuoComponentConfig,
     apiService: ApiService,
     i18nService: I18nService,
     platformUtilsService: PlatformUtilsService,
@@ -71,8 +71,17 @@ export class TwoFactorDuoComponent extends TwoFactorBaseComponent {
   }
 
   async ngOnInit() {
-    super.auth(this.data);
-    this.processResponse(this.data.response);
+    if (!this.data?.authResponse) {
+      throw Error("TwoFactorDuoComponent requires a TwoFactorDuoResponse to initialize");
+    }
+
+    super.auth(this.data.authResponse);
+    this.processResponse(this.data.authResponse.response);
+
+    if (this.data.organizationId) {
+      this.type = TwoFactorProviderType.OrganizationDuo;
+      this.organizationId = this.data.organizationId;
+    }
   }
 
   submit = async () => {
@@ -124,8 +133,13 @@ export class TwoFactorDuoComponent extends TwoFactorBaseComponent {
    */
   static open = (
     dialogService: DialogService,
-    config: DialogConfig<AuthResponse<TwoFactorDuoResponse>>,
+    config: DialogConfig<TwoFactorDuoComponentConfig>,
   ) => {
     return dialogService.open<boolean>(TwoFactorDuoComponent, config);
   };
 }
+
+type TwoFactorDuoComponentConfig = {
+  authResponse: AuthResponse<TwoFactorDuoResponse>;
+  organizationId?: string;
+};


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-9317
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We weren't sending the organization id or the correct two factor type to the dialog when configuring Organization Duo. This fixes that and adds some better handling of the dialog callbacks.
## 📸 Screenshots

https://github.com/bitwarden/clients/assets/24985544/773d55a1-fee2-4862-8485-1ddcb63a1d1b


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
