### PR TITLE
[PM-11429] Item Menu Copy Password Permissions

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
@@ -13,7 +13,13 @@
     <button type="button" bitMenuItem appCopyField="username" [cipher]="cipher">
       {{ "copyUsername" | i18n }}
     </button>
-    <button type="button" bitMenuItem appCopyField="password" [cipher]="cipher">
+    <button
+      *ngIf="cipher.viewPassword"
+      type="button"
+      bitMenuItem
+      appCopyField="password"
+      [cipher]="cipher"
+    >
       {{ "copyPassword" | i18n }}
     </button>
     <button type="button" bitMenuItem appCopyField="totp" [cipher]="cipher">

--- a/libs/vault/src/services/copy-cipher-field.service.spec.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.spec.ts
@@ -62,12 +62,6 @@ describe("CopyCipherFieldService", () => {
       expect(platformUtilsService.copyToClipboard).not.toHaveBeenCalled();
     });
 
-    it("should return early when cipher.viewPassword is false", async () => {
-      cipher.viewPassword = false;
-      await service.copy(valueToCopy, actionType, cipher, skipReprompt);
-      expect(platformUtilsService.copyToClipboard).not.toHaveBeenCalled();
-    });
-
     it("should copy value to clipboard", async () => {
       await service.copy(valueToCopy, actionType, cipher, skipReprompt);
       expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(valueToCopy);

--- a/libs/vault/src/services/copy-cipher-field.service.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.ts
@@ -106,7 +106,7 @@ export class CopyCipherFieldService {
       return;
     }
 
-    if (valueToCopy == null || !cipher.viewPassword) {
+    if (valueToCopy == null) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11429](https://bitwarden.atlassian.net/browse/PM-11429)

## 📔 Objective

- Users with the `Can View/Edit, Except Passwords` permissions will be able to copy values from an item except passwords. 
- The `Copy password` option in the item dropdown will not be shown if `viewPassword` is false. 
- The `viewPassword` check inside `copy-cipher-field` has been removed

## 📸 Screen Recording

https://github.com/user-attachments/assets/b2200f5e-a7b9-43b6-a670-d134eb9d9930

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11429]: https://bitwarden.atlassian.net/browse/PM-11429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ