### PR TITLE
[PM-10026] [Defect] Zip code is not being enforced when subscribing in Password Manager

### DIFF
--- a/apps/web/src/app/billing/individual/premium.component.ts
+++ b/apps/web/src/app/billing/individual/premium.component.ts
@@ -65,7 +65,7 @@ export class PremiumComponent implements OnInit {
     }
   }
   submit = async () => {
-    if (!this.taxInfoComponent?.taxFormGroup.valid && this.taxInfoComponent?.taxFormGroup.touched) {
+    if (!this.taxInfoComponent?.taxFormGroup.valid) {
       this.taxInfoComponent.taxFormGroup.markAllAsTouched();
       return;
     }

--- a/apps/web/src/app/billing/individual/premium.component.ts
+++ b/apps/web/src/app/billing/individual/premium.component.ts
@@ -65,9 +65,11 @@ export class PremiumComponent implements OnInit {
     }
   }
   submit = async () => {
-    if (!this.taxInfoComponent?.taxFormGroup.valid) {
-      this.taxInfoComponent.taxFormGroup.markAllAsTouched();
-      return;
+    if (this.taxInfoComponent) {
+      if (!this.taxInfoComponent?.taxFormGroup.valid) {
+        this.taxInfoComponent.taxFormGroup.markAllAsTouched();
+        return;
+      }
     }
     this.licenseForm.markAllAsTouched();
     this.addonForm.markAllAsTouched();

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -554,9 +554,11 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
   }
 
   submit = async () => {
-    if (!this.taxComponent?.taxFormGroup.valid) {
-      this.taxComponent?.taxFormGroup.markAllAsTouched();
-      return;
+    if (this.taxComponent) {
+      if (!this.taxComponent?.taxFormGroup.valid) {
+        this.taxComponent?.taxFormGroup.markAllAsTouched();
+        return;
+      }
     }
 
     if (this.singleOrgPolicyBlock) {

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -554,7 +554,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
   }
 
   submit = async () => {
-    if (!this.taxComponent?.taxFormGroup.valid && this.taxComponent?.taxFormGroup.touched) {
+    if (!this.taxComponent?.taxFormGroup.valid) {
       this.taxComponent?.taxFormGroup.markAllAsTouched();
       return;
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10026

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In main the zip code field is marked as (Required), but you can still create a subscription without entering one. In production you can also subscribe without having to enter a zip code. It is not this way when upgrading your organization in Admin Console though. I’m not certain what the expected behavior in production should be at this point, if it’s always been this way or was just introduced recently, but it seems like it should behave like the other required fields. Because of this I’m not sure if I marked the priority correct or if this is not a big issue.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/099b853d-66c9-4062-8f0a-5f2d00ecc6f0


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
