### PR TITLE
[PM-11130] Accessibility in Login and Autofill View V2

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4242,5 +4242,8 @@
   },
   "enterprisePolicyRequirementsApplied": {
     "message": "Enterprise policy requirements have been applied to this setting"
+  },
+  "additionalContentAvailable": {
+    "message": "Additional content is available"
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9016,5 +9016,8 @@
   "publicApi": {
     "message": "Public API",
     "description": "The text, 'API', is an acronymn and should not be translated."
+  },
+  "additionalContentAvailable": {
+    "message": "Additional content is available"
   }
 }

--- a/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
+++ b/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
@@ -22,6 +22,7 @@
           type="button"
           (click)="openWebsite(login.launchUri)"
           data-testid="launch-website"
+          [attr.aria-label]="('launch' | i18n) + ' ' + login.hostOrUri"
         ></button>
         <button
           bitIconButton="bwi-clone"

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -54,6 +54,7 @@
         [appA11yTitle]="'toggleCharacterCount' | i18n"
         appStopClick
         (click)="togglePasswordCount()"
+        [attr.aria-label]="'additionalContentAvailable' | i18n"
       ></button>
       <button
         *ngIf="cipher.viewPassword"


### PR DESCRIPTION
## 🎟️ Tracking

(PM-11130)[https://bitwarden.atlassian.net/browse/PM-11130]

## 📔 Objective

Added aria-labels to PW count button in login credentials and updated aria-label for launch website button in autofill

## 📸 Screen Recording

https://github.com/user-attachments/assets/b8548954-4cf4-4e9b-9164-33b37a110c62

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
