### PR TITLE
[PM-11433] Add title for attachment name

### DIFF
--- a/libs/vault/src/cipher-form/components/attachments/cipher-attachments.component.html
+++ b/libs/vault/src/cipher-form/components/attachments/cipher-attachments.component.html
@@ -4,7 +4,7 @@
   <li *ngFor="let attachment of cipher.attachments">
     <bit-item>
       <bit-item-content>
-        <span data-testid="file-name">{{ attachment.fileName }}</span>
+        <span data-testid="file-name" [title]="attachment.fileName">{{ attachment.fileName }}</span>
         <span slot="secondary" data-testid="file-size">{{ attachment.sizeName }}</span>
       </bit-item-content>
       <ng-container slot="end">

--- a/libs/vault/src/cipher-view/attachments/attachments-v2-view.component.html
+++ b/libs/vault/src/cipher-view/attachments/attachments-v2-view.component.html
@@ -5,7 +5,7 @@
   <bit-item-group>
     <bit-item *ngFor="let attachment of cipher.attachments">
       <bit-item-content>
-        <span data-testid="file-name">{{ attachment.fileName }}</span>
+        <span data-testid="file-name" [title]="attachment.fileName">{{ attachment.fileName }}</span>
         <span slot="secondary" data-testid="file-size">{{ attachment.sizeName }}</span>
       </bit-item-content>
       <ng-container slot="end">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11433](https://bitwarden.atlassian.net/browse/PM-11433)

## 📔 Objective

- Adds the ability for a user to see the attachment name while hovering over it, especially helpful when the name is truncated. 

## 📸 Screenshots

|View|Attachments|
|-|-|
|![Screenshot 2024-09-05 at 11 04 39 AM](https://github.com/user-attachments/assets/85a1e800-a8f6-49ef-8f46-7bbc105e6da2)|
![Screenshot 2024-09-05 at 11 04 25 AM](https://github.com/user-attachments/assets/f5d1e480-74bf-45a8-a097-5d1345f50ecc)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
