### PR TITLE
[SM-1141] migrate secrets manager toasts to CL toastService

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.ts
@@ -10,7 +10,7 @@ import {
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ProjectListView } from "../../models/view/project-list.view";
 import {
@@ -39,6 +39,7 @@ export class ProjectDeleteDialogComponent implements OnInit {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private dialogService: DialogService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -84,7 +85,11 @@ export class ProjectDeleteDialogComponent implements OnInit {
     }
 
     const message = this.data.projects.length === 1 ? "deleteProjectToast" : "deleteProjectsToast";
-    this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t(message),
+    });
   }
 
   openBulkStatusDialog(bulkStatusResults: BulkOperationStatus[]) {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.ts
@@ -5,7 +5,7 @@ import { Router } from "@angular/router";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { BitValidators } from "@bitwarden/components";
+import { BitValidators, ToastService } from "@bitwarden/components";
 
 import { ProjectView } from "../../models/view/project.view";
 import { ProjectService } from "../../projects/project.service";
@@ -41,6 +41,7 @@ export class ProjectDialogComponent implements OnInit {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private router: Router,
+    private toastService: ToastService,
   ) {}
 
   async ngOnInit() {
@@ -65,11 +66,11 @@ export class ProjectDialogComponent implements OnInit {
 
   submit = async () => {
     if (!this.data.organizationEnabled) {
-      this.platformUtilsService.showToast(
-        "error",
-        null,
-        this.i18nService.t("projectsCannotCreate"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("projectsCannotCreate"),
+      });
       return;
     }
 
@@ -92,13 +93,21 @@ export class ProjectDialogComponent implements OnInit {
 
   private async createProject(projectView: ProjectView) {
     const newProject = await this.projectService.create(this.data.organizationId, projectView);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("projectCreated"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("projectCreated"),
+    });
     return newProject;
   }
 
   private async updateProject(projectView: ProjectView) {
     await this.projectService.update(this.data.organizationId, projectView);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("projectSaved"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("projectSaved"),
+    });
   }
 
   private getProjectView() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/guards/project-access.guard.spec.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/guards/project-access.guard.spec.ts
@@ -7,7 +7,7 @@ import { MockProxy, mock } from "jest-mock-extended";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { RouterService } from "../../../../../../../apps/web/src/app/core/router.service";
 import { ProjectView } from "../../models/view/project.view";
@@ -30,7 +30,7 @@ describe("Project Redirect Guard", () => {
   let routerService: MockProxy<RouterService>;
   let projectServiceMock: MockProxy<ProjectService>;
   let i18nServiceMock: MockProxy<I18nService>;
-  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let toastService: MockProxy<ToastService>;
   let router: Router;
 
   const smOrg1 = { id: "123", canAccessSecretsManager: true } as Organization;
@@ -49,7 +49,7 @@ describe("Project Redirect Guard", () => {
     routerService = mock<RouterService>();
     projectServiceMock = mock<ProjectService>();
     i18nServiceMock = mock<I18nService>();
-    platformUtilsService = mock<PlatformUtilsService>();
+    toastService = mock<ToastService>();
 
     TestBed.configureTestingModule({
       imports: [
@@ -74,7 +74,7 @@ describe("Project Redirect Guard", () => {
         { provide: RouterService, useValue: routerService },
         { provide: ProjectService, useValue: projectServiceMock },
         { provide: I18nService, useValue: i18nServiceMock },
-        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: ToastService, useValue: toastService },
       ],
     });
 
@@ -114,7 +114,11 @@ describe("Project Redirect Guard", () => {
     // Act
     await router.navigateByUrl("sm/123/projects/123");
     // Assert
-    expect(platformUtilsService.showToast).toHaveBeenCalledWith("error", null, "Project not found");
+    expect(toastService.showToast).toHaveBeenCalledWith({
+      variant: "error",
+      title: null,
+      message: "Project not found",
+    });
     expect(router.url).toBe("/sm/123/projects");
   });
 });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/guards/project-access.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/guards/project-access.guard.ts
@@ -2,7 +2,7 @@ import { inject } from "@angular/core";
 import { ActivatedRouteSnapshot, CanActivateFn, createUrlTreeFromSnapshot } from "@angular/router";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { ProjectService } from "../project.service";
 
@@ -11,7 +11,7 @@ import { ProjectService } from "../project.service";
  */
 export const projectAccessGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
   const projectService = inject(ProjectService);
-  const platformUtilsService = inject(PlatformUtilsService);
+  const toastService = inject(ToastService);
   const i18nService = inject(I18nService);
 
   try {
@@ -20,11 +20,11 @@ export const projectAccessGuard: CanActivateFn = async (route: ActivatedRouteSna
       return true;
     }
   } catch {
-    platformUtilsService.showToast(
-      "error",
-      null,
-      i18nService.t("notFound", i18nService.t("project")),
-    );
+    toastService.showToast({
+      variant: "error",
+      title: null,
+      message: i18nService.t("notFound", i18nService.t("project")),
+    });
     return createUrlTreeFromSnapshot(route, ["/sm", route.params.organizationId, "projects"]);
   }
   return createUrlTreeFromSnapshot(route, ["/sm", route.params.organizationId, "projects"]);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
@@ -7,7 +7,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { AccessPolicySelectorService } from "../../shared/access-policies/access-policy-selector/access-policy-selector.service";
 import {
@@ -73,6 +73,7 @@ export class ProjectPeopleComponent implements OnInit, OnDestroy {
     private i18nService: I18nService,
     private accessPolicySelectorService: AccessPolicySelectorService,
     private logService: LogService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -129,11 +130,11 @@ export class ProjectPeopleComponent implements OnInit, OnDestroy {
       if (showAccessRemovalWarning) {
         await this.router.navigate(["sm", this.organizationId, "projects"]);
       }
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("projectAccessUpdated"),
-      );
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("projectAccessUpdated"),
+      });
     } catch (e) {
       this.validationService.showError(e);
       this.setSelected(this.currentAccessPolicies);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-service-accounts.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-service-accounts.component.ts
@@ -6,6 +6,7 @@ import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { ToastService } from "@bitwarden/components";
 
 import { ProjectServiceAccountsAccessPoliciesView } from "../../models/view/access-policies/project-service-accounts-access-policies.view";
 import {
@@ -64,6 +65,7 @@ export class ProjectServiceAccountsComponent implements OnInit, OnDestroy {
     private accessPolicyService: AccessPolicyService,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -104,11 +106,11 @@ export class ProjectServiceAccountsComponent implements OnInit, OnDestroy {
       this.items = this.getItems(this.potentialGrantees, updatedView);
       this.setSelected(updatedView);
 
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("projectAccessUpdated"),
-      );
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("projectAccessUpdated"),
+      });
     } catch (e) {
       this.validationService.showError(e);
       this.setSelected(this.currentAccessPolicies);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-delete.component.ts
@@ -3,7 +3,7 @@ import { Component, Inject } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { SecretListView } from "../../models/view/secret-list.view";
 import {
@@ -28,6 +28,7 @@ export class SecretDeleteDialogComponent {
     private platformUtilsService: PlatformUtilsService,
     @Inject(DIALOG_DATA) private data: SecretDeleteOperation,
     private dialogService: DialogService,
+    private toastService: ToastService,
   ) {}
 
   showSoftDeleteSecretWarning = this.data.secrets.length === 1;
@@ -51,7 +52,11 @@ export class SecretDeleteDialogComponent {
 
     const message =
       this.data.secrets.length === 1 ? "softDeleteSuccessToast" : "softDeletesSuccessToast";
-    this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t(message),
+    });
 
     this.dialogRef.close(true);
   };

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -7,7 +7,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { DialogService, BitValidators } from "@bitwarden/components";
+import { DialogService, BitValidators, ToastService } from "@bitwarden/components";
 
 import { SecretAccessPoliciesView } from "../../models/view/access-policies/secret-access-policies.view";
 import { ProjectListView } from "../../models/view/project-list.view";
@@ -97,6 +97,7 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     private organizationService: OrganizationService,
     private accessPolicyService: AccessPolicyService,
     private accessPolicySelectorService: AccessPolicySelectorService,
+    private toastService: ToastService,
   ) {}
 
   get title() {
@@ -139,7 +140,11 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
 
   submit = async () => {
     if (!this.data.organizationEnabled) {
-      this.platformUtilsService.showToast("error", null, this.i18nService.t("secretsCannotCreate"));
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("secretsCannotCreate"),
+      });
       return;
     }
 
@@ -318,7 +323,11 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     secretAccessPoliciesView: SecretAccessPoliciesView,
   ) {
     await this.secretService.create(this.data.organizationId, secretView, secretAccessPoliciesView);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("secretCreated"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("secretCreated"),
+    });
   }
 
   private getNewProjectView() {
@@ -333,7 +342,11 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     secretAccessPoliciesView: SecretAccessPoliciesView,
   ) {
     await this.secretService.update(this.data.organizationId, secretView, secretAccessPoliciesView);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("secretEdited"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("secretEdited"),
+    });
   }
 
   private getSecretView() {
@@ -417,11 +430,14 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     this.formGroup.markAllAsTouched();
 
     if (this.formGroup.invalid && this.tabIndex !== SecretDialogTabType.NameValuePair) {
-      this.platformUtilsService.showToast(
-        "error",
-        null,
-        this.i18nService.t("fieldOnTabRequiresAttention", this.i18nService.t("nameValuePair")),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t(
+          "fieldOnTabRequiresAttention",
+          this.i18nService.t("nameValuePair"),
+        ),
+      });
     }
 
     return this.formGroup.invalid;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-tokens.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-tokens.component.ts
@@ -12,7 +12,7 @@ import {
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { openUserVerificationPrompt } from "@bitwarden/web-vault/app/auth/shared/components/user-verification";
 
 import { ServiceAccountView } from "../../models/view/service-account.view";
@@ -39,6 +39,7 @@ export class AccessTokenComponent implements OnInit, OnDestroy {
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
     private serviceAccountService: ServiceAccountService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit() {
@@ -74,11 +75,11 @@ export class AccessTokenComponent implements OnInit, OnDestroy {
 
   protected async revoke(tokens: AccessTokenView[]) {
     if (!tokens?.length) {
-      this.platformUtilsService.showToast(
-        "error",
-        null,
-        this.i18nService.t("noAccessTokenSelected"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("noAccessTokenSelected"),
+      });
       return;
     }
 
@@ -91,7 +92,11 @@ export class AccessTokenComponent implements OnInit, OnDestroy {
       tokens.map((t) => t.id),
     );
 
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("accessTokenRevoked"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("accessTokenRevoked"),
+    });
   }
 
   protected openNewAccessTokenDialog() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.ts
@@ -10,7 +10,7 @@ import {
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ServiceAccountView } from "../../models/view/service-account.view";
 import {
@@ -39,6 +39,7 @@ export class ServiceAccountDeleteDialogComponent {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private dialogService: DialogService,
+    private toastService: ToastService,
   ) {}
 
   get title() {
@@ -81,7 +82,11 @@ export class ServiceAccountDeleteDialogComponent {
       this.data.serviceAccounts.length === 1
         ? "deleteMachineAccountToast"
         : "deleteMachineAccountsToast";
-    this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t(message),
+    });
   }
 
   openBulkStatusDialog(bulkStatusResults: BulkOperationStatus[]) {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.ts
@@ -4,7 +4,7 @@ import { FormControl, FormGroup, Validators } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { BitValidators } from "@bitwarden/components";
+import { BitValidators, ToastService } from "@bitwarden/components";
 
 import { ServiceAccountView } from "../../models/view/service-account.view";
 import { ServiceAccountService } from "../service-account.service";
@@ -43,6 +43,7 @@ export class ServiceAccountDialogComponent implements OnInit {
     private serviceAccountService: ServiceAccountService,
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
+    private toastService: ToastService,
   ) {}
 
   async ngOnInit() {
@@ -64,11 +65,11 @@ export class ServiceAccountDialogComponent implements OnInit {
 
   submit = async () => {
     if (!this.data.organizationEnabled) {
-      this.platformUtilsService.showToast(
-        "error",
-        null,
-        this.i18nService.t("machineAccountsCannotCreate"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("machineAccountsCannotCreate"),
+      });
       return;
     }
 
@@ -93,7 +94,11 @@ export class ServiceAccountDialogComponent implements OnInit {
       serviceAccountMessage = this.i18nService.t("machineAccountUpdated");
     }
 
-    this.platformUtilsService.showToast("success", null, serviceAccountMessage);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: serviceAccountMessage,
+    });
     this.dialogRef.close();
   };
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/guards/service-account-access.guard.spec.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/guards/service-account-access.guard.spec.ts
@@ -7,7 +7,7 @@ import { MockProxy, mock } from "jest-mock-extended";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { RouterService } from "../../../../../../../../clients/apps/web/src/app/core/router.service";
 import { ServiceAccountView } from "../../models/view/service-account.view";
@@ -30,7 +30,7 @@ describe("Service account Redirect Guard", () => {
   let routerService: MockProxy<RouterService>;
   let serviceAccountServiceMock: MockProxy<ServiceAccountService>;
   let i18nServiceMock: MockProxy<I18nService>;
-  let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let toastService: MockProxy<ToastService>;
   let router: Router;
 
   const smOrg1 = { id: "123", canAccessSecretsManager: true } as Organization;
@@ -45,7 +45,7 @@ describe("Service account Redirect Guard", () => {
     routerService = mock<RouterService>();
     serviceAccountServiceMock = mock<ServiceAccountService>();
     i18nServiceMock = mock<I18nService>();
-    platformUtilsService = mock<PlatformUtilsService>();
+    toastService = mock<ToastService>();
 
     TestBed.configureTestingModule({
       imports: [
@@ -70,7 +70,7 @@ describe("Service account Redirect Guard", () => {
         { provide: RouterService, useValue: routerService },
         { provide: ServiceAccountService, useValue: serviceAccountServiceMock },
         { provide: I18nService, useValue: i18nServiceMock },
-        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: ToastService, useValue: toastService },
       ],
     });
 
@@ -112,11 +112,11 @@ describe("Service account Redirect Guard", () => {
     // Act
     await router.navigateByUrl("sm/123/machine-accounts/123");
     // Assert
-    expect(platformUtilsService.showToast).toHaveBeenCalledWith(
-      "error",
-      null,
-      "Service account not found",
-    );
+    expect(toastService.showToast).toHaveBeenCalledWith({
+      variant: "error",
+      title: null,
+      message: "Service account not found",
+    });
     expect(router.url).toBe("/sm/123/machine-accounts");
   });
 });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/guards/service-account-access.guard.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/guards/service-account-access.guard.ts
@@ -2,7 +2,7 @@ import { inject } from "@angular/core";
 import { ActivatedRouteSnapshot, CanActivateFn, createUrlTreeFromSnapshot } from "@angular/router";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { ServiceAccountService } from "../service-account.service";
 
@@ -11,7 +11,7 @@ import { ServiceAccountService } from "../service-account.service";
  */
 export const serviceAccountAccessGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
   const serviceAccountService = inject(ServiceAccountService);
-  const platformUtilsService = inject(PlatformUtilsService);
+  const toastService = inject(ToastService);
   const i18nService = inject(I18nService);
 
   try {
@@ -23,11 +23,11 @@ export const serviceAccountAccessGuard: CanActivateFn = async (route: ActivatedR
       return true;
     }
   } catch {
-    platformUtilsService.showToast(
-      "error",
-      null,
-      i18nService.t("notFound", i18nService.t("machineAccount")),
-    );
+    toastService.showToast({
+      variant: "error",
+      title: null,
+      message: i18nService.t("notFound", i18nService.t("machineAccount")),
+    });
 
     return createUrlTreeFromSnapshot(route, [
       "/sm",

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/people/service-account-people.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/people/service-account-people.component.ts
@@ -6,7 +6,7 @@ import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ServiceAccountPeopleAccessPoliciesView } from "../../models/view/access-policies/service-account-people-access-policies.view";
 import { AccessPolicySelectorService } from "../../shared/access-policies/access-policy-selector/access-policy-selector.service";
@@ -71,6 +71,7 @@ export class ServiceAccountPeopleComponent implements OnInit, OnDestroy {
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
     private accessPolicySelectorService: AccessPolicySelectorService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -126,11 +127,11 @@ export class ServiceAccountPeopleComponent implements OnInit, OnDestroy {
 
       this.currentAccessPolicies = convertToAccessPolicyItemViews(peoplePoliciesViews);
 
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("machineAccountAccessUpdated"),
-      );
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("machineAccountAccessUpdated"),
+      });
     } catch (e) {
       this.validationService.showError(e);
       this.setSelected(this.currentAccessPolicies);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/projects/service-account-projects.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/projects/service-account-projects.component.ts
@@ -6,6 +6,7 @@ import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { ToastService } from "@bitwarden/components";
 
 import { ServiceAccountGrantedPoliciesView } from "../../models/view/access-policies/service-account-granted-policies.view";
 import {
@@ -63,6 +64,7 @@ export class ServiceAccountProjectsComponent implements OnInit, OnDestroy {
     private accessPolicyService: AccessPolicyService,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -103,11 +105,11 @@ export class ServiceAccountProjectsComponent implements OnInit, OnDestroy {
 
       this.currentAccessPolicies = convertGrantedPoliciesToAccessPolicyItemViews(grantedViews);
 
-      this.platformUtilsService.showToast(
-        "success",
-        null,
-        this.i18nService.t("serviceAccountAccessUpdated"),
-      );
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("serviceAccountAccessUpdated"),
+      });
     } catch (e) {
       this.validationService.showError(e);
       this.setSelected(this.currentAccessPolicies);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
@@ -4,7 +4,7 @@ import { Subject, takeUntil } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { TableDataSource } from "@bitwarden/components";
+import { TableDataSource, ToastService } from "@bitwarden/components";
 
 import {
   ServiceAccountSecretsDetailsView,
@@ -47,6 +47,7 @@ export class ServiceAccountsListComponent implements OnDestroy {
   constructor(
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
+    private toastService: ToastService,
   ) {
     this.selection.changed
       .pipe(takeUntil(this.destroy$))
@@ -85,11 +86,11 @@ export class ServiceAccountsListComponent implements OnDestroy {
         this.serviceAccounts.filter((sa) => this.selection.isSelected(sa.id)),
       );
     } else {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        this.i18nService.t("nothingSelected"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("nothingSelected"),
+      });
     }
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.ts
@@ -8,7 +8,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { openUserVerificationPrompt } from "@bitwarden/web-vault/app/auth/shared/components/user-verification";
 
 import { SecretsManagerPortingApiService } from "../services/sm-porting-api.service";
@@ -44,6 +44,7 @@ export class SecretsManagerExportComponent implements OnInit, OnDestroy {
     private logService: LogService,
     private dialogService: DialogService,
     private secretsManagerApiService: SecretsManagerPortingApiService,
+    private toastService: ToastService,
   ) {}
 
   async ngOnInit() {
@@ -85,7 +86,11 @@ export class SecretsManagerExportComponent implements OnInit, OnDestroy {
     const exportData = await this.secretsManagerApiService.export(this.orgId);
 
     await this.downloadFile(exportData, fileExtension);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t("dataExportSuccess"));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("dataExportSuccess"),
+    });
   }
 
   private async downloadFile(data: string, format: string) {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
@@ -4,7 +4,7 @@ import { map } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { TableDataSource } from "@bitwarden/components";
+import { TableDataSource, ToastService } from "@bitwarden/components";
 
 import { ProjectListView } from "../models/view/project-list.view";
 
@@ -43,6 +43,7 @@ export class ProjectsListComponent {
   constructor(
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
+    private toastService: ToastService,
   ) {}
 
   isAllSelected() {
@@ -72,11 +73,11 @@ export class ProjectsListComponent {
         this.projects.filter((project) => this.selection.isSelected(project.id)),
       );
     } else {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        this.i18nService.t("nothingSelected"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("nothingSelected"),
+      });
     }
   }
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
@@ -5,7 +5,7 @@ import { Subject, takeUntil } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { TableDataSource } from "@bitwarden/components";
+import { TableDataSource, ToastService } from "@bitwarden/components";
 
 import { SecretListView } from "../models/view/secret-list.view";
 import { SecretService } from "../secrets/secret.service";
@@ -53,6 +53,7 @@ export class SecretsListComponent implements OnDestroy {
   constructor(
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
+    private toastService: ToastService,
   ) {
     this.selection.changed
       .pipe(takeUntil(this.destroy$))
@@ -87,11 +88,11 @@ export class SecretsListComponent implements OnDestroy {
         this.secrets.filter((secret) => this.selection.isSelected(secret.id)),
       );
     } else {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        this.i18nService.t("nothingSelected"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("nothingSelected"),
+      });
     }
   }
 
@@ -99,11 +100,11 @@ export class SecretsListComponent implements OnDestroy {
     if (this.selection.selected.length >= 1) {
       this.restoreSecretsEvent.emit(this.selection.selected);
     } else {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        this.i18nService.t("nothingSelected"),
-      );
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("nothingSelected"),
+      });
     }
   }
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-hard-delete.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-hard-delete.component.ts
@@ -3,6 +3,7 @@ import { Component, Inject } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { SecretService } from "../../secrets/secret.service";
 
@@ -21,6 +22,7 @@ export class SecretHardDeleteDialogComponent {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     @Inject(DIALOG_DATA) public data: SecretHardDeleteOperation,
+    private toastService: ToastService,
   ) {}
 
   get title() {
@@ -36,6 +38,10 @@ export class SecretHardDeleteDialogComponent {
     const message =
       this.data.secretIds.length === 1 ? "hardDeleteSuccessToast" : "hardDeletesSuccessToast";
     this.dialogRef.close(this.data.secretIds);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t(message),
+    });
   };
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-restore.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/trash/dialog/secret-restore.component.ts
@@ -3,6 +3,7 @@ import { Component, Inject } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ToastService } from "@bitwarden/components";
 
 import { SecretService } from "../../secrets/secret.service";
 
@@ -21,6 +22,7 @@ export class SecretRestoreDialogComponent {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     @Inject(DIALOG_DATA) public data: SecretRestoreOperation,
+    private toastService: ToastService,
   ) {}
 
   get title() {
@@ -35,6 +37,10 @@ export class SecretRestoreDialogComponent {
         ? "secretRestoredSuccessToast"
         : "secretsRestoredSuccessToast";
     this.dialogRef.close(this.data.secretIds);
-    this.platformUtilsService.showToast("success", null, this.i18nService.t(message));
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t(message),
+    });
   };
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SM-1141
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR migrates all secrets manager toasts to the new CL toastService

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
