### PR TITLE
[PM-10134] Add text to default URI match detection select

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1647,7 +1647,7 @@
     "message": "This password was not found in any known data breaches. It should be safe to use."
   },
   "baseDomain": {
-    "message": "Base domain",
+    "message": "Base domain (recommended)",
     "description": "Domain name. Ex. website.com"
   },
   "domainName": {

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1647,6 +1647,10 @@
     "message": "This password was not found in any known data breaches. It should be safe to use."
   },
   "baseDomain": {
+    "message": "Base domain",
+    "description": "Domain name. Ex. website.com"
+  },
+  "baseDomainOptionRecommended": {
     "message": "Base domain (recommended)",
     "description": "Domain name. Ex. website.com"
   },

--- a/apps/browser/src/autofill/popup/settings/autofill-v1.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill-v1.component.ts
@@ -84,7 +84,7 @@ export class AutofillV1Component implements OnInit {
       { name: i18nService.t("fiveMinutes"), value: 300 },
     ];
     this.uriMatchOptions = [
-      { name: i18nService.t("baseDomain"), value: UriMatchStrategy.Domain },
+      { name: i18nService.t("baseDomainOptionRecommended"), value: UriMatchStrategy.Domain },
       { name: i18nService.t("host"), value: UriMatchStrategy.Host },
       { name: i18nService.t("startsWith"), value: UriMatchStrategy.StartsWith },
       { name: i18nService.t("regEx"), value: UriMatchStrategy.RegularExpression },

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -126,7 +126,7 @@ export class AutofillComponent implements OnInit {
       { name: i18nService.t("fiveMinutes"), value: ClearClipboardDelay.FiveMinutes },
     ];
     this.uriMatchOptions = [
-      { name: i18nService.t("baseDomain"), value: UriMatchStrategy.Domain },
+      { name: i18nService.t("baseDomainOptionRecommended"), value: UriMatchStrategy.Domain },
       { name: i18nService.t("host"), value: UriMatchStrategy.Host },
       { name: i18nService.t("startsWith"), value: UriMatchStrategy.StartsWith },
       { name: i18nService.t("regEx"), value: UriMatchStrategy.RegularExpression },


### PR DESCRIPTION
## 🎟️ Tracking

PM-10134

## 📔 Objective

Add text to default URI match detection select.

- This applies to both the current AND v2 browser autofill settings experience (per @danielleflinn )
- This does **not** update the value of the same selection in the add/edit cipher view
- This does not affect the corresponding message catalog keys in the desktop or web clients

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
