### PR TITLE
[PM-11206] Collection inline and bulk menu copy updates

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -75,7 +75,7 @@
       </button>
       <button type="button" bitMenuItem (click)="access(false)">
         <i class="bwi bwi-fw bwi-users" aria-hidden="true"></i>
-        {{ "access" | i18n }}
+        {{ "editAccess" | i18n }}
       </button>
     </ng-container>
     <ng-container *ngIf="!canEditCollection && canViewCollectionInfo">

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -47,7 +47,7 @@
               (click)="bulkEditCollectionAccess()"
             >
               <i class="bwi bwi-fw bwi-users" aria-hidden="true"></i>
-              {{ "access" | i18n }}
+              {{ "editAccess" | i18n }}
             </button>
             <button
               *ngIf="
@@ -81,14 +81,7 @@
             >
               <span class="tw-text-danger">
                 <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
-                {{
-                  (showBulkTrashOptions
-                    ? "permanentlyDeleteSelected"
-                    : vaultBulkManagementActionEnabled
-                      ? "delete"
-                      : "deleteSelected"
-                  ) | i18n
-                }}
+                {{ (showBulkTrashOptions ? "permanentlyDeleteSelected" : "delete") | i18n }}
               </span>
             </button>
           </bit-menu>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9025,5 +9025,8 @@
   },
   "additionalContentAvailable": {
     "message": "Additional content is available"
+  },
+  "editAccess": {
+    "message": "Edit access"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-11206](https://bitwarden.atlassian.net/browse/PM-11206)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
For clarity purposes, we would like to rename some of the bulk and inline menu actions for collections
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/1f662b15-3330-4331-852b-afbf13fb366d


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11206]: https://bitwarden.atlassian.net/browse/PM-11206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ