### PR TITLE
[PM-8836] Adust CODEOWNERS to move biometrics native IPC to auth ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,9 @@ apps/web/src/connectors @bitwarden/team-auth-dev
 bitwarden_license/bit-web/src/app/auth @bitwarden/team-auth-dev
 libs/angular/src/auth @bitwarden/team-auth-dev
 libs/common/src/auth @bitwarden/team-auth-dev
+# biometrics
+apps/desktop/src/services/native-messaging.service.ts @bitwarden/team-auth-dev
+app/browser/src/background/nativeMessaging.background.ts @bitwarden/team-auth-dev
 
 ## Tools team files ##
 apps/browser/src/tools @bitwarden/team-tools-dev
@@ -92,7 +95,6 @@ libs/common/src/autofill @bitwarden/team-autofill-dev
 # DuckDuckGo integration
 apps/desktop/native-messaging-test-runner @bitwarden/team-autofill-dev
 apps/desktop/src/services/native-message-handler.service.ts @bitwarden/team-autofill-dev
-apps/desktop/src/services/native-messaging.service.ts @bitwarden/team-autofill-dev
 
 ## Component Library ##
 .storybook @bitwarden/team-design-system


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C04MF5S8XKN/p1721252901769749?thread_ts=1721034173.235149&cid=C04MF5S8XKN
https://bitwarden.atlassian.net/browse/PM-8836

## 📔 Objective

Move native messaging ipc to auth for now, DDG is still under autofill ownership. This will be returned/(given to platform) once there is a more clear separation between biometrics and ipc.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
