### PR TITLE
Auth/PM-10684 - Fix CLI asking for MP even if session key provided as command option

### DIFF
--- a/apps/cli/src/base-program.ts
+++ b/apps/cli/src/base-program.ts
@@ -136,12 +136,11 @@ export abstract class BaseProgram {
 
   protected async exitIfLocked() {
     const userId = await this.exitIfNotAuthed();
-    let hasUserKey = false;
 
     // If the process.env does not have a BW_SESSION key, then we will never be able to retrieve
     // the auto user key from secure storage. This is because the auto user key is encrypted with
     // the session key.
-    hasUserKey =
+    const hasUserKey =
       await this.serviceContainer.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(
         userId,
       );

--- a/apps/cli/src/base-program.ts
+++ b/apps/cli/src/base-program.ts
@@ -3,6 +3,7 @@ import { firstValueFrom, map } from "rxjs";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { UserId } from "@bitwarden/common/types/guid";
 
 import { UnlockCommand } from "./auth/commands/unlock.command";
 import { Response } from "./models/response";
@@ -135,37 +136,56 @@ export abstract class BaseProgram {
 
   protected async exitIfLocked() {
     const userId = await this.exitIfNotAuthed();
-    if (await this.serviceContainer.cryptoService.hasUserKey()) {
+    let hasUserKey = false;
+
+    // If the process.env does not have a BW_SESSION key, then we will never be able to retrieve
+    // the auto user key from secure storage. This is because the auto user key is encrypted with
+    // the session key.
+    hasUserKey =
+      await this.serviceContainer.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(
+        userId,
+      );
+
+    if (hasUserKey) {
+      // User is unlocked
       return;
-    } else if (process.env.BW_NOINTERACTION !== "true") {
-      // must unlock
-      if (await this.serviceContainer.keyConnectorService.getUsesKeyConnector(userId)) {
-        const response = Response.error(
-          "Your vault is locked. You must unlock your vault using your session key.\n" +
-            "If you do not have your session key, you can get a new one by logging out and logging in again.",
-        );
-        this.processResponse(response, true);
-      } else {
-        const command = new UnlockCommand(
-          this.serviceContainer.accountService,
-          this.serviceContainer.masterPasswordService,
-          this.serviceContainer.cryptoService,
-          this.serviceContainer.userVerificationService,
-          this.serviceContainer.cryptoFunctionService,
-          this.serviceContainer.logService,
-          this.serviceContainer.keyConnectorService,
-          this.serviceContainer.environmentService,
-          this.serviceContainer.syncService,
-          this.serviceContainer.organizationApiService,
-          this.serviceContainer.logout,
-        );
-        const response = await command.run(null, null);
-        if (!response.success) {
-          this.processResponse(response, true);
-        }
-      }
-    } else {
+    }
+
+    // User is locked
+    await this.handleLockedUser(userId);
+  }
+
+  private async handleLockedUser(userId: UserId) {
+    if (process.env.BW_NOINTERACTION === "true") {
       this.processResponse(Response.error("Vault is locked."), true);
+      return;
+    }
+
+    // must unlock with interaction allowed
+    if (await this.serviceContainer.keyConnectorService.getUsesKeyConnector(userId)) {
+      const response = Response.error(
+        "Your vault is locked. You must unlock your vault using your session key.\n" +
+          "If you do not have your session key, you can get a new one by logging out and logging in again.",
+      );
+      this.processResponse(response, true);
+    } else {
+      const command = new UnlockCommand(
+        this.serviceContainer.accountService,
+        this.serviceContainer.masterPasswordService,
+        this.serviceContainer.cryptoService,
+        this.serviceContainer.userVerificationService,
+        this.serviceContainer.cryptoFunctionService,
+        this.serviceContainer.logService,
+        this.serviceContainer.keyConnectorService,
+        this.serviceContainer.environmentService,
+        this.serviceContainer.syncService,
+        this.serviceContainer.organizationApiService,
+        this.serviceContainer.logout,
+      );
+      const response = await command.run(null, null);
+      if (!response.success) {
+        this.processResponse(response, true);
+      }
     }
   }
 

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -1,6 +1,5 @@
 import * as chalk from "chalk";
 import { program, Command, OptionValues } from "commander";
-import { firstValueFrom } from "rxjs";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 
@@ -61,18 +60,8 @@ export class Program extends BaseProgram {
       process.env.BW_NOINTERACTION = "true";
     });
 
-    program.on("option:session", async (key) => {
+    program.on("option:session", (key) => {
       process.env.BW_SESSION = key;
-
-      // once we have the session key, we can set the user key in memory
-      const activeAccount = await firstValueFrom(
-        this.serviceContainer.accountService.activeAccount$,
-      );
-      if (activeAccount) {
-        await this.serviceContainer.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(
-          activeAccount.id,
-        );
-      }
     });
 
     program.on("command:*", () => {

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -803,6 +803,10 @@ export class ServiceContainer {
     await this.i18nService.init();
     this.twoFactorService.init();
 
+    // If a user has a BW_SESSION key stored in their env (not process.env.BW_SESSION),
+    // this should set the user key to unlock the vault on init.
+    // TODO: ideally, we wouldn't want to do this here but instead only for commands that require the vault to be unlocked
+    // as this runs on every command and could be a performance hit
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
     if (activeAccount?.id) {
       await this.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(activeAccount.id);

--- a/libs/common/src/platform/services/user-auto-unlock-key.service.ts
+++ b/libs/common/src/platform/services/user-auto-unlock-key.service.ts
@@ -16,10 +16,11 @@ export class UserAutoUnlockKeyService {
    * However, for users that have the auto unlock user key set, we need to set the user key in memory
    * on application bootstrap and on active account changes so that the user's vault loads unlocked.
    * @param userId - The user id to check for an auto user key.
+   * @returns True if the auto user key is set successfully, false otherwise.
    */
-  async setUserKeyInMemoryIfAutoUserKeySet(userId: UserId): Promise<void> {
+  async setUserKeyInMemoryIfAutoUserKeySet(userId: UserId): Promise<boolean> {
     if (userId == null) {
-      return;
+      return false;
     }
 
     const autoUserKey = await this.cryptoService.getUserKeyFromStorage(
@@ -28,9 +29,10 @@ export class UserAutoUnlockKeyService {
     );
 
     if (autoUserKey == null) {
-      return;
+      return false;
     }
 
     await this.cryptoService.setUserKey(autoUserKey, userId);
+    return true;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10684

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To remove a race condition between checking for the user key in state and setting the auto user key. 
The `apps/cli/src/program.ts` "option:session" handler being async allowed it to execute in parallel with the command and `apps/cli/src/base-program.ts` `exitIfLocked()` method. The `exitIfLocked()` method was calling to check if there was a user key before the "option:session" handler had finished setting the user key from the auto user key. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/3b0b9742-16ee-49d9-92b1-17dbe5399366



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
