### PR TITLE
[PM9632] added MP reprompt check to edit button in view-v2

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -102,7 +102,20 @@ export class ViewV2Component {
     return await cipher.decrypt(await this.cipherService.getKeyForCipherKeyDecryption(cipher));
   }
 
-  editCipher() {
+  async checkForPasswordReprompt() {
+    this.passwordReprompted =
+      this.passwordReprompted ||
+      (await this.passwordRepromptService.passwordRepromptCheck(this.cipher));
+    if (!this.passwordReprompted) {
+      return false;
+    }
+    return true;
+  }
+
+  async editCipher() {
+    if (!(await this.checkForPasswordReprompt())) {
+      return;
+    }
     if (this.cipher.isDeleted) {
       return false;
     }
@@ -113,10 +126,7 @@ export class ViewV2Component {
   }
 
   delete = async (): Promise<boolean> => {
-    this.passwordReprompted =
-      this.passwordReprompted ||
-      (await this.passwordRepromptService.passwordRepromptCheck(this.cipher));
-    if (!this.passwordReprompted) {
+    if (!(await this.checkForPasswordReprompt())) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9632](https://bitwarden.atlassian.net/browse/PM-9632)

## 📔 Objective

created a method `checkForPasswordReprompt` for the password reprompt logic. Will be used in both the edit and delete methods. 

## 📸 Screen Recording

https://github.com/user-attachments/assets/acb08627-e66d-48d9-9ab9-144b5d0c7abb

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9632]: https://bitwarden.atlassian.net/browse/PM-9632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ