### PR TITLE
Added functionality to edit members on MemberAccessReportComponent

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
@@ -32,7 +32,7 @@
         <div class="tw-flex tw-items-center">
           <bit-avatar size="small" [text]="r.name" class="tw-mr-3"></bit-avatar>
           <div class="tw-flex tw-flex-col">
-            <button type="button" bitLink>
+            <button type="button" bitLink (click)="edit(r)">
               {{ r.name }}
             </button>
 

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.ts
@@ -2,14 +2,22 @@ import { Component, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { debounceTime, firstValueFrom } from "rxjs";
+import { debounceTime, firstValueFrom, lastValueFrom } from "rxjs";
 
+import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
 import { safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
+import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
-import { SearchModule, TableDataSource } from "@bitwarden/components";
+import { DialogService, SearchModule, TableDataSource } from "@bitwarden/components";
 import { ExportHelper } from "@bitwarden/vault-export-core";
+import { CoreOrganizationModule } from "@bitwarden/web-vault/app/admin-console/organizations/core";
+import {
+  openUserAddEditDialog,
+  MemberDialogResult,
+  MemberDialogTab,
+} from "@bitwarden/web-vault/app/admin-console/organizations/members/components/member-dialog";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 import { SharedModule } from "@bitwarden/web-vault/app/shared";
 import { exportToCSV } from "@bitwarden/web-vault/app/tools/reports/report-utils";
@@ -23,7 +31,7 @@ import { MemberAccessReportView } from "./view/member-access-report.view";
 @Component({
   selector: "member-access-report",
   templateUrl: "member-access-report.component.html",
-  imports: [SharedModule, SearchModule, HeaderModule],
+  imports: [SharedModule, SearchModule, HeaderModule, CoreOrganizationModule],
   providers: [
     safeProvider({
       provide: MemberAccessReportServiceAbstraction,
@@ -37,11 +45,15 @@ export class MemberAccessReportComponent implements OnInit {
   protected dataSource = new TableDataSource<MemberAccessReportView>();
   protected searchControl = new FormControl("", { nonNullable: true });
   protected organizationId: OrganizationId;
+  protected orgIsOnSecretsManagerStandalone: boolean;
 
   constructor(
     private route: ActivatedRoute,
     protected reportService: MemberAccessReportService,
     protected fileDownloadService: FileDownloadService,
+    protected dialogService: DialogService,
+    protected userNamePipe: UserNamePipe,
+    protected billingApiService: BillingApiServiceAbstraction,
   ) {
     // Connect the search input to the table dataSource filter input
     this.searchControl.valueChanges
@@ -52,6 +64,17 @@ export class MemberAccessReportComponent implements OnInit {
   async ngOnInit() {
     const params = await firstValueFrom(this.route.params);
     this.organizationId = params.organizationId;
+
+    const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+      this.organizationId,
+    );
+
+    this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
+
+    await this.load();
+  }
+
+  async load() {
     this.dataSource.data = await this.reportService.generateMemberAccessReportView(
       this.organizationId,
     );
@@ -66,5 +89,30 @@ export class MemberAccessReportComponent implements OnInit {
       ),
       blobOptions: { type: "text/plain" },
     });
+  };
+
+  edit = async (user: MemberAccessReportView | null): Promise<void> => {
+    const dialog = openUserAddEditDialog(this.dialogService, {
+      data: {
+        name: this.userNamePipe.transform(user),
+        organizationId: this.organizationId,
+        organizationUserId: user != null ? user.userGuid : null,
+        allOrganizationUserEmails: this.dataSource.data?.map((user) => user.email) ?? [],
+        usesKeyConnector: user?.usesKeyConnector,
+        isOnSecretsManagerStandalone: this.orgIsOnSecretsManagerStandalone,
+        initialTab: MemberDialogTab.Role,
+        numConfirmedMembers: this.dataSource.data.length,
+      },
+    });
+
+    const result = await lastValueFrom(dialog.closed);
+    switch (result) {
+      case MemberDialogResult.Deleted:
+      case MemberDialogResult.Saved:
+      case MemberDialogResult.Revoked:
+      case MemberDialogResult.Restored:
+        await this.load();
+        return;
+    }
   };
 }

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/response/member-access-report.response.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/response/member-access-report.response.ts
@@ -1,5 +1,6 @@
 import { BaseResponse } from "@bitwarden/common/models/response/base.response";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { Guid } from "@bitwarden/common/types/guid";
 
 export class MemberAccessDetails extends BaseResponse {
   collectionId: string;
@@ -33,6 +34,8 @@ export class MemberAccessResponse extends BaseResponse {
   groupsCount: number;
   totalItemCount: number;
   accessDetails: MemberAccessDetails[] = [];
+  userGuid: Guid;
+  usesKeyConnector: boolean;
 
   constructor(response: any) {
     super(response);
@@ -43,6 +46,8 @@ export class MemberAccessResponse extends BaseResponse {
     this.collectionsCount = this.getResponseProperty("CollectionsCount");
     this.groupsCount = this.getResponseProperty("GroupsCount");
     this.totalItemCount = this.getResponseProperty("TotalItemCount");
+    this.userGuid = this.getResponseProperty("UserGuid");
+    this.usesKeyConnector = this.getResponseProperty("UsesKeyConnector");
 
     const details = this.getResponseProperty("AccessDetails");
     if (details != null) {

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
@@ -14,13 +14,13 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
     groupsCount: 2,
     collectionsCount: 4,
     totalItemCount: 20,
+    userGuid: "1234",
+    usesKeyConnector: false,
     accessDetails: [
       {
         groupId: "",
         collectionId: "c1",
-        collectionName: new EncString(
-          "2.UiXa3L3Ol1G4QnfFfBjMQw==|sbVTj0EiEkhIrDiropn2Cg==|82P78YgmapW4TdN9jQJgMWKv2gGyK1AnGkr+W9/sq+A=",
-        ),
+        collectionName: new EncString("Collection 1"),
         groupName: "",
         itemCount: 10,
         readOnly: false,
@@ -50,9 +50,7 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
       {
         groupId: "g1",
         collectionId: "c1",
-        collectionName: new EncString(
-          "2.UiXa3L3Ol1G4QnfFfBjMQw==|sbVTj0EiEkhIrDiropn2Cg==|82P78YgmapW4TdN9jQJgMWKv2gGyK1AnGkr+W9/sq+A=",
-        ),
+        collectionName: new EncString("Collection 1"),
         groupName: "Group 1",
         itemCount: 30,
         readOnly: false,
@@ -79,6 +77,8 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
     groupsCount: 2,
     collectionsCount: 4,
     totalItemCount: 20,
+    userGuid: "1234",
+    usesKeyConnector: false,
     accessDetails: [
       {
         groupId: "g4",
@@ -130,6 +130,8 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
     groupsCount: 2,
     collectionsCount: 4,
     totalItemCount: 20,
+    userGuid: "1234",
+    usesKeyConnector: false,
     accessDetails: [
       {
         groupId: "",
@@ -161,6 +163,8 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
     groupsCount: 2,
     collectionsCount: 4,
     totalItemCount: 20,
+    userGuid: "1234",
+    usesKeyConnector: false,
     accessDetails: [
       {
         groupId: "",

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.spec.ts
@@ -20,37 +20,46 @@ describe("ImportService", () => {
   });
 
   describe("generateMemberAccessReportView", () => {
-    it("should generate member access report view", () => {
-      const result = memberAccessReportService.generateMemberAccessReportView(mockOrganizationId);
+    it("should generate member access report view", async () => {
+      const result =
+        await memberAccessReportService.generateMemberAccessReportView(mockOrganizationId);
 
       expect(result).toEqual([
         {
           name: "Sarah Johnson",
           email: "sjohnson@email.com",
           collectionsCount: 4,
-          groupsCount: 3,
-          itemsCount: 70,
+          groupsCount: 2,
+          itemsCount: 20,
+          userGuid: expect.any(String),
+          usesKeyConnector: expect.any(Boolean),
         },
         {
           name: "James Lull",
           email: "jlull@email.com",
-          collectionsCount: 2,
+          collectionsCount: 4,
           groupsCount: 2,
           itemsCount: 20,
+          userGuid: expect.any(String),
+          usesKeyConnector: expect.any(Boolean),
         },
         {
           name: "Beth Williams",
           email: "bwilliams@email.com",
-          collectionsCount: 2,
-          groupsCount: 1,
-          itemsCount: 60,
+          collectionsCount: 4,
+          groupsCount: 2,
+          itemsCount: 20,
+          userGuid: expect.any(String),
+          usesKeyConnector: expect.any(Boolean),
         },
         {
           name: "Ray Williams",
           email: "rwilliams@email.com",
-          collectionsCount: 3,
-          groupsCount: 3,
-          itemsCount: 36,
+          collectionsCount: 4,
+          groupsCount: 2,
+          itemsCount: 20,
+          userGuid: expect.any(String),
+          usesKeyConnector: expect.any(Boolean),
         },
       ]);
     });
@@ -61,7 +70,24 @@ describe("ImportService", () => {
       const result =
         await memberAccessReportService.generateUserReportExportItems(mockOrganizationId);
 
-      expect(result).toEqual(
+      const filteredReportItems = result
+        .filter(
+          (item) =>
+            (item.name === "Sarah Johnson" &&
+              item.group === "Group 1" &&
+              item.totalItems === "20") ||
+            (item.name === "James Lull" && item.group === "Group 4" && item.totalItems === "5"),
+        )
+        .map((item) => ({
+          name: item.name,
+          email: item.email,
+          group: item.group,
+          totalItems: item.totalItems,
+          accountRecovery: item.accountRecovery,
+          twoStepLogin: item.twoStepLogin,
+        }));
+
+      expect(filteredReportItems).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             email: "sjohnson@email.com",
@@ -69,19 +95,15 @@ describe("ImportService", () => {
             twoStepLogin: "On",
             accountRecovery: "On",
             group: "Group 1",
-            collection: expect.any(String),
-            collectionPermission: "read only",
-            totalItems: "10",
+            totalItems: "20",
           }),
           expect.objectContaining({
             email: "jlull@email.com",
             name: "James Lull",
             twoStepLogin: "Off",
             accountRecovery: "Off",
-            group: "(No group)",
-            collection: expect.any(String),
-            collectionPermission: "read only",
-            totalItems: "15",
+            group: "Group 4",
+            totalItems: "5",
           }),
         ]),
       );

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.ts
@@ -38,6 +38,8 @@ export class MemberAccessReportService {
       collectionsCount: userData.collectionsCount,
       groupsCount: userData.groupsCount,
       itemsCount: userData.totalItemCount,
+      userGuid: userData.userGuid,
+      usesKeyConnector: userData.usesKeyConnector,
     }));
     return memberAccessReportViewCollection;
   }

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/view/member-access-report.view.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/view/member-access-report.view.ts
@@ -1,7 +1,11 @@
+import { Guid } from "@bitwarden/common/types/guid";
+
 export type MemberAccessReportView = {
   name: string;
   email: string;
   collectionsCount: number;
   groupsCount: number;
   itemsCount: number;
+  userGuid: Guid;
+  usesKeyConnector: boolean;
 };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-3004

## 📔 Objective

Adds the functionality of editing a member on a popup while on the member access report screen

## 📸 Screenshots
<img width="1720" alt="image" src="https://github.com/user-attachments/assets/55092f47-94ff-4aa3-92b2-ff6b68f53351">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
