### PR TITLE
[PM-2505] Pre-Select enterprise on upgrade from MemberAccessReport dialog

### DIFF
--- a/apps/web/src/app/admin-console/organizations/guards/is-enterprise-org.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/is-enterprise-org.guard.ts
@@ -56,7 +56,7 @@ export class IsEnterpriseOrgGuard implements CanActivate {
         });
         if (upgradeConfirmed) {
           await this.router.navigate(["organizations", org.id, "billing", "subscription"], {
-            queryParams: { upgrade: true },
+            queryParams: { upgrade: true, productTierType: ProductTierType.Enterprise },
           });
         }
       }

--- a/apps/web/src/app/billing/organizations/change-plan.component.html
+++ b/apps/web/src/app/billing/organizations/change-plan.component.html
@@ -18,6 +18,7 @@
       [showCancel]="true"
       [organizationId]="organizationId"
       [currentPlan]="currentPlan"
+      [preSelectedProductTier]="preSelectedProductTier"
       (onCanceled)="cancel()"
     >
     </app-organization-plans>

--- a/apps/web/src/app/billing/organizations/change-plan.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
+import { ProductTierType } from "@bitwarden/common/billing/enums";
 import { PlanResponse } from "@bitwarden/common/billing/models/response/plan.response";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
@@ -10,6 +11,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 export class ChangePlanComponent {
   @Input() organizationId: string;
   @Input() currentPlan: PlanResponse;
+  @Input() preSelectedProductTier: ProductTierType;
   @Output() onChanged = new EventEmitter();
   @Output() onCanceled = new EventEmitter();
 

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -95,6 +95,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
 
   private _plan = PlanType.Free;
   @Input() providerId?: string;
+  @Input() preSelectedProductTier?: ProductTierType;
   @Output() onSuccess = new EventEmitter<OnSuccessArgs>();
   @Output() onCanceled = new EventEmitter<void>();
   @Output() onTrialBillingSuccess = new EventEmitter();
@@ -209,6 +210,9 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
         this.singleOrgPolicyAppliesToActiveUser = policyAppliesToActiveUser;
       });
 
+    if (this.preSelectedProductTier != null && this.productTier < this.preSelectedProductTier) {
+      this.productTier = this.preSelectedProductTier;
+    }
     if (!this.selfHosted) {
       this.changedProduct();
     }

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -122,6 +122,7 @@
         <app-change-plan
           [organizationId]="organizationId"
           [currentPlan]="sub.plan"
+          [preSelectedProductTier]="preSelectedProductTier"
           (onChanged)="closeChangePlan()"
           (onCanceled)="closeChangePlan()"
           *ngIf="showChangePlan"

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -52,6 +52,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   manageBillingFromProviderPortal = ManageBilling;
   isProviderManaged = false;
   enableTimeThreshold: boolean;
+  preSelectedProductTier: ProductTierType = ProductTierType.Free;
 
   protected readonly teamsStarter = ProductTierType.TeamsStarter;
 
@@ -83,6 +84,13 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
       // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.changePlan();
+      const productTierTypeStr = this.route.snapshot.queryParamMap.get("productTierType");
+      if (productTierTypeStr != null) {
+        const productTier = Number(productTierTypeStr);
+        if (Object.values(ProductTierType).includes(productTier as ProductTierType)) {
+          this.preSelectedProductTier = productTier;
+        }
+      }
     }
 
     this.route.params


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2505

## 📔 Objective

The objective is to pre select the enterprise option when clicking upgrade from the member access report dialog on the reports page.
To achieve this was added an option through queryParams that will pre select the desired upgrade option on the subscription page

- **is-enterprise-org.guard.ts:** Passing a new queryParam to the subscription page that has `ProductTierType.Enterprise` as value
- **organization-subscription-cloud.component.ts:** Checks if the `productTierType` queryParam exists, if it exists tries to convert into the `ProductTierType` and set it to be passed as an input bind
- **organization-plans.component.ts:** Updates the `productTier` option from the component with the `preSelectedProductTier` that was sent as an input, in case it has an higher value.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
