### PR TITLE
[AC-2902] Fix hardcoded strings on MemberAccessReportComponent

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
@@ -20,10 +20,10 @@
 <bit-table [dataSource]="dataSource" class="tw-mt-2">
   <ng-container header>
     <tr>
-      <th bitCell bitSortable="name" default>Members</th>
-      <th bitCell bitSortable="groupsCount">Groups</th>
-      <th bitCell bitSortable="collectionsCount">Collections</th>
-      <th bitCell bitSortable="itemsCount">Items</th>
+      <th bitCell bitSortable="name" default>{{ "members" | i18n }}</th>
+      <th bitCell bitSortable="groupsCount">{{ "groups" | i18n }}</th>
+      <th bitCell bitSortable="collectionsCount">{{ "collections" | i18n }}</th>
+      <th bitCell bitSortable="itemsCount">{{ "items" | i18n }}</th>
     </tr>
   </ng-container>
   <ng-template body let-rows$>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2902

## 📔 Objective

String were hardcoded instead of using the localization service. Fixed it

It doesn't require QA as this feature is under feature flag and has not been tested yet

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
