### PR TITLE
[PM-9503] Add paperclip icon for items with attachments

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -32,6 +32,11 @@
           [size]="'small'"
           [appA11yTitle]="orgIconTooltip(cipher)"
         ></i>
+        <i
+          *ngIf="cipher.hasAttachments"
+          class="bwi bwi-paperclip bwi-sm"
+          [appA11yTitle]="'attachments' | i18n"
+        ></i>
         <span slot="secondary">{{ cipher.subTitle }}</span>
       </a>
       <ng-container slot="end">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9503](https://bitwarden.atlassian.net/browse/PM-9503)

## 📔 Objective

Add missing paperclip icon to items with attachments

## 📸 Screenshots

<img width="376" alt="image" src="https://github.com/user-attachments/assets/8302e156-0369-4c54-9bfa-4ce565035d1e">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
