### PR TITLE
[PM-9633] Test Windows COM API usage

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -317,6 +317,8 @@ dependencies = [
  "typenum",
  "widestring",
  "windows",
+ "windows-core",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -26,13 +26,17 @@ typenum = "=1.17.0"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "=1.1.0"
+windows-core = "=0.57.0"
+windows-targets = "=0.52.5"
 windows = { version = "=0.57.0", features = [
   "Foundation",
+  "implement",
   "Security_Credentials_UI",
   "Security_Cryptography",
   "Storage_Streams",
   "Win32_Foundation",
   "Win32_Security_Credentials",
+  "Win32_System_Com",
   "Win32_System_WinRT",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",

--- a/apps/desktop/desktop_native/core/src/lib.rs
+++ b/apps/desktop/desktop_native/core/src/lib.rs
@@ -3,3 +3,252 @@ pub mod clipboard;
 pub mod crypto;
 pub mod error;
 pub mod password;
+
+#[allow(non_snake_case)]
+pub mod com {
+    use windows::{
+        core::*,
+        Win32::{Foundation::BOOL, System::Com::*},
+    };
+
+    // Implemented using windows-rs provided traits
+    #[implement(IMallocSpy)]
+    struct MallocSpy();
+
+    impl IMallocSpy_Impl for MallocSpy {
+        fn PreAlloc(&self, cbrequest: usize) -> usize {
+            println!("PreAlloc");
+            cbrequest
+        }
+
+        fn PostAlloc(&self, pactual: *const core::ffi::c_void) -> *mut core::ffi::c_void {
+            println!("PostAlloc");
+            pactual as *mut core::ffi::c_void
+        }
+
+        fn PreFree(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreFree");
+            prequest as *mut core::ffi::c_void
+        }
+
+        fn PostFree(&self, fspyed: BOOL) {
+            println!("PostFree");
+        }
+
+        fn PreRealloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            cbrequest: usize,
+            ppnewrequest: *mut *mut core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> usize {
+            println!("PreRealloc");
+            cbrequest
+        }
+
+        fn PostRealloc(
+            &self,
+            pactual: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PostRealloc");
+            pactual as *mut core::ffi::c_void
+        }
+
+        fn PreGetSize(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreGetSize");
+            prequest as *mut core::ffi::c_void
+        }
+
+        fn PostGetSize(&self, cbactual: usize, fspyed: BOOL) -> usize {
+            println!("PostGetSize");
+            cbactual
+        }
+
+        fn PreDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreDidAlloc");
+            prequest as *mut core::ffi::c_void
+        }
+
+        fn PostDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+            factual: i32,
+        ) -> i32 {
+            println!("PostDidAlloc");
+            factual
+        }
+
+        fn PreHeapMinimize(&self) {
+            println!("PreHeapMinimize");
+        }
+
+        fn PostHeapMinimize(&self) {
+            println!("PostHeapMinimize");
+        }
+    }
+
+    // Implemented with our own traits
+    // https://gist.github.com/kant2002/0b50eeb6cf770bd72854b95a99b86deb
+    #[interface("0000001d-0000-0000-C000-000000000046")]
+    unsafe trait IMallocSpy2: IUnknown {
+        fn PreAlloc(&self, cbrequest: usize) -> usize;
+        fn PostAlloc(&self, pactual: *const core::ffi::c_void) -> *mut core::ffi::c_void;
+        fn PreFree(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void;
+        fn PostFree(&self, fspyed: BOOL);
+        fn PreRealloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            cbrequest: usize,
+            ppnewrequest: *mut *mut core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> usize;
+        fn PostRealloc(
+            &self,
+            pactual: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void;
+        fn PreGetSize(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void;
+        fn PostGetSize(&self, cbactual: usize, fspyed: BOOL) -> usize;
+        fn PreDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void;
+        fn PostDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+            factual: i32,
+        ) -> i32;
+        fn PreHeapMinimize(&self);
+        fn PostHeapMinimize(&self);
+    }
+
+    #[implement(IMallocSpy2)]
+    struct MallocSpy2();
+
+    impl IMallocSpy2_Impl for MallocSpy2 {
+        unsafe fn PreAlloc(&self, cbrequest: usize) -> usize {
+            println!("PreAlloc2");
+            cbrequest
+        }
+
+        unsafe fn PostAlloc(&self, pactual: *const core::ffi::c_void) -> *mut core::ffi::c_void {
+            println!("PostAlloc2");
+            pactual as *mut core::ffi::c_void
+        }
+
+        unsafe fn PreFree(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreFree2");
+            prequest as *mut core::ffi::c_void
+        }
+
+        unsafe fn PostFree(&self, fspyed: BOOL) {
+            println!("PostFree2");
+        }
+
+        unsafe fn PreRealloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            cbrequest: usize,
+            ppnewrequest: *mut *mut core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> usize {
+            println!("PreRealloc2");
+            cbrequest
+        }
+
+        unsafe fn PostRealloc(
+            &self,
+            pactual: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PostRealloc2");
+            pactual as *mut core::ffi::c_void
+        }
+
+        unsafe fn PreGetSize(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreGetSize2");
+            prequest as *mut core::ffi::c_void
+        }
+
+        unsafe fn PostGetSize(&self, cbactual: usize, fspyed: BOOL) -> usize {
+            println!("PostGetSize2");
+            cbactual
+        }
+
+        unsafe fn PreDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+        ) -> *mut core::ffi::c_void {
+            println!("PreDidAlloc2");
+            prequest as *mut core::ffi::c_void
+        }
+
+        unsafe fn PostDidAlloc(
+            &self,
+            prequest: *const core::ffi::c_void,
+            fspyed: BOOL,
+            factual: i32,
+        ) -> i32 {
+            println!("PostDidAlloc2");
+            factual
+        }
+
+        unsafe fn PreHeapMinimize(&self) {
+            println!("PreHeapMinimize2");
+        }
+
+        unsafe fn PostHeapMinimize(&self) {
+            println!("PostHeapMinimize2");
+        }
+    }
+
+    #[inline]
+    unsafe fn CoRegisterMallocSpy2<P0>(pmallocspy: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<IMallocSpy2>,
+    {
+        windows_targets::link!("ole32.dll" "system" fn CoRegisterMallocSpy(pmallocspy : * mut core::ffi::c_void) -> windows_core::HRESULT);
+        CoRegisterMallocSpy(pmallocspy.param().abi()).ok()
+    }
+
+    pub fn register() {
+        //let m: IMallocSpy = MallocSpy().into();
+        // unsafe { CoRegisterMallocSpy(&m).unwrap() };
+
+        let m: IMallocSpy2 = MallocSpy2().into();
+        unsafe { CoRegisterMallocSpy2(&m).unwrap() };
+    }
+}

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -41,3 +41,6 @@ export namespace clipboards {
   export function read(): Promise<string>
   export function write(text: string, password: boolean): Promise<void>
 }
+export namespace com {
+  export function register(): void
+}

--- a/apps/desktop/desktop_native/napi/index.js
+++ b/apps/desktop/desktop_native/napi/index.js
@@ -206,8 +206,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { passwords, biometrics, clipboards } = nativeBinding
+const { passwords, biometrics, clipboards, com } = nativeBinding
 
 module.exports.passwords = passwords
 module.exports.biometrics = biometrics
 module.exports.clipboards = clipboards
+module.exports.com = com

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -142,3 +142,11 @@ pub mod clipboards {
             .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 }
+
+#[napi]
+pub mod com {
+    #[napi]
+    pub fn register() {
+        desktop_core::com::register();
+    }
+}

--- a/apps/desktop/src/entry.ts
+++ b/apps/desktop/src/entry.ts
@@ -1,3 +1,5 @@
+import { com } from "@bitwarden/desktop-napi";
+
 import { NativeMessagingProxy } from "./proxy/native-messaging-proxy";
 
 // We need to import the other dependencies using `require` since `import` will
@@ -29,6 +31,8 @@ if (
 } else {
   // eslint-disable-next-line
   const Main = require("./main").Main;
+
+  com.register();
 
   const main = new Main();
   main.bootstrap();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9633

## 📔 Objective

This is an integration test of a Windows COM API in the `desktop_native` module. In this case I picked the `IMallocSpy` API, which when registered, will send notifications about all the memory allocations done to our implementation of the COM interface.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
