### PR TITLE
[PM-10416] Address field is used to populate state field when adding identity cipher from inline menu

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -393,6 +393,7 @@ export class IdentityAutoFillConstants {
     "address-line-2",
     "addr-2",
     "street-2",
+    "address-ext",
   ];
 
   static readonly Address3FieldNames: string[] = [
@@ -409,6 +410,7 @@ export class IdentityAutoFillConstants {
     "zip-code",
     "postal-code",
     "post-code",
+    "postcode",
     "address-zip",
     "address-postal",
     "address-code",

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -658,7 +658,14 @@ export class InlineMenuFieldQualificationService
 
     return (
       !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.Address1FieldNames, false)
+      this.keywordsFoundInFieldData(
+        field,
+        [
+          ...IdentityAutoFillConstants.AddressFieldNames,
+          ...IdentityAutoFillConstants.Address1FieldNames,
+        ],
+        false,
+      )
     );
   };
 
@@ -722,7 +729,7 @@ export class InlineMenuFieldQualificationService
 
     return (
       !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.AddressFieldNames, false)
+      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.StateFieldNames, false)
     );
   };
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10416

## 📔 Objective

A couple of smaller issues have been found with how we capture data from user filled identity fields. This PR fixes the captured value used to populate the state field, address level 1 and level 2 fields, and zip code field.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
