### PR TITLE
[PM-10423] Fix notification settings spacing and labels

### DIFF
--- a/apps/browser/src/autofill/popup/settings/notifications.component.html
+++ b/apps/browser/src/autofill/popup/settings/notifications.component.html
@@ -11,39 +11,40 @@
         <h2 bitTypography="h6">{{ "vaultSaveOptionsTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
-        <div>
+        <bit-form-control>
           <input
-            type="checkbox"
             bitCheckbox
             id="use-passkeys"
             type="checkbox"
             (change)="updateEnablePasskeys()"
             [(ngModel)]="enablePasskeys"
           />
-          <label for="use-passkeys">{{ "enableUsePasskeys" | i18n }}</label>
-        </div>
-        <div>
+          <bit-label for="use-passkeys">{{ "enableUsePasskeys" | i18n }}</bit-label>
+        </bit-form-control>
+        <bit-form-control>
           <input
+            bitCheckbox
             id="addlogin-notification-bar"
             type="checkbox"
-            bitCheckbox
             (change)="updateAddLoginNotification()"
             [(ngModel)]="enableAddLoginNotification"
           />
-          <label for="addlogin-notification-bar">{{ "enableAddLoginNotification" | i18n }}</label>
-        </div>
-        <div>
+          <bit-label for="addlogin-notification-bar">{{
+            "enableAddLoginNotification" | i18n
+          }}</bit-label>
+        </bit-form-control>
+        <bit-form-control disableMargin>
           <input
+            bitCheckbox
             id="changedpass-notification-bar"
             type="checkbox"
-            bitCheckbox
             (change)="updateChangedPasswordNotification()"
             [(ngModel)]="enableChangedPasswordNotification"
           />
-          <label for="changedpass-notification-bar">{{
+          <bit-label for="changedpass-notification-bar">{{
             "enableChangedPasswordNotification" | i18n
-          }}</label>
-        </div>
+          }}</bit-label>
+        </bit-form-control>
       </bit-card>
     </bit-section>
     <bit-section>


### PR DESCRIPTION
## 🎟️ Tracking

PM-10423

## 📔 Objective

Fix notification settings view to match spacing and labels found elsewhere (e.g. Autofill settings)

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-08-07 at 1 25 34 PM](https://github.com/user-attachments/assets/6a81aff3-77f4-4637-8e23-6e8c128cb196) | ![Screenshot 2024-08-07 at 1 16 23 PM](https://github.com/user-attachments/assets/65c8d8e4-420f-43a2-a36d-6a785d172154) |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
