### PR TITLE
[PM-9922] Custom Fields - Focus Management

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -174,9 +174,9 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
     zip(this.focusOnNewInput$, this.customFieldRows.changes)
       .pipe(takeUntilDestroyed(this.destroyed$))
       .subscribe(() => {
-        const input =
-          this.customFieldRows.last.nativeElement.querySelector<HTMLInputElement>("input");
-        const label = document.querySelector(`label[for="${input.id}"]`).textContent.trim();
+        const mostRecentRow = this.customFieldRows.last.nativeElement;
+        const input = mostRecentRow.querySelector<HTMLInputElement>("input");
+        const label = mostRecentRow.querySelector<HTMLLabelElement>("label").textContent.trim();
 
         // Focus the input after the announcement element is added to the DOM,
         // this should stop the announcement from being cut off by the "focus" event.

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -16,7 +16,7 @@ import {
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormArray, FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { Subject, switchMap, take } from "rxjs";
+import { Subject, zip } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -171,12 +171,8 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
   ngAfterViewInit(): void {
     // Focus on the new input field when it is added
     // This is done after the view is initialized to ensure the input is rendered
-    this.focusOnNewInput$
-      .pipe(
-        takeUntilDestroyed(this.destroyed$),
-        // QueryList changes are emitted after the view is updated
-        switchMap(() => this.customFieldRows.changes.pipe(take(1))),
-      )
+    zip(this.focusOnNewInput$, this.customFieldRows.changes)
+      .pipe(takeUntilDestroyed(this.destroyed$))
       .subscribe(() => {
         const input =
           this.customFieldRows.last.nativeElement.querySelector<HTMLInputElement>("input");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-9922](https://bitwarden.atlassian.net/browse/PM-9922)

## 📔 Objective

Fix focus management related bugs:
- Focus isn't directed into the input when first adding a custom field
  - Issue; This was a timing issue, on the first add of a custom item, `this.customFieldRows.changes` was emitting before `this.focusOnNewInput$` was emitting. Thus the subscribe was never called. 
  - Fix: I switched to using `zip` so the subscribe will be called when both `this.customFieldRows.changes` & `this.focusOnNewInput$` emit in pairs which is more inlined with my intention.
- Checkbox fields were not being focused
  - Issue: I missed that the checkbox implementation is wrapped in a `label` rather than associating the checkbox & label by `id`. When querying for the label, `null` would be returned and the method would error.
  - Fix: Rather than query by the associated label for an input, I swapped to querying the entire row for the label because of the scope of the query there will only be one label.

## 📸 Screenshots

|Two issues, one video, first custom field as a checkbox|
|-|
| <video src="https://github.com/user-attachments/assets/a58fa3d9-e4f6-4386-a4af-478930255350" />|

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9922]: https://bitwarden.atlassian.net/browse/PM-9922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ