### PR TITLE
[PM-9599] Filter out deleted ciphers in popup service

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -311,6 +311,19 @@ describe("VaultPopupItemsService", () => {
         done();
       });
     });
+
+    it("should return true when all ciphers are deleted", (done) => {
+      cipherServiceMock.getAllDecrypted.mockResolvedValue([
+        { id: "1", type: CipherType.Login, name: "Login 1", isDeleted: true },
+        { id: "2", type: CipherType.Login, name: "Login 2", isDeleted: true },
+        { id: "3", type: CipherType.Login, name: "Login 3", isDeleted: true },
+      ] as CipherView[]);
+
+      service.emptyVault$.subscribe((empty) => {
+        expect(empty).toBe(true);
+        done();
+      });
+    });
   });
 
   describe("noFilteredResults$", () => {

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -87,14 +87,16 @@ export class VaultPopupItemsService {
         map(([organizations, collections]) => {
           const orgMap = Object.fromEntries(organizations.map((org) => [org.id, org]));
           const collectionMap = Object.fromEntries(collections.map((col) => [col.id, col]));
-          return ciphers.map(
-            (cipher) =>
-              new PopupCipherView(
-                cipher,
-                cipher.collectionIds?.map((colId) => collectionMap[colId as CollectionId]),
-                orgMap[cipher.organizationId as OrganizationId],
-              ),
-          );
+          return ciphers
+            .filter((c) => !c.isDeleted)
+            .map(
+              (cipher) =>
+                new PopupCipherView(
+                  cipher,
+                  cipher.collectionIds?.map((colId) => collectionMap[colId as CollectionId]),
+                  orgMap[cipher.organizationId as OrganizationId],
+                ),
+            );
         }),
       ),
     ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9599](https://bitwarden.atlassian.net/browse/PM-9599)

## 📔 Objective

Filter out deleted ciphers from the cipher list that is provided to the vault filter service.

❓ Would deleted ciphers ever be needed? My current fix here would eliminate them from the lowest level, they would never be available. 

## 📸 Screenshots

|Before|After|
|-|-|
|![Screenshot 2024-07-09 at 10 43 47 AM](https://github.com/bitwarden/clients/assets/125900171/1750717c-370b-426e-93e0-1e7258af6355)|![Screenshot 2024-07-09 at 10 43 29 AM](https://github.com/bitwarden/clients/assets/125900171/78737800-23e5-4b43-9f18-ce31f4ab58b4)|


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9599]: https://bitwarden.atlassian.net/browse/PM-9599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ