### PR TITLE
Fixed SecureSafe csv import fail

### DIFF
--- a/libs/importer/spec/securesafe-csv-importer.spec.ts
+++ b/libs/importer/spec/securesafe-csv-importer.spec.ts
@@ -4,7 +4,11 @@ import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 
 import { SecureSafeCsvImporter } from "../src/importers";
 
-import { data_upperUrl, data_lowerUrl } from "./test-data/securesafe-csv/securesafe-example.csv";
+import {
+  data_upperUrl,
+  data_lowerUrl,
+  data_surrounding_slashes,
+} from "./test-data/securesafe-csv/securesafe-example.csv";
 
 const CipherData = [
   {
@@ -46,6 +50,27 @@ const CipherData = [
         ],
       }),
       notes: null,
+      type: 1,
+    }),
+  },
+  {
+    title: "should remove surrounding slashes if present",
+    csv: data_surrounding_slashes,
+    expected: Object.assign(new CipherView(), {
+      id: null,
+      organizationId: null,
+      folderId: null,
+      name: "Gmail",
+      login: Object.assign(new LoginView(), {
+        username: "test@gmail.com",
+        password: "test",
+        uris: [
+          Object.assign(new LoginUriView(), {
+            uri: "https://gmail.com",
+          }),
+        ],
+      }),
+      notes: "comment",
       type: 1,
     }),
   },

--- a/libs/importer/spec/test-data/securesafe-csv/securesafe-example.csv.ts
+++ b/libs/importer/spec/test-data/securesafe-csv/securesafe-example.csv.ts
@@ -3,3 +3,6 @@ export const data_upperUrl = `"Title","Username","Password","URL","Comment"
 
 export const data_lowerUrl = `"Title","Username","Password","url","Comment"
 "Gmail","test@gmail.com","test","https://gmail.com"`;
+
+export const data_surrounding_slashes = `"/Title/","/Username/","/Password/","/URL/","/Comment/",
+"/Gmail/","/test@gmail.com/","/test/","/https://gmail.com/","/comment/"`;


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/10786

## 📔 Objective

SecureSafe exports csvs if a format where every value is surrounded by slashes (Ex: /Title/). This was causing the import to fail when trying to reference `value.Title` and so on. I added some functionality to remove any surrounding slashes so the import succeeds.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
