### PR TITLE
[PM-11692] [PM-11693] [PM-11694] Fixed defects with browser refresh trash component

### DIFF
--- a/apps/browser/src/popup/app-routing.animations.ts
+++ b/apps/browser/src/popup/app-routing.animations.ts
@@ -202,6 +202,9 @@ export const routerTransition = trigger("routerTransition", [
   transition("vault-settings => trash", inSlideLeft),
   transition("trash => vault-settings", outSlideRight),
 
+  transition("trash => view-cipher", inSlideLeft),
+  transition("view-cipher => trash", outSlideRight),
+
   // Appearance settings
   transition("tabs => appearance", inSlideLeft),
   transition("appearance => tabs", outSlideRight),

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -33,7 +33,7 @@
       type="button"
       buttonType="danger"
       bitIconButton="bwi-trash"
-      [appA11yTitle]="'delete' | i18n"
+      [appA11yTitle]="(cipher.isDeleted ? 'deleteForever' : 'delete') | i18n"
     ></button>
   </popup-footer>
 </popup-page>

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
@@ -55,6 +55,8 @@ export class TrashListItemsContainerComponent {
   async restore(cipher: CipherView) {
     try {
       await this.cipherService.restoreWithServer(cipher.id);
+
+      await this.router.navigate(["/vault"]);
       this.toastService.showToast({
         variant: "success",
         title: null,
@@ -84,10 +86,12 @@ export class TrashListItemsContainerComponent {
 
     try {
       await this.cipherService.deleteWithServer(cipher.id);
+
+      await this.router.navigate(["/vault"]);
       this.toastService.showToast({
         variant: "success",
         title: null,
-        message: this.i18nService.t("deletedItem"),
+        message: this.i18nService.t("permanentlyDeletedItem"),
       });
     } catch (e) {
       this.logService.error(e);


### PR DESCRIPTION
## 🎟️ Tracking
[PM-11692](https://bitwarden.atlassian.net/browse/PM-11692)
[PM-11693](https://bitwarden.atlassian.net/browse/PM-11693)
[PM-11694](https://bitwarden.atlassian.net/browse/PM-11694)

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
* Viewing item does not slide transition in
* Restoring/permanently deleting item from View item page takes you to Vault page
* Permanently Delete button has incorrect screenreader announcement

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/5ecc3ea8-56fa-46aa-88d8-1696a5cd460a


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11692]: https://bitwarden.atlassian.net/browse/PM-11692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-11693]: https://bitwarden.atlassian.net/browse/PM-11693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-11694]: https://bitwarden.atlassian.net/browse/PM-11694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ