### PR TITLE
[CL-381] Update spacing around form elements

### DIFF
--- a/libs/components/src/form-control/form-control.component.ts
+++ b/libs/components/src/form-control/form-control.component.ts
@@ -33,7 +33,7 @@ export class FormControlComponent {
   @HostBinding("class") get classes() {
     return []
       .concat(this.inline ? ["tw-inline-block", "tw-mr-4"] : ["tw-block"])
-      .concat(this.disableMargin ? [] : ["tw-mb-6"]);
+      .concat(this.disableMargin ? [] : ["tw-mb-4"]);
   }
 
   constructor(private i18nService: I18nService) {}

--- a/libs/components/src/form-field/form-field.component.ts
+++ b/libs/components/src/form-field/form-field.component.ts
@@ -66,7 +66,7 @@ export class BitFormFieldComponent implements AfterContentChecked {
 
   @HostBinding("class")
   get classList() {
-    return ["tw-block"].concat(this.disableMargin ? [] : ["tw-mb-4", "tw-pt-1.5"]);
+    return ["tw-block", "tw-pt-2"].concat(this.disableMargin ? [] : ["tw-mb-4"]);
   }
 
   /**

--- a/libs/components/src/form-field/form-field.component.ts
+++ b/libs/components/src/form-field/form-field.component.ts
@@ -66,7 +66,7 @@ export class BitFormFieldComponent implements AfterContentChecked {
 
   @HostBinding("class")
   get classList() {
-    return ["tw-block"].concat(this.disableMargin ? [] : ["tw-mb-4", "tw-pt-1"]);
+    return ["tw-block"].concat(this.disableMargin ? [] : ["tw-mb-4", "tw-pt-1.5"]);
   }
 
   /**

--- a/libs/components/src/form-field/form-field.component.ts
+++ b/libs/components/src/form-field/form-field.component.ts
@@ -66,7 +66,7 @@ export class BitFormFieldComponent implements AfterContentChecked {
 
   @HostBinding("class")
   get classList() {
-    return ["tw-block"].concat(this.disableMargin ? [] : ["tw-mb-6"]);
+    return ["tw-block"].concat(this.disableMargin ? [] : ["tw-mb-4", "tw-pt-1"]);
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-381](https://bitwarden.atlassian.net/browse/CL-381)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the margin for the form control and form field elements so that they are spaced more evenly. The form field also now has top padding to account for the vertical space that the absolutely placed label takes up.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

See the Storybook Publish action's Form stories.

<img width="942" alt="Screenshot 2024-08-07 at 12 21 31 PM" src="https://github.com/user-attachments/assets/73cd5989-bc8f-4b0f-8bd2-61fcd8e5a128">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-381]: https://bitwarden.atlassian.net/browse/CL-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ