### PR TITLE
[PM-10734] Brand Only Cards

### DIFF
--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -70,8 +70,8 @@ export class CipherViewComponent implements OnInit, OnDestroy {
   }
 
   get hasCard() {
-    const { cardholderName, code, expMonth, expYear, brand, number } = this.cipher.card;
-    return cardholderName || code || expMonth || expYear || brand || number;
+    const { cardholderName, code, expMonth, expYear, number } = this.cipher.card;
+    return cardholderName || code || expMonth || expYear || number;
   }
 
   get hasLogin() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10734](https://bitwarden.atlassian.net/browse/PM-10734)

## 📔 Objective

Remove brand from logic that determines if the card section should show, thus removing the scenario of when _only_ a brand exists.

## 📸 Screenshots

|Before|After|
|-|-|
|![Screenshot 2024-09-03 at 2 57 53 PM](https://github.com/user-attachments/assets/26af187b-902b-4197-841d-ee6168c22809)|![Screenshot 2024-09-03 at 2 57 28 PM](https://github.com/user-attachments/assets/c383ea56-d1d7-4300-9d1a-8af5a2ad327a)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10734]: https://bitwarden.atlassian.net/browse/PM-10734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ