### PR TITLE
[CL-337] Fix toggle group visual bug from tw-group collisions

### DIFF
--- a/libs/components/src/toggle-group/toggle.component.ts
+++ b/libs/components/src/toggle-group/toggle.component.ts
@@ -17,7 +17,7 @@ export class ToggleComponent<TValue> {
   constructor(private groupComponent: ToggleGroupComponent<TValue>) {}
 
   @HostBinding("tabIndex") tabIndex = "-1";
-  @HostBinding("class") classList = ["tw-group"];
+  @HostBinding("class") classList = ["tw-group/toggle"];
 
   get name() {
     return this.groupComponent.name;
@@ -28,7 +28,7 @@ export class ToggleComponent<TValue> {
   }
 
   get inputClasses() {
-    return ["tw-peer", "tw-appearance-none", "tw-outline-none"];
+    return ["tw-peer/toggle-input", "tw-appearance-none", "tw-outline-none"];
   }
 
   get labelClasses() {
@@ -43,27 +43,27 @@ export class ToggleComponent<TValue> {
       "tw-border-r",
       "tw-border-l-0",
       "tw-cursor-pointer",
-      "group-first-of-type:tw-border-l",
-      "group-first-of-type:tw-rounded-l",
-      "group-last-of-type:tw-rounded-r",
+      "group-first-of-type/toggle:tw-border-l",
+      "group-first-of-type/toggle:tw-rounded-l",
+      "group-last-of-type/toggle:tw-rounded-r",
 
-      "peer-focus:tw-outline-none",
-      "peer-focus:tw-ring",
-      "peer-focus:tw-ring-offset-2",
-      "peer-focus:tw-ring-primary-600",
-      "peer-focus:tw-z-10",
-      "peer-focus:tw-bg-primary-600",
-      "peer-focus:tw-border-primary-600",
-      "peer-focus:!tw-text-contrast",
+      "peer-focus/toggle-input:tw-outline-none",
+      "peer-focus/toggle-input:tw-ring",
+      "peer-focus/toggle-input:tw-ring-offset-2",
+      "peer-focus/toggle-input:tw-ring-primary-600",
+      "peer-focus/toggle-input:tw-z-10",
+      "peer-focus/toggle-input:tw-bg-primary-600",
+      "peer-focus/toggle-input:tw-border-primary-600",
+      "peer-focus/toggle-input:!tw-text-contrast",
 
       "hover:tw-no-underline",
       "hover:tw-bg-text-muted",
       "hover:tw-border-text-muted",
       "hover:!tw-text-contrast",
 
-      "peer-checked:tw-bg-primary-600",
-      "peer-checked:tw-border-primary-600",
-      "peer-checked:!tw-text-contrast",
+      "peer-checked/toggle-input:tw-bg-primary-600",
+      "peer-checked/toggle-input:tw-border-primary-600",
+      "peer-checked/toggle-input:!tw-text-contrast",
       "tw-py-1.5",
       "tw-px-3",
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-337](https://bitwarden.atlassian.net/browse/CL-337)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The toggle group was displaying incorrectly when used on a page with another parent component utilizing `tw-group`. If not namespaced (like `tw-group/namespace-here`), the groups will interact and cause styling issues. This PR fixes this issue for the toggle group by giving namespaces to both `tw-group` and `tw-peer`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
This can be checked in the Storybook Publish > Kitchen Sink stories, which use toggle group. Additionally, in the web app:

Before:

![image](https://github.com/user-attachments/assets/875e7724-2041-4ef9-b3fe-8e1dfe46dfec)

After:

![Screenshot 2024-07-19 at 12 36 27 PM](https://github.com/user-attachments/assets/937755f6-ad6e-4312-97e4-8699588496db)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-337]: https://bitwarden.atlassian.net/browse/CL-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ