### PR TITLE
[PM-9600] [Defect] Update license dialog - Validation text is missing when submitting without file attachment

### DIFF
--- a/apps/web/src/app/billing/shared/update-license-dialog.component.ts
+++ b/apps/web/src/app/billing/shared/update-license-dialog.component.ts
@@ -29,11 +29,14 @@ export class UpdateLicenseDialogComponent extends UpdateLicenseComponent {
     super(apiService, i18nService, platformUtilsService, organizationApiService, formBuilder);
   }
   async submitLicense() {
-    await this.submit();
+    const result = await this.submit();
+    if (result === UpdateLicenseDialogResult.Updated) {
+      this.dialogRef.close(UpdateLicenseDialogResult.Updated);
+    }
   }
+
   submitLicenseDialog = async () => {
     await this.submitLicense();
-    this.dialogRef.close(UpdateLicenseDialogResult.Updated);
   };
 
   cancel = async () => {

--- a/apps/web/src/app/billing/shared/update-license.component.ts
+++ b/apps/web/src/app/billing/shared/update-license.component.ts
@@ -6,6 +6,8 @@ import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-conso
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
+import { UpdateLicenseDialogResult } from "./update-license-dialog.component";
+
 @Component({
   selector: "app-update-license",
   templateUrl: "update-license.component.html",
@@ -69,6 +71,7 @@ export class UpdateLicenseComponent {
       this.i18nService.t("licenseUploadSuccess"),
     );
     this.onUpdated.emit();
+    return new Promise((resolve) => resolve(UpdateLicenseDialogResult.Updated));
   };
 
   cancel = () => {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-9600
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Resolve the validation message that is not been displayed when there is no uploaded file
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" alt="Screenshot 2024-07-09 at 15 58 25" src="https://github.com/bitwarden/clients/assets/108260115/7e4a311c-77a0-4884-9f87-52a8539d4632">
<img width="1728" alt="Screenshot 2024-07-09 at 15 58 34" src="https://github.com/bitwarden/clients/assets/108260115/15509511-b618-42b0-aa0d-1f89bde89407">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
