### PR TITLE
[PM-11628] Fix set password when there is no key

### DIFF
--- a/libs/angular/src/auth/components/set-password.component.ts
+++ b/libs/angular/src/auth/components/set-password.component.ts
@@ -173,9 +173,9 @@ export class SetPasswordComponent extends BaseChangePasswordComponent implements
       const existingUserPrivateKey = (await firstValueFrom(
         this.cryptoService.userPrivateKey$(this.userId),
       )) as Uint8Array;
-      const existingUserPublicKey = await firstValueFrom(
-        this.cryptoService.userPublicKey$(this.userId),
-      );
+      const existingUserPublicKey = existingUserPrivateKey
+        ? await firstValueFrom(this.cryptoService.userPublicKey$(this.userId))
+        : undefined;
       if (existingUserPrivateKey != null && existingUserPublicKey != null) {
         const existingUserPublicKeyB64 = Utils.fromBufferToB64(existingUserPublicKey);
         newKeyPair = [


### PR DESCRIPTION
## 📔 Objective

Fix set pasword form when no keys previously existed.

Since [userPublicKey$](https://github.com/bitwarden/clients/blob/77e03aee47071f7a4d41361c2be91012a639c7ea/libs/common/src/platform/services/crypto.service.ts#L942) derive the key from the private key it will fail when there is no private key.

Edit: It could make sense to directly call `derivePublicKey(UserPrivateKey)` instead of relying twice on `firstValueFrom`, but since it's `private` at the moment decided for the simplest fix.