### PR TITLE
apply offset

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -144,7 +144,6 @@ export class WindowMain {
 
     this.session = session.fromPartition("persist:bitwarden", { cache: false });
 
-    // Create the browser window.
     this.win = new BrowserWindow({
       width: this.windowStates[mainWindowSizeKey].width,
       height: this.windowStates[mainWindowSizeKey].height,
@@ -168,6 +167,8 @@ export class WindowMain {
         devTools: isDev(),
       },
     });
+
+    this.win.setBounds({x: this.windowStates[mainWindowSizeKey].x, y: this.windowStates[mainWindowSizeKey].y, width: this.windowStates[mainWindowSizeKey].width, height: this.windowStates[mainWindowSizeKey].height});
 
     this.win.webContents.on("dom-ready", () => {
       this.win.webContents.zoomFactor = this.windowStates[mainWindowSizeKey].zoomFactor ?? 1.0;
@@ -335,15 +336,21 @@ export class WindowMain {
       }
     }
 
+    var widthCompare = state.width;
+    var heightCompare = state.height
+    if (isWindows()) {
+      widthCompare = state.width - 14;
+      heightCompare = state.height - 7;
+    }
+
     if (displayBounds != null) {
-      if (state.width > displayBounds.width && state.height > displayBounds.height) {
+      if (widthCompare > displayBounds.width && heightCompare > displayBounds.height) {
         state.isMaximized = true;
       }
-
-      if (state.width > displayBounds.width) {
+      if (widthCompare > displayBounds.width) {
         state.width = displayBounds.width - 10;
       }
-      if (state.height > displayBounds.height) {
+      if (heightCompare > displayBounds.height) {
         state.height = displayBounds.height - 10;
       }
     }


### PR DESCRIPTION
## 🎟️ Tracking

Github Issue #10307

## 📔 Objective

Fixing the bug from the issue above.

The currently used method <code>getBounds()</code> represents the window size including the app window title bar and borders.
However on Windows (10,11) this includes the "old" 8 pixel wide border (on the sides and bottom) known from windows 7, which in practice only displays as a 1 pixel wide border.
Ergo we have a 7 pixel wide "invisible" border on the left, bottom and right. see [here](https://github.com/electron/electron/issues/4045#issuecomment-170453161) for reference

![image](https://github.com/user-attachments/assets/e53e68fa-f644-4c34-ab56-6d6ffaf98b75)
This info can bee seen using WindowSpy from AutoHotKey. Notice the screen width is 16 pixels larger than the client width, even though we can see that the window is filling the whole width (see screenshot below)

When we are calculating if a window is stepping over screen bounds and we are using <code>getBounds()</code>, we think a window is stepping over, even though it doesn't look like it (-> the invisible border).

This Pull Request implements an offset for the mis-reported <code>getBounds()</code> border size.
I have tested this PR **on Windows** with multiple normal and abnormal window positions and sizes and it works now as expected.

## 📸 Screenshots
## current <code>main</code>
setting the position and bounds
![image](https://github.com/user-attachments/assets/cb43a81c-1adc-43c4-8f67-55f052f34838)

after restart of app
![image](https://github.com/user-attachments/assets/750f9586-9e22-45b0-8109-da77832902e0)


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
