### PR TITLE
Make biometrics ipc more type-safe by adding enums and command classes

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -9,7 +9,7 @@ import {
   AuthRequestService,
   LoginEmailServiceAbstraction,
   LogoutReason,
-  BiometricUnlockResponse,
+  BiometricUnlockResponses,
   BiometricProvideUserKeyCommand,
 } from "@bitwarden/auth/common";
 import { ApiService as ApiServiceAbstraction } from "@bitwarden/common/abstractions/api.service";
@@ -1494,7 +1494,7 @@ export default class MainBackground {
     const responsePromise = this.nativeMessagingBackground.getResponse();
     await this.nativeMessagingBackground.send({ command: "biometricUnlock" });
     const response = await responsePromise;
-    return response.response === BiometricUnlockResponse.UNLOCKED;
+    return response.response === BiometricUnlockResponses.UNLOCKED;
   }
 
   private async fullSync(override = false) {

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -295,7 +295,11 @@ export class NativeMessagingBackground {
       );
     }
 
-    if (Math.abs(message.timestamp - Date.now()) > MessageValidTimeout) {
+    // Check to prevent replay of old messages. This is disabled in dev mode
+    if (
+      Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
+      !this.platformUtilsService.isDev()
+    ) {
       this.logService.error("NativeMessage is to old, ignoring.");
       return;
     }

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -300,7 +300,7 @@ export class NativeMessagingBackground {
       Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
       !this.platformUtilsService.isDev()
     ) {
-      this.logService.error("NativeMessage is to old, ignoring.");
+      this.logService.error("NativeMessage is too old, ignoring.");
       return;
     }
 

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -1,8 +1,8 @@
 import { firstValueFrom } from "rxjs";
 
 import {
-  NativeMessageCommandType,
-  BiometricUnlockResponse,
+  NativeMessageCommandTypes,
+  BiometricUnlockResponses,
   BiometricCommandSetupEncryption,
 } from "@bitwarden/auth/common";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -133,7 +133,7 @@ export class NativeMessagingBackground {
             this.connected = false;
             this.port.disconnect();
             break;
-          case NativeMessageCommandType.SETUP_ENCRYPTION: {
+          case NativeMessageCommandTypes.SETUP_ENCRYPTION: {
             // Ignore since it belongs to another device
             if (message.appId !== this.appId) {
               return;
@@ -154,7 +154,7 @@ export class NativeMessagingBackground {
             this.secureSetupResolve();
             break;
           }
-          case NativeMessageCommandType.INVALIDATE_ENCRYPTION:
+          case NativeMessageCommandTypes.INVALIDATE_ENCRYPTION:
             // Ignore since it belongs to another device
             if (message.appId !== this.appId) {
               return;
@@ -177,7 +177,7 @@ export class NativeMessagingBackground {
             }
 
             break;
-          case NativeMessageCommandType.VERIFY_FINGERPRINT: {
+          case NativeMessageCommandTypes.VERIFY_FINGERPRINT: {
             if (this.sharedSecret == null) {
               this.validatingFingerprint = true;
               // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
@@ -186,7 +186,7 @@ export class NativeMessagingBackground {
             }
             break;
           }
-          case NativeMessageCommandType.WRONG_USER:
+          case NativeMessageCommandTypes.WRONG_USER:
             this.showWrongUserDialog();
             break;
           default:
@@ -310,8 +310,8 @@ export class NativeMessagingBackground {
     }
 
     switch (message.command) {
-      case NativeMessageCommandType.BIOMETRIC_UNLOCK: {
-        if (message.response === BiometricUnlockResponse.NOT_ENABLED) {
+      case NativeMessageCommandTypes.BIOMETRIC_UNLOCK: {
+        if (message.response === BiometricUnlockResponses.NOT_ENABLED) {
           this.messagingService.send("showDialog", {
             title: { key: "biometricsNotEnabledTitle" },
             content: { key: "biometricsNotEnabledDesc" },
@@ -320,7 +320,7 @@ export class NativeMessagingBackground {
             type: "warning",
           });
           break;
-        } else if (message.response === BiometricUnlockResponse.NOT_SUPPORTED) {
+        } else if (message.response === BiometricUnlockResponses.NOT_SUPPORTED) {
           this.messagingService.send("showDialog", {
             title: { key: "biometricsNotSupportedTitle" },
             content: { key: "biometricsNotSupportedDesc" },
@@ -329,7 +329,7 @@ export class NativeMessagingBackground {
             type: "warning",
           });
           break;
-        } else if (message.response === BiometricUnlockResponse.NO_USER_ID) {
+        } else if (message.response === BiometricUnlockResponses.NO_USER_ID) {
           this.messagingService.send("showDialog", {
             title: { key: "biometricsNoUserIdTitle" },
             content: { key: "biometricsNoUserIdDesc" },
@@ -338,7 +338,7 @@ export class NativeMessagingBackground {
             type: "warning",
           });
           break;
-        } else if (message.response === BiometricUnlockResponse.NO_USER) {
+        } else if (message.response === BiometricUnlockResponses.NO_USER) {
           this.messagingService.send("showDialog", {
             title: { key: "biometricsNoUserTitle" },
             content: { key: "biometricsNoUserDesc" },
@@ -347,7 +347,7 @@ export class NativeMessagingBackground {
             type: "warning",
           });
           break;
-        } else if (message.response === BiometricUnlockResponse.NO_CLIENT_KEY_HALF) {
+        } else if (message.response === BiometricUnlockResponses.NO_CLIENT_KEY_HALF) {
           this.messagingService.send("showDialog", {
             title: { key: "biometricsNoClientKeyHalfTitle" },
             content: { key: "biometricsNoClientKeyHalfDesc" },
@@ -356,14 +356,14 @@ export class NativeMessagingBackground {
             type: "warning",
           });
           break;
-        } else if (message.response === BiometricUnlockResponse.CANCELED) {
+        } else if (message.response === BiometricUnlockResponses.CANCELED) {
           break;
         }
 
         // Check for initial setup of biometric unlock
         const enabled = await firstValueFrom(this.biometricStateService.biometricUnlockEnabled$);
         if (enabled === null || enabled === false) {
-          if (message.response === BiometricUnlockResponse.UNLOCKED) {
+          if (message.response === BiometricUnlockResponses.UNLOCKED) {
             await this.biometricStateService.setBiometricUnlockEnabled(true);
           }
           break;
@@ -374,7 +374,7 @@ export class NativeMessagingBackground {
           break;
         }
 
-        if (message.response === BiometricUnlockResponse.UNLOCKED) {
+        if (message.response === BiometricUnlockResponses.UNLOCKED) {
           try {
             if (message.userKeyB64) {
               const userKey = new SymmetricCryptoKey(

--- a/apps/desktop/src/models/native-messaging/index.ts
+++ b/apps/desktop/src/models/native-messaging/index.ts
@@ -16,7 +16,6 @@ export * from "./decrypted-command-data";
 export * from "./encrypted-command";
 export * from "./encrypted-message";
 export * from "./encrypted-message-response";
-export * from "./legacy-message";
 export * from "./legacy-message-wrapper";
 export * from "./message";
 export * from "./message-common";

--- a/apps/desktop/src/models/native-messaging/legacy-message-wrapper.ts
+++ b/apps/desktop/src/models/native-messaging/legacy-message-wrapper.ts
@@ -1,8 +1,7 @@
+import { LegacyInnerCommandMessage } from "@bitwarden/auth/common";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 
-import { LegacyMessage } from "./legacy-message";
-
 export type LegacyMessageWrapper = {
-  message: LegacyMessage | EncString;
+  message: LegacyInnerCommandMessage | EncString;
   appId: string;
 };

--- a/apps/desktop/src/models/native-messaging/legacy-message.ts
+++ b/apps/desktop/src/models/native-messaging/legacy-message.ts
@@ -1,9 +1,0 @@
-export type LegacyMessage = {
-  command: string;
-
-  userId?: string;
-  timestamp?: number;
-
-  publicKey?: string;
-  userKeyB64?: string;
-};

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -1,8 +1,11 @@
 import { ipcRenderer } from "electron";
 
+import {
+  LegacySetupEncryptionResponse,
+  LegacyUnencryptedCommandMessage,
+} from "@bitwarden/auth/common";
 import { DeviceType } from "@bitwarden/common/enums";
 import { ThemeType, KeySuffixOptions, LogLevelType } from "@bitwarden/common/platform/enums";
-import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 
 import {
   EncryptedMessageResponse,
@@ -63,12 +66,9 @@ const nativeMessaging = {
   sendReply: (message: EncryptedMessageResponse | UnencryptedMessageResponse) => {
     ipcRenderer.send("nativeMessagingReply", message);
   },
-  sendMessage: (message: {
-    appId: string;
-    command?: string;
-    sharedSecret?: string;
-    message?: EncString;
-  }) => {
+  sendMessage: (
+    message: LegacyUnencryptedCommandMessage | LegacyMessageWrapper | LegacySetupEncryptionResponse,
+  ) => {
     ipcRenderer.send("nativeMessagingReply", message);
   },
   onMessage: (callback: (message: LegacyMessageWrapper | Message) => void) => {

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -131,7 +131,11 @@ export class NativeMessagingService {
       return;
     }
 
-    if (Math.abs(message.timestamp - Date.now()) > MessageValidTimeout) {
+    // Check to prevent replay of old messages. This is disabled in dev mode
+    if (
+      Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
+      !this.platformUtilService.isDev()
+    ) {
       this.logService.error("NativeMessage is to old, ignoring.");
       return;
     }

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -136,7 +136,7 @@ export class NativeMessagingService {
       Math.abs(message.timestamp - Date.now()) > MessageValidTimeout &&
       !this.platformUtilService.isDev()
     ) {
-      this.logService.error("NativeMessage is to old, ignoring.");
+      this.logService.error("NativeMessage is too old, ignoring.");
       return;
     }
 

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NgZone } from "@angular/core";
 import { firstValueFrom, map } from "rxjs";
 
 import {
-  NativeMessageCommandType,
+  NativeMessageCommandTypes,
   BiometricUnlockNotSupportedResponse,
   BiometricUnlockCanceledResponse,
   BiometricUnlockNoUserResponse,
@@ -83,7 +83,7 @@ export class NativeMessagingService {
     // Request to setup secure encryption
     if (
       "command" in rawMessage &&
-      rawMessage.command === NativeMessageCommandType.SETUP_ENCRYPTION
+      rawMessage.command === NativeMessageCommandTypes.SETUP_ENCRYPTION
     ) {
       const innerMessage = rawMessage as BiometricCommandSetupEncryption;
       const remotePublicKey = Utils.fromB64ToArray(innerMessage.publicKey);
@@ -149,7 +149,7 @@ export class NativeMessagingService {
     }
 
     switch (message.command) {
-      case NativeMessageCommandType.BIOMETRIC_UNLOCK: {
+      case NativeMessageCommandTypes.BIOMETRIC_UNLOCK: {
         if (!(await this.platformUtilService.supportsBiometric())) {
           await this.sendBiometricCommandResponse(new BiometricUnlockNotSupportedResponse(), appId);
           return;
@@ -219,7 +219,7 @@ export class NativeMessagingService {
 
         break;
       }
-      case NativeMessageCommandType.BROWSER_PROVIDED_USER_KEY: {
+      case NativeMessageCommandTypes.BROWSER_PROVIDED_USER_KEY: {
         const innerMessage = message as BiometricCommandProvideUserKey;
         const userId = innerMessage.userId as UserId;
         const userKey = SymmetricCryptoKey.fromString(innerMessage.userKeyB64) as UserKey;

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -39,5 +39,9 @@
     "strictTemplates": true,
     "preserveWhitespaces": true
   },
-  "include": ["src", "../../libs/common/src/platform/services/**/*.worker.ts"]
+  "include": [
+    "src",
+    "../../libs/common/src/platform/services/**/*.worker.ts",
+    "../../node_modules/@bitwarden/auth/src/common/services/native-messaging/legacy-message.ts"
+  ]
 }

--- a/libs/auth/src/common/models/domain/index.ts
+++ b/libs/auth/src/common/models/domain/index.ts
@@ -1,3 +1,4 @@
 export * from "./rotateable-key-set";
 export * from "./login-credentials";
 export * from "./user-decryption-options";
+export * from "./native-messages";

--- a/libs/auth/src/common/models/domain/native-messages.ts
+++ b/libs/auth/src/common/models/domain/native-messages.ts
@@ -1,25 +1,29 @@
-export enum NativeMessageCommandType {
-  WRONG_USER = "wrongUserId",
-  VERIFY_FINGERPRINT = "verifyFingerprint",
-  SETUP_ENCRYPTION = "setupEncryption",
-  INVALIDATE_ENCRYPTION = "invalidateEncryption",
-  BIOMETRIC_UNLOCK = "biometricUnlock",
-  BROWSER_PROVIDED_USER_KEY = "browserProvidedUserKey",
-}
+export const NativeMessageCommandTypes = {
+  WRONG_USER: "wrongUserId",
+  VERIFY_FINGERPRINT: "verifyFingerprint",
+  SETUP_ENCRYPTION: "setupEncryption",
+  INVALIDATE_ENCRYPTION: "invalidateEncryption",
+  BIOMETRIC_UNLOCK: "biometricUnlock",
+  BROWSER_PROVIDED_USER_KEY: "browserProvidedUserKey",
+} as const;
+type NativeMessagingCommandTypeKeys =
+  (typeof NativeMessageCommandTypes)[keyof typeof NativeMessageCommandTypes];
 
-export enum BiometricUnlockResponse {
-  NO_USER = "no user",
-  NO_USER_ID = "no userId",
-  NOT_SUPPORTED = "not supported",
-  NO_CLIENT_KEY_HALF = "no client key half",
-  NOT_ENABLED = "not enabled",
-  CANCELED = "canceled",
-  UNLOCKED = "unlocked",
-}
+export const BiometricUnlockResponses = {
+  NO_USER: "no user",
+  NO_USER_ID: "no userId",
+  NOT_SUPPORTED: "not supported",
+  NO_CLIENT_KEY_HALF: "no client key half",
+  NOT_ENABLED: "not enabled",
+  CANCELED: "canceled",
+  UNLOCKED: "unlocked",
+} as const;
+type BiometricUnlockResponseTypeKeys =
+  (typeof BiometricUnlockResponses)[keyof typeof BiometricUnlockResponses];
 
 export class LegacyUnencryptedCommandMessage {
   constructor(
-    public command: NativeMessageCommandType,
+    public command: NativeMessagingCommandTypeKeys,
     public appId: string,
   ) {}
 }
@@ -29,24 +33,24 @@ export class LegacySetupEncryptionResponse extends LegacyUnencryptedCommandMessa
     appId: string,
     public sharedSecret: string,
   ) {
-    super(NativeMessageCommandType.SETUP_ENCRYPTION, appId);
+    super(NativeMessageCommandTypes.SETUP_ENCRYPTION, appId);
   }
 }
 
 export class LegacyInnerCommandMessage {
-  command: NativeMessageCommandType;
+  command: NativeMessagingCommandTypeKeys;
 
   userId?: string;
   timestamp?: number;
 
-  constructor(command: NativeMessageCommandType) {
+  constructor(command: NativeMessagingCommandTypeKeys) {
     this.command = command;
   }
 }
 
 export class BrowserCommandLegacyMessage extends LegacyInnerCommandMessage {
   constructor(
-    command: NativeMessageCommandType,
+    command: NativeMessagingCommandTypeKeys,
     public appId: string,
   ) {
     super(command);
@@ -55,20 +59,20 @@ export class BrowserCommandLegacyMessage extends LegacyInnerCommandMessage {
 
 export class BiometricUnlockCommand extends LegacyInnerCommandMessage {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK);
   }
 }
 
 export class BiometricProvideUserKeyCommand extends LegacyInnerCommandMessage {
   constructor(public userKeyB64: string) {
-    super(NativeMessageCommandType.BROWSER_PROVIDED_USER_KEY);
+    super(NativeMessageCommandTypes.BROWSER_PROVIDED_USER_KEY);
   }
 }
 
 export class BiometricNativeCommandResponse extends LegacyInnerCommandMessage {
   constructor(
-    public command: NativeMessageCommandType,
-    public response: BiometricUnlockResponse,
+    public command: NativeMessagingCommandTypeKeys,
+    public response: BiometricUnlockResponseTypeKeys,
   ) {
     super(command);
   }
@@ -76,13 +80,13 @@ export class BiometricNativeCommandResponse extends LegacyInnerCommandMessage {
 
 export class BiometricCommandWrongUser extends LegacyUnencryptedCommandMessage {
   constructor(appId: string) {
-    super(NativeMessageCommandType.WRONG_USER, appId);
+    super(NativeMessageCommandTypes.WRONG_USER, appId);
   }
 }
 
 export class BiometricCommandVerifyFingerprint extends LegacyUnencryptedCommandMessage {
   constructor(appId: string) {
-    super(NativeMessageCommandType.VERIFY_FINGERPRINT, appId);
+    super(NativeMessageCommandTypes.VERIFY_FINGERPRINT, appId);
   }
 }
 
@@ -91,60 +95,60 @@ export class BiometricCommandSetupEncryption extends LegacyInnerCommandMessage {
     public publicKey: string,
     public userId: string,
   ) {
-    super(NativeMessageCommandType.SETUP_ENCRYPTION);
+    super(NativeMessageCommandTypes.SETUP_ENCRYPTION);
   }
 }
 
 export class BiometricCommandInvalidateEncryption extends LegacyUnencryptedCommandMessage {
   constructor(appId: string) {
-    super(NativeMessageCommandType.INVALIDATE_ENCRYPTION, appId);
+    super(NativeMessageCommandTypes.INVALIDATE_ENCRYPTION, appId);
   }
 }
 
 export class BiometricCommandProvideUserKey extends LegacyInnerCommandMessage {
   constructor(public userKeyB64: string) {
-    super(NativeMessageCommandType.BROWSER_PROVIDED_USER_KEY);
+    super(NativeMessageCommandTypes.BROWSER_PROVIDED_USER_KEY);
   }
 }
 
 export class BiometricUnlockNotSupportedResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NOT_SUPPORTED);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.NOT_SUPPORTED);
   }
 }
 
 export class BiometricUnlockCanceledResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.CANCELED);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.CANCELED);
   }
 }
 
 export class BiometricUnlockUnlockedResponse extends BiometricNativeCommandResponse {
   constructor(public userKeyB64: string) {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.UNLOCKED);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.UNLOCKED);
   }
 }
 
 export class BiometricUnlockNoUserResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_USER);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.NO_USER);
   }
 }
 
 export class BiometricUnlockNoUserIdResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_USER_ID);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.NO_USER_ID);
   }
 }
 
 export class BiometricUnlockNoClientKeyHalfResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_CLIENT_KEY_HALF);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.NO_CLIENT_KEY_HALF);
   }
 }
 
 export class BiometricUnlockNotEnabledResponse extends BiometricNativeCommandResponse {
   constructor() {
-    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NOT_ENABLED);
+    super(NativeMessageCommandTypes.BIOMETRIC_UNLOCK, BiometricUnlockResponses.NOT_ENABLED);
   }
 }

--- a/libs/auth/src/common/models/domain/native-messages.ts
+++ b/libs/auth/src/common/models/domain/native-messages.ts
@@ -1,0 +1,150 @@
+export enum NativeMessageCommandType {
+  WRONG_USER = "wrongUserId",
+  VERIFY_FINGERPRINT = "verifyFingerprint",
+  SETUP_ENCRYPTION = "setupEncryption",
+  INVALIDATE_ENCRYPTION = "invalidateEncryption",
+  BIOMETRIC_UNLOCK = "biometricUnlock",
+  BROWSER_PROVIDED_USER_KEY = "browserProvidedUserKey",
+}
+
+export enum BiometricUnlockResponse {
+  NO_USER = "no user",
+  NO_USER_ID = "no userId",
+  NOT_SUPPORTED = "not supported",
+  NO_CLIENT_KEY_HALF = "no client key half",
+  NOT_ENABLED = "not enabled",
+  CANCELED = "canceled",
+  UNLOCKED = "unlocked",
+}
+
+export class LegacyUnencryptedCommandMessage {
+  constructor(
+    public command: NativeMessageCommandType,
+    public appId: string,
+  ) {}
+}
+
+export class LegacySetupEncryptionResponse extends LegacyUnencryptedCommandMessage {
+  constructor(
+    appId: string,
+    public sharedSecret: string,
+  ) {
+    super(NativeMessageCommandType.SETUP_ENCRYPTION, appId);
+  }
+}
+
+export class LegacyInnerCommandMessage {
+  command: NativeMessageCommandType;
+
+  userId?: string;
+  timestamp?: number;
+
+  constructor(command: NativeMessageCommandType) {
+    this.command = command;
+  }
+}
+
+export class BrowserCommandLegacyMessage extends LegacyInnerCommandMessage {
+  constructor(
+    command: NativeMessageCommandType,
+    public appId: string,
+  ) {
+    super(command);
+  }
+}
+
+export class BiometricUnlockCommand extends LegacyInnerCommandMessage {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK);
+  }
+}
+
+export class BiometricProvideUserKeyCommand extends LegacyInnerCommandMessage {
+  constructor(public userKeyB64: string) {
+    super(NativeMessageCommandType.BROWSER_PROVIDED_USER_KEY);
+  }
+}
+
+export class BiometricNativeCommandResponse extends LegacyInnerCommandMessage {
+  constructor(
+    public command: NativeMessageCommandType,
+    public response: BiometricUnlockResponse,
+  ) {
+    super(command);
+  }
+}
+
+export class BiometricCommandWrongUser extends LegacyUnencryptedCommandMessage {
+  constructor(appId: string) {
+    super(NativeMessageCommandType.WRONG_USER, appId);
+  }
+}
+
+export class BiometricCommandVerifyFingerprint extends LegacyUnencryptedCommandMessage {
+  constructor(appId: string) {
+    super(NativeMessageCommandType.VERIFY_FINGERPRINT, appId);
+  }
+}
+
+export class BiometricCommandSetupEncryption extends LegacyInnerCommandMessage {
+  constructor(
+    public publicKey: string,
+    public userId: string,
+  ) {
+    super(NativeMessageCommandType.SETUP_ENCRYPTION);
+  }
+}
+
+export class BiometricCommandInvalidateEncryption extends LegacyUnencryptedCommandMessage {
+  constructor(appId: string) {
+    super(NativeMessageCommandType.INVALIDATE_ENCRYPTION, appId);
+  }
+}
+
+export class BiometricCommandProvideUserKey extends LegacyInnerCommandMessage {
+  constructor(public userKeyB64: string) {
+    super(NativeMessageCommandType.BROWSER_PROVIDED_USER_KEY);
+  }
+}
+
+export class BiometricUnlockNotSupportedResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NOT_SUPPORTED);
+  }
+}
+
+export class BiometricUnlockCanceledResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.CANCELED);
+  }
+}
+
+export class BiometricUnlockUnlockedResponse extends BiometricNativeCommandResponse {
+  constructor(public userKeyB64: string) {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.UNLOCKED);
+  }
+}
+
+export class BiometricUnlockNoUserResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_USER);
+  }
+}
+
+export class BiometricUnlockNoUserIdResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_USER_ID);
+  }
+}
+
+export class BiometricUnlockNoClientKeyHalfResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NO_CLIENT_KEY_HALF);
+  }
+}
+
+export class BiometricUnlockNotEnabledResponse extends BiometricNativeCommandResponse {
+  constructor() {
+    super(NativeMessageCommandType.BIOMETRIC_UNLOCK, BiometricUnlockResponse.NOT_ENABLED);
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9798

## 📔 Objective

Improve type-safetey of biometrics IPC by using shared enums instead of magic strings, and by introducing classes for the message / response types.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
