### PR TITLE
[PM-10433] Missing Focus state for Learn More button 

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-ui-onboarding/vault-ui-onboarding.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-ui-onboarding/vault-ui-onboarding.component.ts
@@ -45,10 +45,16 @@ const announcementIcon = svgIcon`
       </span>
 
       <ng-container bitDialogFooter>
-        <a bitButton buttonType="primary" bitDialogClose (click)="navigateToLink()">
+        <button
+          bitButton
+          type="button"
+          buttonType="primary"
+          (click)="navigateToLink()"
+          bitDialogClose
+        >
           {{ "learnMore" | i18n }}
           <i class="bwi bwi-external-link bwi-fw" aria-hidden="true"></i>
-        </a>
+        </button>
         <button bitButton type="button" buttonType="secondary" bitDialogClose>
           {{ "close" | i18n }}
         </button>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-10433](https://bitwarden.atlassian.net/browse/PM-10433)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Expected to be able to get to the Learn More button with keyboard navigation and be able to hit Enter key to be directed to blog post
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10433]: https://bitwarden.atlassian.net/browse/PM-10433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ