### PR TITLE
[PM-11332] Prevent dead object error in Firefox due to timing issue

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -370,8 +370,6 @@ export default class AutofillService implements AutofillServiceInterface {
 
         didAutofill = true;
         if (!options.skipLastUsed) {
-          // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           await this.cipherService.updateLastUsedDate(options.cipher.id);
         }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -372,7 +372,7 @@ export default class AutofillService implements AutofillServiceInterface {
         if (!options.skipLastUsed) {
           // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.cipherService.updateLastUsedDate(options.cipher.id);
+          await this.cipherService.updateLastUsedDate(options.cipher.id);
         }
 
         // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -212,7 +212,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
       }
       if (BrowserPopupUtils.inPopup(window)) {
         if (!closePopupDelay) {
-          if (this.platformUtilsService.isFirefox() || this.platformUtilsService.isSafari()) {
+          if (this.platformUtilsService.isSafari()) {
             BrowserApi.closePopup(window);
           } else {
             // Slight delay to fix bug in Chromium browsers where popup closes without copying totp to clipboard

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -212,7 +212,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
       }
       if (BrowserPopupUtils.inPopup(window)) {
         if (!closePopupDelay) {
-          if (this.platformUtilsService.isSafari()) {
+          if (this.platformUtilsService.isFirefox() || this.platformUtilsService.isSafari()) {
             BrowserApi.closePopup(window);
           } else {
             // Slight delay to fix bug in Chromium browsers where popup closes without copying totp to clipboard


### PR DESCRIPTION
## 🎟️ Tracking
(https://github.com/bitwarden/clients/issues/10475)

## 📔 Objective

Firefox disallows add-ons to keep strong references to DOM objects after their parent document (the popup in this case) has been destroyed. The result is a "TypeError: can't access dead object", which prevents successfully calling updateLastUsedDate() to move the selected cipher to the top of the list. A similar issue with totp copy is resolved in https://github.com/bitwarden/clients/pull/2067, but has an exclusion for Firefox. Removing Firefox from that exclusion stops the issue.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
