### PR TITLE
[PM-10059] alert server if device trust is lost

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -697,6 +697,7 @@ export default class MainBackground {
       this.secureStorageService,
       this.userDecryptionOptionsService,
       this.logService,
+      this.configService,
     );
 
     this.devicesService = new DevicesServiceImplementation(this.devicesApiService);

--- a/apps/cli/src/service-container.ts
+++ b/apps/cli/src/service-container.ts
@@ -534,6 +534,7 @@ export class ServiceContainer {
       this.secureStorageService,
       this.userDecryptionOptionsService,
       this.logService,
+      this.configService,
     );
 
     this.authRequestService = new AuthRequestService(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1050,6 +1050,7 @@ const safeProviders: SafeProvider[] = [
       SECURE_STORAGE,
       UserDecryptionOptionsServiceAbstraction,
       LogService,
+      ConfigService,
     ],
   }),
   safeProvider({

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.spec.ts
@@ -312,6 +312,27 @@ describe("SsoLoginStrategy", () => {
       expect(cryptoService.setUserKey).not.toHaveBeenCalled();
     });
 
+    it("logs when a device key is found but no decryption keys were recieved in token response", async () => {
+      // Arrange
+      const userDecryptionOpts = userDecryptionOptsServerResponseWithTdeOption;
+      userDecryptionOpts.TrustedDeviceOption.EncryptedPrivateKey = null;
+      userDecryptionOpts.TrustedDeviceOption.EncryptedUserKey = null;
+
+      const idTokenResponse: IdentityTokenResponse = identityTokenResponseFactory(
+        null,
+        userDecryptionOpts,
+      );
+
+      apiService.postIdentityToken.mockResolvedValue(idTokenResponse);
+      deviceTrustService.getDeviceKey.mockResolvedValue(mockDeviceKey);
+
+      // Act
+      await ssoLoginStrategy.logIn(credentials);
+
+      // Assert
+      expect(deviceTrustService.recordDeviceTrustLoss).toHaveBeenCalledTimes(1);
+    });
+
     describe("AdminAuthRequest", () => {
       let tokenResponse: IdentityTokenResponse;
 

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.ts
@@ -298,7 +298,7 @@ export class SsoLoginStrategy extends LoginStrategy {
       if (!deviceKey) {
         this.logService.warning("Unable to set user key due to missing device key.");
       } else if (!encDevicePrivateKey || !encUserKey) {
-        // Tell the server that we have a device key, but received no encrypted keys
+        // Tell the server that we have a device key, but received no decryption keys
         await this.deviceTrustService.recordDeviceTrustLoss();
       }
       if (!encDevicePrivateKey) {

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.ts
@@ -296,16 +296,20 @@ export class SsoLoginStrategy extends LoginStrategy {
 
     if (!deviceKey || !encDevicePrivateKey || !encUserKey) {
       if (!deviceKey) {
-        await this.logService.warning("Unable to set user key due to missing device key.");
+        this.logService.warning("Unable to set user key due to missing device key.");
+      } else if (!encDevicePrivateKey || !encUserKey) {
+        // Tell the server that we have a device key, but received no encrypted keys
+        await this.deviceTrustService.recordDeviceTrustLoss();
       }
       if (!encDevicePrivateKey) {
-        await this.logService.warning(
+        this.logService.warning(
           "Unable to set user key due to missing encrypted device private key.",
         );
       }
       if (!encUserKey) {
-        await this.logService.warning("Unable to set user key due to missing encrypted user key.");
+        this.logService.warning("Unable to set user key due to missing encrypted user key.");
       }
+
       return;
     }
 

--- a/libs/common/src/auth/abstractions/device-trust.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/device-trust.service.abstraction.ts
@@ -32,4 +32,9 @@ export abstract class DeviceTrustServiceAbstraction {
     newUserKey: UserKey,
     masterPasswordHash: string,
   ) => Promise<void>;
+  /**
+   * Notifies the server that the device has a device key, but didn't receive any associated decryption keys.
+   * Note: For debugging purposes only.
+   */
+  recordDeviceTrustLoss: () => Promise<void>;
 }

--- a/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
@@ -27,4 +27,11 @@ export abstract class DevicesApiServiceAbstraction {
     deviceIdentifier: string,
     secretVerificationRequest: SecretVerificationRequest,
   ) => Promise<ProtectedDeviceResponse>;
+
+  /**
+   * Notifies the server that the device has a device key, but didn't receive any associated decryption keys.
+   * Note: For debugging purposes only.
+   * @param deviceIdentifier - current device identifier
+   */
+  postDeviceTrustLoss: (deviceIdentifier: string) => Promise<void>;
 }

--- a/libs/common/src/auth/services/device-trust.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust.service.spec.ts
@@ -9,6 +9,7 @@ import { FakeActiveUserState } from "../../../spec/fake-state";
 import { FakeStateProvider } from "../../../spec/fake-state-provider";
 import { DeviceType } from "../../enums";
 import { AppIdService } from "../../platform/abstractions/app-id.service";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
 import { CryptoFunctionService } from "../../platform/abstractions/crypto-function.service";
 import { CryptoService } from "../../platform/abstractions/crypto.service";
 import { EncryptService } from "../../platform/abstractions/encrypt.service";
@@ -50,6 +51,7 @@ describe("deviceTrustService", () => {
   const platformUtilsService = mock<PlatformUtilsService>();
   const secureStorageService = mock<AbstractStorageService>();
   const logService = mock<LogService>();
+  const configService = mock<ConfigService>();
 
   const userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
   const decryptionOptions = new BehaviorSubject<UserDecryptionOptions>(null);
@@ -533,6 +535,32 @@ describe("deviceTrustService", () => {
         ).rejects.toThrow("UserId is required. Cannot decrypt user key with device key.");
       });
 
+      it("throws an error when a nullish encrypted device private key is passed in", async () => {
+        await expect(
+          deviceTrustService.decryptUserKeyWithDeviceKey(
+            mockUserId,
+            null,
+            mockEncryptedUserKey,
+            mockDeviceKey,
+          ),
+        ).rejects.toThrow(
+          "Encrypted device private key is required. Cannot decrypt user key with device key.",
+        );
+      });
+
+      it("throws an error when a nullish encrypted user key is passed in", async () => {
+        await expect(
+          deviceTrustService.decryptUserKeyWithDeviceKey(
+            mockUserId,
+            mockEncryptedDevicePrivateKey,
+            null,
+            mockDeviceKey,
+          ),
+        ).rejects.toThrow(
+          "Encrypted user key is required. Cannot decrypt user key with device key.",
+        );
+      });
+
       it("returns null when device key isn't provided", async () => {
         const result = await deviceTrustService.decryptUserKeyWithDeviceKey(
           mockUserId,
@@ -731,6 +759,7 @@ describe("deviceTrustService", () => {
       secureStorageService,
       userDecryptionOptionsService,
       logService,
+      configService,
     );
   }
 });

--- a/libs/common/src/auth/services/devices-api.service.implementation.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.ts
@@ -101,4 +101,18 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
     );
     return new ProtectedDeviceResponse(result);
   }
+
+  async postDeviceTrustLoss(deviceIdentifier: string): Promise<void> {
+    await this.apiService.send(
+      "POST",
+      "/devices/lost-trust",
+      null,
+      true,
+      false,
+      null,
+      (headers) => {
+        headers.set("Device-Identifier", deviceIdentifier);
+      },
+    );
+  }
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -26,6 +26,7 @@ export enum FeatureFlag {
   ProviderClientVaultPrivacyBanner = "ac-2833-provider-client-vault-privacy-banner",
   VaultBulkManagementAction = "vault-bulk-management-action",
   AC2828_ProviderPortalMembersPage = "AC-2828_provider-portal-members-page",
+  DeviceTrustLogging = "pm-8285-device-trust-logging",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -62,6 +63,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ProviderClientVaultPrivacyBanner]: FALSE,
   [FeatureFlag.VaultBulkManagementAction]: FALSE,
   [FeatureFlag.AC2828_ProviderPortalMembersPage]: FALSE,
+  [FeatureFlag.DeviceTrustLogging]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10059
bitwarden/server#4554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Notifies server when the client has a device key, but doesn't receive decryption keys from the server.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
