### PR TITLE
[PM-10155] Fixing broken jest tests for auto-submit content script

### DIFF
--- a/apps/browser/src/autofill/content/auto-submit-login.spec.ts
+++ b/apps/browser/src/autofill/content/auto-submit-login.spec.ts
@@ -61,10 +61,13 @@ describe("AutoSubmitLogin content script", () => {
 
     await initAutoSubmitWorkflow();
 
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
-      command: "updateIsFieldCurrentlyFilling",
-      isFieldCurrentlyFilling: false,
-    });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      {
+        command: "updateIsFieldCurrentlyFilling",
+        isFieldCurrentlyFilling: false,
+      },
+      expect.any(Function),
+    );
   });
 
   describe("when the page contains form fields", () => {
@@ -78,10 +81,13 @@ describe("AutoSubmitLogin content script", () => {
       });
       await flushPromises();
 
-      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
-        command: "updateIsFieldCurrentlyFilling",
-        isFieldCurrentlyFilling: false,
-      });
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        {
+          command: "updateIsFieldCurrentlyFilling",
+          isFieldCurrentlyFilling: false,
+        },
+        expect.any(Function),
+      );
     });
 
     describe("triggering auto-submit on formless fields", () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10155

## 📔 Objective

Fixing jest tests within the auto-submit content script. Triggered in an invalid manner due to a change within the sendMessage util used within autofill scripts.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
