### PR TITLE
[PM-9643] Add translation for Add account option in account switcher

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3636,5 +3636,8 @@
         "example": "Visa"
       }
     }
+  },
+  "addAccount": {
+    "message": "Add account"
   }
 }

--- a/apps/browser/src/auth/popup/account-switching/account.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account.component.html
@@ -49,6 +49,6 @@
 >
   <i class="bwi bwi-plus tw-text-2xl" aria-hidden="true"></i>
   <div>
-    {{ account.name }}
+    {{ account.name | i18n }}
   </div>
 </button>

--- a/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.ts
+++ b/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.ts
@@ -80,7 +80,7 @@ export class AccountSwitcherService {
 
         if (!hasMaxAccounts) {
           options.push({
-            name: "Add account",
+            name: "addAccount",
             id: this.SPECIAL_ADD_ACCOUNT_ID,
             isActive: false,
           });


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/10051

## 📔 Objective

As the PR title states, it will translate the omitted string in the account switch dialog