### PR TITLE
[PM-11629] Handle detached table cells in autofill service

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -644,6 +644,10 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     }
 
     const tableDataElementIndex = tableDataElement.cellIndex;
+    if (tableDataElementIndex < 0) {
+      return null;
+    }
+
     const parentSiblingTableRowElement = tableDataElement.closest("tr")
       ?.previousElementSibling as HTMLTableRowElement;
 


### PR DESCRIPTION
Fixes errors and high CPU usage / browser lockup on offending webpages.

HTMLTableCellElement.cellIndex will be -1 if the cell is not part of any row, which will cause getTextContentFromElement to fail since it will not receive a valid sibling cell.

## 🎟️ Tracking

PM-11629

## 📔 Objective

[PR to build artifacts for "link to original PR"](https://github.com/bitwarden/clients/pull/10880)