### PR TITLE
[CL-338] Remove extra space in item content when end slot is empty

### DIFF
--- a/libs/components/src/item/item-content.component.html
+++ b/libs/components/src/item/item-content.component.html
@@ -11,6 +11,6 @@
   </div>
 </div>
 
-<div class="tw-flex tw-gap-2 tw-items-center">
+<div class="tw-flex tw-gap-2 tw-items-center" #endSlot [hidden]="!endSlotHasChildren()">
   <ng-content select="[slot=end]"></ng-content>
 </div>

--- a/libs/components/src/item/item-content.component.ts
+++ b/libs/components/src/item/item-content.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import {
+  AfterContentChecked,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  signal,
+  ViewChild,
+} from "@angular/core";
 
 @Component({
   selector: "bit-item-content, [bit-item-content]",
@@ -12,4 +19,12 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ItemContentComponent {}
+export class ItemContentComponent implements AfterContentChecked {
+  @ViewChild("endSlot") endSlot: ElementRef<HTMLDivElement>;
+
+  protected endSlotHasChildren = signal(false);
+
+  ngAfterContentChecked(): void {
+    this.endSlotHasChildren.set(this.endSlot?.nativeElement.childElementCount > 0);
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-338](https://bitwarden.atlassian.net/browse/CL-338)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
If the end slot of the item content is empty, then it should not render. The parent container uses `tw-gap` to separate the end slot from the main content, so if the end slot is empty, we don't want the gap to display because this puts extra blank space at the end of the container. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

With end slot content:
<img width="496" alt="Screenshot 2024-07-31 at 3 00 52 PM" src="https://github.com/user-attachments/assets/e6626852-e8dd-47da-916f-9d6a38c48f76">

Without end slot content:
<img width="496" alt="Screenshot 2024-07-31 at 3 01 06 PM" src="https://github.com/user-attachments/assets/0c31d806-b5c0-49b8-96db-6e91eca228c5">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-338]: https://bitwarden.atlassian.net/browse/CL-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ