### PR TITLE
[PM-10598] Revert autocomplete="off" removal when qualifying the inline menu for identity fields

### DIFF
--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -286,7 +286,10 @@ export class InlineMenuFieldQualificationService
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, this.identityFieldKeywords);
+    return (
+      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
+      this.keywordsFoundInFieldData(field, this.identityFieldKeywords)
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/93?selectedIssue=PM-10598

## 📔 Objective

We recently removed a qualification rule for ensuring the inline menu appears in valid locations for identity ciphers. This rule involved a check for the `autocomplete="off"` attribute on the field. If this check showed that the autocomplete attribute was set to a disabled value, it would not show the inline menu within that field.

This has led to a situation where the inline menu appears is many unrelated fields, which isn't helpful. I'm reverting that check to ensure the inline menu appears for identities only when autocomplete is expected. 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
