### PR TITLE
[PM-8626] FireFox no-items alignment

### DIFF
--- a/libs/components/src/no-items/no-items.component.html
+++ b/libs/components/src/no-items/no-items.component.html
@@ -1,12 +1,10 @@
-<div
-  class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-pt-6 tw-text-center"
->
-  <div class="tw-max-w-sm">
+<div class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-pt-6">
+  <div class="tw-max-w-sm tw-flex tw-flex-col tw-items-center">
     <bit-icon [icon]="icon" aria-hidden="true"></bit-icon>
-    <h3 class="tw-font-semibold">
+    <h3 class="tw-font-semibold tw-text-center">
       <ng-content select="[slot=title]"></ng-content>
     </h3>
-    <p>
+    <p class="tw-text-center">
       <ng-content select="[slot=description]"></ng-content>
     </p>
   </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8626](https://bitwarden.atlassian.net/browse/PM-8626)

## 📔 Objective

Center all content in no items content
- FireFox extensions have default css that overrides the inheritance of text alignment:
  ![Screen Shot 2024-08-07 at 09 10 43 AM](https://github.com/user-attachments/assets/0dc7008e-5733-425f-ba3d-1852531e92b3)

## 📸 Screenshots

|Empty Vault|No Results|Deactivated Org|
|-|-|-|
|<img width="431" alt="empty-vault" src="https://github.com/user-attachments/assets/5898d623-d71b-4db6-b0b2-0ea7202a778c">|<img width="436" src="https://github.com/user-attachments/assets/5deca452-c6ab-4cf2-a057-defec87b8e0b"/>|<img width="436" alt="deactivated-state" src="https://github.com/user-attachments/assets/7f0f3d1d-6e12-467f-98cb-9ddac4a8d21a">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8626]: https://bitwarden.atlassian.net/browse/PM-8626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ