### PR TITLE
[PM-9629] custom fields checkbox

### DIFF
--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -46,7 +46,7 @@
           <input
             bitCheckbox
             type="checkbox"
-            [checked]="field.value"
+            [checked]="field.value === 'true'"
             aria-readonly="true"
             disabled
           />


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9629](https://bitwarden.atlassian.net/browse/PM-9629)

## 📔 Objective

field value comes in as a string. updated checkbox in custom fields to account for that. 

## 📸 Screenshots

<img width="358" alt="PM-9629" src="https://github.com/user-attachments/assets/d0829347-51ba-4911-8f08-3d00a48b3c8a">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9629]: https://bitwarden.atlassian.net/browse/PM-9629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ