### PR TITLE
[PM-11657] Stripe + Browser Refresh Styling

### DIFF
--- a/apps/web/src/app/billing/shared/payment/payment-label-v2.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment-label-v2.component.html
@@ -1,0 +1,20 @@
+<ng-template #defaultContent>
+  <ng-content></ng-content>
+</ng-template>
+
+<ng-container *ngIf="extensionRefreshFlag; else defaultLabel">
+  <bit-label
+    [attr.for]="for"
+    class="tw-bg-background tw-px-1 tw-text-sm tw-text-muted tw-translate-y-3 tw-translate-x-3 tw-mb-0 tw-max-w-full tw-pointer-events-auto"
+  >
+    <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
+    <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
+  </bit-label>
+</ng-container>
+
+<ng-template #defaultLabel>
+  <label [attr.for]="for">
+    <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
+    <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
+  </label>
+</ng-template>

--- a/apps/web/src/app/billing/shared/payment/payment-label-v2.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment-label-v2.component.html
@@ -3,13 +3,15 @@
 </ng-template>
 
 <ng-container *ngIf="extensionRefreshFlag; else defaultLabel">
-  <bit-label
-    [attr.for]="for"
-    class="tw-bg-background tw-px-1 tw-text-sm tw-text-muted tw-translate-y-3 tw-translate-x-3 tw-mb-0 tw-max-w-full tw-pointer-events-auto"
-  >
-    <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
-    <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-  </bit-label>
+  <div class="tw-relative tw-mt-2">
+    <bit-label
+      [attr.for]="for"
+      class="tw-absolute tw-bg-background tw-px-1 tw-text-sm tw-text-muted -tw-top-2.5 tw-left-3 tw-mb-0 tw-max-w-full tw-pointer-events-auto"
+    >
+      <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
+      <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
+    </bit-label>
+  </div>
 </ng-container>
 
 <ng-template #defaultLabel>

--- a/apps/web/src/app/billing/shared/payment/payment-label-v2.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment-label-v2.component.ts
@@ -1,0 +1,36 @@
+import { booleanAttribute, Component, Input, OnInit } from "@angular/core";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { FormFieldModule } from "@bitwarden/components";
+
+import { SharedModule } from "../../../shared";
+
+/**
+ * Label that should be used for elements loaded via Stripe API.
+ *
+ * Applies the same label styles from CL form-field component when
+ * the `ExtensionRefresh` flag is set.
+ */
+@Component({
+  selector: "app-payment-label-v2",
+  templateUrl: "./payment-label-v2.component.html",
+  standalone: true,
+  imports: [FormFieldModule, SharedModule],
+})
+export class PaymentLabelV2 implements OnInit {
+  /** `id` of the associated input */
+  @Input({ required: true }) for: string;
+  /** Displays required text on the label */
+  @Input({ transform: booleanAttribute }) required = false;
+
+  protected extensionRefreshFlag = false;
+
+  constructor(private configService: ConfigService) {}
+
+  async ngOnInit(): Promise<void> {
+    this.extensionRefreshFlag = await this.configService.getFeatureFlag(
+      FeatureFlag.ExtensionRefresh,
+    );
+  }
+}

--- a/apps/web/src/app/billing/shared/payment/payment-v2.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment-v2.component.html
@@ -43,10 +43,9 @@
   <ng-container *ngIf="usingCard">
     <div class="tw-grid tw-grid-cols-2 tw-gap-4 tw-mb-4">
       <div class="tw-col-span-1">
-        <label for="stripe-card-number">
+        <app-payment-label-v2 for="stripe-card-number" required>
           {{ "number" | i18n }}
-          <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-        </label>
+        </app-payment-label-v2>
         <div id="stripe-card-number" class="form-control stripe-form-control"></div>
       </div>
       <div class="tw-col-span-1 tw-flex tw-items-end">
@@ -57,29 +56,24 @@
         />
       </div>
       <div class="tw-col-span-1">
-        <label for="stripe-card-expiry">
+        <app-payment-label-v2 for="stripe-card-expiry" required>
           {{ "expiration" | i18n }}
-          <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-        </label>
+        </app-payment-label-v2>
         <div id="stripe-card-expiry" class="form-control stripe-form-control"></div>
       </div>
       <div class="tw-col-span-1">
-        <div class="tw-flex">
-          <label for="stripe-card-cvc">
-            {{ "securityCode" | i18n }}
-            <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-          </label>
+        <app-payment-label-v2 for="stripe-card-cvc" required>
+          {{ "securityCodeSlashCVV" | i18n }}
           <a
             href="https://www.cvvnumber.com/cvv.html"
-            tabindex="-1"
             target="_blank"
             rel="noreferrer"
-            class="ml-auto"
             appA11yTitle="{{ 'learnMore' | i18n }}"
+            class="hover:tw-no-underline"
           >
             <i class="bwi bwi-question-circle" aria-hidden="true"></i>
           </a>
-        </div>
+        </app-payment-label-v2>
         <div id="stripe-card-cvc" class="form-control stripe-form-control"></div>
       </div>
     </div>

--- a/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
@@ -10,6 +10,8 @@ import { TokenizedPaymentSourceRequest } from "@bitwarden/common/billing/models/
 import { SharedModule } from "../../../shared";
 import { BillingServicesModule, BraintreeService, StripeService } from "../../services";
 
+import { PaymentLabelV2 } from "./payment-label-v2.component";
+
 /**
  * Render a form that allows the user to enter their payment method, tokenize it against one of our payment providers and,
  * optionally, submit it using the {@link onSubmit} function if it is provided.
@@ -20,7 +22,7 @@ import { BillingServicesModule, BraintreeService, StripeService } from "../../se
   selector: "app-payment-v2",
   templateUrl: "./payment-v2.component.html",
   standalone: true,
-  imports: [BillingServicesModule, SharedModule],
+  imports: [BillingServicesModule, SharedModule, PaymentLabelV2],
 })
 export class PaymentV2Component implements OnInit, OnDestroy {
   /** Show account credit as a payment option. */

--- a/apps/web/src/app/billing/shared/payment/payment.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment.component.html
@@ -48,7 +48,7 @@
       </div>
       <div class="tw-col-span-4">
         <app-payment-label-v2 for="stripe-card-cvc-element">
-          {{ "securityCode" | i18n }}
+          {{ "securityCodeSlashCVV" | i18n }}
           <a
             href="https://www.cvvnumber.com/cvv.html"
             tabindex="-1"

--- a/apps/web/src/app/billing/shared/payment/payment.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment.component.html
@@ -27,7 +27,9 @@
   <ng-container *ngIf="showMethods && method === paymentMethodType.Card">
     <div class="tw-grid tw-grid-cols-12 tw-gap-4 tw-mb-4">
       <div [ngClass]="trialFlow ? 'tw-col-span-5' : 'tw-col-span-4'">
-        <label for="stripe-card-number-element">{{ "number" | i18n }}</label>
+        <app-payment-label-v2 for="stripe-card-number-element">{{
+          "number" | i18n
+        }}</app-payment-label-v2>
         <div id="stripe-card-number-element" class="form-control stripe-form-control"></div>
       </div>
       <div *ngIf="!trialFlow" class="tw-col-span-8 tw-flex tw-items-end">
@@ -39,25 +41,25 @@
         />
       </div>
       <div [ngClass]="trialFlow ? 'tw-col-span-3' : 'tw-col-span-4'">
-        <label for="stripe-card-expiry-element">{{ "expiration" | i18n }}</label>
+        <app-payment-label-v2 for="stripe-card-expiry-element">{{
+          "expiration" | i18n
+        }}</app-payment-label-v2>
         <div id="stripe-card-expiry-element" class="form-control stripe-form-control"></div>
       </div>
       <div class="tw-col-span-4">
-        <div class="tw-flex">
-          <label for="stripe-card-cvc-element">
-            {{ "securityCode" | i18n }}
-          </label>
+        <app-payment-label-v2 for="stripe-card-cvc-element">
+          {{ "securityCode" | i18n }}
           <a
             href="https://www.cvvnumber.com/cvv.html"
             tabindex="-1"
             target="_blank"
             rel="noreferrer"
-            class="ml-auto"
+            class="hover:tw-no-underline"
             appA11yTitle="{{ 'learnMore' | i18n }}"
           >
             <i class="bwi bwi-question-circle" aria-hidden="true"></i>
           </a>
-        </div>
+        </app-payment-label-v2>
         <div id="stripe-card-cvc-element" class="form-control stripe-form-control"></div>
       </div>
     </div>

--- a/apps/web/src/app/billing/shared/payment/payment.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment.component.html
@@ -26,7 +26,7 @@
   </div>
   <ng-container *ngIf="showMethods && method === paymentMethodType.Card">
     <div class="tw-grid tw-grid-cols-12 tw-gap-4 tw-mb-4">
-      <div [ngClass]="trialFlow ? 'tw-col-span-5' : 'tw-col-span-4'">
+      <div [ngClass]="trialFlow ? 'tw-col-span-12' : 'tw-col-span-4'">
         <app-payment-label-v2 for="stripe-card-number-element">{{
           "number" | i18n
         }}</app-payment-label-v2>
@@ -40,13 +40,13 @@
           height="32"
         />
       </div>
-      <div [ngClass]="trialFlow ? 'tw-col-span-3' : 'tw-col-span-4'">
+      <div [ngClass]="trialFlow ? 'tw-col-span-6' : 'tw-col-span-4'">
         <app-payment-label-v2 for="stripe-card-expiry-element">{{
           "expiration" | i18n
         }}</app-payment-label-v2>
         <div id="stripe-card-expiry-element" class="form-control stripe-form-control"></div>
       </div>
-      <div class="tw-col-span-4">
+      <div [ngClass]="trialFlow ? 'tw-col-span-6' : 'tw-col-span-4'">
         <app-payment-label-v2 for="stripe-card-cvc-element">
           {{ "securityCodeSlashCVV" | i18n }}
           <a

--- a/apps/web/src/app/billing/shared/payment/payment.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment.component.ts
@@ -11,11 +11,13 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 
 import { SharedModule } from "../../../shared";
 
+import { PaymentLabelV2 } from "./payment-label-v2.component";
+
 @Component({
   selector: "app-payment",
   templateUrl: "payment.component.html",
   standalone: true,
-  imports: [SharedModule],
+  imports: [SharedModule, PaymentLabelV2],
 })
 export class PaymentComponent implements OnInit, OnDestroy {
   @Input() showMethods = true;

--- a/apps/web/src/app/billing/shared/tax-info.component.html
+++ b/apps/web/src/app/billing/shared/tax-info.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="taxFormGroup">
   <div class="tw-grid tw-grid-cols-12 tw-gap-4">
-    <div [ngClass]="trialFlow ? 'tw-col-span-7' : 'tw-col-span-6'">
+    <div [ngClass]="trialFlow ? 'tw-col-span-6' : 'tw-col-span-6'">
       <bit-form-field>
         <bit-label>{{ "country" | i18n }}</bit-label>
         <bit-select formControlName="country" autocomplete="country">
@@ -13,7 +13,7 @@
         </bit-select>
       </bit-form-field>
     </div>
-    <div [ngClass]="trialFlow ? 'tw-col-span-5' : 'tw-col-span-4'">
+    <div [ngClass]="trialFlow ? 'tw-col-span-6' : 'tw-col-span-4'">
       <bit-form-field>
         <bit-label>{{ "zipPostalCode" | i18n }}</bit-label>
         <input bitInput type="text" formControlName="postalCode" autocomplete="postal-code" />

--- a/apps/web/src/app/billing/shared/tax-info.component.html
+++ b/apps/web/src/app/billing/shared/tax-info.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="taxFormGroup">
   <div class="tw-grid tw-grid-cols-12 tw-gap-4">
-    <div [ngClass]="trialFlow ? 'tw-col-span-6' : 'tw-col-span-6'">
+    <div class="tw-col-span-6">
       <bit-form-field>
         <bit-label>{{ "country" | i18n }}</bit-label>
         <bit-select formControlName="country" autocomplete="country">

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -143,6 +143,9 @@
   "securityCode": {
     "message": "Security code (CVV)"
   },
+  "securityCodeSlashCVV": {
+    "message": "Security code / CVV"
+  },
   "identityName": {
     "message": "Identity name"
   },

--- a/apps/web/src/scss/forms.scss
+++ b/apps/web/src/scss/forms.scss
@@ -98,7 +98,7 @@ input[type="checkbox"] {
   cursor: pointer;
 }
 
-.form-control.stripe-form-control {
+.form-control.stripe-form-control:not(.v2) {
   padding-top: 0.55rem;
 
   &.is-focused {
@@ -123,6 +123,30 @@ input[type="checkbox"] {
     @include themify($themes) {
       border-color: themed("danger");
     }
+  }
+}
+
+.form-control.stripe-form-control.v2 {
+  padding: 0.6875rem 0.875rem;
+  border-radius: 0.5rem;
+  border-color: rgb(var(--color-text-muted));
+  height: unset;
+  font-weight: 500;
+  color: rgb(var(--color-text-main));
+  background-color: rgb(var(--color-background));
+
+  &:hover {
+    border-color: rgb(var(--color-primary-500));
+  }
+
+  &.is-focused {
+    outline: 0;
+    border-color: rgb(var(--color-primary-500));
+  }
+
+  &.is-invalid {
+    color: rgb(var(--color-text-main));
+    border-color: rgb(var(--color-danger-600));
   }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11657](https://bitwarden.atlassian.net/browse/PM-11657)

## 📔 Objective

Update Stripe components to match the new design components that are currently in development on the `ps/extension-refresh` branch.
- This work is separate from the working going on around the `AC2476_DeprecateStripeSourcesAPI` flag, so I implemented the changes on both `payment.component` and `payment-v2.component`.
- One change that _isn't_ behind a flag is switching the copy for Security code from `Security code (CVV)` to `Security code / CVV`. I wanted to refrain from injecting feature flag logic there so I got the go ahead from @danielleflinn that this change can go in to main now. 

### Font Shortfall

I wasn't able to get the `DM Sans` font to load within the iframe from Stripe. Their documentation does allow for passing a [font](https://docs.stripe.com/js/elements_object/create#stripe_elements-options-fonts) object but with how the font is bundled and hashed with Angular, I couldn't find a way to reliably load the custom font. 

If there are any ideas out there, let me know! 

## 📸 Screenshots

#### Current CL components (i.e. `main`)

|Disabled: AC2476_DeprecateStripeSourcesAPI|Enabled:AC2476_DeprecateStripeSourcesAPI|
|-|-|
|![current-components-refresh-off-stripe-off](https://github.com/user-attachments/assets/52187557-7056-47b7-808d-d9652b452999)|![current-components-refresh-off-stripe-on](https://github.com/user-attachments/assets/01be188c-637e-40a5-946a-2349313abb02)|

#### New refreshed components (i.e. `ps/extension-refresh`)

|Disabled: AC2476_DeprecateStripeSourcesAPI|Enabled:AC2476_DeprecateStripeSourcesAPI|
|-|-|
|![new-components-refresh-on-stripe-off](https://github.com/user-attachments/assets/e97d6b95-6e5e-4b7f-a7fe-bc2cf1b44c27)|![new-components-refresh-on-stripe-on](https://github.com/user-attachments/assets/c822b25c-069b-4e89-86a9-f782aee31f34)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11657]: https://bitwarden.atlassian.net/browse/PM-11657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ