### PR TITLE
[PM-10100] Remove auto password generation

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1815,6 +1815,17 @@
   "useThisUsername": {
       "message": "Use this username"
   },
+  "securePasswordGenerated": {
+    "message": "Secure password generated! Don't forget to also update your password on the website."
+  },
+  "useGeneratorHelpTextPartOne": {
+    "message": "Use the generator",
+    "description": "This will be used as part of a larger sentence, broken up to include the generator icon. The full sentence will read 'Use the generator [GENERATOR_ICON] to create a strong unique password'"
+  },
+  "useGeneratorHelpTextPartTwo": {
+    "message": "to create a strong unique password",
+    "description": "This will be used as part of a larger sentence, broken up to include the generator icon. The full sentence will read 'Use the generator [GENERATOR_ICON] to create a strong unique password'"
+  },
   "vaultTimeoutAction": {
     "message": "Vault timeout action"
   },

--- a/apps/browser/src/vault/popup/services/browser-cipher-form-generation.service.ts
+++ b/apps/browser/src/vault/popup/services/browser-cipher-form-generation.service.ts
@@ -39,7 +39,4 @@ export class BrowserCipherFormGenerationService implements CipherFormGenerationS
 
     return result.generatedValue;
   }
-  async generateInitialPassword(): Promise<string> {
-    return "";
-  }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6050,6 +6050,26 @@
   "randomWord": {
     "message": "Random word"
   },
+  "usernameGenerator": {
+    "message": "Username generator"
+  },
+  "useThisPassword": {
+    "message": "Use this password"
+  },
+  "useThisUsername": {
+    "message": "Use this username"
+  },
+  "securePasswordGenerated": {
+    "message": "Secure password generated! Don't forget to also update your password on the website."
+  },
+  "useGeneratorHelpTextPartOne": {
+    "message": "Use the generator",
+    "description": "This will be used as part of a larger sentence, broken up to include the generator icon. The full sentence will read 'Use the generator [GENERATOR_ICON] to create a strong unique password'"
+  },
+  "useGeneratorHelpTextPartTwo": {
+    "message": "to create a strong unique password",
+    "description": "This will be used as part of a larger sentence, broken up to include the generator icon. The full sentence will read 'Use the generator [GENERATOR_ICON] to create a strong unique password'"
+  },
   "service": {
     "message": "Service"
   },

--- a/libs/vault/src/cipher-form/abstractions/cipher-form-generation.service.ts
+++ b/libs/vault/src/cipher-form/abstractions/cipher-form-generation.service.ts
@@ -11,10 +11,4 @@ export abstract class CipherFormGenerationService {
    * Generates a random username. Called when the user clicks the "Generate Username" button in the UI.
    */
   abstract generateUsername(): Promise<string | null>;
-
-  /**
-   * Generates an initial password for a new cipher. This should not involve any user interaction as it will
-   * be used to pre-fill the password field in the UI for new Login ciphers.
-   */
-  abstract generateInitialPassword(): Promise<string | null>;
 }

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, DestroyRef, EventEmitter, Input, Output } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, Input, OnChanges, Output } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { firstValueFrom, map, startWith, Subject, Subscription, switchMap, tap } from "rxjs";
 
@@ -42,7 +42,7 @@ import {
     TypographyModule,
   ],
 })
-export class CipherFormGeneratorComponent {
+export class CipherFormGeneratorComponent implements OnChanges {
   /**
    * The type of generator form to show.
    */

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -23,6 +23,16 @@
     <bit-form-field>
       <bit-label>{{ "password" | i18n }}</bit-label>
       <input bitInput formControlName="password" type="password" />
+      <bit-hint *ngIf="loginDetailsForm.controls.password.enabled">
+        <ng-container *ngIf="newPasswordGenerated">
+          {{ "securePasswordGenerated" | i18n }}
+        </ng-container>
+        <ng-container *ngIf="!newPasswordGenerated">
+          {{ "useGeneratorHelpTextPartOne" | i18n }}
+          <i class="bwi bwi-generate" aria-hidden="true"></i>
+          {{ "useGeneratorHelpTextPartTwo" | i18n }}
+        </ng-container>
+      </bit-hint>
       <button
         type="button"
         bitIconButton="bwi-check-circle"

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.spec.ts
@@ -125,14 +125,6 @@ describe("LoginDetailsSectionComponent", () => {
     });
   });
 
-  it("initializes 'loginDetailsForm' with generated password when creating a new cipher", async () => {
-    generationService.generateInitialPassword.mockResolvedValue("generated-password");
-
-    await component.ngOnInit();
-
-    expect(component.loginDetailsForm.controls.password.value).toBe("generated-password");
-  });
-
   describe("viewHiddenFields", () => {
     beforeEach(() => {
       (cipherFormContainer.originalCipherView as CipherView) = {

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
@@ -148,7 +148,7 @@ export class LoginDetailsSectionComponent implements OnInit {
   private async initNewCipher() {
     this.loginDetailsForm.patchValue({
       username: this.cipherFormContainer.config.initialValues?.username || "",
-      password: await this.generationService.generateInitialPassword(),
+      password: "",
     });
   }
 

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
@@ -53,6 +53,11 @@ export class LoginDetailsSectionComponent implements OnInit {
   });
 
   /**
+   * Flag indicating whether a new password has been generated for the current form.
+   */
+  newPasswordGenerated: boolean;
+
+  /**
    * Whether the TOTP field can be captured from the current tab. Only available in the browser extension.
    */
   get canCaptureTotp() {
@@ -193,6 +198,7 @@ export class LoginDetailsSectionComponent implements OnInit {
 
     if (newPassword) {
       this.loginDetailsForm.controls.password.patchValue(newPassword);
+      this.newPasswordGenerated = true;
     }
   };
 

--- a/libs/vault/src/cipher-form/services/default-cipher-form-generation.service.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form-generation.service.ts
@@ -23,8 +23,4 @@ export class DefaultCipherFormGenerationService implements CipherFormGenerationS
     const options = await this.usernameGenerationService.getOptions();
     return await this.usernameGenerationService.generateUsername(options);
   }
-
-  async generateInitialPassword(): Promise<string> {
-    return await this.generatePassword();
-  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10100](https://bitwarden.atlassian.net/browse/PM-10100)

## 📔 Objective

Stacked on top of https://github.com/bitwarden/clients/pull/10352

Remove the automatic password generation for new login items. Instead, new help text will be shown encouraging users to use the password generator.

## 📸 Screenshots

https://github.com/user-attachments/assets/5af5c249-4f8c-451b-8aa8-b2c750b506ea

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-10100]: https://bitwarden.atlassian.net/browse/PM-10100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ