### PR TITLE
[CL-322] Remove tw-sr-only from form field labels

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/entity-events.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/entity-events.component.html
@@ -6,31 +6,27 @@
   <div bitDialogContent>
     <form [formGroup]="filterFormGroup" [bitSubmit]="refreshEvents">
       <div class="tw-flex tw-items-center tw-space-x-2">
-        <div>
-          <label class="tw-sr-only" for="start">{{ "startDate" | i18n }}</label>
-          <span>
-            <input
-              bitInput
-              type="datetime-local"
-              id="start"
-              placeholder="{{ 'startDate' | i18n }}"
-              formControlName="start"
-            />
-          </span>
-        </div>
+        <bit-form-field>
+          <bit-label>{{ "from" | i18n }}</bit-label>
+          <input
+            bitInput
+            type="datetime-local"
+            id="start"
+            placeholder="{{ 'startDate' | i18n }}"
+            formControlName="start"
+          />
+        </bit-form-field>
         <span class="tw-mx-2">-</span>
-        <div>
-          <label class="tw-sr-only" for="end">{{ "endDate" | i18n }}</label>
-          <span>
-            <input
-              bitInput
-              type="datetime-local"
-              id="end"
-              placeholder="{{ 'endDate' | i18n }}"
-              formControlName="end"
-            />
-          </span>
-        </div>
+        <bit-form-field>
+          <bit-label>{{ "to" | i18n }}</bit-label>
+          <input
+            bitInput
+            type="datetime-local"
+            id="end"
+            placeholder="{{ 'endDate' | i18n }}"
+            formControlName="end"
+          />
+        </bit-form-field>
         <button type="submit" bitButton buttonType="primary" bitFormButton>
           <i class="bwi bwi-refresh bwi-fw" aria-hidden="true"></i>
           {{ "refresh" | i18n }}

--- a/apps/web/src/app/auth/two-factor.component.html
+++ b/apps/web/src/app/auth/two-factor.component.html
@@ -36,7 +36,7 @@
         <img src="../../images/yubikey.jpg" class="tw-rounded img-fluid tw-mb-3" alt="" />
       </picture>
       <bit-form-field>
-        <bit-label class="tw-sr-only">{{ "verificationCode" | i18n }}</bit-label>
+        <bit-label>{{ "verificationCode" | i18n }}</bit-label>
         <input type="password" bitInput formControlName="token" appAutofocus appInputVerbatim />
       </bit-form-field>
     </ng-container>

--- a/apps/web/src/app/settings/domain-rules.component.html
+++ b/apps/web/src/app/settings/domain-rules.component.html
@@ -18,7 +18,7 @@
         *ngFor="let d of custom; let i = index; trackBy: indexTrackBy"
       >
         <bit-form-field class="tw-flex-1 !tw-mb-0" formGroupName="{{ i }}">
-          <bit-label class="tw-sr-only">{{ "customDomainX" | i18n: i + 1 }} </bit-label>
+          <bit-label>{{ "customDomainX" | i18n: i + 1 }} </bit-label>
           <textarea
             rows="2"
             bitInput


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-322](https://bitwarden.atlassian.net/browse/CL-322)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In the extension refresh feature branch, we are restyling form fields and will no longer be supporting fields without labels. This PR removes `tw-sr-only` from the few form fields that had sr-only labels. It also updates the entity events dialog to use the form field component properly.

Design has approved the copy (in some cases, we are using the existing sr-only text; in others, we are replacing the label with different copy). Design has also ok'd this being merged to `main` with no flag because these fields should have labels anyway, so these fields will gain visible labels in the next release after this PR is merged. Please let me know if you have concerns.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img src="https://github.com/user-attachments/assets/1d3fc137-0d04-4cef-8dce-5b544db8d247" width="75%"/>

<img src="https://github.com/user-attachments/assets/5c431d70-e45c-4f7c-b5fe-c8557c872d26" width="75%"/>


I haven't successfully set up 2 factor locally, but it's this form field that was changed:
<img src="https://github.com/user-attachments/assets/23beacca-09ec-4099-8f3c-788012be088f" width="50%"/>


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-322]: https://bitwarden.atlassian.net/browse/CL-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ