### PR TITLE
[AC-2814]Reestructued IsEnterpriseOrgGuard to be compliant with Angular 17+

### DIFF
--- a/apps/web/src/app/admin-console/organizations/guards/is-enterprise-org.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/is-enterprise-org.guard.ts
@@ -1,44 +1,45 @@
-import { Injectable } from "@angular/core";
-import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from "@angular/router";
-import { firstValueFrom } from "rxjs";
+import { inject } from "@angular/core";
+import {
+  ActivatedRouteSnapshot,
+  CanActivateFn,
+  Router,
+  RouterStateSnapshot,
+} from "@angular/router";
 
+import { canAccessFeature } from "@bitwarden/angular/platform/guard/feature-flag.guard";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { DialogService } from "@bitwarden/components";
 
-@Injectable({
-  providedIn: "root",
-})
-export class IsEnterpriseOrgGuard implements CanActivate {
-  constructor(
-    private router: Router,
-    private organizationService: OrganizationService,
-    private dialogService: DialogService,
-    private configService: ConfigService,
-  ) {}
+/**
+ * `CanActivateFn` that checks if the organization matching the id in the URL
+ * parameters is of enterprise type. If the organization is not enterprise instructions are
+ * provided on how to upgrade into an enterprise organization, and the user is redirected
+ * if they have access to upgrade the organization. If the organization is
+ * enterprise routing proceeds."
+ */
+export function isEnterpriseOrgGuard(): CanActivateFn {
+  return async (route: ActivatedRouteSnapshot, _state: RouterStateSnapshot) => {
+    const router = inject(Router);
+    const organizationService = inject(OrganizationService);
+    const dialogService = inject(DialogService);
 
-  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    const isMemberAccessReportEnabled = await firstValueFrom(
-      this.configService.getFeatureFlag$(FeatureFlag.MemberAccessReport),
-    );
-
-    // TODO: Remove on "MemberAccessReport" feature flag cleanup
-    if (!isMemberAccessReportEnabled) {
-      return this.router.createUrlTree(["/"]);
-    }
-
-    const org = await this.organizationService.get(route.params.organizationId);
+    const org = await organizationService.get(route.params.organizationId);
 
     if (org == null) {
-      return this.router.createUrlTree(["/"]);
+      return router.createUrlTree(["/"]);
+    }
+
+    // TODO: Remove on "MemberAccessReport" feature flag cleanup
+    if (!canAccessFeature(FeatureFlag.MemberAccessReport)) {
+      return router.createUrlTree(["/"]);
     }
 
     if (org.productTierType != ProductTierType.Enterprise) {
       // Users without billing permission can't access billing
       if (!org.canEditSubscription) {
-        await this.dialogService.openSimpleDialog({
+        await dialogService.openSimpleDialog({
           title: { key: "upgradeOrganizationEnterprise" },
           content: { key: "onlyAvailableForEnterpriseOrganization" },
           acceptButtonText: { key: "ok" },
@@ -47,7 +48,7 @@ export class IsEnterpriseOrgGuard implements CanActivate {
         });
         return false;
       } else {
-        const upgradeConfirmed = await this.dialogService.openSimpleDialog({
+        const upgradeConfirmed = await dialogService.openSimpleDialog({
           title: { key: "upgradeOrganizationEnterprise" },
           content: { key: "onlyAvailableForEnterpriseOrganization" },
           acceptButtonText: { key: "upgradeOrganization" },
@@ -55,7 +56,7 @@ export class IsEnterpriseOrgGuard implements CanActivate {
           icon: "bwi-arrow-circle-up",
         });
         if (upgradeConfirmed) {
-          await this.router.navigate(["organizations", org.id, "billing", "subscription"], {
+          await router.navigate(["organizations", org.id, "billing", "subscription"], {
             queryParams: { upgrade: true },
           });
         }
@@ -63,5 +64,5 @@ export class IsEnterpriseOrgGuard implements CanActivate {
     }
 
     return org.productTierType == ProductTierType.Enterprise;
-  }
+  };
 }

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/organizations-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/organizations-routing.module.ts
@@ -3,7 +3,7 @@ import { RouterModule, Routes } from "@angular/router";
 
 import { AuthGuard } from "@bitwarden/angular/auth/guards";
 import { canAccessSettingsTab } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { IsEnterpriseOrgGuard } from "@bitwarden/web-vault/app/admin-console/organizations/guards/is-enterprise-org.guard";
+import { isEnterpriseOrgGuard } from "@bitwarden/web-vault/app/admin-console/organizations/guards/is-enterprise-org.guard";
 import { organizationPermissionsGuard } from "@bitwarden/web-vault/app/admin-console/organizations/guards/org-permissions.guard";
 import { OrganizationLayoutComponent } from "@bitwarden/web-vault/app/admin-console/organizations/layouts/organization-layout.component";
 
@@ -72,7 +72,7 @@ const routes: Routes = [
             data: {
               titleId: "memberAccessReport",
             },
-            canActivate: [IsEnterpriseOrgGuard],
+            canActivate: [isEnterpriseOrgGuard()],
           },
         ],
       },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2814

## 📔 Objective

Following the work done on https://github.com/bitwarden/clients/pull/9598. This changes the `IsEnterpriseOrgGuard` to use a function in order to be compliant with the Angular 17+.

This guard is only used for the MemberAccessReport that currently is protected by a feature flag.
Should have no changes on the current behaviour.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
