### PR TITLE
[PM-9707] [Boostrap] Fix avatar and customize placement

### DIFF
--- a/apps/web/src/app/auth/settings/account/profile.component.html
+++ b/apps/web/src/app/auth/settings/account/profile.component.html
@@ -19,8 +19,8 @@
       </bit-form-field>
     </div>
     <div class="tw-col-span-6">
-      <div class="tw-mb-3">
-        <dynamic-avatar text="{{ profile | userName }}" [id]="profile.id" [size]="'large'">
+      <div class="tw-mb-3 tw-flex tw-align-middle tw-items-center">
+        <dynamic-avatar text="{{ profile | userName }}" [id]="profile.id" size="large">
         </dynamic-avatar>
         <button
           class="tw-ml-3"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-9707

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We're in the process of removing bootstrap from our web vault. As part of this I've started to audit the areas that breaks in #8071.

The Avatar customize button appeared below the avatar after removing Boostrap. This resolves it by adding flex, it also has the added benefit of aligning the button vertically as it's currently slightly misaligned.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

|Before|After|
|--|--|
| ![image](https://github.com/user-attachments/assets/5cae2de8-3a62-44c6-b4ef-54a2667f4a36) | ![image](https://github.com/user-attachments/assets/abc72d55-3cd3-4bca-b384-e70bbac8761a) |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
