### PR TITLE
[AC-2926] Fix status toggles for new Members page

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/members.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/members.component.ts
@@ -9,11 +9,7 @@ import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationManagementPreferencesService } from "@bitwarden/common/admin-console/abstractions/organization-management-preferences/organization-management-preferences.service";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
-import {
-  OrganizationUserStatusType,
-  ProviderUserStatusType,
-  ProviderUserType,
-} from "@bitwarden/common/admin-console/enums";
+import { ProviderUserStatusType, ProviderUserType } from "@bitwarden/common/admin-console/enums";
 import { ProviderUserBulkRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-user-bulk.request";
 import { ProviderUserConfirmRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-user-confirm.request";
 import { ProviderUserUserDetailsResponse } from "@bitwarden/common/admin-console/models/response/provider/provider-user.response";
@@ -42,7 +38,7 @@ import { BulkRemoveDialogComponent } from "./dialogs/bulk-remove-dialog.componen
 type ProviderUser = ProviderUserUserDetailsResponse;
 
 class MembersTableDataSource extends PeopleTableDataSource<ProviderUser> {
-  protected statusType = OrganizationUserStatusType;
+  protected statusType = ProviderUserStatusType;
 }
 
 @Component({
@@ -92,7 +88,7 @@ export class MembersComponent extends BaseMembersComponent<ProviderUser> {
     ])
       .pipe(
         switchMap(async ([urlParams, queryParams]) => {
-          this.searchControl.setValue(queryParams.search, { emitEvent: false });
+          this.searchControl.setValue(queryParams.search);
           this.dataSource.filter = peopleFilter(queryParams.search, null);
 
           this.providerId = urlParams.providerId;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2926

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

@eliykat caught an issue where the subscription that wires up the `searchControl` and `statusToggle` was not receiving an initial value for `searchControl`. This was due to an `emitEvent: false` option being used when `searchControl` was set in the component constructor. Removing it fixed the status toggles.

## 📸 Screenshots

https://github.com/user-attachments/assets/673b1149-3bd9-442d-9b56-154f49946673


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
