### PR TITLE
[PM-11458] Bugfix - If two digit year was entered for card, the expired card message shows if card is not expired

### DIFF
--- a/apps/web/src/app/vault/individual-vault/add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.ts
@@ -24,7 +24,7 @@ import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folde
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { Launchable } from "@bitwarden/common/vault/interfaces/launchable";
-import { CardView } from "@bitwarden/common/vault/models/view/card.view";
+import { isCardExpired } from "@bitwarden/common/vault/utils";
 import { DialogService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 import { PasswordRepromptService } from "@bitwarden/vault";
@@ -123,7 +123,7 @@ export class AddEditComponent extends BaseAddEditComponent implements OnInit, On
       this.configService.getFeatureFlag$(FeatureFlag.ExtensionRefresh),
     );
 
-    this.cardIsExpired = extensionRefreshEnabled && this.isCardExpiryInThePast();
+    this.cardIsExpired = extensionRefreshEnabled && isCardExpired(this.cipher.card);
   }
 
   ngOnDestroy() {
@@ -233,24 +233,6 @@ export class AddEditComponent extends BaseAddEditComponent implements OnInit, On
 
   viewHistory() {
     this.viewingPasswordHistory = !this.viewingPasswordHistory;
-  }
-
-  isCardExpiryInThePast() {
-    if (this.cipher.card) {
-      const { expMonth, expYear }: CardView = this.cipher.card;
-
-      if (expYear && expMonth) {
-        // `Date` months are zero-indexed
-        const parsedMonth = parseInt(expMonth) - 1;
-        const parsedYear = parseInt(expYear);
-
-        // First day of the next month minus one, to get last day of the card month
-        const cardExpiry = new Date(parsedYear, parsedMonth + 1, 0);
-        const now = new Date();
-
-        return cardExpiry < now;
-      }
-    }
   }
 
   protected cleanUp() {

--- a/libs/common/src/vault/utils.spec.ts
+++ b/libs/common/src/vault/utils.spec.ts
@@ -1,4 +1,5 @@
-import { normalizeExpiryYearFormat } from "@bitwarden/common/vault/utils";
+import { CardView } from "@bitwarden/common/vault/models/view/card.view";
+import { normalizeExpiryYearFormat, isCardExpired } from "@bitwarden/common/vault/utils";
 
 function getExpiryYearValueFormats(currentCentury: string) {
   return [
@@ -71,4 +72,51 @@ describe("normalizeExpiryYearFormat", () => {
     });
     jest.clearAllTimers();
   });
+});
+
+function getCardExpiryDateValues() {
+  const currentDate = new Date();
+
+  const currentYear = currentDate.getFullYear();
+
+  // `Date` months are zero-indexed, our expiry date month inputs are one-indexed
+  const currentMonth = currentDate.getMonth() + 1;
+
+  return [
+    [null, null, false], // no month, no year
+    [undefined, undefined, false], // no month, no year, invalid values
+    ["", "", false], // no month, no year, invalid values
+    ["12", "agdredg42grg35grrr. ea3534@#^145345ag$%^  -_#$rdg ", false], // invalid values
+    ["0", `${currentYear - 1}`, true], // invalid 0 month
+    ["00", `${currentYear + 1}`, false], // invalid 0 month
+    [`${currentMonth}`, "0000", true], // current month, in the year 2000
+    [null, `${currentYear}`.slice(-2), false], // no month, this year
+    [null, `${currentYear - 1}`.slice(-2), true], // no month, last year
+    ["1", null, false], // no year, January
+    ["1", `${currentYear - 1}`, true], // January last year
+    ["13", `${currentYear}`, false], // 12 + 1 is Feb. in the next year (Date is zero-indexed)
+    [`${currentMonth + 36}`, `${currentYear - 1}`, true], // even though the month value would put the date 3 years into the future when calculated with `Date`, an explicit year in the past indicates the card is expired
+    [`${currentMonth}`, `${currentYear}`, false], // this year, this month (not expired until the month is over)
+    [`${currentMonth}`, `${currentYear}`.slice(-2), false], // This month, this year (not expired until the month is over)
+    [`${currentMonth - 1}`, `${currentYear}`, true], // last month
+    [`${currentMonth - 1}`, `${currentYear + 1}`, false], // 11 months from now
+  ];
+}
+
+describe("isCardExpired", () => {
+  const expiryYearValueFormats = getCardExpiryDateValues();
+
+  expiryYearValueFormats.forEach(
+    ([inputMonth, inputYear, expectedValue]: [string | null, string | null, boolean]) => {
+      it(`should return ${expectedValue} when the card expiry month is ${inputMonth} and the card expiry year is ${inputYear}`, () => {
+        const testCardView = new CardView();
+        testCardView.expMonth = inputMonth;
+        testCardView.expYear = inputYear;
+
+        const cardIsExpired = isCardExpired(testCardView);
+
+        expect(cardIsExpired).toBe(expectedValue);
+      });
+    },
+  );
 });

--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -8,10 +8,10 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { CollectionId } from "@bitwarden/common/types/guid";
 import { CollectionService } from "@bitwarden/common/vault/abstractions/collection.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CollectionView } from "@bitwarden/common/vault/models/view/collection.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { isCardExpired } from "@bitwarden/common/vault/utils";
 import { SearchModule, CalloutModule } from "@bitwarden/components";
 
 import { AdditionalOptionsComponent } from "./additional-options/additional-options.component";
@@ -61,7 +61,7 @@ export class CipherViewComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     await this.loadCipherData();
 
-    this.cardIsExpired = this.isCardExpiryInThePast();
+    this.cardIsExpired = isCardExpired(this.cipher.card);
   }
 
   ngOnDestroy(): void {
@@ -101,25 +101,5 @@ export class CipherViewComponent implements OnInit, OnDestroy {
         .getDecrypted$(this.cipher.folderId)
         .pipe(takeUntil(this.destroyed$));
     }
-  }
-
-  isCardExpiryInThePast() {
-    if (this.cipher.card) {
-      const { expMonth, expYear }: CardView = this.cipher.card;
-
-      if (expYear && expMonth) {
-        // `Date` months are zero-indexed
-        const parsedMonth = parseInt(expMonth) - 1;
-        const parsedYear = parseInt(expYear);
-
-        // First day of the next month minus one, to get last day of the card month
-        const cardExpiry = new Date(parsedYear, parsedMonth + 1, 0);
-        const now = new Date();
-
-        return cardExpiry < now;
-      }
-    }
-
-    return false;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-11458

## 📔 Objective

When determining whether the card expiration message should display or not, we don't consider `Date`s parsing of non-standard values. We can leverage the work in https://github.com/bitwarden/clients/pull/10735 to ensure the expiration Year is normalized correctly, resulting in a correct evaluation of the card expiry.

Additionally, add logic to disregard expiration month if the expiration year is in the past

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
