### PR TITLE
[PM-11427] Copy TOTP Code without space

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -105,7 +105,7 @@
         readonly
         bitInput
         [type]="!(isPremium$ | async) ? 'password' : 'text'"
-        [value]="totpCopyCode || '*** ***'"
+        [value]="totpCodeCopyObj?.totpCodeFormatted || '*** ***'"
         aria-readonly="true"
         data-testid="login-totp"
         [disabled]="!(isPremium$ | async)"
@@ -123,7 +123,7 @@
         bitIconButton="bwi-clone"
         bitSuffix
         type="button"
-        [appCopyClick]="totpCopyCode"
+        [appCopyClick]="totpCodeCopyObj?.totpCode"
         [valueLabel]="'verificationCodeTotp' | i18n"
         showToast
         [appA11yTitle]="'copyValue' | i18n"

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.ts
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.ts
@@ -20,6 +20,11 @@ import {
 
 import { BitTotpCountdownComponent } from "../../components/totp-countdown/totp-countdown.component";
 
+type TotpCodeValues = {
+  totpCode: string;
+  totpCodeFormatted?: string;
+};
+
 @Component({
   selector: "app-login-credentials-view",
   templateUrl: "login-credentials-view.component.html",
@@ -47,7 +52,7 @@ export class LoginCredentialsViewComponent {
     );
   showPasswordCount: boolean = false;
   passwordRevealed: boolean = false;
-  totpCopyCode: string;
+  totpCodeCopyObj: TotpCodeValues;
   private datePipe = inject(DatePipe);
 
   constructor(
@@ -77,7 +82,7 @@ export class LoginCredentialsViewComponent {
     this.showPasswordCount = !this.showPasswordCount;
   }
 
-  setTotpCopyCode(e: any) {
-    this.totpCopyCode = e;
+  setTotpCopyCode(e: TotpCodeValues) {
+    this.totpCodeCopyObj = e;
   }
 }

--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
@@ -44,13 +44,16 @@ export class BitTotpCountdownComponent implements OnInit {
     if (this.totpCode != null) {
       if (this.totpCode.length > 4) {
         this.totpCodeFormatted = this.formatTotpCode();
-        this.sendCopyCode.emit(this.totpCodeFormatted);
+        this.sendCopyCode.emit({
+          totpCode: this.totpCode,
+          totpCodeFormatted: this.totpCodeFormatted,
+        });
       } else {
         this.totpCodeFormatted = this.totpCode;
       }
     } else {
       this.totpCodeFormatted = null;
-      this.sendCopyCode.emit(this.totpCodeFormatted);
+      this.sendCopyCode.emit({ totpCode: null, totpCodeFormatted: null });
       this.clearTotp();
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11427 Copy TOTP code without space](https://bitwarden.atlassian.net/browse/PM-11427)

## 📔 Objective

update totp-countdown-component to pass to login both the totpcode and the formatted code. one for display and the other for copy

## 📸 Screen Recording

https://github.com/user-attachments/assets/ce480c31-5c35-48ad-abbc-15f6585f6350

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
