### PR TITLE
[CL-382] Reduce element shifting on readonly hover

### DIFF
--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -85,7 +85,7 @@
     <div
       class="tw-gap-1 tw-flex tw-min-h-[1.85rem] tw-pb-0.5 tw-border-0 tw-border-solid"
       [ngClass]="{
-        'tw-border-secondary-300/50 tw-border-b':
+        'tw-border-secondary-300/50 tw-border-b tw-pb-[1px]':
           !disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-transparent': disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-primary-500': defaultContentIsFocused(),

--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -87,7 +87,8 @@
       [ngClass]="{
         'tw-border-secondary-300/50 tw-border-b tw-pb-[3px]':
           !disableReadOnlyBorder && !defaultContentIsFocused(),
-        'tw-border-b-2 tw-border-transparent': disableReadOnlyBorder && !defaultContentIsFocused(),
+        'tw-border-b-2 tw-border-transparent tw-pb-[4px]':
+          disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-primary-500': defaultContentIsFocused(),
       }"
     >

--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -83,9 +83,9 @@
       <ng-container *ngTemplateOutlet="labelContent"></ng-container>
     </label>
     <div
-      class="tw-gap-1 tw-flex tw-min-h-[1.85rem] tw-pb-0.5 tw-border-0 tw-border-solid"
+      class="tw-gap-1 tw-flex tw-min-h-[1.85rem] tw-pb-[2px] tw-border-0 tw-border-solid"
       [ngClass]="{
-        'tw-border-secondary-300/50 tw-border-b tw-pb-[1px]':
+        'tw-border-secondary-300/50 tw-border-b tw-pb-[3px]':
           !disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-transparent': disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-primary-500': defaultContentIsFocused(),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-382](https://bitwarden.atlassian.net/browse/CL-382)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds padding to the readonly form field to account for the change in border width when the field is focused, which prevents the elements around the form field from shifting around as the field is focused and unfocused. Because border widths are in pixels, I switched the existing padding to a pixel unit and then accounted for the added focus border width when the field is unfocused.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before:

https://github.com/user-attachments/assets/084c39d9-2507-4257-85c8-1cc32f28729d


After:

https://github.com/user-attachments/assets/4ed6b471-0aa4-4866-8af3-8287ba7e3917



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-382]: https://bitwarden.atlassian.net/browse/CL-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ