### PR TITLE
[PM-11590] Collection dialog - reduce api calls

### DIFF
--- a/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/vault/components/collection-dialog/collection-dialog.component.ts
@@ -157,14 +157,23 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
       collections: this.collectionAdminService.getAll(orgId),
       groups: groups$,
       // Collection(s) needed to map readonlypermission for (potential) access selector disabled state
-      users: this.organizationUserApiService.getAllUsers(orgId, { includeCollections: true }),
+      users: this.organizationUserApiService.getAllUsers(orgId),
     })
       .pipe(takeUntil(this.formGroup.controls.selectedOrg.valueChanges), takeUntil(this.destroy$))
       .subscribe(({ organization, collections: allCollections, groups, users }) => {
         this.organization = organization;
+
+        if (this.params.collectionId) {
+          this.collection = allCollections.find((c) => c.id === this.collectionId);
+
+          if (!this.collection) {
+            throw new Error("Could not find collection to edit.");
+          }
+        }
+
         this.accessItems = [].concat(
-          groups.map((group) => mapGroupToAccessItemView(group, this.collectionId)),
-          users.data.map((user) => mapUserToAccessItemView(user, this.collectionId)),
+          groups.map((group) => mapGroupToAccessItemView(group, this.collection)),
+          users.data.map((user) => mapUserToAccessItemView(user, this.collection)),
         );
 
         // Force change detection to update the access selector's items
@@ -174,14 +183,9 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
           ? allCollections.filter((c) => c.manage)
           : allCollections;
 
-        if (this.params.collectionId) {
-          this.collection = allCollections.find((c) => c.id === this.collectionId);
+        if (this.collection) {
           // Ensure we don't allow nesting the current collection within itself
           this.nestOptions = this.nestOptions.filter((c) => c.id !== this.collectionId);
-
-          if (!this.collection) {
-            throw new Error("Could not find collection to edit.");
-          }
 
           // Parse the name to find its parent name
           const { name, parent: parentName } = parseName(this.collection);
@@ -423,7 +427,10 @@ function validateCanManagePermission(control: AbstractControl) {
  * @param collectionId Current collection being viewed/edited
  * @returns AccessItemView customized to set a readonlyPermission to be displayed if the access selector is in a disabled state
  */
-function mapGroupToAccessItemView(group: GroupView, collectionId: string): AccessItemView {
+function mapGroupToAccessItemView(
+  group: GroupView,
+  collection: CollectionAdminView,
+): AccessItemView {
   return {
     id: group.id,
     type: AccessItemType.Group,
@@ -431,8 +438,8 @@ function mapGroupToAccessItemView(group: GroupView, collectionId: string): Acces
     labelName: group.name,
     readonly: false,
     readonlyPermission:
-      collectionId != null
-        ? convertToPermission(group.collections.find((gc) => gc.id == collectionId))
+      collection != null
+        ? convertToPermission(collection.groups.find((g) => g.id === group.id))
         : undefined,
   };
 }
@@ -445,7 +452,7 @@ function mapGroupToAccessItemView(group: GroupView, collectionId: string): Acces
  */
 function mapUserToAccessItemView(
   user: OrganizationUserUserDetailsResponse,
-  collectionId: string,
+  collection: CollectionAdminView,
 ): AccessItemView {
   return {
     id: user.id,
@@ -457,9 +464,9 @@ function mapUserToAccessItemView(
     status: user.status,
     readonly: false,
     readonlyPermission:
-      collectionId != null
+      collection != null
         ? convertToPermission(
-            new CollectionAccessSelectionView(user.collections.find((uc) => uc.id == collectionId)),
+            new CollectionAccessSelectionView(collection.users.find((u) => u.id === user.id)),
           )
         : undefined,
   };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11590
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Reduce the amount of data required from the api for the collections dialog.

Currently we fetch user-collection associations from the `OrganizationUsersController` to check whether a user has access to the collection. However, this is already available from when we load the collection data, using the `collection.users` property. This PR updates the logic to not fetch user-collection associations when fetching member details, and use the collection data we already have.

I've also made a similar change to the group mapping logic.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
