### PR TITLE
[CL-395] Remove text headers color

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-header.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.html
@@ -17,7 +17,7 @@
         [attr.aria-label]="'back' | i18n"
         [bitAction]="backAction"
       ></button>
-      <h1 *ngIf="pageTitle" bitTypography="h3" class="!tw-mb-0.5 tw-text-headers">
+      <h1 *ngIf="pageTitle" bitTypography="h3" class="!tw-mb-0.5">
         {{ pageTitle }}
       </h1>
       <ng-content></ng-content>

--- a/libs/components/src/section/section-header.component.html
+++ b/libs/components/src/section/section-header.component.html
@@ -1,5 +1,5 @@
 <div class="tw-flex tw-justify-between tw-items-end tw-gap-1">
-  <div class="[&>*]:tw-mb-0 [&>*]:tw-text-headers tw-flex tw-items-center tw-gap-1">
+  <div class="[&>*]:tw-mb-0 [&>*]:tw-text-main tw-flex tw-items-center tw-gap-1">
     <ng-content></ng-content>
   </div>
   <div class="tw-text-muted has-[button]:-tw-mb-1">

--- a/libs/components/src/stories/colors.mdx
+++ b/libs/components/src/stories/colors.mdx
@@ -74,7 +74,6 @@ export const Table = (args) => (
       {Row("text-contrast")}
       {Row("text-alt2")}
       {Row("text-code")}
-      {Row("text-headers")}
     </tbody>
   </table>
 );

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -12,7 +12,7 @@
   --color-primary-100: 219 229 246;
   --color-primary-300: 121 161 233;
   --color-primary-500: 23 93 220;
-  --color-primary-600: 23 93 200;
+  --color-primary-600: 23 93 220;
   --color-primary-700: 26 65 172;
 
   --color-secondary-100: 230 233 239;
@@ -45,7 +45,6 @@
   --color-text-contrast: 255 255 255;
   --color-text-alt2: 255 255 255;
   --color-text-code: 192 17 118;
-  --color-text-headers: 2 15 102;
 
   --color-marketing-logo: 23 93 220;
 
@@ -101,7 +100,6 @@
   --color-text-contrast: 18 26 39;
   --color-text-alt2: 255 255 255;
   --color-text-code: 255 143 208;
-  --color-text-headers: 226 227 228;
 
   --color-marketing-logo: 255 255 255;
 

--- a/libs/components/src/typography/typography.directive.ts
+++ b/libs/components/src/typography/typography.directive.ts
@@ -4,12 +4,12 @@ import { Directive, HostBinding, Input } from "@angular/core";
 type TypographyType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "body1" | "body2" | "helper";
 
 const styles: Record<TypographyType, string[]> = {
-  h1: ["!tw-text-3xl", "tw-font-semibold", "tw-text-headers"],
-  h2: ["!tw-text-2xl", "tw-font-semibold", "tw-text-headers"],
-  h3: ["!tw-text-xl", "tw-font-semibold", "tw-text-headers"],
-  h4: ["!tw-text-lg", "tw-font-semibold", "tw-text-headers"],
-  h5: ["!tw-text-base", "tw-font-bold", "tw-text-headers"],
-  h6: ["!tw-text-sm", "tw-font-bold", "tw-text-headers"],
+  h1: ["!tw-text-3xl", "tw-font-semibold", "tw-text-main"],
+  h2: ["!tw-text-2xl", "tw-font-semibold", "tw-text-main"],
+  h3: ["!tw-text-xl", "tw-font-semibold", "tw-text-main"],
+  h4: ["!tw-text-lg", "tw-font-semibold", "tw-text-main"],
+  h5: ["!tw-text-base", "tw-font-bold", "tw-text-main"],
+  h6: ["!tw-text-sm", "tw-font-bold", "tw-text-main"],
   body1: ["!tw-text-base"],
   body2: ["!tw-text-sm"],
   helper: ["!tw-text-xs"],


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-395](https://bitwarden.atlassian.net/browse/CL-395)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We are removing the `text-headers` color to use `text-main` instead. I also fixed a typo with the primary-600 color.

SVGs were already updated to use the `art` palette colors instead of `text-headers` and `info-600` here: #10990 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See Storybook (Typography story is the most affected)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-395]: https://bitwarden.atlassian.net/browse/CL-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ