### PR TITLE
[PM-9892] Linked Types for adding a cipher

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -21,8 +21,11 @@ import { Subject, switchMap, take } from "rxjs";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { FieldType, LinkedIdType } from "@bitwarden/common/vault/enums";
+import { CipherType, FieldType, LinkedIdType } from "@bitwarden/common/vault/enums";
+import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import {
   DialogService,
   SectionComponent,
@@ -131,10 +134,9 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+    const linkedFieldsOptionsForCipher = this.getLinkedFieldsOptionsForCipher();
     // Populate options for linked custom fields
-    this.linkedFieldOptions = Array.from(
-      this.cipherFormContainer.originalCipherView?.linkedFieldOptions?.entries() ?? [],
-    )
+    this.linkedFieldOptions = Array.from(linkedFieldsOptionsForCipher?.entries() ?? [])
       .map(([id, linkedFieldOption]) => ({
         name: this.i18nService.t(linkedFieldOption.i18nKey),
         value: id,
@@ -299,6 +301,24 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
         this.i18nService.t("reorderFieldDown", label, currentIndex + 1, this.fields.length),
         "assertive",
       );
+    }
+  }
+
+  /**
+   * Returns the linked field options for the current cipher type
+   *
+   * Note: Note ciphers do not have linked fields
+   */
+  private getLinkedFieldsOptionsForCipher() {
+    switch (this.cipherFormContainer.config.cipherType) {
+      case CipherType.Login:
+        return LoginView.prototype.linkedFieldOptions;
+      case CipherType.Card:
+        return CardView.prototype.linkedFieldOptions;
+      case CipherType.Identity:
+        return IdentityView.prototype.linkedFieldOptions;
+      default:
+        return null;
     }
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-9892](https://bitwarden.atlassian.net/browse/PM-9892)

## 📔 Objective

Originally I was using the `originalCipherView` for retrieving the linked options for the custom field. This doesn't work when a user adds a cipher because the `originalCipherView` is null. 

Swapping to using the `linkedFieldOptions` from the view prototypes instead. 

## 📸 Screenshots

|Adding Login|Adding Card|Adding Identity|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/bd65da05-a0e8-4be1-a81a-217605566d17" />|<video src="https://github.com/user-attachments/assets/6f2dc4d7-d52b-4059-99a8-7b7df59a95ac" />|<video src="https://github.com/user-attachments/assets/772359cf-d080-4fe5-898b-c95c29e20c68" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9892]: https://bitwarden.atlassian.net/browse/PM-9892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ