### PR TITLE
[CL-405] Allow toggle group input to be full width

### DIFF
--- a/libs/components/src/toggle-group/toggle-group.component.ts
+++ b/libs/components/src/toggle-group/toggle-group.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, HostBinding, Input, Output } from "@angular/core";
+import {
+  booleanAttribute,
+  Component,
+  EventEmitter,
+  HostBinding,
+  Input,
+  Output,
+} from "@angular/core";
 
 let nextId = 0;
 
@@ -11,11 +18,15 @@ export class ToggleGroupComponent<TValue = unknown> {
   private id = nextId++;
   name = `bit-toggle-group-${this.id}`;
 
+  @Input({ transform: booleanAttribute }) fullWidth?: boolean;
   @Input() selected?: TValue;
   @Output() selectedChange = new EventEmitter<TValue>();
 
   @HostBinding("attr.role") role = "radiogroup";
-  @HostBinding("class") classList = ["tw-flex"];
+  @HostBinding("class")
+  get classList() {
+    return ["tw-flex"].concat(this.fullWidth ? ["tw-w-full", "[&>*]:tw-grow"] : []);
+  }
 
   onInputInteraction(value: TValue) {
     this.selected = value;

--- a/libs/components/src/toggle-group/toggle-group.mdx
+++ b/libs/components/src/toggle-group/toggle-group.mdx
@@ -15,21 +15,34 @@ Toggle groups function as radio buttons and a radio group under the hood.
 A button in a toggle group can have a badge counter added to show the number of items existing
 within that filter.
 
+## Default
+
+<Canvas of={stories.Default} />
+
+<Controls />
+
+## Label wrap
+
 If the labels in a toggle group would overflow the width of the toggle group container, then the
 labels will wrap to 2 lines and truncate with an ellipsis past that. The full label text is
 accessible via the `title` prop (i.e. visible on hover).
 
-<Canvas>
-  <Story of={stories.Default} />
-</Canvas>
+<Canvas of={stories.LabelWrap} />
 
-<Canvas>
-  <Story of={stories.LabelWrap} />
-</Canvas>
+## Full width
 
-<Controls />
+If a toggle group should span the width of its container, pass the `fullWidth` input to the toggle
+group.
 
-## Accessibility
+```
+<bit-toggle-group fullWidth>
+...toggle components here...
+</bit-toggle-group>
+```
+
+<Canvas of={stories.FullWidth} />
+
+# Accessibility
 
 - Since only 1 button can be selected at a time, the toggle group acts similarly to a radio group.
 - The user may navigate the options via left/right arrow keys.

--- a/libs/components/src/toggle-group/toggle-group.stories.ts
+++ b/libs/components/src/toggle-group/toggle-group.stories.ts
@@ -74,3 +74,28 @@ export const LabelWrap: Story = {
     selected: "all",
   },
 };
+
+export const FullWidth: Story = {
+  render: (args) => ({
+    props: args,
+    template: /* HTML */ `
+      <bit-toggle-group
+        [(selected)]="selected"
+        aria-label="People list filter"
+        [fullWidth]="fullWidth"
+      >
+        <bit-toggle value="all"> All <span bitBadge variant="info">3</span> </bit-toggle>
+
+        <bit-toggle value="invited"> Invited </bit-toggle>
+
+        <bit-toggle value="accepted"> Accepted <span bitBadge variant="info">2</span> </bit-toggle>
+
+        <bit-toggle value="deactivated"> Deactivated </bit-toggle>
+      </bit-toggle-group>
+    `,
+  }),
+  args: {
+    selected: "all",
+    fullWidth: true,
+  },
+};

--- a/libs/components/src/toggle-group/toggle.component.ts
+++ b/libs/components/src/toggle-group/toggle.component.ts
@@ -50,8 +50,10 @@ export class ToggleComponent<TValue> implements AfterContentChecked {
   get labelClasses() {
     return [
       "tw-h-full",
+      "tw-w-full",
       "tw-flex",
       "tw-items-center",
+      "tw-justify-center",
       "tw-gap-1.5",
       "!tw-font-semibold",
       "tw-leading-5",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-405](https://bitwarden.atlassian.net/browse/CL-405)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the option for toggle groups to span the full width of their container. The default behavior remains the same (i.e. not spanning full width).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![Screenshot 2024-08-21 at 4 56 17 PM](https://github.com/user-attachments/assets/ba07ee60-8eb1-4fc1-9d72-9a72c2e212f4)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-405]: https://bitwarden.atlassian.net/browse/CL-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ