### PR TITLE
[PM-9673] Autofocus newly added input in the excluded domains view

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -78,8 +78,8 @@ export class AutofillComponent implements OnInit {
    * Default values set here are used in component state operations
    * until corresponding stored settings have loaded on init.
    */
-  protected canOverrideBrowserAutofillSetting = false;
-  protected defaultBrowserAutofillDisabled = false;
+  protected canOverrideBrowserAutofillSetting: boolean = false;
+  protected defaultBrowserAutofillDisabled: boolean = false;
   protected inlineMenuVisibility: InlineMenuVisibilitySetting =
     AutofillOverlayVisibility.OnFieldFocus;
   protected browserClientVendor: BrowserClientVendor = BrowserClientVendors.Unknown;
@@ -90,21 +90,21 @@ export class AutofillComponent implements OnInit {
   protected autofillOnPageLoadFromPolicy$ =
     this.autofillSettingsService.activateAutofillOnPageLoadFromPolicy$;
 
-  enableAutofillOnPageLoad = false;
-  enableInlineMenu = false;
-  enableInlineMenuOnIconSelect = false;
-  autofillOnPageLoadDefault = false;
+  enableAutofillOnPageLoad: boolean = false;
+  enableInlineMenu: boolean = false;
+  enableInlineMenuOnIconSelect: boolean = false;
+  autofillOnPageLoadDefault: boolean = false;
   autofillOnPageLoadOptions: { name: string; value: boolean }[];
-  enableContextMenuItem = false;
-  enableAutoTotpCopy = false;
+  enableContextMenuItem: boolean = false;
+  enableAutoTotpCopy: boolean = false;
   clearClipboard: ClearClipboardDelaySetting;
   clearClipboardOptions: { name: string; value: ClearClipboardDelaySetting }[];
   defaultUriMatch: UriMatchStrategySetting = UriMatchStrategy.Domain;
   uriMatchOptions: { name: string; value: UriMatchStrategySetting }[];
-  showCardsCurrentTab = true;
-  showIdentitiesCurrentTab = true;
+  showCardsCurrentTab: boolean = true;
+  showIdentitiesCurrentTab: boolean = true;
   autofillKeyboardHelperText: string;
-  accountSwitcherEnabled = false;
+  accountSwitcherEnabled: boolean = false;
 
   constructor(
     private i18nService: I18nService,

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
@@ -27,6 +27,7 @@
             }}</bit-label>
             <input
               *ngIf="i >= fieldsEditThreshold"
+              #uriInput
               appInputVerbatim
               bitInput
               id="excludedDomain{{ i }}"

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { QueryList, Component, ElementRef, OnDestroy, OnInit, ViewChildren } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Router, RouterModule } from "@angular/router";
 import { firstValueFrom } from "rxjs";
@@ -56,6 +56,8 @@ const BroadcasterSubscriptionId = "excludedDomainsState";
   ],
 })
 export class ExcludedDomainsComponent implements OnInit, OnDestroy {
+  @ViewChildren("uriInput") uriInputElements: QueryList<ElementRef<HTMLInputElement>>;
+
   accountSwitcherEnabled = false;
   dataIsPristine = true;
   excludedDomainsState: string[] = [];
@@ -84,10 +86,20 @@ export class ExcludedDomainsComponent implements OnInit, OnDestroy {
 
     // Do not allow the first x (pre-existing) fields to be edited
     this.fieldsEditThreshold = this.storedExcludedDomains.length;
+
+    this.uriInputElements.changes.subscribe(() => {
+      this.focusNewUriInput();
+    });
   }
 
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+  }
+
+  focusNewUriInput() {
+    if (this.uriInputElements?.last?.nativeElement) {
+      this.uriInputElements.last.nativeElement.focus();
+    }
   }
 
   async addNewDomain() {


### PR DESCRIPTION
## 🎟️ Tracking

PM-9673

## 📔 Objective

The updated excluded domains view in the browser client does not focus inputs when they are first created and should, as an a11y concern.

## 📸 Screenshots

https://github.com/user-attachments/assets/78b7cd62-ec11-4996-af4b-089b9ca8c4e2

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
