### PR TITLE
[PM-11634] Return null in derivePublicKey if privateKey is null

### DIFF
--- a/libs/common/src/platform/services/crypto.service.ts
+++ b/libs/common/src/platform/services/crypto.service.ts
@@ -945,6 +945,10 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   private async derivePublicKey(privateKey: UserPrivateKey) {
+    if (privateKey == null) {
+      return null;
+    }
+
     return (await this.cryptoFunctionService.rsaExtractPublicKey(privateKey)) as UserPublicKey;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11634

## 📔 Objective

The userPublicKey$ observable is documented as returning null, however it instead throws an error if the private key is null / the user does not have a keypair. This PR fixes this behaviour by returning null early if the privatekey for the user is null.

## 📸 Screenshots


https://github.com/user-attachments/assets/cd756337-b5c0-4146-ad5d-d16d8079363b


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
