### PR TITLE
Auth/PM-11635 - Extension Registration Bugfix - Unable to login after account creation issue

### DIFF
--- a/apps/browser/src/auth/popup/login.component.ts
+++ b/apps/browser/src/auth/popup/login.component.ts
@@ -86,10 +86,8 @@ export class LoginComponent extends BaseLoginComponent implements OnInit {
   }
 
   async ngOnInit(): Promise<void> {
+    await super.ngOnInit();
     if (this.showPasswordless) {
-      const loginEmail = await firstValueFrom(this.loginEmailService.loginEmail$);
-      this.formGroup.controls.email.setValue(loginEmail);
-      this.formGroup.controls.rememberEmail.setValue(this.loginEmailService.getRememberEmail());
       await this.validateEmail();
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11635

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

To resolve registration being broken on the extension due to the login component no longer executing the base component `ngOnInit` logic which was responsible for parsing the email from the query params. The extension register and login flows both use query params to pass email to the login component. They probably should use the `loginEmailService` in the future so we only have one method of saving the user's email in app, but we probably will still have to support query params as we offer links with prefilled email, I think. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
I recorded logging in to prove the login flow still preserves email and then I recorded new account creation to show it is fixed. 

https://github.com/user-attachments/assets/a6e55db1-76f5-41cd-bdf6-03ff36af34bf


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
