### PR TITLE
[PM-9825] Remove margin from last field in section

### DIFF
--- a/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
+++ b/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
@@ -8,7 +8,10 @@
       <bit-label>{{ "notes" | i18n }}</bit-label>
       <textarea bitInput formControlName="notes"></textarea>
     </bit-form-field>
-    <bit-form-control *ngIf="passwordRepromptEnabled$ | async" [disableMargin]="true">
+    <bit-form-control
+      *ngIf="passwordRepromptEnabled$ | async"
+      [disableMargin]="hasCustomFields || isPartialEdit"
+    >
       <input type="checkbox" bitCheckbox formControlName="reprompt" />
       <bit-label>{{ "passwordPrompt" | i18n }}</bit-label>
     </bit-form-control>

--- a/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
+++ b/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
@@ -8,7 +8,7 @@
       <bit-label>{{ "notes" | i18n }}</bit-label>
       <textarea bitInput formControlName="notes"></textarea>
     </bit-form-field>
-    <bit-form-control *ngIf="passwordRepromptEnabled$ | async">
+    <bit-form-control *ngIf="passwordRepromptEnabled$ | async" [disableMargin]="true">
       <input type="checkbox" bitCheckbox formControlName="reprompt" />
       <bit-label>{{ "passwordPrompt" | i18n }}</bit-label>
     </bit-form-control>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -51,7 +51,7 @@
       </bit-form-field>
     </div>
 
-    <bit-form-field>
+    <bit-form-field [disableMargin]="true">
       <bit-label>{{ "securityCode" | i18n }}</bit-label>
       <input id="cardCode" bitInput formControlName="code" type="password" />
       <button

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -51,7 +51,7 @@
       </bit-form-field>
     </div>
 
-    <bit-form-field [disableMargin]="true">
+    <bit-form-field disableMargin>
       <bit-label>{{ "securityCode" | i18n }}</bit-label>
       <input id="cardCode" bitInput formControlName="code" type="password" />
       <button

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -12,7 +12,7 @@
       <div
         *ngFor="let field of fields.controls; let i = index"
         [formGroupName]="i"
-        class="tw-flex tw-p-3 -tw-mx-3 tw-gap-4 tw-bg-background tw-rounded-lg first:-tw-mt-3 last-of-type:tw-mb-3"
+        class="tw-flex tw-p-3 -tw-mx-3 tw-gap-4 tw-bg-background tw-rounded-lg first:-tw-mt-3 last-of-type:tw-mb-0"
         [ngClass]="{
           'tw-items-center': field.value.type === FieldType.Boolean
         }"

--- a/libs/vault/src/cipher-form/components/identity/identity.component.html
+++ b/libs/vault/src/cipher-form/components/identity/identity.component.html
@@ -41,7 +41,7 @@
         </bit-label>
         <input bitInput formControlName="username" />
       </bit-form-field>
-      <bit-form-field [disableMargin]="true">
+      <bit-form-field disableMargin>
         <bit-label>
           {{ "company" | i18n }}
         </bit-label>
@@ -80,7 +80,7 @@
           data-testid="visibility-for-passport-number"
         ></button>
       </bit-form-field>
-      <bit-form-field [disableMargin]="true">
+      <bit-form-field disableMargin>
         <bit-label>
           {{ "licenseNumber" | i18n }}
         </bit-label>
@@ -99,7 +99,7 @@
         </bit-label>
         <input bitInput formControlName="email" />
       </bit-form-field>
-      <bit-form-field [disableMargin]="true">
+      <bit-form-field disableMargin>
         <bit-label>
           {{ "phone" | i18n }}
         </bit-label>
@@ -148,7 +148,7 @@
         </bit-label>
         <input bitInput formControlName="postalCode" />
       </bit-form-field>
-      <bit-form-field [disableMargin]="true">
+      <bit-form-field disableMargin>
         <bit-label>
           {{ "country" | i18n }}
         </bit-label>

--- a/libs/vault/src/cipher-form/components/identity/identity.component.html
+++ b/libs/vault/src/cipher-form/components/identity/identity.component.html
@@ -41,7 +41,7 @@
         </bit-label>
         <input bitInput formControlName="username" />
       </bit-form-field>
-      <bit-form-field>
+      <bit-form-field [disableMargin]="true">
         <bit-label>
           {{ "company" | i18n }}
         </bit-label>
@@ -80,7 +80,7 @@
           data-testid="visibility-for-passport-number"
         ></button>
       </bit-form-field>
-      <bit-form-field>
+      <bit-form-field [disableMargin]="true">
         <bit-label>
           {{ "licenseNumber" | i18n }}
         </bit-label>
@@ -99,7 +99,7 @@
         </bit-label>
         <input bitInput formControlName="email" />
       </bit-form-field>
-      <bit-form-field>
+      <bit-form-field [disableMargin]="true">
         <bit-label>
           {{ "phone" | i18n }}
         </bit-label>
@@ -148,7 +148,7 @@
         </bit-label>
         <input bitInput formControlName="postalCode" />
       </bit-form-field>
-      <bit-form-field>
+      <bit-form-field [disableMargin]="true">
         <bit-label>
           {{ "country" | i18n }}
         </bit-label>

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
@@ -18,7 +18,11 @@
       <input bitInput formControlName="name" />
     </bit-form-field>
     <div class="tw-flex tw-flex-wrap tw-gap-1">
-      <bit-form-field class="tw-flex-1" *ngIf="showOwnership">
+      <bit-form-field
+        class="tw-flex-1"
+        *ngIf="showOwnership"
+        [disableMargin]="!showCollectionsControl"
+      >
         <bit-label>{{ "owner" | i18n }}</bit-label>
         <bit-select formControlName="organizationId">
           <bit-option
@@ -33,7 +37,7 @@
           ></bit-option>
         </bit-select>
       </bit-form-field>
-      <bit-form-field class="tw-flex-1">
+      <bit-form-field class="tw-flex-1" [disableMargin]="!showCollectionsControl">
         <bit-label>{{ "folder" | i18n }}</bit-label>
         <bit-select formControlName="folderId">
           <bit-option
@@ -45,7 +49,7 @@
       </bit-form-field>
     </div>
     <ng-container *ngIf="showCollectionsControl">
-      <bit-form-field class="tw-w-full">
+      <bit-form-field class="tw-w-full" [disableMargin]="true">
         <bit-label>{{ "collections" | i18n }}</bit-label>
         <bit-multi-select
           class="tw-w-full"

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
@@ -49,7 +49,7 @@
       </bit-form-field>
     </div>
     <ng-container *ngIf="showCollectionsControl">
-      <bit-form-field class="tw-w-full" [disableMargin]="true">
+      <bit-form-field class="tw-w-full" disableMargin>
         <bit-label>{{ "collections" | i18n }}</bit-label>
         <bit-multi-select
           class="tw-w-full"

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -74,7 +74,7 @@
       ></button>
     </bit-form-field>
 
-    <bit-form-field>
+    <bit-form-field [disableMargin]="true">
       <bit-label>
         {{ "authenticatorKey" | i18n }}
         <button

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -74,7 +74,7 @@
       ></button>
     </bit-form-field>
 
-    <bit-form-field [disableMargin]="true">
+    <bit-form-field disableMargin>
       <bit-label>
         {{ "authenticatorKey" | i18n }}
         <button


### PR DESCRIPTION
## 🎟️ Tracking
[PM-9825](https://bitwarden.atlassian.net/browse/PM-9825)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The bottom margin on the section should match the left/right margin.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Before  | After  |
|---|---|
|<img width="376" alt="Screenshot 2024-07-29 at 10 03 03 AM" src="https://github.com/user-attachments/assets/0fb68a2c-27f2-496b-85c3-9aed04b5b388">|<img width="376" alt="Screenshot 2024-07-29 at 10 00 21 AM" src="https://github.com/user-attachments/assets/c7ac774d-b2ca-4ead-ac04-1c3be1635924">|
|<img width="374" alt="Screenshot 2024-07-29 at 10 03 27 AM" src="https://github.com/user-attachments/assets/5d5533c8-4842-47d5-a32c-2eed50e0bde3">|<img width="377" alt="Screenshot 2024-07-29 at 9 59 53 AM" src="https://github.com/user-attachments/assets/734e7d8a-c7fe-4939-9bdd-cf3b896b3c78">|

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9825]: https://bitwarden.atlassian.net/browse/PM-9825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ