### PR TITLE
[PM-9710] [Bootstrap] Hide file inputs when not using bootstrap

### DIFF
--- a/apps/web/src/app/billing/individual/premium.component.html
+++ b/apps/web/src/app/billing/individual/premium.component.html
@@ -82,6 +82,7 @@
         formControlName="file"
         (change)="setSelectedFile($event)"
         hidden
+        class="tw-hidden"
       />
       <bit-hint>{{ "licenseFileDesc" | i18n: "bitwarden_premium_license.json" }}</bit-hint>
     </bit-form-field>

--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -19,12 +19,13 @@
       </div>
       <input
         #fileSelector
-        hidden
         bitInput
         type="file"
         formControlName="file"
         (change)="setSelectedFile($event)"
         accept="application/JSON"
+        hidden
+        class="tw-hidden"
       />
       <bit-hint>{{ "licenseFileDesc" | i18n: "bitwarden_organization_license.json" }}</bit-hint>
     </bit-form-field>

--- a/apps/web/src/app/billing/shared/update-license-dialog.component.html
+++ b/apps/web/src/app/billing/shared/update-license-dialog.component.html
@@ -16,6 +16,7 @@
           formControlName="file"
           (change)="setSelectedFile($event)"
           hidden
+          class="tw-hidden"
         />
         <bit-hint>{{ "licenseFileDesc" | i18n: "bitwarden_premium_license.json" }}</bit-hint>
       </bit-form-field>

--- a/apps/web/src/app/billing/shared/update-license.component.html
+++ b/apps/web/src/app/billing/shared/update-license.component.html
@@ -13,7 +13,7 @@
       type="file"
       formControlName="file"
       (change)="setSelectedFile($event)"
-      hidden
+      class="tw-hidden"
     />
     <bit-hint>{{
       "licenseFileDesc"

--- a/apps/web/src/app/tools/send/add-edit.component.html
+++ b/apps/web/src/app/tools/send/add-edit.component.html
@@ -76,12 +76,13 @@
             <input
               bitInput
               #fileSelector
-              hidden
               type="file"
               id="file"
               name="file"
               formControlName="file"
               (change)="setSelectedFile($event)"
+              hidden
+              class="tw-hidden"
             />
             <bit-hint>{{ "sendFileDesc" | i18n }} {{ "maxFileSize" | i18n }}</bit-hint>
           </bit-form-field>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
@@ -11,7 +11,6 @@
     </div>
     <input
       #fileSelector
-      hidden
       bitInput
       type="file"
       id="file"
@@ -19,6 +18,8 @@
       name="file"
       (change)="setSelectedFile($event)"
       accept="application/JSON"
+      hidden
+      class="tw-hidden"
     />
     <bit-hint>{{ "acceptedFormats" | i18n }} Bitwarden (json)</bit-hint>
   </bit-form-field>

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -382,6 +382,7 @@
         formControlName="file"
         (change)="setSelectedFile($event)"
         hidden
+        class="tw-hidden"
       />
     </bit-form-field>
     <bit-form-field>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-9710

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When removing boostrap it seems the `hidden` attribute to the file inputs stops working. This implements a "quick" fix by just adding the `tw-hidden` class.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
