### PR TITLE
[PM-9912] "Boolean" to "Checked" for custom label

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1295,6 +1295,9 @@
   "cfTypeBoolean": {
     "message": "Boolean"
   },
+  "cfTypeChecked": {
+    "message": "Checked"
+  },
   "cfTypeLinked": {
     "message": "Linked",
     "description": "This describes a field that is 'linked' (tied) to another field."

--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
@@ -52,7 +52,7 @@ export class AddEditCustomFieldDialogComponent {
   fieldTypeOptions = [
     { name: this.i18nService.t("cfTypeText"), value: FieldType.Text },
     { name: this.i18nService.t("cfTypeHidden"), value: FieldType.Hidden },
-    { name: this.i18nService.t("cfTypeBoolean"), value: FieldType.Boolean },
+    { name: this.i18nService.t("cfTypeChecked"), value: FieldType.Boolean },
     { name: this.i18nService.t("cfTypeLinked"), value: FieldType.Linked },
   ];
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9912](https://bitwarden.atlassian.net/browse/PM-9912)

## 📔 Objective

Swap custom field labels for boolean field from "Boolean" to "Checked"

## 📸 Screenshots

<img width="392" alt="Screenshot 2024-07-18 at 2 06 43 PM" src="https://github.com/user-attachments/assets/56a5d8d9-82b9-4b19-ac33-e631df61db74">

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9912]: https://bitwarden.atlassian.net/browse/PM-9912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ