### PR TITLE
[CL-239][CL-251][CL-342] dialog style refresh

### DIFF
--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -78,6 +78,7 @@ export default {
           useFactory: () => {
             return new I18nMockService({
               close: "Close",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -1,5 +1,5 @@
 <section
-  class="tw-flex tw-w-full tw-flex-col tw-self-center tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-background tw-text-main"
+  class="tw-flex tw-w-full tw-flex-col tw-self-center tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-secondary-300 tw-bg-background tw-text-main"
   [ngClass]="width"
   @fadeIn
 >
@@ -32,11 +32,12 @@
       <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
     </div>
     <div
-      class="tw-pb-8"
       [ngClass]="{
         'tw-p-4': !disablePadding,
         'tw-overflow-y-auto': !loading,
-        'tw-invisible tw-overflow-y-hidden': loading
+        'tw-invisible tw-overflow-y-hidden': loading,
+        'tw-bg-background': background === 'default',
+        'tw-bg-background-alt': background === 'alt'
       }"
     >
       <ng-content select="[bitDialogContent]"></ng-content>
@@ -44,7 +45,7 @@
   </div>
 
   <footer
-    class="tw-flex tw-flex-row tw-items-center tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background-alt tw-p-4"
+    class="tw-flex tw-flex-row tw-items-center tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-secondary-300 tw-bg-background tw-p-4"
   >
     <ng-content select="[bitDialogFooter]"></ng-content>
   </footer>

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -6,7 +6,12 @@
   <header
     class="tw-flex tw-justify-between tw-items-center tw-gap-4 tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300 tw-p-4"
   >
-    <h1 bitDialogTitleContainer bitTypography="h3" noMargin class="tw-mb-0 tw-truncate">
+    <h1
+      bitDialogTitleContainer
+      bitTypography="h3"
+      noMargin
+      class="tw-text-main tw-mb-0 tw-truncate"
+    >
       {{ title }}
       <span *ngIf="subtitle" class="tw-text-muted tw-font-normal tw-text-sm">
         {{ subtitle }}

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -29,12 +29,17 @@
     ></button>
   </header>
 
-  <div class="tw-relative tw-flex tw-flex-col tw-overflow-hidden">
+  <div
+    class="tw-relative tw-flex tw-flex-col tw-overflow-hidden"
+    [ngClass]="{
+      'tw-min-h-60': loading
+    }"
+  >
     <div
       *ngIf="loading"
       class="tw-absolute tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center"
     >
-      <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
+      <i class="bwi bwi-spinner bwi-spin bwi-lg" [attr.aria-label]="'loading' | i18n"></i>
     </div>
     <div
       [ngClass]="{

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -9,6 +9,10 @@ import { fadeIn } from "../animations";
   animations: [fadeIn],
 })
 export class DialogComponent {
+  /** Background color */
+  @Input()
+  background: "default" | "alt" = "default";
+
   /**
    * Dialog size, more complex dialogs should use large, otherwise default is fine.
    */

--- a/libs/components/src/dialog/dialog/dialog.mdx
+++ b/libs/components/src/dialog/dialog/dialog.mdx
@@ -4,6 +4,10 @@ import * as stories from "./dialog.stories";
 
 <Meta of={stories} />
 
+```ts
+import { DialogModule } from "@bitwarden/components";
+```
+
 # Dialog
 
 Dialogs are used throughout the app to help the user focus on a specific action. Use this dialog
@@ -71,3 +75,10 @@ loading state.
 Use tabs to separate related content within a dialog.
 
 <Story of={stories.TabContent} />
+
+## Background Color
+
+The `background` input can be set to `alt` to change the background color. This is useful for
+dialogs that contain multiple card sections.
+
+<Story of={stories.WithCards} />

--- a/libs/components/src/dialog/dialog/dialog.stories.ts
+++ b/libs/components/src/dialog/dialog/dialog.stories.ts
@@ -1,12 +1,18 @@
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { ButtonModule } from "../../button";
+import { CardComponent } from "../../card";
+import { FormFieldModule } from "../../form-field";
 import { IconButtonModule } from "../../icon-button";
+import { InputModule } from "../../input";
+import { SectionComponent, SectionHeaderComponent } from "../../section";
 import { SharedModule } from "../../shared";
 import { TabsModule } from "../../tabs";
+import { TypographyModule } from "../../typography";
 import { I18nMockService } from "../../utils/i18n-mock.service";
 import { DialogModule } from "../dialog.module";
 
@@ -24,6 +30,14 @@ export default {
         IconButtonModule,
         TabsModule,
         NoopAnimationsModule,
+        SectionComponent,
+        SectionHeaderComponent,
+        CardComponent,
+        TypographyModule,
+        FormsModule,
+        ReactiveFormsModule,
+        FormFieldModule,
+        InputModule,
       ],
       providers: [
         {
@@ -171,5 +185,81 @@ export const TabContent: Story = {
       storyDescription: `An example of using the \`bitTabGroup\` component within the Dialog. The content padding should be
       disabled (via \`disablePadding\`) so that the tabs are flush against the dialog title.`,
     },
+  },
+};
+
+export const WithCards: Story = {
+  render: (args: DialogComponent) => ({
+    props: {
+      formObj: new FormGroup({
+        name: new FormControl(""),
+      }),
+      ...args,
+    },
+    template: /*html*/ `
+      <form [formGroup]="formObj">
+      <bit-dialog background="alt" [dialogSize]="dialogSize" [title]="title" [subtitle]="subtitle" [loading]="loading" [disablePadding]="disablePadding">
+        <ng-container bitDialogContent>
+          <bit-section>
+            <bit-section-header>
+              <h2 bitTypography="h6">
+                Foo
+              </h2>
+              <button bitIconButton="bwi-star" size="small" slot="end"></button>
+            </bit-section-header>
+            <bit-card>
+              <bit-form-field>
+                <bit-label>Label</bit-label>
+                <input bitInput formControlName="name" />
+                <bit-hint>Optional Hint</bit-hint>
+              </bit-form-field>
+              <bit-form-field disableMargin>
+                <bit-label>Label</bit-label>
+                <input bitInput formControlName="name" />
+                <bit-hint>Optional Hint</bit-hint>
+              </bit-form-field>
+            </bit-card>
+          </bit-section>
+          <bit-section>
+            <bit-section-header>
+              <h2 bitTypography="h6">
+                Bar
+              </h2>
+              <button bitIconButton="bwi-star" size="small" slot="end"></button>
+            </bit-section-header>
+            <bit-card>
+              <bit-form-field>
+                <bit-label>Label</bit-label>
+                <input bitInput formControlName="name" />
+                <bit-hint>Optional Hint</bit-hint>
+              </bit-form-field>
+              <bit-form-field disableMargin>
+                <bit-label>Label</bit-label>
+                <input bitInput formControlName="name" />
+                <bit-hint>Optional Hint</bit-hint>
+              </bit-form-field>
+            </bit-card>
+          </bit-section>
+        </ng-container>
+        <ng-container bitDialogFooter>
+          <button bitButton buttonType="primary" [disabled]="loading">Save</button>
+          <button bitButton buttonType="secondary" [disabled]="loading">Cancel</button>
+          <button
+            [disabled]="loading"
+            class="tw-ml-auto"
+            bitIconButton="bwi-trash"
+            buttonType="danger"
+            size="default"
+            title="Delete"
+            aria-label="Delete"></button>
+        </ng-container>
+      </bit-dialog>
+  </form>
+    `,
+  }),
+  args: {
+    dialogSize: "default",
+    title: "Default",
+    subtitle: "Subtitle",
   },
 };

--- a/libs/components/src/dialog/dialog/dialog.stories.ts
+++ b/libs/components/src/dialog/dialog/dialog.stories.ts
@@ -45,6 +45,7 @@ export default {
           useFactory: () => {
             return new I18nMockService({
               close: "Close",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/dialog/dialog/dialog.stories.ts
+++ b/libs/components/src/dialog/dialog/dialog.stories.ts
@@ -4,6 +4,7 @@ import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
+import { BadgeModule } from "../../badge";
 import { ButtonModule } from "../../button";
 import { CardComponent } from "../../card";
 import { FormFieldModule } from "../../form-field";
@@ -25,6 +26,7 @@ export default {
     moduleMetadata({
       imports: [
         DialogModule,
+        BadgeModule,
         ButtonModule,
         SharedModule,
         IconButtonModule,
@@ -78,6 +80,9 @@ export const Default: Story = {
     props: args,
     template: `
       <bit-dialog [dialogSize]="dialogSize" [title]="title" [subtitle]="subtitle" [loading]="loading" [disablePadding]="disablePadding">
+        <ng-container bitDialogTitle>
+          <span bitBadge variant="success">Foobar</span>
+        </ng-container>
         <ng-container bitDialogContent>Dialog body text goes here.</ng-container>
         <ng-container bitDialogFooter>
           <button bitButton buttonType="primary" [disabled]="loading">Save</button>

--- a/libs/components/src/dialog/dialogs.mdx
+++ b/libs/components/src/dialog/dialogs.mdx
@@ -2,6 +2,10 @@ import { Meta, Story, Source } from "@storybook/addon-docs";
 
 <Meta title="Component Library/Dialogs" />
 
+```ts
+import { DialogModule } from "@bitwarden/components";
+```
+
 # Dialog
 
 Dialogs are used throughout the app to help the user focus on a specific action.

--- a/libs/components/src/dialog/simple-dialog/simple-configurable-dialog/simple-configurable-dialog.service.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-configurable-dialog/simple-configurable-dialog.service.stories.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -144,7 +145,7 @@ export default {
   component: StoryDialogComponent,
   decorators: [
     moduleMetadata({
-      imports: [ButtonModule, DialogModule, CalloutModule],
+      imports: [ButtonModule, BrowserAnimationsModule, DialogModule, CalloutModule],
     }),
     applicationConfig({
       providers: [

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -1,5 +1,5 @@
 <div
-  class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
+  class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
   @fadeIn
 >
   <div class="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-px-4 tw-pt-4 tw-text-center">
@@ -9,11 +9,11 @@
     <ng-template #elseBlock>
       <i class="bwi bwi-exclamation-triangle tw-text-3xl tw-text-warning" aria-hidden="true"></i>
     </ng-template>
-    <h1 bitDialogTitleContainer class="tw-mb-0 tw-text-base tw-font-semibold">
+    <h1 bitDialogTitleContainer bitTypography="h3" noMargin>
       <ng-content select="[bitDialogTitle]"></ng-content>
     </h1>
   </div>
-  <div class="tw-overflow-y-auto tw-px-4 tw-pb-4 tw-pt-2 tw-text-center tw-text-base">
+  <div class="tw-overflow-y-auto tw-px-4 tw-pb-4 tw-text-center tw-text-base">
     <ng-content select="[bitDialogContent]"></ng-content>
   </div>
   <div

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -13,7 +13,7 @@
       bitDialogTitleContainer
       bitTypography="h3"
       noMargin
-      class="tw-w-full tw-break-words tw-hyphens-auto"
+      class="tw-w-full tw-text-main tw-break-words tw-hyphens-auto"
     >
       <ng-content select="[bitDialogTitle]"></ng-content>
     </h1>

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -1,5 +1,5 @@
 <div
-  class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
+  class="tw-my-4 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded-3xl tw-border tw-border-solid tw-border-secondary-300 tw-bg-text-contrast tw-text-main"
   @fadeIn
 >
   <div class="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-px-4 tw-pt-4 tw-text-center">

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -9,11 +9,18 @@
     <ng-template #elseBlock>
       <i class="bwi bwi-exclamation-triangle tw-text-3xl tw-text-warning" aria-hidden="true"></i>
     </ng-template>
-    <h1 bitDialogTitleContainer bitTypography="h3" noMargin>
+    <h1
+      bitDialogTitleContainer
+      bitTypography="h3"
+      noMargin
+      class="tw-w-full tw-break-words tw-hyphens-auto"
+    >
       <ng-content select="[bitDialogTitle]"></ng-content>
     </h1>
   </div>
-  <div class="tw-overflow-y-auto tw-px-4 tw-pb-4 tw-text-center tw-text-base">
+  <div
+    class="tw-overflow-y-auto tw-px-4 tw-pb-4 tw-text-center tw-text-base tw-break-words tw-hyphens-auto"
+  >
     <ng-content select="[bitDialogContent]"></ng-content>
   </div>
   <div

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.mdx
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.mdx
@@ -4,6 +4,10 @@ import * as stories from "./simple-dialog.stories";
 
 <Meta of={stories} />
 
+```ts
+import { DialogModule } from "@bitwarden/components";
+```
+
 # Simple Dialogs
 
 Simple Dialogs are used throughout the app for simple alert or confirmation actions such as

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.service.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.service.stories.ts
@@ -1,5 +1,6 @@
-import { DialogModule, DialogRef, DIALOG_DATA } from "@angular/cdk/dialog";
+import { DialogRef, DIALOG_DATA } from "@angular/cdk/dialog";
 import { Component, Inject } from "@angular/core";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -8,11 +9,8 @@ import { ButtonModule } from "../../button";
 import { IconButtonModule } from "../../icon-button";
 import { SharedModule } from "../../shared/shared.module";
 import { I18nMockService } from "../../utils/i18n-mock.service";
+import { DialogModule } from "../dialog.module";
 import { DialogService } from "../dialog.service";
-import { DialogCloseDirective } from "../directives/dialog-close.directive";
-import { DialogTitleContainerDirective } from "../directives/dialog-title-container.directive";
-
-import { SimpleDialogComponent } from "./simple-dialog.component";
 
 interface Animal {
   animal: string;
@@ -65,13 +63,14 @@ export default {
   component: StoryDialogComponent,
   decorators: [
     moduleMetadata({
-      declarations: [
-        StoryDialogContentComponent,
-        DialogCloseDirective,
-        DialogTitleContainerDirective,
-        SimpleDialogComponent,
+      declarations: [StoryDialogContentComponent],
+      imports: [
+        SharedModule,
+        IconButtonModule,
+        ButtonModule,
+        BrowserAnimationsModule,
+        DialogModule,
       ],
-      imports: [SharedModule, IconButtonModule, ButtonModule, DialogModule],
       providers: [
         DialogService,
         {

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
@@ -1,17 +1,17 @@
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
 import { ButtonModule } from "../../button";
-import { DialogTitleContainerDirective } from "../directives/dialog-title-container.directive";
+import { DialogModule } from "../dialog.module";
 
-import { IconDirective, SimpleDialogComponent } from "./simple-dialog.component";
+import { SimpleDialogComponent } from "./simple-dialog.component";
 
 export default {
   title: "Component Library/Dialogs/Simple Dialog",
   component: SimpleDialogComponent,
   decorators: [
     moduleMetadata({
-      imports: [ButtonModule],
-      declarations: [IconDirective, DialogTitleContainerDirective],
+      imports: [ButtonModule, NoopAnimationsModule, DialogModule],
     }),
   ],
   parameters: {

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
@@ -82,3 +82,19 @@ export const ScrollingContent: Story = {
     useDefaultIcon: true,
   },
 };
+
+export const TextOverlow: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <bit-simple-dialog>
+        <span bitDialogTitle>Alert Dialogdialogdialogdialogdialogdialogdialogdialogdialogdialogdialogdialogdialog</span>
+        <span bitDialogContent>Message Contentcontentcontentcontentcontentcontentcontentcontentcontentcontentcontent</span>
+        <ng-container bitDialogFooter>
+          <button bitButton buttonType="primary">Yes</button>
+          <button bitButton buttonType="secondary">No</button>
+        </ng-container>
+      </bit-simple-dialog>
+    `,
+  }),
+};

--- a/libs/components/src/typography/typography.directive.ts
+++ b/libs/components/src/typography/typography.directive.ts
@@ -4,15 +4,15 @@ import { Directive, HostBinding, Input } from "@angular/core";
 type TypographyType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body1" | "body2" | "helper";
 
 const styles: Record<TypographyType, string[]> = {
-  h1: ["tw-text-3xl", "tw-font-semibold", "tw-text-headers"],
-  h2: ["tw-text-2xl", "tw-font-semibold", "tw-text-headers"],
-  h3: ["tw-text-xl", "tw-font-semibold", "tw-text-headers"],
-  h4: ["tw-text-lg", "tw-font-semibold", "tw-text-headers"],
-  h5: ["tw-text-base", "tw-font-bold", "tw-text-headers"],
-  h6: ["tw-text-sm", "tw-font-bold", "tw-text-headers"],
-  body1: ["tw-text-base"],
-  body2: ["tw-text-sm"],
-  helper: ["tw-text-xs"],
+  h1: ["!tw-text-3xl", "tw-font-semibold", "tw-text-headers"],
+  h2: ["!tw-text-2xl", "tw-font-semibold", "tw-text-headers"],
+  h3: ["!tw-text-xl", "tw-font-semibold", "tw-text-headers"],
+  h4: ["!tw-text-lg", "tw-font-semibold", "tw-text-headers"],
+  h5: ["!tw-text-base", "tw-font-bold", "tw-text-headers"],
+  h6: ["!tw-text-sm", "tw-font-bold", "tw-text-headers"],
+  body1: ["!tw-text-base"],
+  body2: ["!tw-text-sm"],
+  helper: ["!tw-text-xs"],
 };
 
 const margins: Record<TypographyType, string[]> = {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-251

## 📔 Objective

- Update dialog and simple dialog styles for extension refresh
- add `background` input to dialog to change the bg color
- Add import block to docs. 
- Fix simple dialog text overflow bug

## 📸 Screenshots

See Storybook for more.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/4d06818d-b162-4860-a44d-be8343d1fecd">

<img width="508" alt="image" src="https://github.com/user-attachments/assets/2bbf439f-c59c-4063-acaf-39d5f573c786">

<img width="508" alt="image" src="https://github.com/user-attachments/assets/23680953-b905-475a-9c0d-cfd86b53a79e">

<img width="353" alt="image" src="https://github.com/user-attachments/assets/95dc8828-83c8-4d0a-9351-296a4accecf0">

<img width="357" alt="image" src="https://github.com/user-attachments/assets/39e6db38-8c6d-4fd7-912a-6681130269eb">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
