### PR TITLE
[PM-9344] Clarify accepted user state

### DIFF
--- a/apps/web/src/app/auth/settings/emergency-access/emergency-access.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/emergency-access.component.html
@@ -64,7 +64,7 @@
                 bitBadge
                 variant="warning"
                 *ngIf="c.status === emergencyAccessStatusType.Accepted"
-                >{{ "accepted" | i18n }}</span
+                >{{ "needsConfirmation" | i18n }}</span
               >
               <span
                 bitBadge
@@ -184,7 +184,7 @@
                 bitBadge
                 variant="warning"
                 *ngIf="c.status === emergencyAccessStatusType.Accepted"
-                >{{ "accepted" | i18n }}</span
+                >{{ "needsConfirmation" | i18n }}</span
               >
               <span
                 bitBadge

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2795,9 +2795,6 @@
   "invited": {
     "message": "Invited"
   },
-  "accepted": {
-    "message": "Accepted"
-  },
   "confirmed": {
     "message": "Confirmed"
   },

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/people.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/people.component.html
@@ -27,7 +27,7 @@
     </bit-toggle>
 
     <bit-toggle [value]="userStatusType.Accepted">
-      {{ "accepted" | i18n }}
+      {{ "needsConfirmation" | i18n }}
       <span bitBadge variant="warning" *ngIf="acceptedCount">{{ acceptedCount }}</span>
     </bit-toggle>
   </bit-toggle-group>
@@ -123,7 +123,7 @@
               "invited" | i18n
             }}</span>
             <span bitBadge variant="warning" *ngIf="u.status === userStatusType.Accepted">{{
-              "accepted" | i18n
+              "needsConfirmation" | i18n
             }}</span>
             <small class="text-muted d-block" *ngIf="u.name">{{ u.name }}</small>
           </td>


### PR DESCRIPTION
## 🎟️ Tracking

User feedback of lost vaults due to thinking that Emergency Access was completed.

https://bitwarden.atlassian.net/browse/PM-9344

## 📔 Objective

Prefer `Needs confirmation` to `Accepted` display status. This emphasizes that action is still required to complete setup.

## 📸 Screenshots

<img width="871" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/825ab046-33b0-4f37-b672-bb6ed74c4b72">

<img width="1636" alt="image" src="https://github.com/bitwarden/clients/assets/18214891/7d9ad014-9944-4402-a42f-8ce6686c83a8">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
