### PR TITLE
[PM-11314] Fix system auth typo 'autometic' -> 'automatic'

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1817,7 +1817,7 @@
     "message": "Browser biometrics requires desktop biometrics to be set up in the settings first."
   },
   "biometricsManualSetupTitle": {
-    "message": "Autometic setup not available"
+    "message": "Automatic setup not available"
   },
   "biometricsManualSetupDesc": {
     "message": "Due to the installation method, biometrics support could not be automatically enabled. Would you like to open the documentation on how to do this manually?"


### PR DESCRIPTION
## 🎟️ Tracking

I suppose this change is relevant to:

https://bitwarden.atlassian.net/browse/PM-990

as it's a follow up to:
- https://github.com/bitwarden/clients/pull/4586

## 📔 Objective

Trying to fix this `autometic` typo by updating it to `automatic`.

## 📸 Screenshots

Location of the typo is this modal that currently appears when toggling `Unlock with system authentication` on my Flatpak installation on my Fedora system.

![Screenshot from 2024-08-24 09-38-00](https://github.com/user-attachments/assets/40204926-ac2a-4191-a78b-4485aefe2aa4)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
