### PR TITLE
[PM-10784] New Folder button

### DIFF
--- a/apps/browser/src/vault/popup/settings/folders-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/folders-v2.component.html
@@ -1,7 +1,10 @@
 <popup-page>
   <popup-header slot="header" [pageTitle]="'folders' | i18n" showBackButton>
     <ng-container slot="end">
-      <app-new-item-dropdown></app-new-item-dropdown>
+      <button bitButton buttonType="primary" type="button" (click)="openAddEditFolderDialog()">
+        <i class="bwi bwi-plus-f" aria-hidden="true"></i>
+        {{ "new" | i18n }}
+      </button>
       <app-pop-out></app-pop-out>
     </ng-container>
   </popup-header>

--- a/apps/browser/src/vault/popup/settings/folders-v2.component.ts
+++ b/apps/browser/src/vault/popup/settings/folders-v2.component.ts
@@ -23,7 +23,6 @@ import {
   AddEditFolderDialogComponent,
   AddEditFolderDialogData,
 } from "../components/vault-v2/add-edit-folder-dialog/add-edit-folder-dialog.component";
-import { NewItemDropdownV2Component } from "../components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component";
 
 @Component({
   standalone: true,
@@ -31,7 +30,6 @@ import { NewItemDropdownV2Component } from "../components/vault-v2/new-item-drop
   imports: [
     CommonModule,
     JslibModule,
-    NewItemDropdownV2Component,
     PopOutComponent,
     PopupPageComponent,
     PopupHeaderComponent,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10784](https://bitwarden.atlassian.net/browse/PM-10784)

## 📔 Objective

Rather than allowing a user to create any type of cipher on the folders page, the new button should show the new folder button

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="384" alt="folder-before" src="https://github.com/user-attachments/assets/9a89c8ad-3234-4670-91bb-d3d6459963cc">|<video src="https://github.com/user-attachments/assets/48831e20-597f-481b-8692-c97efe1e80ea" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10784]: https://bitwarden.atlassian.net/browse/PM-10784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ