### PR TITLE
[PM-4311] Populate the collection's external id when importing

### DIFF
--- a/libs/common/src/vault/models/domain/collection.ts
+++ b/libs/common/src/vault/models/domain/collection.ts
@@ -31,7 +31,7 @@ export class Collection extends Domain {
         hidePasswords: null,
         manage: null,
       },
-      ["id", "organizationId", "externalId", "readOnly", "hidePasswords", "manage"],
+      ["id", "organizationId", "readOnly", "hidePasswords", "manage"],
     );
   }
 

--- a/libs/common/src/vault/services/collection.service.ts
+++ b/libs/common/src/vault/services/collection.service.ts
@@ -100,6 +100,7 @@ export class CollectionService implements CollectionServiceAbstraction {
     collection.id = model.id;
     collection.organizationId = model.organizationId;
     collection.readOnly = model.readOnly;
+    collection.externalId = model.externalId;
     collection.name = await this.cryptoService.encrypt(model.name, key);
     return collection;
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-4311
## 📔 Objective

This will allow external id from collections to be correctly imported into the vault. We already export it but it is not imported.

- **domain/collection.ts:** Removed "externalId" from not include list
- **collection.service.ts:** Setting the externalId data on the encrypt method

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
