### PR TITLE
[PM-10139] Section headers should use heading 6 styling

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -8,7 +8,7 @@
   <div class="tw-bg-background-alt tw-p-2">
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-form-control>
@@ -103,7 +103,7 @@
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "autofillKeyboardShortcutSectionTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "autofillKeyboardShortcutSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-item>
         <button bit-item-content type="button" (click)="openURI($event, browserShortcutsURI)">
@@ -122,7 +122,7 @@
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "enableAutoFillOnPageLoadSectionTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "enableAutoFillOnPageLoadSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-hint class="tw-mb-6 tw-text-sm">
@@ -171,7 +171,7 @@
     </bit-section>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "additionalOptions" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "additionalOptions" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <bit-form-control>

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
@@ -13,7 +13,7 @@
     </p>
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "domainsTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "domainsTitle" | i18n }}</h2>
         <span bitTypography="body2" slot="end">{{ excludedDomainsState?.length || 0 }}</span>
       </bit-section-header>
 

--- a/apps/browser/src/autofill/popup/settings/notifications.component.html
+++ b/apps/browser/src/autofill/popup/settings/notifications.component.html
@@ -8,7 +8,7 @@
   <div class="tw-bg-background-alt tw-p-2">
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "vaultSaveOptionsTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">{{ "vaultSaveOptionsTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <div>


### PR DESCRIPTION
## 🎟️ Tracking

PM-10139

## 📔 Objective

Section headers should use heading 6 styling

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
