### PR TITLE
Auth/pm-10964/explicitly-define-userId-on-org-create

### DIFF
--- a/apps/web/src/app/auth/organization-invite/accept-organization.component.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
 import { RegisterRouteService } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -26,6 +27,7 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     route: ActivatedRoute,
     authService: AuthService,
     registerRouteService: RegisterRouteService,
+    private accountService: AccountService,
     private acceptOrganizationInviteService: AcceptOrganizationInviteService,
   ) {
     super(router, platformUtilsService, i18nService, route, authService, registerRouteService);
@@ -33,7 +35,11 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
 
   async authedHandler(qParams: Params): Promise<void> {
     const invite = OrganizationInvite.fromParams(qParams);
-    const success = await this.acceptOrganizationInviteService.validateAndAcceptInvite(invite);
+    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+    const success = await this.acceptOrganizationInviteService.validateAndAcceptInvite(
+      userId,
+      invite,
+    );
 
     if (!success) {
       return;

--- a/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
@@ -13,8 +13,10 @@ import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { FakeGlobalState } from "@bitwarden/common/spec/fake-state";
+import { UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 
 import { I18nService } from "../../core/i18n.service";
@@ -26,6 +28,7 @@ import {
 import { OrganizationInvite } from "./organization-invite";
 
 describe("AcceptOrganizationInviteService", () => {
+  const mockUserId = Utils.newGuid() as UserId;
   let sut: AcceptOrganizationInviteService;
   let apiService: MockProxy<ApiService>;
   let authService: MockProxy<AuthService>;
@@ -82,7 +85,7 @@ describe("AcceptOrganizationInviteService", () => {
       encryptService.encrypt.mockResolvedValue({ encryptedString: "string" } as EncString);
       const invite = createOrgInvite({ initOrganization: true });
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAcceptInit).toHaveBeenCalled();
@@ -101,7 +104,7 @@ describe("AcceptOrganizationInviteService", () => {
         } as Policy,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(false);
       expect(authService.logOut).toHaveBeenCalled();
@@ -119,7 +122,7 @@ describe("AcceptOrganizationInviteService", () => {
         } as Policy,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(providedInvite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, providedInvite);
 
       expect(result).toBe(false);
       expect(authService.logOut).toHaveBeenCalled();
@@ -130,7 +133,7 @@ describe("AcceptOrganizationInviteService", () => {
       const invite = createOrgInvite();
       policyApiService.getPoliciesByToken.mockResolvedValue([]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAccept).toHaveBeenCalled();
@@ -158,7 +161,7 @@ describe("AcceptOrganizationInviteService", () => {
         false,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAccept).toHaveBeenCalled();

--- a/apps/web/src/app/auth/trial-initiation/secrets-manager/secrets-manager-trial-free-stepper.component.ts
+++ b/apps/web/src/app/auth/trial-initiation/secrets-manager/secrets-manager-trial-free-stepper.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { UntypedFormBuilder, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { OrganizationBillingServiceAbstraction as OrganizationBillingService } from "@bitwarden/common/billing/abstractions/organization-billing.service";
 import { PlanType } from "@bitwarden/common/billing/enums";
 import { ReferenceEventRequest } from "@bitwarden/common/models/request/reference-event.request";
@@ -47,6 +49,7 @@ export class SecretsManagerTrialFreeStepperComponent implements OnInit {
     protected i18nService: I18nService,
     protected organizationBillingService: OrganizationBillingService,
     private router: Router,
+    private accountService: AccountService,
   ) {}
 
   ngOnInit(): void {
@@ -61,7 +64,8 @@ export class SecretsManagerTrialFreeStepperComponent implements OnInit {
   }
 
   async createOrganization(): Promise<void> {
-    const response = await this.organizationBillingService.startFree({
+    const activeUserId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+    const response = await this.organizationBillingService.startFree(activeUserId, {
       organization: {
         name: this.formGroup.get("name").value,
         billingEmail: this.formGroup.get("email").value,

--- a/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
+++ b/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
@@ -1,7 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
+import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import {
   BillingInformation,
   OrganizationBillingServiceAbstraction as OrganizationBillingService,
@@ -75,6 +77,7 @@ export class TrialBillingStepComponent implements OnInit {
     private messagingService: MessagingService,
     private organizationBillingService: OrganizationBillingService,
     private platformUtilsService: PlatformUtilsService,
+    private accountService: AccountService,
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -166,7 +169,9 @@ export class TrialBillingStepComponent implements OnInit {
       billing: this.getBillingInformationFromTaxInfoComponent(),
     };
 
-    const response = await this.organizationBillingService.purchaseSubscription({
+    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+
+    const response = await this.organizationBillingService.purchaseSubscription(userId, {
       organization,
       plan,
       payment,

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -9,7 +9,7 @@ import {
 } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
+import { firstValueFrom, Subject, takeUntil } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
@@ -23,6 +23,7 @@ import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/
 import { OrganizationUpgradeRequest } from "@bitwarden/common/admin-console/models/request/organization-upgrade.request";
 import { ProviderOrganizationCreateRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-organization-create.request";
 import { ProviderResponse } from "@bitwarden/common/admin-console/models/response/provider/provider.response";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { PaymentMethodType, PlanType, ProductTierType } from "@bitwarden/common/billing/enums";
 import { PaymentRequest } from "@bitwarden/common/billing/models/request/payment.request";
 import { BillingResponse } from "@bitwarden/common/billing/models/response/billing.response";
@@ -150,6 +151,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
     private formBuilder: FormBuilder,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private providerApiService: ProviderApiServiceAbstraction,
+    private accountService: AccountService,
   ) {
     this.selfHosted = platformUtilsService.isSelfHost();
   }
@@ -567,7 +569,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
     const doSubmit = async (): Promise<string> => {
       let orgId: string = null;
       if (this.createOrganization) {
-        const orgKey = await this.cryptoService.makeOrgKey<OrgKey>();
+        const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+        const orgKey = await this.cryptoService.makeOrgKey<OrgKey>(userId);
         const key = orgKey[0].encryptedString;
         const collection = await this.cryptoService.encrypt(
           this.i18nService.t("defaultCollection"),

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
@@ -9,6 +9,7 @@ import { CreateClientOrganizationRequest } from "@bitwarden/common/billing/model
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 
@@ -39,13 +40,14 @@ export class WebProviderService {
   }
 
   async createClientOrganization(
+    userId: UserId,
     providerId: string,
     name: string,
     ownerEmail: string,
     planType: PlanType,
     seats: number,
   ): Promise<void> {
-    const organizationKey = (await this.cryptoService.makeOrgKey<OrgKey>())[1];
+    const organizationKey = (await this.cryptoService.makeOrgKey<OrgKey>(userId))[1];
 
     const [publicKey, encryptedPrivateKey] = await this.cryptoService.makeKeyPair(organizationKey);
 

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
@@ -7,6 +7,7 @@ import { first, takeUntil } from "rxjs/operators";
 import { ManageTaxInformationComponent } from "@bitwarden/angular/billing/components";
 import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
 import { ProviderSetupRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-setup.request";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TaxInformation } from "@bitwarden/common/billing/models/domain";
 import { ExpandedTaxInfoUpdateRequest } from "@bitwarden/common/billing/models/request/expanded-tax-info-update.request";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -58,6 +59,7 @@ export class SetupComponent implements OnInit, OnDestroy {
     private providerApiService: ProviderApiServiceAbstraction,
     private formBuilder: FormBuilder,
     private toastService: ToastService,
+    private accountService: AccountService,
   ) {}
 
   ngOnInit() {
@@ -131,7 +133,8 @@ export class SetupComponent implements OnInit, OnDestroy {
         return;
       }
 
-      const providerKey = await this.cryptoService.makeOrgKey<ProviderKey>();
+      const activeUserId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+      const providerKey = await this.cryptoService.makeOrgKey<ProviderKey>(activeUserId);
       const key = providerKey[0].encryptedString;
 
       const request = new ProviderSetupRequest();

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/create-client-dialog.component.ts
@@ -1,7 +1,9 @@
 import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
 import { Component, Inject, OnInit } from "@angular/core";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billilng-api.service.abstraction";
 import { PlanType } from "@bitwarden/common/billing/enums";
 import { PlanResponse } from "@bitwarden/common/billing/models/response/plan.response";
@@ -61,6 +63,7 @@ export class CreateClientDialogComponent implements OnInit {
     private i18nService: I18nService,
     private toastService: ToastService,
     private webProviderService: WebProviderService,
+    private accountService: AccountService,
   ) {}
 
   protected getPlanCardContainerClasses(selected: boolean) {
@@ -143,9 +146,12 @@ export class CreateClientDialogComponent implements OnInit {
       return;
     }
 
+    const activeUserId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+
     const selectedPlanCard = this.planCards.find((planCard) => planCard.selected);
 
     await this.webProviderService.createClientOrganization(
+      activeUserId,
       this.dialogParams.providerId,
       this.formGroup.value.organizationName,
       this.formGroup.value.clientOwnerEmail,

--- a/libs/common/src/billing/abstractions/organization-billing.service.ts
+++ b/libs/common/src/billing/abstractions/organization-billing.service.ts
@@ -1,3 +1,5 @@
+import { UserId } from "@bitwarden/common/types/guid";
+
 import { OrganizationResponse } from "../../admin-console/models/response/organization.response";
 import { InitiationPath } from "../../models/request/reference-event.request";
 import { PaymentMethodType, PlanType } from "../enums";
@@ -41,7 +43,13 @@ export type SubscriptionInformation = {
 };
 
 export abstract class OrganizationBillingServiceAbstraction {
-  purchaseSubscription: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;
+  purchaseSubscription: (
+    userId: UserId,
+    subscription: SubscriptionInformation,
+  ) => Promise<OrganizationResponse>;
 
-  startFree: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;
+  startFree: (
+    userId: UserId,
+    subscription: SubscriptionInformation,
+  ) => Promise<OrganizationResponse>;
 }

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -1,3 +1,5 @@
+import { UserId } from "@bitwarden/common/types/guid";
+
 import { ApiService } from "../../abstractions/api.service";
 import { OrganizationApiServiceAbstraction as OrganizationApiService } from "../../admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationCreateRequest } from "../../admin-console/models/request/organization-create.request";
@@ -35,10 +37,13 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
     private syncService: SyncService,
   ) {}
 
-  async purchaseSubscription(subscription: SubscriptionInformation): Promise<OrganizationResponse> {
+  async purchaseSubscription(
+    userId: UserId,
+    subscription: SubscriptionInformation,
+  ): Promise<OrganizationResponse> {
     const request = new OrganizationCreateRequest();
 
-    const organizationKeys = await this.makeOrganizationKeys();
+    const organizationKeys = await this.makeOrganizationKeys(userId);
 
     this.setOrganizationKeys(request, organizationKeys);
 
@@ -57,10 +62,13 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
     return response;
   }
 
-  async startFree(subscription: SubscriptionInformation): Promise<OrganizationResponse> {
+  async startFree(
+    userId: UserId,
+    subscription: SubscriptionInformation,
+  ): Promise<OrganizationResponse> {
     const request = new OrganizationCreateRequest();
 
-    const organizationKeys = await this.makeOrganizationKeys();
+    const organizationKeys = await this.makeOrganizationKeys(userId);
 
     this.setOrganizationKeys(request, organizationKeys);
 
@@ -77,8 +85,8 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
     return response;
   }
 
-  private async makeOrganizationKeys(): Promise<OrganizationKeys> {
-    const [encryptedKey, key] = await this.cryptoService.makeOrgKey<OrgKey>();
+  private async makeOrganizationKeys(userId: UserId): Promise<OrganizationKeys> {
+    const [encryptedKey, key] = await this.cryptoService.makeOrgKey<OrgKey>(userId);
     const [publicKey, encryptedPrivateKey] = await this.cryptoService.makeKeyPair(key);
     const encryptedCollectionName = await this.encryptService.encrypt(
       this.i18nService.t("defaultCollection"),

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -239,9 +239,10 @@ export abstract class CryptoService {
   /**
    * Creates a new organization key and encrypts it with the user's public key.
    * This method can also return Provider keys for creating new Provider users.
+   * @param userId The user id of the user to create the key for.
    * @returns The new encrypted org key and the decrypted key itself
    */
-  abstract makeOrgKey<T extends OrgKey | ProviderKey>(): Promise<[EncString, T]>;
+  abstract makeOrgKey<T extends OrgKey | ProviderKey>(userId: UserId): Promise<[EncString, T]>;
   /**
    * Sets the user's encrypted private key in storage and
    * clears the decrypted private key from memory

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -412,10 +412,8 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.stateProvider.setUserState(USER_ENCRYPTED_PROVIDER_KEYS, null, userId);
   }
 
-  // TODO: Make userId required
-  async makeOrgKey<T extends OrgKey | ProviderKey>(userId?: UserId): Promise<[EncString, T]> {
+  async makeOrgKey<T extends OrgKey | ProviderKey>(userId: UserId): Promise<[EncString, T]> {
     const shareKey = await this.keyGenerationService.createKey(512);
-    userId ??= await firstValueFrom(this.stateProvider.activeUserId$);
     const publicKey = await firstValueFrom(this.userPublicKey$(userId));
     const encShareKey = await this.rsaEncrypt(shareKey.key, publicKey);
     return [encShareKey, shareKey as T];


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10964

## 📔 Objective

Adjust the interface to `makeOrgKey()` to require `userId` to avoid any eventual consistency issues when accepting org invites.  The `userId` is used to get the appropriate `publicKey` with which we can encrypt the newly-created org's symmetric encryption key.

The `userId` is read from the `AccountService` in the following components to feed the proper value into the eventual org key creation:
- `organization-plans.component.ts` (via `OrganizationBillingService`)
- `trial-billing-step.component.ts` (via `OrganizationBillingService`)
- `complete-trial-initiation.component.ts` (via `OrganizationBillingService`)
- `accept-organization.component.ts` (via `AcceptOrganizationService`)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
