### PR TITLE
Disable a button during initial page load

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -5,7 +5,7 @@
     [placeholder]="'searchMembers' | i18n"
   ></bit-search>
 
-  <button type="button" bitButton buttonType="primary" (click)="invite()">
+  <button type="button" bitButton buttonType="primary" (click)="invite()" [disabled]="!firstLoaded">
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "inviteMember" | i18n }}
   </button>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-1463

## 📔 Objective

The people screen has a button that can be clicked to open a modal for inviting new users to an organization. This modal depends on data from the people list for conditional logic, like whether or not the seat count cor the organization has been reached. If the modal is opened before the people list loads these conditions can not process correctly, causing bugs.

This commit disabled the button until the people list loads to prevent this kind of behavior.

## 📸 Screenshots

https://github.com/user-attachments/assets/3d39a4f1-f144-47e3-980d-b50d82ee9c05

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
