### PR TITLE
[PM-5165][PM-8645] Migrate password strength component

### DIFF
--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.html
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.html
@@ -1,0 +1,7 @@
+<bit-progress
+  [size]="size"
+  [text]="text"
+  [bgColor]="color"
+  [showText]="showText"
+  [barWidth]="scoreWidth"
+></bit-progress>

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.spec.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+
+import {
+  PasswordColorText,
+  PasswordStrengthScore,
+  PasswordStrengthV2Component,
+} from "./password-strength-v2.component";
+
+describe("PasswordStrengthV2Component", () => {
+  let component: PasswordStrengthV2Component;
+  let fixture: ComponentFixture<PasswordStrengthV2Component>;
+
+  const mockPasswordStrengthService = mock<PasswordStrengthServiceAbstraction>();
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: PasswordStrengthServiceAbstraction, useValue: mockPasswordStrengthService },
+      ],
+    });
+    fixture = TestBed.createComponent(PasswordStrengthV2Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create the component", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should update password strength when password changes", () => {
+    const password = "testPassword";
+    jest.spyOn(component, "updatePasswordStrength");
+    component.password = password;
+    expect(component.updatePasswordStrength).toHaveBeenCalledWith(password);
+    expect(mockPasswordStrengthService.getPasswordStrength).toHaveBeenCalledWith(
+      password,
+      undefined,
+      undefined,
+    );
+  });
+
+  it("should emit password strength result when password changes", () => {
+    const password = "testPassword";
+    jest.spyOn(component.passwordStrengthScore, "emit");
+    component.password = password;
+    expect(component.passwordStrengthScore.emit).toHaveBeenCalled();
+  });
+
+  it("should emit password score text and color when ngOnChanges executes", () => {
+    jest.spyOn(component.passwordScoreTextWithColor, "emit");
+    jest.useFakeTimers();
+    component.ngOnChanges();
+    jest.runAllTimers();
+    expect(component.passwordScoreTextWithColor.emit).toHaveBeenCalled();
+  });
+
+  const table = [
+    [4, { color: "success", text: "strong" }],
+    [3, { color: "primary", text: "good" }],
+    [2, { color: "warning", text: "weak" }],
+    [1, { color: "danger", text: "weak" }],
+    [null, { color: "danger", text: null }],
+  ];
+
+  test.each(table)(
+    "should passwordScore be %d then emit passwordScoreTextWithColor = %s",
+    (score: PasswordStrengthScore, expected: PasswordColorText) => {
+      jest.useFakeTimers();
+      jest.spyOn(component.passwordScoreTextWithColor, "emit");
+      component.passwordScore = score;
+      component.ngOnChanges();
+      jest.runAllTimers();
+      expect(component.passwordScoreTextWithColor.emit).toHaveBeenCalledWith(expected);
+    },
+  );
+});

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -1,0 +1,92 @@
+import { CommonModule } from "@angular/common";
+import { Component, EventEmitter, Input, OnChanges, Output } from "@angular/core";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { ProgressModule } from "@bitwarden/components";
+
+export interface PasswordColorText {
+  color: string;
+  text: string;
+}
+type SizeTypes = "small" | "default" | "large";
+type BackgroundTypes = "danger" | "primary" | "success" | "warning";
+
+@Component({
+  selector: "tools-password-strength",
+  templateUrl: "password-strength-v2.component.html",
+  standalone: true,
+  imports: [CommonModule, JslibModule, ProgressModule],
+})
+export class PasswordStrengthV2Component implements OnChanges {
+  @Input() size: SizeTypes = "default";
+  @Input() showText = false;
+  @Input() email: string;
+  @Input() name: string;
+  @Input() set password(value: string) {
+    this.updatePasswordStrength(value);
+  }
+  @Output() passwordStrengthResult = new EventEmitter<any>();
+  @Output() passwordScoreColor = new EventEmitter<PasswordColorText>();
+
+  passwordScore: number;
+  scoreWidth = 0;
+  color: BackgroundTypes = "danger";
+  text: string;
+
+  private passwordStrengthTimeout: any;
+
+  constructor(
+    private i18nService: I18nService,
+    private passwordStrengthService: PasswordStrengthServiceAbstraction,
+  ) {}
+
+  ngOnChanges(): void {
+    this.passwordStrengthTimeout = setTimeout(() => {
+      this.scoreWidth = this.passwordScore == null ? 0 : (this.passwordScore + 1) * 20;
+
+      switch (this.passwordScore) {
+        case 4:
+          this.color = "success";
+          this.text = this.i18nService.t("strong");
+          break;
+        case 3:
+          this.color = "primary";
+          this.text = this.i18nService.t("good");
+          break;
+        case 2:
+          this.color = "warning";
+          this.text = this.i18nService.t("weak");
+          break;
+        default:
+          this.color = "danger";
+          this.text = this.passwordScore != null ? this.i18nService.t("weak") : null;
+          break;
+      }
+
+      this.setPasswordScoreText(this.color, this.text);
+    }, 300);
+  }
+
+  updatePasswordStrength(password: string) {
+    const masterPassword = password;
+
+    if (this.passwordStrengthTimeout != null) {
+      clearTimeout(this.passwordStrengthTimeout);
+    }
+
+    const strengthResult = this.passwordStrengthService.getPasswordStrength(
+      masterPassword,
+      this.email,
+      this.name?.trim().toLowerCase().split(" "),
+    );
+    this.passwordStrengthResult.emit(strengthResult);
+    this.passwordScore = strengthResult == null ? null : strengthResult.score;
+  }
+
+  setPasswordScoreText(color: string, text: string) {
+    color = color.slice(3);
+    this.passwordScoreColor.emit({ color: color, text: text });
+  }
+}

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -28,7 +28,7 @@ export class PasswordStrengthV2Component implements OnChanges {
     this.updatePasswordStrength(value);
   }
   @Output() passwordStrengthResult = new EventEmitter<any>();
-  @Output() passwordScoreColor = new EventEmitter<PasswordColorText>();
+  @Output() passwordScoreTextWithColor = new EventEmitter<PasswordColorText>();
 
   passwordScore: number;
   scoreWidth = 0;
@@ -65,7 +65,10 @@ export class PasswordStrengthV2Component implements OnChanges {
           break;
       }
 
-      this.setPasswordScoreText(this.color, this.text);
+      this.passwordScoreTextWithColor.emit({
+        color: this.color,
+        text: this.text,
+      } as PasswordColorText);
     }, 300);
   }
 
@@ -81,10 +84,5 @@ export class PasswordStrengthV2Component implements OnChanges {
     );
     this.passwordStrengthResult.emit(strengthResult);
     this.passwordScore = strengthResult == null ? null : strengthResult.score;
-  }
-
-  setPasswordScoreText(color: string, text: string) {
-    color = color.slice(3);
-    this.passwordScoreColor.emit({ color: color, text: text });
   }
 }

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -10,6 +10,8 @@ export interface PasswordColorText {
   color: string;
   text: string;
 }
+export type PasswordStrengthScore = 0 | 1 | 2 | 3 | 4;
+
 type SizeTypes = "small" | "default" | "large";
 type BackgroundTypes = "danger" | "primary" | "success" | "warning";
 
@@ -27,10 +29,10 @@ export class PasswordStrengthV2Component implements OnChanges {
   @Input() set password(value: string) {
     this.updatePasswordStrength(value);
   }
-  @Output() passwordStrengthResult = new EventEmitter<any>();
+  @Output() passwordStrengthScore = new EventEmitter<PasswordStrengthScore>();
   @Output() passwordScoreTextWithColor = new EventEmitter<PasswordColorText>();
 
-  passwordScore: number;
+  passwordScore: PasswordStrengthScore;
   scoreWidth = 0;
   color: BackgroundTypes = "danger";
   text: string;
@@ -82,7 +84,7 @@ export class PasswordStrengthV2Component implements OnChanges {
       this.email,
       this.name?.trim().toLowerCase().split(" "),
     );
-    this.passwordStrengthResult.emit(strengthResult);
     this.passwordScore = strengthResult == null ? null : strengthResult.score;
+    this.passwordStrengthScore.emit(this.passwordScore);
   }
 }

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -70,14 +70,12 @@ export class PasswordStrengthV2Component implements OnChanges {
   }
 
   updatePasswordStrength(password: string) {
-    const masterPassword = password;
-
     if (this.passwordStrengthTimeout != null) {
       clearTimeout(this.passwordStrengthTimeout);
     }
 
     const strengthResult = this.passwordStrengthService.getPasswordStrength(
-      masterPassword,
+      password,
       this.email,
       this.name?.trim().toLowerCase().split(" "),
     );

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -22,14 +22,43 @@ type BackgroundTypes = "danger" | "primary" | "success" | "warning";
   imports: [CommonModule, JslibModule, ProgressModule],
 })
 export class PasswordStrengthV2Component implements OnChanges {
+  /**
+   * The size (height) of the password strength component.
+   * Possible values are "default", "small" and "large".
+   */
   @Input() size: SizeTypes = "default";
+  /**
+   * Determines whether to show the password strength score text on the progress bar or not.
+   */
   @Input() showText = false;
+  /**
+   * Optional email address which can be used as input for the password strength calculation
+   */
   @Input() email: string;
+  /**
+   * Optional name which can be used as input for the password strength calculation
+   */
   @Input() name: string;
+  /**
+   * Sets the password value and updates the password strength.
+   *
+   * @param value - password provided by the hosting component
+   */
   @Input() set password(value: string) {
     this.updatePasswordStrength(value);
   }
+  /**
+   * Emits the password strength score.
+   *
+   * @remarks
+   * The password strength score represents the strength of a password.
+   * It is emitted as an event when the password strength changes.
+   */
   @Output() passwordStrengthScore = new EventEmitter<PasswordStrengthScore>();
+
+  /**
+   * Emits an event with the password score text and color.
+   */
   @Output() passwordScoreTextWithColor = new EventEmitter<PasswordColorText>();
 
   passwordScore: PasswordStrengthScore;

--- a/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength-v2.component.ts
@@ -7,7 +7,7 @@ import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/pass
 import { ProgressModule } from "@bitwarden/components";
 
 export interface PasswordColorText {
-  color: string;
+  color: BackgroundTypes;
   text: string;
 }
 export type PasswordStrengthScore = 0 | 1 | 2 | 3 | 4;
@@ -37,7 +37,7 @@ export class PasswordStrengthV2Component implements OnChanges {
   color: BackgroundTypes = "danger";
   text: string;
 
-  private passwordStrengthTimeout: any;
+  private passwordStrengthTimeout: number | NodeJS.Timeout;
 
   constructor(
     private i18nService: I18nService,

--- a/libs/angular/src/tools/password-strength/password-strength.component.ts
+++ b/libs/angular/src/tools/password-strength/password-strength.component.ts
@@ -8,6 +8,9 @@ export interface PasswordColorText {
   text: string;
 }
 
+/**
+ * @deprecated July 2024: Use new PasswordStrengthV2Component instead
+ */
 @Component({
   selector: "app-password-strength",
   templateUrl: "password-strength.component.html",

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -76,7 +76,8 @@
           ></button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>
-        <app-password-strength [password]="filePassword" [showText]="true"> </app-password-strength>
+        <tools-password-strength [password]="filePassword" [showText]="true">
+        </tools-password-strength>
       </div>
       <bit-form-field>
         <bit-label>{{ "confirmFilePassword" | i18n }}</bit-label>

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -12,7 +12,7 @@ import { ReactiveFormsModule, UntypedFormBuilder, Validators } from "@angular/fo
 import { map, merge, Observable, startWith, Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { PasswordStrengthComponent } from "@bitwarden/angular/tools/password-strength/password-strength.component";
+import { PasswordStrengthV2Component } from "@bitwarden/angular/tools/password-strength/password-strength-v2.component";
 import { UserVerificationDialogComponent } from "@bitwarden/auth/angular";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -58,6 +58,7 @@ import { ExportScopeCalloutComponent } from "./export-scope-callout.component";
     RadioButtonModule,
     ExportScopeCalloutComponent,
     UserVerificationDialogComponent,
+    PasswordStrengthV2Component,
   ],
 })
 export class ExportComponent implements OnInit, OnDestroy {
@@ -110,7 +111,7 @@ export class ExportComponent implements OnInit, OnDestroy {
   @Output()
   onSuccessfulExport = new EventEmitter<string>();
 
-  @ViewChild(PasswordStrengthComponent) passwordStrengthComponent: PasswordStrengthComponent;
+  @ViewChild(PasswordStrengthV2Component) passwordStrengthComponent: PasswordStrengthV2Component;
 
   encryptedExportType = EncryptedExportType;
   protected showFilePassword: boolean;


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-5165
https://bitwarden.atlassian.net/browse/PM-8645
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Create a new password-strength component using the ProgressComponent from the Component library.

The existing component was kept to not break visual styles on non-CL-pages. A follow-up to this is to replace all existing usages with the new component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before
![image](https://github.com/bitwarden/clients/assets/2670567/2c72b253-c182-401a-bde2-0cd127f1e7de)
![image](https://github.com/bitwarden/clients/assets/2670567/486e2d87-c297-480f-a66b-d224eb0b9b6d)

### After
![image](https://github.com/bitwarden/clients/assets/2670567/0f89f9ec-49ec-4237-94c5-6bc95e2ec397)
![image](https://github.com/bitwarden/clients/assets/2670567/ab030609-aae6-496c-93be-b32fbb5bc7e5)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
