### PR TITLE
[PM-6838] Fix wrong minlength message on ChangePasswordComponent

### DIFF
--- a/libs/angular/src/auth/components/change-password.component.ts
+++ b/libs/angular/src/auth/components/change-password.component.ts
@@ -62,6 +62,10 @@ export class ChangePasswordComponent implements OnInit, OnDestroy {
         (enforcedPasswordPolicyOptions) =>
           (this.enforcedPolicyOptions ??= enforcedPasswordPolicyOptions),
       );
+
+    if (this.enforcedPolicyOptions?.minLength) {
+      this.minimumLength = this.enforcedPolicyOptions.minLength;
+    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6838

## 📔 Objective

Ensures that when changing the master password, the minimum length message under the master password input matches the minimum length required by an enforced MP length policy, if present.

If no policy is present, the message will default to 12.

## 📸 Screenshots

| Old | New |
| ------------- | ------------- |
| ![Screenshot 2024-07-12 at 12 35 30 PM](https://github.com/user-attachments/assets/70279491-1620-47da-aa99-14cd426ae383) | ![Screenshot 2024-07-12 at 12 23 38 PM](https://github.com/user-attachments/assets/597ea15d-894c-49e9-a72f-19b299d46571)  |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
