### PR TITLE
[PM-9619] Fix broken vault upon saving empty URI

### DIFF
--- a/libs/common/src/vault/models/domain/login.ts
+++ b/libs/common/src/vault/models/domain/login.ts
@@ -69,6 +69,11 @@ export class Login extends Domain {
     if (this.uris != null) {
       view.uris = [];
       for (let i = 0; i < this.uris.length; i++) {
+        // If the uri is null, there is nothing to decrypt or validate
+        if (this.uris[i].uri == null) {
+          continue;
+        }
+
         const uri = await this.uris[i].decrypt(orgId, encKey);
         // URIs are shared remotely after decryption
         // we need to validate that the string hasn't been changed by a compromised server

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1374,7 +1374,7 @@ export class CipherService implements CipherServiceAbstraction {
 
         if (model.login.uris != null) {
           cipher.login.uris = [];
-          model.login.uris = model.login.uris.filter((u) => u.uri != null);
+          model.login.uris = model.login.uris.filter((u) => u.uri != null && u.uri !== "");
           for (let i = 0; i < model.login.uris.length; i++) {
             const loginUri = new LoginUri();
             loginUri.match = model.login.uris[i].match;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9619](https://bitwarden.atlassian.net/browse/PM-9619)

## 📔 Objective

Prevent saving empty string `""` login URIs. The cipher service originally saved a `null` value when the URI was an empty string which would then cause the checksum validation step to fail upon decryption.

Also, if an empty string / `null` value has already been saved add a null check to avoid trying to validate a checksum for a null value. We should simply treat the URI as if it does not exist and skip it. The next save of the cipher will clean up the null value due to the above change.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9619]: https://bitwarden.atlassian.net/browse/PM-9619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ