### PR TITLE
[PM-9593] Long Attachment Names

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/cipher-attachments/cipher-attachments.component.html
@@ -47,7 +47,13 @@
         (change)="onFileChange($event)"
       />
       <div class="tw-flex tw-gap-2 tw-items-center" aria-hidden="true">
-        <button bitButton buttonType="secondary" type="button" (click)="fileInput.click()">
+        <button
+          bitButton
+          buttonType="secondary"
+          type="button"
+          (click)="fileInput.click()"
+          class="tw-whitespace-nowrap"
+        >
           {{ "chooseFile" | i18n }}
         </button>
         <p bitTypography="body2" class="tw-text-muted tw-mb-0">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9593](https://bitwarden.atlassian.net/browse/PM-9593)

## 📔 Objective

For long attachment names, the width of the name was forcing the chose file button to wrap. Adding `white-space: nowrap` to keep minimum width of the button preserved.

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="383" alt="Screenshot 2024-07-08 at 10 18 00 PM" src="https://github.com/bitwarden/clients/assets/125900171/ca9f5b9f-4882-43e0-a1b0-904d44fe823d">|<img width="383" alt="Screenshot 2024-07-08 at 10 17 16 PM" src="https://github.com/bitwarden/clients/assets/125900171/f536c682-d221-49ab-a3d8-ddcde3ae4e79">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9593]: https://bitwarden.atlassian.net/browse/PM-9593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ