### PR TITLE
[PM-10799] Login UI Width

### DIFF
--- a/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
+++ b/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
@@ -20,6 +20,7 @@
     [showReadonlyHostname]="showReadonlyHostname"
     [hideLogo]="true"
     [decreaseTopPadding]="true"
+    [maxWidth]="maxWidth"
   >
     <router-outlet></router-outlet>
     <router-outlet slot="secondary" name="secondary"></router-outlet>

--- a/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
+++ b/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
@@ -189,6 +189,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.showAcctSwitcher = null;
     this.showBackButton = null;
     this.showLogo = null;
+    this.maxWidth = null;
   }
 
   ngOnDestroy() {

--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
@@ -129,6 +129,7 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.pageSubtitle = null;
     this.pageIcon = null;
     this.showReadonlyHostname = null;
+    this.maxWidth = null;
   }
 
   ngOnDestroy() {

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.ts
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.ts
@@ -76,6 +76,10 @@ export class AnonLayoutComponent implements OnInit, OnChanges {
       const theme = await firstValueFrom(this.themeStateService.selectedTheme$);
       await this.updateIcon(theme);
     }
+
+    if (changes.maxWidth) {
+      this.maxWidth = changes.maxWidth.currentValue ?? "md";
+    }
   }
 
   private async updateIcon(theme: string) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10799](https://bitwarden.atlassian.net/browse/PM-10799)

## 📔 Objective

**Issue**: When navigating from the create account screen to the login screen the `maxWidth` on the anon layout is being lost. 

**Cause**: The input was becoming `undefined` during the routing change but wasn't being set to the initial value again. Resulting in no max width being set on the layout.

**Fix**: Catch changes to the `maxWidth` input with `ngOnChanges` and ensure that `'md'` is used for as default value

## 📸 Screenshots

https://github.com/user-attachments/assets/d0bb03fa-0fc5-462f-aee6-08397fb83174

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10799]: https://bitwarden.atlassian.net/browse/PM-10799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ