### PR TITLE
[PM-11136] Convert LoginEmailService email property to state provider

### DIFF
--- a/apps/browser/src/auth/popup/home.component.ts
+++ b/apps/browser/src/auth/popup/home.component.ts
@@ -39,7 +39,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    const email = this.loginEmailService.getEmail();
+    const email = await firstValueFrom(this.loginEmailService.loginEmail$);
     const rememberEmail = this.loginEmailService.getRememberEmail();
 
     if (email != null) {
@@ -91,7 +91,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   async setLoginEmailValues() {
     // Note: Browser saves email settings here instead of the login component
     this.loginEmailService.setRememberEmail(this.formGroup.value.rememberEmail);
-    this.loginEmailService.setEmail(this.formGroup.value.email);
+    await this.loginEmailService.setLoginEmail(this.formGroup.value.email);
     await this.loginEmailService.saveEmailSettings();
   }
 }

--- a/apps/browser/src/auth/popup/login.component.ts
+++ b/apps/browser/src/auth/popup/login.component.ts
@@ -84,9 +84,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     if (this.showPasswordless) {
-      this.formGroup.controls.email.setValue(
-        await firstValueFrom(this.loginEmailService.loginEmail$),
-      );
+      const loginEmail = await firstValueFrom(this.loginEmailService.loginEmail$);
+      this.formGroup.controls.email.setValue(loginEmail);
       this.formGroup.controls.rememberEmail.setValue(this.loginEmailService.getRememberEmail());
       await this.validateEmail();
     }

--- a/apps/browser/src/auth/popup/login.component.ts
+++ b/apps/browser/src/auth/popup/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, NgZone } from "@angular/core";
+import { Component, NgZone, OnInit } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { firstValueFrom } from "rxjs";
@@ -30,7 +30,7 @@ import { flagEnabled } from "../../platform/flags";
   selector: "app-login",
   templateUrl: "login.component.html",
 })
-export class LoginComponent extends BaseLoginComponent {
+export class LoginComponent extends BaseLoginComponent implements OnInit {
   showPasswordless = false;
   constructor(
     devicesApiService: DevicesApiServiceAbstraction,
@@ -80,13 +80,15 @@ export class LoginComponent extends BaseLoginComponent {
     };
     super.successRoute = "/tabs/vault";
     this.showPasswordless = flagEnabled("showPasswordless");
+  }
 
+  async ngOnInit(): Promise<void> {
     if (this.showPasswordless) {
-      this.formGroup.controls.email.setValue(this.loginEmailService.getEmail());
+      this.formGroup.controls.email.setValue(
+        await firstValueFrom(this.loginEmailService.loginEmail$),
+      );
       this.formGroup.controls.rememberEmail.setValue(this.loginEmailService.getRememberEmail());
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.validateEmail();
+      await this.validateEmail();
     }
   }
 

--- a/apps/web/src/app/auth/hint.component.ts
+++ b/apps/web/src/app/auth/hint.component.ts
@@ -34,8 +34,8 @@ export class HintComponent extends BaseHintComponent implements OnInit {
     super(router, i18nService, apiService, platformUtilsService, logService, loginEmailService);
   }
 
-  ngOnInit(): void {
-    super.ngOnInit();
+  async ngOnInit(): Promise<void> {
+    await super.ngOnInit();
     this.emailFormControl.setValue(this.email);
   }
 

--- a/libs/angular/src/auth/components/base-login-decryption-options.component.ts
+++ b/libs/angular/src/auth/components/base-login-decryption-options.component.ts
@@ -249,12 +249,12 @@ export class BaseLoginDecryptionOptionsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.loginEmailService.setEmail(this.data.userEmail);
+    this.loginEmailService.setLoginEmail(this.data.userEmail);
     await this.router.navigate(["/login-with-device"]);
   }
 
   async requestAdminApproval() {
-    this.loginEmailService.setEmail(this.data.userEmail);
+    this.loginEmailService.setLoginEmail(this.data.userEmail);
     await this.router.navigate(["/admin-approval-requested"]);
   }
 

--- a/libs/angular/src/auth/components/hint.component.ts
+++ b/libs/angular/src/auth/components/hint.component.ts
@@ -1,5 +1,6 @@
 import { Directive, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 
 import { LoginEmailServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -25,8 +26,8 @@ export class HintComponent implements OnInit {
     private loginEmailService: LoginEmailServiceAbstraction,
   ) {}
 
-  ngOnInit(): void {
-    this.email = this.loginEmailService.getEmail() ?? "";
+  async ngOnInit(): Promise<void> {
+    this.email = (await firstValueFrom(this.loginEmailService.loginEmail$)) ?? "";
   }
 
   async submit() {

--- a/libs/angular/src/auth/components/login-via-auth-request.component.ts
+++ b/libs/angular/src/auth/components/login-via-auth-request.component.ts
@@ -91,13 +91,6 @@ export class LoginViaAuthRequestComponent
   ) {
     super(environmentService, i18nService, platformUtilsService);
 
-    // TODO: I don't know why this is necessary.
-    // Why would the existence of the email depend on the navigation?
-    const navigation = this.router.getCurrentNavigation();
-    if (navigation) {
-      this.email = this.loginEmailService.getEmail();
-    }
-
     // Gets signalR push notification
     // Only fires on approval to prevent enumeration
     this.authRequestService.authRequestPushNotification$
@@ -112,6 +105,13 @@ export class LoginViaAuthRequestComponent
   }
 
   async ngOnInit() {
+    // TODO: I don't know why this is necessary.
+    // Why would the existence of the email depend on the navigation?
+    const navigation = this.router.getCurrentNavigation();
+    if (navigation) {
+      this.email = await firstValueFrom(this.loginEmailService.loginEmail$);
+    }
+
     this.userAuthNStatus = await this.authService.getAuthStatus();
 
     const matchOptions: IsActiveMatchOptions = {
@@ -155,7 +155,7 @@ export class LoginViaAuthRequestComponent
     } else {
       // Standard auth request
       // TODO: evaluate if we can remove the setting of this.email in the constructor
-      this.email = this.loginEmailService.getEmail();
+      this.email = await firstValueFrom(this.loginEmailService.loginEmail$);
 
       if (!this.email) {
         this.platformUtilsService.showToast("error", null, this.i18nService.t("userEmailMissing"));

--- a/libs/angular/src/auth/components/login-via-auth-request.component.ts
+++ b/libs/angular/src/auth/components/login-via-auth-request.component.ts
@@ -105,13 +105,7 @@ export class LoginViaAuthRequestComponent
   }
 
   async ngOnInit() {
-    // TODO: I don't know why this is necessary.
-    // Why would the existence of the email depend on the navigation?
-    const navigation = this.router.getCurrentNavigation();
-    if (navigation) {
-      this.email = await firstValueFrom(this.loginEmailService.loginEmail$);
-    }
-
+    this.email = await firstValueFrom(this.loginEmailService.loginEmail$);
     this.userAuthNStatus = await this.authService.getAuthStatus();
 
     const matchOptions: IsActiveMatchOptions = {

--- a/libs/angular/src/auth/components/login.component.ts
+++ b/libs/angular/src/auth/components/login.component.ts
@@ -297,7 +297,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit,
 
   private async loadEmailSettings() {
     // Try to load from memory first
-    const email = this.loginEmailService.getEmail();
+    const email = await firstValueFrom(this.loginEmailService.loginEmail$);
     const rememberEmail = this.loginEmailService.getRememberEmail();
     if (email) {
       this.formGroup.controls.email.setValue(email);
@@ -314,7 +314,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit,
   }
 
   protected async saveEmailSettings() {
-    this.loginEmailService.setEmail(this.formGroup.value.email);
+    this.loginEmailService.setLoginEmail(this.formGroup.value.email);
     this.loginEmailService.setRememberEmail(this.formGroup.value.rememberEmail);
     await this.loginEmailService.saveEmailSettings();
   }

--- a/libs/auth/src/common/abstractions/login-email.service.ts
+++ b/libs/auth/src/common/abstractions/login-email.service.ts
@@ -2,28 +2,27 @@ import { Observable } from "rxjs";
 
 export abstract class LoginEmailServiceAbstraction {
   /**
+   * An observable that monitors the loginEmail in memory.
+   * The loginEmail is the email that is being used in the current login process.
+   */
+  loginEmail$: Observable<string | null>;
+  /**
    * An observable that monitors the storedEmail on disk.
    * This will return null if an account is being added.
    */
   storedEmail$: Observable<string | null>;
   /**
-   * Gets the current email being used in the login process from memory.
-   * @returns A string of the email.
+   * Sets the loginEmail in memory.
+   * The loginEmail is the email that is being used in the current login process.
    */
-  getEmail: () => string;
-  /**
-   * Sets the current email being used in the login process in memory.
-   * @param email The email to be set.
-   */
-  setEmail: (email: string) => void;
+  setLoginEmail: (email: string) => Promise<void>;
   /**
    * Gets from memory whether or not the email should be stored on disk when `saveEmailSettings` is called.
    * @returns A boolean stating whether or not the email should be stored on disk.
    */
   getRememberEmail: () => boolean;
   /**
-   * Sets in memory whether or not the email should be stored on disk when
-   * `saveEmailSettings` is called.
+   * Sets in memory whether or not the email should be stored on disk when `saveEmailSettings` is called.
    */
   setRememberEmail: (value: boolean) => void;
   /**

--- a/libs/auth/src/common/services/login-email/login-email.service.spec.ts
+++ b/libs/auth/src/common/services/login-email/login-email.service.spec.ts
@@ -43,7 +43,7 @@ describe("LoginEmailService", () => {
 
   describe("storedEmail$", () => {
     it("returns the stored email when not adding an account", async () => {
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
@@ -53,7 +53,7 @@ describe("LoginEmailService", () => {
     });
 
     it("returns the stored email when not adding an account and the user has just logged in", async () => {
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
@@ -66,7 +66,7 @@ describe("LoginEmailService", () => {
     });
 
     it("returns null when adding an account", async () => {
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
@@ -83,7 +83,7 @@ describe("LoginEmailService", () => {
 
   describe("saveEmailSettings", () => {
     it("saves the email when not adding an account", async () => {
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
@@ -95,7 +95,7 @@ describe("LoginEmailService", () => {
     it("clears the email when not adding an account and rememberEmail is false", async () => {
       storedEmailState.stateSubject.next("initialEmail@bitwarden.com");
 
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(false);
       await sut.saveEmailSettings();
 
@@ -110,7 +110,7 @@ describe("LoginEmailService", () => {
         ["OtherUserId" as UserId]: AuthenticationStatus.Locked,
       });
 
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
@@ -127,7 +127,7 @@ describe("LoginEmailService", () => {
         ["OtherUserId" as UserId]: AuthenticationStatus.Locked,
       });
 
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(false);
       await sut.saveEmailSettings();
 
@@ -140,11 +140,11 @@ describe("LoginEmailService", () => {
     it("does not clear the email and rememberEmail after saving", async () => {
       // Browser uses these values to maintain the email between login and 2fa components so
       // we do not want to clear them too early.
-      sut.setEmail("userEmail@bitwarden.com");
+      await sut.setLoginEmail("userEmail@bitwarden.com");
       sut.setRememberEmail(true);
       await sut.saveEmailSettings();
 
-      const result = sut.getEmail();
+      const result = await firstValueFrom(sut.loginEmail$);
 
       expect(result).toBe("userEmail@bitwarden.com");
     });

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -53,6 +53,7 @@ export const KEY_CONNECTOR_DISK = new StateDefinition("keyConnector", "disk");
 export const LOGIN_EMAIL_DISK = new StateDefinition("loginEmail", "disk", {
   web: "disk-local",
 });
+export const LOGIN_EMAIL_MEMORY = new StateDefinition("loginEmail", "memory");
 export const LOGIN_STRATEGY_MEMORY = new StateDefinition("loginStrategy", "memory");
 export const MASTER_PASSWORD_DISK = new StateDefinition("masterPassword", "disk");
 export const MASTER_PASSWORD_MEMORY = new StateDefinition("masterPassword", "memory");


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11136

## 📔 Objective

With the Auth Browser Refresh work (in progress), we will have a popout option on each page of the Browser Extension. This means that for certain flows, we will need a better way of retaining / persisting the login email to the popout.

Currently, the LoginEmailService has an `email` property that exists as a normal property on the service. This PR converts it to a state provider (in memory), and updates any components where the `getEmail()` and `setEmail()` methods are being used.

- `getEmail()` changes to `loginEmail$`
- `setEmail()` changes to `setLoginEmail()`

## 📸 Screencasts

### Web

**Showing (a) normal login, (b) normal login with remember email, (c) password hint flow**

https://github.com/user-attachments/assets/2381a72a-58bd-40c0-9854-0a372176f52b

**Showing Login with Device flow**

https://github.com/user-attachments/assets/d207a2a8-c2db-456e-9198-596b23e9d5a9

**Showing Login via SSO with TD - Admin Auth Approval flow**

https://github.com/user-attachments/assets/699f1ba8-bd31-44c1-abd4-a0f49bb9e099

### Extension

**Showing (a) normal login, (b) normal login with remember email, (c) password hint flow**

https://github.com/user-attachments/assets/aafed98a-cf03-433a-bfd9-8ddcbacba9eb

**Showing Login with Device flow**

https://github.com/user-attachments/assets/27d45665-3455-475d-87e0-119528ae38f3

**Showing Login via SSO with TD - Device Approval flow**

https://github.com/user-attachments/assets/4c24ae1a-eb9d-40e5-a410-bfe5f34685a2

### Desktop

**Showing (a) normal login, (b) normal login with remember email, (c) password hint flow**

https://github.com/user-attachments/assets/3c259375-0b01-44ce-9021-0f4f1529ca40

**Showing Login via SSO with TD - Master Password Approval flow**

https://github.com/user-attachments/assets/37ac5b97-7477-487b-8f92-61a3b5c9dd77

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
