### PR TITLE
[PM-8525] Edit Card

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3558,5 +3558,17 @@
   },
   "filters": {
     "message": "Filters"
+  },
+  "cardDetails": {
+    "message": "Card details"
+  },
+  "cardBrandDetails": {
+    "message": "$BRAND$ details",
+    "placeholders": {
+      "brand": {
+        "content": "$1",
+        "example": "Visa"
+      }
+    }
   }
 }

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -104,7 +104,6 @@ export class DefaultConfigService implements ConfigService {
           return DefaultFeatureFlagValue[key];
         }
 
-        serverConfig.featureStates[FeatureFlag.ExtensionRefresh] = true;
         return serverConfig.featureStates[key] as FeatureFlagValueType<Flag>;
       }),
     );

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -104,6 +104,7 @@ export class DefaultConfigService implements ConfigService {
           return DefaultFeatureFlagValue[key];
         }
 
+        serverConfig.featureStates[FeatureFlag.ExtensionRefresh] = true;
         return serverConfig.featureStates[key] as FeatureFlagValueType<Flag>;
       }),
     );

--- a/libs/vault/src/cipher-form/cipher-form-container.ts
+++ b/libs/vault/src/cipher-form/cipher-form-container.ts
@@ -1,5 +1,6 @@
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { CardDetailsSectionComponent } from "./components/card-details-section/card-details-section.component";
 import { ItemDetailsSectionComponent } from "./components/item-details/item-details-section.component";
 
 /**
@@ -8,6 +9,7 @@ import { ItemDetailsSectionComponent } from "./components/item-details/item-deta
  */
 export type CipherForm = {
   itemDetails?: ItemDetailsSectionComponent["itemDetailsForm"];
+  cardDetails?: CardDetailsSectionComponent["cardDetailsForm"];
 };
 
 /**

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -39,7 +39,14 @@
 
       <bit-form-field class="tw-flex-1">
         <bit-label>{{ "expirationYear" | i18n }}</bit-label>
-        <input id="cardExpYear" #yearInput bitInput formControlName="expYear" type="number" />
+        <!-- `ngStyle` to force the number input to be the same height as the expiration month select. -->
+        <input
+          id="cardExpYear"
+          bitInput
+          formControlName="expYear"
+          type="number"
+          [ngStyle]="{ height: '35px' }"
+        />
       </bit-form-field>
     </div>
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -7,5 +7,10 @@
       <bit-label>{{ "cardholderName" | i18n }}</bit-label>
       <input bitInput formControlName="cardholderName" />
     </bit-form-field>
+    <bit-form-field>
+      <bit-label>{{ "number" | i18n }}</bit-label>
+      <input bitInput formControlName="number" type="text" />
+      <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+    </bit-form-field>
   </bit-card>
 </bit-section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -7,11 +7,13 @@
       <bit-label>{{ "cardholderName" | i18n }}</bit-label>
       <input bitInput formControlName="cardholderName" />
     </bit-form-field>
+
     <bit-form-field>
       <bit-label>{{ "number" | i18n }}</bit-label>
       <input bitInput formControlName="number" type="text" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
+
     <bit-form-field>
       <bit-label>{{ "brand" | i18n }}</bit-label>
       <bit-select formControlName="brand">
@@ -22,5 +24,23 @@
         ></bit-option>
       </bit-select>
     </bit-form-field>
+
+    <div class="tw-flex tw-flex-wrap tw-gap-1">
+      <bit-form-field class="tw-flex-1">
+        <bit-label>{{ "expirationMonth" | i18n }}</bit-label>
+        <bit-select formControlName="expMonth">
+          <bit-option
+            *ngFor="let month of expirationMonths"
+            [value]="month.value"
+            [label]="month.name | i18n"
+          ></bit-option>
+        </bit-select>
+      </bit-form-field>
+
+      <bit-form-field class="tw-flex-1">
+        <bit-label>{{ "expirationYear" | i18n }}</bit-label>
+        <input #yearInput bitInput formControlName="expYear" type="text" />
+      </bit-form-field>
+    </div>
   </bit-card>
 </bit-section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -46,14 +46,7 @@
 
       <bit-form-field class="tw-flex-1">
         <bit-label>{{ "expirationYear" | i18n }}</bit-label>
-        <!-- `ngStyle` to force the number input to be the same height as the expiration month select. -->
-        <input
-          id="cardExpYear"
-          bitInput
-          formControlName="expYear"
-          type="number"
-          [ngStyle]="{ height: '35px' }"
-        />
+        <input id="cardExpYear" bitInput formControlName="expYear" type="number" />
       </bit-form-field>
     </div>
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -12,5 +12,15 @@
       <input bitInput formControlName="number" type="text" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
+    <bit-form-field>
+      <bit-label>{{ "brand" | i18n }}</bit-label>
+      <bit-select formControlName="brand">
+        <bit-option
+          *ngFor="let brand of cardBrands"
+          [value]="brand.value"
+          [label]="brand.name"
+        ></bit-option>
+      </bit-select>
+    </bit-form-field>
   </bit-card>
 </bit-section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -39,7 +39,7 @@
 
       <bit-form-field class="tw-flex-1">
         <bit-label>{{ "expirationYear" | i18n }}</bit-label>
-        <input id="cardExpYear" #yearInput bitInput formControlName="expYear" type="text" />
+        <input id="cardExpYear" #yearInput bitInput formControlName="expYear" type="number" />
       </bit-form-field>
     </div>
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -1,6 +1,13 @@
 <bit-section [formGroup]="cardDetailsForm">
   <bit-section-header>
-    <h2 bitTypography="h5">{{ "cardDetails" | i18n }}</h2>
+    <h2 bitTypography="h5">
+      <ng-container *ngIf="cardDetailsForm.value.brand; else defaultHeading">
+        {{ "cardBrandDetails" | i18n: cardDetailsForm.value.brand }}
+      </ng-container>
+      <ng-template #defaultHeading>
+        {{ "cardDetails" | i18n }}
+      </ng-template>
+    </h2>
   </bit-section-header>
   <bit-card>
     <bit-form-field>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -10,7 +10,7 @@
 
     <bit-form-field>
       <bit-label>{{ "number" | i18n }}</bit-label>
-      <input bitInput formControlName="number" type="text" />
+      <input bitInput formControlName="number" type="password" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
 
@@ -45,7 +45,7 @@
 
     <bit-form-field>
       <bit-label>{{ "securityCode" | i18n }}</bit-label>
-      <input bitInput formControlName="code" type="text" />
+      <input bitInput formControlName="code" type="password" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
   </bit-card>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -42,5 +42,11 @@
         <input #yearInput bitInput formControlName="expYear" type="text" />
       </bit-form-field>
     </div>
+
+    <bit-form-field>
+      <bit-label>{{ "securityCode" | i18n }}</bit-label>
+      <input bitInput formControlName="code" type="text" />
+      <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+    </bit-form-field>
   </bit-card>
 </bit-section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -1,0 +1,11 @@
+<bit-section [formGroup]="cardDetailsForm">
+  <bit-section-header>
+    <h2 bitTypography="h5">{{ "cardDetails" | i18n }}</h2>
+  </bit-section-header>
+  <bit-card>
+    <bit-form-field>
+      <bit-label>{{ "cardholderName" | i18n }}</bit-label>
+      <input bitInput formControlName="cardholderName" />
+    </bit-form-field>
+  </bit-card>
+</bit-section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -5,18 +5,18 @@
   <bit-card>
     <bit-form-field>
       <bit-label>{{ "cardholderName" | i18n }}</bit-label>
-      <input bitInput formControlName="cardholderName" />
+      <input id="cardholderName" bitInput formControlName="cardholderName" />
     </bit-form-field>
 
     <bit-form-field>
       <bit-label>{{ "number" | i18n }}</bit-label>
-      <input bitInput formControlName="number" type="password" />
+      <input id="cardNumber" bitInput formControlName="number" type="password" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
 
     <bit-form-field>
       <bit-label>{{ "brand" | i18n }}</bit-label>
-      <bit-select formControlName="brand">
+      <bit-select id="cardBrand" formControlName="brand">
         <bit-option
           *ngFor="let brand of cardBrands"
           [value]="brand.value"
@@ -28,7 +28,7 @@
     <div class="tw-flex tw-flex-wrap tw-gap-1">
       <bit-form-field class="tw-flex-1">
         <bit-label>{{ "expirationMonth" | i18n }}</bit-label>
-        <bit-select formControlName="expMonth">
+        <bit-select id="cardExpMonth" formControlName="expMonth">
           <bit-option
             *ngFor="let month of expirationMonths"
             [value]="month.value"
@@ -39,13 +39,13 @@
 
       <bit-form-field class="tw-flex-1">
         <bit-label>{{ "expirationYear" | i18n }}</bit-label>
-        <input #yearInput bitInput formControlName="expYear" type="text" />
+        <input id="cardExpYear" #yearInput bitInput formControlName="expYear" type="text" />
       </bit-form-field>
     </div>
 
     <bit-form-field>
       <bit-label>{{ "securityCode" | i18n }}</bit-label>
-      <input bitInput formControlName="code" type="password" />
+      <input id="cardCode" bitInput formControlName="code" type="password" />
       <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
     </bit-form-field>
   </bit-card>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -32,7 +32,7 @@
           <bit-option
             *ngFor="let month of expirationMonths"
             [value]="month.value"
-            [label]="month.name | i18n"
+            [label]="month.name"
           ></bit-option>
         </bit-select>
       </bit-form-field>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -39,7 +40,6 @@ describe("CardDetailsSectionComponent", () => {
   });
 
   it("registers `cardDetailsForm` with `CipherFormContainer`", () => {
-    expect(registerChildFormSpy).toHaveBeenCalledTimes(1);
     expect(registerChildFormSpy).toHaveBeenCalledWith("cardDetails", component.cardDetailsForm);
   });
 
@@ -52,7 +52,8 @@ describe("CardDetailsSectionComponent", () => {
     const cardView = new CardView();
     cardView.cardholderName = "Ron Burgundy";
     cardView.number = "4242 4242 4242 4242";
-    expect(patchCipherSpy).toHaveBeenCalledTimes(1);
+    cardView.brand = "Visa";
+
     expect(patchCipherSpy).toHaveBeenCalledWith({
       card: cardView,
     });
@@ -67,6 +68,7 @@ describe("CardDetailsSectionComponent", () => {
     cardView.cardholderName = cardholderName;
     cardView.number = number;
     cardView.code = code;
+    cardView.brand = "Visa";
 
     component.originalCipherView = {
       card: cardView,
@@ -78,9 +80,17 @@ describe("CardDetailsSectionComponent", () => {
       cardholderName,
       number,
       code,
-      brand: null,
+      brand: cardView.brand,
       expMonth: null,
       expYear: null,
     });
+  });
+
+  it("sets brand based on number changes", () => {
+    const numberInput = fixture.debugElement.query(By.css('input[formControlName="number"]'));
+    numberInput.nativeElement.value = "4111 1111 1111 1111";
+    numberInput.nativeElement.dispatchEvent(new Event("input"));
+
+    expect(component.cardDetailsForm.controls.brand.value).toBe("Visa");
   });
 });

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
@@ -36,6 +36,14 @@ describe("CardDetailsSectionComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CardDetailsSectionComponent);
     component = fixture.componentInstance;
+    component.cardDetailsForm.reset({
+      cardholderName: null,
+      number: null,
+      brand: null,
+      expMonth: null,
+      expYear: null,
+      code: null,
+    });
     fixture.detectChanges();
   });
 
@@ -53,6 +61,19 @@ describe("CardDetailsSectionComponent", () => {
     cardView.cardholderName = "Ron Burgundy";
     cardView.number = "4242 4242 4242 4242";
     cardView.brand = "Visa";
+
+    expect(patchCipherSpy).toHaveBeenCalledWith({
+      card: cardView,
+    });
+  });
+
+  it("it converts the year integer to a string", () => {
+    component.cardDetailsForm.patchValue({
+      expYear: 2022,
+    });
+
+    const cardView = new CardView();
+    cardView.expYear = "2022";
 
     expect(patchCipherSpy).toHaveBeenCalledWith({
       card: cardView,

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
@@ -1,0 +1,86 @@
+import { CommonModule } from "@angular/common";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CardView } from "@bitwarden/common/vault/models/view/card.view";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { CipherFormContainer } from "../../cipher-form-container";
+
+import { CardDetailsSectionComponent } from "./card-details-section.component";
+
+describe("CardDetailsSectionComponent", () => {
+  let component: CardDetailsSectionComponent;
+  let fixture: ComponentFixture<CardDetailsSectionComponent>;
+  let cipherFormProvider: MockProxy<CipherFormContainer>;
+  let registerChildFormSpy: jest.SpyInstance;
+  let patchCipherSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    cipherFormProvider = mock<CipherFormContainer>();
+    registerChildFormSpy = jest.spyOn(cipherFormProvider, "registerChildForm");
+    patchCipherSpy = jest.spyOn(cipherFormProvider, "patchCipher");
+
+    await TestBed.configureTestingModule({
+      imports: [CardDetailsSectionComponent, CommonModule, ReactiveFormsModule],
+      providers: [
+        { provide: CipherFormContainer, useValue: cipherFormProvider },
+        { provide: I18nService, useValue: mock<I18nService>() },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardDetailsSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("registers `cardDetailsForm` with `CipherFormContainer`", () => {
+    expect(registerChildFormSpy).toHaveBeenCalledTimes(1);
+    expect(registerChildFormSpy).toHaveBeenCalledWith("cardDetails", component.cardDetailsForm);
+  });
+
+  it("patches `cardDetailsForm` changes to cipherFormContainer", () => {
+    component.cardDetailsForm.patchValue({
+      cardholderName: "Ron Burgundy",
+      number: "4242 4242 4242 4242",
+    });
+
+    const cardView = new CardView();
+    cardView.cardholderName = "Ron Burgundy";
+    cardView.number = "4242 4242 4242 4242";
+    expect(patchCipherSpy).toHaveBeenCalledTimes(1);
+    expect(patchCipherSpy).toHaveBeenCalledWith({
+      card: cardView,
+    });
+  });
+
+  it("initializes `cardDetailsForm` with current values", () => {
+    const cardholderName = "Ron Burgundy";
+    const number = "4242 4242 4242 4242";
+    const code = "619";
+
+    const cardView = new CardView();
+    cardView.cardholderName = cardholderName;
+    cardView.number = number;
+    cardView.code = code;
+
+    component.originalCipherView = {
+      card: cardView,
+    } as CipherView;
+
+    component.ngOnInit();
+
+    expect(component.cardDetailsForm.value).toEqual({
+      cardholderName,
+      number,
+      code,
+      brand: null,
+      expMonth: null,
+      expYear: null,
+    });
+  });
+});

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
@@ -80,6 +80,14 @@ describe("CardDetailsSectionComponent", () => {
     });
   });
 
+  it('disables `cardDetailsForm` when "disabled" is true', () => {
+    component.disabled = true;
+
+    component.ngOnInit();
+
+    expect(component.cardDetailsForm.disabled).toBe(true);
+  });
+
   it("initializes `cardDetailsForm` with current values", () => {
     const cardholderName = "Ron Burgundy";
     const number = "4242 4242 4242 4242";

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -61,8 +61,9 @@ export class CardDetailsSectionComponent implements OnInit, AfterViewInit {
     code: null,
   });
 
+  /** Available Card Brands */
   readonly cardBrands = [
-    { name: " ", value: null },
+    { name: "-- " + this.i18nService.t("select") + " --", value: null },
     { name: "Visa", value: "Visa" },
     { name: "Mastercard", value: "Mastercard" },
     { name: "American Express", value: "Amex" },
@@ -75,24 +76,21 @@ export class CardDetailsSectionComponent implements OnInit, AfterViewInit {
     { name: this.i18nService.t("other"), value: "Other" },
   ];
 
-  /**
-   * Available expiration months
-   * NOTE: `name` is an i18n key
-   */
+  /** Available expiration months */
   readonly expirationMonths = [
-    { name: " ", value: null },
-    { name: "january", value: "1" },
-    { name: "february", value: "2" },
-    { name: "march", value: "3" },
-    { name: "april", value: "4" },
-    { name: "may", value: "5" },
-    { name: "june", value: "6" },
-    { name: "july", value: "7" },
-    { name: "august", value: "8" },
-    { name: "september", value: "9" },
-    { name: "october", value: "10" },
-    { name: "november", value: "11" },
-    { name: "december", value: "12" },
+    { name: "-- " + this.i18nService.t("select") + " --", value: null },
+    { name: "01 - " + this.i18nService.t("january"), value: "1" },
+    { name: "02 - " + this.i18nService.t("february"), value: "2" },
+    { name: "03 - " + this.i18nService.t("march"), value: "3" },
+    { name: "04 - " + this.i18nService.t("april"), value: "4" },
+    { name: "05 - " + this.i18nService.t("may"), value: "5" },
+    { name: "06 - " + this.i18nService.t("june"), value: "6" },
+    { name: "07 - " + this.i18nService.t("july"), value: "7" },
+    { name: "08 - " + this.i18nService.t("august"), value: "8" },
+    { name: "09 - " + this.i18nService.t("september"), value: "9" },
+    { name: "10 - " + this.i18nService.t("october"), value: "10" },
+    { name: "11 - " + this.i18nService.t("november"), value: "11" },
+    { name: "12 - " + this.i18nService.t("december"), value: "12" },
   ];
 
   /** Local CardView, either created empty or set to the existing card instance  */

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -143,6 +143,10 @@ export class CardDetailsSectionComponent implements OnInit {
     if (this.originalCipherView?.card) {
       this.setInitialValues();
     }
+
+    if (this.disabled) {
+      this.cardDetailsForm.disable();
+    }
   }
 
   /** Set form initial form values from the current cipher */

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -4,6 +4,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
@@ -58,14 +59,30 @@ export class CardDetailsSectionComponent implements OnInit {
     code: null,
   });
 
+  readonly cardBrands = [
+    { name: " ", value: null },
+    { name: "Visa", value: "Visa" },
+    { name: "Mastercard", value: "Mastercard" },
+    { name: "American Express", value: "Amex" },
+    { name: "Discover", value: "Discover" },
+    { name: "Diners Club", value: "Diners Club" },
+    { name: "JCB", value: "JCB" },
+    { name: "Maestro", value: "Maestro" },
+    { name: "UnionPay", value: "UnionPay" },
+    { name: "RuPay", value: "RuPay" },
+    { name: this.i18nService.t("other"), value: "Other" },
+  ];
+
   /** Local CardView, either created empty or set to the existing card instance  */
   private cardView: CardView;
 
   constructor(
     private cipherFormContainer: CipherFormContainer,
     private formBuilder: FormBuilder,
+    private i18nService: I18nService,
   ) {
     this.cipherFormContainer.registerChildForm("cardDetails", this.cardDetailsForm);
+
     this.cardDetailsForm.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe(({ cardholderName, number, brand, expMonth, expYear, code }) => {
@@ -81,6 +98,16 @@ export class CardDetailsSectionComponent implements OnInit {
         this.cipherFormContainer.patchCipher({
           card: patchedCard,
         });
+      });
+
+    this.cardDetailsForm.controls.number.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((number) => {
+        const brand = CardView.getCardBrandByPatterns(number);
+
+        if (brand) {
+          this.cardDetailsForm.controls.brand.setValue(brand);
+        }
       });
   }
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -20,12 +20,12 @@ import {
 import { CipherFormContainer } from "../../cipher-form-container";
 
 type CardDetailsForm = {
-  cardholderName: string;
-  number: string;
-  brand: string;
-  expMonth: string;
-  expYear: string | number;
-  code: string;
+  cardholderName: CardView["cardholderName"];
+  number: CardView["number"];
+  brand: CardView["brand"];
+  expMonth: CardView["expMonth"];
+  expYear: CardView["expYear"];
+  code: CardView["code"];
 };
 
 @Component({

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { AfterViewInit, Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
+import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
@@ -45,7 +45,7 @@ type CardDetailsForm = {
     CommonModule,
   ],
 })
-export class CardDetailsSectionComponent implements OnInit, AfterViewInit {
+export class CardDetailsSectionComponent implements OnInit {
   /** The original cipher */
   @Input() originalCipherView: CipherView;
 
@@ -138,12 +138,6 @@ export class CardDetailsSectionComponent implements OnInit, AfterViewInit {
     if (this.originalCipherView?.card) {
       this.setInitialValues();
     }
-  }
-
-  ngAfterViewInit(): void {
-    // Force the year input to have the same height as the month select adjacent to it
-    // The bitInput directive overrides classes
-    this.yearInput.nativeElement.style.lineHeight = "1.6";
   }
 
   /** Set form initial form values from the current cipher */

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, Input, OnInit } from "@angular/core";
+import { AfterViewInit, Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
@@ -45,9 +45,11 @@ type CardDetailsForm = {
     CommonModule,
   ],
 })
-export class CardDetailsSectionComponent implements OnInit {
+export class CardDetailsSectionComponent implements OnInit, AfterViewInit {
   /** The original cipher */
   @Input() originalCipherView: CipherView;
+
+  @ViewChild("yearInput") yearInput: ElementRef<HTMLInputElement>;
 
   /** All form fields associated with the card details */
   cardDetailsForm = this.formBuilder.group<CardDetailsForm>({
@@ -71,6 +73,26 @@ export class CardDetailsSectionComponent implements OnInit {
     { name: "UnionPay", value: "UnionPay" },
     { name: "RuPay", value: "RuPay" },
     { name: this.i18nService.t("other"), value: "Other" },
+  ];
+
+  /**
+   * Available expiration months
+   * NOTE: `name` is an i18n key
+   */
+  readonly expirationMonths = [
+    { name: " ", value: null },
+    { name: "january", value: "1" },
+    { name: "february", value: "2" },
+    { name: "march", value: "3" },
+    { name: "april", value: "4" },
+    { name: "may", value: "5" },
+    { name: "june", value: "6" },
+    { name: "july", value: "7" },
+    { name: "august", value: "8" },
+    { name: "september", value: "9" },
+    { name: "october", value: "10" },
+    { name: "november", value: "11" },
+    { name: "december", value: "12" },
   ];
 
   /** Local CardView, either created empty or set to the existing card instance  */
@@ -118,6 +140,12 @@ export class CardDetailsSectionComponent implements OnInit {
     if (this.originalCipherView?.card) {
       this.setInitialValues();
     }
+  }
+
+  ngAfterViewInit(): void {
+    // Force the year input to have the same height as the month select adjacent to it
+    // The bitInput directive overrides classes
+    this.yearInput.nativeElement.style.lineHeight = "1.6";
   }
 
   /** Set form initial form values from the current cipher */

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -19,15 +19,6 @@ import {
 
 import { CipherFormContainer } from "../../cipher-form-container";
 
-type CardDetailsForm = {
-  cardholderName: CardView["cardholderName"];
-  number: CardView["number"];
-  brand: CardView["brand"];
-  expMonth: CardView["expMonth"];
-  expYear: CardView["expYear"] | number;
-  code: CardView["code"];
-};
-
 @Component({
   selector: "vault-card-details-section",
   templateUrl: "./card-details-section.component.html",
@@ -52,14 +43,19 @@ export class CardDetailsSectionComponent implements OnInit {
   /** True when all fields should be disabled */
   @Input() disabled: boolean;
 
-  /** All form fields associated with the card details */
-  cardDetailsForm = this.formBuilder.group<CardDetailsForm>({
-    cardholderName: null,
-    number: null,
-    brand: null,
-    expMonth: null,
-    expYear: null,
-    code: null,
+  /**
+   * All form fields associated with the card details
+   *
+   * Note: `as` is used to assert the type of the form control,
+   * leaving as just null gets inferred as `unknown`
+   */
+  cardDetailsForm = this.formBuilder.group({
+    cardholderName: null as string | null,
+    number: null as string | null,
+    brand: null as string | null,
+    expMonth: null as string | null,
+    expYear: null as string | number | null,
+    code: null as string | null,
   });
 
   /** Available Card Brands */

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -24,7 +24,7 @@ type CardDetailsForm = {
   number: CardView["number"];
   brand: CardView["brand"];
   expMonth: CardView["expMonth"];
-  expYear: CardView["expYear"];
+  expYear: CardView["expYear"] | number;
   code: CardView["code"];
 };
 
@@ -48,6 +48,9 @@ type CardDetailsForm = {
 export class CardDetailsSectionComponent implements OnInit {
   /** The original cipher */
   @Input() originalCipherView: CipherView;
+
+  /** True when all fields should be disabled */
+  @Input() disabled: boolean;
 
   /** All form fields associated with the card details */
   cardDetailsForm = this.formBuilder.group<CardDetailsForm>({

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -24,7 +24,7 @@ type CardDetailsForm = {
   number: string;
   brand: string;
   expMonth: string;
-  expYear: string;
+  expYear: string | number;
   code: string;
 };
 
@@ -106,12 +106,16 @@ export class CardDetailsSectionComponent implements OnInit {
     this.cardDetailsForm.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe(({ cardholderName, number, brand, expMonth, expYear, code }) => {
+        // The input[type="number"] is returning a number, convert it to a string
+        // An empty field returns null, avoid casting `"null"` to a string
+        const expirationYear = expYear !== null ? `${expYear}` : null;
+
         const patchedCard = Object.assign(this.cardView, {
           cardholderName,
           number,
           brand,
           expMonth,
-          expYear,
+          expYear: expirationYear,
           code,
         });
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
@@ -48,8 +48,6 @@ type CardDetailsForm = {
 export class CardDetailsSectionComponent implements OnInit {
   /** The original cipher */
   @Input() originalCipherView: CipherView;
-
-  @ViewChild("yearInput") yearInput: ElementRef<HTMLInputElement>;
 
   /** All form fields associated with the card details */
   cardDetailsForm = this.formBuilder.group<CardDetailsForm>({

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -1,0 +1,109 @@
+import { CommonModule } from "@angular/common";
+import { Component, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CardView } from "@bitwarden/common/vault/models/view/card.view";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  CardComponent,
+  FormFieldModule,
+  IconButtonModule,
+  SectionComponent,
+  SectionHeaderComponent,
+  SelectModule,
+  TypographyModule,
+} from "@bitwarden/components";
+
+import { CipherFormContainer } from "../../cipher-form-container";
+
+type CardDetailsForm = {
+  cardholderName: string;
+  number: string;
+  brand: string;
+  expMonth: string;
+  expYear: string;
+  code: string;
+};
+
+@Component({
+  selector: "vault-card-details-section",
+  templateUrl: "./card-details-section.component.html",
+  standalone: true,
+  imports: [
+    CardComponent,
+    SectionComponent,
+    TypographyModule,
+    FormFieldModule,
+    ReactiveFormsModule,
+    SelectModule,
+    SectionHeaderComponent,
+    IconButtonModule,
+    JslibModule,
+    CommonModule,
+  ],
+})
+export class CardDetailsSectionComponent implements OnInit {
+  /** The original cipher */
+  @Input() originalCipherView: CipherView;
+
+  /** All form fields associated with the card details */
+  cardDetailsForm = this.formBuilder.group<CardDetailsForm>({
+    cardholderName: null,
+    number: null,
+    brand: null,
+    expMonth: null,
+    expYear: null,
+    code: null,
+  });
+
+  /** Local CardView, either created empty or set to the existing card instance  */
+  private cardView: CardView;
+
+  constructor(
+    private cipherFormContainer: CipherFormContainer,
+    private formBuilder: FormBuilder,
+  ) {
+    this.cipherFormContainer.registerChildForm("cardDetails", this.cardDetailsForm);
+    this.cardDetailsForm.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ cardholderName, number, brand, expMonth, expYear, code }) => {
+        const patchedCard = Object.assign(this.cardView, {
+          cardholderName,
+          number,
+          brand,
+          expMonth,
+          expYear,
+          code,
+        });
+
+        this.cipherFormContainer.patchCipher({
+          card: patchedCard,
+        });
+      });
+  }
+
+  ngOnInit() {
+    // If the original cipher has a card, use it. Otherwise, create a new card instance
+    this.cardView = this.originalCipherView?.card ?? new CardView();
+
+    if (this.originalCipherView?.card) {
+      this.setInitialValues();
+    }
+  }
+
+  /** Set form initial form values from the current cipher */
+  private setInitialValues() {
+    const { cardholderName, number, brand, expMonth, expYear, code } = this.originalCipherView.card;
+
+    this.cardDetailsForm.setValue({
+      cardholderName: cardholderName,
+      number: number,
+      brand: brand,
+      expMonth: expMonth,
+      expYear: expYear,
+      code: code,
+    });
+  }
+}

--- a/libs/vault/src/cipher-form/components/cipher-form.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.html
@@ -6,6 +6,10 @@
       [originalCipherView]="originalCipherView"
     ></vault-item-details-section>
 
+    <vault-card-details-section
+      [originalCipherView]="originalCipherView"
+    ></vault-card-details-section>
+
     <!-- Attachments are only available for existing ciphers -->
     <ng-container *ngIf="config.mode == 'edit'">
       <ng-content select="[slot=attachment-button]"></ng-content>

--- a/libs/vault/src/cipher-form/components/cipher-form.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.html
@@ -7,6 +7,7 @@
     ></vault-item-details-section>
 
     <vault-card-details-section
+      *ngIf="config.cipherType === CipherType.Card"
       [originalCipherView]="originalCipherView"
     ></vault-card-details-section>
 

--- a/libs/vault/src/cipher-form/components/cipher-form.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.html
@@ -9,6 +9,7 @@
     <vault-card-details-section
       *ngIf="config.cipherType === CipherType.Card"
       [originalCipherView]="originalCipherView"
+      [disabled]="config.mode === 'partial-edit'"
     ></vault-card-details-section>
 
     <!-- Attachments are only available for existing ciphers -->

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -16,6 +16,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   AsyncActionsModule,
@@ -34,6 +35,7 @@ import { CipherFormConfig } from "../abstractions/cipher-form-config.service";
 import { CipherFormService } from "../abstractions/cipher-form.service";
 import { CipherForm, CipherFormContainer } from "../cipher-form-container";
 
+import { CardDetailsSectionComponent } from "./card-details-section/card-details-section.component";
 import { ItemDetailsSectionComponent } from "./item-details/item-details-section.component";
 
 @Component({
@@ -56,6 +58,7 @@ import { ItemDetailsSectionComponent } from "./item-details/item-details-section
     ReactiveFormsModule,
     SelectModule,
     ItemDetailsSectionComponent,
+    CardDetailsSectionComponent,
     NgIf,
   ],
 })
@@ -105,6 +108,8 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
    */
   protected updatedCipherView: CipherView | null;
   protected loading: boolean = true;
+
+  CipherType = CipherType;
 
   ngAfterViewInit(): void {
     if (this.submitBtn) {


### PR DESCRIPTION
Stacked on top of @shane-melton's https://github.com/bitwarden/clients/pull/9758 to integrate with `CipherFormConfigService`

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8525](https://bitwarden.atlassian.net/browse/PM-8525)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add Card Details section for editing a card cipher
- Slight changes from the current implementation:
  - Expiration year is now a numerical input to limit the input to numerical values
  - The year input doesn't take up as much vertical space as the month select. I manually applied a height here because the `bitInput` seems to override all classes applied to it's host element.

## 📸 Screenshots

|Edit Card|
|-|
|<video src="https://github.com/bitwarden/clients/assets/125900171/f6595f05-5466-4b9f-a84e-dda935741b47" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8525]: https://bitwarden.atlassian.net/browse/PM-8525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ