### PR TITLE
[PM-10796] Fix inline menu cipher list scroll behavior

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -169,19 +169,15 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       return;
     }
 
-    const cipherListClasses = ["inline-menu-list-actions"];
-    if (ciphers.length > 2) {
-      cipherListClasses.push("inline-menu-list-actions--scrollbar");
-    }
-
     this.ciphersList = globalThis.document.createElement("ul");
-    this.ciphersList.classList.add(...cipherListClasses);
+    this.ciphersList.classList.add("inline-menu-list-actions");
     this.ciphersList.setAttribute("role", "list");
     this.setupCipherListScrollListeners();
 
     this.loadPageOfCiphers();
 
     this.inlineMenuListContainer.appendChild(this.ciphersList);
+    this.toggleScrollClass();
 
     if (!this.showInlineMenuAccountCreation) {
       return;
@@ -978,13 +974,19 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    *
    * @param height - The height of the inline menu list actions container.
    */
-  private toggleScrollClass = (height: number) => {
+  private toggleScrollClass = (height?: number) => {
     if (!this.ciphersList) {
       return;
     }
     const scrollbarClass = "inline-menu-list-actions--scrollbar";
 
-    if (height >= 170) {
+    let containerHeight = height;
+    if (!containerHeight) {
+      const inlineMenuListContainerRects = this.inlineMenuListContainer.getBoundingClientRect();
+      containerHeight = inlineMenuListContainerRects.height;
+    }
+
+    if (containerHeight >= 170) {
       this.ciphersList.classList.add(scrollbarClass);
       return;
     }

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -169,8 +169,13 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       return;
     }
 
+    const cipherListClasses = ["inline-menu-list-actions"];
+    if (ciphers.length > 2) {
+      cipherListClasses.push("inline-menu-list-actions--scrollbar");
+    }
+
     this.ciphersList = globalThis.document.createElement("ul");
-    this.ciphersList.classList.add("inline-menu-list-actions");
+    this.ciphersList.classList.add(...cipherListClasses);
     this.ciphersList.setAttribute("role", "list");
     this.setupCipherListScrollListeners();
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10796

## 📔 Objective

An issue was identified where a list of ciphers within the inline menu could potentially overlay the "New Login Item" button when switching between form fields. This occurs as a result of how we handle refreshing the list of ciphers as a user navigates from field to field. To resolve this, we are doing a check on the size of the cipher list container when updating a list of ciphers. This will ensure that we properly set the scroll class when the list is updated, even if a resize even does not trigger. 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
