### PR TITLE
[PM-11623] Refactor access-selector stories

### DIFF
--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
@@ -1,59 +1,18 @@
-import { importProvidersFrom } from "@angular/core";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
-
-import { JslibModule } from "@bitwarden/angular/jslib.module";
-import {
-  AvatarModule,
-  BadgeModule,
-  ButtonModule,
-  DialogModule,
-  FormFieldModule,
-  IconButtonModule,
-  TableModule,
-  TabsModule,
-} from "@bitwarden/components";
-
-import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
+import { Meta, StoryObj } from "@storybook/angular";
 
 import { AccessSelectorComponent, PermissionMode } from "./access-selector.component";
 import { AccessItemType, AccessItemValue } from "./access-selector.models";
+import { default as baseComponentDefinition } from "./access-selector.stories";
 import { actionsData, itemsFactory } from "./storybook-utils";
-import { UserTypePipe } from "./user-type.pipe";
-
-type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
 
 export default {
   title: "Web/Organizations/Access Selector/Dialog",
-  decorators: [
-    moduleMetadata({
-      declarations: [AccessSelectorComponent, UserTypePipe],
-      imports: [
-        DialogModule,
-        ButtonModule,
-        FormFieldModule,
-        AvatarModule,
-        BadgeModule,
-        ReactiveFormsModule,
-        FormsModule,
-        TabsModule,
-        TableModule,
-        JslibModule,
-        IconButtonModule,
-      ],
-      providers: [],
-    }),
-    applicationConfig({
-      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
-    }),
-  ],
-  parameters: {},
-  argTypes: {
-    formObj: { table: { disable: true } },
-  },
+  decorators: baseComponentDefinition.decorators,
 } as Meta;
 
-const DialogAccessSelectorRender = (args: any) => ({
+type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
+
+const render: Story["render"] = (args) => ({
   props: {
     items: [],
     valueChanged: actionsData.onValueChanged,
@@ -108,5 +67,5 @@ export const Dialog: Story = {
     initialValue: [] as any[],
     items: dialogAccessItems,
   },
-  render: DialogAccessSelectorRender,
+  render,
 };

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
@@ -16,13 +16,12 @@ import {
 
 import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
 
-import { AccessSelectorComponent } from "./access-selector.component";
-import { AccessItemType } from "./access-selector.models";
+import { AccessSelectorComponent, PermissionMode } from "./access-selector.component";
+import { AccessItemType, AccessItemValue } from "./access-selector.models";
 import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
-// TODO: This is a workaround since this story does weird things.
-type Story = StoryObj<any>;
+type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
 
 export default {
   title: "Web/Organizations/Access Selector/Dialog",
@@ -98,7 +97,7 @@ const dialogAccessItems = itemsFactory(10, AccessItemType.Collection);
 
 export const Dialog: Story = {
   args: {
-    permissionMode: "edit",
+    permissionMode: PermissionMode.Edit,
     showMemberRoles: false,
     showGroupColumn: true,
     columnHeader: "Collection",

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
@@ -1,0 +1,113 @@
+import { importProvidersFrom } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import {
+  AvatarModule,
+  BadgeModule,
+  ButtonModule,
+  DialogModule,
+  FormFieldModule,
+  IconButtonModule,
+  TableModule,
+  TabsModule,
+} from "@bitwarden/components";
+
+import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
+
+import { AccessSelectorComponent } from "./access-selector.component";
+import { AccessItemType } from "./access-selector.models";
+import { actionsData, itemsFactory } from "./storybook-utils";
+import { UserTypePipe } from "./user-type.pipe";
+
+// TODO: This is a workaround since this story does weird things.
+type Story = StoryObj<any>;
+
+export default {
+  title: "Web/Organizations/Access Selector",
+  decorators: [
+    moduleMetadata({
+      declarations: [AccessSelectorComponent, UserTypePipe],
+      imports: [
+        DialogModule,
+        ButtonModule,
+        FormFieldModule,
+        AvatarModule,
+        BadgeModule,
+        ReactiveFormsModule,
+        FormsModule,
+        TabsModule,
+        TableModule,
+        JslibModule,
+        IconButtonModule,
+      ],
+      providers: [],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+  parameters: {},
+  argTypes: {
+    formObj: { table: { disable: true } },
+  },
+} as Meta;
+
+const DialogAccessSelectorRender = (args: any) => ({
+  props: {
+    items: [],
+    valueChanged: actionsData.onValueChanged,
+    initialValue: [],
+    ...args,
+  },
+  template: `
+    <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
+      <span bitDialogTitle>Access selector</span>
+      <span bitDialogContent>
+        <bit-access-selector
+          (ngModelChange)="valueChanged($event)"
+          [ngModel]="initialValue"
+          [items]="items"
+          [disabled]="disabled"
+          [columnHeader]="columnHeader"
+          [showGroupColumn]="showGroupColumn"
+          [selectorLabelText]="selectorLabelText"
+          [selectorHelpText]="selectorHelpText"
+          [emptySelectionText]="emptySelectionText"
+          [permissionMode]="permissionMode"
+          [showMemberRoles]="showMemberRoles"
+        ></bit-access-selector>
+      </span>
+      <ng-container bitDialogFooter>
+        <button bitButton buttonType="primary">Save</button>
+        <button bitButton buttonType="secondary">Cancel</button>
+        <button
+          class="tw-ml-auto"
+          bitIconButton="bwi-trash"
+          buttonType="danger"
+          size="default"
+          title="Delete"
+          aria-label="Delete"></button>
+      </ng-container>
+    </bit-dialog>
+  `,
+});
+
+const dialogAccessItems = itemsFactory(10, AccessItemType.Collection);
+
+export const Dialog: Story = {
+  args: {
+    permissionMode: "edit",
+    showMemberRoles: false,
+    showGroupColumn: true,
+    columnHeader: "Collection",
+    selectorLabelText: "Select Collections",
+    selectorHelpText: "Some helper text describing what this does",
+    emptySelectionText: "No collections added",
+    disabled: false,
+    initialValue: [] as any[],
+    items: dialogAccessItems,
+  },
+  render: DialogAccessSelectorRender,
+};

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
@@ -25,7 +25,7 @@ import { UserTypePipe } from "./user-type.pipe";
 type Story = StoryObj<any>;
 
 export default {
-  title: "Web/Organizations/Access Selector",
+  title: "Web/Organizations/Access Selector/Dialog",
   decorators: [
     moduleMetadata({
       declarations: [AccessSelectorComponent, UserTypePipe],

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-dialog.stories.ts
@@ -5,6 +5,9 @@ import { AccessItemType, AccessItemValue } from "./access-selector.models";
 import { default as baseComponentDefinition } from "./access-selector.stories";
 import { actionsData, itemsFactory } from "./storybook-utils";
 
+/**
+ * Displays the Access Selector in a dialog.
+ */
 export default {
   title: "Web/Organizations/Access Selector/Dialog",
   decorators: baseComponentDefinition.decorators,

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
@@ -1,0 +1,97 @@
+import { importProvidersFrom } from "@angular/core";
+import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import {
+  AvatarModule,
+  BadgeModule,
+  ButtonModule,
+  DialogModule,
+  FormFieldModule,
+  IconButtonModule,
+  TableModule,
+  TabsModule,
+} from "@bitwarden/components";
+
+import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
+
+import { AccessSelectorComponent } from "./access-selector.component";
+import { AccessItemType } from "./access-selector.models";
+import { actionsData, itemsFactory } from "./storybook-utils";
+import { UserTypePipe } from "./user-type.pipe";
+
+export default {
+  title: "Web/Organizations/Access Selector",
+  decorators: [
+    moduleMetadata({
+      declarations: [AccessSelectorComponent, UserTypePipe],
+      imports: [
+        DialogModule,
+        ButtonModule,
+        FormFieldModule,
+        AvatarModule,
+        BadgeModule,
+        ReactiveFormsModule,
+        FormsModule,
+        TabsModule,
+        TableModule,
+        JslibModule,
+        IconButtonModule,
+      ],
+      providers: [],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+  parameters: {},
+  argTypes: {
+    formObj: { table: { disable: true } },
+  },
+} as Meta;
+
+// TODO: This is a workaround since this story does weird things.
+type Story = StoryObj<any>;
+const fb = new FormBuilder();
+
+const ReactiveFormAccessSelectorRender = (args: any) => ({
+  props: {
+    items: [],
+    onSubmit: actionsData.onSubmit,
+    ...args,
+  },
+  template: `
+    <form [formGroup]="formObj" (ngSubmit)="onSubmit(formObj.controls.formItems.value)">
+      <bit-access-selector
+        formControlName="formItems"
+        [items]="items"
+        [columnHeader]="columnHeader"
+        [selectorLabelText]="selectorLabelText"
+        [selectorHelpText]="selectorHelpText"
+        [emptySelectionText]="emptySelectionText"
+        [permissionMode]="permissionMode"
+        [showMemberRoles]="showMemberRoles"
+      ></bit-access-selector>
+      <button type="submit" bitButton buttonType="primary" class="tw-mt-5">Submit</button>
+    </form>
+`,
+});
+
+const sampleMembers = itemsFactory(10, AccessItemType.Member);
+const sampleGroups = itemsFactory(6, AccessItemType.Group);
+
+export const ReactiveForm: Story = {
+  args: {
+    formObj: fb.group({ formItems: [[{ id: "1g" }]] }),
+    permissionMode: "edit",
+    showMemberRoles: false,
+    columnHeader: "Groups/Members",
+    selectorLabelText: "Select groups and members",
+    selectorHelpText:
+      "Permissions set for a member will replace permissions set by that member's group",
+    emptySelectionText: "No members or groups added",
+    items: sampleGroups.concat(sampleMembers),
+  },
+  render: ReactiveFormAccessSelectorRender,
+};

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
@@ -22,7 +22,7 @@ import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
 export default {
-  title: "Web/Organizations/Access Selector",
+  title: "Web/Organizations/Access Selector/Reactive form",
   decorators: [
     moduleMetadata({
       declarations: [AccessSelectorComponent, UserTypePipe],

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
@@ -1,68 +1,25 @@
-import { importProvidersFrom } from "@angular/core";
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from "@angular/forms";
-import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
-
-import { JslibModule } from "@bitwarden/angular/jslib.module";
-import {
-  AvatarModule,
-  BadgeModule,
-  ButtonModule,
-  DialogModule,
-  FormFieldModule,
-  IconButtonModule,
-  TableModule,
-  TabsModule,
-} from "@bitwarden/components";
-
-import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
+import { FormBuilder, FormControl, FormGroup } from "@angular/forms";
+import { Meta, StoryObj } from "@storybook/angular";
 
 import { AccessSelectorComponent, PermissionMode } from "./access-selector.component";
 import { AccessItemType, AccessItemValue } from "./access-selector.models";
+import { default as baseComponentDefinition } from "./access-selector.stories";
 import { actionsData, itemsFactory } from "./storybook-utils";
-import { UserTypePipe } from "./user-type.pipe";
 
 export default {
   title: "Web/Organizations/Access Selector/Reactive form",
-  decorators: [
-    moduleMetadata({
-      declarations: [AccessSelectorComponent, UserTypePipe],
-      imports: [
-        DialogModule,
-        ButtonModule,
-        FormFieldModule,
-        AvatarModule,
-        BadgeModule,
-        ReactiveFormsModule,
-        FormsModule,
-        TabsModule,
-        TableModule,
-        JslibModule,
-        IconButtonModule,
-      ],
-      providers: [],
-    }),
-    applicationConfig({
-      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
-    }),
-  ],
-  parameters: {},
+  decorators: baseComponentDefinition.decorators,
   argTypes: {
     formObj: { table: { disable: true } },
   },
 } as Meta;
 
-// TODO: This is a workaround since this story does weird things.
 type FormObj = { formObj: FormGroup<{ formItems: FormControl<AccessItemValue[]> }> };
 type Story = StoryObj<AccessSelectorComponent & FormObj>;
+
 const fb = new FormBuilder();
 
-const ReactiveFormAccessSelectorRender = (args: any) => ({
+const render: Story["render"] = (args) => ({
   props: {
     items: [],
     onSubmit: actionsData.onSubmit,
@@ -100,5 +57,5 @@ export const ReactiveForm: Story = {
     emptySelectionText: "No members or groups added",
     items: sampleGroups.concat(sampleMembers),
   },
-  render: ReactiveFormAccessSelectorRender,
+  render,
 };

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
@@ -1,5 +1,11 @@
 import { importProvidersFrom } from "@angular/core";
-import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from "@angular/forms";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -16,8 +22,8 @@ import {
 
 import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
 
-import { AccessSelectorComponent } from "./access-selector.component";
-import { AccessItemType } from "./access-selector.models";
+import { AccessSelectorComponent, PermissionMode } from "./access-selector.component";
+import { AccessItemType, AccessItemValue } from "./access-selector.models";
 import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
@@ -52,7 +58,8 @@ export default {
 } as Meta;
 
 // TODO: This is a workaround since this story does weird things.
-type Story = StoryObj<any>;
+type FormObj = { formObj: FormGroup<{ formItems: FormControl<AccessItemValue[]> }> };
+type Story = StoryObj<AccessSelectorComponent & FormObj>;
 const fb = new FormBuilder();
 
 const ReactiveFormAccessSelectorRender = (args: any) => ({
@@ -83,8 +90,8 @@ const sampleGroups = itemsFactory(6, AccessItemType.Group);
 
 export const ReactiveForm: Story = {
   args: {
-    formObj: fb.group({ formItems: [[{ id: "1g" }]] }),
-    permissionMode: "edit",
+    formObj: fb.group({ formItems: [[{ id: "1g", type: AccessItemType.Group }]] }),
+    permissionMode: PermissionMode.Edit,
     showMemberRoles: false,
     columnHeader: "Groups/Members",
     selectorLabelText: "Select groups and members",

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector-reactive.stories.ts
@@ -6,6 +6,9 @@ import { AccessItemType, AccessItemValue } from "./access-selector.models";
 import { default as baseComponentDefinition } from "./access-selector.stories";
 import { actionsData, itemsFactory } from "./storybook-utils";
 
+/**
+ * Displays the Access Selector embedded in a reactive form.
+ */
 export default {
   title: "Web/Organizations/Access Selector/Reactive form",
   decorators: baseComponentDefinition.decorators,

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -1,7 +1,7 @@
 import { importProvidersFrom } from "@angular/core";
 import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { action } from "@storybook/addon-actions";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
@@ -22,7 +22,8 @@ import {
 import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
 
 import { AccessSelectorComponent } from "./access-selector.component";
-import { AccessItemType, AccessItemView, CollectionPermission } from "./access-selector.models";
+import { AccessItemType, CollectionPermission } from "./access-selector.models";
+import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
 export default {
@@ -58,47 +59,6 @@ export default {
 // TODO: This is a workaround since this story does weird things.
 type Story = StoryObj<any>;
 
-const actionsData = {
-  onValueChanged: action("onValueChanged"),
-  onSubmit: action("onSubmit"),
-};
-
-/**
- * Factory to help build semi-realistic looking items
- * @param n - The number of items to build
- * @param type - Which type to build
- */
-const itemsFactory = (n: number, type: AccessItemType) => {
-  return [...Array(n)].map((_: unknown, id: number) => {
-    const item: AccessItemView = {
-      id: id.toString(),
-      type: type,
-    } as AccessItemView;
-
-    switch (item.type) {
-      case AccessItemType.Collection:
-        item.labelName = item.listName = `Collection ${id}`;
-        item.id = item.id + "c";
-        item.parentGrouping = "Collection Parent Group " + ((id % 2) + 1);
-        break;
-      case AccessItemType.Group:
-        item.labelName = item.listName = `Group ${id}`;
-        item.id = item.id + "g";
-        break;
-      case AccessItemType.Member:
-        item.id = item.id + "m";
-        item.email = `member${id}@email.com`;
-        item.status = id % 3 == 0 ? 0 : 2;
-        item.labelName = item.status == 2 ? `Member ${id}` : item.email;
-        item.listName = item.status == 2 ? `${item.labelName} (${item.email})` : item.email;
-        item.role = id % 5;
-        break;
-    }
-
-    return item;
-  });
-};
-
 const sampleMembers = itemsFactory(10, AccessItemType.Member);
 const sampleGroups = itemsFactory(6, AccessItemType.Group);
 
@@ -127,48 +87,6 @@ const StandaloneAccessSelectorRender = (args: any) => ({
   `,
 });
 
-const DialogAccessSelectorRender = (args: any) => ({
-  props: {
-    items: [],
-    valueChanged: actionsData.onValueChanged,
-    initialValue: [],
-    ...args,
-  },
-  template: `
-    <bit-dialog [dialogSize]="dialogSize" [disablePadding]="disablePadding">
-      <span bitDialogTitle>Access selector</span>
-      <span bitDialogContent>
-        <bit-access-selector
-          (ngModelChange)="valueChanged($event)"
-          [ngModel]="initialValue"
-          [items]="items"
-          [disabled]="disabled"
-          [columnHeader]="columnHeader"
-          [showGroupColumn]="showGroupColumn"
-          [selectorLabelText]="selectorLabelText"
-          [selectorHelpText]="selectorHelpText"
-          [emptySelectionText]="emptySelectionText"
-          [permissionMode]="permissionMode"
-          [showMemberRoles]="showMemberRoles"
-        ></bit-access-selector>
-      </span>
-      <ng-container bitDialogFooter>
-        <button bitButton buttonType="primary">Save</button>
-        <button bitButton buttonType="secondary">Cancel</button>
-        <button
-          class="tw-ml-auto"
-          bitIconButton="bwi-trash"
-          buttonType="danger"
-          size="default"
-          title="Delete"
-          aria-label="Delete"></button>
-      </ng-container>
-    </bit-dialog>
-  `,
-});
-
-const dialogAccessItems = itemsFactory(10, AccessItemType.Collection);
-
 const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).concat([
   {
     id: "c1-group1",
@@ -189,22 +107,6 @@ const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).c
     readonly: true,
   },
 ]);
-
-export const Dialog: Story = {
-  args: {
-    permissionMode: "edit",
-    showMemberRoles: false,
-    showGroupColumn: true,
-    columnHeader: "Collection",
-    selectorLabelText: "Select Collections",
-    selectorHelpText: "Some helper text describing what this does",
-    emptySelectionText: "No collections added",
-    disabled: false,
-    initialValue: [] as any[],
-    items: dialogAccessItems,
-  },
-  render: DialogAccessSelectorRender,
-};
 
 export const MemberCollectionAccess: Story = {
   args: {

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -1,7 +1,6 @@
 import { importProvidersFrom } from "@angular/core";
-import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
-
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
@@ -196,44 +195,4 @@ export const CollectionAccess: Story = {
     ]),
   },
   render: StandaloneAccessSelectorRender,
-};
-
-const fb = new FormBuilder();
-
-const ReactiveFormAccessSelectorRender = (args: any) => ({
-  props: {
-    items: [],
-    onSubmit: actionsData.onSubmit,
-    ...args,
-  },
-  template: `
-    <form [formGroup]="formObj" (ngSubmit)="onSubmit(formObj.controls.formItems.value)">
-      <bit-access-selector
-        formControlName="formItems"
-        [items]="items"
-        [columnHeader]="columnHeader"
-        [selectorLabelText]="selectorLabelText"
-        [selectorHelpText]="selectorHelpText"
-        [emptySelectionText]="emptySelectionText"
-        [permissionMode]="permissionMode"
-        [showMemberRoles]="showMemberRoles"
-      ></bit-access-selector>
-      <button type="submit" bitButton buttonType="primary" class="tw-mt-5">Submit</button>
-    </form>
-`,
-});
-
-export const ReactiveForm: Story = {
-  args: {
-    formObj: fb.group({ formItems: [[{ id: "1g" }]] }),
-    permissionMode: "edit",
-    showMemberRoles: false,
-    columnHeader: "Groups/Members",
-    selectorLabelText: "Select groups and members",
-    selectorHelpText:
-      "Permissions set for a member will replace permissions set by that member's group",
-    emptySelectionText: "No members or groups added",
-    items: sampleGroups.concat(sampleMembers),
-  },
-  render: ReactiveFormAccessSelectorRender,
 };

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -53,7 +53,7 @@ export default {
   argTypes: {
     formObj: { table: { disable: true } },
   },
-} as Meta;
+} as Meta<typeof AccessSelectorComponent>;
 
 type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
 

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -49,11 +49,7 @@ export default {
       providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
     }),
   ],
-  parameters: {},
-  argTypes: {
-    formObj: { table: { disable: true } },
-  },
-} as Meta<typeof AccessSelectorComponent>;
+} as Meta;
 
 type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
 

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -20,8 +20,8 @@ import {
 
 import { PreloadedEnglishI18nModule } from "../../../../../core/tests";
 
-import { AccessSelectorComponent } from "./access-selector.component";
-import { AccessItemType, CollectionPermission } from "./access-selector.models";
+import { AccessSelectorComponent, PermissionMode } from "./access-selector.component";
+import { AccessItemType, AccessItemValue, CollectionPermission } from "./access-selector.models";
 import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
@@ -55,18 +55,14 @@ export default {
   },
 } as Meta;
 
-// TODO: This is a workaround since this story does weird things.
-type Story = StoryObj<any>;
+type Story = StoryObj<AccessSelectorComponent & { initialValue: AccessItemValue[] }>;
 
 const sampleMembers = itemsFactory(10, AccessItemType.Member);
 const sampleGroups = itemsFactory(6, AccessItemType.Group);
 
-// TODO: These renders are badly handled but storybook has made it more difficult to use multiple renders in a single story.
-const StandaloneAccessSelectorRender = (args: any) => ({
+const render: Story["render"] = (args) => ({
   props: {
-    items: [],
     valueChanged: actionsData.onValueChanged,
-    initialValue: [],
     ...args,
   },
   template: `
@@ -109,7 +105,7 @@ const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).c
 
 export const MemberCollectionAccess: Story = {
   args: {
-    permissionMode: "edit",
+    permissionMode: PermissionMode.Edit,
     showMemberRoles: false,
     showGroupColumn: true,
     columnHeader: "Collection",
@@ -120,19 +116,22 @@ export const MemberCollectionAccess: Story = {
     initialValue: [],
     items: memberCollectionAccessItems,
   },
-  render: StandaloneAccessSelectorRender,
+  render,
 };
 
 export const MemberGroupAccess: Story = {
   args: {
-    permissionMode: "readonly",
+    permissionMode: PermissionMode.Readonly,
     showMemberRoles: false,
     columnHeader: "Groups",
     selectorLabelText: "Select Groups",
     selectorHelpText: "Some helper text describing what this does",
     emptySelectionText: "No groups added",
     disabled: false,
-    initialValue: [{ id: "3g" }, { id: "0g" }],
+    initialValue: [
+      { id: "3g", type: AccessItemType.Group },
+      { id: "0g", type: AccessItemType.Group },
+    ],
     items: itemsFactory(4, AccessItemType.Group).concat([
       {
         id: "admin",
@@ -142,27 +141,30 @@ export const MemberGroupAccess: Story = {
       },
     ]),
   },
-  render: StandaloneAccessSelectorRender,
+  render,
 };
 
 export const GroupMembersAccess: Story = {
   args: {
-    permissionMode: "hidden",
+    permissionMode: PermissionMode.Hidden,
     showMemberRoles: true,
     columnHeader: "Members",
     selectorLabelText: "Select Members",
     selectorHelpText: "Some helper text describing what this does",
     emptySelectionText: "No members added",
     disabled: false,
-    initialValue: [{ id: "2m" }, { id: "0m" }],
+    initialValue: [
+      { id: "2m", type: AccessItemType.Member },
+      { id: "0m", type: AccessItemType.Member },
+    ],
     items: sampleMembers,
   },
-  render: StandaloneAccessSelectorRender,
+  render,
 };
 
 export const CollectionAccess: Story = {
   args: {
-    permissionMode: "edit",
+    permissionMode: PermissionMode.Edit,
     showMemberRoles: false,
     columnHeader: "Groups/Members",
     selectorLabelText: "Select groups and members",
@@ -171,8 +173,8 @@ export const CollectionAccess: Story = {
     emptySelectionText: "No members or groups added",
     disabled: false,
     initialValue: [
-      { id: "3g", permission: CollectionPermission.EditExceptPass },
-      { id: "0m", permission: CollectionPermission.View },
+      { id: "3g", type: AccessItemType.Group, permission: CollectionPermission.EditExceptPass },
+      { id: "0m", type: AccessItemType.Member, permission: CollectionPermission.View },
     ],
     items: sampleGroups.concat(sampleMembers).concat([
       {
@@ -194,5 +196,5 @@ export const CollectionAccess: Story = {
       },
     ]),
   },
-  render: StandaloneAccessSelectorRender,
+  render,
 };

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.stories.ts
@@ -25,6 +25,15 @@ import { AccessItemType, AccessItemValue, CollectionPermission } from "./access-
 import { actionsData, itemsFactory } from "./storybook-utils";
 import { UserTypePipe } from "./user-type.pipe";
 
+/**
+ * The Access Selector is used to view and edit:
+ * - member and group access to collections
+ * - members assigned to groups
+ *
+ * It is highly configurable in order to display these relationships from each perspective. For example, you can
+ * manage member-group relationships from the perspective of a particular member (showing all their groups) or a
+ * particular group (showing all its members).
+ */
 export default {
   title: "Web/Organizations/Access Selector",
   decorators: [
@@ -99,6 +108,12 @@ const memberCollectionAccessItems = itemsFactory(3, AccessItemType.Collection).c
   },
 ]);
 
+/**
+ * Displays a member's collection access.
+ *
+ * This is currently used in the **Member dialog -> Collections tab**.
+ * It is also used with similar inputs in the **Groups dialog -> Collections tab** to show a group's collection access.
+ */
 export const MemberCollectionAccess: Story = {
   args: {
     permissionMode: PermissionMode.Edit,
@@ -115,6 +130,11 @@ export const MemberCollectionAccess: Story = {
   render,
 };
 
+/**
+ * Displays the groups a member is assigned to.
+ *
+ * This is currently used in the **Member dialog -> Groups tab**.
+ */
 export const MemberGroupAccess: Story = {
   args: {
     permissionMode: PermissionMode.Readonly,
@@ -140,6 +160,11 @@ export const MemberGroupAccess: Story = {
   render,
 };
 
+/**
+ * Displays the members assigned to a group.
+ *
+ * This is currently used in the **Group dialog -> Members tab**.
+ */
 export const GroupMembersAccess: Story = {
   args: {
     permissionMode: PermissionMode.Hidden,
@@ -158,6 +183,11 @@ export const GroupMembersAccess: Story = {
   render,
 };
 
+/**
+ * Displays the members and groups assigned to a collection.
+ *
+ * This is currently used in the **Collection dialog -> Access tab**.
+ */
 export const CollectionAccess: Story = {
   args: {
     permissionMode: PermissionMode.Edit,

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/storybook-utils.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/storybook-utils.ts
@@ -1,0 +1,44 @@
+import { action } from "@storybook/addon-actions";
+
+import { AccessItemType, AccessItemView } from "./access-selector.models";
+
+export const actionsData = {
+  onValueChanged: action("onValueChanged"),
+  onSubmit: action("onSubmit"),
+};
+
+/**
+ * Factory to help build semi-realistic looking items
+ * @param n - The number of items to build
+ * @param type - Which type to build
+ */
+export const itemsFactory = (n: number, type: AccessItemType) => {
+  return [...Array(n)].map((_: unknown, id: number) => {
+    const item: AccessItemView = {
+      id: id.toString(),
+      type: type,
+    } as AccessItemView;
+
+    switch (item.type) {
+      case AccessItemType.Collection:
+        item.labelName = item.listName = `Collection ${id}`;
+        item.id = item.id + "c";
+        item.parentGrouping = "Collection Parent Group " + ((id % 2) + 1);
+        break;
+      case AccessItemType.Group:
+        item.labelName = item.listName = `Group ${id}`;
+        item.id = item.id + "g";
+        break;
+      case AccessItemType.Member:
+        item.id = item.id + "m";
+        item.email = `member${id}@email.com`;
+        item.status = id % 3 == 0 ? 0 : 2;
+        item.labelName = item.status == 2 ? `Member ${id}` : item.email;
+        item.listName = item.status == 2 ? `${item.labelName} (${item.email})` : item.email;
+        item.role = id % 5;
+        break;
+    }
+
+    return item;
+  });
+};


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11623

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The access selector stories were in a single file which was hard to understand and maintain. This was called out during the last major Storybook update.

Notable changes:
- split stories into separate files
- move common helper methods to a utils file
- add typesafety to the `Story` type, instead of using `StoryObj<any>`
- add jsdoc comments, which are displayed in Storybook in the autogenerated Docs page of each category. This really helps understand what we're actually looking at and how it mirrors what's in our production app
- add a story for the Collection dialog in a disabled state
- tweak some of the test data to better represent real world examples after flexible collection changes, e.g. disabled rows
- fix the group member access story showing an empty "Permission" column

The last 2 items have triggered changes in Storybook, however these are intentional. Note that they are changes to stories only, the production code hasn't changed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See Storybook

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
