### PR TITLE
[PM-10788] Handle `chrome.runtime.lastError`

### DIFF
--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -74,8 +74,12 @@ export default abstract class AbstractChromeStorageService
   }
 
   async get<T>(key: string): Promise<T> {
-    return new Promise((resolve) => {
-      this.chromeStorageApi.get(key, (obj: any) => {
+    return new Promise((resolve, reject) => {
+      this.chromeStorageApi.get(key, (obj) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+
         if (obj != null && obj[key] != null) {
           resolve(this.processGetObject(obj[key]));
           return;
@@ -98,16 +102,24 @@ export default abstract class AbstractChromeStorageService
     }
 
     const keyedObj = { [key]: obj };
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       this.chromeStorageApi.set(keyedObj, () => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+
         resolve();
       });
     });
   }
 
   async remove(key: string): Promise<void> {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       this.chromeStorageApi.remove(key, () => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+
         resolve();
       });
     });

--- a/apps/browser/src/platform/services/browser-local-storage.service.spec.ts
+++ b/apps/browser/src/platform/services/browser-local-storage.service.spec.ts
@@ -62,6 +62,7 @@ describe("BrowserLocalStorageService", () => {
   });
 
   afterEach(() => {
+    chrome.runtime.lastError = undefined;
     jest.resetAllMocks();
   });
 
@@ -120,6 +121,24 @@ describe("BrowserLocalStorageService", () => {
       await service.reseed();
 
       expect(clearMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws if get has chrome.runtime.lastError", async () => {
+      getMock.mockImplementation((key, callback) => {
+        chrome.runtime.lastError = new Error("Get Test Error");
+        callback();
+      });
+
+      await expect(async () => await service.reseed()).rejects.toThrow("Get Test Error");
+    });
+
+    it("throws if save has chrome.runtime.lastError", async () => {
+      saveMock.mockImplementation((obj, callback) => {
+        chrome.runtime.lastError = new Error("Save Test Error");
+        callback();
+      });
+
+      await expect(async () => await service.reseed()).rejects.toThrow("Save Test Error");
     });
   });
 

--- a/apps/browser/src/platform/services/browser-local-storage.service.ts
+++ b/apps/browser/src/platform/services/browser-local-storage.service.ts
@@ -81,8 +81,11 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
    * Clears local storage
    */
   private async clear() {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       this.chromeStorageApi.clear(() => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
         resolve();
       });
     });
@@ -95,8 +98,12 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
    * @returns Promise resolving to keyed object of all stored data
    */
   private async getAll(): Promise<Record<string, unknown>> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.chromeStorageApi.get(null, (allStorage) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+
         const resolved = Object.entries(allStorage).reduce(
           (agg, [key, value]) => {
             agg[key] = this.processGetObject(value);
@@ -110,7 +117,7 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
   }
 
   private async saveAll(data: Record<string, unknown>): Promise<void> {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       const keyedData = Object.entries(data).reduce(
         (agg, [key, value]) => {
           agg[key] = objToStore(value);
@@ -119,6 +126,10 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
         {} as Record<string, SerializedValue>,
       );
       this.chromeStorageApi.set(keyedData, () => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+
         resolve();
       });
     });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10788

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The docs on these methods state: `or on failure (in which case runtime.lastError will be set).` which means we should reject the promise if this value is set. Not doing so could mean that if a `get` call fails we would instead resolve the promise with null.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
