### PR TITLE
[PM-9739] Update method names in biometric and add docs

### DIFF
--- a/apps/desktop/src/platform/main/biometric/biometric.darwin.main.ts
+++ b/apps/desktop/src/platform/main/biometric/biometric.darwin.main.ts
@@ -21,7 +21,7 @@ export default class BiometricDarwinMain implements OsBiometricService {
     }
   }
 
-  async getBiometricKey(service: string, key: string): Promise<string | null> {
+  async getBiometricEncryptedData(service: string, key: string): Promise<string | null> {
     const success = await this.authenticateBiometric();
 
     if (!success) {
@@ -31,7 +31,7 @@ export default class BiometricDarwinMain implements OsBiometricService {
     return await passwords.getPassword(service, key);
   }
 
-  async setBiometricKey(service: string, key: string, value: string): Promise<void> {
+  async setBiometricEncryptedData(service: string, key: string, value: string): Promise<void> {
     if (await this.valueUpToDate(service, key, value)) {
       return;
     }
@@ -39,7 +39,7 @@ export default class BiometricDarwinMain implements OsBiometricService {
     return await passwords.setPassword(service, key, value);
   }
 
-  async deleteBiometricKey(service: string, key: string): Promise<void> {
+  async deleteBiometricEncryptedData(service: string, key: string): Promise<void> {
     return await passwords.deletePassword(service, key);
   }
 

--- a/apps/desktop/src/platform/main/biometric/biometric.noop.main.ts
+++ b/apps/desktop/src/platform/main/biometric/biometric.noop.main.ts
@@ -9,7 +9,7 @@ export default class NoopBiometricsService implements OsBiometricService {
     return false;
   }
 
-  async getBiometricKey(
+  async getBiometricEncryptedData(
     service: string,
     storageKey: string,
     clientKeyHalfB64: string,
@@ -17,7 +17,7 @@ export default class NoopBiometricsService implements OsBiometricService {
     return null;
   }
 
-  async setBiometricKey(
+  async setBiometricEncryptedData(
     service: string,
     storageKey: string,
     value: string,
@@ -26,7 +26,7 @@ export default class NoopBiometricsService implements OsBiometricService {
     return;
   }
 
-  async deleteBiometricKey(service: string, key: string): Promise<void> {}
+  async deleteBiometricEncryptedData(service: string, key: string): Promise<void> {}
 
   async authenticateBiometric(): Promise<boolean> {
     throw new Error("Not supported on this platform");

--- a/apps/desktop/src/platform/main/biometric/biometric.windows.main.ts
+++ b/apps/desktop/src/platform/main/biometric/biometric.windows.main.ts
@@ -27,7 +27,7 @@ export default class BiometricWindowsMain implements OsBiometricService {
     return await biometrics.available();
   }
 
-  async getBiometricKey(
+  async getBiometricEncryptedData(
     service: string,
     storageKey: string,
     clientKeyHalfB64: string,
@@ -60,7 +60,7 @@ export default class BiometricWindowsMain implements OsBiometricService {
     }
   }
 
-  async setBiometricKey(
+  async setBiometricEncryptedData(
     service: string,
     storageKey: string,
     value: string,
@@ -89,7 +89,7 @@ export default class BiometricWindowsMain implements OsBiometricService {
     );
   }
 
-  async deleteBiometricKey(service: string, key: string): Promise<void> {
+  async deleteBiometricEncryptedData(service: string, key: string): Promise<void> {
     await passwords.deletePassword(service, key);
     await passwords.deletePassword(service, key + KEY_WITNESS_SUFFIX);
   }

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.abstraction.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.abstraction.ts
@@ -1,42 +1,85 @@
 export abstract class BiometricsServiceAbstraction {
+  /**
+   * Checks if the OS supports biometric authentication.
+   * @returns True if the OS supports biometric authentication, false otherwise.
+   */
   abstract osSupportsBiometric(): Promise<boolean>;
+  /**
+   * Checks to see if the user can authenticate using biometric authentication by ensuring that
+   * the OS supports biometric authentication and that the user has registered a client key half if configured.
+   * @param service The name of the service under which the client key half shoul be registered.
+   * @param storageKey The name with which the client key half shoul be registered.
+   * @param userId The `userID` for which the client key half should be registered.
+   * @returns True if the user can authenticate using biometric authentication, false otherwise.
+   */
   abstract canAuthBiometric({
     service,
-    key,
+    storageKey,
     userId,
   }: {
     service: string;
-    key: string;
+    storageKey: string;
     userId: string;
   }): Promise<boolean>;
+  /**
+   * Authenticates the user using biometric authentication.
+   * @returns True if the user was successfully authenticated, false otherwise.
+   */
   abstract authenticateBiometric(): Promise<boolean>;
-  abstract getBiometricKey(service: string, key: string): Promise<string | null>;
-  abstract setBiometricKey(service: string, key: string, value: string): Promise<void>;
+  /**
+   * Retrieves data from the platform's secure storage after decrypting with a biometrically-derived key.
+   * @param service The name of the service under which the key is registered.
+   * @param storageKey The name with which the key is stored in secure storage.
+   * @returns The decrypted data, or null if the data could not be retrieved.
+   */
+  abstract getBiometricEncryptedData(service: string, storageKey: string): Promise<string | null>;
+  /**
+   * Sets data in the platform's secure storage after encrypting with a biometrically-derived key.
+   * @param service The name of the service under which the data should be registered.
+   * @param storageKey The name with which the data is stored in secure storage.
+   * @param value The data to store.
+   */
+  abstract setBiometricEncryptedData(
+    service: string,
+    storageKey: string,
+    value: string,
+  ): Promise<void>;
+  /**
+   * Registers the client key half for encrypting and decrypting the data stored in `storageKey`. The other half is protected by the OS.
+   * @param service The name of the service under which the key should be registered.
+   * @param storageKey The name with which the data is stored in secure storage.
+   * @param value The client-side encryption key half to store.
+   */
   abstract setEncryptionKeyHalf({
     service,
-    key,
+    storageKey,
     value,
   }: {
     service: string;
-    key: string;
+    storageKey: string;
     value: string;
   }): void;
-  abstract deleteBiometricKey(service: string, key: string): Promise<void>;
+  /**
+   * Deletes the biometrically-protected data stored under `storageKey`.
+   * @param service The name of the service under which the key was registered.
+   * @param storageKey The name with which the key was stored in secure storage.
+   */
+  abstract deleteBiometricEncryptedData(service: string, storageKey: string): Promise<void>;
 }
 
 export interface OsBiometricService {
   osSupportsBiometric(): Promise<boolean>;
   authenticateBiometric(): Promise<boolean>;
-  getBiometricKey(
+  getBiometricEncryptedData(
     service: string,
-    key: string,
+    storageKey: string,
     clientKeyHalfB64: string | undefined,
   ): Promise<string | null>;
-  setBiometricKey(
+  setBiometricEncryptedData(
     service: string,
-    key: string,
+    storageKey: string,
     value: string,
     clientKeyHalfB64: string | undefined,
   ): Promise<void>;
-  deleteBiometricKey(service: string, key: string): Promise<void>;
+  deleteBiometricEncryptedData(service: string, storageKey: string): Promise<void>;
 }

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.spec.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.spec.ts
@@ -40,15 +40,15 @@ describe("biometrics tests", function () {
 
     const mockService = mock<OsBiometricService>();
     (sut as any).platformSpecificService = mockService;
-    await sut.setEncryptionKeyHalf({ service: "test", key: "test", value: "test" });
+    await sut.setEncryptionKeyHalf({ service: "test", storageKey: "test", value: "test" });
 
-    await sut.canAuthBiometric({ service: "test", key: "test", userId });
-    expect(mockService.osSupportsBiometric).toBeCalled();
+    await sut.canAuthBiometric({ service: "test", storageKey: "test", userId });
+    expect(mockService.osSupportsBiometric).toHaveBeenCalled();
 
     // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     sut.authenticateBiometric();
-    expect(mockService.authenticateBiometric).toBeCalled();
+    expect(mockService.authenticateBiometric).toHaveBeenCalled();
   });
 
   describe("Should create a platform specific service", function () {
@@ -104,7 +104,7 @@ describe("biometrics tests", function () {
     it("should return false if client key half is required and not provided", async () => {
       biometricStateService.getRequirePasswordOnStart.mockResolvedValue(true);
 
-      const result = await sut.canAuthBiometric({ service: "test", key: "test", userId });
+      const result = await sut.canAuthBiometric({ service: "test", storageKey: "test", userId });
 
       expect(result).toBe(false);
     });
@@ -112,17 +112,17 @@ describe("biometrics tests", function () {
     it("should call osSupportsBiometric if client key half is provided", async () => {
       // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      sut.setEncryptionKeyHalf({ service: "test", key: "test", value: "test" });
+      sut.setEncryptionKeyHalf({ service: "test", storageKey: "test", value: "test" });
 
-      await sut.canAuthBiometric({ service: "test", key: "test", userId });
-      expect(innerService.osSupportsBiometric).toBeCalled();
+      await sut.canAuthBiometric({ service: "test", storageKey: "test", userId });
+      expect(innerService.osSupportsBiometric).toHaveBeenCalled();
     });
 
     it("should call osSupportBiometric if client key half is not required", async () => {
       biometricStateService.getRequirePasswordOnStart.mockResolvedValue(false);
       innerService.osSupportsBiometric.mockResolvedValue(true);
 
-      const result = await sut.canAuthBiometric({ service: "test", key: "test", userId });
+      const result = await sut.canAuthBiometric({ service: "test", storageKey: "test", userId });
 
       expect(result).toBe(true);
       expect(innerService.osSupportsBiometric).toHaveBeenCalled();

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.ts
@@ -90,11 +90,11 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     return result;
   }
 
-  async getBiometricKey(service: string, storageKey: string): Promise<string | null> {
+  async getBiometricEncryptedData(service: string, storageKey: string): Promise<string | null> {
     return await this.interruptProcessReload(async () => {
       await this.enforceClientKeyHalf(service, storageKey);
 
-      return await this.platformSpecificService.getBiometricKey(
+      return await this.platformSpecificService.getBiometricEncryptedData(
         service,
         storageKey,
         this.getClientKeyHalf(service, storageKey),
@@ -102,10 +102,14 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     });
   }
 
-  async setBiometricKey(service: string, storageKey: string, value: string): Promise<void> {
+  async setBiometricEncryptedData(
+    service: string,
+    storageKey: string,
+    value: string,
+  ): Promise<void> {
     await this.enforceClientKeyHalf(service, storageKey);
 
-    return await this.platformSpecificService.setBiometricKey(
+    return await this.platformSpecificService.setBiometricEncryptedData(
       service,
       storageKey,
       value,
@@ -113,26 +117,25 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     );
   }
 
-  /** Registers the client-side encryption key half for the OS stored Biometric key. The other half is protected by the OS.*/
   async setEncryptionKeyHalf({
     service,
-    key,
+    storageKey,
     value,
   }: {
     service: string;
-    key: string;
+    storageKey: string;
     value: string;
   }): Promise<void> {
     if (value == null) {
-      this.clientKeyHalves.delete(this.clientKeyHalfKey(service, key));
+      this.clientKeyHalves.delete(this.clientKeyHalfKey(service, storageKey));
     } else {
-      this.clientKeyHalves.set(this.clientKeyHalfKey(service, key), value);
+      this.clientKeyHalves.set(this.clientKeyHalfKey(service, storageKey), value);
     }
   }
 
-  async deleteBiometricKey(service: string, storageKey: string): Promise<void> {
+  async deleteBiometricEncryptedData(service: string, storageKey: string): Promise<void> {
     this.clientKeyHalves.delete(this.clientKeyHalfKey(service, storageKey));
-    return await this.platformSpecificService.deleteBiometricKey(service, storageKey);
+    return await this.platformSpecificService.deleteBiometricEncryptedData(service, storageKey);
   }
 
   private async interruptProcessReload<T>(

--- a/apps/desktop/src/platform/main/biometric/biometrics.service.ts
+++ b/apps/desktop/src/platform/main/biometric/biometrics.service.ts
@@ -61,15 +61,15 @@ export class BiometricsService implements BiometricsServiceAbstraction {
 
   async canAuthBiometric({
     service,
-    key,
+    storageKey,
     userId,
   }: {
     service: string;
-    key: string;
+    storageKey: string;
     userId: UserId;
   }): Promise<boolean> {
     const requireClientKeyHalf = await this.biometricStateService.getRequirePasswordOnStart(userId);
-    const clientKeyHalfB64 = this.getClientKeyHalf(service, key);
+    const clientKeyHalfB64 = this.getClientKeyHalf(service, storageKey);
     const clientKeyHalfSatisfied = !requireClientKeyHalf || !!clientKeyHalfB64;
     return clientKeyHalfSatisfied && (await this.osSupportsBiometric());
   }
@@ -159,12 +159,12 @@ export class BiometricsService implements BiometricsServiceAbstraction {
     return response;
   }
 
-  private clientKeyHalfKey(service: string, key: string): string {
-    return `${service}:${key}`;
+  private clientKeyHalfKey(service: string, storageKey: string): string {
+    return `${service}:${storageKey}`;
   }
 
-  private getClientKeyHalf(service: string, key: string): string | undefined {
-    return this.clientKeyHalves.get(this.clientKeyHalfKey(service, key)) ?? undefined;
+  private getClientKeyHalf(service: string, storageKey: string): string | undefined {
+    return this.clientKeyHalves.get(this.clientKeyHalfKey(service, storageKey)) ?? undefined;
   }
 
   private async enforceClientKeyHalf(service: string, storageKey: string): Promise<void> {

--- a/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
+++ b/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
@@ -93,7 +93,7 @@ export class DesktopCredentialStorageListener {
   private async getPassword(serviceName: string, key: string, keySuffix: string) {
     let val: string;
     if (keySuffix === AuthRequiredSuffix) {
-      val = (await this.biometricService.getBiometricKey(serviceName, key)) ?? null;
+      val = (await this.biometricService.getBiometricEncryptedData(serviceName, key)) ?? null;
     } else {
       val = await passwords.getPassword(serviceName, key);
     }
@@ -112,11 +112,15 @@ export class DesktopCredentialStorageListener {
       const valueObj = JSON.parse(value) as BiometricKey;
       await this.biometricService.setEncryptionKeyHalf({
         service: serviceName,
-        key,
+        storageKey: key,
         value: valueObj?.clientEncKeyHalf,
       });
       // Value is usually a JSON string, but we need to pass the key half as well, so we re-stringify key here.
-      await this.biometricService.setBiometricKey(serviceName, key, JSON.stringify(valueObj?.key));
+      await this.biometricService.setBiometricEncryptedData(
+        serviceName,
+        key,
+        JSON.stringify(valueObj?.key),
+      );
     } else {
       await passwords.setPassword(serviceName, key, value);
     }
@@ -124,7 +128,7 @@ export class DesktopCredentialStorageListener {
 
   private async deletePassword(serviceName: string, key: string, keySuffix: string) {
     if (keySuffix === AuthRequiredSuffix) {
-      await this.biometricService.deleteBiometricKey(serviceName, key);
+      await this.biometricService.deleteBiometricEncryptedData(serviceName, key);
     } else {
       await passwords.deletePassword(serviceName, key);
     }

--- a/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
+++ b/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
@@ -72,7 +72,7 @@ export class DesktopCredentialStorageListener {
             }
             val = await this.biometricService.canAuthBiometric({
               service: serviceName,
-              key: message.key,
+              storageKey: message.key,
               userId: message.userId,
             });
             break;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9739

## 📔 Objective

The use of the word "key" in `getBiometricKey()` and in the input structure was confusing.  This PR addresses both.

- In `getBiometricKey()`, we are not retrieving the biometric key, but rather the user encryption key that has been protected with a biometric key (or partially in the case of a client key half).  As there is nothing specific about any of the methods that requires the data encrypted biometrically to be a user encryption key (that just happens to be the payload we're using it for), I opted for `getBiometricEncryptedData()` as the replacement method name.
- In addition, the use of the word `key` in the input structure for the methods used to store and retrieve the data was confusing - it meant "key" as in "key/value pair", not "encryption key".  It had been replaced at some places with `storageKey`, and I made this same change throughout.

This PR also adds documentation to the `BiometricServiceAbstraction` so that consumers of the service have more clarity on what the methods do.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
