### PR TITLE
Fix Web Vault Lock throwing error due to missing nullish collection check

### DIFF
--- a/apps/web/src/app/vault/utils/collection-utils.spec.ts
+++ b/apps/web/src/app/vault/utils/collection-utils.spec.ts
@@ -24,5 +24,16 @@ describe("CollectionUtils Service", () => {
       expect(result[0].node.name).toBe("Parent");
       expect(result[0].children[0].node.name).toBe("Child");
     });
+
+    it("should return an empty array if no collections are provided", () => {
+      // Arrange
+      const collections: CollectionView[] = [];
+
+      // Act
+      const result = getNestedCollectionTree(collections);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/apps/web/src/app/vault/utils/collection-utils.ts
+++ b/apps/web/src/app/vault/utils/collection-utils.ts
@@ -14,6 +14,10 @@ export function getNestedCollectionTree(collections: CollectionView[]): TreeNode
 export function getNestedCollectionTree(
   collections: (CollectionView | CollectionAdminView)[],
 ): TreeNode<CollectionView | CollectionAdminView>[] {
+  if (!collections) {
+    return [];
+  }
+
   // Collections need to be cloned because ServiceUtils.nestedTraverse actively
   // modifies the names of collections.
   // These changes risk affecting collections store in StateService.


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[Slack thread](https://bitwarden.slack.com/archives/C04N1TX1CGM/p1713382222824719)

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve an error that occurs every time I lock the web vault where the collections get cleared during the lock process but the `collection-utils` `getNestedCollectionTree(...)` method doesn't have nullish data handling so it errors. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Video: 

https://github.com/user-attachments/assets/17ee347f-9dfc-4836-815c-6f016d1bc9da

Screenshot

![Web Vault Lock Error - CollectionUtils missing nullish check](https://github.com/user-attachments/assets/8d51f610-e31c-453b-84bb-d1ff97e3ded2)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
