### PR TITLE
[PM-11126] Do Not Show PW Toggle or Copy Unless User Can View PW

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -37,6 +37,7 @@
         data-testid="login-password"
       />
       <button
+        *ngIf="cipher.viewPassword"
         bitSuffix
         type="button"
         bitIconButton
@@ -55,6 +56,7 @@
         (click)="togglePasswordCount()"
       ></button>
       <button
+        *ngIf="cipher.viewPassword"
         bitIconButton="bwi-clone"
         bitSuffix
         type="button"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11126](https://bitwarden.atlassian.net/browse/PM-11126)

## 📔 Objective

Do not show the `copy` or `toggle` icons in `login-credentials` unless user has `viewPassword` set to true

## 📸 Screen Recording

https://github.com/user-attachments/assets/e6de0274-1511-4567-a3e5-bb52592827eb

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11126]: https://bitwarden.atlassian.net/browse/PM-11126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ