### PR TITLE
Fix Flaky Promise resolution matcher tests

### DIFF
--- a/libs/common/spec/matchers/promise-fulfilled.spec.ts
+++ b/libs/common/spec/matchers/promise-fulfilled.spec.ts
@@ -18,11 +18,11 @@ describe("toBeFulfilled", () => {
 
   it("passes when the promise is fulfilled within the given time limit", async () => {
     const promise = new Promise((resolve) => setTimeout(resolve, 1));
-    await expect(promise).toBeFulfilled(2);
+    await expect(promise).toBeFulfilled(25);
   });
 
   it("passes when the promise is not fulfilled within the given time limit", async () => {
-    const promise = new Promise((resolve) => setTimeout(resolve, 2));
+    const promise = new Promise(() => {});
     await expect(promise).not.toBeFulfilled(1);
   });
 });
@@ -47,11 +47,11 @@ describe("toBeResolved", () => {
 
   it("passes when the promise is resolved within the given time limit", async () => {
     const promise = new Promise((resolve) => setTimeout(resolve, 1));
-    await expect(promise).toBeResolved(2);
+    await expect(promise).toBeResolved(50);
   });
 
   it("passes when the promise is not resolved within the given time limit", async () => {
-    const promise = new Promise((resolve) => setTimeout(resolve, 2));
+    const promise = new Promise(() => {});
     await expect(promise).not.toBeResolved(1);
   });
 });
@@ -76,11 +76,11 @@ describe("toBeRejected", () => {
 
   it("passes when the promise is resolved within the given time limit", async () => {
     const promise = new Promise((_, reject) => setTimeout(reject, 1));
-    await expect(promise).toBeFulfilled(2);
+    await expect(promise).toBeFulfilled(50);
   });
 
   it("passes when the promise is not resolved within the given time limit", async () => {
-    const promise = new Promise((_, reject) => setTimeout(reject, 2));
+    const promise = new Promise(() => {});
     await expect(promise).not.toBeFulfilled(1);
   });
 });


### PR DESCRIPTION
## 📔 Objective

Loosen timings to avoid false failures.

Biggest ones here are the not resolved tests that can be evaluated at any time, so they just never resolve/reject.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
