### PR TITLE
[PM-8316] Fix account switcher on logged out account on startup

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1234,18 +1234,6 @@ export default class MainBackground {
       );
     }
 
-    // If the user is logged out, switch to the next account
-    const active = await firstValueFrom(this.accountService.activeAccount$);
-    if (active == null) {
-      return;
-    }
-    const authStatus = await firstValueFrom(
-      this.authService.authStatuses$.pipe(map((statuses) => statuses[active.id])),
-    );
-    if (authStatus === AuthenticationStatus.LoggedOut) {
-      const nextUpAccount = await firstValueFrom(this.accountService.nextUpAccount$);
-      await this.switchAccount(nextUpAccount?.id);
-    }
     await this.initOverlayAndTabsBackground();
 
     return new Promise<void>((resolve) => {

--- a/apps/desktop/src/app/layout/account-switcher.component.ts
+++ b/apps/desktop/src/app/layout/account-switcher.component.ts
@@ -151,24 +151,6 @@ export class AccountSwitcherComponent {
     );
   }
 
-  async ngOnInit() {
-    const active = await firstValueFrom(this.accountService.activeAccount$);
-    if (active == null) {
-      return;
-    }
-    const authStatus = await firstValueFrom(
-      this.authService.authStatuses$.pipe(map((statuses) => statuses[active.id])),
-    );
-    if (authStatus === AuthenticationStatus.LoggedOut) {
-      const nextUpAccount = await firstValueFrom(this.accountService.nextUpAccount$);
-      if (nextUpAccount != null) {
-        await this.switch(nextUpAccount.id);
-      } else {
-        await this.addAccount();
-      }
-    }
-  }
-
   toggle() {
     this.isOpen = !this.isOpen;
   }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-8316

## 📔 Objective

Fix account switcher on desktop and browser. The active account on startup can be logged out (for an account with the vault timeout action logout).

On desktop, this PR adds a check on the account switcher init, that checks whether the account is logged out, and if so switches to the next account, so that the account switcher is never in a broken state.

On browser, this happens in the main.background, because otherwise the badge is in an incorrect state before opening the extension after launching the browser.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
