### PR TITLE
[PM-12067] Add sorting to exposed passwords report

### DIFF
--- a/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.html
@@ -30,9 +30,9 @@
         <ng-container header *ngIf="!isAdminConsoleActive">
           <tr bitRow>
             <th bitCell></th>
-            <th bitCell>{{ "name" | i18n }}</th>
-            <th bitCell>{{ "owner" | i18n }}</th>
-            <th bitCell></th>
+            <th bitCell bitSortable="name">{{ "name" | i18n }}</th>
+            <th bitCell bitSortable="organizationId">{{ "owner" | i18n }}</th>
+            <th bitCell class="tw-text-right" bitSortable="exposedXTimes"></th>
           </tr>
         </ng-container>
         <ng-template body let-rows$>
@@ -86,7 +86,7 @@
             </td>
             <td bitCell class="tw-text-right">
               <span bitBadge variant="warning">
-                {{ "exposedXTimes" | i18n: (exposedPasswordMap.get(r.id) | number) }}
+                {{ "exposedXTimes" | i18n: (r.exposedXTimes | number) }}
               </span>
             </td>
           </tr>

--- a/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.html
@@ -27,11 +27,13 @@
         </ng-container>
       </bit-toggle-group>
       <bit-table [dataSource]="dataSource">
-        <ng-container header *ngIf="!isAdminConsoleActive">
+        <ng-container header>
           <tr bitRow>
             <th bitCell></th>
             <th bitCell bitSortable="name">{{ "name" | i18n }}</th>
-            <th bitCell bitSortable="organizationId">{{ "owner" | i18n }}</th>
+            <th bitCell bitSortable="organizationId" *ngIf="!isAdminConsoleActive">
+              {{ "owner" | i18n }}
+            </th>
             <th bitCell class="tw-text-right" bitSortable="exposedXTimes"></th>
           </tr>
         </ng-container>
@@ -74,7 +76,7 @@
               <br />
               <small>{{ r.subTitle }}</small>
             </td>
-            <td bitCell>
+            <td bitCell *ngIf="!isAdminConsoleActive">
               <app-org-badge
                 *ngIf="!organization"
                 [disabled]="disabled"


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12067

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With the migration to use the [TableComponent](https://components.bitwarden.com/?path=/docs/component-library-table--docs) from the Component library, it enables us to add column sorting to the exposed passwords report.

### Code changes
- **Add sorting to exposed passwords report -** https://github.com/bitwarden/clients/commit/8020734b85a3b199a470b2b8c0b7ef085d398b88
  - Create new type to represent a row within the report
  - Add types and remove usage of any
  - Include the exposed number of times within the data passed to the datasource/table instead of looking it up via the `exposedPasswordMap`
  - Enable sorting via bitSortable
  - Set default sort to order by exposed number of times in descending order
- **Show headers and sort also within AC version of exposed-passwords report but hide the Owner column -** https://github.com/bitwarden/clients/commit/4c19c9bfdc5eccc7f462f85388d003780d709d4f

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Password Manager
#### Before
![image](https://github.com/user-attachments/assets/6aac3efe-8ba0-49b3-bc0b-28b3a4bbebf1)

#### After
![image](https://github.com/user-attachments/assets/9661fe0c-7212-4ad8-aae7-352dddaeaaa6)

### Admin Console
#### Before
![image](https://github.com/user-attachments/assets/4a552b3e-07fe-4388-aedc-d91a8bb80b5e)

#### After
![image](https://github.com/user-attachments/assets/97e9daea-80a6-41a0-8fbb-23bd4b00c8fb)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
