### PR TITLE
[PM-9630] Custom Field Browser V2 updates

### DIFF
--- a/libs/vault/src/cipher-view/cipher-view.component.html
+++ b/libs/vault/src/cipher-view/cipher-view.component.html
@@ -15,7 +15,8 @@
 
   <!-- CUSTOM FIELDS -->
   <ng-container *ngIf="cipher.fields">
-    <app-custom-fields-v2 [fields]="cipher.fields"> </app-custom-fields-v2>
+    <app-custom-fields-v2 [fields]="cipher.fields" [cipherType]="cipher.type">
+    </app-custom-fields-v2>
   </ng-container>
 
   <!-- ATTACHMENTS SECTION -->

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -65,14 +65,6 @@
             [value]="getLinkedType(field.linkedId)"
             aria-readonly="true"
           />
-          <button
-            bitIconButton="bwi-clone"
-            bitSuffix
-            type="button"
-            [appCopyClick]="field.name"
-            showToast
-            [appA11yTitle]="'copyValue' | i18n"
-          ></button>
         </bit-form-field>
       </ng-container>
     </div>

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
@@ -1,10 +1,13 @@
 import { CommonModule } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { FieldType, LinkedIdType, LoginLinkedId } from "@bitwarden/common/vault/enums";
+import { CipherType, FieldType, LinkedIdType } from "@bitwarden/common/vault/enums";
+import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import {
   CardComponent,
   IconButtonModule,
@@ -33,19 +36,33 @@ import {
     CheckboxModule,
   ],
 })
-export class CustomFieldV2Component {
+export class CustomFieldV2Component implements OnInit {
   @Input() fields: FieldView[];
+  @Input() cipherType: CipherType;
   fieldType = FieldType;
+  fieldOptions: any;
 
   constructor(private i18nService: I18nService) {}
 
-  getLinkedType(linkedId: LinkedIdType) {
-    if (linkedId === LoginLinkedId.Username) {
-      return this.i18nService.t("username");
-    }
+  ngOnInit(): void {
+    this.fieldOptions = this.getLinkedFieldsOptionsForCipher();
+  }
 
-    if (linkedId === LoginLinkedId.Password) {
-      return this.i18nService.t("password");
+  getLinkedType(linkedId: LinkedIdType) {
+    const linkedType = this.fieldOptions.get(linkedId);
+    return this.i18nService.t(linkedType.i18nKey);
+  }
+
+  private getLinkedFieldsOptionsForCipher() {
+    switch (this.cipherType) {
+      case CipherType.Login:
+        return LoginView.prototype.linkedFieldOptions;
+      case CipherType.Card:
+        return CardView.prototype.linkedFieldOptions;
+      case CipherType.Identity:
+        return IdentityView.prototype.linkedFieldOptions;
+      default:
+        return null;
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9630 remove copy icon](https://bitwarden.atlassian.net/browse/PM-9630)
[PM-10018 linked fields in Card and Identity](https://bitwarden.atlassian.net/browse/PM-10018)

## 📔 Objective

Removed the copy icon from Linked Fields in custom fields
Update Linked Fields to utilize the new `linkedfieldoptions`. Showing the proper text for Card and Identity fields

## 📸 Screenshots

![Login](https://github.com/user-attachments/assets/f978103d-8437-4b36-a305-c6939e7b4e38)

![Identity](https://github.com/user-attachments/assets/f88b2867-0575-40f6-9908-20745104830a)

![Card](https://github.com/user-attachments/assets/0856942f-2838-45ca-93d1-c73dd3d3fb67)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
