### PR TITLE
[PM-11949] Fix generating and copying export password

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1285,6 +1285,9 @@
       }
     }
   },
+  "copySuccessful": {
+    "message": "Copy Successful"
+  },
   "errorRefreshingAccessToken": {
     "message": "Access Token Refresh Error"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9085,7 +9085,7 @@
   },
   "hideCharacterCount": {
     "message": "Hide character count"
-  },  
+  },
   "editAccess": {
     "message": "Edit access"
   }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -562,6 +562,9 @@
       }
     }
   },
+  "copySuccessful": {
+    "message": "Copy Successful"
+  },
   "copyValue": {
     "message": "Copy value",
     "description": "Copy value to clipboard"
@@ -9082,7 +9085,7 @@
   },
   "hideCharacterCount": {
     "message": "Hide character count"
-  },
+  },  
   "editAccess": {
     "message": "Edit access"
   }

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -87,7 +87,9 @@
             [disabled]="!filePassword"
             appStopClick
             bitSuffix
-            (click)="copyPasswordToClipboard()"
+            [appCopyClick]="filePassword"
+            [valueLabel]="'password' | i18n"
+            showToast
           ></button>
           <bit-hint>{{ "exportPasswordDescription" | i18n }}</bit-hint>
         </bit-form-field>

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -121,7 +121,6 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   encryptedExportType = EncryptedExportType;
   protected showFilePassword: boolean;
 
-  filePasswordValue: string = null;
   private _disabledByPolicy = false;
 
   organizations$: Observable<Organization[]>;
@@ -278,18 +277,9 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
 
   generatePassword = async () => {
     const [options] = await this.passwordGenerationService.getOptions();
-    this.filePasswordValue = await this.passwordGenerationService.generatePassword(options);
-    this.exportForm.get("filePassword").setValue(this.filePasswordValue);
-    this.exportForm.get("confirmFilePassword").setValue(this.filePasswordValue);
-  };
-
-  copyPasswordToClipboard = async () => {
-    this.platformUtilsService.copyToClipboard(this.filePasswordValue);
-    this.toastService.showToast({
-      variant: "success",
-      title: null,
-      message: this.i18nService.t("valueCopied", this.i18nService.t("password")),
-    });
+    const generatedPassword = await this.passwordGenerationService.generatePassword(options);
+    this.exportForm.get("filePassword").setValue(generatedPassword);
+    this.exportForm.get("confirmFilePassword").setValue(generatedPassword);
   };
 
   submit = async () => {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11949

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With https://github.com/bitwarden/clients/pull/10539 we introduced a generate password and copy password button for password-protected exports. 

The generate password button worked, but instead of just setting the field values it also stored it within a local variable. This was then used for the copy password button. When a user had not used or modified the content of the password field, the value of the local variable was copied to the clipboard instead of then password field content.

This PR fixes this by removing the local variable and instead of manually copying the values and showing the success toast, we now use the copy-click-directive.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
