### PR TITLE
Swap "edit" for "save" in edit dialog

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
@@ -28,7 +28,7 @@
     </div>
     <div bitDialogFooter class="tw-flex tw-gap-2 tw-w-full">
       <button bitButton buttonType="primary" type="submit" [disabled]="customFieldForm.invalid">
-        {{ (variant === "add" ? "add" : "edit") | i18n }}
+        {{ (variant === "add" ? "add" : "save") | i18n }}
       </button>
       <button bitButton bitDialogClose buttonType="secondary" type="button">
         {{ "cancel" | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

None - Noticed myself

## 📔 Objective

Swap "Edit" for "Save" on the edit custom field dialog

## 📸 Screenshots

<img width="387" alt="Screenshot 2024-07-18 at 2 40 35 PM" src="https://github.com/user-attachments/assets/4c5c5b31-929e-444a-bea5-2ff991987933">

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
