### PR TITLE
[AC-2962] Remove unused payment.component from adjust-subscription.component

### DIFF
--- a/apps/web/src/app/billing/organizations/adjust-subscription.component.html
+++ b/apps/web/src/app/billing/organizations/adjust-subscription.component.html
@@ -56,4 +56,3 @@
     {{ "save" | i18n }}
   </button>
 </form>
-<app-payment [showMethods]="false"></app-payment>

--- a/apps/web/src/app/billing/organizations/adjust-subscription.component.ts
+++ b/apps/web/src/app/billing/organizations/adjust-subscription.component.ts
@@ -1,43 +1,36 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationSubscriptionUpdateRequest } from "@bitwarden/common/billing/models/request/organization-subscription-update.request";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ToastService } from "@bitwarden/components";
 
 @Component({
   selector: "app-adjust-subscription",
   templateUrl: "adjust-subscription.component.html",
 })
-export class AdjustSubscription implements OnInit, OnDestroy {
+export class AdjustSubscription {
   @Input() organizationId: string;
   @Input() maxAutoscaleSeats: number;
   @Input() currentSeatCount: number;
   @Input() seatPrice = 0;
   @Input() interval = "year";
   @Output() onAdjusted = new EventEmitter();
-  private destroy$ = new Subject<void>();
 
   adjustSubscriptionForm = this.formBuilder.group({
     newSeatCount: [0, [Validators.min(0)]],
     limitSubscription: [false],
     newMaxSeats: [0, [Validators.min(0)]],
   });
-  get limitSubscription(): boolean {
-    return this.adjustSubscriptionForm.value.limitSubscription;
-  }
+
   constructor(
     private i18nService: I18nService,
-    private platformUtilsService: PlatformUtilsService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private formBuilder: FormBuilder,
     private toastService: ToastService,
-  ) {}
-
-  ngOnInit() {
+  ) {
     this.adjustSubscriptionForm.patchValue({
       newSeatCount: this.currentSeatCount,
       limitSubscription: this.maxAutoscaleSeats != null,
@@ -45,7 +38,7 @@ export class AdjustSubscription implements OnInit, OnDestroy {
     });
     this.adjustSubscriptionForm
       .get("limitSubscription")
-      .valueChanges.pipe(takeUntil(this.destroy$))
+      .valueChanges.pipe(takeUntilDestroyed())
       .subscribe((value: boolean) => {
         if (value) {
           this.adjustSubscriptionForm
@@ -63,10 +56,6 @@ export class AdjustSubscription implements OnInit, OnDestroy {
       });
   }
 
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
   submit = async () => {
     this.adjustSubscriptionForm.markAllAsTouched();
     if (this.adjustSubscriptionForm.invalid) {
@@ -99,18 +88,15 @@ export class AdjustSubscription implements OnInit, OnDestroy {
       : 0;
   }
 
-  get additionalMaxSeatCount(): number {
-    return this.adjustSubscriptionForm.value.newMaxSeats
-      ? this.adjustSubscriptionForm.value.newMaxSeats - this.currentSeatCount
-      : 0;
-  }
-
   get maxSeatTotal(): number {
     return Math.abs((this.adjustSubscriptionForm.value.newMaxSeats ?? 0) * this.seatPrice);
   }
 
   get seatTotalCost(): number {
-    const totalSeat = Math.abs(this.adjustSubscriptionForm.value.newSeatCount * this.seatPrice);
-    return totalSeat;
+    return Math.abs(this.adjustSubscriptionForm.value.newSeatCount * this.seatPrice);
+  }
+
+  get limitSubscription(): boolean {
+    return this.adjustSubscriptionForm.value.limitSubscription;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2962

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR removes the unused `payment.component` from the `adjust-subscription.component` template. For most of this work, we're migrating usage of the `payment.component` to the `payment-v2.component`, but since the original `payment.component` wasn't even being used in the first place, this is a simple removal.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
