### PR TITLE
make sure to use offset and length of input buffer

### DIFF
--- a/libs/common/src/platform/services/fido2/fido2-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-utils.ts
@@ -4,7 +4,11 @@ export class Fido2Utils {
     if (bufferSource instanceof ArrayBuffer || bufferSource.buffer === undefined) {
       buffer = new Uint8Array(bufferSource as ArrayBuffer);
     } else {
-      buffer = new Uint8Array(bufferSource.buffer);
+      buffer = new Uint8Array(
+        bufferSource.buffer,
+        bufferSource.byteOffset,
+        bufferSource.byteLength,
+      );
     }
 
     return Fido2Utils.fromBufferToB64(buffer)


### PR DESCRIPTION
# 🎟️ Tracking

Fix for issue #8756 
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Works for test application and also for gandi.net as described in issue

## 📔 Objective

A TypedArray can view into a larger buffer so make sure to use byteOffset and byteLength properties when creating the new Uint8Array.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
