### PR TITLE
[PM-10700] Navigate to View after cipher creation

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -229,7 +229,8 @@ export class AddEditV2Component implements OnInit {
     }
 
     await this.router.navigate(["/view-cipher"], {
-      queryParams: { cipherId: cipher.id, newCipher: true },
+      replaceUrl: true,
+      queryParams: { cipherId: cipher.id },
     });
   }
 

--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -228,7 +228,9 @@ export class AddEditV2Component implements OnInit {
       return;
     }
 
-    this.location.back();
+    await this.router.navigate(["/view-cipher"], {
+      queryParams: { cipherId: cipher.id, newCipher: true },
+    });
   }
 
   subscribeToParams(): void {

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -1,5 +1,10 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="headerText" showBackButton>
+  <popup-header
+    slot="header"
+    [pageTitle]="headerText"
+    [backAction]="handleBack.bind(this)"
+    showBackButton
+  >
     <app-pop-out slot="end" />
   </popup-header>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -1,10 +1,5 @@
 <popup-page>
-  <popup-header
-    slot="header"
-    [pageTitle]="headerText"
-    [backAction]="handleBack.bind(this)"
-    showBackButton
-  >
+  <popup-header slot="header" [pageTitle]="headerText" showBackButton>
     <app-pop-out slot="end" />
   </popup-header>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -1,4 +1,3 @@
-import { Location } from "@angular/common";
 import { ComponentFixture, fakeAsync, flush, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { mock } from "jest-mock-extended";
@@ -75,20 +74,6 @@ describe("ViewV2Component", () => {
       expect(component.cipher).toEqual(mockCipher);
     }));
 
-    it("sets isNewCipher to true when newCipher is true", fakeAsync(() => {
-      params$.next({ cipherId: "122-333-444", newCipher: "true" });
-
-      flush(); // Resolve all promises
-
-      expect(component.isNewCipher).toBe(true);
-
-      params$.next({ cipherId: "122-333-444" });
-
-      flush(); // Resolve all promises
-
-      expect(component.isNewCipher).toBe(false);
-    }));
-
     it("sets the correct header text", fakeAsync(() => {
       // Set header text for a login
       mockCipher.type = CipherType.Login;
@@ -118,26 +103,5 @@ describe("ViewV2Component", () => {
 
       expect(component.headerText).toEqual("viewItemHeader note");
     }));
-  });
-
-  describe("handleBack", () => {
-    it("navigates to /vault when isNewCipher is true", async () => {
-      component.isNewCipher = true;
-
-      await component.handleBack();
-
-      expect(mockNavigate).toHaveBeenCalledWith(["/vault"]);
-    });
-
-    it("calls location.back when isNewCipher is false", async () => {
-      component.isNewCipher = false;
-      const location = TestBed.inject(Location);
-      const backSpy = jest.spyOn(location, "back");
-
-      await component.handleBack();
-
-      expect(mockNavigate).not.toHaveBeenCalled();
-      expect(backSpy).toHaveBeenCalled();
-    });
   });
 });

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -12,8 +12,8 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 
 import { ViewV2Component } from "./view-v2.component";
 
-// 'qrcode-parser' is used by `BrowserTotpCaptureService` but is an es6 module that jest doesn't like
-// mocking it here to prevent jest from throwing an error. I wasn't able to find a way to mock the
+// 'qrcode-parser' is used by `BrowserTotpCaptureService` but is an es6 module that jest can't compile.
+// Mock the entire module here to prevent jest from throwing an error. I wasn't able to find a way to mock the
 // `BrowserTotpCaptureService` where jest would not load the file in the first place.
 jest.mock("qrcode-parser", () => {});
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -1,0 +1,143 @@
+import { Location } from "@angular/common";
+import { ComponentFixture, fakeAsync, flush, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { mock } from "jest-mock-extended";
+import { Subject } from "rxjs";
+
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+
+import { ViewV2Component } from "./view-v2.component";
+
+// 'qrcode-parser' is used by `BrowserTotpCaptureService` but is an es6 module that jest doesn't like
+// mocking it here to prevent jest from throwing an error. I wasn't able to find a way to mock the
+// `BrowserTotpCaptureService` where jest would not load the file in the first place.
+jest.mock("qrcode-parser", () => {});
+
+describe("ViewV2Component", () => {
+  let component: ViewV2Component;
+  let fixture: ComponentFixture<ViewV2Component>;
+  const params$ = new Subject();
+  const mockNavigate = jest.fn();
+
+  const mockCipher = {
+    id: "122-333-444",
+    type: CipherType.Login,
+  };
+
+  const mockCipherService = {
+    get: jest.fn().mockResolvedValue({ decrypt: jest.fn().mockResolvedValue(mockCipher) }),
+    getKeyForCipherKeyDecryption: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeEach(async () => {
+    mockNavigate.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [ViewV2Component],
+      providers: [
+        { provide: Router, useValue: { navigate: mockNavigate } },
+        { provide: CipherService, useValue: mockCipherService },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: PlatformUtilsService, useValue: mock<PlatformUtilsService>() },
+        { provide: ConfigService, useValue: mock<ConfigService>() },
+        { provide: ActivatedRoute, useValue: { queryParams: params$ } },
+        {
+          provide: I18nService,
+          useValue: {
+            t: (key: string, ...rest: string[]) => {
+              if (rest?.length) {
+                return `${key} ${rest.join(" ")}`;
+              }
+              return key;
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ViewV2Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe("queryParams", () => {
+    it("loads an existing cipher", fakeAsync(() => {
+      params$.next({ cipherId: "122-333-444" });
+
+      flush(); // Resolve all promises
+
+      expect(mockCipherService.get).toHaveBeenCalledWith("122-333-444");
+      expect(component.cipher).toEqual(mockCipher);
+    }));
+
+    it("sets isNewCipher to true when newCipher is true", fakeAsync(() => {
+      params$.next({ cipherId: "122-333-444", newCipher: "true" });
+
+      flush(); // Resolve all promises
+
+      expect(component.isNewCipher).toBe(true);
+
+      params$.next({ cipherId: "122-333-444" });
+
+      flush(); // Resolve all promises
+
+      expect(component.isNewCipher).toBe(false);
+    }));
+
+    it("sets the correct header text", fakeAsync(() => {
+      // Set header text for a login
+      mockCipher.type = CipherType.Login;
+      params$.next({ cipherId: mockCipher.id });
+      flush(); // Resolve all promises
+
+      expect(component.headerText).toEqual("viewItemHeader typelogin");
+
+      // Set header text for a card
+      mockCipher.type = CipherType.Card;
+      params$.next({ cipherId: mockCipher.id });
+      flush(); // Resolve all promises
+
+      expect(component.headerText).toEqual("viewItemHeader typecard");
+
+      // Set header text for an identity
+      mockCipher.type = CipherType.Identity;
+      params$.next({ cipherId: mockCipher.id });
+      flush(); // Resolve all promises
+
+      expect(component.headerText).toEqual("viewItemHeader typeidentity");
+
+      // Set header text for a secure note
+      mockCipher.type = CipherType.SecureNote;
+      params$.next({ cipherId: mockCipher.id });
+      flush(); // Resolve all promises
+
+      expect(component.headerText).toEqual("viewItemHeader note");
+    }));
+  });
+
+  describe("handleBack", () => {
+    it("navigates to /vault when isNewCipher is true", async () => {
+      component.isNewCipher = true;
+
+      await component.handleBack();
+
+      expect(mockNavigate).toHaveBeenCalledWith(["/vault"]);
+    });
+
+    it("calls location.back when isNewCipher is false", async () => {
+      component.isNewCipher = false;
+      const location = TestBed.inject(Location);
+      const backSpy = jest.spyOn(location, "back");
+
+      await component.handleBack();
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(backSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -75,14 +75,14 @@ export class ViewV2Component {
   subscribeToParams(): void {
     this.route.queryParams
       .pipe(
-        switchMap((param) => {
-          return this.getCipherData(param.cipherId);
+        switchMap((params) => {
+          return this.getCipherData(params.cipherId);
         }),
         takeUntilDestroyed(),
       )
-      .subscribe((data) => {
-        this.cipher = data;
-        this.headerText = this.setHeader(data.type);
+      .subscribe((cipher) => {
+        this.cipher = cipher;
+        this.headerText = this.setHeader(cipher.type);
       });
   }
 

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from "@angular/common";
+import { CommonModule, Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
@@ -60,6 +60,9 @@ export class ViewV2Component {
   folder$: Observable<FolderView>;
   collections$: Observable<CollectionView[]>;
 
+  /** True when the view route is navigated to after creation of a new cipher */
+  isNewCipher = false;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -68,6 +71,7 @@ export class ViewV2Component {
     private dialogService: DialogService,
     private logService: LogService,
     private toastService: ToastService,
+    private location: Location,
   ) {
     this.subscribeToParams();
   }
@@ -75,14 +79,17 @@ export class ViewV2Component {
   subscribeToParams(): void {
     this.route.queryParams
       .pipe(
-        switchMap((params) => {
-          return this.getCipherData(params.cipherId);
+        switchMap(async (params): Promise<[CipherView, boolean]> => {
+          const cipher = await this.getCipherData(params.cipherId);
+          const isNewCipher = params.newCipher === "true";
+          return [cipher, isNewCipher];
         }),
         takeUntilDestroyed(),
       )
-      .subscribe((cipher) => {
+      .subscribe(([cipher, isNewCipher]) => {
         this.cipher = cipher;
         this.headerText = this.setHeader(cipher.type);
+        this.isNewCipher = isNewCipher;
       });
   }
 
@@ -100,6 +107,18 @@ export class ViewV2Component {
       case CipherType.SecureNote:
         return this.i18nService.t("viewItemHeader", this.i18nService.t("note").toLowerCase());
     }
+  }
+
+  /** Handle the back button within the popout header */
+  async handleBack() {
+    if (this.isNewCipher) {
+      // For new ciphers the last item in the history will be the add/edit page
+      // Navigate back to the vault in these cases
+      await this.router.navigate(["/vault"]);
+      return;
+    }
+
+    this.location.back();
   }
 
   async getCipherData(id: string) {

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -54,7 +54,6 @@ import { PopupPageComponent } from "./../../../../../platform/popup/layout/popup
 })
 export class ViewV2Component {
   headerText: string;
-  cipherId: string;
   cipher: CipherView;
   organization$: Observable<Organization>;
   folder$: Observable<FolderView>;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10700](https://bitwarden.atlassian.net/browse/PM-10700)

## 📔 Objective

Navigate the user to the "View" screen after creating a cipher.
- I also added logic to navigate the user back to the vault from the view when the "back" button is hit. Otherwise the user would get navigated back to the add/edit screen.
- Added test file for the view component

## 📸 Screenshots

https://github.com/user-attachments/assets/541ab4f9-aa32-484d-83ad-41a5d78251fa

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10700]: https://bitwarden.atlassian.net/browse/PM-10700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ