### PR TITLE
[CL-442][CL-405] Fix toggle group display in extension and add fullWidth input to main

### DIFF
--- a/libs/components/src/toggle-group/toggle-group.component.ts
+++ b/libs/components/src/toggle-group/toggle-group.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, HostBinding, Input, Output } from "@angular/core";
+import {
+  booleanAttribute,
+  Component,
+  EventEmitter,
+  HostBinding,
+  Input,
+  Output,
+} from "@angular/core";
 
 let nextId = 0;
 
@@ -11,11 +18,15 @@ export class ToggleGroupComponent<TValue = unknown> {
   private id = nextId++;
   name = `bit-toggle-group-${this.id}`;
 
+  @Input({ transform: booleanAttribute }) fullWidth?: boolean;
   @Input() selected?: TValue;
   @Output() selectedChange = new EventEmitter<TValue>();
 
   @HostBinding("attr.role") role = "radiogroup";
-  @HostBinding("class") classList = ["tw-flex"];
+  @HostBinding("class")
+  get classList() {
+    return ["tw-flex"].concat(this.fullWidth ? ["tw-w-full", "[&>*]:tw-grow"] : []);
+  }
 
   onInputInteraction(value: TValue) {
     this.selected = value;

--- a/libs/components/src/toggle-group/toggle.component.ts
+++ b/libs/components/src/toggle-group/toggle.component.ts
@@ -33,7 +33,10 @@ export class ToggleComponent<TValue> {
 
   get labelClasses() {
     return [
+      "tw-w-full",
+      "tw-justify-center",
       "!tw-font-semibold",
+      "tw-inline-block",
       "tw-transition",
       "tw-text-center",
       "tw-border-text-muted",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-442](https://bitwarden.atlassian.net/browse/CL-442)
[CL-405](https://bitwarden.atlassian.net/browse/CL-405)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR addresses 2 things:
1. There was a bug with the toggle group that caused it to display incorrectly in the browser extension. It was relying on global css present in the web app and Storybook that affects the `label` element `display` property. This PR explicitly sets the `display` property on the component.
2. The ticket to enable full width toggle groups was merged to the feature branch, but needs to be applied to `main` so that teams can use it during development prior to the merge of the feature branch. This PR applies the relevant css classes and input required to render a full width toggle group without the extension refresh changes, from #10658.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

A randomly placed full width toggle group for example purposes
![Screenshot 2024-08-29 at 5 56 42 PM](https://github.com/user-attachments/assets/c98424a4-7e52-4f97-ad55-66a792137297)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-442]: https://bitwarden.atlassian.net/browse/CL-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-405]: https://bitwarden.atlassian.net/browse/CL-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ