### PR TITLE
[PM-9414] Modal not dismissed when moving items only from personal vault

### DIFF
--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -217,22 +217,20 @@ export class AssignCollectionsComponent implements OnInit {
       );
     }
 
-    if (cipherIds.length === 0) {
-      return;
+    if (cipherIds.length > 0) {
+      const isSingleOrgCipher = cipherIds.length === 1 && this.personalItemsCount === 0;
+
+      // Update assigned collections for single org cipher or bulk update collections for multiple org ciphers
+      await (isSingleOrgCipher
+        ? this.updateAssignedCollections(this.editableItems[0])
+        : this.bulkUpdateCollections(cipherIds));
+
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("successfullyAssignedCollections"),
+      });
     }
-
-    const isSingleOrgCipher = cipherIds.length === 1 && this.personalItemsCount === 0;
-
-    // Update assigned collections for single org cipher or bulk update collections for multiple org ciphers
-    await (isSingleOrgCipher
-      ? this.updateAssignedCollections(this.editableItems[0])
-      : this.bulkUpdateCollections(cipherIds));
-
-    this.toastService.showToast({
-      variant: "success",
-      title: null,
-      message: this.i18nService.t("successfullyAssignedCollections"),
-    });
 
     this.onCollectionAssign.emit(CollectionAssignmentResult.Saved);
   };


### PR DESCRIPTION
## 🎟️ Tracking
[PM-9414](https://bitwarden.atlassian.net/browse/PM-9414)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Modal should be closed after personal item(s) are successfully assigned to an organization.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/13024008/d5467114-3fce-4e79-83b8-2df5cb4b0e29


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9414]: https://bitwarden.atlassian.net/browse/PM-9414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ