### PR TITLE
[PM-8379] Fix Vault Popup Items service loading

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed } from "@angular/core/testing";
 import { mock } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, firstValueFrom, timeout } from "rxjs";
 
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { ObservableTracker } from "@bitwarden/common/spec";
 import { CipherId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -37,6 +38,7 @@ describe("VaultPopupItemsService", () => {
   const searchService = mock<SearchService>();
   const collectionService = mock<CollectionService>();
   const vaultAutofillServiceMock = mock<VaultPopupAutofillService>();
+  const syncServiceMock = mock<SyncService>();
 
   beforeEach(() => {
     allCiphers = cipherFactory(10);
@@ -90,6 +92,8 @@ describe("VaultPopupItemsService", () => {
     organizationServiceMock.organizations$ = new BehaviorSubject([mockOrg]);
     collectionService.decryptedCollections$ = new BehaviorSubject(mockCollections);
 
+    syncServiceMock.getLastSync.mockResolvedValue(new Date());
+
     testBed = TestBed.configureTestingModule({
       providers: [
         { provide: CipherService, useValue: cipherServiceMock },
@@ -99,6 +103,7 @@ describe("VaultPopupItemsService", () => {
         { provide: VaultPopupListFiltersService, useValue: vaultPopupListFiltersServiceMock },
         { provide: CollectionService, useValue: collectionService },
         { provide: VaultPopupAutofillService, useValue: vaultAutofillServiceMock },
+        { provide: SyncService, useValue: syncServiceMock },
       ],
     });
 
@@ -153,6 +158,14 @@ describe("VaultPopupItemsService", () => {
     // Should only emit twice
     expect(tracker.emissions.length).toBe(2);
     await expect(tracker.pauseUntilReceived(3)).rejects.toThrow("Timeout exceeded");
+  });
+
+  it("should not emit cipher list if syncService.getLastSync returns null", async () => {
+    syncServiceMock.getLastSync.mockResolvedValue(null);
+
+    const obs$ = service.autoFillCiphers$.pipe(timeout(50));
+
+    await expect(firstValueFrom(obs$)).rejects.toThrow("Timeout has occurred");
   });
 
   describe("autoFillCiphers$", () => {

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -407,19 +407,6 @@ describe("VaultPopupItemsService", () => {
       expect(tracked.emissions[1]).toBe(true);
       expect(tracked.emissions[2]).toBe(false);
     });
-
-    it("should cycle when filters are applied", async () => {
-      // Restart tracking
-      tracked = new ObservableTracker(service.loading$);
-      service.applyFilter("test");
-
-      await trackedCiphers.pauseUntilReceived(2);
-
-      expect(tracked.emissions.length).toBe(3);
-      expect(tracked.emissions[0]).toBe(false);
-      expect(tracked.emissions[1]).toBe(true);
-      expect(tracked.emissions[2]).toBe(false);
-    });
   });
 
   describe("applyFilter", () => {

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -112,7 +112,6 @@ export class VaultPopupItemsService {
     this._searchText$,
     this.vaultPopupListFiltersService.filterFunction$,
   ]).pipe(
-    tap(() => this._ciphersLoading$.next()),
     map(([ciphers, searchText, filterFunction]): [CipherView[], string] => [
       filterFunction(ciphers),
       searchText,

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -5,6 +5,7 @@ import {
   concatMap,
   distinctUntilChanged,
   distinctUntilKeyChanged,
+  filter,
   from,
   map,
   merge,
@@ -21,6 +22,7 @@ import {
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
@@ -78,6 +80,8 @@ export class VaultPopupItemsService {
   ).pipe(
     runInsideAngular(inject(NgZone)), // Workaround to ensure cipher$ state provider emissions are run inside Angular
     tap(() => this._ciphersLoading$.next()),
+    switchMap(() => Utils.asyncToObservable(() => this.syncService.getLastSync())),
+    filter((lastSync) => lastSync !== null), // Only attempt to load ciphers if we performed a sync
     switchMap(() => Utils.asyncToObservable(() => this.cipherService.getAllDecrypted())),
     switchMap((ciphers) =>
       combineLatest([
@@ -236,6 +240,7 @@ export class VaultPopupItemsService {
     private searchService: SearchService,
     private collectionService: CollectionService,
     private vaultPopupAutofillService: VaultPopupAutofillService,
+    private syncService: SyncService,
   ) {}
 
   applyFilter(newSearchText: string) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8379](https://bitwarden.atlassian.net/browse/PM-8379)

## 📔 Objective

The vault popup item service would attempt to fetch decrypted ciphers before a sync finished. This would lead to the loading state to flip to `false` and show an empty vault. The PR adds a `filter` to the `cipherList$` observable to avoid emitting unless `syncService.getLastSync()` returns a value (implying a sync has occurred).

Additionally, avoid emitting `vaultPopupItemsService.loading$` whenever a filter is updated as it causes the UI to flash unexpectedly.

## 📸 Screenshots

https://github.com/user-attachments/assets/f429fbd4-6f4d-4828-9d0d-c61be2ebbde1


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
