### PR TITLE
[PM-9980] Special Case `0` to mean no caching at all

### DIFF
--- a/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.spec.ts
@@ -100,6 +100,24 @@ describe("DefaultSingleUserState", () => {
       );
       expect(state).toBeTruthy();
     });
+
+    it("should go to disk each subscription if a cleanupDelayMs of 0 is given", async () => {
+      const state = new DefaultSingleUserState(
+        userId,
+        new UserKeyDefinition(testStateDefinition, "test", {
+          cleanupDelayMs: 0,
+          deserializer: TestState.fromJSON,
+          clearOn: [],
+        }),
+        diskStorageService,
+        stateEventRegistrarService,
+      );
+
+      await firstValueFrom(state.state$);
+      await firstValueFrom(state.state$);
+
+      expect(diskStorageService.mock.get).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("combinedState$", () => {

--- a/libs/common/src/platform/state/key-definition.spec.ts
+++ b/libs/common/src/platform/state/key-definition.spec.ts
@@ -38,12 +38,12 @@ describe("KeyDefinition", () => {
       expect(keyDefinition.cleanupDelayMs).toBe(500);
     });
 
-    it.each([0, -1])("throws on 0 or negative (%s)", (testValue: number) => {
+    it("throws on negative", () => {
       expect(
         () =>
           new KeyDefinition<boolean>(fakeStateDefinition, "fake", {
             deserializer: (value) => value,
-            cleanupDelayMs: testValue,
+            cleanupDelayMs: -1,
           }),
       ).toThrow();
     });

--- a/libs/common/src/platform/state/key-definition.ts
+++ b/libs/common/src/platform/state/key-definition.ts
@@ -50,9 +50,9 @@ export class KeyDefinition<T> {
       throw new Error(`'deserializer' is a required property on key ${this.errorKeyName}`);
     }
 
-    if (options.cleanupDelayMs <= 0) {
+    if (options.cleanupDelayMs < 0) {
       throw new Error(
-        `'cleanupDelayMs' must be greater than 0. Value of ${options.cleanupDelayMs} passed to key ${this.errorKeyName} `,
+        `'cleanupDelayMs' must be greater than or equal to 0. Value of ${options.cleanupDelayMs} passed to key ${this.errorKeyName} `,
       );
     }
   }

--- a/libs/common/src/platform/state/user-key-definition.ts
+++ b/libs/common/src/platform/state/user-key-definition.ts
@@ -30,9 +30,9 @@ export class UserKeyDefinition<T> {
       throw new Error(`'deserializer' is a required property on key ${this.errorKeyName}`);
     }
 
-    if (options.cleanupDelayMs <= 0) {
+    if (options.cleanupDelayMs < 0) {
       throw new Error(
-        `'cleanupDelayMs' must be greater than 0. Value of ${options.cleanupDelayMs} passed to key ${this.errorKeyName} `,
+        `'cleanupDelayMs' must be greater than or equal to 0. Value of ${options.cleanupDelayMs} passed to key ${this.errorKeyName} `,
       );
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9980

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Special case `0` to mean there should be no cache of the value kept at all, this mean you can configure your state definition to go to the storage service on every retrieval when you subscribe to it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
