### PR TITLE
[AC-2919] Resolve subscription page error for reseller managed organization users when CB is on

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -1,6 +1,6 @@
 <app-header></app-header>
 
-<bit-container *ngIf="!isProviderManaged">
+<bit-container *ngIf="!isManagedByConsolidatedBillingMSP">
   <ng-container *ngIf="!firstLoaded && loading">
     <i class="bwi bwi-spinner bwi-spin text-muted" title="{{ 'loading' | i18n }}"></i>
     <span class="tw-sr-only">{{ "loading" | i18n }}</span>
@@ -274,7 +274,7 @@
     </ng-container>
   </ng-container>
 </bit-container>
-<bit-container *ngIf="isProviderManaged">
+<bit-container *ngIf="isManagedByConsolidatedBillingMSP">
   <div
     class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-pt-24 tw-text-center tw-font-bold"
   >

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -50,7 +50,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   locale: string;
   showUpdatedSubscriptionStatusSection$: Observable<boolean>;
   manageBillingFromProviderPortal = ManageBilling;
-  isProviderManaged = false;
+  isManagedByConsolidatedBillingMSP = false;
   enableTimeThreshold: boolean;
   preSelectedProductTier: ProductTierType = ProductTierType.Free;
 
@@ -126,10 +126,10 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     if (this.userOrg.canViewSubscription) {
       const enableConsolidatedBilling = await firstValueFrom(this.enableConsolidatedBilling$);
       const provider = await this.providerService.get(this.userOrg.providerId);
-      this.isProviderManaged =
+      this.isManagedByConsolidatedBillingMSP =
         enableConsolidatedBilling &&
         this.userOrg.hasProvider &&
-        provider.providerStatus == ProviderStatusType.Billable;
+        provider?.providerStatus == ProviderStatusType.Billable;
 
       this.sub = await this.organizationApiService.getSubscription(this.organizationId);
       this.lineItems = this.sub?.subscription?.items;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2919

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When the user of a reseller's client organization loads the Subscription page, the provider is not going to be stored in state because it's not returned from the sync response. We need to null check the provider in the call to determine whether or not the organization is a consolidated billing client. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/34ae3fcd-ae9b-4dae-b818-f3f7e1fd57f5



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
