### PR TITLE
[PM-10993] Browser Refresh - Fix duplicate password generation emissions in Firefox

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.spec.ts
@@ -126,15 +126,22 @@ describe("CipherFormGeneratorComponent", () => {
       expect(fixture.nativeElement.querySelector("bit-toggle-group")).toBeTruthy();
     });
 
-    it("should save password options when the password type is updated", async () => {
-      mockLegacyPasswordGenerationService.generatePassword.mockResolvedValue("generated-password");
+    it("should update the generated value when the password type is updated", fakeAsync(async () => {
+      mockLegacyPasswordGenerationService.generatePassword
+        .mockResolvedValueOnce("first-password")
+        .mockResolvedValueOnce("second-password");
+
+      component.ngOnChanges();
+      tick();
+
+      expect(component["generatedValue"]).toBe("first-password");
 
       await component["updatePasswordType"]("passphrase");
+      tick();
 
-      expect(mockLegacyPasswordGenerationService.saveOptions).toHaveBeenCalledWith({
-        type: "passphrase",
-      });
-    });
+      expect(component["generatedValue"]).toBe("second-password");
+      expect(mockLegacyPasswordGenerationService.generatePassword).toHaveBeenCalledTimes(2);
+    }));
 
     it("should update the password history when a new password is generated", fakeAsync(() => {
       mockLegacyPasswordGenerationService.generatePassword.mockResolvedValue("new-password");


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10993](https://bitwarden.atlassian.net/browse/PM-10993)

## 📔 Objective

The legacy password generation service implementation causes the state to be modified multiple times with a single save call. The upcoming replacement services from Tools will better support our use case here. So for now, I'm removing the call to save the password type option to the users settings in state. This avoids the multiple calls to update state and thus the repeated emissions (some outside of NgZone) that was causing unexpected behaviors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10993]: https://bitwarden.atlassian.net/browse/PM-10993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ