### PR TITLE
[PM-10550] Card inline menu not displayed on popup payment form

### DIFF
--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -258,10 +258,7 @@ export class InlineMenuFieldQualificationService
 
       // If no password fields are found on the page, check for keywords that indicate the field is
       // part of an account creation form.
-      return (
-        !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-        this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords)
-      );
+      return this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords);
     }
 
     // If the field has a parent form, check the fields from that form exclusively
@@ -271,10 +268,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords)
-    );
+    return this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords);
   }
 
   /**
@@ -292,10 +286,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, this.identityFieldKeywords)
-    );
+    return this.keywordsFoundInFieldData(field, this.identityFieldKeywords);
   }
 
   /**
@@ -580,10 +571,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.TitleFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.TitleFieldNames, false);
   };
 
   /**
@@ -596,9 +584,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.FirstnameFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.FirstnameFieldNames,
+      false,
     );
   };
 
@@ -612,9 +601,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.MiddlenameFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.MiddlenameFieldNames,
+      false,
     );
   };
 
@@ -628,9 +618,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.LastnameFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.LastnameFieldNames,
+      false,
     );
   };
 
@@ -644,9 +635,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.FullNameFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.FullNameFieldNames,
+      false,
     );
   };
 
@@ -660,16 +652,13 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(
-        field,
-        [
-          ...IdentityAutoFillConstants.AddressFieldNames,
-          ...IdentityAutoFillConstants.Address1FieldNames,
-        ],
-        false,
-      )
+    return this.keywordsFoundInFieldData(
+      field,
+      [
+        ...IdentityAutoFillConstants.AddressFieldNames,
+        ...IdentityAutoFillConstants.Address1FieldNames,
+      ],
+      false,
     );
   };
 
@@ -683,9 +672,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.Address2FieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.Address2FieldNames,
+      false,
     );
   };
 
@@ -699,9 +689,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.Address3FieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.Address3FieldNames,
+      false,
     );
   };
 
@@ -715,10 +706,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CityFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CityFieldNames, false);
   };
 
   /**
@@ -731,10 +719,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.StateFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.StateFieldNames, false);
   };
 
   /**
@@ -747,9 +732,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.PostalCodeFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.PostalCodeFieldNames,
+      false,
     );
   };
 
@@ -763,10 +749,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CountryFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CountryFieldNames, false);
   };
 
   /**
@@ -779,10 +762,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CompanyFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CompanyFieldNames, false);
   };
 
   /**
@@ -795,10 +775,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.PhoneFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.PhoneFieldNames, false);
   };
 
   /**
@@ -814,10 +791,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.EmailFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.EmailFieldNames, false);
   };
 
   /**
@@ -830,9 +804,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.UserNameFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      IdentityAutoFillConstants.UserNameFieldNames,
+      false,
     );
   };
 

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -209,10 +209,7 @@ export class InlineMenuFieldQualificationService
         return false;
       }
 
-      return (
-        !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-        this.keywordsFoundInFieldData(field, this.creditCardFieldKeywords)
-      );
+      return this.keywordsFoundInFieldData(field, this.creditCardFieldKeywords);
     }
 
     // If the field has a parent form, check the fields from that form exclusively
@@ -232,10 +229,7 @@ export class InlineMenuFieldQualificationService
       return false;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, [...this.creditCardFieldKeywords])
-    );
+    return this.keywordsFoundInFieldData(field, [...this.creditCardFieldKeywords]);
   }
 
   /** Validates the provided field as a field for an account creation form.
@@ -480,9 +474,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CardHolderFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      CreditCardAutoFillConstants.CardHolderFieldNames,
+      false,
     );
   };
 
@@ -496,9 +491,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CardNumberFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      CreditCardAutoFillConstants.CardNumberFieldNames,
+      false,
     );
   };
 
@@ -514,9 +510,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CardExpiryFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      CreditCardAutoFillConstants.CardExpiryFieldNames,
+      false,
     );
   };
 
@@ -532,9 +529,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.ExpiryMonthFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      CreditCardAutoFillConstants.ExpiryMonthFieldNames,
+      false,
     );
   };
 
@@ -550,9 +548,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.ExpiryYearFieldNames, false)
+    return this.keywordsFoundInFieldData(
+      field,
+      CreditCardAutoFillConstants.ExpiryYearFieldNames,
+      false,
     );
   };
 
@@ -566,10 +565,7 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return (
-      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
-      this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CVVFieldNames, false)
-    );
+    return this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CVVFieldNames, false);
   };
 
   /**
@@ -1039,11 +1035,13 @@ export class InlineMenuFieldQualificationService
     fuzzyMatchKeywords = true,
   ) {
     const searchedValues = this.getAutofillFieldDataKeywords(autofillFieldData, fuzzyMatchKeywords);
+    const parsedKeywords = keywords.map((keyword) => keyword.replace(/-/g, ""));
+
     if (typeof searchedValues === "string") {
-      return keywords.some((keyword) => searchedValues.indexOf(keyword) > -1);
+      return parsedKeywords.some((keyword) => searchedValues.indexOf(keyword) > -1);
     }
 
-    return keywords.some((keyword) => searchedValues.has(keyword));
+    return parsedKeywords.some((keyword) => searchedValues.has(keyword));
   }
 
   /**
@@ -1072,8 +1070,19 @@ export class InlineMenuFieldQualificationService
         autofillFieldData["label-tag"],
         autofillFieldData["label-top"],
       ];
-      const keywordsSet = new Set<string>(keywords);
-      const stringValue = keywords.join(",").toLowerCase();
+      const keywordsSet = new Set<string>();
+      for (let i = 0; i < keywords.length; i++) {
+        if (typeof keywords[i] === "string") {
+          keywords[i]
+            .toLowerCase()
+            .replace(/-/g, "")
+            .replace(/[^a-zA-Z0-9]+/g, "|")
+            .split("|")
+            .forEach((keyword) => keywordsSet.add(keyword));
+        }
+      }
+
+      const stringValue = Array.from(keywordsSet).join(",");
       this.autofillFieldKeywordsMap.set(autofillFieldData, { keywordsSet, stringValue });
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10550

## 📔 Objective

An issue was found with how we handle qualifying credit card fields for the inline menu. Two problems arose during testing, the first being that we were not positioning the inline menu on credit card fields that contain an autocomplete="off" attribute. The second was how we were handling verification of keywords within the field, and issues with how we were parsing multi-word meta data values.

This PR fixes those issues and allows for presentation of the credit card inline menu on the example website listed in the linked Jira ticket.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
