### PR TITLE
Move extension refresh swap function to libs so other clients can use it

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -9,6 +9,7 @@ import {
   unauthGuardFn,
 } from "@bitwarden/angular/auth/guards";
 import { canAccessFeature } from "@bitwarden/angular/platform/guard/feature-flag.guard";
+import { extensionRefreshSwap } from "@bitwarden/angular/utils/extension-refresh-swap";
 import {
   AnonLayoutWrapperComponent,
   AnonLayoutWrapperData,
@@ -91,7 +92,7 @@ import { SyncComponent } from "../vault/popup/settings/sync.component";
 import { VaultSettingsV2Component } from "../vault/popup/settings/vault-settings-v2.component";
 import { VaultSettingsComponent } from "../vault/popup/settings/vault-settings.component";
 
-import { extensionRefreshRedirect, extensionRefreshSwap } from "./extension-refresh-route-utils";
+import { extensionRefreshRedirect } from "./extension-refresh-route-utils";
 import { debounceNavigationGuard } from "./services/debounce-navigation.service";
 import { TabsV2Component } from "./tabs-v2.component";
 import { TabsComponent } from "./tabs.component";

--- a/apps/browser/src/popup/extension-refresh-route-utils.ts
+++ b/apps/browser/src/popup/extension-refresh-route-utils.ts
@@ -1,31 +1,8 @@
-import { inject, Type } from "@angular/core";
-import { Route, Router, Routes, UrlTree } from "@angular/router";
+import { inject } from "@angular/core";
+import { Router, UrlTree } from "@angular/router";
 
-import { componentRouteSwap } from "@bitwarden/angular/utils/component-route-swap";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-
-/**
- * Helper function to swap between two components based on the ExtensionRefresh feature flag.
- * @param defaultComponent - The current non-refreshed component to render.
- * @param refreshedComponent - The new refreshed component to render.
- * @param options - The shared route options to apply to both components.
- */
-export function extensionRefreshSwap(
-  defaultComponent: Type<any>,
-  refreshedComponent: Type<any>,
-  options: Route,
-): Routes {
-  return componentRouteSwap(
-    defaultComponent,
-    refreshedComponent,
-    async () => {
-      const configService = inject(ConfigService);
-      return configService.getFeatureFlag(FeatureFlag.ExtensionRefresh);
-    },
-    options,
-  );
-}
 
 /**
  * Helper function to redirect to a new URL based on the ExtensionRefresh feature flag.

--- a/libs/angular/src/utils/extension-refresh-swap.ts
+++ b/libs/angular/src/utils/extension-refresh-swap.ts
@@ -10,7 +10,8 @@ import { componentRouteSwap } from "./component-route-swap";
  * Helper function to swap between two components based on the ExtensionRefresh feature flag.
  * @param defaultComponent - The current non-refreshed component to render.
  * @param refreshedComponent - The new refreshed component to render.
- * @param options - The shared route options to apply to both components.
+ * @param options - The shared route options to apply to the default component, and to the alt component if altOptions is not provided.
+ * @param altOptions - The alt route options to apply to the alt component.
  */
 export function extensionRefreshSwap(
   defaultComponent: Type<any>,

--- a/libs/angular/src/utils/extension-refresh-swap.ts
+++ b/libs/angular/src/utils/extension-refresh-swap.ts
@@ -1,0 +1,31 @@
+import { Type, inject } from "@angular/core";
+import { Route, Routes } from "@angular/router";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+
+import { componentRouteSwap } from "./component-route-swap";
+
+/**
+ * Helper function to swap between two components based on the ExtensionRefresh feature flag.
+ * @param defaultComponent - The current non-refreshed component to render.
+ * @param refreshedComponent - The new refreshed component to render.
+ * @param options - The shared route options to apply to both components.
+ */
+export function extensionRefreshSwap(
+  defaultComponent: Type<any>,
+  refreshedComponent: Type<any>,
+  options: Route,
+  altOptions?: Route,
+): Routes {
+  return componentRouteSwap(
+    defaultComponent,
+    refreshedComponent,
+    async () => {
+      const configService = inject(ConfigService);
+      return configService.getFeatureFlag(FeatureFlag.ExtensionRefresh);
+    },
+    options,
+    altOptions,
+  );
+}


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a but blocks #10451 

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To move the extension refresh route swap utility function to be available to non-extension clients. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
