### PR TITLE
Auth/PM-10601 - Tech Debt Cleanup - Refactor Lock Component and User Verification to use PinService

### DIFF
--- a/libs/angular/src/auth/components/lock.component.ts
+++ b/libs/angular/src/auth/components/lock.component.ts
@@ -323,10 +323,7 @@ export class LockComponent implements OnInit, OnDestroy {
   private async load(userId: UserId) {
     this.pinLockType = await this.pinService.getPinLockType(userId);
 
-    const ephemeralPinSet = await this.pinService.getPinKeyEncryptedUserKeyEphemeral(userId);
-
-    this.pinEnabled =
-      (this.pinLockType === "EPHEMERAL" && !!ephemeralPinSet) || this.pinLockType === "PERSISTENT";
+    this.pinEnabled = await this.pinService.isPinDecryptionAvailable(userId);
 
     this.masterPasswordEnabled = await this.userVerificationService.hasMasterPassword();
 

--- a/libs/auth/src/common/abstractions/pin.service.abstraction.ts
+++ b/libs/auth/src/common/abstractions/pin.service.abstraction.ts
@@ -113,6 +113,8 @@ export abstract class PinServiceAbstraction {
 
   /**
    * Declares whether or not the user has a PIN set (either persistent or ephemeral).
+   * Note: for ephemeral, this does not check if we actual have an ephemeral PIN-encrypted UserKey stored in memory.
+   * Decryption might not be possible even if this returns true. Use {@link isPinDecryptionAvailable} if decryption is required.
    */
   abstract isPinSet: (userId: UserId) => Promise<boolean>;
 

--- a/libs/auth/src/common/abstractions/pin.service.abstraction.ts
+++ b/libs/auth/src/common/abstractions/pin.service.abstraction.ts
@@ -117,6 +117,12 @@ export abstract class PinServiceAbstraction {
   abstract isPinSet: (userId: UserId) => Promise<boolean>;
 
   /**
+   * Checks if PIN-encrypted keys are stored for the user.
+   * Used for unlock / user verification scenarios where we will need to decrypt the UserKey with the PIN.
+   */
+  abstract isPinDecryptionAvailable: (userId: UserId) => Promise<boolean>;
+
+  /**
    * Decrypts the UserKey with the provided PIN.
    *
    * @remarks - If the user has an old pinKeyEncryptedMasterKey (formerly called `pinProtected`), the UserKey

--- a/libs/auth/src/common/services/pin/pin.service.implementation.ts
+++ b/libs/auth/src/common/services/pin/pin.service.implementation.ts
@@ -292,6 +292,31 @@ export class PinService implements PinServiceAbstraction {
     return (await this.getPinLockType(userId)) !== "DISABLED";
   }
 
+  // For unlock & user verification scenarios
+  async canDecryptUserKeyWithPin(userId: UserId) {
+    this.validateUserId(userId, "Cannot determine if PIN is set.");
+
+    // TODO: change to exhaustive switch
+
+    const pinLockType = await this.getPinLockType(userId);
+
+    if (pinLockType === "DISABLED") {
+      return false;
+    }
+
+    const ephemeralPinSet = Boolean(await this.getPinKeyEncryptedUserKeyEphemeral(userId));
+
+    if (pinLockType === "EPHEMERAL" && ephemeralPinSet) {
+      return true;
+    }
+
+    if (pinLockType === "PERSISTENT") {
+      return true;
+    }
+
+    return false; // unsupported pinLockType
+  }
+
   async decryptUserKeyWithPin(pin: string, userId: UserId): Promise<UserKey | null> {
     this.validateUserId(userId, "Cannot decrypt user key with PIN.");
 

--- a/libs/auth/src/common/services/pin/pin.service.spec.ts
+++ b/libs/auth/src/common/services/pin/pin.service.spec.ts
@@ -416,6 +416,66 @@ describe("PinService", () => {
     });
   });
 
+  describe("isPinDecryptionAvailable()", () => {
+    it("should return false if pinLockType is DISABLED", async () => {
+      // Arrange
+      sut.getPinLockType = jest.fn().mockResolvedValue("DISABLED");
+
+      // Act
+      const result = await sut.isPinDecryptionAvailable(mockUserId);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it("should return true if pinLockType is PERSISTENT", async () => {
+      // Arrange
+      sut.getPinLockType = jest.fn().mockResolvedValue("PERSISTENT");
+
+      // Act
+      const result = await sut.isPinDecryptionAvailable(mockUserId);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it("should return true if pinLockType is EPHEMERAL and we have an ephemeral PIN key encrypted user key", async () => {
+      // Arrange
+      sut.getPinLockType = jest.fn().mockResolvedValue("EPHEMERAL");
+      sut.getPinKeyEncryptedUserKeyEphemeral = jest
+        .fn()
+        .mockResolvedValue(pinKeyEncryptedUserKeyEphemeral);
+
+      // Act
+      const result = await sut.isPinDecryptionAvailable(mockUserId);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it("should return false if pinLockType is EPHEMERAL and we do not have an ephemeral PIN key encrypted user key", async () => {
+      // Arrange
+      sut.getPinLockType = jest.fn().mockResolvedValue("EPHEMERAL");
+      sut.getPinKeyEncryptedUserKeyEphemeral = jest.fn().mockResolvedValue(null);
+
+      // Act
+      const result = await sut.isPinDecryptionAvailable(mockUserId);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it("should throw an error if an unexpected pinLockType is returned", async () => {
+      // Arrange
+      sut.getPinLockType = jest.fn().mockResolvedValue("UNKNOWN");
+
+      // Act & Assert
+      await expect(sut.isPinDecryptionAvailable(mockUserId)).rejects.toThrow(
+        "Unexpected pinLockType: UNKNOWN",
+      );
+    });
+  });
+
   describe("decryptUserKeyWithPin()", () => {
     async function setupDecryptUserKeyWithPinMocks(
       pinLockType: PinLockType,

--- a/libs/common/src/auth/services/user-verification/user-verification.service.spec.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.spec.ts
@@ -410,6 +410,12 @@ describe("UserVerificationService", () => {
 
   function setPinAvailability(type: PinLockType) {
     pinService.getPinLockType.mockResolvedValue(type);
+
+    if (type === "EPHEMERAL" || type === "PERSISTENT") {
+      pinService.isPinDecryptionAvailable.mockResolvedValue(true);
+    } else if (type === "DISABLED") {
+      pinService.isPinDecryptionAvailable.mockResolvedValue(false);
+    }
   }
 
   function disableBiometricsAvailability() {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10601

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Builds on work from https://github.com/bitwarden/clients/pull/10332. 

To clean up the base `LockComponent` load logic which had too much PIN specific logic that should have been in a tested service.  This also applied to the `UserVerificationService`. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Note: for this test, I temporarily changed the `verificationType` to "client" for the user verification dialog prompt. 

https://github.com/user-attachments/assets/a53d3abf-04c9-44d9-93e2-b583f6d7d8f5


https://github.com/user-attachments/assets/62c17d7e-635d-460c-b779-9de6ea1ffba5


https://github.com/user-attachments/assets/cc70d4e6-f40d-4ffb-84fc-be07317bdad6


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
