### PR TITLE
[PM-10374] Remove last margin from Item Details V2

### DIFF
--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -47,12 +47,12 @@
         *ngIf="cipher.collectionIds && collections"
         [attr.aria-label]="'collection' | i18n"
       >
-        <ul data-testid="collections">
+        <ul data-testid="collections" [ngClass]="{ 'tw-mb-0': !cipher.folderId }">
           <li
             *ngFor="let collection of collections; let last = last"
             class="tw-flex tw-items-center tw-list-none"
             bitTypography="body2"
-            [ngClass]="{ 'tw-mb-3': last }"
+            [ngClass]="{ 'tw-mb-3': last && cipher.folderId }"
             [attr.aria-label]="collection.name"
           >
             <i


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10374 last margin item details](https://bitwarden.atlassian.net/browse/PM-10374)

## 📔 Objective

Remove margin from collections list if there are no folders inside item details v2

## 📸 Screenshots

![Screenshot 2024-08-28 at 3 06 38 PM](https://github.com/user-attachments/assets/b16815bf-e7e6-440c-afe5-56d7d0de489a)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
