### PR TITLE
[PM-10761] Fix broken text for screen readers

### DIFF
--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -28,9 +28,14 @@
           {{ "securePasswordGenerated" | i18n }}
         </ng-container>
         <ng-container *ngIf="!newPasswordGenerated">
-          {{ "useGeneratorHelpTextPartOne" | i18n }}
-          <i class="bwi bwi-generate" aria-hidden="true"></i>
-          {{ "useGeneratorHelpTextPartTwo" | i18n }}
+          <span class="tw-sr-only">
+            {{ "useGeneratorHelpTextPartOne" | i18n }} {{ "useGeneratorHelpTextPartTwo" | i18n }}
+          </span>
+          <span aria-hidden="true">
+            {{ "useGeneratorHelpTextPartOne" | i18n }}
+            <i class="bwi bwi-generate" aria-hidden="true"></i>
+            {{ "useGeneratorHelpTextPartTwo" | i18n }}
+          </span>
         </ng-container>
       </bit-hint>
       <button


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10761](https://bitwarden.atlassian.net/browse/PM-10761)

## 📔 Objective

Fix the password help text so that it is not broken up for screen readers due to the visual icon.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10761]: https://bitwarden.atlassian.net/browse/PM-10761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ