### PR TITLE
Allow to set devServer protocol in config

### DIFF
--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -189,7 +189,7 @@ const devServer =
     ? {}
     : {
         server: {
-          type: "https",
+          type: envConfig.dev?.protocol ?? "https",
           options: {
             key: fs.readFileSync("dev-server" + certSuffix + ".pem"),
             cert: fs.readFileSync("dev-server" + certSuffix + ".pem"),


### PR DESCRIPTION
## 📔 Objective

Simple change to allow running the dev server without TLS.

I find it easier than having to accept self-signed cert and on Firefox `dom.securecontext.allowlist` allow running with no issues.

