### PR TITLE
[CL-274] Update styling for radio button

### DIFF
--- a/libs/components/src/radio-button/radio-button.component.ts
+++ b/libs/components/src/radio-button/radio-button.component.ts
@@ -11,7 +11,7 @@ let nextId = 0;
 export class RadioButtonComponent {
   @HostBinding("attr.id") @Input() id = `bit-radio-button-${nextId++}`;
   @HostBinding("class") get classList() {
-    return [this.block ? "tw-block" : "tw-inline-block", "tw-mb-2"];
+    return [this.block ? "tw-block" : "tw-inline-block", "tw-mb-1"];
   }
 
   @Input() value: unknown;

--- a/libs/components/src/radio-button/radio-button.stories.ts
+++ b/libs/components/src/radio-button/radio-button.stories.ts
@@ -164,3 +164,32 @@ export const BlockHint: Story = {
     `,
   }),
 };
+
+export const Disabled: Story = {
+  render: () => ({
+    props: {
+      formObj: new FormGroup({
+        radio: new FormControl(0),
+      }),
+    },
+    template: /* HTML */ `
+      <form [formGroup]="formObj">
+        <bit-radio-group formControlName="radio" aria-label="Example radio group">
+          <bit-label>Group of radio buttons</bit-label>
+
+          <bit-radio-button id="radio-first" [value]="0" [disabled]="true">
+            <bit-label>First</bit-label>
+          </bit-radio-button>
+
+          <bit-radio-button id="radio-second" [value]="1" [disabled]="true">
+            <bit-label>Second</bit-label>
+          </bit-radio-button>
+
+          <bit-radio-button id="radio-third" [value]="2" [disabled]="true">
+            <bit-label>Third</bit-label>
+          </bit-radio-button>
+        </bit-radio-group>
+      </form>
+    `,
+  }),
+};

--- a/libs/components/src/radio-button/radio-input.component.ts
+++ b/libs/components/src/radio-button/radio-input.component.ts
@@ -25,14 +25,19 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "tw-border",
     "tw-border-solid",
     "tw-border-secondary-600",
-    "tw-w-3.5",
-    "tw-h-3.5",
+    "tw-w-5",
+    "tw-h-5",
     "tw-mr-1.5",
     "tw-bottom-[-1px]", // Fix checkbox looking off-center
     "tw-flex-none", // Flexbox fix for bit-form-control
 
     "hover:tw-border-2",
     "[&>label:hover]:tw-border-2",
+
+    // if it exists, the parent form control handles focus
+    "[&:not(bit-form-control_*)]:focus-visible:tw-ring-2",
+    "[&:not(bit-form-control_*)]:focus-visible:tw-ring-offset-2",
+    "[&:not(bit-form-control_*)]:focus-visible:tw-ring-primary-500",
 
     "before:tw-content-['']",
     "before:tw-transition",
@@ -41,18 +46,15 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "before:tw-rounded-full",
     "before:tw-inset-[2px]",
 
-    "focus-visible:tw-ring-2",
-    "focus-visible:tw-ring-offset-2",
-    "focus-visible:tw-ring-primary-700",
-
     "disabled:tw-cursor-auto",
-    "disabled:tw-border",
     "disabled:tw-bg-secondary-100",
+    "disabled:hover:tw-border",
 
     "checked:tw-bg-text-contrast",
     "checked:tw-border-primary-600",
+    "checked:tw-border-2",
 
-    "checked:hover:tw-border",
+    "checked:hover:tw-border-2",
     "checked:hover:tw-border-primary-700",
     "checked:hover:before:tw-bg-primary-700",
     "[&>label:hover]:checked:tw-bg-primary-700",
@@ -60,10 +62,13 @@ export class RadioInputComponent implements BitFormControlAbstraction {
 
     "checked:before:tw-bg-primary-600",
 
-    "checked:disabled:tw-border-secondary-100",
-    "checked:disabled:tw-bg-secondary-100",
+    "checked:disabled:tw-border-secondary-600",
+    "checked:disabled:hover:tw-border-secondary-600",
+    "checked:disabled:hover:tw-border-2",
+    "checked:disabled:tw-bg-background",
 
-    "checked:disabled:before:tw-bg-text-muted",
+    "checked:disabled:hover:before:tw-bg-secondary-600",
+    "checked:disabled:before:tw-bg-secondary-600",
   ];
 
   constructor(@Optional() @Self() private ngControl?: NgControl) {}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-274](https://bitwarden.atlassian.net/browse/CL-274)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the styling for the radio button to match the new extension refresh styles and adds a new story for the disabled state. Some styling was completed as part of the checkbox updates because they share a wrapper component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See more in the Storybook Publish action (Form > Radio Button stories).

<img width="248" alt="Screenshot 2024-07-30 at 4 24 12 PM" src="https://github.com/user-attachments/assets/b0287283-3307-4cbb-8ee0-91625075320f">

<img width="249" alt="Screenshot 2024-07-30 at 3 54 09 PM" src="https://github.com/user-attachments/assets/ec889f07-2e86-475f-9360-c91f6300c7f2">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-274]: https://bitwarden.atlassian.net/browse/CL-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ