### PR TITLE
[PM-11702] BitItemContent overflow

### DIFF
--- a/libs/components/src/item/item-content.component.html
+++ b/libs/components/src/item/item-content.component.html
@@ -1,4 +1,4 @@
-<div class="tw-flex tw-gap-2 tw-items-center tw-w-full">
+<div class="tw-flex tw-gap-2 tw-items-center tw-w-full tw-min-w-0">
   <ng-content select="[slot=start]"></ng-content>
 
   <div class="tw-flex tw-flex-col tw-items-start tw-text-start tw-w-full tw-truncate [&_p]:tw-mb-0">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11702](https://bitwarden.atlassian.net/browse/PM-11702)

## 📔 Objective

- Issue: If a user has a larger default font size and longer email address the icons can be pushed out of view of the account switcher.
- Fix: Reset `min-width` within `bit-item-content` to `0` to override flex from setting `min-width` to `auto`.
  - I don't get to link to a spec often but here it's the only thing that makes sense. [CSS Spec for Flex](https://www.w3.org/TR/css-flexbox-1/#min-size-auto)
  - TLDR; `flex` sets `min-width: auto` whose overflow is visible and not a scroll element, auto equates to the "content-based minimum size". Which I understand to be the natural width of the content. The width of the item  content grows with the `rem` unit causing overflow. Rather than having the text be truncated.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/4d8184e5-50c6-468d-8de0-f44dfbb448f8"/>|<video src="https://github.com/user-attachments/assets/dc0d9e82-6ae5-4227-a796-60fa2cce9a47"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11702]: https://bitwarden.atlassian.net/browse/PM-11702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ