### PR TITLE
[CL-357] Remove border radius when displayed in web app

### DIFF
--- a/libs/components/src/card/card.component.ts
+++ b/libs/components/src/card/card.component.ts
@@ -9,7 +9,7 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class:
-      "tw-box-border tw-block tw-bg-background tw-text-main tw-border-solid tw-border-b tw-border-0 tw-border-b-secondary-300 tw-rounded-lg tw-py-4 tw-px-3",
+      "tw-box-border tw-block tw-bg-background tw-text-main tw-border-solid tw-border-b tw-border-0 tw-border-b-secondary-300 [&:not(bit-layout_*)]:tw-rounded-lg tw-py-4 tw-px-3",
   },
 })
 export class CardComponent {}

--- a/libs/components/src/card/card.stories.ts
+++ b/libs/components/src/card/card.stories.ts
@@ -1,7 +1,12 @@
+import { RouterTestingModule } from "@angular/router/testing";
 import { Meta, StoryObj, componentWrapperDecorator, moduleMetadata } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { LayoutComponent } from "../layout";
 import { SectionComponent } from "../section";
 import { TypographyModule } from "../typography";
+import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { CardComponent } from "./card.component";
 
@@ -10,7 +15,20 @@ export default {
   component: CardComponent,
   decorators: [
     moduleMetadata({
-      imports: [TypographyModule, SectionComponent],
+      imports: [TypographyModule, SectionComponent, LayoutComponent, RouterTestingModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              toggleSideNavigation: "Toggle side navigation",
+              skipToContent: "Skip to content",
+              submenu: "submenu",
+              toggleCollapse: "toggle collapse",
+            });
+          },
+        },
+      ],
     }),
     componentWrapperDecorator(
       (story) => `<div class="tw-bg-background-alt tw-p-10 tw-text-main">${story}</div>`,
@@ -58,5 +76,18 @@ export const WithinSections: Story = {
             </bit-card>
           </bit-section>
       `,
+  }),
+};
+
+export const WithoutBorderRadius: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+    <bit-layout>
+      <bit-card>
+        <p bitTypography="body1" class="!tw-mb-0">Cards used in <code>bit-layout</code> will not have a border radius</p>
+      </bit-card>
+    </bit-layout>
+    `,
   }),
 };

--- a/libs/components/src/item/item.component.html
+++ b/libs/components/src/item/item.component.html
@@ -1,6 +1,6 @@
 <!-- TODO: Colors will be finalized in the extension refresh feature branch -->
 <div
-  class="tw-box-border tw-overflow-auto tw-flex tw-bg-background [&:has(.item-main-content_button:hover,.item-main-content_a:hover)]:tw-bg-primary-300/20 tw-text-main tw-border-solid tw-border-b tw-border-0 tw-rounded-lg tw-mb-1.5"
+  class="tw-box-border tw-overflow-auto tw-flex tw-bg-background [&:has(.item-main-content_button:hover,.item-main-content_a:hover)]:tw-bg-primary-300/20 tw-text-main tw-border-solid tw-border-b tw-border-0 [&:not(bit-layout_*)]:tw-rounded-lg tw-mb-1.5"
   [ngClass]="
     focusVisibleWithin()
       ? 'tw-z-10 tw-rounded tw-outline-none tw-ring tw-ring-primary-600 tw-border-transparent'

--- a/libs/components/src/item/item.mdx
+++ b/libs/components/src/item/item.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Primary, Controls, Canvas } from "@storybook/addon-docs";
+import { Meta, Story, Primary, Controls } from "@storybook/addon-docs";
 
 import * as stories from "./item.stories";
 
@@ -15,9 +15,17 @@ import { ItemModule } from "@bitwarden/components";
 It is a generic container that can be used for either standalone content, an alternative to tables,
 or to list nav links.
 
-<Canvas>
-  <Story of={stories.Default} />
-</Canvas>
+<Story of={stories.Default} />
+
+<br />
+
+Items used within a parent `bit-layout` component will not have a border radius, since the
+`bit-layout` background is white.
+
+<Story of={stories.WithoutBorderRadius} />
+
+<br />
+<br />
 
 ## Primary Content
 
@@ -41,9 +49,7 @@ The content can be a button, anchor, or static container.
 </bit-item>
 ```
 
-<Canvas>
-  <Story of={stories.ContentTypes} />
-</Canvas>
+<Story of={stories.ContentTypes} />
 
 ### Content Slots
 
@@ -74,9 +80,7 @@ The content can be a button, anchor, or static container.
 </bit-item>
 ```
 
-<Canvas>
-  <Story of={stories.ContentSlots} />
-</Canvas>
+<Story of={stories.ContentSlots} />
 
 ## Secondary Actions
 
@@ -109,13 +113,9 @@ Actions are commonly icon buttons or badge buttons.
 
 Groups of items can be associated by wrapping them in the `<bit-item-group>`.
 
-<Canvas>
-  <Story of={stories.MultipleActionList} />
-</Canvas>
+<Story of={stories.MultipleActionList} />
 
-<Canvas>
-  <Story of={stories.SingleActionList} />
-</Canvas>
+<Story of={stories.SingleActionList} />
 
 ### A11y
 
@@ -136,6 +136,4 @@ Use `aria-label` or `aria-labelledby` to give groups an accessible name.
 
 ### Virtual Scrolling
 
-<Canvas>
-  <Story of={stories.VirtualScrolling} />
-</Canvas>
+<Story of={stories.VirtualScrolling} />

--- a/libs/components/src/item/item.stories.ts
+++ b/libs/components/src/item/item.stories.ts
@@ -1,12 +1,17 @@
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
+import { RouterTestingModule } from "@angular/router/testing";
 import { Meta, StoryObj, componentWrapperDecorator, moduleMetadata } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { A11yGridDirective } from "../a11y/a11y-grid.directive";
 import { AvatarModule } from "../avatar";
 import { BadgeModule } from "../badge";
 import { IconButtonModule } from "../icon-button";
+import { LayoutComponent } from "../layout";
 import { TypographyModule } from "../typography";
+import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { ItemActionComponent } from "./item-action.component";
 import { ItemContentComponent } from "./item-content.component";
@@ -29,6 +34,21 @@ export default {
         ItemContentComponent,
         A11yGridDirective,
         ScrollingModule,
+        LayoutComponent,
+        RouterTestingModule,
+      ],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              toggleSideNavigation: "Toggle side navigation",
+              skipToContent: "Skip to content",
+              submenu: "submenu",
+              toggleCollapse: "toggle collapse",
+            });
+          },
+        },
       ],
     }),
     componentWrapperDecorator((story) => `<div class="tw-bg-background-alt tw-p-2">${story}</div>`),
@@ -330,6 +350,35 @@ export const VirtualScrolling: Story = {
           </bit-item>
         </bit-item-group>
       </cdk-virtual-scroll-viewport>
+    `,
+  }),
+};
+
+export const WithoutBorderRadius: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-layout>
+      <bit-item>
+        <button bit-item-content>
+          <i slot="start" class="bwi bwi-globe tw-text-3xl tw-text-muted" aria-hidden="true"></i>
+          Foo
+          <span slot="secondary">Bar</span>
+        </button>
+
+        <ng-container slot="end">
+          <bit-item-action>
+            <button type="button" bitBadge variant="primary">Auto-fill</button>
+          </bit-item-action>
+          <bit-item-action>
+            <button type="button" bitIconButton="bwi-clone"></button>
+          </bit-item-action>
+          <bit-item-action>
+            <button type="button" bitIconButton="bwi-ellipsis-v"></button>
+          </bit-item-action>
+        </ng-container>
+      </bit-item>
+    </bit-layout>
     `,
   }),
 };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-357](https://bitwarden.atlassian.net/browse/CL-357)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
If a `bit-card` or `bit-item` are used in the web app, we want to remove the border radius. This is because the background of the web app is white, and the `card` and `item` backgrounds are also white, which makes the bottom border look strange if it has a radius. 

This is meant to be a short-term solution to the white-on-white problem, so we are using a simple css ancestor selector to check if the `card` or `item` is rendered within the web app's `bit-layout`. This means that `card`s and `item`s used in the browser extension will still retain their border radius as per design specifications, as will `card`s and `item`s in dialogs in both the web app and the browser extension. (Dialogs are rendered outside of the `bit-layout` even on web.) 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Items in `bit-layout`:
![Screenshot 2024-09-04 at 11 11 56 AM](https://github.com/user-attachments/assets/3ced8e68-5185-47cf-a2a1-d335d1024d04)

Cards in `bit-layout`:
![Screenshot 2024-09-04 at 11 12 07 AM](https://github.com/user-attachments/assets/631d29f3-91c9-4c92-999a-56bbe7107e99)

Example in web app:
![Screenshot 2024-09-04 at 11 14 17 AM](https://github.com/user-attachments/assets/24815939-2c91-4058-9852-bc334d4cdb5c)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-357]: https://bitwarden.atlassian.net/browse/CL-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ