### PR TITLE
[PM-10964] Add userId to interface to accept organization invite

### DIFF
--- a/apps/web/src/app/auth/organization-invite/accept-organization.component.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
 import { RegisterRouteService } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -27,13 +28,18 @@ export class AcceptOrganizationComponent extends BaseAcceptComponent {
     authService: AuthService,
     registerRouteService: RegisterRouteService,
     private acceptOrganizationInviteService: AcceptOrganizationInviteService,
+    private accountService: AccountService,
   ) {
     super(router, platformUtilsService, i18nService, route, authService, registerRouteService);
   }
 
   async authedHandler(qParams: Params): Promise<void> {
     const invite = OrganizationInvite.fromParams(qParams);
-    const success = await this.acceptOrganizationInviteService.validateAndAcceptInvite(invite);
+    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+    const success = await this.acceptOrganizationInviteService.validateAndAcceptInvite(
+      userId,
+      invite,
+    );
 
     if (!success) {
       return;

--- a/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
@@ -13,8 +13,10 @@ import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { FakeGlobalState } from "@bitwarden/common/spec/fake-state";
+import { UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 
 import { I18nService } from "../../core/i18n.service";
@@ -26,6 +28,7 @@ import {
 import { OrganizationInvite } from "./organization-invite";
 
 describe("AcceptOrganizationInviteService", () => {
+  const mockUserId = Utils.newGuid() as UserId;
   let sut: AcceptOrganizationInviteService;
   let apiService: MockProxy<ApiService>;
   let authService: MockProxy<AuthService>;
@@ -82,7 +85,7 @@ describe("AcceptOrganizationInviteService", () => {
       encryptService.encrypt.mockResolvedValue({ encryptedString: "string" } as EncString);
       const invite = createOrgInvite({ initOrganization: true });
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAcceptInit).toHaveBeenCalled();
@@ -101,7 +104,7 @@ describe("AcceptOrganizationInviteService", () => {
         } as Policy,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(false);
       expect(authService.logOut).toHaveBeenCalled();
@@ -119,7 +122,7 @@ describe("AcceptOrganizationInviteService", () => {
         } as Policy,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(providedInvite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, providedInvite);
 
       expect(result).toBe(false);
       expect(authService.logOut).toHaveBeenCalled();
@@ -130,7 +133,7 @@ describe("AcceptOrganizationInviteService", () => {
       const invite = createOrgInvite();
       policyApiService.getPoliciesByToken.mockResolvedValue([]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAccept).toHaveBeenCalled();
@@ -158,7 +161,7 @@ describe("AcceptOrganizationInviteService", () => {
         false,
       ]);
 
-      const result = await sut.validateAndAcceptInvite(invite);
+      const result = await sut.validateAndAcceptInvite(mockUserId, invite);
 
       expect(result).toBe(true);
       expect(organizationUserService.postOrganizationUserAccept).toHaveBeenCalled();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10964

## 📔 Objective

Updated account acceptance to pass in the `userId` from the component into the org invite acceptance.

This is intended to avoid any eventual consistency race conditions on the active `userId`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
