### PR TITLE
[PM-8009] Fixing the test for unsecured reports

### DIFF
--- a/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.spec.ts
+++ b/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.spec.ts
@@ -8,6 +8,7 @@ import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
@@ -19,11 +20,13 @@ describe("UnsecuredWebsitesReportComponent", () => {
   let fixture: ComponentFixture<UnsecuredWebsitesReportComponent>;
   let organizationService: MockProxy<OrganizationService>;
   let syncServiceMock: MockProxy<SyncService>;
+  let collectionService: MockProxy<CollectionService>;
 
   beforeEach(() => {
     organizationService = mock<OrganizationService>();
     organizationService.organizations$ = of([]);
     syncServiceMock = mock<SyncService>();
+    collectionService = mock<CollectionService>();
     // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     TestBed.configureTestingModule({
@@ -52,6 +55,10 @@ describe("UnsecuredWebsitesReportComponent", () => {
         {
           provide: I18nService,
           useValue: mock<I18nService>(),
+        },
+        {
+          provide: CollectionService,
+          useValue: collectionService,
         },
       ],
       schemas: [],


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8009

## 📔 Objective

Fixing the test cases for unsecured websites report. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
