### PR TITLE
[PM-11725] Use payment-v2.component in trial-billing-step.component

### DIFF
--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.ts
+++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.ts
@@ -19,7 +19,7 @@ export class OrganizationInformationComponent implements OnInit {
   constructor(private accountService: AccountService) {}
 
   async ngOnInit(): Promise<void> {
-    if (this.formGroup.controls.billingEmail.value) {
+    if (this.formGroup?.controls?.billingEmail?.value) {
       return;
     }
 

--- a/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.html
+++ b/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.html
@@ -49,7 +49,15 @@
     </div>
     <div class="tw-mb-4">
       <h2 class="tw-mb-3 tw-text-base tw-font-semibold">{{ "paymentType" | i18n }}</h2>
-      <app-payment [hideCredit]="true" [trialFlow]="true"></app-payment>
+      <app-payment
+        *ngIf="!deprecateStripeSourcesAPI"
+        [hideCredit]="true"
+        [trialFlow]="true"
+      ></app-payment>
+      <app-payment-v2
+        *ngIf="deprecateStripeSourcesAPI"
+        [showAccountCredit]="false"
+      ></app-payment-v2>
       <app-tax-info [trialFlow]="true" (onCountryChanged)="changedCountry()"></app-tax-info>
     </div>
     <div class="tw-flex tw-space-x-2">


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-11725

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR adds the `payment-v2.component` to the `trial-billing-step.component` and uses it when the `AC-2476-deprecate-stripe-sources-api` is active. All supporting server-side changes have already been made.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
