### PR TITLE
[PM-11631] - hide free Bitwarden Families button if user is not eligible

### DIFF
--- a/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.html
@@ -12,7 +12,7 @@
         <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </a>
     </bit-item>
-    <bit-item>
+    <bit-item *ngIf="familySponsorshipAvailable$ | async">
       <button type="button" bit-item-content (click)="openFreeBitwardenFamiliesPage()">
         {{ "freeBitwardenFamilies" | i18n }}
         <i slot="end" class="bwi bwi-external-link" aria-hidden="true"></i>

--- a/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
@@ -1,9 +1,11 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
-import { Observable, firstValueFrom } from "rxjs";
+import { BehaviorSubject, Observable, firstValueFrom, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { DialogService, ItemModule } from "@bitwarden/components";
@@ -28,13 +30,21 @@ import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page
 })
 export class MoreFromBitwardenPageV2Component {
   canAccessPremium$: Observable<boolean>;
+  protected familySponsorshipAvailable$ = new BehaviorSubject<boolean>(false);
 
   constructor(
     private dialogService: DialogService,
     billingAccountProfileStateService: BillingAccountProfileStateService,
     private environmentService: EnvironmentService,
+    private organizationService: OrganizationService,
   ) {
     this.canAccessPremium$ = billingAccountProfileStateService.hasPremiumFromAnySource$;
+    this.organizationService.organizations$
+      .pipe(
+        takeUntilDestroyed(),
+        map((orgs) => orgs.some((o) => o.familySponsorshipAvailable)),
+      )
+      .subscribe(this.familySponsorshipAvailable$);
   }
 
   async openFreeBitwardenFamiliesPage() {

--- a/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
@@ -1,8 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
-import { BehaviorSubject, Observable, firstValueFrom, map } from "rxjs";
+import { Observable, firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -30,7 +29,7 @@ import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page
 })
 export class MoreFromBitwardenPageV2Component {
   canAccessPremium$: Observable<boolean>;
-  protected familySponsorshipAvailable$ = new BehaviorSubject<boolean>(false);
+  protected familySponsorshipAvailable$: Observable<boolean>;
 
   constructor(
     private dialogService: DialogService,
@@ -39,12 +38,7 @@ export class MoreFromBitwardenPageV2Component {
     private organizationService: OrganizationService,
   ) {
     this.canAccessPremium$ = billingAccountProfileStateService.hasPremiumFromAnySource$;
-    this.organizationService.organizations$
-      .pipe(
-        takeUntilDestroyed(),
-        map((orgs) => orgs.some((o) => o.familySponsorshipAvailable)),
-      )
-      .subscribe(this.familySponsorshipAvailable$);
+    this.familySponsorshipAvailable$ = this.organizationService.canManageSponsorships$;
   }
 
   async openFreeBitwardenFamiliesPage() {

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -114,8 +114,7 @@ export abstract class OrganizationService {
    */
   getFromState: (id: string) => Promise<Organization>;
   /**
-   * Returns true if the user is eligible for free bitwarden families.
-   * Determined by the user's organization's ability to manage sponsorships
+   * Emits true if the user can create or manage a Free Bitwarden Families sponsorship.
    */
   canManageSponsorships$: Observable<boolean>;
   hasOrganizations: () => Promise<boolean>;

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -113,6 +113,10 @@ export abstract class OrganizationService {
    * https://bitwarden.atlassian.net/browse/AC-2252.
    */
   getFromState: (id: string) => Promise<Organization>;
+  /**
+   * Returns true if the user is eligible for free bitwarden families.
+   * Determined by the user's organization's ability to manage sponsorships
+   */
   canManageSponsorships$: Observable<boolean>;
   hasOrganizations: () => Promise<boolean>;
   get$: (id: string) => Observable<Organization | undefined>;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11631

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR hides the "Free Bitwarden Families" button if none of their orgs have family sponsorship available.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
