### PR TITLE
[PM-9638] Browser V2 Item Details Defects

### DIFF
--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -3,7 +3,7 @@
     <h2 bitTypography="h6">{{ "itemDetails" | i18n }}</h2>
   </bit-section-header>
   <bit-card>
-    <div class="tw-pb-2 tw-mb-4 tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300">
+    <div>
       <label class="tw-block tw-w-full tw-mb-1 tw-text-xs tw-text-muted tw-select-none">
         {{ "itemName" | i18n }}
       </label>
@@ -12,26 +12,32 @@
 
     <div *ngIf="cipher.collectionIds || cipher.organizationId || cipher.folderId">
       <p
-        *ngIf="!cipher.organizationId"
-        [ngClass]="{ 'tw-mb-3': cipher.collectionIds }"
-        bitTypography="body2"
-      >
-        <i class="bwi bwi-user bwi-lg bwi-fw"></i> {{ "ownerYou" | i18n }}
-      </p>
-      <p
         *ngIf="cipher.organizationId && organization"
         [ngClass]="{ 'tw-mb-3': cipher.collectionIds }"
         bitTypography="body2"
       >
-        <i class="bwi bwi-business bwi-lg bwi-fw"></i> {{ organization.name }}
+        <i
+          class="bwi bwi-lg bwi-fw tw-pt-1"
+          [ngClass]="{
+            'bwi-family':
+              organization.productTierType === productTierType.Free ||
+              organization.productTierType === productTierType.Families,
+            'bwi-business':
+              organization.productTierType !== productTierType.Free &&
+              organization.productTierType !== productTierType.Families
+          }"
+        >
+        </i>
+        {{ organization.name }}
       </p>
       <ul *ngIf="cipher.collectionIds && collections" [ngClass]="{ 'tw-mb-2': cipher.folderId }">
-        <p *ngFor="let collection of collections" class="tw-mb-1" bitTypography="body2">
-          <i class="bwi bwi-collection bwi-lg bwi-fw"></i> {{ collection.name }}
-        </p>
+        <div *ngFor="let collection of collections" class="tw-mb-1 tw-flex" bitTypography="body2">
+          <i class="bwi bwi-collection bwi-lg bwi-fw tw-pt-1"></i>
+          <p>{{ collection.name }}</p>
+        </div>
       </ul>
       <p *ngIf="cipher.folderId && folder" bitTypography="body2">
-        <i class="bwi bwi-folder bwi-lg bwi-fw"></i> {{ folder.name }}
+        <i class="bwi bwi-folder bwi-lg bwi-fw tw-pt-1"></i> {{ folder.name }}
       </p>
     </div>
   </bit-card>

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
@@ -3,6 +3,7 @@ import { Component, Input } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { ProductTierType } from "@bitwarden/common/billing/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
@@ -31,4 +32,6 @@ export class ItemDetailsV2Component {
   @Input() organization?: Organization;
   @Input() collections?: CollectionView[];
   @Input() folder?: FolderView;
+
+  productTierType = ProductTierType;
 }


### PR DESCRIPTION

## 🎟️ Tracking

[PM-9638 Remove Owner](https://bitwarden.atlassian.net/browse/PM-9638)
[PM-9799 Update Organization Icons](https://bitwarden.atlassian.net/browse/PM-9799)
[PM-9808 Collection Word Wrap](https://bitwarden.atlassian.net/browse/PM-9808)

## 📔 Objective

- Removed excess Owner Element
- Updated Organization Icons to show `bwi-family` or `bwi-business` depending on org type
- Update styling for collections list
- Removed styling on item name - this should be added when we use the new display-field

## 📸 Screenshots

![Screenshot 2024-07-15 at 2 33 38 PM](https://github.com/user-attachments/assets/ba64d5f4-058b-41a2-aea3-4da07db88a1f)

![Screenshot 2024-07-15 at 2 33 22 PM](https://github.com/user-attachments/assets/c065ae87-456b-40a2-9a19-a1c991f0adbc)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
