### PR TITLE
[CL-330] close select overlay on scroll

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -14,6 +14,7 @@
   <div
     class="tw-max-w-screen-sm tw-mx-auto tw-overflow-y-auto tw-flex tw-flex-col tw-w-full tw-h-full"
     (scroll)="handleScroll($event)"
+    cdkScrollable
     [ngClass]="{ 'tw-invisible': loading }"
   >
     <div

--- a/apps/browser/src/platform/popup/layout/popup-page.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.ts
@@ -1,3 +1,4 @@
+import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
 import { booleanAttribute, Component, inject, Input, signal } from "@angular/core";
 
@@ -10,7 +11,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
   host: {
     class: "tw-h-full tw-flex tw-flex-col tw-flex-1 tw-overflow-y-hidden",
   },
-  imports: [CommonModule],
+  imports: [CommonModule, ScrollingModule],
 })
 export class PopupPageComponent {
   protected i18nService = inject(I18nService);

--- a/libs/components/src/multi-select/multi-select.component.ts
+++ b/libs/components/src/multi-select/multi-select.component.ts
@@ -2,13 +2,16 @@ import { hasModifierKey } from "@angular/cdk/keycodes";
 import {
   Component,
   Input,
-  OnInit,
   Output,
   ViewChild,
   EventEmitter,
   HostBinding,
   Optional,
   Self,
+  inject,
+  DestroyRef,
+  AfterViewInit,
+  OnInit,
 } from "@angular/core";
 import { ControlValueAccessor, NgControl, Validators } from "@angular/forms";
 import { NgSelectComponent } from "@ng-select/ng-select";
@@ -16,6 +19,7 @@ import { NgSelectComponent } from "@ng-select/ng-select";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { BitFormFieldControl } from "../form-field/form-field-control";
+import { SelectScrollStrategy } from "../select";
 
 import { SelectItemView } from "./models/select-item-view";
 
@@ -30,7 +34,12 @@ let nextId = 0;
 /**
  * This component has been implemented to only support Multi-select list events
  */
-export class MultiSelectComponent implements OnInit, BitFormFieldControl, ControlValueAccessor {
+export class MultiSelectComponent
+  implements OnInit, AfterViewInit, BitFormFieldControl, ControlValueAccessor
+{
+  private scrollStrategy = inject(SelectScrollStrategy);
+  private destroyRef = inject(DestroyRef);
+
   @ViewChild(NgSelectComponent) select: NgSelectComponent;
 
   // Parent component should only pass selectable items (complete list - selected items = baseItems)
@@ -69,6 +78,10 @@ export class MultiSelectComponent implements OnInit, BitFormFieldControl, Contro
     // Default Text Values
     this.placeholder = this.placeholder ?? this.i18nService.t("multiSelectPlaceholder");
     this.loadingText = this.i18nService.t("multiSelectLoading");
+  }
+
+  ngAfterViewInit(): void {
+    this.scrollStrategy.closeOnScroll(this.select, this.destroyRef);
   }
 
   /** Function for customizing keyboard navigation */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-330

## 📔 Objective

Close select overlays when an ancestor is scrolled. Temporary workaround for https://github.com/ng-select/ng-select/issues/1130.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
