### PR TITLE
Invert PopupRouterCache conditional

### DIFF
--- a/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
@@ -92,7 +92,8 @@ export class PopupRouterCacheService {
 
     const url = this.router.url;
     this.location.back();
-    if (url !== this.router.url) {
+
+    if (url === this.router.url) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

Semi-related to [PM-8781](https://bitwarden.atlassian.net/browse/PM-8781) but in general just a bug (possibly)

## 📔 Objective

After testing based on Fede's comment here, I noticed that the `navigate([""])` was being called on every `back` call. That doesn't seem the purpose based on the comment in the code about it being fallback when history isn't present. 

But I could be mistaken, I think I'm looking for @willmartian's opinion as the original author.

## 📸 Screenshots

|Bug example|Code screenshot of `console.log`s|
|-|-|
|<video src="https://github.com/user-attachments/assets/19299ace-8b51-4333-9c10-f465eafe110b" />|![Screen Shot 2024-08-16 at 09 07 20 AM](https://github.com/user-attachments/assets/f656b9df-8d4f-48f2-b3b2-151ed2e5969e)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8781]: https://bitwarden.atlassian.net/browse/PM-8781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ