### PR TITLE
[PM-11593] Fix backgroundbrowserbiometricservice initialization

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -378,7 +378,7 @@ export default class MainBackground {
 
   private syncTimeout: any;
   private isSafari: boolean;
-  private nativeMessagingBackground: NativeMessagingBackground;
+  nativeMessagingBackground: NativeMessagingBackground;
 
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
 
@@ -400,6 +400,8 @@ export default class MainBackground {
 
     const logoutCallback = async (logoutReason: LogoutReason, userId?: UserId) =>
       await this.logout(logoutReason, userId);
+
+    const runtimeNativeMessagingBackground = () => this.nativeMessagingBackground;
 
     const refreshAccessTokenErrorCallback = () => {
       // Send toast to popup
@@ -616,7 +618,9 @@ export default class MainBackground {
 
     this.i18nService = new I18nService(BrowserApi.getUILanguage(), this.globalStateProvider);
 
-    this.biometricsService = new BackgroundBrowserBiometricsService(this.nativeMessagingBackground);
+    this.biometricsService = new BackgroundBrowserBiometricsService(
+      runtimeNativeMessagingBackground,
+    );
 
     this.kdfConfigService = new KdfConfigService(this.stateProvider);
 

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -378,7 +378,7 @@ export default class MainBackground {
 
   private syncTimeout: any;
   private isSafari: boolean;
-  nativeMessagingBackground: NativeMessagingBackground;
+  private nativeMessagingBackground: NativeMessagingBackground;
 
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
 

--- a/apps/browser/src/platform/services/background-browser-biometrics.service.ts
+++ b/apps/browser/src/platform/services/background-browser-biometrics.service.ts
@@ -1,25 +1,25 @@
 import { Injectable } from "@angular/core";
 
-import { NativeMessagingBackground } from "../../background/nativeMessaging.background";
+import { NativeMessagingBackground } from "src/background/nativeMessaging.background";
 
 import { BrowserBiometricsService } from "./browser-biometrics.service";
 
 @Injectable()
 export class BackgroundBrowserBiometricsService extends BrowserBiometricsService {
-  constructor(private nativeMessagingBackground: NativeMessagingBackground) {
+  constructor(private nativeMessagingBackground: () => NativeMessagingBackground) {
     super();
   }
 
   async authenticateBiometric(): Promise<boolean> {
-    const responsePromise = this.nativeMessagingBackground.getResponse();
-    await this.nativeMessagingBackground.send({ command: "biometricUnlock" });
+    const responsePromise = this.nativeMessagingBackground().getResponse();
+    await this.nativeMessagingBackground().send({ command: "biometricUnlock" });
     const response = await responsePromise;
     return response.response === "unlocked";
   }
 
   async isBiometricUnlockAvailable(): Promise<boolean> {
-    const responsePromise = this.nativeMessagingBackground.getResponse();
-    await this.nativeMessagingBackground.send({ command: "biometricUnlockAvailable" });
+    const responsePromise = this.nativeMessagingBackground().getResponse();
+    await this.nativeMessagingBackground().send({ command: "biometricUnlockAvailable" });
     const response = await responsePromise;
     return response.response === "available";
   }

--- a/apps/browser/src/platform/services/background-browser-biometrics.service.ts
+++ b/apps/browser/src/platform/services/background-browser-biometrics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 
-import { NativeMessagingBackground } from "src/background/nativeMessaging.background";
+import { NativeMessagingBackground } from "../../background/nativeMessaging.background";
 
 import { BrowserBiometricsService } from "./browser-biometrics.service";
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11593

## 📔 Objective

There is a dependency cycle of nativemessagingbackground -> cryptoservice -> browserbackgroundbiometricservice. This lead to browserbiometricsservice not having the nativemessagingbackground passed in. Before  https://github.com/bitwarden/clients/pull/10374 this was not an issue since the biometric callback was in the MainBackground and got the nativemessagingbackground during runtime.

This PR fixes the dependency cycle by instead passing in a function that dynamically returns the nativemessagingbackground during runtime to the browserbackgroundbiometricservice.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
