### PR TITLE
[PM-10131] Remove margin from last field in each card of autofill settings

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -87,7 +87,7 @@
           />
           <bit-label for="showCardsSuggestions">{{ "showCardsInVaultView" | i18n }}</bit-label>
         </bit-form-control>
-        <bit-form-control>
+        <bit-form-control disableMargin>
           <input
             bitCheckbox
             id="showIdentitiesSuggestions"
@@ -148,7 +148,7 @@
           />
           <bit-label for="autofillOnPageLoad">{{ "enableAutoFillOnPageLoad" | i18n }}</bit-label>
         </bit-form-control>
-        <bit-form-field>
+        <bit-form-field disableMargin>
           <bit-label for="defaultAutofill">{{ "defaultAutoFillOnPageLoad" | i18n }}</bit-label>
           <select
             bitInput
@@ -213,7 +213,7 @@
             {{ "clearClipboardDesc" | i18n }}
           </bit-hint>
         </bit-form-field>
-        <bit-form-field>
+        <bit-form-field disableMargin>
           <bit-label for="defaultUriMatch">{{ "defaultUriMatchDetection" | i18n }}</bit-label>
           <select
             aria-describedby="defaultUriMatchHelp"


### PR DESCRIPTION
## 🎟️ Tracking

PM-10131

## 📔 Objective

Remove margin from last field in each card of autofill settings

## Screenshot with changes

![Screenshot 2024-07-31 at 12 03 34 PM](https://github.com/user-attachments/assets/f7e209ab-7e76-4846-9aa1-14c2afafc670)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
