### PR TITLE
[PM-5506] Enable electron fuses

### DIFF
--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -3,6 +3,8 @@ require("dotenv").config();
 const child_process = require("child_process");
 const path = require("path");
 
+const { flipFuses, FuseVersion, FuseV1Options } = require("@electron/fuses");
+const builder = require("electron-builder");
 const fse = require("fs-extra");
 
 exports.default = run;
@@ -10,6 +12,10 @@ exports.default = run;
 async function run(context) {
   console.log("## After pack");
   // console.log(context);
+
+  if (context.packager.platform.nodeName !== "darwin" || context.arch === builder.Arch.universal) {
+    await addElectronFuses(context);
+  }
 
   if (context.electronPlatformName === "linux") {
     console.log("Creating memory-protection wrapper script");
@@ -82,4 +88,57 @@ function getIdentities(csc_name) {
       const name = split.slice(2).join(" ").replace(/"/g, "");
       return { id, name };
     });
+}
+
+/**
+ * @param {import("electron-builder").AfterPackContext} context
+ */
+async function addElectronFuses(context) {
+  const platform = context.packager.platform.nodeName;
+
+  const ext = {
+    darwin: ".app",
+    win32: ".exe",
+    linux: "",
+  }[platform];
+
+  const IS_LINUX = platform === "linux";
+  const executableName = IS_LINUX
+    ? context.packager.appInfo.productFilename.toLowerCase().replace("-dev", "").replace(" ", "-")
+    : context.packager.appInfo.productFilename; // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
+
+  const electronBinaryPath = path.join(context.appOutDir, `${executableName}${ext}`);
+
+  console.log("## Adding fuses to the electron binary", electronBinaryPath);
+
+  await flipFuses(electronBinaryPath, {
+    version: FuseVersion.V1,
+    strictlyRequireAllFuses: true,
+    resetAdHocDarwinSignature: platform === "darwin" && context.arch === builder.Arch.universal,
+
+    // List of fuses and their default values is available at:
+    // https://www.electronjs.org/docs/latest/tutorial/fuses
+
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableCookieEncryption]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+
+    // Currently, asar integrity is only implemented for macOS and Windows
+    // https://www.electronjs.org/docs/latest/tutorial/asar-integrity
+    // On macOS, it works by default, but on Windows it requires the
+    // asarIntegrity feature of electron-builder v25, currently in alpha
+    // https://github.com/electron-userland/electron-builder/releases/tag/v25.0.0-alpha.10
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: platform === "darwin",
+
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
+
+    // App refuses to open when enabled
+    [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
+
+    // To disable this, we should stop using the file:// protocol to load the app bundle
+    // This can be done by defining a custom app:// protocol and loading the bundle from there,
+    // but then any requests to the server will be blocked by CORS policy
+    [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@angular/platform-browser": "16.2.12",
         "@angular/platform-browser-dynamic": "16.2.12",
         "@angular/router": "16.2.12",
+        "@electron/fuses": "1.8.0",
         "@koa/multer": "3.0.2",
         "@koa/router": "12.0.1",
         "@microsoft/signalr": "8.0.7",
@@ -5098,6 +5099,33 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/get": {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "@angular/platform-browser": "16.2.12",
     "@angular/platform-browser-dynamic": "16.2.12",
     "@angular/router": "16.2.12",
+    "@electron/fuses": "1.8.0",
     "@koa/multer": "3.0.2",
     "@koa/router": "12.0.1",
     "@microsoft/signalr": "8.0.7",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5506

## 📔 Objective

Enable the use of electron fuses to forbid the use of `ELECTRON_RUN_AS_NODE`.

While I was at it, I also enabled the r[est of the fuses](https://www.electronjs.org/docs/latest/tutorial/fuses):
- `EnableCookieEncyption`: I don't think we really use cookies for anything, but it doesn't cost anything to encrypt them anyway.
- `EnableNodeOptionsEnvironmentVariable`: Forbids the use of `NODE_OPTIONS` and `NODE_EXTRA_CA_CERTS`. Some people might use these to set some self signed CA, but other than that it seems safe to enable.
- `EnableNodeCliInspectArguments`: Disables the use of `--inspect`, the node debugging tool. Might make it harder to extract secrets from memory?
- `EnableEmbeddedAsarIntegrityValidation` and `OnlyLoadAppFromAsar`: Validates the integrity of the ASAR file and forbids loading an unpacked ASAR file. Don't see why anyone would want to unpack the ASAR and modify it, so this seems safe. Note that for the moment this is only implemented for Mac.
- `GrantFileProtocolExtraPrivileges`: ~~By default the `file://` protocol has special privileges that could be exploited. Disabling this by itself breaks the app as we use this protocol to read the app bundle. Instead I've created another privileged protocol that we control and where we can validate the requests. For now just some basic host and path traversal checks. This is similar to the changes we've had to make to disable `nodeIntegration`.~~ This is not disabled, as the protocol aproach introduces CORS errors in the server API requests.

Depends on #9894 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
