### PR TITLE
[PM-9839] Extension - Safari - Disable Account Switching

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4093,5 +4093,8 @@
   },
   "bitwardenNewLookDesc": {
     "message": "It's easier and more intuitive than ever to autofill and search from the Vault tab. Take a look around!"
+  },
+  "accountActions": {
+    "message": "Account actions"
   }
 }

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -8,9 +8,9 @@
     </popup-header>
 
     <ng-container *ngIf="availableAccounts$ | async as availableAccounts">
-      <bit-section>
+      <bit-section [disableMargin]="!enableAccountSwitching">
         <ng-container *ngFor="let availableAccount of availableAccounts; first as isFirst">
-          <div *ngIf="availableAccount.isActive" class="tw-mb-6">
+          <div *ngIf="availableAccount.isActive" [ngClass]="{ 'tw-mb-6': enableAccountSwitching }">
             <auth-account
               [account]="availableAccount"
               [extensionRefreshFlag]="extensionRefreshFlag"
@@ -18,17 +18,19 @@
             ></auth-account>
           </div>
 
-          <bit-section-header *ngIf="isFirst">
-            <h2 bitTypography="h6" class="tw-font-semibold">{{ "availableAccounts" | i18n }}</h2>
-          </bit-section-header>
+          <ng-container *ngIf="enableAccountSwitching">
+            <bit-section-header *ngIf="isFirst">
+              <h2 bitTypography="h6" class="tw-font-semibold">{{ "availableAccounts" | i18n }}</h2>
+            </bit-section-header>
 
-          <div *ngIf="!availableAccount.isActive">
-            <auth-account
-              [account]="availableAccount"
-              [extensionRefreshFlag]="extensionRefreshFlag"
-              (loading)="loading = $event"
-            ></auth-account>
-          </div>
+            <div *ngIf="!availableAccount.isActive">
+              <auth-account
+                [account]="availableAccount"
+                [extensionRefreshFlag]="extensionRefreshFlag"
+                (loading)="loading = $event"
+              ></auth-account>
+            </div>
+          </ng-container>
         </ng-container>
 
         <!--

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="extensionRefreshFlag">
   <popup-page [loading]="loading">
-    <popup-header slot="header" pageTitle="{{ 'switchAccounts' | i18n }}" showBackButton>
+    <popup-header slot="header" pageTitle="{{ 'accountActions' | i18n }}" showBackButton>
       <ng-container slot="end">
         <app-pop-out></app-pop-out>
         <app-current-account></app-current-account>

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -116,15 +116,17 @@
                 (loading)="loading = $event"
               ></auth-account>
             </li>
-            <div *ngIf="isFirst" class="tw-uppercase tw-text-muted">
-              {{ "availableAccounts" | i18n }}
-            </div>
-            <li *ngIf="!availableAccount.isActive" role="option">
-              <auth-account
-                [account]="availableAccount"
-                (loading)="loading = $event"
-              ></auth-account>
-            </li>
+            <ng-container *ngIf="enableAccountSwitching">
+              <div *ngIf="isFirst" class="tw-uppercase tw-text-muted">
+                {{ "availableAccounts" | i18n }}
+              </div>
+              <li *ngIf="!availableAccount.isActive" role="option">
+                <auth-account
+                  [account]="availableAccount"
+                  (loading)="loading = $event"
+                ></auth-account>
+              </li>
+            </ng-container>
           </ng-container>
         </ul>
         <!--
@@ -168,6 +170,7 @@
             type="button"
             class="account-switcher-row tw-flex tw-w-full tw-items-center tw-gap-3 tw-rounded-md tw-p-3"
             (click)="lockAll()"
+            *ngIf="showLockAll$ | async"
           >
             <i class="bwi bwi-lock tw-text-2xl" aria-hidden="true"></i>
             {{ "lockAll" | i18n }}

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.html
@@ -80,7 +80,7 @@
             {{ "logOut" | i18n }}
           </button>
         </bit-item>
-        <bit-item>
+        <bit-item *ngIf="showLockAll$ | async">
           <button type="button" bit-item-content (click)="lockAll()">
             <i slot="start" class="bwi bwi-lock tw-text-2xl tw-text-main" aria-hidden="true"></i>
             {{ "lockAll" | i18n }}

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, Location } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
-import { Subject, firstValueFrom, map, of, switchMap, takeUntil } from "rxjs";
+import { Subject, firstValueFrom, map, of, startWith, switchMap, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
@@ -87,6 +87,22 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
         ? of(null)
         : this.authService.activeAccountStatus$.pipe(map((s) => ({ ...a, status: s }))),
     ),
+  );
+
+  readonly showLockAll$ = this.availableAccounts$.pipe(
+    startWith([]),
+    map((accounts) => accounts.filter((a) => !a.isActive)),
+    switchMap((accounts) => {
+      // If account switching is disabled, don't show the lock all button
+      // as only one account should be shown.
+      if (!enableAccountSwitching()) {
+        return of(false);
+      }
+
+      // When there are an inactive accounts provide the option to lock all accounts
+      // Note: "Add account" is counted as an inactive account, so check for more than one account
+      return of(accounts.length > 1);
+    }),
   );
 
   async ngOnInit() {

--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -22,6 +22,7 @@ import {
   SectionHeaderComponent,
 } from "@bitwarden/components";
 
+import { enableAccountSwitching } from "../../../platform/flags";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { HeaderComponent } from "../../../platform/popup/header.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
@@ -57,6 +58,7 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
   loading = false;
   activeUserCanLock = false;
   extensionRefreshFlag = false;
+  enableAccountSwitching = true;
 
   constructor(
     private accountSwitcherService: AccountSwitcherService,
@@ -88,6 +90,7 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
   );
 
   async ngOnInit() {
+    this.enableAccountSwitching = enableAccountSwitching();
     this.extensionRefreshFlag = await this.configService.getFeatureFlag(
       FeatureFlag.ExtensionRefresh,
     );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9839](https://bitwarden.atlassian.net/browse/PM-9839)

## 📔 Objective

- Disable account switching within the `AccountSwitcherComponent` component for safari users.
  - This utilizes the [`enableAccountSwitching`](https://github.com/bitwarden/clients/blob/9c8d5a2b3555c977840946c727aa6882d2791b53/apps/browser/src/platform/flags.ts#L41-L46) method that automatically returns false when the browser is safari.
  - @JaredSnider-Bitwarden I went a little beyond what we discussed and implemented the same checks for both the extension refresh and non-extension refresh instances on the page. The `account-switcher` path isn't guarded by anything so it could technically be accessed. Maybe unneeded defensive programming but it was a trivial add.
- Added logic to only show the `Lock All` button if there were any inactive accounts. 

## 📸 Screenshots

| Safari - Extension Refresh | Safari - Non-Extension Refresh | Chrome - Multiple Accounts |
|-|-|-|
|![safari-refresh](https://github.com/user-attachments/assets/386de976-b165-4263-8bf4-02aadf3cd8dd)|![safari-not-fresh](https://github.com/user-attachments/assets/96319fee-3b79-4e26-9092-a9370accc856)|<video src="https://github.com/user-attachments/assets/9f373cf7-155a-4d76-9999-55323d2e3410" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9839]: https://bitwarden.atlassian.net/browse/PM-9839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ