### PR TITLE
[PM-9868] Fix key rotation being broken due to org ciphers being included

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -352,8 +352,10 @@ describe("Cipher Service", () => {
 
       const cipher1 = new CipherView(cipherObj);
       cipher1.id = "Cipher 1";
+      cipher1.organizationId = null;
       const cipher2 = new CipherView(cipherObj);
       cipher2.id = "Cipher 2";
+      cipher2.organizationId = null;
 
       decryptedCiphers = new BehaviorSubject({
         Cipher1: cipher1,

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1184,11 +1184,16 @@ export class CipherService implements CipherServiceAbstraction {
     let encryptedCiphers: CipherWithIdRequest[] = [];
 
     const ciphers = await this.getAllDecrypted();
-    if (!ciphers || ciphers.length === 0) {
+    if (!ciphers) {
+      return encryptedCiphers;
+    }
+
+    const userCiphers = ciphers.filter((c) => c.organizationId == null);
+    if (userCiphers.length === 0) {
       return encryptedCiphers;
     }
     encryptedCiphers = await Promise.all(
-      ciphers.map(async (cipher) => {
+      userCiphers.map(async (cipher) => {
         const encryptedCipher = await this.encrypt(cipher, newUserKey, originalUserKey);
         return new CipherWithIdRequest(encryptedCipher);
       }),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9868
https://github.com/bitwarden/server/pull/4522

## 📔 Objective

Fixes key rotation for org members. It was broken since the user account key rotation tried to rotate org ciphers using the user-key.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
