### PR TITLE
[PM-11329] [chore] Add "otp" TotpFieldNames array in autofill-constants.ts

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -38,6 +38,7 @@ export class AutoFillConstants {
     "mfacode",
     "otc",
     "otc-code",
+    "otp",
     "otp-code",
     "otpcode",
     "pin",


### PR DESCRIPTION
Add "otp" TotpFieldNames array in autofill-constants.ts. Noticed on https://id.fedoraproject.org/login/

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add "otp" TotpFieldNames array in autofill-constants.ts. Noticed on https://id.fedoraproject.org/login/

As an aside, has a custom "linked" field been considered here like with passwords? I noticed at least [one request](https://community.bitwarden.com/t/allow-custom-field-names-for-totp-autofill/62103
) on the forum, but couldn't find much here with a search.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
