### PR TITLE
[PM-9595] Browser Refresh - Fix owner / folder selects expanding out of container

### DIFF
--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
@@ -17,12 +17,8 @@
       <bit-label>{{ "itemName" | i18n }}</bit-label>
       <input bitInput formControlName="name" />
     </bit-form-field>
-    <div class="tw-flex tw-flex-wrap tw-gap-1">
-      <bit-form-field
-        class="tw-flex-1"
-        *ngIf="showOwnership"
-        [disableMargin]="!showCollectionsControl"
-      >
+    <div class="tw-grid tw-grid-cols-2 tw-gap-1">
+      <bit-form-field *ngIf="showOwnership" [disableMargin]="!showCollectionsControl">
         <bit-label>{{ "owner" | i18n }}</bit-label>
         <bit-select formControlName="organizationId">
           <bit-option
@@ -37,7 +33,10 @@
           ></bit-option>
         </bit-select>
       </bit-form-field>
-      <bit-form-field class="tw-flex-1" [disableMargin]="!showCollectionsControl">
+      <bit-form-field
+        [class.tw-col-span-2]="!showOwnership"
+        [disableMargin]="!showCollectionsControl"
+      >
         <bit-label>{{ "folder" | i18n }}</bit-label>
         <bit-select formControlName="folderId">
           <bit-option


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9595](https://bitwarden.atlassian.net/browse/PM-9595)

## 📔 Objective

Fix the Owner and Folder inputs from resizing based on their selected contents.

## 📸 Screenshots

https://github.com/user-attachments/assets/f942083d-bc04-42aa-973a-e84ffdb1c6f1


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9595]: https://bitwarden.atlassian.net/browse/PM-9595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ