### PR TITLE
[PM-11117] update autofill options to show different uri

### DIFF
--- a/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
+++ b/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
@@ -8,7 +8,7 @@
         <bit-label>
           {{ "website" | i18n }}
         </bit-label>
-        <input readonly bitInput type="text" [value]="login.launchUri" aria-readonly="true" />
+        <input readonly bitInput type="text" [value]="login.hostOrUri" aria-readonly="true" />
         <button
           bitIconButton="bwi-external-link"
           bitSuffix


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11117 Different URI](https://bitwarden.atlassian.net/browse/PM-11117)

## 📔 Objective

Changing the value of the input in `autofill options view` to show the user the `hostOrUri` value. This will not contain any website prefixes such as `http`, `https`, `ftp`

## 📸 Screenshots


![Screenshot 2024-08-19 at 4 39 38 PM](https://github.com/user-attachments/assets/641c938c-cf3a-44f1-8cb9-8fdfacfcfec5)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
