### PR TITLE
[PM-9925] Tokenable for User Verification on Two Factor Authenticator settings

### DIFF
--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -30,6 +30,7 @@ import {
 import { SelectionReadOnlyResponse } from "../admin-console/models/response/selection-read-only.response";
 import { CreateAuthRequest } from "../auth/models/request/create-auth.request";
 import { DeviceVerificationRequest } from "../auth/models/request/device-verification.request";
+import { DisableTwoFactorAuthenticatorRequest } from "../auth/models/request/disable-two-factor-authenticator.request";
 import { EmailTokenRequest } from "../auth/models/request/email-token.request";
 import { EmailRequest } from "../auth/models/request/email.request";
 import { PasswordTokenRequest } from "../auth/models/request/identity-token/password-token.request";
@@ -323,6 +324,9 @@ export abstract class ApiService {
   putTwoFactorAuthenticator: (
     request: UpdateTwoFactorAuthenticatorRequest,
   ) => Promise<TwoFactorAuthenticatorResponse>;
+  deleteTwoFactorAuthenticator: (
+    request: DisableTwoFactorAuthenticatorRequest,
+  ) => Promise<TwoFactorProviderResponse>;
   putTwoFactorEmail: (request: UpdateTwoFactorEmailRequest) => Promise<TwoFactorEmailResponse>;
   putTwoFactorDuo: (request: UpdateTwoFactorDuoRequest) => Promise<TwoFactorDuoResponse>;
   putTwoFactorOrganizationDuo: (

--- a/libs/common/src/auth/models/request/disable-two-factor-authenticator.request.ts
+++ b/libs/common/src/auth/models/request/disable-two-factor-authenticator.request.ts
@@ -1,0 +1,6 @@
+import { TwoFactorProviderRequest } from "./two-factor-provider.request";
+
+export class DisableTwoFactorAuthenticatorRequest extends TwoFactorProviderRequest {
+  key: string;
+  userVerificationToken: string;
+}

--- a/libs/common/src/auth/models/request/update-two-factor-authenticator.request.ts
+++ b/libs/common/src/auth/models/request/update-two-factor-authenticator.request.ts
@@ -3,4 +3,5 @@ import { SecretVerificationRequest } from "./secret-verification.request";
 export class UpdateTwoFactorAuthenticatorRequest extends SecretVerificationRequest {
   token: string;
   key: string;
+  userVerificationToken: string;
 }

--- a/libs/common/src/auth/models/response/two-factor-authenticator.response.ts
+++ b/libs/common/src/auth/models/response/two-factor-authenticator.response.ts
@@ -3,10 +3,12 @@ import { BaseResponse } from "../../../models/response/base.response";
 export class TwoFactorAuthenticatorResponse extends BaseResponse {
   enabled: boolean;
   key: string;
+  userVerificationToken: string;
 
   constructor(response: any) {
     super(response);
     this.enabled = this.getResponseProperty("Enabled");
     this.key = this.getResponseProperty("Key");
+    this.userVerificationToken = this.getResponseProperty("UserVerificationToken");
   }
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -27,6 +27,7 @@ export enum FeatureFlag {
   VaultBulkManagementAction = "vault-bulk-management-action",
   AC2828_ProviderPortalMembersPage = "AC-2828_provider-portal-members-page",
   DeviceTrustLogging = "pm-8285-device-trust-logging",
+  AuthenticatorTwoFactorToken = "authenticator-2fa-token",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -64,6 +65,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.VaultBulkManagementAction]: FALSE,
   [FeatureFlag.AC2828_ProviderPortalMembersPage]: FALSE,
   [FeatureFlag.DeviceTrustLogging]: FALSE,
+  [FeatureFlag.AuthenticatorTwoFactorToken]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -37,6 +37,7 @@ import { SelectionReadOnlyResponse } from "../admin-console/models/response/sele
 import { TokenService } from "../auth/abstractions/token.service";
 import { CreateAuthRequest } from "../auth/models/request/create-auth.request";
 import { DeviceVerificationRequest } from "../auth/models/request/device-verification.request";
+import { DisableTwoFactorAuthenticatorRequest } from "../auth/models/request/disable-two-factor-authenticator.request";
 import { EmailTokenRequest } from "../auth/models/request/email-token.request";
 import { EmailRequest } from "../auth/models/request/email.request";
 import { DeviceRequest } from "../auth/models/request/identity-token/device.request";
@@ -996,6 +997,13 @@ export class ApiService implements ApiServiceAbstraction {
   ): Promise<TwoFactorAuthenticatorResponse> {
     const r = await this.send("PUT", "/two-factor/authenticator", request, true, true);
     return new TwoFactorAuthenticatorResponse(r);
+  }
+
+  async deleteTwoFactorAuthenticator(
+    request: DisableTwoFactorAuthenticatorRequest,
+  ): Promise<TwoFactorProviderResponse> {
+    const r = await this.send("DELETE", "/two-factor/authenticator", request, true, true);
+    return new TwoFactorProviderResponse(r);
   }
 
   async putTwoFactorEmail(request: UpdateTwoFactorEmailRequest): Promise<TwoFactorEmailResponse> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9925](https://bitwarden.atlassian.net/browse/PM-9925)

[Server PR](url)

These changes are behind feature flag: `authenticator-2fa-token`
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Currently to have a compliant TOTP implementation we do not allow users to re-use any TOTP. We support two TOTPs: Email and Authenticator. Both of these are used for two factor authentication. Email however is used for Bitwarden implementations that use Trusted Device Encryption as a means to verify a user.

There are some actions in Bitwarden that require User Verification. One of them being setting up Two Factor Authentication. Since any TOTP is invalidated after they are used this means the current flow for setting up Two Factor needed to be adjusted. We now only consume the OTP when a user is writing two factor data. We do not require it when reading two factor configuration data. This causes an issue with Authenticator Configuration.

Most Two Factor configuration data is already obfuscated but the Authenticator configuration uses a unique Key value that is visible. This creates a vulnerability for opportunistic attackers. So, we will protect the Authenticator Key behind User Verification (we are protecting the read). But we still need to verify the user again when a user is writing, but the OTP has already been used.

Instead of requiring the user to request another email OTP we generate an encrypted expiring token (30 minutes) that is sent back to the server which acts as User Verification for writes. This creates a sort of "session" for the user to configure or modify the Authenticator configuration.

### Process
Primary addition is the `override` of the `disableMethod` in the `base-two-factor.component.ts`. There is a different endpoint for disabling the Authenticator than the other two-factor methods. All other methods use the same endpoint but the Authenticator needs to target a specific endpoint to properly consume the new `userVerificationToken`. 

Everything else is about the same just the addition of the `userVerificationToken: string` to the request and response models in some cases.
 
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Local test with Feature Flag on
https://github.com/user-attachments/assets/79c82664-1828-4f0f-91ae-6bb82facefd0

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9925]: https://bitwarden.atlassian.net/browse/PM-9925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ