### PR TITLE
[PM-9921] Add Popout to Add/Edit/View components

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.html
@@ -4,7 +4,9 @@
     [pageTitle]="headerText"
     [backAction]="handleBackButton.bind(this)"
     showBackButton
-  ></popup-header>
+  >
+    <app-pop-out slot="end" />
+  </popup-header>
 
   <vault-cipher-form
     *ngIf="!loading"

--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -21,6 +21,7 @@ import {
 } from "@bitwarden/vault";
 
 import BrowserPopupUtils from "../../../../../platform/popup/browser-popup-utils";
+import { PopOutComponent } from "../../../../../platform/popup/components/pop-out.component";
 import { PopupFooterComponent } from "../../../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
@@ -118,6 +119,7 @@ export type AddEditQueryParams = Partial<Record<keyof QueryParams, string>>;
     PopupFooterComponent,
     CipherFormModule,
     AsyncActionsModule,
+    PopOutComponent,
   ],
 })
 export class AddEditV2Component implements OnInit {

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -1,5 +1,7 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="headerText" showBackButton> </popup-header>
+  <popup-header slot="header" [pageTitle]="headerText" showBackButton
+    ><app-pop-out slot="end"
+  /></popup-header>
 
   <app-cipher-view *ngIf="cipher" [cipher]="cipher"></app-cipher-view>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -1,7 +1,7 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="headerText" showBackButton
-    ><app-pop-out slot="end"
-  /></popup-header>
+  <popup-header slot="header" [pageTitle]="headerText" showBackButton>
+    <app-pop-out slot="end" />
+  </popup-header>
 
   <app-cipher-view *ngIf="cipher" [cipher]="cipher"></app-cipher-view>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -24,6 +24,7 @@ import {
 } from "@bitwarden/components";
 
 import { CipherViewComponent } from "../../../../../../../../libs/vault/src/cipher-view";
+import { PopOutComponent } from "../../../../../platform/popup/components/pop-out.component";
 
 import { PopupFooterComponent } from "./../../../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "./../../../../../platform/popup/layout/popup-header.component";
@@ -45,6 +46,7 @@ import { PopupPageComponent } from "./../../../../../platform/popup/layout/popup
     IconButtonModule,
     CipherViewComponent,
     AsyncActionsModule,
+    PopOutComponent,
   ],
 })
 export class ViewV2Component {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9921](https://bitwarden.atlassian.net/browse/PM-9921)

## 📔 Objective

Add `PopOutComponent` to the header of the Add/Edit/View cipher components within the browser refresh

### Note

The back button behavior is broken once the extension is popped out. I expect that to be fixed in [PR 9556](https://github.com/bitwarden/clients/pull/9556) & [PM-9455](https://bitwarden.atlassian.net/browse/PM-9455)  

## 📸 Screenshots

https://github.com/user-attachments/assets/6a382a13-1bbf-4e13-867f-50c0830b1c49

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9921]: https://bitwarden.atlassian.net/browse/PM-9921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-9455]: https://bitwarden.atlassian.net/browse/PM-9455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ