### PR TITLE
[CL-234] callout style refresh

### DIFF
--- a/libs/components/src/callout/callout.component.html
+++ b/libs/components/src/callout/callout.component.html
@@ -1,16 +1,13 @@
 <aside
-  class="tw-mb-4 tw-box-border tw-rounded tw-border tw-border-l-8 tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-px-5 tw-py-3 tw-leading-5 tw-text-main"
+  class="tw-mb-4 tw-box-border tw-rounded-lg tw-border tw-border-l-4 tw-border-solid tw-bg-background tw-pl-3 tw-pr-2 tw-py-2 tw-leading-5 tw-text-main"
   [ngClass]="calloutClass"
   [attr.aria-labelledby]="titleId"
 >
-  <header
-    id="{{ titleId }}"
-    class="tw-mb-2 tw-mt-0 tw-text-base tw-font-bold tw-uppercase"
-    [ngClass]="headerClass"
-    *ngIf="title"
-  >
-    <i class="bwi {{ icon }}" *ngIf="icon" aria-hidden="true"></i>
+  <header id="{{ titleId }}" class="tw-mb-2 tw-mt-0 tw-text-base tw-font-bold" *ngIf="title">
+    <i class="bwi" [ngClass]="[icon, headerClass]" *ngIf="icon" aria-hidden="true"></i>
     {{ title }}
   </header>
-  <ng-content></ng-content>
+  <div bitTypography="body2">
+    <ng-content></ng-content>
+  </div>
 </aside>

--- a/libs/components/src/callout/callout.component.html
+++ b/libs/components/src/callout/callout.component.html
@@ -3,7 +3,7 @@
   [ngClass]="calloutClass"
   [attr.aria-labelledby]="titleId"
 >
-  <header id="{{ titleId }}" class="tw-mb-2 tw-mt-0 tw-text-base tw-font-bold" *ngIf="title">
+  <header id="{{ titleId }}" class="tw-mb-1 tw-mt-0 tw-text-base tw-font-semibold" *ngIf="title">
     <i class="bwi" [ngClass]="[icon, headerClass]" *ngIf="icon" aria-hidden="true"></i>
     {{ title }}
   </header>

--- a/libs/components/src/callout/callout.component.spec.ts
+++ b/libs/components/src/callout/callout.component.spec.ts
@@ -12,7 +12,7 @@ describe("Callout", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [CalloutComponent],
+      imports: [CalloutComponent],
       providers: [
         {
           provide: I18nService,

--- a/libs/components/src/callout/callout.component.ts
+++ b/libs/components/src/callout/callout.component.ts
@@ -2,6 +2,9 @@ import { Component, Input, OnInit } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
+import { SharedModule } from "../shared";
+import { TypographyModule } from "../typography";
+
 type CalloutTypes = "success" | "info" | "warning" | "danger";
 
 const defaultIcon: Record<CalloutTypes, string> = {
@@ -22,6 +25,8 @@ let nextId = 0;
 @Component({
   selector: "bit-callout",
   templateUrl: "callout.component.html",
+  standalone: true,
+  imports: [SharedModule, TypographyModule],
 })
 export class CalloutComponent implements OnInit {
   @Input() type: CalloutTypes = "info";
@@ -42,13 +47,13 @@ export class CalloutComponent implements OnInit {
   get calloutClass() {
     switch (this.type) {
       case "danger":
-        return "tw-border-l-danger-600";
+        return "tw-border-danger-600";
       case "info":
-        return "tw-border-l-info-600";
+        return "tw-border-info-600";
       case "success":
-        return "tw-border-l-success-600";
+        return "tw-border-success-600";
       case "warning":
-        return "tw-border-l-warning-600";
+        return "tw-border-warning-600";
     }
   }
 

--- a/libs/components/src/callout/callout.mdx
+++ b/libs/components/src/callout/callout.mdx
@@ -2,6 +2,10 @@ import { Meta, Story, Primary, Controls } from "@storybook/addon-docs";
 
 import * as stories from "./callout.stories";
 
+```ts
+import { CalloutModule } from "@bitwarden/components";
+```
+
 <Meta of={stories} />
 
 # Callouts

--- a/libs/components/src/callout/callout.module.ts
+++ b/libs/components/src/callout/callout.module.ts
@@ -1,11 +1,9 @@
-import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 
 import { CalloutComponent } from "./callout.component";
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CalloutComponent],
   exports: [CalloutComponent],
-  declarations: [CalloutComponent],
 })
 export class CalloutModule {}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-234

## 📔 Objective

Update `bit-callout` component to use new styles.

side quests:
- update docs
- make component standalone
- https://github.com/bitwarden/clients/pull/9925
  - brought this into scope so we don't have two different callout styles within the app.

## 📸 Screenshots

See Storybook for more.

![image](https://github.com/bitwarden/clients/assets/17113462/554e28b5-c116-4725-9e26-51ca50169e3c)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
