### PR TITLE
[PM-11428] Style Totp View Input Browser V2

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -109,7 +109,6 @@
         [value]="totpCopyCode || '*** ***'"
         aria-readonly="true"
         data-testid="login-totp"
-        [disabled]="!(isPremium$ | async)"
       />
       <button
         *ngIf="isPremium$ | async"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11428](https://bitwarden.atlassian.net/browse/PM-11428)

## 📔 Objective

Removing the `disable` attr on the TOTP input in `login-credentials-view`. This will remove that extra shaded background. The view is already read only so there is no interaction for the user. 

## 📸 Screenshots

This is how it will look once merged into main, and main is brought into the `ps/extension-refresh` branch

![Screenshot 2024-08-30 at 11 43 33 AM](https://github.com/user-attachments/assets/c426c66f-8b74-4a5d-be34-6bba51332a96)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11428]: https://bitwarden.atlassian.net/browse/PM-11428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ