### PR TITLE
[PM-2718] Set nspasteboard.ConcealedType for clipboard on MacOS

### DIFF
--- a/apps/desktop/desktop_native/core/src/clipboard.rs
+++ b/apps/desktop/desktop_native/core/src/clipboard.rs
@@ -37,8 +37,14 @@ fn clipboard_set(set: Set, _password: bool) -> Set {
 }
 
 #[cfg(target_os = "macos")]
-fn clipboard_set(set: Set, _password: bool) -> Set {
-    set
+fn clipboard_set(set: Set, password: bool) -> Set {
+    use arboard::SetExtApple;
+
+    if password {
+        set.exclude_from_history()
+    } else {
+        set
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-2718

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We added support for setting `exclude_from_history` https://github.com/1Password/arboard/pull/159, which hides values from MacOS clipboard managers by setting `org.nspasteboard.ConcealedType`. This enables the use of `exclude_from_history` in our desktop application.

Resolves #2633.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![image](https://github.com/user-attachments/assets/b90ec781-5516-4152-a535-98dbbd302fd6)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
