### PR TITLE
[PM-8338] New Autofill Settings Components

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3401,6 +3401,30 @@
     "message": "Common formats",
     "description": "Label indicating the most common import formats"
   },
+  "confirmContinueToBrowserSettingsTitle": {
+    "message": "Continue to browser settings?",
+    "description": "Title for dialog which asks if the user wants to proceed to a relevant browser settings page"
+  },
+  "confirmContinueToHelpCenter": {
+    "message": "Continue to Help Center?",
+    "description": "Title for dialog which asks if the user wants to proceed to a relevant Help Center page"
+  },
+  "confirmContinueToHelpCenterPasswordManagementContent": {
+    "message": "Change your browser's autofill and password management settings.",
+    "description": "Body content for dialog which asks if the user wants to proceed to the Help Center's page about browser password management settings"
+  },
+  "confirmContinueToHelpCenterKeyboardShortcutsContent": {
+    "message": "You can view and set extension shortcuts in your browser's settings.",
+    "description": "Body content for dialog which asks if the user wants to proceed to the Help Center's page about browser keyboard shortcut settings"
+  },
+  "confirmContinueToBrowserPasswordManagementSettingsContent": {
+    "message": "Change your browser's autofill and password management settings.",
+    "description": "Body content for dialog which asks if the user wants to proceed to the browser's password management settings page"
+  },
+  "confirmContinueToBrowserKeyboardShortcutSettingsContent": {
+    "message": "You can view and set extension shortcuts in your browser's settings.",
+    "description": "Body content for dialog which asks if the user wants to proceed to the browser's keyboard shortcut settings page"
+  },
   "overrideDefaultBrowserAutofillTitle": {
     "message": "Make Bitwarden your default password manager?",
     "description": "Dialog title facilitating the ability to override a chrome browser's default autofill behavior"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1272,6 +1272,20 @@
   "enableAutoFillOnPageLoadDesc": {
     "message": "If a login form is detected, autofill when the web page loads."
   },
+  "autofillOnPageLoadWarning": {
+    "message": "$OPENTAG$Warning:$CLOSETAG$ Compromised or untrusted websites can exploit autofill on page load.",
+    "placeholders": {
+      "openTag": {
+        "content": "$1",
+        "example": "<b>"
+      },
+      "closeTag": {
+        "content": "$2",
+        "example": "</b>"
+      }
+
+    }
+  },
   "experimentalFeature": {
     "message": "Compromised or untrusted websites can exploit autofill on page load."
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -108,7 +108,7 @@
     "message": "Copy security code"
   },
   "autoFill": {
-    "message": "Auto-fill"
+    "message": "Autofill"
   },
   "autoFillLogin": {
     "message": "Auto-fill login"
@@ -789,11 +789,17 @@
   "addLoginNotificationDescAlt": {
     "message": "Ask to add an item if one isn't found in your vault. Applies to all logged in accounts."
   },
+  "showCardsInVaultView": {
+    "message": "Show cards as Autofill suggestions on Vault view"
+  },
   "showCardsCurrentTab": {
     "message": "Show cards on Tab page"
   },
   "showCardsCurrentTabDesc": {
     "message": "List card items on the Tab page for easy auto-fill."
+  },
+  "showIdentitiesInVaultView": {
+    "message": "Show identifies as Autofill suggestions on Vault view"
   },
   "showIdentitiesCurrentTab": {
     "message": "Show identities on Tab page"
@@ -1227,11 +1233,20 @@
     "message": "Show auto-fill menu on form fields",
     "description": "Represents the message for allowing the user to enable the auto-fill overlay"
   },
-  "showAutoFillMenuOnFormFieldsDescAlt": {
+  "autofillSuggestionsSectionTitle": {
+    "message": "Autofill suggestions"
+  },
+  "showInlineMenuLabel": {
+    "message": "Show autofill suggestions on form fields"
+  },
+  "showInlineMenuOnIconSelectionLabel": {
+    "message": "Display suggestions when icon is selected"
+  },
+  "showInlineMenuOnFormFieldsDescAlt": {
     "message": "Applies to all logged in accounts."
   },
   "turnOffBrowserBuiltInPasswordManagerSettings": {
-    "message": "Turn off your browser’s built in password manager settings to avoid conflicts."
+    "message": "Turn off your browser's built in password manager settings to avoid conflicts."
   },
   "turnOffBrowserBuiltInPasswordManagerSettingsLink": {
     "message": "Edit browser settings."
@@ -1248,23 +1263,29 @@
     "message": "When auto-fill icon is selected",
     "description": "Overlay appearance select option for showing the field on click of the overlay icon"
   },
+  "enableAutoFillOnPageLoadSectionTitle": {
+    "message": "Autofill on page load"
+  },
   "enableAutoFillOnPageLoad": {
-    "message": "Auto-fill on page load"
+    "message": "Autofill on page load"
   },
   "enableAutoFillOnPageLoadDesc": {
-    "message": "If a login form is detected, auto-fill when the web page loads."
+    "message": "If a login form is detected, autofill when the web page loads."
   },
   "experimentalFeature": {
-    "message": "Compromised or untrusted websites can exploit auto-fill on page load."
+    "message": "Compromised or untrusted websites can exploit autofill on page load."
+  },
+  "learnMoreAboutAutofillOnPageLoadLinkText": {
+    "message": "Learn more about risks"
   },
   "learnMoreAboutAutofill": {
-    "message": "Learn more about auto-fill"
+    "message": "Learn more about autofill"
   },
   "defaultAutoFillOnPageLoad": {
     "message": "Default autofill setting for login items"
   },
   "defaultAutoFillOnPageLoadDesc": {
-    "message": "You can turn off auto-fill on page load for individual login items from the item's Edit view."
+    "message": "You can turn off autofill on page load for individual login items from the item's Edit view."
   },
   "itemAutoFillOnPageLoad": {
     "message": "Auto-fill on page load (if set up in Options)"
@@ -1273,10 +1294,10 @@
     "message": "Use default setting"
   },
   "autoFillOnPageLoadYes": {
-    "message": "Auto-fill on page load"
+    "message": "Autofill on page load"
   },
   "autoFillOnPageLoadNo": {
-    "message": "Do not auto-fill on page load"
+    "message": "Do not autofill on page load"
   },
   "commandOpenPopup": {
     "message": "Open vault popup"
@@ -2001,7 +2022,7 @@
     "placeholders": {
       "domain": {
         "content": "$1",
-        "example": "google.com"
+        "example": "duckduckgo.com"
       }
     }
   },
@@ -2703,14 +2724,20 @@
   "autofillSettings": {
     "message": "Auto-fill settings"
   },
+  "autofillKeyboardShortcutSectionTitle": {
+    "message": "Autofill shortcut"
+  },
+  "autofillKeyboardShortcutUpdateLabel": {
+    "message": "Change shortcut"
+  },
   "autofillShortcut": {
-    "message": "Auto-fill keyboard shortcut"
+    "message": "Autofill keyboard shortcut"
   },
   "autofillShortcutNotSet": {
-    "message": "The auto-fill shortcut is not set. Change this in the browser's settings."
+    "message": "The autofill shortcut is not set. Change this in the browser's settings."
   },
   "autofillShortcutText": {
-    "message": "The auto-fill shortcut is: $COMMAND$. Change this in the browser's settings.",
+    "message": "The autofill shortcut is: $COMMAND$. Change this in the browser's settings.",
     "placeholders": {
       "command": {
         "content": "$1",
@@ -3366,7 +3393,7 @@
     "placeholders": {
       "domain": {
         "content": "$1",
-        "example": "google.com"
+        "example": "duckduckgo.com"
       }
     }
   },
@@ -3379,7 +3406,7 @@
     "description": "Dialog title facilitating the ability to override a chrome browser's default autofill behavior"
   },
   "overrideDefaultBrowserAutofillDescription": {
-    "message": "Ignoring this option may cause conflicts between the Bitwarden auto-fill menu and your browser's.",
+    "message": "Ignoring this option may cause conflicts between Bitwarden autofill suggestions and your browser's.",
     "description": "Dialog message facilitating the ability to override a chrome browser's default autofill behavior"
   },
   "overrideDefaultBrowserAutoFillSettings": {

--- a/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
@@ -1,0 +1,221 @@
+<header>
+  <div class="left">
+    <button type="button" routerLink="/tabs/settings">
+      <span class="header-icon"><i class="bwi bwi-angle-left" aria-hidden="true"></i></span>
+      <span>{{ "back" | i18n }}</span>
+    </button>
+  </div>
+  <h1 class="center">
+    <span class="title">{{ "autofill" | i18n }}</span>
+  </h1>
+  <div class="right"></div>
+</header>
+<main tabindex="-1">
+  <div class="box tw-mt-4">
+    <div class="box-content">
+      <button
+        type="button"
+        class="box-content-row box-content-row-link box-content-row-flex"
+        (click)="commandSettings()"
+      >
+        <div class="row-main">{{ "autofillShortcut" | i18n }}</div>
+        <i class="bwi bwi-external-link bwi-lg bwi-fw" aria-hidden="true"></i>
+      </button>
+    </div>
+    <div id="autofillKeyboardHelp" class="box-footer">
+      {{ autofillKeyboardHelperText }}
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="autofill-overlay-settings">{{ "showAutoFillMenuOnFormFields" | i18n }}</label>
+        <select
+          id="autofill-overlay-settings"
+          name="autofill-overlay-settings"
+          [(ngModel)]="autoFillOverlayVisibility"
+          (change)="updateAutoFillOverlayVisibility()"
+        >
+          <option *ngFor="let o of autoFillOverlayVisibilityOptions" [ngValue]="o.value">
+            {{ o.name }}
+          </option>
+        </select>
+      </div>
+      <div class="box-footer" *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting">
+        {{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}
+      </div>
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-content" *ngIf="canOverrideBrowserAutofillSetting">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="overrideBrowserAutofill" class="!tw-mr-0">{{
+          "overrideDefaultBrowserAutoFillSettings" | i18n
+        }}</label>
+        <input
+          id="overrideBrowserAutofill"
+          type="checkbox"
+          (change)="updateDefaultBrowserAutofillDisabled()"
+          [(ngModel)]="defaultBrowserAutofillDisabled"
+        />
+      </div>
+    </div>
+    <div class="box-footer">
+      <span *ngIf="accountSwitcherEnabled">{{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}</span>
+      {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
+      <a
+        [attr.href]="disablePasswordManagerLink"
+        (click)="openDisablePasswordManagerLink($event)"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+      </a>
+    </div>
+  </div>
+  <div class="box tw-mt-4">
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
+        <input
+          id="autofill"
+          type="checkbox"
+          aria-describedby="autofillHelp"
+          (change)="updateAutoFillOnPageLoad()"
+          [(ngModel)]="enableAutoFillOnPageLoad"
+        />
+      </div>
+    </div>
+    <div id="autofillHelp" class="box-footer">
+      {{ "enableAutoFillOnPageLoadDesc" | i18n }}
+      <b>{{ "warning" | i18n }}</b
+      >: {{ "experimentalFeature" | i18n }}
+      <a href="https://bitwarden.com/help/auto-fill-browser/" target="_blank" rel="noreferrer">
+        {{ "learnMoreAboutAutofill" | i18n }}.
+        <i
+          [attr.aria-label]="'opensInANewWindow' | i18n"
+          class="bwi bwi-external-link bwi-sm bwi-fw"
+        ></i>
+      </a>
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
+        <select
+          id="defaultAutofill"
+          name="DefaultAutofill"
+          aria-describedby="defaultAutofillHelp"
+          [(ngModel)]="autoFillOnPageLoadDefault"
+          (change)="updateAutoFillOnPageLoadDefault()"
+          [disabled]="!enableAutoFillOnPageLoad"
+        >
+          <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
+            {{ o.name }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div id="defaultAutofillHelp" class="box-footer">
+      {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
+    </div>
+  </div>
+  <div class="box">
+    <h2 class="box-header">{{ "additionalOptions" | i18n }}</h2>
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="context-menu">{{ "enableContextMenuItem" | i18n }}</label>
+        <input
+          id="context-menu"
+          type="checkbox"
+          aria-describedby="context-menuHelp"
+          (change)="updateContextMenuItem()"
+          [(ngModel)]="enableContextMenuItem"
+        />
+      </div>
+    </div>
+    <div id="context-menuHelp" class="box-footer">
+      {{
+        accountSwitcherEnabled ? ("contextMenuItemDescAlt" | i18n) : ("contextMenuItemDesc" | i18n)
+      }}
+    </div>
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="totp">{{ "enableAutoTotpCopy" | i18n }}</label>
+        <input
+          id="totp"
+          type="checkbox"
+          aria-describedby="totpHelp"
+          (change)="updateAutoTotpCopy()"
+          [(ngModel)]="enableAutoTotpCopy"
+        />
+      </div>
+    </div>
+    <div id="totpHelp" class="box-footer">{{ "disableAutoTotpCopyDesc" | i18n }}</div>
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
+        <select
+          id="clearClipboard"
+          name="ClearClipboard"
+          aria-describedby="clearClipboardHelp"
+          [(ngModel)]="clearClipboard"
+          (change)="saveClearClipboard()"
+        >
+          <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
+            {{ o.name }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div id="clearClipboardHelp" class="box-footer">{{ "clearClipboardDesc" | i18n }}</div>
+    <div class="box-content">
+      <div class="box-content-row" appBoxRow>
+        <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
+        <select
+          id="defaultUriMatch"
+          name="DefaultUriMatch"
+          aria-describedby="defaultUriMatchHelp"
+          [(ngModel)]="defaultUriMatch"
+          (change)="saveDefaultUriMatch()"
+        >
+          <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
+        </select>
+      </div>
+    </div>
+    <div id="defaultUriMatchHelp" class="box-footer">
+      {{ "defaultUriMatchDetectionDesc" | i18n }}
+    </div>
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="showCardsCurrentTab">{{ "showCardsCurrentTab" | i18n }}</label>
+        <input
+          id="showCardsCurrentTab"
+          type="checkbox"
+          aria-describedby="showCardsCurrentTabHelp"
+          (change)="updateShowCardsCurrentTab()"
+          [(ngModel)]="showCardsCurrentTab"
+        />
+      </div>
+    </div>
+    <div id="showCardsCurrentTabHelp" class="box-footer">
+      {{ "showCardsCurrentTabDesc" | i18n }}
+    </div>
+    <div class="box-content">
+      <div class="box-content-row box-content-row-checkbox" appBoxRow>
+        <label for="showIdentitiesCurrentTab">{{ "showIdentitiesCurrentTab" | i18n }}</label>
+        <input
+          id="showIdentitiesCurrentTab"
+          type="checkbox"
+          aria-describedby="showIdentitiesCurrentTabHelp"
+          (change)="updateShowIdentitiesCurrentTab()"
+          [(ngModel)]="showIdentitiesCurrentTab"
+        />
+      </div>
+    </div>
+    <div id="showIdentitiesCurrentTabHelp" class="box-footer">
+      {{ "showIdentitiesCurrentTabDesc" | i18n }}
+    </div>
+  </div>
+</main>

--- a/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
@@ -42,7 +42,7 @@
         </select>
       </div>
       <div class="box-footer" *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting">
-        {{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}
+        {{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}
       </div>
     </div>
   </div>
@@ -61,7 +61,7 @@
       </div>
     </div>
     <div class="box-footer">
-      <span *ngIf="accountSwitcherEnabled">{{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}</span>
+      <span *ngIf="accountSwitcherEnabled">{{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}</span>
       {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
       <a
         [attr.href]="disablePasswordManagerLink"

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -143,7 +143,7 @@
             bitCheckbox
             id="autofillOnPageLoad"
             type="checkbox"
-            (change)="updateAutoFillOnPageLoad()"
+            (change)="updateAutofillOnPageLoad()"
             [(ngModel)]="enableAutofillOnPageLoad"
           />
           <bit-label for="autofillOnPageLoad">{{ "enableAutoFillOnPageLoad" | i18n }}</bit-label>
@@ -153,7 +153,7 @@
           <select
             bitInput
             id="defaultAutofill"
-            (change)="updateAutoFillOnPageLoadDefault()"
+            (change)="updateAutofillOnPageLoadDefault()"
             [(ngModel)]="autofillOnPageLoadDefault"
             [disabled]="!enableAutofillOnPageLoad"
           >

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -8,7 +8,7 @@
   <div class="tw-bg-background-alt tw-p-2">
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">Autofill suggestions</h2>
+        <h2 bitTypography="h5">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-form-control>
@@ -19,16 +19,15 @@
             (change)="updateInlineMenuVisibility()"
             [(ngModel)]="enableInlineMenu"
           />
-          <bit-label for="show-inline-menu">Show autofill suggestions on form fields</bit-label>
+          <bit-label for="show-inline-menu">{{ "showInlineMenuLabel" | i18n }}</bit-label>
           <bit-hint
             *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting"
             class="tw-text-sm"
           >
-            {{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}
+            {{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}
           </bit-hint>
         </bit-form-control>
-
-        <bit-form-control *ngIf="enableInlineMenu" class="tw-pl-11">
+        <bit-form-control *ngIf="enableInlineMenu" class="tw-pl-5">
           <input
             bitCheckbox
             id="show-autofill-suggestions-on-icon"
@@ -36,11 +35,11 @@
             (change)="updateInlineMenuVisibility()"
             [(ngModel)]="enableInlineMenuOnIconSelect"
           />
-          <bit-label for="show-autofill-suggestions-on-icon"
-            >Display suggestions when icon is selected</bit-label
-          >
+          <bit-label for="show-autofill-suggestions-on-icon">
+            {{ "showInlineMenuOnIconSelectionLabel" | i18n }}
+          </bit-label>
           <bit-hint class="tw-text-sm" *ngIf="!canOverrideBrowserAutofillSetting">
-            Turn off your browser's built in password manager settings to avoid conflicts.
+            {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
             <a
               bitLink
               class="tw-no-underline"
@@ -65,7 +64,7 @@
             "overrideDefaultBrowserAutoFillSettings" | i18n
           }}</bit-label>
           <bit-hint class="tw-text-sm">
-            Turn off your browser's built in password manager settings to avoid conflicts.
+            {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
             <a
               bitLink
               class="tw-no-underline"
@@ -86,9 +85,7 @@
             (change)="updateShowCardsCurrentTab()"
             [(ngModel)]="showCardsCurrentTab"
           />
-          <bit-label for="showCardsSuggestions"
-            >Show cards as Autofill suggestions on Vault view</bit-label
-          >
+          <bit-label for="showCardsSuggestions">{{ "showCardsInVaultView" | i18n }}</bit-label>
         </bit-form-control>
         <bit-form-control>
           <input
@@ -98,22 +95,22 @@
             (change)="updateShowIdentitiesCurrentTab()"
             [(ngModel)]="showIdentitiesCurrentTab"
           />
-          <bit-label for="showIdentitiesSuggestions" class="tw-whitespace-normal"
-            >Show identifies as Autofill suggestions on Vault view</bit-label
-          >
+          <bit-label for="showIdentitiesSuggestions" class="tw-whitespace-normal">
+            {{ "showIdentitiesInVaultView" | i18n }}
+          </bit-label>
         </bit-form-control>
       </bit-card>
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">Autofill shortcut</h2>
+        <h2 bitTypography="h5">{{ "autofillKeyboardShortcutSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-item>
         <button bit-item-content type="button" (click)="openURI($event, browserShortcutsURI)">
-          <h3 bitTypography="h5">Change shortcut</h3>
-          <bit-hint slot="secondary" class="tw-text-sm tw-whitespace-normal">{{
-            autofillKeyboardHelperText
-          }}</bit-hint>
+          <h3 bitTypography="h5">{{ "autofillKeyboardShortcutUpdateLabel" | i18n }}</h3>
+          <bit-hint slot="secondary" class="tw-text-sm tw-whitespace-normal">
+            {{ autofillKeyboardHelperText }}
+          </bit-hint>
           <i
             appA11yTitle="{{ 'opensInANewWindow' | i18n }}"
             aria-hidden="true"
@@ -125,7 +122,7 @@
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">Autofill on page load</h2>
+        <h2 bitTypography="h5">{{ "enableAutoFillOnPageLoadSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-hint class="tw-mb-6 tw-text-sm">
@@ -139,7 +136,7 @@
             rel="noreferrer"
             target="_blank"
           >
-            Learn more about risks
+            {{ "learnMoreAboutAutofillOnPageLoadLinkText" | i18n }}
           </a>
         </bit-hint>
         <bit-form-control>
@@ -175,7 +172,7 @@
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">Additional options</h2>
+        <h2 bitTypography="h5">{{ "additionalOptions" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-form-control>

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -127,8 +127,7 @@
       <bit-card>
         <bit-hint class="tw-mb-6 tw-text-sm">
           {{ "enableAutoFillOnPageLoadDesc" | i18n }}
-          <b class="tw-capitalize">{{ "warning" | i18n }}</b
-          >: {{ "experimentalFeature" | i18n }}
+          <span [innerHTML]="'autofillOnPageLoadWarning' | i18n: '\<b>' : '\</b>'"></span>
           <a
             bitLink
             class="tw-no-underline"

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -1,221 +1,238 @@
-<header>
-  <div class="left">
-    <button type="button" routerLink="/tabs/settings">
-      <span class="header-icon"><i class="bwi bwi-angle-left" aria-hidden="true"></i></span>
-      <span>{{ "back" | i18n }}</span>
-    </button>
+<popup-page>
+  <popup-header slot="header" pageTitle="{{ 'autofill' | i18n }}" showBackButton>
+    <ng-container slot="end">
+      <app-pop-out></app-pop-out>
+    </ng-container>
+  </popup-header>
+
+  <div class="tw-bg-background-alt tw-p-2">
+    <bit-section>
+      <bit-section-header>
+        <h2 bitTypography="h5">Autofill suggestions</h2>
+      </bit-section-header>
+      <bit-card>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="show-inline-menu"
+            type="checkbox"
+            (change)="updateInlineMenuVisibility()"
+            [(ngModel)]="enableInlineMenu"
+          />
+          <bit-label for="show-inline-menu">Show autofill suggestions on form fields</bit-label>
+          <bit-hint
+            *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting"
+            class="tw-text-sm"
+          >
+            {{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}
+          </bit-hint>
+        </bit-form-control>
+
+        <bit-form-control *ngIf="enableInlineMenu" class="tw-pl-11">
+          <input
+            bitCheckbox
+            id="show-autofill-suggestions-on-icon"
+            type="checkbox"
+            (change)="updateInlineMenuVisibility()"
+            [(ngModel)]="enableInlineMenuOnIconSelect"
+          />
+          <bit-label for="show-autofill-suggestions-on-icon"
+            >Display suggestions when icon is selected</bit-label
+          >
+          <bit-hint class="tw-text-sm" *ngIf="!canOverrideBrowserAutofillSetting">
+            Turn off your browser's built in password manager settings to avoid conflicts.
+            <a
+              bitLink
+              class="tw-no-underline"
+              rel="noreferrer"
+              target="_blank"
+              (click)="openURI($event, disablePasswordManagerURI)"
+              [attr.href]="disablePasswordManagerURI"
+            >
+              {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+            </a>
+          </bit-hint>
+        </bit-form-control>
+        <bit-form-control *ngIf="canOverrideBrowserAutofillSetting">
+          <input
+            bitCheckbox
+            id="overrideBrowserAutofill"
+            type="checkbox"
+            (change)="updateDefaultBrowserAutofillDisabled()"
+            [(ngModel)]="defaultBrowserAutofillDisabled"
+          />
+          <bit-label for="overrideBrowserAutofill">{{
+            "overrideDefaultBrowserAutoFillSettings" | i18n
+          }}</bit-label>
+          <bit-hint class="tw-text-sm">
+            Turn off your browser's built in password manager settings to avoid conflicts.
+            <a
+              bitLink
+              class="tw-no-underline"
+              rel="noreferrer"
+              target="_blank"
+              (click)="openURI($event, disablePasswordManagerURI)"
+              [attr.href]="disablePasswordManagerURI"
+            >
+              {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+            </a>
+          </bit-hint>
+        </bit-form-control>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="showCardsSuggestions"
+            type="checkbox"
+            (change)="updateShowCardsCurrentTab()"
+            [(ngModel)]="showCardsCurrentTab"
+          />
+          <bit-label for="showCardsSuggestions"
+            >Show cards as Autofill suggestions on Vault view</bit-label
+          >
+        </bit-form-control>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="showIdentitiesSuggestions"
+            type="checkbox"
+            (change)="updateShowIdentitiesCurrentTab()"
+            [(ngModel)]="showIdentitiesCurrentTab"
+          />
+          <bit-label for="showIdentitiesSuggestions" class="tw-whitespace-normal"
+            >Show identifies as Autofill suggestions on Vault view</bit-label
+          >
+        </bit-form-control>
+      </bit-card>
+    </bit-section>
+    <bit-section>
+      <bit-section-header>
+        <h2 bitTypography="h5">Autofill shortcut</h2>
+      </bit-section-header>
+      <bit-item>
+        <button bit-item-content type="button" (click)="openURI($event, browserShortcutsURI)">
+          <h3 bitTypography="h5">Change shortcut</h3>
+          <bit-hint slot="secondary" class="tw-text-sm tw-whitespace-normal">{{
+            autofillKeyboardHelperText
+          }}</bit-hint>
+          <i
+            appA11yTitle="{{ 'opensInANewWindow' | i18n }}"
+            aria-hidden="true"
+            class="bwi bwi-fw bwi-external-link bwi-lg tw-text-muted"
+            slot="end"
+          ></i>
+        </button>
+      </bit-item>
+    </bit-section>
+    <bit-section>
+      <bit-section-header>
+        <h2 bitTypography="h5">Autofill on page load</h2>
+      </bit-section-header>
+      <bit-card>
+        <bit-hint class="tw-mb-6 tw-text-sm">
+          {{ "enableAutoFillOnPageLoadDesc" | i18n }}
+          <b class="tw-capitalize">{{ "warning" | i18n }}</b
+          >: {{ "experimentalFeature" | i18n }}
+          <a
+            bitLink
+            class="tw-no-underline"
+            href="https://bitwarden.com/help/auto-fill-browser/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Learn more about risks
+          </a>
+        </bit-hint>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="autofillOnPageLoad"
+            type="checkbox"
+            (change)="updateAutoFillOnPageLoad()"
+            [(ngModel)]="enableAutofillOnPageLoad"
+          />
+          <bit-label for="autofillOnPageLoad">{{ "enableAutoFillOnPageLoad" | i18n }}</bit-label>
+        </bit-form-control>
+        <bit-form-field>
+          <bit-label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</bit-label>
+          <select
+            bitInput
+            id="defaultAutofill"
+            (change)="updateAutoFillOnPageLoadDefault()"
+            [(ngModel)]="autofillOnPageLoadDefault"
+            [disabled]="!enableAutofillOnPageLoad"
+          >
+            <option
+              *ngFor="let o of autofillOnPageLoadOptions"
+              [value]="o.value"
+              [label]="o.name"
+            ></option>
+          </select>
+          <bit-hint class="tw-text-sm">
+            {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
+          </bit-hint>
+        </bit-form-field>
+      </bit-card>
+    </bit-section>
+    <bit-section>
+      <bit-section-header>
+        <h2 bitTypography="h5">Additional options</h2>
+      </bit-section-header>
+      <bit-card>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="context-menu"
+            type="checkbox"
+            (change)="updateContextMenuItem()"
+            [(ngModel)]="enableContextMenuItem"
+          />
+          <bit-label for="context-menu">{{ "enableContextMenuItem" | i18n }}</bit-label>
+        </bit-form-control>
+        <bit-form-control>
+          <input
+            bitCheckbox
+            id="totp"
+            type="checkbox"
+            (change)="updateAutoTotpCopy()"
+            [(ngModel)]="enableAutoTotpCopy"
+          />
+          <bit-label for="totp">{{ "enableAutoTotpCopy" | i18n }}</bit-label>
+        </bit-form-control>
+        <bit-form-field>
+          <bit-label for="clearClipboard">{{ "clearClipboard" | i18n }}</bit-label>
+          <select
+            aria-describedby="clearClipboardHelp"
+            bitInput
+            id="clearClipboard"
+            (change)="saveClearClipboard()"
+            [(ngModel)]="clearClipboard"
+          >
+            <option
+              *ngFor="let o of clearClipboardOptions"
+              [label]="o.name"
+              [value]="o.value"
+            ></option>
+          </select>
+          <bit-hint class="tw-text-sm" id="clearClipboardHelp">
+            {{ "clearClipboardDesc" | i18n }}
+          </bit-hint>
+        </bit-form-field>
+        <bit-form-field>
+          <bit-label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</bit-label>
+          <select
+            aria-describedby="defaultUriMatchHelp"
+            bitInput
+            id="defaultUriMatch"
+            (change)="saveDefaultUriMatch()"
+            [(ngModel)]="defaultUriMatch"
+          >
+            <option *ngFor="let o of uriMatchOptions" [label]="o.name" [value]="o.value"></option>
+          </select>
+          <bit-hint class="tw-text-sm" id="defaultUriMatchHelp">
+            {{ "defaultUriMatchDetectionDesc" | i18n }}
+          </bit-hint>
+        </bit-form-field>
+      </bit-card>
+    </bit-section>
   </div>
-  <h1 class="center">
-    <span class="title">{{ "autofill" | i18n }}</span>
-  </h1>
-  <div class="right"></div>
-</header>
-<main tabindex="-1">
-  <div class="box tw-mt-4">
-    <div class="box-content">
-      <button
-        type="button"
-        class="box-content-row box-content-row-link box-content-row-flex"
-        (click)="commandSettings()"
-      >
-        <div class="row-main">{{ "autofillShortcut" | i18n }}</div>
-        <i class="bwi bwi-external-link bwi-lg bwi-fw" aria-hidden="true"></i>
-      </button>
-    </div>
-    <div id="autofillKeyboardHelp" class="box-footer">
-      {{ autofillKeyboardHelperText }}
-    </div>
-  </div>
-  <div class="box">
-    <div class="box-content">
-      <div class="box-content-row" appBoxRow>
-        <label for="autofill-overlay-settings">{{ "showAutoFillMenuOnFormFields" | i18n }}</label>
-        <select
-          id="autofill-overlay-settings"
-          name="autofill-overlay-settings"
-          [(ngModel)]="autoFillOverlayVisibility"
-          (change)="updateAutoFillOverlayVisibility()"
-        >
-          <option *ngFor="let o of autoFillOverlayVisibilityOptions" [ngValue]="o.value">
-            {{ o.name }}
-          </option>
-        </select>
-      </div>
-      <div class="box-footer" *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting">
-        {{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}
-      </div>
-    </div>
-  </div>
-  <div class="box">
-    <div class="box-content" *ngIf="canOverrideBrowserAutofillSetting">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="overrideBrowserAutofill" class="!tw-mr-0">{{
-          "overrideDefaultBrowserAutoFillSettings" | i18n
-        }}</label>
-        <input
-          id="overrideBrowserAutofill"
-          type="checkbox"
-          (change)="updateDefaultBrowserAutofillDisabled()"
-          [(ngModel)]="defaultBrowserAutofillDisabled"
-        />
-      </div>
-    </div>
-    <div class="box-footer">
-      <span *ngIf="accountSwitcherEnabled">{{ "showAutoFillMenuOnFormFieldsDescAlt" | i18n }}</span>
-      {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
-      <a
-        [attr.href]="disablePasswordManagerLink"
-        (click)="openDisablePasswordManagerLink($event)"
-        target="_blank"
-        rel="noreferrer"
-      >
-        {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
-      </a>
-    </div>
-  </div>
-  <div class="box tw-mt-4">
-    <div class="box-content">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="autofill">{{ "enableAutoFillOnPageLoad" | i18n }}</label>
-        <input
-          id="autofill"
-          type="checkbox"
-          aria-describedby="autofillHelp"
-          (change)="updateAutoFillOnPageLoad()"
-          [(ngModel)]="enableAutoFillOnPageLoad"
-        />
-      </div>
-    </div>
-    <div id="autofillHelp" class="box-footer">
-      {{ "enableAutoFillOnPageLoadDesc" | i18n }}
-      <b>{{ "warning" | i18n }}</b
-      >: {{ "experimentalFeature" | i18n }}
-      <a href="https://bitwarden.com/help/auto-fill-browser/" target="_blank" rel="noreferrer">
-        {{ "learnMoreAboutAutofill" | i18n }}.
-        <i
-          [attr.aria-label]="'opensInANewWindow' | i18n"
-          class="bwi bwi-external-link bwi-sm bwi-fw"
-        ></i>
-      </a>
-    </div>
-  </div>
-  <div class="box">
-    <div class="box-content">
-      <div class="box-content-row" appBoxRow>
-        <label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</label>
-        <select
-          id="defaultAutofill"
-          name="DefaultAutofill"
-          aria-describedby="defaultAutofillHelp"
-          [(ngModel)]="autoFillOnPageLoadDefault"
-          (change)="updateAutoFillOnPageLoadDefault()"
-          [disabled]="!enableAutoFillOnPageLoad"
-        >
-          <option *ngFor="let o of autoFillOnPageLoadOptions" [ngValue]="o.value">
-            {{ o.name }}
-          </option>
-        </select>
-      </div>
-    </div>
-    <div id="defaultAutofillHelp" class="box-footer">
-      {{ "defaultAutoFillOnPageLoadDesc" | i18n }}
-    </div>
-  </div>
-  <div class="box">
-    <h2 class="box-header">{{ "additionalOptions" | i18n }}</h2>
-    <div class="box-content">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="context-menu">{{ "enableContextMenuItem" | i18n }}</label>
-        <input
-          id="context-menu"
-          type="checkbox"
-          aria-describedby="context-menuHelp"
-          (change)="updateContextMenuItem()"
-          [(ngModel)]="enableContextMenuItem"
-        />
-      </div>
-    </div>
-    <div id="context-menuHelp" class="box-footer">
-      {{
-        accountSwitcherEnabled ? ("contextMenuItemDescAlt" | i18n) : ("contextMenuItemDesc" | i18n)
-      }}
-    </div>
-    <div class="box-content">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="totp">{{ "enableAutoTotpCopy" | i18n }}</label>
-        <input
-          id="totp"
-          type="checkbox"
-          aria-describedby="totpHelp"
-          (change)="updateAutoTotpCopy()"
-          [(ngModel)]="enableAutoTotpCopy"
-        />
-      </div>
-    </div>
-    <div id="totpHelp" class="box-footer">{{ "disableAutoTotpCopyDesc" | i18n }}</div>
-    <div class="box-content">
-      <div class="box-content-row" appBoxRow>
-        <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
-        <select
-          id="clearClipboard"
-          name="ClearClipboard"
-          aria-describedby="clearClipboardHelp"
-          [(ngModel)]="clearClipboard"
-          (change)="saveClearClipboard()"
-        >
-          <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
-            {{ o.name }}
-          </option>
-        </select>
-      </div>
-    </div>
-    <div id="clearClipboardHelp" class="box-footer">{{ "clearClipboardDesc" | i18n }}</div>
-    <div class="box-content">
-      <div class="box-content-row" appBoxRow>
-        <label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</label>
-        <select
-          id="defaultUriMatch"
-          name="DefaultUriMatch"
-          aria-describedby="defaultUriMatchHelp"
-          [(ngModel)]="defaultUriMatch"
-          (change)="saveDefaultUriMatch()"
-        >
-          <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{ o.name }}</option>
-        </select>
-      </div>
-    </div>
-    <div id="defaultUriMatchHelp" class="box-footer">
-      {{ "defaultUriMatchDetectionDesc" | i18n }}
-    </div>
-    <div class="box-content">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="showCardsCurrentTab">{{ "showCardsCurrentTab" | i18n }}</label>
-        <input
-          id="showCardsCurrentTab"
-          type="checkbox"
-          aria-describedby="showCardsCurrentTabHelp"
-          (change)="updateShowCardsCurrentTab()"
-          [(ngModel)]="showCardsCurrentTab"
-        />
-      </div>
-    </div>
-    <div id="showCardsCurrentTabHelp" class="box-footer">
-      {{ "showCardsCurrentTabDesc" | i18n }}
-    </div>
-    <div class="box-content">
-      <div class="box-content-row box-content-row-checkbox" appBoxRow>
-        <label for="showIdentitiesCurrentTab">{{ "showIdentitiesCurrentTab" | i18n }}</label>
-        <input
-          id="showIdentitiesCurrentTab"
-          type="checkbox"
-          aria-describedby="showIdentitiesCurrentTabHelp"
-          (change)="updateShowIdentitiesCurrentTab()"
-          [(ngModel)]="showIdentitiesCurrentTab"
-        />
-      </div>
-    </div>
-    <div id="showIdentitiesCurrentTabHelp" class="box-footer">
-      {{ "showIdentitiesCurrentTabDesc" | i18n }}
-    </div>
-  </div>
-</main>
+</popup-page>

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -44,7 +44,6 @@ import {
 } from "@bitwarden/components";
 
 import { BrowserApi } from "../../../platform/browser/browser-api";
-import { enableAccountSwitching } from "../../../platform/flags";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupFooterComponent } from "../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
@@ -135,7 +134,6 @@ export class AutofillComponent implements OnInit {
       { name: i18nService.t("never"), value: UriMatchStrategy.Never },
     ];
 
-    this.accountSwitcherEnabled = enableAccountSwitching();
     this.browserClientVendor = this.getBrowserClientVendor();
     this.disablePasswordManagerURI = DisablePasswordManagerUris[this.browserClientVendor];
     this.browserShortcutsURI = BrowserShortcutsUris[this.browserClientVendor];
@@ -203,11 +201,11 @@ export class AutofillComponent implements OnInit {
     await this.requestPrivacyPermission();
   }
 
-  async updateAutoFillOnPageLoad() {
+  async updateAutofillOnPageLoad() {
     await this.autofillSettingsService.setAutofillOnPageLoad(this.enableAutofillOnPageLoad);
   }
 
-  async updateAutoFillOnPageLoadDefault() {
+  async updateAutofillOnPageLoadDefault() {
     await this.autofillSettingsService.setAutofillOnPageLoadDefault(this.autofillOnPageLoadDefault);
   }
 

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -38,6 +38,7 @@ import { TwoFactorAuthComponent } from "../auth/popup/two-factor-auth.component"
 import { TwoFactorOptionsComponent } from "../auth/popup/two-factor-options.component";
 import { TwoFactorComponent } from "../auth/popup/two-factor.component";
 import { UpdateTempPasswordComponent } from "../auth/popup/update-temp-password.component";
+import { AutofillV1Component } from "../autofill/popup/settings/autofill-v1.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { ExcludedDomainsV1Component } from "../autofill/popup/settings/excluded-domains-v1.component";
 import { ExcludedDomainsComponent } from "../autofill/popup/settings/excluded-domains.component";
@@ -278,12 +279,11 @@ const routes: Routes = [
     canActivate: [AuthGuard],
     data: { state: "export" },
   }),
-  {
+  ...extensionRefreshSwap(AutofillV1Component, AutofillComponent, {
     path: "autofill",
-    component: AutofillComponent,
     canActivate: [AuthGuard],
     data: { state: "autofill" },
-  },
+  }),
   {
     path: "account-security",
     component: AccountSecurityComponent,

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -36,6 +36,7 @@ import { SsoComponent } from "../auth/popup/sso.component";
 import { TwoFactorOptionsComponent } from "../auth/popup/two-factor-options.component";
 import { TwoFactorComponent } from "../auth/popup/two-factor.component";
 import { UpdateTempPasswordComponent } from "../auth/popup/update-temp-password.component";
+import { AutofillV1Component } from "../autofill/popup/settings/autofill-v1.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { ExcludedDomainsV1Component } from "../autofill/popup/settings/excluded-domains-v1.component";
 import { ExcludedDomainsComponent } from "../autofill/popup/settings/excluded-domains.component";
@@ -93,6 +94,7 @@ import "../platform/popup/locales";
   imports: [
     A11yModule,
     AppRoutingModule,
+    AutofillComponent,
     ToastModule.forRoot({
       maxOpened: 2,
       autoDismiss: true,
@@ -180,7 +182,7 @@ import "../platform/popup/locales";
     RemovePasswordComponent,
     VaultSelectComponent,
     Fido2Component,
-    AutofillComponent,
+    AutofillV1Component,
     EnvironmentSelectorComponent,
     AccountSwitcherComponent,
   ],

--- a/libs/common/src/autofill/constants/index.ts
+++ b/libs/common/src/autofill/constants/index.ts
@@ -61,3 +61,27 @@ export const AutofillOverlayVisibility = {
   OnButtonClick: 1,
   OnFieldFocus: 2,
 } as const;
+
+export const BrowserClientVendors = {
+  Chrome: "Chrome",
+  Opera: "Opera",
+  Edge: "Edge",
+  Vivaldi: "Vivaldi",
+  Unknown: "Unknown",
+} as const;
+
+export const BrowserShortcutsUris = {
+  Chrome: "chrome://extensions/shortcuts",
+  Opera: "opera://extensions/shortcuts",
+  Edge: "edge://extensions/shortcuts",
+  Vivaldi: "vivaldi://extensions/shortcuts",
+  Unknown: "https://bitwarden.com/help/keyboard-shortcuts",
+} as const;
+
+export const DisablePasswordManagerUris = {
+  Chrome: "chrome://settings/autofill",
+  Opera: "opera://settings/autofill",
+  Edge: "edge://settings/passwords",
+  Vivaldi: "vivaldi://settings/autofill",
+  Unknown: "https://bitwarden.com/help/disable-browser-autofill/",
+} as const;

--- a/libs/common/src/autofill/types/index.ts
+++ b/libs/common/src/autofill/types/index.ts
@@ -1,7 +1,18 @@
-import { ClearClipboardDelay, AutofillOverlayVisibility } from "../constants";
+import {
+  AutofillOverlayVisibility,
+  BrowserClientVendors,
+  BrowserShortcutsUris,
+  ClearClipboardDelay,
+  DisablePasswordManagerUris,
+} from "../constants";
 
 export type ClearClipboardDelaySetting =
   (typeof ClearClipboardDelay)[keyof typeof ClearClipboardDelay];
 
 export type InlineMenuVisibilitySetting =
   (typeof AutofillOverlayVisibility)[keyof typeof AutofillOverlayVisibility];
+
+export type BrowserClientVendor = (typeof BrowserClientVendors)[keyof typeof BrowserClientVendors];
+export type BrowserShortcutsUri = (typeof BrowserShortcutsUris)[keyof typeof BrowserShortcutsUris];
+export type DisablePasswordManagerUri =
+  (typeof DisablePasswordManagerUris)[keyof typeof DisablePasswordManagerUris];


### PR DESCRIPTION
## 🎟️ Tracking

PM-8338

## 📔 Objective

Create a new Autofill Settings and Excluded Domains components to match Design specs.

## Notes

- Like other extension refresh work, the new components are behind the `extension-refresh` feature flag.
- Existing components have been renamed to use a "v1" naming scheme for easier deprecation in the future
- There are some expected/approved differences from design due to presumptive design system work on the horizon
- Replacements of hyphenated "auto-fill" to "autofill" in the existing view are expected/approved by Design

## 📸 Screenshots

Note: some of the screenshots below were taken before the Autofill on page load warning text update, which looks like this: 
![Screenshot 2024-07-19 at 11 45 28 AM](https://github.com/user-attachments/assets/7351a91c-299a-4eef-892f-353cd1ea12d5)

**UX Recording**
https://github.com/user-attachments/assets/2494df29-8889-40e2-9ec4-d2747ef28b7c

![Screenshot 2024-07-19 at 10 18 43 AM](https://github.com/user-attachments/assets/1e1c288e-ecae-4f6b-ac16-37d1025e85fd)
![Screenshot 2024-07-19 at 10 21 05 AM](https://github.com/user-attachments/assets/419f665e-2a25-45c3-b66b-664ac476db0e)

**Firefox**
![image](https://github.com/user-attachments/assets/f5c77330-a92a-4a8a-812d-c4fca0bf5215)

**Unknown/unsupported client**
![Screenshot 2024-07-19 at 11 39 40 AM](https://github.com/user-attachments/assets/c77ee82e-61ba-4ebd-bd4c-abfdbd646a40)

### Dialogs

### Supported/Identified Browser
![Screenshot 2024-07-19 at 10 19 57 AM](https://github.com/user-attachments/assets/fa7a48e0-05f5-48e1-a66f-8e6df0b67531)
![Screenshot 2024-07-19 at 10 20 12 AM](https://github.com/user-attachments/assets/3af8f41e-a556-404c-9305-d723adf00fd2)
![Screenshot 2024-07-19 at 10 20 28 AM](https://github.com/user-attachments/assets/2ccabc7b-ca0c-4e1c-bc00-382f8ac155a0)
![Screenshot 2024-07-19 at 10 21 18 AM](https://github.com/user-attachments/assets/0c3bde03-c675-4430-ba39-e3d3f581ad43)
![Screenshot 2024-07-19 at 10 21 28 AM](https://github.com/user-attachments/assets/9d78bcf2-b5cb-4a6b-bdc7-bb2aeb373f4b)
![Screenshot 2024-07-19 at 10 21 44 AM](https://github.com/user-attachments/assets/6cef342e-d84e-4a31-a346-1c971579c3ba)
![Screenshot 2024-07-19 at 10 26 07 AM](https://github.com/user-attachments/assets/f2ecd097-4f90-4653-b15a-c6b9cc9a0a39)

### Unsupported/unidentified browser

![Screenshot 2024-07-19 at 11 40 53 AM](https://github.com/user-attachments/assets/c19a626c-07c6-46a3-ae07-b70900209823)
![Screenshot 2024-07-19 at 11 40 43 AM](https://github.com/user-attachments/assets/3f72d935-23a7-4c2f-873f-54ee3ca58520)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
