### PR TITLE
[PM-9601] [PM-9602] When collection management setting is turned on view only collections and assign to collections menu option show up

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -214,10 +214,12 @@ export class VaultItemsComponent {
 
     const organization = this.allOrganizations.find((o) => o.id === cipher.organizationId);
     return (
-      organization.canEditAllCiphers(
+      (organization.canEditAllCiphers(
         this.flexibleCollectionsV1Enabled,
         this.restrictProviderAccess,
-      ) || cipher.edit
+      ) &&
+        this.viewingOrgVault) ||
+      cipher.edit
     );
   }
 
@@ -290,10 +292,11 @@ export class VaultItemsComponent {
     const [orgId] = uniqueCipherOrgIds;
     const organization = this.allOrganizations.find((o) => o.id === orgId);
 
-    const canEditOrManageAllCiphers = organization?.canEditAllCiphers(
-      this.flexibleCollectionsV1Enabled,
-      this.restrictProviderAccess,
-    );
+    const canEditOrManageAllCiphers =
+      organization?.canEditAllCiphers(
+        this.flexibleCollectionsV1Enabled,
+        this.restrictProviderAccess,
+      ) && this.viewingOrgVault;
 
     const collectionNotSelected =
       this.selection.selected.filter((item) => item.collection).length === 0;

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -739,11 +739,8 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     if (orgId && orgId !== "MyVault") {
       const organization = this.allOrganizations.find((o) => o.id === orgId);
-      const flexibleCollectionsV1Enabled = await this.flexibleCollectionsV1Enabled();
       availableCollections = this.allCollections.filter(
-        (c) =>
-          c.organizationId === organization.id &&
-          c.canEditItems(organization, flexibleCollectionsV1Enabled, false),
+        (c) => c.organizationId === organization.id && !c.readOnly,
       );
     }
 

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -172,7 +172,7 @@ export class AssignCollectionsComponent implements OnInit {
       await this.handleOrganizationCiphers();
     }
 
-    this.setupFormSubscriptions(v1FCEnabled, restrictProviderAccess);
+    this.setupFormSubscriptions();
   }
 
   ngAfterViewInit(): void {
@@ -343,11 +343,8 @@ export class AssignCollectionsComponent implements OnInit {
 
   /**
    * Sets up form subscriptions for selected organizations.
-   *
-   * @param v1FCEnabled - Indicates if flexible collection flag is enabled.
-   * @param restrictProviderAccess - Indicates if provider access flag is enabled.
    */
-  private setupFormSubscriptions(v1FCEnabled: boolean, restrictProviderAccess: boolean) {
+  private setupFormSubscriptions() {
     // Listen to changes in selected organization and update collections
     this.formGroup.controls.selectedOrg.valueChanges
       .pipe(

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -355,11 +355,7 @@ export class AssignCollectionsComponent implements OnInit {
           this.formGroup.controls.collections.setValue([], { emitEvent: false });
         }),
         switchMap((orgId) => {
-          return this.getCollectionsForOrganization(
-            orgId as OrganizationId,
-            v1FCEnabled,
-            restrictProviderAccess,
-          );
+          return this.getCollectionsForOrganization(orgId as OrganizationId);
         }),
         takeUntil(this.destroy$),
       )
@@ -376,15 +372,9 @@ export class AssignCollectionsComponent implements OnInit {
   /**
    * Retrieves the collections for the organization with the given ID.
    * @param orgId
-   * @param v1FCEnabled
-   * @param restrictProviderAccess
    * @returns An observable of the collections for the organization.
    */
-  private getCollectionsForOrganization(
-    orgId: OrganizationId,
-    v1FCEnabled: boolean,
-    restrictProviderAccess: boolean,
-  ): Observable<CollectionView[]> {
+  private getCollectionsForOrganization(orgId: OrganizationId): Observable<CollectionView[]> {
     return combineLatest([
       this.collectionService.decryptedCollections$,
       this.organizationService.organizations$,
@@ -394,9 +384,7 @@ export class AssignCollectionsComponent implements OnInit {
         this.orgName = org.name;
 
         return collections.filter((c) => {
-          return (
-            c.organizationId === orgId && c.canEditItems(org, v1FCEnabled, restrictProviderAccess)
-          );
+          return c.organizationId === orgId && !c.readOnly;
         });
       }),
       shareReplay({ refCount: true, bufferSize: 1 }),


### PR DESCRIPTION
## 🎟️ Tracking
[PM-9601](https://bitwarden.atlassian.net/browse/PM-9601)
[PM-9602](https://bitwarden.atlassian.net/browse/PM-9602)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- `Assign to Collections` menu option should not show up on view-only items when the collection management setting is on
- View-only collections should not show up when assigning collections to an item when the collection management setting is on
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/bitwarden/clients/assets/13024008/d8c3d773-7772-4f1b-a44c-4409da423ff0


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9601]: https://bitwarden.atlassian.net/browse/PM-9601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-9602]: https://bitwarden.atlassian.net/browse/PM-9602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ