### PR TITLE
InputPassword Button Adjustment

### DIFF
--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -70,7 +70,7 @@
     bitButton
     bitFormButton
     buttonType="primary"
-    [block]="true"
+    [block]="btnBlock"
     [loading]="loading"
   >
     {{ buttonText || ("setMasterPassword" | i18n) }}

--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -55,6 +55,7 @@ export class InputPasswordComponent implements OnInit {
   @Input() protected buttonText: string;
   @Input() masterPasswordPolicyOptions: MasterPasswordPolicyOptions | null = null;
   @Input() loading: boolean = false;
+  @Input() btnBlock: boolean = true;
 
   private minHintLength = 0;
   protected maxHintLength = 50;

--- a/libs/auth/src/angular/input-password/input-password.stories.ts
+++ b/libs/auth/src/angular/input-password/input-password.stories.ts
@@ -113,3 +113,12 @@ export const WithPolicy: Story = {
     `,
   }),
 };
+
+export const InlineButton: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <auth-input-password [btnBlock]="false" [masterPasswordPolicyOptions]="masterPasswordPolicyOptions"></auth-input-password>
+    `,
+  }),
+};


### PR DESCRIPTION
## 📔 Objective

Per discussion with design, this PR adds an input to the `InputPasswordComponent` to control whether the button is inline or block (spanning the full width of the form). The default is block.

## 🎨 Storybook

https://62a88a6de5b807fa98886113-jcwogneslh.chromatic.com/?path=/story/auth-input-password--inline-button

## 📸 Screenshots

| Full Width | Inline |
| ----- | ----- |
| <img width="494" alt="Screenshot 2024-07-19 at 5 12 07 PM" src="https://github.com/user-attachments/assets/79f9d2fc-fb2c-495d-82eb-2b92d7b4877e"> | <img width="495" alt="Screenshot 2024-07-19 at 5 12 17 PM" src="https://github.com/user-attachments/assets/2d6d27cd-ce8f-4a85-9a38-35d41f9fc21e"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
