### PR TITLE
[PM-10723] Remove autocomplete="new-password" attribute from 2fa based code inputs

### DIFF
--- a/apps/web/src/app/auth/settings/two-factor-duo.component.html
+++ b/apps/web/src/app/auth/settings/two-factor-duo.component.html
@@ -25,13 +25,7 @@
         </bit-form-field>
         <bit-form-field>
           <bit-label>{{ "twoFactorDuoClientSecret" | i18n }}</bit-label>
-          <input
-            bitInput
-            type="password"
-            formControlName="clientSecret"
-            appInputVerbatim
-            autocomplete="off"
-          />
+          <input bitInput type="password" formControlName="clientSecret" appInputVerbatim />
         </bit-form-field>
         <bit-form-field>
           <bit-label>{{ "twoFactorDuoApiHostname" | i18n }}</bit-label>

--- a/apps/web/src/app/auth/settings/two-factor-duo.component.html
+++ b/apps/web/src/app/auth/settings/two-factor-duo.component.html
@@ -30,7 +30,7 @@
             type="password"
             formControlName="clientSecret"
             appInputVerbatim
-            autocomplete="new-password"
+            autocomplete="off"
           />
         </bit-form-field>
         <bit-form-field>

--- a/apps/web/src/app/auth/two-factor.component.html
+++ b/apps/web/src/app/auth/two-factor.component.html
@@ -37,14 +37,7 @@
       </picture>
       <bit-form-field>
         <bit-label class="tw-sr-only">{{ "verificationCode" | i18n }}</bit-label>
-        <input
-          type="password"
-          bitInput
-          formControlName="token"
-          appAutofocus
-          appInputVerbatim
-          autocomplete="off"
-        />
+        <input type="password" bitInput formControlName="token" appAutofocus appInputVerbatim />
       </bit-form-field>
     </ng-container>
     <ng-container *ngIf="selectedProviderType === providerType.WebAuthn">

--- a/apps/web/src/app/auth/two-factor.component.html
+++ b/apps/web/src/app/auth/two-factor.component.html
@@ -43,7 +43,7 @@
           formControlName="token"
           appAutofocus
           appInputVerbatim
-          autocomplete="new-password"
+          autocomplete="off"
         />
       </bit-form-field>
     </ng-container>

--- a/libs/angular/src/auth/components/two-factor-auth/two-factor-auth-yubikey.component.html
+++ b/libs/angular/src/auth/components/two-factor-auth/two-factor-auth-yubikey.component.html
@@ -11,7 +11,7 @@
     bitInput
     appAutofocus
     appInputVerbatim
-    autocomplete="new-password"
+    autocomplete="off"
     [(ngModel)]="tokenValue"
     (input)="token.emit(tokenValue)"
   />

--- a/libs/angular/src/auth/components/two-factor-auth/two-factor-auth-yubikey.component.html
+++ b/libs/angular/src/auth/components/two-factor-auth/two-factor-auth-yubikey.component.html
@@ -11,7 +11,6 @@
     bitInput
     appAutofocus
     appInputVerbatim
-    autocomplete="off"
     [(ngModel)]="tokenValue"
     (input)="token.emit(tokenValue)"
   />


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10723

## 📔 Objective

The inline menu is appearing within the vault on `type="password"` fields that are set to accept a 2fa code in some manner. That shouldn't happen, but guarding against that behavior in the inline menu's logic isn't the right approach to resolve the issue. 

Instead, for these types of fields we need to set the `autocomplete` attribute to `autocomplete="off"`, which ensures the inline menu ignores the field.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
