### PR TITLE
[PM-9910] Filter out linked option for notes

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.spec.ts
@@ -2,7 +2,7 @@ import { DIALOG_DATA } from "@angular/cdk/dialog";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { FieldType } from "@bitwarden/common/vault/enums";
+import { CipherType, FieldType } from "@bitwarden/common/vault/enums";
 
 import {
   AddEditCustomFieldDialogComponent,
@@ -20,6 +20,7 @@ describe("AddEditCustomFieldDialogComponent", () => {
     addField,
     updateLabel,
     removeField,
+    cipherType: CipherType.Login,
   } as AddEditCustomFieldDialogData;
 
   beforeEach(async () => {
@@ -68,5 +69,16 @@ describe("AddEditCustomFieldDialogComponent", () => {
     component.removeField();
 
     expect(removeField).toHaveBeenCalledWith(2);
+  });
+
+  it('filters out "Linked" field type for SecureNote cipher type', () => {
+    dialogData.cipherType = CipherType.SecureNote;
+
+    fixture = TestBed.createComponent(AddEditCustomFieldDialogComponent);
+    component = fixture.componentInstance;
+
+    expect(component.fieldTypeOptions).not.toContainEqual(
+      expect.objectContaining({ value: FieldType.Linked }),
+    );
   });
 });

--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
@@ -5,7 +5,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { FieldType } from "@bitwarden/common/vault/enums";
+import { CipherType, FieldType } from "@bitwarden/common/vault/enums";
 import {
   AsyncActionsModule,
   ButtonModule,
@@ -19,6 +19,8 @@ export type AddEditCustomFieldDialogData = {
   addField: (type: FieldType, label: string) => void;
   updateLabel: (index: number, label: string) => void;
   removeField: (index: number) => void;
+  /** Type of cipher */
+  cipherType: CipherType;
   /** When provided, dialog will display edit label variants */
   editLabelConfig?: { index: number; label: string };
 };
@@ -62,6 +64,15 @@ export class AddEditCustomFieldDialogComponent {
     private i18nService: I18nService,
   ) {
     this.variant = data.editLabelConfig ? "edit" : "add";
+
+    this.fieldTypeOptions = this.fieldTypeOptions.filter((option) => {
+      // Filter out the Linked field type for Secure Notes
+      if (this.data.cipherType === CipherType.SecureNote) {
+        return option.value !== FieldType.Linked;
+      }
+
+      return true;
+    });
 
     if (this.variant === "edit") {
       this.customFieldForm.controls.label.setValue(data.editLabelConfig.label);

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -201,6 +201,7 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
           addField: this.addField.bind(this),
           updateLabel: this.updateLabel.bind(this),
           removeField: this.removeField.bind(this),
+          cipherType: this.cipherFormContainer.config.cipherType,
           editLabelConfig,
         },
       },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-9910](https://bitwarden.atlassian.net/browse/PM-9910)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When adding/editing a note cipher, "Linked" should not be an option for custom fields.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Adding|Editing|
|-|-|
|<video src="https://github.com/user-attachments/assets/fdd8a119-deba-40d4-bd43-38edd5b8e1fe" />|<video src="https://github.com/user-attachments/assets/6b035483-c01e-439d-8d06-f19812441ccf" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9910]: https://bitwarden.atlassian.net/browse/PM-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ