### PR TITLE
Add consistent and contextual logging around decryption failure

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -452,6 +452,9 @@ export default class MainBackground {
         return new ForegroundMemoryStorageService();
       }
 
+      // For local backed session storage, we expect that the encrypted data on disk will persist longer than the encryption key in memory
+      // and failures to decrypt because of that are completely expected. For this reason, we pass in `false` to the `EncryptServiceImplementation`
+      // so that MAC failures are not logged.
       return new LocalBackedSessionStorageService(
         sessionKey,
         this.storageService,

--- a/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
+++ b/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
@@ -71,12 +71,12 @@ export class EncryptServiceImplementation implements EncryptService {
     key = this.resolveLegacyKey(key, encString);
 
     if (key.macKey != null && encString?.mac == null) {
-      this.logService.error("mac required.");
+      this.logService.error("MAC required but not provided.");
       return null;
     }
 
     if (key.encType !== encString.encryptionType) {
-      this.logService.error("encType unavailable.");
+      this.logService.error("Key encryption type does not match payload encryption type.");
       return null;
     }
 
@@ -94,7 +94,7 @@ export class EncryptServiceImplementation implements EncryptService {
       );
       const macsEqual = await this.cryptoFunctionService.compareFast(fastParams.mac, computedMac);
       if (!macsEqual) {
-        this.logMacFailed("mac failed.");
+        this.logMacFailed("MAC comparison failed. Key or payload has changed.");
         return null;
       }
     }
@@ -114,10 +114,12 @@ export class EncryptServiceImplementation implements EncryptService {
     key = this.resolveLegacyKey(key, encThing);
 
     if (key.macKey != null && encThing.macBytes == null) {
+      this.logService.error("MAC required but not provided");
       return null;
     }
 
     if (key.encType !== encThing.encryptionType) {
+      this.logService.error("Key encryption type does not match payload encryption type.");
       return null;
     }
 
@@ -127,12 +129,13 @@ export class EncryptServiceImplementation implements EncryptService {
       macData.set(new Uint8Array(encThing.dataBytes), encThing.ivBytes.byteLength);
       const computedMac = await this.cryptoFunctionService.hmac(macData, key.macKey, "sha256");
       if (computedMac === null) {
+        this.logMacFailed("Failed to compute MAC.");
         return null;
       }
 
       const macsMatch = await this.cryptoFunctionService.compare(encThing.macBytes, computedMac);
       if (!macsMatch) {
-        this.logMacFailed("mac failed.");
+        this.logMacFailed("MAC comparison failed. Key or payload has changed.");
         return null;
       }
     }

--- a/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
+++ b/libs/common/src/platform/services/cryptography/encrypt.service.implementation.ts
@@ -114,7 +114,7 @@ export class EncryptServiceImplementation implements EncryptService {
     key = this.resolveLegacyKey(key, encThing);
 
     if (key.macKey != null && encThing.macBytes == null) {
-      this.logService.error("MAC required but not provided");
+      this.logService.error("MAC required but not provided.");
       return null;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10607

## 📔 Objective

Added slightly more verbose and clearer logging around decryption errors to help give context to how they are occurring.

When a user encounters decryption errors, we ask them to send a screenshot of their Console.  This will provide more helpful messages in the console for us to review and also for end users.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
