### PR TITLE
[PM-11118] adjust hover cursor styles for TOTP buttons

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -92,7 +92,7 @@
           *ngIf="!(isPremium$ | async)"
           bitBadge
           variant="success"
-          class="tw-ml-2"
+          class="tw-ml-2 tw-cursor-pointer"
           (click)="getPremium()"
           slot="end"
         >
@@ -115,6 +115,7 @@
         bitSuffix
         type="button"
         (sendCopyCode)="setTotpCopyCode($event)"
+        class="tw-cursor-default"
       ></button>
       <button
         bitIconButton="bwi-clone"
@@ -126,6 +127,7 @@
         [appA11yTitle]="'copyValue' | i18n"
         data-testid="copy-totp"
         [disabled]="!(isPremium$ | async)"
+        class="disabled:tw-cursor-default"
       ></button>
     </bit-form-field>
   </bit-card>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10987 remove hover on copy for non premium users](https://bitwarden.atlassian.net/browse/PM-10987)
[PM-11118 remove hover for TOTP countdown](https://bitwarden.atlassian.net/browse/PM-11118)

## 📔 Objective

Free users could see the TOTP input as hidden, their copy button should be disabled with no hover, and the premium badge should be clickable
Premium users should see the TOTP countdown but it should not show a `cursor-pointer` when hovered 

## 📸 Screen Recording

https://github.com/user-attachments/assets/1b573ff1-afd4-42f0-a7ba-ece93d4e2b50

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
