### PR TITLE
[PM-6727] Implement new `setUserKeys` function in `CryptoService`

### DIFF
--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -19,6 +19,12 @@ import { EncArrayBuffer } from "../models/domain/enc-array-buffer";
 import { EncString } from "../models/domain/enc-string";
 import { SymmetricCryptoKey } from "../models/domain/symmetric-crypto-key";
 
+export class UserPrivateKeyDecryptionFailedError extends Error {
+  constructor() {
+    super("Failed to decrypt the user's private key.");
+  }
+}
+
 /**
  * An object containing all the users key needed to decrypt a users personal and organization vaults.
  */
@@ -65,7 +71,8 @@ export abstract class CryptoService {
    * clears the decrypted private key from memory
    * Note: does not clear the private key if null is provided
    *
-   * @throws when userKey is null or if the userKey cannot decrtyp the private key
+   * @throws Error when userKey, encPrivateKey or userId is null
+   * @throws UserPrivateKeyDecryptionFailedError when the userKey cannot decrypt encPrivateKey
    * @param userKey The user key to set
    * @param encPrivateKey An encrypted private key
    * @param userId The desired user

--- a/libs/common/src/platform/abstractions/crypto.service.ts
+++ b/libs/common/src/platform/abstractions/crypto.service.ts
@@ -59,6 +59,19 @@ export abstract class CryptoService {
    */
   abstract setUserKey(key: UserKey, userId?: string): Promise<void>;
   /**
+   * Sets the provided user keys and stores any other necessary versions
+   * (such as auto, biometrics, or pin).
+   * Also sets the user's encrypted private key in storage and
+   * clears the decrypted private key from memory
+   * Note: does not clear the private key if null is provided
+   *
+   * @throws when userKey is null or if the userKey cannot decrtyp the private key
+   * @param userKey The user key to set
+   * @param encPrivateKey An encrypted private key
+   * @param userId The desired user
+   */
+  abstract setUserKeys(userKey: UserKey, encPrivateKey: string, userId: UserId): Promise<void>;
+  /**
    * Gets the user key from memory and sets it again,
    * kicking off a refresh of any additional keys
    * (such as auto, biometrics, or pin)

--- a/libs/common/src/platform/services/crypto.service.spec.ts
+++ b/libs/common/src/platform/services/crypto.service.spec.ts
@@ -20,6 +20,7 @@ import { OrganizationId, UserId } from "../../types/guid";
 import { UserKey, MasterKey } from "../../types/key";
 import { VaultTimeoutStringType } from "../../types/vault-timeout.type";
 import { CryptoFunctionService } from "../abstractions/crypto-function.service";
+import { UserPrivateKeyDecryptionFailedError } from "../abstractions/crypto.service";
 import { EncryptService } from "../abstractions/encrypt.service";
 import { KeyGenerationService } from "../abstractions/key-generation.service";
 import { LogService } from "../abstractions/log.service";
@@ -359,7 +360,7 @@ describe("cryptoService", () => {
 
       await expect(
         cryptoService.setUserKeys(mockUserKey, mockEncPrivateKey, mockUserId),
-      ).rejects.toThrow("Could not decrypt encPrivateKey with userKey.");
+      ).rejects.toThrow(UserPrivateKeyDecryptionFailedError);
     });
 
     // We already have tests for setUserKey, so we just need to test that the correct methods are called

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -38,6 +38,7 @@ import { CryptoFunctionService } from "../abstractions/crypto-function.service";
 import {
   CipherDecryptionKeys,
   CryptoService as CryptoServiceAbstraction,
+  UserPrivateKeyDecryptionFailedError,
 } from "../abstractions/crypto.service";
 import { EncryptService } from "../abstractions/encrypt.service";
 import { KeyGenerationService } from "../abstractions/key-generation.service";
@@ -121,7 +122,7 @@ export class CryptoService implements CryptoServiceAbstraction {
 
     const decryptedPrivateKey = await this.decryptPrivateKey(encPrivateKey, userKey);
     if (decryptedPrivateKey == null) {
-      throw new Error("Could not decrypt encPrivateKey with userKey.");
+      throw new UserPrivateKeyDecryptionFailedError();
     }
 
     await this.setUserKey(userKey, userId);

--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -104,6 +104,30 @@ export class CryptoService implements CryptoServiceAbstraction {
     await this.storeAdditionalKeys(key, userId);
   }
 
+  async setUserKeys(
+    userKey: UserKey,
+    encPrivateKey: EncryptedString,
+    userId: UserId,
+  ): Promise<void> {
+    if (userKey == null) {
+      throw new Error("No userKey provided. Lock the user to clear the key");
+    }
+    if (encPrivateKey == null) {
+      throw new Error("No encPrivateKey provided.");
+    }
+    if (userId == null) {
+      throw new Error("No userId provided.");
+    }
+
+    const decryptedPrivateKey = await this.decryptPrivateKey(encPrivateKey, userKey);
+    if (decryptedPrivateKey == null) {
+      throw new Error("Could not decrypt encPrivateKey with userKey.");
+    }
+
+    await this.setUserKey(userKey, userId);
+    await this.setPrivateKey(encPrivateKey, userId);
+  }
+
   async refreshAdditionalKeys(): Promise<void> {
     const activeUserId = await firstValueFrom(this.stateProvider.activeUserId$);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Add new function in `CryptoService` that sets both UserKey and UserPrivateKey and also verifies that the private key can actually be decrypted with the user key.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
