### PR TITLE
[PM-8526] Set secureNote type when creating a new note

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -16,7 +16,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherType, SecureNoteType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   AsyncActionsModule,
@@ -185,6 +185,10 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
       this.updatedCipherView = Object.assign(this.updatedCipherView, this.originalCipherView);
     } else {
       this.updatedCipherView.type = this.config.cipherType;
+
+      if (this.config.cipherType === CipherType.SecureNote) {
+        this.updatedCipherView.secureNote.type = SecureNoteType.Generic;
+      }
     }
 
     this.loading = false;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8526](https://bitwarden.atlassian.net/browse/PM-8526)

## 📔 Objective

Fix saving new Note cipher types. The `SecureNoteView` does not automatically set the `type` property (even though there is only 1 option?) so the `CipherFormComponent` now does so explicitly when creating new Note items.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8526]: https://bitwarden.atlassian.net/browse/PM-8526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ