### PR TITLE
[CL-447] Ensure DM Sans displays correctly at all font weights

### DIFF
--- a/libs/angular/src/scss/webfonts.css
+++ b/libs/angular/src/scss/webfonts.css
@@ -4,4 +4,5 @@
     url("webfonts/dm-sans[opsz,wght].woff2") format("woff2 supports variations"),
     url("webfonts/dm-sans[opsz,wght].woff2") format("woff2-variations");
   font-display: swap;
+  font-weight: 100 900;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-447](https://bitwarden.atlassian.net/browse/CL-447)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This is our first time using variable fonts, and it turns out you do need to define the font weight range in order for it to work properly across all browsers. I don't know exactly why, but Chrome and Firefox were rendering it fine while Safari was not. Adding the font weight range gave Safari the correct weight styling.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before:
![Screenshot 2024-09-13 at 4 01 15 PM](https://github.com/user-attachments/assets/e8358288-0763-4a8e-8d68-14d063d41d98)

After:
![Screenshot 2024-09-13 at 4 56 20 PM](https://github.com/user-attachments/assets/997fe348-3754-429b-af49-d14a362ebfb3)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-447]: https://bitwarden.atlassian.net/browse/CL-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ