### PR TITLE
[PM-11436] New "+" button

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -110,7 +110,8 @@
         id="newItemDropdown"
         appA11yTitle="{{ 'new' | i18n }}"
       >
-        {{ "new" | i18n }}<i class="bwi bwi-angle-down tw-ml-2" aria-hidden="true"></i>
+        <i class="bwi bwi-plus-f" aria-hidden="true"></i>
+        {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
       </button>
       <bit-menu #addOptions aria-labelledby="newItemDropdown">
         <ng-container [ngSwitch]="extensionRefreshEnabled">

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -100,7 +100,10 @@
     [placeholder]="'searchCollection' | i18n"
   ></bit-search>
 
-  <div *ngIf="filter.type !== 'trash' && filter.collectionId !== Unassigned" class="tw-shrink-0">
+  <div
+    *ngIf="filter.type !== 'trash' && filter.collectionId !== Unassigned && organization"
+    class="tw-shrink-0"
+  >
     <div *ngIf="canCreateCipher && canCreateCollection" appListDropdown>
       <button
         bitButton

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/new-menu.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/new-menu.component.html
@@ -1,11 +1,6 @@
-<button
-  type="button"
-  bitButton
-  class="tw-min-w-max"
-  buttonType="primary"
-  [bitMenuTriggerFor]="newMenu"
->
-  {{ "new" | i18n }} <i class="bwi bwi-angle-down" aria-hidden="true"></i>
+<button type="button" bitButton buttonType="primary" [bitMenuTriggerFor]="newMenu">
+  <i class="bwi bwi-plus-f" aria-hidden="true"></i>
+  {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
 </button>
 
 <bit-menu #newMenu>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11436](https://bitwarden.atlassian.net/browse/PM-11436)

## 📔 Objective

Standardize the "+ New" button on Password Manager, Secrets Manager and Admin Console
- Also add a check for "organization" to stop the "new item" from flashing before the organization is populated in the Admin Console

## 📸 Screenshots

![Screen Recording 2024-09-05 at 10 44 53 AM](https://github.com/user-attachments/assets/a69995be-e928-40ab-bc2a-54b2bd3d7592)


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11436]: https://bitwarden.atlassian.net/browse/PM-11436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ