### PR TITLE
[PM-9378] add testids for attachment name and size

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.html
@@ -4,8 +4,8 @@
   <li *ngFor="let attachment of cipher.attachments">
     <bit-item>
       <bit-item-content>
-        {{ attachment.fileName }}
-        <span slot="secondary">{{ attachment.sizeName }}</span>
+        <span data-testid="file-name">{{ attachment.fileName }}</span>
+        <span slot="secondary" data-testid="file-size">{{ attachment.sizeName }}</span>
       </bit-item-content>
       <ng-container slot="end">
         <bit-item-action>

--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.spec.ts
@@ -103,6 +103,24 @@ describe("CipherAttachmentsComponent", () => {
     expect(component.cipher).toEqual(cipherView);
   });
 
+  it("sets testids for automation testing", () => {
+    const attachment = {
+      id: "1234-5678",
+      fileName: "test file.txt",
+      sizeName: "244.2 KB",
+    } as AttachmentView;
+
+    component.cipher.attachments = [attachment];
+
+    fixture.detectChanges();
+
+    const fileName = fixture.debugElement.query(By.css('[data-testid="file-name"]'));
+    const fileSize = fixture.debugElement.query(By.css('[data-testid="file-size"]'));
+
+    expect(fileName.nativeElement.textContent).toEqual(attachment.fileName);
+    expect(fileSize.nativeElement.textContent).toEqual(attachment.sizeName);
+  });
+
   describe("bitSubmit", () => {
     beforeEach(() => {
       component.submitBtn.disabled = undefined;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9378](https://bitwarden.atlassian.net/browse/PM-9378)

## 📔 Objective

Add `testid` for an attachment name and size for automated testing. 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9378]: https://bitwarden.atlassian.net/browse/PM-9378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ