### PR TITLE
[PM-10897] Fixing invalid url reference when creating login ciphers from inline menu

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -1299,7 +1299,11 @@ describe("OverlayBackground", () => {
 
       beforeEach(() => {
         jest.useFakeTimers();
-        sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 } });
+        sender = mock<chrome.runtime.MessageSender>({
+          tab: { id: 1 },
+          url: "https://top-frame-test.com",
+          frameId: 0,
+        });
         openAddEditVaultItemPopoutSpy = jest
           .spyOn(overlayBackground as any, "openAddEditVaultItemPopout")
           .mockImplementation();
@@ -1482,10 +1486,15 @@ describe("OverlayBackground", () => {
 
       describe("pulling cipher data from multiple frames of a tab", () => {
         let subFrameSender: MockProxy<chrome.runtime.MessageSender>;
+        let secondSubFrameSender: MockProxy<chrome.runtime.MessageSender>;
         const command = "autofillOverlayAddNewVaultItem";
 
         beforeEach(() => {
           subFrameSender = mock<chrome.runtime.MessageSender>({ tab: sender.tab, frameId: 2 });
+          secondSubFrameSender = mock<chrome.runtime.MessageSender>({
+            tab: sender.tab,
+            frameId: 3,
+          });
         });
 
         it("combines the login cipher data from all frames", async () => {
@@ -1494,9 +1503,15 @@ describe("OverlayBackground", () => {
             "buildLoginCipherView",
           );
           const addNewCipherType = CipherType.Login;
+          const topLevelLoginCipherData = {
+            uri: "https://top-frame-test.com",
+            hostname: "top-frame-test.com",
+            username: "",
+            password: "",
+          };
           const loginCipherData = {
             uri: "https://tacos.com",
-            hostname: "",
+            hostname: "tacos.com",
             username: "username",
             password: "",
           };
@@ -1507,9 +1522,54 @@ describe("OverlayBackground", () => {
             password: "password",
           };
 
-          sendMockExtensionMessage({ command, addNewCipherType, login: loginCipherData }, sender);
+          sendMockExtensionMessage(
+            { command, addNewCipherType, login: topLevelLoginCipherData },
+            sender,
+          );
+          sendMockExtensionMessage(
+            { command, addNewCipherType, login: loginCipherData },
+            subFrameSender,
+          );
           sendMockExtensionMessage(
             { command, addNewCipherType, login: subFrameLoginCipherData },
+            secondSubFrameSender,
+          );
+          jest.advanceTimersByTime(100);
+          await flushPromises();
+
+          expect(buildLoginCipherViewSpy).toHaveBeenCalledWith({
+            uri: "https://top-frame-test.com",
+            hostname: "top-frame-test.com",
+            username: "username",
+            password: "password",
+          });
+        });
+
+        it("sets the uri to the subframe of a tab if the login data is complete", async () => {
+          const buildLoginCipherViewSpy = jest.spyOn(
+            overlayBackground as any,
+            "buildLoginCipherView",
+          );
+          const addNewCipherType = CipherType.Login;
+          const topLevelLoginCipherData = {
+            uri: "https://top-frame-test.com",
+            hostname: "top-frame-test.com",
+            username: "",
+            password: "",
+          };
+          const loginCipherData = {
+            uri: "https://tacos.com",
+            hostname: "tacos.com",
+            username: "username",
+            password: "password",
+          };
+
+          sendMockExtensionMessage(
+            { command, addNewCipherType, login: topLevelLoginCipherData },
+            sender,
+          );
+          sendMockExtensionMessage(
+            { command, addNewCipherType, login: loginCipherData },
             subFrameSender,
           );
           jest.advanceTimersByTime(100);

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -1551,26 +1551,26 @@ describe("OverlayBackground", () => {
             "buildLoginCipherView",
           );
           const addNewCipherType = CipherType.Login;
-          const topLevelLoginCipherData = {
-            uri: "https://top-frame-test.com",
-            hostname: "top-frame-test.com",
-            username: "",
-            password: "",
-          };
           const loginCipherData = {
             uri: "https://tacos.com",
             hostname: "tacos.com",
             username: "username",
             password: "password",
           };
+          const topLevelLoginCipherData = {
+            uri: "https://top-frame-test.com",
+            hostname: "top-frame-test.com",
+            username: "",
+            password: "",
+          };
 
-          sendMockExtensionMessage(
-            { command, addNewCipherType, login: topLevelLoginCipherData },
-            sender,
-          );
           sendMockExtensionMessage(
             { command, addNewCipherType, login: loginCipherData },
             subFrameSender,
+          );
+          sendMockExtensionMessage(
+            { command, addNewCipherType, login: topLevelLoginCipherData },
+            sender,
           );
           jest.advanceTimersByTime(100);
           await flushPromises();

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -1648,6 +1648,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     const currentLoginData = this.currentAddNewItemData.login;
+    if (sender.frameId === 0 && currentLoginData.hostname && !username && !password) {
+      login.uri = "";
+      login.hostname = "";
+    }
+
     this.currentAddNewItemData.login = {
       uri: login.uri || currentLoginData.uri,
       hostname: login.hostname || currentLoginData.hostname,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10897

## 📔 Objective

An issue was identified with the inline menu's behavior when adding a login cipher from the inline menu. In an effect to capture all data that is present within any sub frames of a page, we are effectively overwriting the expected URI for a new login cipher with an invalid URI. 

Resolving this requires us to validate whether a found sub frame contains partial data for a login cipher, and if so we need to treat the top level frame as the authoritative URI for a new login cipher. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
