### PR TITLE
[PM-10047] update name input in item details

### DIFF
--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -7,14 +7,16 @@
       <label class="tw-block tw-w-full tw-mb-1 tw-text-xs tw-text-muted tw-select-none">
         {{ "itemName" | i18n }}
       </label>
-      <input
-        readonly
-        bitInput
-        type="text"
-        [value]="cipher.name"
-        aria-readonly="true"
-        data-testid="item-name"
-      />
+      <bit-form-field>
+        <input
+          readonly
+          bitInput
+          type="text"
+          [value]="cipher.name"
+          aria-readonly="true"
+          data-testid="item-name"
+        />
+      </bit-form-field>
     </div>
 
     <ul

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
@@ -11,6 +11,7 @@ import {
   SectionComponent,
   SectionHeaderComponent,
   TypographyModule,
+  FormFieldModule,
 } from "@bitwarden/components";
 
 import { OrgIconDirective } from "../../components/org-icon.directive";
@@ -27,6 +28,7 @@ import { OrgIconDirective } from "../../components/org-icon.directive";
     SectionHeaderComponent,
     TypographyModule,
     OrgIconDirective,
+    FormFieldModule,
   ],
 })
 export class ItemDetailsV2Component {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10447](https://bitwarden.atlassian.net/browse/PM-10047)

## 📔 Objective

Updated the name input in item details to use the bit-form-field. This will grab the latest style changes. The screenshot below is with our current styles. Will look updated when brought into feature branch `ps/extension-refresh`

## 📸 Screenshots

![Screenshot 2024-07-26 at 12 59 30 PM](https://github.com/user-attachments/assets/3d71ae1d-d78d-470a-8c36-f48dc7bc9d28)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
