### PR TITLE
[PM-11497] If an org has only one collection, check it by default

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -614,6 +614,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
       this.collections = this.writeableCollections?.filter(
         (c) => c.organizationId === this.cipher.organizationId,
       );
+      // If there's only one collection, check it by default
+      if (this.collections.length === 1) {
+        (this.collections[0] as any).checked = true;
+      }
       const org = await this.organizationService.get(this.cipher.organizationId);
       if (org != null) {
         this.cipher.organizationUseTotp = org.useTotp;


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/orgs/bitwarden/discussions/10760

## 📔 Objective

When saving a password into an organization, if there's only one collection available to save to, select it by default. This improves UX by decreasing the number of clicks required.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/4e8039cc-99d3-4d1f-9b43-01a8a358729b)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
