### PR TITLE
[PM-11423] Bugfix - 2FA Auth Component Misalignment

### DIFF
--- a/libs/angular/src/auth/components/two-factor-auth/two-factor-auth.component.html
+++ b/libs/angular/src/auth/components/two-factor-auth/two-factor-auth.component.html
@@ -1,79 +1,76 @@
 <form [bitSubmit]="submitForm" [formGroup]="formGroup" autocomplete="off">
-  <div class="tw-min-w-96">
-    <app-two-factor-auth-email
-      (token)="token = $event"
-      *ngIf="selectedProviderType === providerType.Email"
-    />
-    <app-two-factor-auth-authenticator
-      (token)="token = $event"
-      *ngIf="selectedProviderType === providerType.Authenticator"
-    />
-    <app-two-factor-auth-yubikey
-      (token)="token = $event"
-      *ngIf="selectedProviderType === providerType.Yubikey"
-    />
-    <app-two-factor-auth-webauthn
-      (token)="token = $event; submitForm()"
-      *ngIf="selectedProviderType === providerType.WebAuthn"
-    />
-    <app-two-factor-auth-duo
-      (token)="token = $event; submitForm()"
-      [providerData]="providerData"
+  <app-two-factor-auth-email
+    (token)="token = $event"
+    *ngIf="selectedProviderType === providerType.Email"
+  />
+  <app-two-factor-auth-authenticator
+    (token)="token = $event"
+    *ngIf="selectedProviderType === providerType.Authenticator"
+  />
+  <app-two-factor-auth-yubikey
+    (token)="token = $event"
+    *ngIf="selectedProviderType === providerType.Yubikey"
+  />
+  <app-two-factor-auth-webauthn
+    (token)="token = $event; submitForm()"
+    *ngIf="selectedProviderType === providerType.WebAuthn"
+  />
+  <app-two-factor-auth-duo
+    (token)="token = $event; submitForm()"
+    [providerData]="providerData"
+    *ngIf="
+      selectedProviderType === providerType.OrganizationDuo ||
+      selectedProviderType === providerType.Duo
+    "
+    #duoComponent
+  />
+  <bit-form-control *ngIf="selectedProviderType != null">
+    <bit-label>{{ "rememberMe" | i18n }}</bit-label>
+    <input type="checkbox" bitCheckbox formControlName="remember" />
+  </bit-form-control>
+  <ng-container *ngIf="selectedProviderType == null">
+    <p bitTypography="body1">{{ "noTwoStepProviders" | i18n }}</p>
+    <p bitTypography="body1">{{ "noTwoStepProviders2" | i18n }}</p>
+  </ng-container>
+  <div [hidden]="!showCaptcha()">
+    <iframe id="hcaptcha_iframe" height="80" sandbox="allow-scripts allow-same-origin"></iframe>
+  </div>
+  <!-- Buttons -->
+  <div class="tw-flex tw-flex-col tw-space-y-2.5 tw-mb-3">
+    <button
+      type="submit"
+      buttonType="primary"
+      bitButton
+      bitFormButton
       *ngIf="
-        selectedProviderType === providerType.OrganizationDuo ||
-        selectedProviderType === providerType.Duo
+        selectedProviderType != null &&
+        selectedProviderType !== providerType.WebAuthn &&
+        selectedProviderType !== providerType.Duo &&
+        selectedProviderType !== providerType.OrganizationDuo
       "
-      #duoComponent
-    />
-    <bit-form-control *ngIf="selectedProviderType != null">
-      <bit-label>{{ "rememberMe" | i18n }}</bit-label>
-      <input type="checkbox" bitCheckbox formControlName="remember" />
-    </bit-form-control>
-    <ng-container *ngIf="selectedProviderType == null">
-      <p bitTypography="body1">{{ "noTwoStepProviders" | i18n }}</p>
-      <p bitTypography="body1">{{ "noTwoStepProviders2" | i18n }}</p>
-    </ng-container>
-    <hr />
-    <div [hidden]="!showCaptcha()">
-      <iframe id="hcaptcha_iframe" height="80" sandbox="allow-scripts allow-same-origin"></iframe>
-    </div>
-    <!-- <!-- Buttons -->
-    <div class="tw-flex tw-flex-col tw-space-y-2.5 tw-mb-3">
-      <button
-        type="submit"
-        buttonType="primary"
-        bitButton
-        bitFormButton
-        *ngIf="
-          selectedProviderType != null &&
-          selectedProviderType !== providerType.WebAuthn &&
-          selectedProviderType !== providerType.Duo &&
-          selectedProviderType !== providerType.OrganizationDuo
-        "
-      >
-        <span> <i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ actionButtonText }} </span>
-      </button>
-      <button
-        type="button"
-        buttonType="primary"
-        bitButton
-        (click)="launchDuo()"
-        *ngIf="
-          selectedProviderType === providerType.Duo ||
-          selectedProviderType === providerType.OrganizationDuo
-        "
-      >
-        <span> <i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ "launchDuo" | i18n }}</span>
-      </button>
+    >
+      <span> <i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ actionButtonText }} </span>
+    </button>
+    <button
+      type="button"
+      buttonType="primary"
+      bitButton
+      (click)="launchDuo()"
+      *ngIf="
+        selectedProviderType === providerType.Duo ||
+        selectedProviderType === providerType.OrganizationDuo
+      "
+    >
+      <span> <i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ "launchDuo" | i18n }}</span>
+    </button>
 
-      <a routerLink="/login" bitButton buttonType="secondary">
-        {{ "cancel" | i18n }}
-      </a>
-    </div>
-    <div class="text-center">
-      <a bitLink href="#" appStopClick (click)="selectOtherTwofactorMethod()">{{
-        "useAnotherTwoStepMethod" | i18n
-      }}</a>
-    </div>
+    <a routerLink="/login" bitButton buttonType="secondary">
+      {{ "cancel" | i18n }}
+    </a>
+  </div>
+  <div class="text-center">
+    <a bitLink href="#" appStopClick (click)="selectOtherTwofactorMethod()">{{
+      "useAnotherTwoStepMethod" | i18n
+    }}</a>
   </div>
 </form>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11423

## 📔 Objective

Fixes the alignment of 2fa auth components so they are center instead of leaning right.

Note: there is still a scrollbar in the following screenshot. This is due to the extra space added at the top of the page. That will be fixed (removed) in a separate PR to keep testing separate.

🚨 TIP: review this PR by hiding whitespace:

![Screenshot 2024-08-28 at 3 42 02 PM](https://github.com/user-attachments/assets/cb47a73f-1e9a-4c99-9d61-b61db7b5dfbe)

## 📸 Screenshots

![centered](https://github.com/user-attachments/assets/8ab5753b-64cb-4812-a485-7c17b9a27ab0)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
