### PR TITLE
[PM-9419] Use actual temp directory; Fixes #7758

### DIFF
--- a/apps/desktop/src/proxy/ipc.ts
+++ b/apps/desktop/src/proxy/ipc.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 import { createHash } from "crypto";
 import { existsSync, mkdirSync } from "fs";
-import { homedir } from "os";
-import { join as path_join } from "path";
+import { homedir, tmpdir } from "os";
 
 import * as ipc from "node-ipc";
 
@@ -11,7 +10,7 @@ export function getIpcSocketRoot(): string | null {
 
   switch (process.platform) {
     case "darwin": {
-      const ipcSocketRootDir = path_join(homedir(), "tmp");
+      const ipcSocketRootDir = tmpdir();
       if (!existsSync(ipcSocketRootDir)) {
         mkdirSync(ipcSocketRootDir);
       }


### PR DESCRIPTION
As discussed in issue #7758, the Bitwarden desktop client was creating a /tmp directory in the home directory when not installed via the App Store.

This PR resolves the issue by correctly using the specified OS temporary path. 