### PR TITLE
[PM-9890] Custom Fields - testids for automation testing

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -3,7 +3,12 @@
     <h2 bitTypography="h5">{{ "customFields" | i18n }}</h2>
   </bit-section-header>
   <form [formGroup]="customFieldsForm">
-    <bit-card formArrayName="fields" cdkDropList (cdkDropListDropped)="drop($event)">
+    <bit-card
+      formArrayName="fields"
+      cdkDropList
+      (cdkDropListDropped)="drop($event)"
+      data-testid="custom-fields"
+    >
       <div
         *ngFor="let field of fields.controls; let i = index"
         [formGroupName]="i"
@@ -11,6 +16,7 @@
         [ngClass]="{
           'tw-items-center': field.value.type === FieldType.Boolean
         }"
+        [attr.data-testid]="field.value.name + '-entry'"
         cdkDrag
         #customFieldRow
       >


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9890](https://bitwarden.atlassian.net/browse/PM-9890)
## 📔 Objective

Add testids for automation testing:
> on the <bit-card> that holds the list of custom fields: data-testid="custom-fields"
> on the <div> that holds each custom field entry: data-testid="{fieldLabel}-entry" where {fieldLabel} is the field label for that entry.

## 📸 Screenshots

<img width="1139" alt="Screenshot 2024-07-18 at 2 29 50 PM" src="https://github.com/user-attachments/assets/a2f31c33-9e57-41cf-803a-416479baf9ba">

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9890]: https://bitwarden.atlassian.net/browse/PM-9890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ