### PR TITLE
[PM-8490] - Add generate password to password-protected export

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -74,9 +74,13 @@
             bitPasswordInputToggle
             [(toggled)]="showFilePassword"
           ></button>
-          <button type="button" appStopClick bitSuffix (click)="generatePassword()">
-            <i class="bwi bwi-generate" aria-hidden="true"></i>
-          </button>
+          <button
+            type="button"
+            bitIconButton="bwi-generate"
+            appStopClick
+            bitSuffix
+            (click)="generatePassword()"
+          ></button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>
         <tools-password-strength [password]="filePassword" [showText]="true">

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -74,8 +74,8 @@
             bitPasswordInputToggle
             [(toggled)]="showFilePassword"
           ></button>
-          <button type="button" bitIconButton (click)="generatePassword()">
-            <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+          <button type="button" appStopClick bitSuffix (click)="generatePassword()">
+            <i class="bwi bwi-generate" aria-hidden="true"></i>
           </button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -81,6 +81,14 @@
             bitSuffix
             (click)="generatePassword()"
           ></button>
+          <button
+            type="button"
+            bitIconButton="bwi-clone"
+            [disabled]="!filePassword"
+            appStopClick
+            bitSuffix
+            (click)="copyPasswordToClipboard()"
+          ></button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>
         <tools-password-strength [password]="filePassword" [showText]="true">

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -74,6 +74,9 @@
             bitPasswordInputToggle
             [(toggled)]="showFilePassword"
           ></button>
+          <button type="button" bitIconButton (click)="generatePassword()">
+            <i class="bwi bwi-lg bwi-generate" aria-hidden="true"></i>
+          </button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>
         <tools-password-strength [password]="filePassword" [showText]="true">

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -275,7 +275,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   generatePassword = async () => {
-    const options = await this.passwordGenerationService.getOptions();
+    const [options] = await this.passwordGenerationService.getOptions();
     this.filePasswordValue = await this.passwordGenerationService.generatePassword(options);
     this.exportForm.get("filePassword").setValue(this.filePasswordValue);
     this.exportForm.get("confirmFilePassword").setValue(this.filePasswordValue);
@@ -402,8 +402,6 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   get fileEncryptionType() {
     return this.exportForm.get("fileEncryptionType").value;
   }
-
-  generateFilePassword() {}
 
   adjustValidators() {
     this.exportForm.get("confirmFilePassword").reset();

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -288,7 +288,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
     this.toastService.showToast({
       variant: "success",
       title: null,
-      message: this.i18nService.t("passwordCopied"),
+      message: this.i18nService.t("valueCopied", this.i18nService.t("password")),
     });
   };
 

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -38,6 +38,7 @@ import {
   SelectModule,
   ToastService,
 } from "@bitwarden/components";
+import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 import { VaultExportServiceAbstraction } from "@bitwarden/vault-export-core";
 
 import { EncryptedExportType } from "../enums/encrypted-export-type.enum";
@@ -157,6 +158,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
     protected toastService: ToastService,
     protected exportService: VaultExportServiceAbstraction,
     protected eventCollectionService: EventCollectionService,
+    protected passwordGenerationService: PasswordGenerationServiceAbstraction,
     private policyService: PolicyService,
     private logService: LogService,
     private formBuilder: UntypedFormBuilder,
@@ -271,6 +273,13 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       this.logService.error(e);
     }
   }
+
+  generatePassword = async () => {
+    const options = await this.passwordGenerationService.getOptions();
+    this.filePasswordValue = await this.passwordGenerationService.generatePassword(options);
+    this.exportForm.get("filePassword").setValue(this.filePasswordValue);
+    this.exportForm.get("confirmFilePassword").setValue(this.filePasswordValue);
+  };
 
   submit = async () => {
     if (this.isFileEncryptedExport && this.filePassword != this.confirmFilePassword) {
@@ -393,6 +402,8 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   get fileEncryptionType() {
     return this.exportForm.get("fileEncryptionType").value;
   }
+
+  generateFilePassword() {}
 
   adjustValidators() {
     this.exportForm.get("confirmFilePassword").reset();

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -24,6 +24,7 @@ import { EventType } from "@bitwarden/common/enums";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import {
@@ -159,6 +160,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
     protected exportService: VaultExportServiceAbstraction,
     protected eventCollectionService: EventCollectionService,
     protected passwordGenerationService: PasswordGenerationServiceAbstraction,
+    private platformUtilsService: PlatformUtilsService,
     private policyService: PolicyService,
     private logService: LogService,
     private formBuilder: UntypedFormBuilder,
@@ -279,6 +281,15 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
     this.filePasswordValue = await this.passwordGenerationService.generatePassword(options);
     this.exportForm.get("filePassword").setValue(this.filePasswordValue);
     this.exportForm.get("confirmFilePassword").setValue(this.filePasswordValue);
+  };
+
+  copyPasswordToClipboard = async () => {
+    this.platformUtilsService.copyToClipboard(this.filePasswordValue);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("passwordCopied"),
+    });
   };
 
   submit = async () => {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-8490
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR adds a password generator button to the file password input in the vault export
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-08-15 at 5 15 26 PM](https://github.com/user-attachments/assets/a4e31cc0-59c5-4355-b3c0-3a61b18757f3)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
