### PR TITLE
[PM-10940] misc popout history cache bug fixes

### DIFF
--- a/apps/browser/src/platform/popup/view-cache/popup-router-cache.spec.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-router-cache.spec.ts
@@ -65,6 +65,16 @@ describe("Popup router cache guard", () => {
     expect(response).toBe(true);
   });
 
+  it("returns true if the history stack is null", async () => {
+    await service.setHistory(null);
+
+    const response = await firstValueFrom(
+      testBed.runInInjectionContext(() => popupRouterCacheGuard()),
+    );
+
+    expect(response).toBe(true);
+  });
+
   it("redirects to the latest stored route", async () => {
     await router.navigate(["a"]);
     await router.navigate(["b"]);

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -6,6 +6,7 @@ import {
   GlobalStateProvider,
 } from "@bitwarden/common/platform/state";
 
+import { BrowserApi } from "../browser/browser-api";
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
 const popupClosedPortName = "new_popup";
@@ -27,7 +28,7 @@ export class PopupViewCacheBackgroundService {
     merge(
       // on tab changed, excluding extension tabs
       fromChromeEvent(chrome.tabs.onActivated).pipe(
-        switchMap(([tabInfo]) => chrome.tabs.get(tabInfo.tabId)),
+        switchMap(([tabInfo]) => BrowserApi.getTab(tabInfo.tabId)),
         map((tab) => tab.url || tab.pendingUrl),
         filter((url) => !url.startsWith(chrome.runtime.getURL(""))),
       ),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10940

## 📔 Objective

Fix misc issues with https://github.com/bitwarden/clients/pull/9556:
- adds checks for when state is `null`
  - fixes back navigation when in sidebar, see [here](https://github.com/bitwarden/clients/pull/10619/files#diff-7c27943c4f1d5aa04888448f185ac1e6d18c7f019b6371905a1abb4163144528R100)
  - fixes console error constructing `PopupRouterCacheService`, see [here](https://github.com/bitwarden/clients/pull/10619/files#diff-7c27943c4f1d5aa04888448f185ac1e6d18c7f019b6371905a1abb4163144528R38-R41)
-  fixes back navigation fallback logic, see https://github.com/bitwarden/clients/pull/10541
- fixes Firefox/MV2 error by using `BrowserApi.getTab` instead of direct Chrome API

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
