### PR TITLE
[PM-9912] Checked to Checkbox

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1317,8 +1317,8 @@
   "cfTypeBoolean": {
     "message": "Boolean"
   },
-  "cfTypeChecked": {
-    "message": "Checked"
+  "cfTypeCheckbox": {
+    "message": "Checkbox"
   },
   "cfTypeLinked": {
     "message": "Linked",

--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.ts
@@ -52,7 +52,7 @@ export class AddEditCustomFieldDialogComponent {
   fieldTypeOptions = [
     { name: this.i18nService.t("cfTypeText"), value: FieldType.Text },
     { name: this.i18nService.t("cfTypeHidden"), value: FieldType.Hidden },
-    { name: this.i18nService.t("cfTypeChecked"), value: FieldType.Boolean },
+    { name: this.i18nService.t("cfTypeCheckbox"), value: FieldType.Boolean },
     { name: this.i18nService.t("cfTypeLinked"), value: FieldType.Linked },
   ];
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9912](https://bitwarden.atlassian.net/browse/PM-9912)

## 📔 Objective

The entire time working through https://github.com/bitwarden/clients/pull/10168, I thought it was "Checked", I was wrong. It's supposed to be `Checkbox`. Sometimes it's the simple changes that get ya. 

## 📸 Screenshots

|"Checkbox"|
|-|
|![Screenshot 2024-07-22 at 12 05 56 PM](https://github.com/user-attachments/assets/98d06742-d449-4b0a-8bf7-0e23dbfc5fc9)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9912]: https://bitwarden.atlassian.net/browse/PM-9912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ