### PR TITLE
[PM-6188] Remove getbgservice call for vaulttimeoutservice

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -233,6 +233,9 @@ export default class RuntimeBackground {
       case "addToLockedVaultPendingNotifications":
         this.lockedVaultPendingNotifications.push(msg.data);
         break;
+      case "lockVault":
+        await this.main.vaultTimeoutService.lock(msg.userId);
+        break;
       case "logout":
         await this.main.logout(msg.expired, msg.userId);
         break;

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -55,6 +55,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { KeyGenerationService } from "@bitwarden/common/platform/abstractions/key-generation.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import {
@@ -109,6 +110,7 @@ import { ForegroundPlatformUtilsService } from "../../platform/services/platform
 import { BrowserStorageServiceProvider } from "../../platform/storage/browser-storage-service.provider";
 import { ForegroundMemoryStorageService } from "../../platform/storage/foreground-memory-storage.service";
 import { fromChromeRuntimeMessaging } from "../../platform/utils/from-chrome-runtime-messaging";
+import { ForegroundVaultTimeoutService } from "../../services/vault-timeout/foreground-vault-timeout.service";
 import { BrowserSendStateService } from "../../tools/popup/services/browser-send-state.service";
 import { FilePopoutUtilsService } from "../../tools/popup/services/file-popout-utils.service";
 import { Fido2UserVerificationService } from "../../vault/services/fido2-user-verification.service";
@@ -355,8 +357,8 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: VaultTimeoutService,
-    useFactory: getBgService<VaultTimeoutService>("vaultTimeoutService"),
-    deps: [],
+    useClass: ForegroundVaultTimeoutService,
+    deps: [MessagingServiceAbstraction],
   }),
   safeProvider({
     provide: NotificationsService,

--- a/apps/browser/src/services/vault-timeout/foreground-vault-timeout.service.ts
+++ b/apps/browser/src/services/vault-timeout/foreground-vault-timeout.service.ts
@@ -1,0 +1,18 @@
+import { VaultTimeoutService as BaseVaultTimeoutService } from "@bitwarden/common/src/abstractions/vault-timeout/vault-timeout.service";
+import { MessagingService } from "@bitwarden/common/src/platform/abstractions/messaging.service";
+import { UserId } from "@bitwarden/common/src/types/guid";
+
+export class ForegroundVaultTimeoutService implements BaseVaultTimeoutService {
+  constructor(protected messagingService: MessagingService) {}
+
+  // should only ever run in background
+  async checkVaultTimeout(): Promise<void> {}
+
+  async lock(userId?: UserId): Promise<void> {
+    this.messagingService.send("lockVault", { userId });
+  }
+
+  async logOut(userId?: string): Promise<void> {
+    this.messagingService.send("logout", { userId });
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6188

## 📔 Objective

> [!NOTE]  
> Follow-up to https://github.com/bitwarden/clients/pull/10050

This PR removes the shared reference to the background vaulttimeout service. While the vaulttimeout service only gets inited in the background serviceworker, we do need to watch for manual calls to logout and lock. These need to be passed through via ipc to the background instance, so this PR also introduces a foregroundvaulttimeoutservice that routes the calls to the background serviceworker via IPC.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
