### PR TITLE
[Beeep] [PM-10767] Improve username importing on protonpass importer

### DIFF
--- a/libs/importer/spec/protonpass-json-importer.spec.ts
+++ b/libs/importer/spec/protonpass-json-importer.spec.ts
@@ -31,12 +31,14 @@ describe("Protonpass Json Importer", () => {
     expect(uriView.uri).toEqual("https://example.com/");
     expect(cipher.notes).toEqual("My login secure note.");
 
-    expect(cipher.fields.at(0).name).toEqual("itemUsername");
-    expect(cipher.fields.at(0).value).toEqual("someOtherUsername");
+    expect(cipher.fields.at(0).name).toEqual("username");
+    expect(cipher.fields.at(0).value).toEqual("Username");
+    expect(cipher.fields.at(1).name).toEqual("email");
+    expect(cipher.fields.at(1).value).toEqual("Email");
 
-    expect(cipher.fields.at(3).name).toEqual("second 2fa secret");
-    expect(cipher.fields.at(3).value).toEqual("TOTPCODE");
-    expect(cipher.fields.at(3).type).toEqual(FieldType.Hidden);
+    expect(cipher.fields.at(4).name).toEqual("second 2fa secret");
+    expect(cipher.fields.at(4).value).toEqual("TOTPCODE");
+    expect(cipher.fields.at(4).type).toEqual(FieldType.Hidden);
   });
 
   it("should parse note data", async () => {

--- a/libs/importer/spec/protonpass-json-importer.spec.ts
+++ b/libs/importer/spec/protonpass-json-importer.spec.ts
@@ -31,14 +31,12 @@ describe("Protonpass Json Importer", () => {
     expect(uriView.uri).toEqual("https://example.com/");
     expect(cipher.notes).toEqual("My login secure note.");
 
-    expect(cipher.fields.at(0).name).toEqual("username");
-    expect(cipher.fields.at(0).value).toEqual("Username");
-    expect(cipher.fields.at(1).name).toEqual("email");
-    expect(cipher.fields.at(1).value).toEqual("Email");
+    expect(cipher.fields.at(0).name).toEqual("email");
+    expect(cipher.fields.at(0).value).toEqual("Email");
 
-    expect(cipher.fields.at(4).name).toEqual("second 2fa secret");
-    expect(cipher.fields.at(4).value).toEqual("TOTPCODE");
-    expect(cipher.fields.at(4).type).toEqual(FieldType.Hidden);
+    expect(cipher.fields.at(3).name).toEqual("second 2fa secret");
+    expect(cipher.fields.at(3).value).toEqual("TOTPCODE");
+    expect(cipher.fields.at(3).type).toEqual(FieldType.Hidden);
   });
 
   it("should parse note data", async () => {

--- a/libs/importer/spec/test-data/protonpass-json/protonpass.json.ts
+++ b/libs/importer/spec/test-data/protonpass-json/protonpass.json.ts
@@ -49,12 +49,12 @@ export const testData: ProtonPassJsonFile = {
             ],
             type: "login",
             content: {
-              itemEmail: "Username",
+              itemEmail: "Email",
               password: "Password",
               urls: ["https://example.com/", "https://example2.com/"],
               totpUri:
                 "otpauth://totp/Test%20Login%20-%20Personal%20Vault:Username?issuer=Test%20Login%20-%20Personal%20Vault&secret=TOTPCODE&algorithm=SHA1&digits=6&period=30",
-              itemUsername: "someOtherUsername",
+              itemUsername: "Username",
             },
           },
           state: 1,

--- a/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
+++ b/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
@@ -48,10 +48,17 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
           case "login": {
             const loginContent = item.data.content as ProtonPassLoginItemContent;
             cipher.login.uris = this.makeUriArray(loginContent.urls);
-            cipher.login.username = this.getValueOrDefault(loginContent.itemEmail);
+
+            cipher.login.username = this.getValueOrDefault(loginContent.itemUsername);
+            // if the cipher has no username then the email is used as the username
+            if (cipher.login.username == null) {
+              cipher.login.username = this.getValueOrDefault(loginContent.itemEmail);
+            }
+
             cipher.login.password = this.getValueOrDefault(loginContent.password);
             cipher.login.totp = this.getValueOrDefault(loginContent.totpUri);
-            this.processKvp(cipher, "itemUsername", loginContent.itemUsername);
+            this.processKvp(cipher, "username", loginContent.itemUsername);
+            this.processKvp(cipher, "email", loginContent.itemEmail);
             for (const extraField of item.data.extraFields) {
               this.processKvp(
                 cipher,

--- a/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
+++ b/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
@@ -53,12 +53,12 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
             // if the cipher has no username then the email is used as the username
             if (cipher.login.username == null) {
               cipher.login.username = this.getValueOrDefault(loginContent.itemEmail);
+            } else {
+              this.processKvp(cipher, "email", loginContent.itemEmail);
             }
 
             cipher.login.password = this.getValueOrDefault(loginContent.password);
             cipher.login.totp = this.getValueOrDefault(loginContent.totpUri);
-            this.processKvp(cipher, "username", loginContent.itemUsername);
-            this.processKvp(cipher, "email", loginContent.itemEmail);
             for (const extraField of item.data.extraFields) {
               this.processKvp(
                 cipher,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10767

## 📔 Objective

Proton added an itemUsername field, but the itemEmail field was always used. Support for this in the importer was implemented in https://github.com/bitwarden/clients/pull/9889. Proton's behaviour has changed since then. Now ProtonPass behaviour is as follows: For old items, the itemEmail field contains either username or email (whichever was used), but parsed and placed into the username field in the UI. For new items, itemEmail only contains emails, and itemUsername only contains usernames.

This PR adjusts the importer behavior to accommodate for this. Since Bitwarden's username field is used for either username or email, we first check if the proton item has a username, and use that. If only an email is present, then the email is used as the username (same as would happen when creating the account in Bitwarden directly. This additionally accounts for old entries that used the itemEmail field as the username.

Additionally, we write the itemUsername and itemEmail fields to the "username" and "email" custom fields, so that they can be used with linked custom fields for autofill, and in order not to loose data when both username and email are present.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
