### PR TITLE
[PM-10754] Store DeviceKey In Backup Storage Location

### DIFF
--- a/apps/browser/src/platform/offscreen-document/offscreen-document.ts
+++ b/apps/browser/src/platform/offscreen-document/offscreen-document.ts
@@ -14,6 +14,9 @@ class OffscreenDocument implements OffscreenDocumentInterface {
   private readonly extensionMessageHandlers: OffscreenDocumentExtensionMessageHandlers = {
     offscreenCopyToClipboard: ({ message }) => this.handleOffscreenCopyToClipboard(message),
     offscreenReadFromClipboard: () => this.handleOffscreenReadFromClipboard(),
+    localStorageGet: ({ message }) => this.handleLocalStorageGet(message.key),
+    localStorageSave: ({ message }) => this.handleLocalStorageSave(message.key, message.value),
+    localStorageRemove: ({ message }) => this.handleLocalStorageRemove(message.key),
   };
 
   /**
@@ -37,6 +40,18 @@ class OffscreenDocument implements OffscreenDocumentInterface {
    */
   private async handleOffscreenReadFromClipboard() {
     return await BrowserClipboardService.read(self);
+  }
+
+  private handleLocalStorageGet(key: string) {
+    return self.localStorage.getItem(key);
+  }
+
+  private handleLocalStorageSave(key: string, value: string) {
+    self.localStorage.setItem(key, value);
+  }
+
+  private handleLocalStorageRemove(key: string) {
+    self.localStorage.removeItem(key);
   }
 
   /**

--- a/apps/browser/src/platform/storage/browser-storage-service.provider.ts
+++ b/apps/browser/src/platform/storage/browser-storage-service.provider.ts
@@ -14,6 +14,7 @@ export class BrowserStorageServiceProvider extends StorageServiceProvider {
     diskStorageService: AbstractStorageService & ObservableStorageService,
     limitedMemoryStorageService: AbstractStorageService & ObservableStorageService,
     private largeObjectMemoryStorageService: AbstractStorageService & ObservableStorageService,
+    private readonly diskBackupLocalStorage: AbstractStorageService & ObservableStorageService,
   ) {
     super(diskStorageService, limitedMemoryStorageService);
   }
@@ -26,6 +27,8 @@ export class BrowserStorageServiceProvider extends StorageServiceProvider {
     switch (location) {
       case "memory-large-object":
         return ["memory-large-object", this.largeObjectMemoryStorageService];
+      case "disk-backup-local-storage":
+        return ["disk-backup-local-storage", this.diskBackupLocalStorage];
       default:
         // Pass in computed location to super because they could have
         // override default "disk" with web "memory".

--- a/apps/browser/src/platform/storage/offscreen-storage.service.ts
+++ b/apps/browser/src/platform/storage/offscreen-storage.service.ts
@@ -1,0 +1,55 @@
+import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
+import { StorageOptions } from "@bitwarden/common/platform/models/domain/storage-options";
+
+import { BrowserApi } from "../browser/browser-api";
+import { OffscreenDocumentService } from "../offscreen-document/abstractions/offscreen-document";
+
+export class OffscreenStorageService implements AbstractStorageService {
+  constructor(private readonly offscreenDocumentService: OffscreenDocumentService) {}
+
+  get valuesRequireDeserialization(): boolean {
+    return true;
+  }
+
+  async get<T>(key: string, options?: StorageOptions): Promise<T> {
+    return await this.offscreenDocumentService.withDocument<T>(
+      [chrome.offscreen.Reason.LOCAL_STORAGE],
+      "backup storage of user data",
+      async () => {
+        const response = await BrowserApi.sendMessageWithResponse<string>("localStorageGet", {
+          key,
+        });
+        if (response != null) {
+          return JSON.parse(response);
+        }
+
+        return response;
+      },
+    );
+  }
+  async has(key: string, options?: StorageOptions): Promise<boolean> {
+    return (await this.get(key, options)) != null;
+  }
+
+  async save<T>(key: string, obj: T, options?: StorageOptions): Promise<void> {
+    await this.offscreenDocumentService.withDocument(
+      [chrome.offscreen.Reason.LOCAL_STORAGE],
+      "backup storage of user data",
+      async () =>
+        await BrowserApi.sendMessageWithResponse<void>("localStorageSave", {
+          key,
+          value: JSON.stringify(obj),
+        }),
+    );
+  }
+  async remove(key: string, options?: StorageOptions): Promise<void> {
+    await this.offscreenDocumentService.withDocument(
+      [chrome.offscreen.Reason.LOCAL_STORAGE],
+      "backup storage of user data",
+      async () =>
+        await BrowserApi.sendMessageWithResponse<void>("localStorageRemove", {
+          key,
+        }),
+    );
+  }
+}

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -73,6 +73,8 @@ import {
 } from "@bitwarden/common/platform/state";
 // eslint-disable-next-line import/no-restricted-paths -- Used for dependency injection
 import { InlineDerivedStateProvider } from "@bitwarden/common/platform/state/implementations/inline-derived-state";
+import { PrimarySecondaryStorageService } from "@bitwarden/common/platform/storage/primary-secondary-storage.service";
+import { WindowStorageService } from "@bitwarden/common/platform/storage/window-storage.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { VaultTimeoutStringType } from "@bitwarden/common/types/vault-timeout.type";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -121,6 +123,10 @@ import { PopupCloseWarningService } from "./popup-close-warning.service";
 const OBSERVABLE_LARGE_OBJECT_MEMORY_STORAGE = new SafeInjectionToken<
   AbstractStorageService & ObservableStorageService
 >("OBSERVABLE_LARGE_OBJECT_MEMORY_STORAGE");
+
+const DISK_BACKUP_LOCAL_STORAGE = new SafeInjectionToken<
+  AbstractStorageService & ObservableStorageService
+>("DISK_BACKUP_LOCAL_STORAGE");
 
 const needsBackgroundInit = BrowserPopupUtils.backgroundInitializationRequired();
 const mainBackground: MainBackground = needsBackgroundInit
@@ -497,12 +503,20 @@ const safeProviders: SafeProvider[] = [
     deps: [],
   }),
   safeProvider({
+    provide: DISK_BACKUP_LOCAL_STORAGE,
+    // TODO: Message for localStorage
+    useFactory: (diskStorage: AbstractStorageService & ObservableStorageService) =>
+      new PrimarySecondaryStorageService(diskStorage, new WindowStorageService(self.localStorage)),
+    deps: [OBSERVABLE_DISK_STORAGE],
+  }),
+  safeProvider({
     provide: StorageServiceProvider,
     useClass: BrowserStorageServiceProvider,
     deps: [
       OBSERVABLE_DISK_STORAGE,
       OBSERVABLE_MEMORY_STORAGE,
       OBSERVABLE_LARGE_OBJECT_MEMORY_STORAGE,
+      DISK_BACKUP_LOCAL_STORAGE,
     ],
   }),
   safeProvider({

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -504,7 +504,6 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: DISK_BACKUP_LOCAL_STORAGE,
-    // TODO: Message for localStorage
     useFactory: (diskStorage: AbstractStorageService & ObservableStorageService) =>
       new PrimarySecondaryStorageService(diskStorage, new WindowStorageService(self.localStorage)),
     deps: [OBSERVABLE_DISK_STORAGE],

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -49,6 +49,7 @@ import { StorageServiceProvider } from "@bitwarden/common/platform/services/stor
 import { GlobalStateProvider, StateProvider } from "@bitwarden/common/platform/state";
 import { MemoryStorageService as MemoryStorageServiceForStateProviders } from "@bitwarden/common/platform/state/storage/memory-storage.service";
 /* eslint-enable import/no-restricted-paths -- Implementation for memory storage */
+import { WindowStorageService } from "@bitwarden/common/platform/storage/window-storage.service";
 import {
   DefaultThemeStateService,
   ThemeStateService,
@@ -63,7 +64,6 @@ import { I18nService } from "../core/i18n.service";
 import { WebEnvironmentService } from "../platform/web-environment.service";
 import { WebMigrationRunner } from "../platform/web-migration-runner";
 import { WebStorageServiceProvider } from "../platform/web-storage-service.provider";
-import { WindowStorageService } from "../platform/window-storage.service";
 import { CollectionAdminService } from "../vault/core/collection-admin.service";
 
 import { EventService } from "./event.service";

--- a/apps/web/src/app/platform/web-migration-runner.spec.ts
+++ b/apps/web/src/app/platform/web-migration-runner.spec.ts
@@ -3,11 +3,11 @@ import { MockProxy, mock } from "jest-mock-extended";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
+import { WindowStorageService } from "@bitwarden/common/platform/storage/window-storage.service";
 import { MigrationBuilder } from "@bitwarden/common/state-migrations/migration-builder";
 import { MigrationHelper } from "@bitwarden/common/state-migrations/migration-helper";
 
 import { WebMigrationRunner } from "./web-migration-runner";
-import { WindowStorageService } from "./window-storage.service";
 
 describe("WebMigrationRunner", () => {
   let logService: MockProxy<LogService>;

--- a/apps/web/src/app/platform/web-migration-runner.ts
+++ b/apps/web/src/app/platform/web-migration-runner.ts
@@ -4,9 +4,8 @@ import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
+import { WindowStorageService } from "@bitwarden/common/platform/storage/window-storage.service";
 import { MigrationHelper } from "@bitwarden/common/state-migrations/migration-helper";
-
-import { WindowStorageService } from "./window-storage.service";
 
 export class WebMigrationRunner extends MigrationRunner {
   constructor(

--- a/libs/common/src/platform/state/state-definition.ts
+++ b/libs/common/src/platform/state/state-definition.ts
@@ -25,7 +25,10 @@ export type ClientLocations = {
   /**
    * Overriding storage location for browser clients.
    *
-   * "memory-large-object" is used to store non-countable objects in memory. This exists due to limited persistent memory available to browser extensions.
+   * `"memory-large-object"` is used to store non-countable objects in memory. This exists due to limited persistent memory available to browser extensions.
+   *
+   * `"disk-backup-local-storage"` is used to store object in both disk and in `localStorage`. Data is stored in both locations but is only retrieved
+   * from `localStorage` when a null-ish value is retrieved from disk first.
    */
   browser: StorageLocation | "memory-large-object" | "disk-backup-local-storage";
   /**

--- a/libs/common/src/platform/state/state-definition.ts
+++ b/libs/common/src/platform/state/state-definition.ts
@@ -27,7 +27,7 @@ export type ClientLocations = {
    *
    * "memory-large-object" is used to store non-countable objects in memory. This exists due to limited persistent memory available to browser extensions.
    */
-  browser: StorageLocation | "memory-large-object";
+  browser: StorageLocation | "memory-large-object" | "disk-backup-local-storage";
   /**
    * Overriding storage location for desktop clients.
    */

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -38,10 +38,7 @@ export const BILLING_DISK = new StateDefinition("billing", "disk");
 
 // Auth
 
-export const ACCOUNT_DISK = new StateDefinition("account", "disk", {
-  // DO-NOT-MERGE: For testing only
-  browser: "disk-backup-local-storage",
-});
+export const ACCOUNT_DISK = new StateDefinition("account", "disk");
 export const ACCOUNT_MEMORY = new StateDefinition("account", "memory");
 export const AUTH_REQUEST_DISK_LOCAL = new StateDefinition("authRequestLocal", "disk", {
   web: "disk-local",

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -38,7 +38,10 @@ export const BILLING_DISK = new StateDefinition("billing", "disk");
 
 // Auth
 
-export const ACCOUNT_DISK = new StateDefinition("account", "disk");
+export const ACCOUNT_DISK = new StateDefinition("account", "disk", {
+  // DO-NOT-MERGE: For testing only
+  browser: "disk-backup-local-storage",
+});
 export const ACCOUNT_MEMORY = new StateDefinition("account", "memory");
 export const AUTH_REQUEST_DISK_LOCAL = new StateDefinition("authRequestLocal", "disk", {
   web: "disk-local",
@@ -46,6 +49,7 @@ export const AUTH_REQUEST_DISK_LOCAL = new StateDefinition("authRequestLocal", "
 export const AVATAR_DISK = new StateDefinition("avatar", "disk", { web: "disk-local" });
 export const DEVICE_TRUST_DISK_LOCAL = new StateDefinition("deviceTrust", "disk", {
   web: "disk-local",
+  browser: "disk-backup-local-storage",
 });
 export const KDF_CONFIG_DISK = new StateDefinition("kdfConfig", "disk");
 export const KEY_CONNECTOR_DISK = new StateDefinition("keyConnector", "disk");

--- a/libs/common/src/platform/storage/primary-secondary-storage.service.ts
+++ b/libs/common/src/platform/storage/primary-secondary-storage.service.ts
@@ -11,12 +11,18 @@ export class PrimarySecondaryStorageService
     private readonly primaryStorageService: AbstractStorageService & ObservableStorageService,
     // Secondary service doesn't need to be observable as the only `updates$` are listened to from the primary store
     private readonly secondaryStorageService: AbstractStorageService,
-  ) {}
+  ) {
+    if (
+      primaryStorageService.valuesRequireDeserialization !==
+      secondaryStorageService.valuesRequireDeserialization
+    ) {
+      throw new Error(
+        "Differing values for valuesRequireDeserialization between storage services is not supported.",
+      );
+    }
+  }
   get valuesRequireDeserialization(): boolean {
-    return (
-      this.primaryStorageService.valuesRequireDeserialization ||
-      this.secondaryStorageService.valuesRequireDeserialization
-    );
+    return this.primaryStorageService.valuesRequireDeserialization;
   }
 
   async get<T>(key: string, options?: StorageOptions): Promise<T> {

--- a/libs/common/src/platform/storage/primary-secondary-storage.service.ts
+++ b/libs/common/src/platform/storage/primary-secondary-storage.service.ts
@@ -1,0 +1,53 @@
+import { AbstractStorageService, ObservableStorageService } from "../abstractions/storage.service";
+import { StorageOptions } from "../models/domain/storage-options";
+
+export class PrimarySecondaryStorageService
+  implements AbstractStorageService, ObservableStorageService
+{
+  // Only follow the primary storage service as updates should all be done to both
+  updates$ = this.primaryStorageService.updates$;
+
+  constructor(
+    private readonly primaryStorageService: AbstractStorageService & ObservableStorageService,
+    // Secondary service doesn't need to be observable as the only `updates$` are listened to from the primary store
+    private readonly secondaryStorageService: AbstractStorageService,
+  ) {}
+  get valuesRequireDeserialization(): boolean {
+    return (
+      this.primaryStorageService.valuesRequireDeserialization ||
+      this.secondaryStorageService.valuesRequireDeserialization
+    );
+  }
+
+  async get<T>(key: string, options?: StorageOptions): Promise<T> {
+    const primaryValue = await this.primaryStorageService.get<T>(key, options);
+
+    // If it's null-ish try the secondary location for its value
+    if (primaryValue == null) {
+      return await this.secondaryStorageService.get<T>(key, options);
+    }
+
+    return primaryValue;
+  }
+
+  async has(key: string, options?: StorageOptions): Promise<boolean> {
+    return (
+      (await this.primaryStorageService.has(key, options)) ||
+      (await this.secondaryStorageService.has(key, options))
+    );
+  }
+
+  async save<T>(key: string, obj: T, options?: StorageOptions): Promise<void> {
+    await Promise.allSettled([
+      this.primaryStorageService.save(key, obj, options),
+      this.secondaryStorageService.save(key, obj, options),
+    ]);
+  }
+
+  async remove(key: string, options?: StorageOptions): Promise<void> {
+    await Promise.allSettled([
+      this.primaryStorageService.remove(key, options),
+      this.secondaryStorageService.remove(key, options),
+    ]);
+  }
+}

--- a/libs/common/src/platform/storage/window-storage.service.ts
+++ b/libs/common/src/platform/storage/window-storage.service.ts
@@ -4,8 +4,8 @@ import {
   AbstractStorageService,
   ObservableStorageService,
   StorageUpdate,
-} from "@bitwarden/common/platform/abstractions/storage.service";
-import { StorageOptions } from "@bitwarden/common/platform/models/domain/storage-options";
+} from "../abstractions/storage.service";
+import { StorageOptions } from "../models/domain/storage-options";
 
 export class WindowStorageService implements AbstractStorageService, ObservableStorageService {
   private readonly updatesSubject = new Subject<StorageUpdate>();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-10754

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Adds a new special storage location for browser to allow for duplication of stored data. This makes it so that data can be stored first in `chrome.storage.local` but also in `localStorage`. Data is saved in both places but it's only retrieved from `chrome.storage.local` if a non-null value is found, if a null-ish value is found that is when we will attempt to read from `localStorage`. Since `localStorage` is not available in the MV3 service worker we have to create a offscreen document to access it. 

I created a relatively generic service for having a primary-secondary storage service concept because we may also do this in web with `localStorage` and `IndexedDB`. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
