### PR TITLE
[PM-9466] Allow browser extension unlock while desktop is locked

### DIFF
--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -3,7 +3,6 @@ import { firstValueFrom, map } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { CryptoFunctionService } from "@bitwarden/common/platform/abstractions/crypto-function.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -145,11 +144,6 @@ export class NativeMessagingService {
           return this.send({ command: "biometricUnlock", response: "not unlocked" }, appId);
         }
 
-        const authStatus = await firstValueFrom(this.authService.authStatusFor$(userId));
-        if (authStatus !== AuthenticationStatus.Unlocked) {
-          return this.send({ command: "biometricUnlock", response: "not unlocked" }, appId);
-        }
-
         const biometricUnlockPromise =
           message.userId == null
             ? firstValueFrom(this.biometricStateService.biometricUnlockEnabled$)
@@ -183,6 +177,7 @@ export class NativeMessagingService {
               },
               appId,
             );
+            await ipc.platform.reloadProcess();
           } else {
             await this.send({ command: "biometricUnlock", response: "canceled" }, appId);
           }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9466

## 📔 Objective

This PR allows biometric unlock, even while the desktop app is locked for all accounts. After every unlock with no other unlocked accounts, a process reload is triggered, so that the userkey is cleared from memory.

Fixes https://github.com/bitwarden/clients/issues/9539
Fixes https://github.com/bitwarden/clients/issues/9333
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
