### PR TITLE
[PM-10689] Fix rpm (& deb) packages not starting by following symlink

### DIFF
--- a/apps/desktop/resources/memory-dump-wrapper.sh
+++ b/apps/desktop/resources/memory-dump-wrapper.sh
@@ -3,6 +3,9 @@
 # disable core dumps
 ulimit -c 0
 
-APP_PATH=$(dirname "$0")
+#might be behind symlink
+RAW_PATH=$(readlink -f "$0")
+APP_PATH=$(dirname $RAW_PATH)
+
 # pass through all args
 $APP_PATH/bitwarden-app "$@"

--- a/apps/desktop/resources/memory-dump-wrapper.sh
+++ b/apps/desktop/resources/memory-dump-wrapper.sh
@@ -3,7 +3,7 @@
 # disable core dumps
 ulimit -c 0
 
-#might be behind symlink
+# might be behind symlink
 RAW_PATH=$(readlink -f "$0")
 APP_PATH=$(dirname $RAW_PATH)
 

--- a/apps/desktop/resources/memory-dump-wrapper.sh
+++ b/apps/desktop/resources/memory-dump-wrapper.sh
@@ -9,3 +9,4 @@ APP_PATH=$(dirname $RAW_PATH)
 
 # pass through all args
 $APP_PATH/bitwarden-app "$@"
+


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10689

## 📔 Objective

https://bitwarden.atlassian.net/browse/PM-9434
prevents rpm installed bitwarden instances from starting since the /usr/bin/bitwarden entry is a symlink. This causes the wrapper script use the wrong path to look for the actual bitwarden binary. This PR fixes this by following the symlink (if it is a symlink) and using the original path instead.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
