### PR TITLE
[PM-9455] Back button fallback

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.html
@@ -1,11 +1,16 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="headerText" showBackButton> </popup-header>
+  <popup-header
+    slot="header"
+    [pageTitle]="headerText"
+    [backAction]="handleBackButton.bind(this)"
+    showBackButton
+  ></popup-header>
 
   <vault-cipher-form
     *ngIf="!loading"
     formId="cipherForm"
     [config]="config"
-    (cipherSaved)="onCipherSaved($event)"
+    (cipherSaved)="onCipherSaved()"
     [submitBtn]="submitBtn"
   >
     <app-open-attachments

--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -2,14 +2,13 @@ import { CommonModule, Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
-import { ActivatedRoute, Params } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 import { map, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { AsyncActionsModule, ButtonModule, SearchModule } from "@bitwarden/components";
 import {
   CipherFormConfig,
@@ -112,11 +111,29 @@ export class AddEditV2Component {
     private location: Location,
     private i18nService: I18nService,
     private addEditFormConfigService: CipherFormConfigService,
+    private router: Router,
   ) {
     this.subscribeToParams();
   }
 
-  onCipherSaved(savedCipher: CipherView) {
+  /**
+   * Navigates to previous view or view-cipher path
+   * depending on the history length.
+   *
+   * This can happen when history is lost due to the extension being
+   * forced into a popout window.
+   */
+  async handleBackButton() {
+    if (history.length === 1) {
+      await this.router.navigate(["/view-cipher"], {
+        queryParams: { cipherId: this.originalCipherId },
+      });
+    } else {
+      this.location.back();
+    }
+  }
+
+  onCipherSaved() {
     this.location.back();
   }
 

--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.html
@@ -1,5 +1,10 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="'attachments' | i18n" showBackButton>
+  <popup-header
+    slot="header"
+    [pageTitle]="'attachments' | i18n"
+    showBackButton
+    [backAction]="handleBackButton.bind(this)"
+  >
     <app-pop-out slot="end" />
   </popup-header>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.spec.ts
@@ -26,6 +26,7 @@ import { CipherAttachmentsComponent } from "./cipher-attachments/cipher-attachme
 })
 class MockPopupHeaderComponent {
   @Input() pageTitle: string;
+  @Input() backAction: () => void;
 }
 
 @Component({

--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/attachments-v2.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from "@angular/common";
+import { CommonModule, Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -41,11 +41,27 @@ export class AttachmentsV2Component {
   constructor(
     private router: Router,
     private cipherService: CipherService,
+    private location: Location,
     route: ActivatedRoute,
   ) {
     route.queryParams.pipe(takeUntilDestroyed(), first()).subscribe(({ cipherId }) => {
       this.cipherId = cipherId;
     });
+  }
+
+  /**
+   * Navigates to previous view or edit-cipher path
+   * depending on the history length.
+   *
+   * This can happen when history is lost due to the extension being
+   * forced into a popout window.
+   */
+  async handleBackButton() {
+    if (history.length === 1) {
+      await this.navigateToEditScreen();
+    } else {
+      this.location.back();
+    }
   }
 
   /** Navigate the user back to the edit screen after uploading an attachment */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9455](https://bitwarden.atlassian.net/browse/PM-9455)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The back button within the `PopupHeader` component strictly calls `location.back()`. An issue arises when the extension is forced into a popout window, in this case by the attachments component. When this occurs there is no browser history and thus the user is stuck.

Here I used the `backAction` input to conditionally check if there is a history to navigate to, otherwise navigate to the most probable route the user was on before.

❓ The way this is set up makes it so the logic has to implement this check all the way back to the `/vault` path. This makes sense but also feels kind of manual. Is there another way to hook back into the existing history? Otherwise it might just be the circumstance we're in. 

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/125900171/0330cfa6-0764-414b-a171-d54674d3eb93

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9455]: https://bitwarden.atlassian.net/browse/PM-9455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ