### PR TITLE
[PM-10070] Browser Refresh headings

### DIFF
--- a/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
+++ b/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
@@ -1,6 +1,6 @@
 <bit-section [formGroup]="additionalOptionsForm">
   <bit-section-header>
-    <h2 bitTypography="h5">{{ "additionalOptions" | i18n }}</h2>
+    <h2 bitTypography="h6">{{ "additionalOptions" | i18n }}</h2>
   </bit-section-header>
 
   <bit-card>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -1,6 +1,6 @@
 <bit-section [formGroup]="cardDetailsForm">
   <bit-section-header>
-    <h2 bitTypography="h5">
+    <h2 bitTypography="h6">
       {{ getSectionHeading() }}
     </h2>
   </bit-section-header>

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -1,6 +1,6 @@
 <bit-section *ngIf="hasCustomFields">
   <bit-section-header>
-    <h2 bitTypography="h5">{{ "customFields" | i18n }}</h2>
+    <h2 bitTypography="h6">{{ "customFields" | i18n }}</h2>
   </bit-section-header>
   <form [formGroup]="customFieldsForm">
     <bit-card

--- a/libs/vault/src/cipher-form/components/identity/identity.component.html
+++ b/libs/vault/src/cipher-form/components/identity/identity.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="identityForm">
   <bit-section>
     <bit-section-header>
-      <h2 bitTypography="h5">{{ "personalDetails" | i18n }}</h2>
+      <h2 bitTypography="h6">{{ "personalDetails" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field>
@@ -51,7 +51,7 @@
   </bit-section>
   <bit-section>
     <bit-section-header>
-      <h2 bitTypography="h5">{{ "identification" | i18n }}</h2>
+      <h2 bitTypography="h6">{{ "identification" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field>
@@ -90,7 +90,7 @@
   </bit-section>
   <bit-section>
     <bit-section-header>
-      <h2 bitTypography="h5">{{ "contactInfo" | i18n }}</h2>
+      <h2 bitTypography="h6">{{ "contactInfo" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field>
@@ -109,7 +109,7 @@
   </bit-section>
   <bit-section>
     <bit-section-header>
-      <h2 bitTypography="h5">{{ "address" | i18n }}</h2>
+      <h2 bitTypography="h6">{{ "address" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field>

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
@@ -1,6 +1,6 @@
 <bit-section [formGroup]="itemDetailsForm">
   <bit-section-header>
-    <h2 bitTypography="h5">{{ "itemDetails" | i18n }}</h2>
+    <h2 bitTypography="h6">{{ "itemDetails" | i18n }}</h2>
     <button
       slot="end"
       type="button"

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -1,6 +1,6 @@
 <bit-section [formGroup]="loginDetailsForm">
   <bit-section-header>
-    <h2 bitTypography="h5">
+    <h2 bitTypography="h6">
       {{ "loginCredentials" | i18n }}
     </h2>
   </bit-section-header>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10070](https://bitwarden.atlassian.net/browse/PM-10070)

## 📔 Objective

Standardize section headings across the browser refresh to be `h6` rather than `h5`

## 📸 Screenshots

https://github.com/user-attachments/assets/5842634d-962c-42e2-b31f-8160fc4576c7

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10070]: https://bitwarden.atlassian.net/browse/PM-10070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ