### PR TITLE
[PM-11130] Character Count aria-label

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4300,8 +4300,11 @@
   "enterprisePolicyRequirementsApplied": {
     "message": "Enterprise policy requirements have been applied to this setting"
   },
-  "additionalContentAvailable": {
-    "message": "Additional content is available"
+  "showCharacterCount": {
+    "message": "Show character count"
+  },
+  "hideCharacterCount": {
+    "message": "Hide character count"
   },
   "itemsInTrash": {
     "message": "Items in trash"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -71,7 +71,7 @@
   },
   "itemHistory": {
     "message": "Item history"
-  },  
+  },
   "authenticatorKey": {
     "message": "Authenticator key"
   },
@@ -9050,8 +9050,11 @@
     "message": "Public API",
     "description": "The text, 'API', is an acronymn and should not be translated."
   },
-  "additionalContentAvailable": {
-    "message": "Additional content is available"
+  "showCharacterCount": {
+    "message": "Show character count"
+  },
+  "hideCharacterCount": {
+    "message": "Hide character count"
   },
   "editAccess": {
     "message": "Edit access"

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -51,10 +51,10 @@
         bitSuffix
         type="button"
         data-testid="toggle-password-count"
-        [appA11yTitle]="'toggleCharacterCount' | i18n"
+        [appA11yTitle]="(showPasswordCount ? 'hideCharacterCount' : 'showCharacterCount') | i18n"
+        [attr.aria-expanded]="showPasswordCount"
         appStopClick
         (click)="togglePasswordCount()"
-        [attr.aria-label]="'additionalContentAvailable' | i18n"
       ></button>
       <button
         *ngIf="cipher.viewPassword"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11130](https://bitwarden.atlassian.net/browse/PM-11130)

## 📔 Objective

- Update aria-label of the character count button to have more specific text
  - Also added `aria-expanded` so that the screen reader announces whether the content is expanded or not.
  
  
## 📸 Screenshots

https://github.com/user-attachments/assets/6fcbb2b8-ee6f-4fe3-b86d-7db01f183b5c

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11130]: https://bitwarden.atlassian.net/browse/PM-11130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ