### PR TITLE
[PM-11661]Add New Reseed - Fill Buffer Behind Feature Flag

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1463,7 +1463,14 @@ export default class MainBackground {
     });
 
     if (needStorageReseed) {
-      await this.reseedStorage();
+      await this.reseedStorage(
+        await firstValueFrom(
+          this.configService.userCachedFeatureFlag$(
+            FeatureFlag.StorageReseedRefactor,
+            userBeingLoggedOut,
+          ),
+        ),
+      );
     }
 
     if (BrowserApi.isManifestVersion(3)) {
@@ -1518,7 +1525,7 @@ export default class MainBackground {
     await SafariApp.sendMessageToApp("showPopover", null, true);
   }
 
-  async reseedStorage() {
+  async reseedStorage(doFillBuffer: boolean) {
     if (
       !this.platformUtilsService.isChrome() &&
       !this.platformUtilsService.isVivaldi() &&
@@ -1527,7 +1534,11 @@ export default class MainBackground {
       return;
     }
 
-    await this.storageService.reseed();
+    if (doFillBuffer) {
+      await this.storageService.fillBuffer();
+    } else {
+      await this.storageService.reseed();
+    }
   }
 
   async clearClipboard(clipboardValue: string, clearMs: number) {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, map, mergeMap } from "rxjs";
+import { firstValueFrom, map, mergeMap, of, switchMap } from "rxjs";
 
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -272,9 +272,25 @@ export default class RuntimeBackground {
         await this.main.refreshBadge();
         await this.main.refreshMenu();
         break;
-      case "bgReseedStorage":
-        await this.main.reseedStorage();
+      case "bgReseedStorage": {
+        const doFillBuffer = await firstValueFrom(
+          this.accountService.activeAccount$.pipe(
+            switchMap((account) => {
+              if (account == null) {
+                return of(false);
+              }
+
+              return this.configService.userCachedFeatureFlag$(
+                FeatureFlag.StorageReseedRefactor,
+                account.id,
+              );
+            }),
+          ),
+        );
+
+        await this.main.reseedStorage(doFillBuffer);
         break;
+      }
       case "authResult": {
         const env = await firstValueFrom(this.environmentService.environment$);
         const vaultUrl = env.getWebVaultUrl();

--- a/apps/browser/src/platform/services/browser-local-storage.service.ts
+++ b/apps/browser/src/platform/services/browser-local-storage.service.ts
@@ -32,6 +32,46 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
     }
   }
 
+  async fillBuffer() {
+    // Write 4MB of data in chrome.storage.local, log files will hold 4MB of data (by default)
+    // before forcing a compaction. To force a compaction and have it remove previously saved data,
+    // we want to fill it's buffer so that anything newly marked for deletion is gone.
+    // https://github.com/google/leveldb/blob/main/doc/impl.md#log-files
+    // It's important that if Google uses a different buffer length that we match that, as far as I can tell
+    // Google uses the default value in Chromium:
+    // https://github.com/chromium/chromium/blob/148774efa6b3a047369af6179a4248566b39d68f/components/value_store/lazy_leveldb.cc#L65-L66
+    const fakeData = "0".repeat(1024 * 1024); // 1MB of data
+    await new Promise<void>((resolve, reject) => {
+      this.chromeStorageApi.set(
+        {
+          fake_data_1: fakeData,
+          fake_data_2: fakeData,
+          fake_data_3: fakeData,
+          fake_data_4: fakeData,
+        },
+        () => {
+          if (chrome.runtime.lastError) {
+            return reject(chrome.runtime.lastError);
+          }
+
+          resolve();
+        },
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      this.chromeStorageApi.remove(
+        ["fake_data_1", "fake_data_2", "fake_data_3", "fake_data_4"],
+        () => {
+          if (chrome.runtime.lastError) {
+            return reject(chrome.runtime.lastError);
+          }
+
+          resolve();
+        },
+      );
+    });
+  }
+
   override async get<T>(key: string): Promise<T> {
     await this.awaitReseed();
     return super.get(key);

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -34,6 +34,7 @@ export enum FeatureFlag {
   AccountDeprovisioning = "pm-10308-account-deprovisioning",
   NotificationBarAddLoginImprovements = "notification-bar-add-login-improvements",
   AC2476_DeprecateStripeSourcesAPI = "AC-2476-deprecate-stripe-sources-api",
+  StorageReseedRefactor = "storage-reseed-refactor",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -75,6 +76,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.EnableUpgradePasswordManagerSub]: FALSE,
   [FeatureFlag.GenerateIdentityFillScriptRefactor]: FALSE,
   [FeatureFlag.DelayFido2PageScriptInitWithinMv2]: FALSE,
+  [FeatureFlag.StorageReseedRefactor]: FALSE,
   [FeatureFlag.AccountDeprovisioning]: FALSE,
   [FeatureFlag.NotificationBarAddLoginImprovements]: FALSE,
   [FeatureFlag.AC2476_DeprecateStripeSourcesAPI]: FALSE,

--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -2,6 +2,7 @@ import { Observable } from "rxjs";
 import { SemVer } from "semver";
 
 import { FeatureFlag, FeatureFlagValueType } from "../../../enums/feature-flag.enum";
+import { UserId } from "../../../types/guid";
 import { Region } from "../environment.service";
 
 import { ServerConfig } from "./server-config";
@@ -17,6 +18,18 @@ export abstract class ConfigService {
    * @returns An observable that emits the value of the feature flag, updates as the server config changes
    */
   getFeatureFlag$: <Flag extends FeatureFlag>(key: Flag) => Observable<FeatureFlagValueType<Flag>>;
+
+  /**
+   * Retrieves the cached feature flag value for a give user. This will NOT call to the server to get
+   * the most up to date feature flag.
+   * @param key The feature flag key to get the value for.
+   * @param userId The user id of the user to get the feature flag value for.
+   */
+  abstract userCachedFeatureFlag$<Flag extends FeatureFlag>(
+    key: Flag,
+    userId: UserId,
+  ): Observable<FeatureFlagValueType<Flag>>;
+
   /**
    * Retrieves the value of a feature flag for the currently active user
    * @param key The feature flag to retrieve

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -115,14 +115,25 @@ export class DefaultConfigService implements ConfigService {
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {
     return this.serverConfig$.pipe(
-      map((serverConfig) => {
-        if (serverConfig?.featureStates == null || serverConfig.featureStates[key] == null) {
-          return DefaultFeatureFlagValue[key];
-        }
-
-        return serverConfig.featureStates[key] as FeatureFlagValueType<Flag>;
-      }),
+      map((serverConfig) => this.getFeatureFlagValue(serverConfig, key)),
     );
+  }
+
+  private getFeatureFlagValue<Flag extends FeatureFlag>(
+    serverConfig: ServerConfig | null,
+    flag: Flag,
+  ) {
+    if (serverConfig?.featureStates == null || serverConfig.featureStates[flag] == null) {
+      return DefaultFeatureFlagValue[flag];
+    }
+
+    return serverConfig.featureStates[flag] as FeatureFlagValueType<Flag>;
+  }
+
+  userCachedFeatureFlag$<Flag extends FeatureFlag>(key: Flag, userId: UserId) {
+    return this.stateProvider
+      .getUser(userId, USER_SERVER_CONFIG)
+      .state$.pipe(map((config) => this.getFeatureFlagValue(config, key)));
   }
 
   async getFeatureFlag<Flag extends FeatureFlag>(key: Flag) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-11661

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add a new reseed strategy that fills a 4MB buffer instead of clearing all data and resaving it. The 4MB number comes from the default LOG file size of LevelDB. Since reseed happens during a logout we needed a way to get user specific feature flag values while they are not active. This adds a method to `ConfigService` that only reads the cached value saved in state and does not attempt to go to the server to refresh it. This relies on the user having retrieved config values while they were logged in. This is an alright tradeoff because the other reseed method is just as, if not more secure so if we happened to have gotten an incorrect feature flag value it's fine.

Server PR: TODO

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
