### PR TITLE
Rename "encryptionAlgorithm" to "hashAlgorithmForEncryption" for clarity

### DIFF
--- a/apps/desktop/native-messaging-test-runner/src/variables.ts
+++ b/apps/desktop/native-messaging-test-runner/src/variables.ts
@@ -1,5 +1,5 @@
 export const applicationName = "Native Messaging Test Runner";
-export const encryptionAlgorithm = "sha1";
+export const hashAlgorithmForEncryption = "sha1";
 export const testRsaPublicKey =
   "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl0Vawl/toXzkEvB82FEtqHP" +
   "4xlU2ab/v0crqIfXfIoWF/XXdHGIdrZeilnRXPPJT1B9dTsasttEZNnua/0Rek/cjNDHtzT52irfoZYS7X6HNIfOi54Q+egP" +

--- a/apps/desktop/src/services/native-message-handler.service.ts
+++ b/apps/desktop/src/services/native-message-handler.service.ts
@@ -22,7 +22,7 @@ import { UnencryptedMessageResponse } from "../models/native-messaging/unencrypt
 
 import { EncryptedMessageHandlerService } from "./encrypted-message-handler.service";
 
-const EncryptionAlgorithm = "sha1";
+const HashAlgorithmForAsymmetricEncryption = "sha1";
 
 // This service handles messages using the protocol created for the DuckDuckGo integration.
 @Injectable()
@@ -117,7 +117,7 @@ export class NativeMessageHandlerService {
       const encryptedSecret = await this.cryptoFunctionService.rsaEncrypt(
         secret,
         remotePublicKey,
-        EncryptionAlgorithm,
+        HashAlgorithmForAsymmetricEncryption,
       );
 
       this.sendResponse({

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -27,7 +27,7 @@ import { DesktopSettingsService } from "../platform/services/desktop-settings.se
 import { NativeMessageHandlerService } from "./native-message-handler.service";
 
 const MessageValidTimeout = 10 * 1000;
-const EncryptionAlgorithm = "sha1";
+const HashAlgorithmForAsymmetricEncryption = "sha1";
 
 @Injectable()
 export class NativeMessagingService {
@@ -227,7 +227,7 @@ export class NativeMessagingService {
     const encryptedSecret = await this.cryptoFunctionService.rsaEncrypt(
       secret,
       remotePublicKey,
-      EncryptionAlgorithm,
+      HashAlgorithmForAsymmetricEncryption,
     );
     ipc.platform.nativeMessaging.sendMessage({
       appId: appId,


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Since `sha1` is not an encryption algorithm, but a cryptographic hash function - used in the rsa-oaep padding scheme before encrypting using the actual encryption algorithm - RSA - for clarity, this renames the variables referencing `sha1` from `EncryptionAlgorithm` to `HashAlgorithmForAsymmetricEncryption`, making the code slightly easier to follow.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
