### PR TITLE
[PM-8225] Disable biometrics timeout check in development mode

### DIFF
--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -295,7 +295,11 @@ export class NativeMessagingBackground {
       );
     }
 
-    if (Math.abs(message.timestamp - Date.now()) > MessageValidTimeout) {
+    // Check to prevent replay of old messages. This is disabled in dev mode
+    if (
+      Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
+      !this.platformUtilsService.isDev()
+    ) {
       this.logService.error("NativeMessage is to old, ignoring.");
       return;
     }

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -300,7 +300,7 @@ export class NativeMessagingBackground {
       Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
       !this.platformUtilsService.isDev()
     ) {
-      this.logService.error("NativeMessage is to old, ignoring.");
+      this.logService.error("NativeMessage is too old, ignoring.");
       return;
     }
 

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -131,7 +131,11 @@ export class NativeMessagingService {
       return;
     }
 
-    if (Math.abs(message.timestamp - Date.now()) > MessageValidTimeout) {
+    // Check to prevent replay of old messages. This is disabled in dev mode
+    if (
+      Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
+      !this.platformUtilService.isDev()
+    ) {
       this.logService.error("NativeMessage is to old, ignoring.");
       return;
     }

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -136,7 +136,7 @@ export class NativeMessagingService {
       Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
       !this.platformUtilService.isDev()
     ) {
-      this.logService.error("NativeMessage is to old, ignoring.");
+      this.logService.error("NativeMessage is too old, ignoring.");
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8225

## 📔 Objective

Improves the debugging experience for biometrics ipc by disabling the age check on messages when in dev mode. Since this is limited to development mode it does not impact security.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
