### PR TITLE
[PM-10914] add option to delete all folders if migration fails

### DIFF
--- a/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.ts
+++ b/apps/web/src/app/auth/migrate-encryption/migrate-legacy-encryption.component.ts
@@ -73,9 +73,9 @@ export class MigrateFromLegacyEncryptionComponent {
       // If the error is due to missing folders, we can delete all folders and try again
       if (e.message === "All existing folders must be included in the rotation.") {
         const deleteFolders = await this.dialogService.openSimpleDialog({
-          type: "danger",
-          title: { key: "encryptionKeyUpdateFailed" },
-          content: { key: "decryptionErrorDeleteAllFolders" },
+          type: "warning",
+          title: { key: "encryptionKeyUpdateCannotProceed" },
+          content: { key: "keyUpdateFoldersFailed" },
           acceptButtonText: { key: "ok" },
           cancelButtonText: { key: "cancel" },
         });
@@ -83,17 +83,12 @@ export class MigrateFromLegacyEncryptionComponent {
         if (deleteFolders) {
           await this.folderApiService.deleteAll();
           await this.syncService.fullSync(true, true);
-          this.toastService.showToast({
-            variant: "success",
-            title: this.i18nService.t("foldersDeleted"),
-            message: this.i18nService.t("pleaseAttemptEncryptionKeyUpdate"),
-            timeout: 15000,
-          });
+          await this.submit();
+          return;
         }
-      } else {
-        this.logService.error(e);
-        throw e;
       }
+      this.logService.error(e);
+      throw e;
     }
   };
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3898,7 +3898,7 @@
     "message": "Encryption key update cannot proceed"
   },
   "keyUpdateFoldersFailed": {
-    "message": "When updating your encryption key, some folders could not be decrypted. To continue with the update, these folders must be deleted. No vault items will be deleted if you proceed."
+    "message": "When updating your encryption key, your folders could not be decrypted. To continue with the update, your folders must be deleted. No vault items will be deleted if you proceed."
   },
   "keyUpdated": {
     "message": "Key updated"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3894,17 +3894,11 @@
       }
     }
   },
-  "encryptionKeyUpdateFailed": {
-    "message": "Encryption key update failed."
+  "encryptionKeyUpdateCannotProceed": {
+    "message": "Encryption key update cannot proceed"
   },
-  "decryptionErrorDeleteAllFolders": {
-    "message": "During migration of your data, some of your folders were not decryptable. Would you like to delete them in order to access your vault? Note: Vault entries of the removed folders will be moved into the default folder."
-  },
-  "foldersDeleted": {
-    "message": "Folders deleted"
-  },
-  "pleaseAttemptEncryptionKeyUpdate": {
-    "message": "Please attempt the encryption key update again."
+  "keyUpdateFoldersFailed": {
+    "message": "When updating your encryption key, some folders could not be decrypted. To continue with the update, these folders must be deleted. No vault items will be deleted if you proceed."
   },
   "keyUpdated": {
     "message": "Key updated"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3894,6 +3894,18 @@
       }
     }
   },
+  "encryptionKeyUpdateFailed": {
+    "message": "Encryption key update failed."
+  },
+  "decryptionErrorDeleteAllFolders": {
+    "message": "During migration of your data, some of your folders were not decryptable. Would you like to delete them in order to access your vault? Note: Vault entries of the removed folders will be moved into the default folder."
+  },
+  "foldersDeleted": {
+    "message": "Folders deleted"
+  },
+  "pleaseAttemptEncryptionKeyUpdate": {
+    "message": "Please attempt the encryption key update again."
+  },
   "keyUpdated": {
     "message": "Key updated"
   },

--- a/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
@@ -5,4 +5,5 @@ export class FolderApiServiceAbstraction {
   save: (folder: Folder) => Promise<any>;
   delete: (id: string) => Promise<any>;
   get: (id: string) => Promise<FolderResponse>;
+  deleteAll: () => Promise<void>;
 }

--- a/libs/common/src/vault/services/folder/folder-api.service.ts
+++ b/libs/common/src/vault/services/folder/folder-api.service.ts
@@ -34,7 +34,7 @@ export class FolderApiService implements FolderApiServiceAbstraction {
 
   async deleteAll(): Promise<void> {
     await this.apiService.send("DELETE", "/folders/all", null, true, false);
-    await this.folderService.clearCache();
+    await this.folderService.clear();
   }
 
   async get(id: string): Promise<FolderResponse> {

--- a/libs/common/src/vault/services/folder/folder-api.service.ts
+++ b/libs/common/src/vault/services/folder/folder-api.service.ts
@@ -32,6 +32,11 @@ export class FolderApiService implements FolderApiServiceAbstraction {
     await this.folderService.delete(id);
   }
 
+  async deleteAll(): Promise<void> {
+    await this.apiService.send("DELETE", "/folders/all", null, true, false);
+    await this.folderService.clearCache();
+  }
+
   async get(id: string): Promise<FolderResponse> {
     const r = await this.apiService.send("GET", "/folders/" + id, null, true, true);
     return new FolderResponse(r);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10914
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Many legacy migrations have failed due to un-decryptable folders. This allows the user the option to delete all their folders and attempt the migration again.

See bitwarden/server#4761 for server-side changes
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/67883850-bde4-4b5c-a799-29ad912cd66a



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
