### PR TITLE
Do not test napi crate on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   rust:
-    name: Run Rust tests on ${{ matrix.os }}
+    name: Run Rust tests on ${{ matrix.os }} for ${{ matrix.crate }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        crate:
+          - core
+          - napi
 
     steps:
       - name: Check Rust version
@@ -129,7 +132,7 @@ jobs:
 
       - name: Test Ubuntu
         if: ${{ matrix.os=='ubuntu-latest' }}
-        working-directory: ./apps/desktop/desktop_native
+        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
         run: |
           eval "$(dbus-launch --sh-syntax)"
           mkdir -p ~/.cache
@@ -138,7 +141,12 @@ jobs:
           eval "$(printf '\n' | /usr/bin/gnome-keyring-daemon --start)"
           cargo test -- --test-threads=1
 
-      - name: Test Windows / macOS
-        if: ${{ matrix.os!='ubuntu-latest' }}
-        working-directory: ./apps/desktop/desktop_native
+      - name: Test macOS
+        if: ${{ matrix.os=='macos-latest' }}
+        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
+        run: cargo test -- --test-threads=1
+
+      - name: Test Windows
+        if: ${{ matrix.os=='windows-latest' && matrix.crate!='napi' }}
+        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
         run: cargo test -- --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   rust:
-    name: Run Rust tests on ${{ matrix.os }} for ${{ matrix.crate }}
+    name: Run Rust tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -109,9 +109,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        crate:
-          - core
-          - napi
 
     steps:
       - name: Check Rust version
@@ -132,7 +129,7 @@ jobs:
 
       - name: Test Ubuntu
         if: ${{ matrix.os=='ubuntu-latest' }}
-        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
+        working-directory: ./apps/desktop/desktop_native
         run: |
           eval "$(dbus-launch --sh-syntax)"
           mkdir -p ~/.cache
@@ -143,10 +140,10 @@ jobs:
 
       - name: Test macOS
         if: ${{ matrix.os=='macos-latest' }}
-        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
+        working-directory: ./apps/desktop/desktop_native
         run: cargo test -- --test-threads=1
 
       - name: Test Windows
-        if: ${{ matrix.os=='windows-latest' && matrix.crate!='napi' }}
-        working-directory: ./apps/desktop/desktop_native/${{ matrix.crate }}
+        if: ${{ matrix.os=='windows-latest'}}
+        working-directory: ./apps/desktop/desktop_native/core
         run: cargo test -- --test-threads=1


### PR DESCRIPTION
## 📔 Objective

We are experiencing failures of our CI in validating desktop native integrations on windows in the form of buffer overflows due to repeated Node-API GetProcAddress failures. Possibly related to https://github.com/napi-rs/napi-rs/issues/1405.

I work around that here by only testing the `core` crate in windows. The other two OSes still test the full workspace.

We don't have any tests in the napi crate, so there's no harm in removing those tests right now. If we have tests there in the future, we'll need to actually fix this. However, the napi crate is just a wiring crate, so maybe we won't ever have any unit tests there.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
