### PR TITLE
[PM-10879] Move linux memory isolations behind env variable

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -120,13 +120,15 @@ export class WindowMain {
               }
             }
 
-            this.logService.info(
-              "Disabling external memory dumps & debugger access in main process",
-            );
-            try {
-              await processisolations.disableMemoryAccess();
-            } catch (e) {
-              this.logService.error("Failed to disable memory access", e);
+            // this currently breaks the file portal, so should only be used when
+            // no files are needed but security requirements are super high https://github.com/flatpak/xdg-desktop-portal/issues/785
+            if (process.env.EXPERIMENTAL_PREVENT_DEBUGGER_MEMORY_ACCESS === "true") {
+              this.logService.info("Disabling memory dumps in main process");
+              try {
+                await processisolations.disableMemoryAccess();
+              } catch (e) {
+                this.logService.error("Failed to disable memory dumps", e);
+              }
             }
           }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10879

## 📔 Objective

The change https://github.com/bitwarden/clients/pull/9393 introduced a syscall to PR_SET_DUMPABLE, to prevent memory dumping and debugger attachment of the main process on Linux. This resulted in a defect where portals (including the file portal) do not work anymore:
https://github.com/flatpak/xdg-desktop-portal/issues/785

Until this issue is fixed on the portal side, this PR is moving the feature behind an environment variable, usable by people who do not use file attachments but who have extremely high security requirements.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
