### PR TITLE
Output user-specific associations for collections in the CLI

### DIFF
--- a/apps/cli/src/admin-console/models/response/organization-collection.response.ts
+++ b/apps/cli/src/admin-console/models/response/organization-collection.response.ts
@@ -5,10 +5,12 @@ import { SelectionReadOnly } from "../selection-read-only";
 
 export class OrganizationCollectionResponse extends CollectionResponse {
   groups: SelectionReadOnly[];
+  users: SelectionReadOnly[];
 
-  constructor(o: CollectionView, groups: SelectionReadOnly[]) {
+  constructor(o: CollectionView, groups: SelectionReadOnly[], users: SelectionReadOnly[]) {
     super(o);
     this.object = "org-collection";
     this.groups = groups;
+    this.users = users;
   }
 }

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -184,7 +184,7 @@ export class EditCommand {
       const response = await this.apiService.putCollection(req.organizationId, id, request);
       const view = CollectionExport.toView(req);
       view.id = response.id;
-      const res = new OrganizationCollectionResponse(view, groups);
+      const res = new OrganizationCollectionResponse(view, groups, users);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);

--- a/apps/cli/src/commands/get.command.ts
+++ b/apps/cli/src/commands/get.command.ts
@@ -456,7 +456,13 @@ export class GetCommand extends DownloadCommand {
           : response.groups.map(
               (g) => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords, g.manage),
             );
-      const res = new OrganizationCollectionResponse(decCollection, groups);
+      const users =
+        response.users == null
+          ? null
+          : response.users.map(
+              (g) => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords, g.manage),
+            );
+      const res = new OrganizationCollectionResponse(decCollection, groups, users);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -208,7 +208,7 @@ export class CreateCommand {
       const response = await this.apiService.postCollection(req.organizationId, request);
       const view = CollectionExport.toView(req);
       view.id = response.id;
-      const res = new OrganizationCollectionResponse(view, groups);
+      const res = new OrganizationCollectionResponse(view, groups, users);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2870

## 📔 Objective

Collection management permissions can be set for a group or a specific user. Currently the CLI only outputs group associations when it displays collection configuration information. This can cause bugs when piping commands together.

This commit ensures that `user` associations also get output. In all cases this data was already available and just needed to be added to a response model.

## 📸 Screenshots

<img width="1728" alt="Screenshot 2024-07-17 at 4 08 30 PM" src="https://github.com/user-attachments/assets/6acf60d4-e4c2-4250-8799-4a6c70e7dbf9">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
