### PR TITLE
[PM-11444] swap account font color for muted

### DIFF
--- a/apps/web/src/app/layouts/header/web-header.component.html
+++ b/apps/web/src/app/layouts/header/web-header.component.html
@@ -36,13 +36,13 @@
           <bit-menu #accountMenu>
             <div class="tw-flex tw-min-w-52 tw-max-w-72 tw-flex-col">
               <div
-                class="tw-flex tw-items-center tw-px-4 tw-py-1 tw-leading-tight tw-text-info"
+                class="tw-flex tw-items-center tw-px-4 tw-py-1 tw-leading-tight tw-text-muted"
                 appStopProp
               >
                 <dynamic-avatar [id]="account.id" [text]="account | userName"></dynamic-avatar>
                 <div class="tw-ml-2 tw-block tw-overflow-hidden tw-whitespace-nowrap">
                   <span>{{ "loggedInAs" | i18n }}</span>
-                  <small class="tw-block tw-overflow-hidden tw-whitespace-nowrap tw-text-muted">
+                  <small class="tw-block tw-overflow-hidden tw-whitespace-nowrap">
                     {{ account | userName }}
                   </small>
                 </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11444](https://bitwarden.atlassian.net/browse/PM-11444)

## 📔 Objective

Swap colors of account menu from `info` to `muted`. I verified with Danielle that is this okay to go to main as the defect was more apparent in the `ps/extension-refresh` branch.

## 📸 Screenshots

#### Extension Refresh

|Before|After|
|-|-|
|<img width="240" alt="Screenshot 2024-09-03 at 1 55 17 PM" src="https://github.com/user-attachments/assets/374481eb-3952-4175-8fdf-04db1b2f43eb">|<img width="265" alt="Screenshot 2024-09-03 at 1 54 58 PM" src="https://github.com/user-attachments/assets/ed478e0c-1fd5-404c-b2f2-cb258437637f">|

#### `main`

|Before|After|
|-|-|
|![Screen Shot 2024-09-04 at 10 10 06 AM](https://github.com/user-attachments/assets/08d61fa7-3377-4085-99ed-d3173d49764d)|![Screen Shot 2024-09-04 at 10 10 02 AM](https://github.com/user-attachments/assets/d4e6a17c-5d6b-4c50-b450-a0f4c8dce5fe)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11444]: https://bitwarden.atlassian.net/browse/PM-11444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ