### PR TITLE
[PM-9629] Custom Fields V2 View Section Defects

### DIFF
--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -4,9 +4,9 @@
   </bit-section-header>
   <bit-card>
     <div
-      class="tw-border-secondary-300 tw-bg-background"
+      class="tw-border-secondary-300"
       *ngFor="let field of fields; let last = last"
-      [ngClass]="{ 'tw-border-0 tw-border-b tw-border-solid tw-mb-4': !last }"
+      [ngClass]="{ 'tw-mb-4': !last }"
     >
       <ng-container *ngIf="field.type === fieldType.Text">
         <label class="tw-text-xs tw-text-muted tw-select-none">
@@ -16,7 +16,7 @@
           <input readonly bitInput type="text" [value]="field.value" aria-readonly="true" />
           <button
             bitIconButton="bwi-clone"
-            size="small"
+            bitSuffix
             type="button"
             [appCopyClick]="field.value"
             showToast
@@ -30,10 +30,10 @@
         </label>
         <bit-form-field>
           <input readonly bitInput type="password" [value]="field.value" aria-readonly="true" />
-          <button type="button" bitIconButton bitPasswordInputToggle></button>
+          <button bitSuffix type="button" bitIconButton bitPasswordInputToggle></button>
           <button
             bitIconButton="bwi-clone"
-            size="small"
+            bitSuffix
             type="button"
             [appCopyClick]="field.value"
             showToast
@@ -67,7 +67,7 @@
           />
           <button
             bitIconButton="bwi-clone"
-            size="small"
+            bitSuffix
             type="button"
             [appCopyClick]="field.name"
             showToast

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -4,15 +4,15 @@
   </bit-section-header>
   <bit-card>
     <div
-      class="tw-mb-4 tw-border-secondary-300 tw-bg-background"
+      class="tw-border-secondary-300 tw-bg-background"
       *ngFor="let field of fields; let last = last"
-      [ngClass]="{ 'tw-border-0 tw-border-b tw-border-solid tw-pb-2 tw-mb-4': !last }"
+      [ngClass]="{ 'tw-border-0 tw-border-b tw-border-solid tw-mb-4': !last }"
     >
       <ng-container *ngIf="field.type === fieldType.Text">
         <label class="tw-text-xs tw-text-muted tw-select-none">
           {{ field.name }}
         </label>
-        <div class="tw-flex tw-justify-between">
+        <bit-form-field>
           <input readonly bitInput type="text" [value]="field.value" aria-readonly="true" />
           <button
             bitIconButton="bwi-clone"
@@ -22,7 +22,7 @@
             showToast
             [appA11yTitle]="'copyValue' | i18n"
           ></button>
-        </div>
+        </bit-form-field>
       </ng-container>
       <ng-container *ngIf="field.type === fieldType.Hidden">
         <label class="tw-text-xs tw-text-muted tw-select-none">
@@ -42,18 +42,22 @@
         </bit-form-field>
       </ng-container>
       <ng-container *ngIf="field.type === fieldType.Boolean">
-        <div class="tw-flex tw-my-2">
-          <input type="checkbox" [value]="field.value" readonly aria-readonly="true" />
-          <h5 class="tw-ml-3">
-            {{ field.name }}
-          </h5>
-        </div>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            type="checkbox"
+            [checked]="field.value"
+            aria-readonly="true"
+            disabled
+          />
+          <bit-label> {{ field.name }} </bit-label>
+        </bit-form-control>
       </ng-container>
       <ng-container *ngIf="field.type === fieldType.Linked">
         <label class="tw-text-xs tw-text-muted tw-select-none">
           {{ "linked" | i18n }}: {{ field.name }}
         </label>
-        <div class="tw-flex tw-justify-between">
+        <bit-form-field>
           <input
             readonly
             bitInput
@@ -69,7 +73,7 @@
             showToast
             [appA11yTitle]="'copyValue' | i18n"
           ></button>
-        </div>
+        </bit-form-field>
       </ng-container>
     </div>
   </bit-card>

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
@@ -13,6 +13,7 @@ import {
   SectionComponent,
   SectionHeaderComponent,
   TypographyModule,
+  CheckboxModule,
 } from "@bitwarden/components";
 
 @Component({
@@ -29,6 +30,7 @@ import {
     SectionComponent,
     SectionHeaderComponent,
     TypographyModule,
+    CheckboxModule,
   ],
 })
 export class CustomFieldV2Component {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9629 Checkbox Should Reflect Value](https://bitwarden.atlassian.net/browse/PM-9629)
[PM-9630 Formatting of Custom Fields Spacing](https://bitwarden.atlassian.net/browse/PM-9630)

## 📔 Objective

Updated elements and classes in `custom-fields-v2` to use CL components
Updated checkbox to reflect the proper value of the field
Disabled checkbox

## 📸 Screenshots

![Screenshot 2024-07-12 at 5 26 48 PM](https://github.com/user-attachments/assets/efbfa157-fc6a-4124-aec4-5cbda6a55287)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
