### PR TITLE
[PM-10554] Focused field needs to consider the bounds of a frame to be part of its max height

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1428,7 +1428,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       !globalThis.isNaN(focusedFieldRectsTop) &&
       focusedFieldRectsTop >= 0 &&
       focusedFieldRectsTop < viewportHeight &&
-      focusedFieldRectsBottom < viewportHeight
+      focusedFieldRectsBottom <= viewportHeight
     );
   }
 


### PR DESCRIPTION


## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10554

## 📔 Objective

The inline menu can potentially be closed if the focused field has the same height as its viewport when in an iframe. This shouldn't be the case, and a small logic fix allows the field to be the same height as its wrapping frame without closing the inline menu.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
