### PR TITLE
[PM-12007] Fix vault timeout action logout with account switching

### DIFF
--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -247,7 +247,7 @@ export class AppComponent implements OnInit, OnDestroy {
   // Displaying toasts isn't super useful on the popup due to the reloads we do.
   // However, it is visible for a moment on the FF sidebar logout.
   private async displayLogoutReason(logoutReason: LogoutReason) {
-    let toastOptions: ToastOptions;
+    let toastOptions: ToastOptions | null = null;
     switch (logoutReason) {
       case "invalidSecurityStamp":
       case "sessionExpired": {
@@ -258,6 +258,11 @@ export class AppComponent implements OnInit, OnDestroy {
         };
         break;
       }
+    }
+
+    if (toastOptions == null) {
+      // We don't have anything to show for this particular reason
+      return;
     }
 
     this.toastService.showToast(toastOptions);

--- a/libs/common/src/services/vault-timeout/vault-timeout.service.ts
+++ b/libs/common/src/services/vault-timeout/vault-timeout.service.ts
@@ -1,4 +1,4 @@
-import { combineLatest, filter, firstValueFrom, map, switchMap, timeout } from "rxjs";
+import { combineLatest, concatMap, filter, firstValueFrom, map, timeout } from "rxjs";
 
 import { LogoutReason } from "@bitwarden/auth/common";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -79,7 +79,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         this.accountService.activeAccount$,
         this.accountService.accountActivity$,
       ]).pipe(
-        switchMap(async ([activeAccount, accountActivity]) => {
+        concatMap(async ([activeAccount, accountActivity]) => {
           const activeUserId = activeAccount?.id;
           for (const userIdString in accountActivity) {
             const userId = userIdString as UserId;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12007

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`switchMap` was a bad choice for this particular operation, the logout process can change the active user, so while the the logout process was happening the `AccountService.activeAccount$` will emit again. `switchMap` attempts to cancel the ongoing emission (with a promise like this, that does nothing to actually stop the process) and then moves onto run the code with the new emissions. A `concatMap` will make sure an emission that was started will finish, it seems very clear to me that that is what we intend, by the fact we wrap this operation in a `firstValueFrom`. 

This makes it so that logout only runs once and then we properly calculate the next up user. Before logout seemed to happen about 3 times, the first time it would select the other account but the second and third time it would select no user as the next user. This caused problems during the log in process. 

While testing this ticket I noticed that `showToast` was getting called with `null` and throwing an error, I put a guard on the calling site to not call it when it didn't create options for the given logout reason.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
