### PR TITLE
[PM-8050] Deleting one folder deletes all other folders

### DIFF
--- a/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
@@ -8,7 +8,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 @Component({
   selector: "app-folder-add-edit",
@@ -24,6 +24,7 @@ export class FolderAddEditComponent extends BaseFolderAddEditComponent {
     logService: LogService,
     dialogService: DialogService,
     formBuilder: FormBuilder,
+    protected toastService: ToastService,
     protected dialogRef: DialogRef<FolderAddEditDialogResult>,
     @Inject(DIALOG_DATA) params: FolderAddEditDialogParams,
   ) {
@@ -51,10 +52,12 @@ export class FolderAddEditComponent extends BaseFolderAddEditComponent {
     }
 
     try {
-      this.deletePromise = this.folderApiService.delete(this.folder.id);
-      await this.deletePromise;
-      this.platformUtilsService.showToast("success", null, this.i18nService.t("deletedFolder"));
-      this.onDeletedFolder.emit(this.folder);
+      await this.folderApiService.delete(this.folder.id);
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("deletedFolder"),
+      });
     } catch (e) {
       this.logService.error(e);
     }

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -464,9 +464,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     const result = await lastValueFrom(dialog.closed);
 
     if (result === FolderAddEditDialogResult.Deleted) {
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.router.navigate([], {
+      await this.router.navigate([], {
         queryParams: { folderId: null },
         queryParamsHandling: "merge",
         replaceUrl: true,

--- a/libs/common/src/vault/services/folder/folder.service.ts
+++ b/libs/common/src/vault/services/folder/folder.service.ts
@@ -137,16 +137,14 @@ export class FolderService implements InternalFolderServiceAbstraction {
         return;
       }
 
-      if (typeof id === "string") {
-        if (folders[id] == null) {
-          return;
+      const folderIdsToDelete = Array.isArray(id) ? id : [id];
+
+      folderIdsToDelete.forEach((id) => {
+        if (folders[id] != null) {
+          delete folders[id];
         }
-        delete folders[id];
-      } else {
-        (id as string[]).forEach((i) => {
-          delete folders[i];
-        });
-      }
+      });
+
       return folders;
     });
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-8050](https://bitwarden.atlassian.net/browse/PM-8050)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Deleting a folder should not clear all folders on the client. There seems to be a malfunction with `SyncService.syncDeleteFolder`, which tries to sync the web client after a folder has been deleted on the web client. Previously, we returned when `folders[id] == null`, which clears the folder state.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8050]: https://bitwarden.atlassian.net/browse/PM-8050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ