### PR TITLE
[PM-10652] remove excess MP reprompt call for fill and save

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -76,13 +76,6 @@ export class ItemMoreOptionsComponent {
   }
 
   async doAutofillAndSave() {
-    if (
-      this.cipher.reprompt === CipherRepromptType.Password &&
-      !(await this.passwordRepromptService.showPasswordPrompt())
-    ) {
-      return;
-    }
-
     await this.vaultPopupAutofillService.doAutofillAndSave(this.cipher);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10652](https://bitwarden.atlassian.net/browse/PM-10652)

## 📔 Objective

The fill and save dropdown from an item was calling MP reprompt twice. Looking further the check for MP reprompt already exists inside `this.vaultPopupAutofillService.doAutofillAndSave(this.cipher)`. Removing the excess reprompt logic. 

## 📸 Screen Recording

https://github.com/user-attachments/assets/832618ca-ef48-4287-bdf4-12e5ebcbf4a6


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10652]: https://bitwarden.atlassian.net/browse/PM-10652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ