### PR TITLE
[PM-8841] Passkeys script injection breaks loading of specific websites that are expecting an empty DOM on init

### DIFF
--- a/apps/browser/src/autofill/fido2/content/fido2-page-script-append.mv2.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script-append.mv2.ts
@@ -9,11 +9,19 @@ import { Fido2ContentScript } from "../enums/fido2-content-script.enum";
     return;
   }
 
-  const script = globalContext.document.createElement("script");
-  script.src = chrome.runtime.getURL(Fido2ContentScript.PageScript);
-  script.addEventListener("load", () => script.remove());
+  if (globalContext.document.readyState === "complete") {
+    loadScript();
+  } else {
+    globalContext.addEventListener("DOMContentLoaded", loadScript);
+  }
 
-  const scriptInsertionPoint =
-    globalContext.document.head || globalContext.document.documentElement;
-  scriptInsertionPoint.insertBefore(script, scriptInsertionPoint.firstChild);
+  function loadScript() {
+    const script = globalContext.document.createElement("script");
+    script.src = chrome.runtime.getURL(Fido2ContentScript.PageScript);
+    script.addEventListener("load", () => script.remove());
+
+    const scriptInsertionPoint =
+      globalContext.document.head || globalContext.document.documentElement;
+    scriptInsertionPoint.insertBefore(script, scriptInsertionPoint.firstChild);
+  }
 })(globalThis);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8841

## 📔 Objective

An issue was identified with how we handle injection of the passkeys script that facilitates WebAuthn interactions through Bitwarden. (https://github.com/bitwarden/clients/issues/9618)

After investigating the issue, it seems that problem likely occurs due to a page script within the reference email client that is expecting an empty DOM structure on initialization. That's a guess at the moment, but one thing that I did observe was that waiting until the page's `DOMContentLoaded` event triggered resolved the problem entirely.

A caveat exists with this solution, however. We want to load the Fido2 page script as soon as possible to ensure that Bitwarden is used in place of the browser's native implementation for WebAuthn requests. Loading this after the `DOMContentLoaded` event creates an obvious delay that is undesirable. 

The only solution that I see to this secondary issue is to [migrate Firefox and other browsers to Manifest v3](https://github.com/bitwarden/clients/pull/10419). A POC of this is in place, and we will be working on testing the mv3 implementation in Firefox to help resolve this problem in a better manner. 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
