### PR TITLE
[PM-11295] Add image preview for sends

### DIFF
--- a/apps/web/src/app/tools/send/access.component.html
+++ b/apps/web/src/app/tools/send/access.component.html
@@ -18,6 +18,7 @@
     </bit-callout>
     <div
       class="tw-mt-3 tw-w-10/12 tw-rounded-md tw-border tw-border-solid tw-border-secondary-300 tw-bg-background tw-p-6"
+      [style]="'width: max-content'"
     >
       <ng-container *ngIf="!loading; else spinner">
         <app-send-access-password

--- a/apps/web/src/app/tools/send/send-access-file.component.html
+++ b/apps/web/src/app/tools/send/send-access-file.component.html
@@ -1,4 +1,5 @@
 <p>{{ send.file.fileName }}</p>
+<img [src]="imageUrl" alt="" [style]="'max-width: 1000px; margin-bottom: 20px;'" *ngIf="imageUrl" />
 <button bitButton type="button" buttonType="primary" [bitAction]="download" [block]="true">
   <i class="bwi bwi-download" aria-hidden="true"></i>
   {{ "downloadAttachments" | i18n }} ({{ send.file.sizeName }})

--- a/apps/web/src/app/tools/send/send-access-file.component.ts
+++ b/apps/web/src/app/tools/send/send-access-file.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 import { DomSanitizer, SafeUrl } from "@angular/platform-browser";
 
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
@@ -24,7 +24,6 @@ export class SendAccessFileComponent implements OnInit {
   @Input() send: SendAccessView;
   @Input() decKey: SymmetricCryptoKey;
   @Input() accessRequest: SendAccessRequest;
-  @Output() preview = new EventEmitter<void>();
 
   imageFileExtensions = ["jpg", "jpeg", "png", "avif"];
   imageMimeTypes = {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11295

## 📔 Objective

Add image preview to bitwarden sends for jpeg, png, avif, when the send is under 10 MiB.


## 📸 Screenshots


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
