### PR TITLE
[PM-11417] Customers' Expiration Date in Admin Console changing to next invoice date when Pending Invoice items exist.

### DIFF
--- a/apps/web/src/app/auth/trial-initiation/trial-initiation.component.html
+++ b/apps/web/src/app/auth/trial-initiation/trial-initiation.component.html
@@ -91,12 +91,16 @@
                   bitButton
                   buttonType="primary"
                   [disabled]="orgInfoFormGroup.get('name').invalid"
-                  cdkStepperNext
+                  (click)="createOrganizationOnFreeTrial()"
                 >
-                  {{ "next" | i18n }}
+                  {{ isTrialPaymentEnabled ? ("startTrial" | i18n) : ("next" | i18n) }}
                 </button>
               </app-vertical-step>
-              <app-vertical-step label="Billing" [subLabel]="billingSubLabel">
+              <app-vertical-step
+                label="Billing"
+                [subLabel]="billingSubLabel"
+                *ngIf="!isTrialPaymentEnabled"
+              >
                 <app-trial-billing-step
                   *ngIf="stepper.selectedIndex === 2"
                   [organizationInfo]="{

--- a/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
+++ b/apps/web/src/app/auth/trial-initiation/trial-initiation.component.spec.ts
@@ -13,6 +13,7 @@ import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abs
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
+import { OrganizationBillingServiceAbstraction as OrganizationBillingService } from "@bitwarden/common/billing/abstractions/organization-billing.service";
 import { PlanType } from "@bitwarden/common/billing/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -39,6 +40,7 @@ describe("TrialInitiationComponent", () => {
   let policyServiceMock: MockProxy<PolicyService>;
   let routerServiceMock: MockProxy<RouterService>;
   let acceptOrgInviteServiceMock: MockProxy<AcceptOrganizationInviteService>;
+  let organizationBillingServiceMock: MockProxy<OrganizationBillingService>;
 
   beforeEach(() => {
     // only define services directly that we want to mock return values in this component
@@ -47,6 +49,7 @@ describe("TrialInitiationComponent", () => {
     policyServiceMock = mock<PolicyService>();
     routerServiceMock = mock<RouterService>();
     acceptOrgInviteServiceMock = mock<AcceptOrganizationInviteService>();
+    organizationBillingServiceMock = mock<OrganizationBillingService>();
 
     // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -91,6 +94,10 @@ describe("TrialInitiationComponent", () => {
         {
           provide: AcceptOrganizationInviteService,
           useValue: acceptOrgInviteServiceMock,
+        },
+        {
+          provide: OrganizationBillingService,
+          useValue: organizationBillingServiceMock,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Allows child components to be ignored (such as register component)

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -54,7 +54,7 @@
             {{ "subscriptionExpiration" | i18n }}
           </dt>
           <dd [ngClass]="{ 'tw-text-danger': isExpired }">
-            {{ nextInvoice ? (nextInvoice.date | date: "mediumDate") : "-" }}
+            {{ nextInvoice ? (sub.expiration | date: "mediumDate") : "-" }}
           </dd>
         </ng-container>
       </dl>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11417
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a customer is adding seats to their account, their expiration date on their subscription changes to the next available invoice. This has started since we made the change to invoice for prorations once per month, rather than immediate invoices. This is causing confusion for customers on annual plans when they notice their full year term has a new expiration of the next available invoice, rather than their term end date.

This seems to really only affect annual customers with pending invoice items, as monthly customers will have theirs added to their monthly invoice regardless. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Uploading Screen Recording 2024-08-28 at 16.56.54.mov…


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
