### PR TITLE
[PM-9370] Assign to Collections now hidden in Admin Console

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -104,7 +104,7 @@ export class VaultItemsComponent {
   }
 
   get bulkAssignToCollectionsAllowed() {
-    return this.showBulkAddToCollections && this.showBulkMove && this.ciphers.length > 0;
+    return this.showBulkAddToCollections && this.ciphers.length > 0;
   }
 
   // Use new bulk management delete if vaultBulkManagementActionEnabled feature flag is enabled
@@ -266,6 +266,10 @@ export class VaultItemsComponent {
   }
 
   protected showAssignToCollections(): boolean {
+    if (!this.showBulkMove) {
+      return false;
+    }
+
     if (this.selection.selected.length === 0) {
       return true;
     }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-9370
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Assign to collections should show up on the admin console. 

The fix for this was to move the `showBulkMove`(which is only set for individual vault to prevent the `assign to collection` option from showing up in the trash filter) from `bulkAssignToCollectionsAllowed` function to `showAssignToCollections`. `showAssignToCollections` is used by the individual vault to know when to hide or show the menu option.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
<img width="1502" alt="image" src="https://github.com/bitwarden/clients/assets/13024008/a67c3bc1-634e-4ba6-97f8-36a73d08af09">

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
