### PR TITLE
[PM-10654] Inline menu not working in MS Edge

### DIFF
--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -105,7 +105,19 @@ export async function sendExtensionMessage(
   command: string,
   options: Record<string, any> = {},
 ): Promise<any> {
-  return chrome.runtime.sendMessage({ command, ...options });
+  if (typeof browser !== "undefined") {
+    return browser.runtime.sendMessage({ command, ...options });
+  }
+
+  return new Promise((resolve) =>
+    chrome.runtime.sendMessage(Object.assign({ command }, options), (response) => {
+      if (chrome.runtime.lastError) {
+        resolve(null);
+      }
+
+      resolve(response);
+    }),
+  );
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10654

## 📔 Objective

An issue was identified where MS Edge (which is currently still using mv2) no longer receives `chrome.runtime.sendMessage` responses correctly. This issue was introduced due to a change made to help Safari resolve responses from these messages more effectively. The change allowed Safari to handle a returned promise from the API, rather than by using the legacy callback method that was supported in mv2 on Chromium browsers.

Until we move all browsers to mv3, we will need to account for these two scenarios separate. These changes allow for that. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
