### PR TITLE
[PM-9951] Assignment Collections copy (part 2)

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3699,7 +3699,10 @@
   "assign": {
     "message": "Assign"
   },
-  "bulkCollectionAssignmentDialogDescription": {
+  "bulkCollectionAssignmentDialogDescriptionSingular": {
+    "message": "Only organization members with access to these collections will be able to see the item."
+  },
+  "bulkCollectionAssignmentDialogDescriptionPlural": {
     "message": "Only organization members with access to these collections will be able to see the items."
   },
   "bulkCollectionAssignmentWarning": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7933,7 +7933,10 @@
   "assignToTheseCollections": {
     "message": "Assign to these collections"
   },
-  "bulkCollectionAssignmentDialogDescription": {
+  "bulkCollectionAssignmentDialogDescriptionSingular": {
+    "message": "Only organization members with access to these collections will be able to see the item."
+  },
+  "bulkCollectionAssignmentDialogDescriptionPlural": {
     "message": "Only organization members with access to these collections will be able to see the items."
   },
   "selectCollectionsToAssign": {

--- a/libs/vault/src/components/assign-collections.component.html
+++ b/libs/vault/src/components/assign-collections.component.html
@@ -1,5 +1,12 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit" id="assign_collections_form">
-  <p>{{ "bulkCollectionAssignmentDialogDescription" | i18n }}</p>
+  <p>
+    {{
+      (personalItemsCount === 1
+        ? "bulkCollectionAssignmentDialogDescriptionSingular"
+        : "bulkCollectionAssignmentDialogDescriptionPlural"
+      ) | i18n
+    }}
+  </p>
 
   <ul class="tw-list-disc tw-pl-5 tw-space-y-2 tw-break-words">
     <li *ngIf="readonlyItemCount > 0">

--- a/libs/vault/src/components/assign-collections.component.html
+++ b/libs/vault/src/components/assign-collections.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit" id="assign_collections_form">
   <p>{{ "bulkCollectionAssignmentDialogDescription" | i18n }}</p>
 
-  <ul class="tw-list-none tw-pl-5 tw-space-y-2 tw-break-words">
+  <ul class="tw-list-disc tw-pl-5 tw-space-y-2 tw-break-words">
     <li *ngIf="readonlyItemCount > 0">
       <p>
         {{ "bulkCollectionAssignmentWarning" | i18n: totalItemCount : readonlyItemCount }}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9951](https://bitwarden.atlassian.net/browse/PM-9951)

## 📔 Objective

Refine copy of the assignment collection copy/design:
- Make singular and plural versions of the bulk assignment description so `item` has the correct plurality. 
- Add back the bullet for the assignment warning message

## 📸 Screenshots

|Extension|Web - plural|Web - singular|
|-|-|-|
|<img width="382" alt="Screenshot 2024-07-24 at 10 31 23 AM" src="https://github.com/user-attachments/assets/185f0df9-77ca-4f66-a78b-294a353b26dd">|<img width="1731" alt="Screenshot 2024-07-24 at 10 31 45 AM" src="https://github.com/user-attachments/assets/1bd52740-b7d2-4e46-a8b0-aab35366b8ab">|<img width="1730" alt="Screenshot 2024-07-24 at 10 36 21 AM" src="https://github.com/user-attachments/assets/e75b751d-9163-46a6-87ca-94b14b3d07ec">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9951]: https://bitwarden.atlassian.net/browse/PM-9951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ