### PR TITLE
Add privatekey publickey and fingerprint to both add-edit and view co…

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -131,6 +131,15 @@
   "copyLicenseNumber": {
     "message": "Copy license number"
   },
+  "copyPrivateKey": {
+    "message": "Copy private key"
+  },
+  "copyPublicKey": {
+    "message": "Copy public key"
+  },
+  "copyFingerprint": {
+    "message": "Copy fingerprint"
+  },
   "autoFill": {
     "message": "Autofill"
   },

--- a/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
@@ -89,12 +89,12 @@
     bitIconButton="bwi-clone"
     size="small"
     [appA11yTitle]="
-      hasIdentityValues ? ('copyInfoTitle' | i18n: cipher.name) : ('noValuesToCopy' | i18n)
+      hasSshKeyValues ? ('copyInfoTitle' | i18n: cipher.name) : ('noValuesToCopy' | i18n)
     "
-    [disabled]="!hasIdentityValues"
-    [bitMenuTriggerFor]="identityOptions"
+    [disabled]="!hasSshKeyValues"
+    [bitMenuTriggerFor]="sshKeyOptions"
   ></button>
-  <bit-menu #identityOptions>
+  <bit-menu #sshKeyOptions>
     <button type="button" bitMenuItem appCopyField="privateKey" [cipher]="cipher">
       {{ "copyPrivateKey" | i18n }}
     </button>

--- a/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.ts
@@ -48,7 +48,7 @@ export class ItemCopyActionsComponent {
     return !!this.cipher.notes;
   }
 
-  get hasSSHKeyValues() {
+  get hasSshKeyValues() {
     return (
       !!this.cipher.sshKey.privateKey ||
       !!this.cipher.sshKey.publicKey ||

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -536,6 +536,18 @@
             <span class="row-label"> {{ "sshPrivateKey" | i18n }}</span>
             {{ cipher.sshKey.privateKey }}
           </div>
+          <div class="box-content-row" *ngIf="cipher.sshKey.publicKey" style="overflow: hidden">
+            <span class="row-label"> {{ "sshPublicKey" | i18n }}</span>
+            {{ cipher.sshKey.publicKey }}
+          </div>
+          <div
+            class="box-content-row"
+            *ngIf="cipher.sshKey.keyFingerprint"
+            style="overflow: hidden"
+          >
+            <span class="row-label"> {{ "sshKeyFingerprint" | i18n }}</span>
+            {{ cipher.sshKey.keyFingerprint }}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -431,6 +431,16 @@
       </div>
       <!-- SSHKey -->
       <div *ngIf="cipher.sshKey">
+        <div class="box-content-row" *ngIf="cipher.sshKey.privateKey" style="overflow: hidden">
+          <span
+            class="row-label draggable"
+            draggable="true"
+            (dragstart)="setTextDataOnDrag($event, cipher.sshKey.privateKey)"
+          >
+            {{ "sshPrivateKey" | i18n }}
+          </span>
+          <div [innerText]="cipher.sshKey.maskedPrivateKey" class="monospaced"></div>
+        </div>
         <div class="box-content-row" *ngIf="cipher.sshKey.publicKey" style="overflow: hidden">
           <span
             class="row-label draggable"

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -476,23 +476,20 @@
             <div class="box-content-row box-content-row-flex" appBoxRow>
               <div class="row-main">
                 <label for="sshPrivateKey">{{ "sshPrivateKey" | i18n }}</label>
-                <input
-                  id="sshPublicKey"
-                  type="{{ showPrivateKey ? 'text' : 'password' }}"
-                  name="SSHKey.SSHPrivateKey"
-                  [ngModel]="cipher.sshKey.privateKey"
-                  readonly
-                />
+                <div
+                  *ngIf="!showPrivateKey"
+                  class="monospaced"
+                  style="white-space: pre-line"
+                  [innerText]="cipher.sshKey.maskedPrivateKey"
+                ></div>
+                <div
+                  *ngIf="showPrivateKey"
+                  class="monospaced"
+                  style="white-space: pre-line"
+                  [innerText]="cipher.sshKey.privateKey"
+                ></div>
               </div>
               <div class="action-buttons">
-                <button
-                  type="button"
-                  class="row-btn"
-                  appStopClick
-                  (click)="copy(this.cipher.sshKey.privateKey, 'sshPrivateKey', 'SSHPrivateKey')"
-                >
-                  <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
-                </button>
                 <button
                   type="button"
                   class="row-btn"
@@ -505,6 +502,60 @@
                     aria-hidden="true"
                     [ngClass]="{ 'bwi-eye': !showPrivateKey, 'bwi-eye-slash': showPrivateKey }"
                   ></i>
+                </button>
+                <button
+                  type="button"
+                  class="row-btn"
+                  appStopClick
+                  (click)="copy(this.cipher.sshKey.privateKey, 'sshPrivateKey', 'SSHPrivateKey')"
+                >
+                  <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
+            <div class="box-content-row box-content-row-flex" appBoxRow>
+              <div class="row-main">
+                <label for="sshPublicKey">{{ "sshPublicKey" | i18n }}</label>
+                <input
+                  id="sshPublicKey"
+                  type="text"
+                  name="SSHKey.SSHPublicKey"
+                  [ngModel]="cipher.sshKey.publicKey"
+                  readonly
+                />
+              </div>
+              <div class="action-buttons">
+                <button
+                  type="button"
+                  class="row-btn"
+                  appStopClick
+                  (click)="copy(cipher.sshKey.publicKey, 'sshPublicKey', 'SSHPublicKey')"
+                  appA11yTitle="{{ 'generateSSHKey' | i18n }}"
+                >
+                  <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
+            <div class="box-content-row box-content-row-flex" appBoxRow>
+              <div class="row-main">
+                <label for="sshKeyFingerprint">{{ "sshFingerprint" | i18n }}</label>
+                <input
+                  id="sshKeyFingerprint"
+                  type="text"
+                  name="SSHKey.SSHKeyFingerprint"
+                  [ngModel]="cipher.sshKey.keyFingerprint"
+                  readonly
+                />
+              </div>
+              <div class="action-buttons">
+                <button
+                  type="button"
+                  class="row-btn"
+                  appStopClick
+                  (click)="copy(cipher.sshKey.keyFingerprint, 'sshFingerprint', 'SSHFingerprint')"
+                  appA11yTitle="{{ 'generateSSHKey' | i18n }}"
+                >
+                  <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
                 </button>
               </div>
             </div>

--- a/apps/desktop/src/vault/app/vault/add-edit.component.ts
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.ts
@@ -30,7 +30,6 @@ const BroadcasterSubscriptionId = "AddEditComponent";
 export class AddEditComponent extends BaseAddEditComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild("form")
   private form: NgForm;
-  showPrivateKey = false;
 
   constructor(
     cipherService: CipherService,

--- a/apps/desktop/src/vault/app/vault/view.component.html
+++ b/apps/desktop/src/vault/app/vault/view.component.html
@@ -401,7 +401,53 @@
         </div>
         <!-- SSH Key -->
         <div *ngIf="cipher.sshKey">
-          <div class="box-content-row box-content-row-flex" appBoxRow>
+          <div class="box-content-row box-content-row-flex" *ngIf="cipher.sshKey.privateKey">
+            <div class="row-main">
+              <span class="row-label">{{ "sshPrivateKey" | i18n }}</span>
+              <div
+                *ngIf="!showPrivateKey"
+                class="monospaced"
+                style="white-space: pre-line"
+                [innerText]="cipher.sshKey.maskedPrivateKey"
+              ></div>
+              <div
+                *ngIf="showPrivateKey"
+                class="monospaced"
+                style="white-space: pre-line"
+                [innerText]="cipher.sshKey.privateKey"
+              ></div>
+            </div>
+            <div class="action-buttons" *ngIf="cipher.viewPassword">
+              <button
+                type="button"
+                class="row-btn"
+                appStopClick
+                appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showPrivateKey"
+                (click)="togglePrivateKey()"
+              >
+                <i
+                  class="bwi bwi-lg"
+                  aria-hidden="true"
+                  [ngClass]="{ 'bwi-eye': !showPrivateKey, 'bwi-eye-slash': showPrivateKey }"
+                ></i>
+              </button>
+              <button
+                type="button"
+                class="row-btn"
+                appStopClick
+                appA11yTitle="{{ 'copySSHPrivateKey' | i18n }}"
+                (click)="copy(cipher.sshKey.privateKey, 'sshPrivateKey', 'SshPrivateKey')"
+              >
+                <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+              </button>
+            </div>
+          </div>
+          <div
+            class="box-content-row box-content-row-flex"
+            *ngIf="cipher.sshKey.publicKey"
+            appBoxRow
+          >
             <div class="row-main">
               <label for="sshPublicKey">{{ "sshPublicKey" | i18n }}</label>
               <input
@@ -424,7 +470,11 @@
               </button>
             </div>
           </div>
-          <div class="box-content-row box-content-row-flex" appBoxRow>
+          <div
+            class="box-content-row box-content-row-flex"
+            *ngIf="cipher.sshKey.keyFingerprint"
+            appBoxRow
+          >
             <div class="row-main">
               <label for="sshKeyFingerprint">{{ "sshFingerprint" | i18n }}</label>
               <input

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.html
@@ -851,6 +851,44 @@
         <ng-container *ngIf="cipher.type === cipherType.SSHKey">
           <div class="row">
             <div class="col-12 form-group">
+              <label for="sshKeyPrivateKey">{{ "sshKeyPrivateKey" | i18n }}</label>
+              <div class="input-group">
+                <input
+                  id="sshKeyPrivateKey"
+                  class="form-control"
+                  type="{{ showPrivateKey ? 'text' : 'password' }}"
+                  name="SSHKey.PrivateKey"
+                  [(ngModel)]="cipher.sshKey.privateKey"
+                  appInputVerbatim
+                  disabled
+                  readonly
+                />
+                <div class="input-group-append" *ngIf="!cipher.isDeleted">
+                  <button
+                    type="button"
+                    class="btn btn-outline-secondary"
+                    appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                    (click)="togglePrivateKey()"
+                    [disabled]="!cipher.viewPassword"
+                  >
+                    <i
+                      class="bwi bwi-lg"
+                      aria-hidden="true"
+                      [ngClass]="{ 'bwi-eye': !showPrivateKey, 'bwi-eye-slash': showPrivateKey }"
+                    ></i>
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-outline-secondary"
+                    appA11yTitle="{{ 'copySSHPrivateKey' | i18n }}"
+                    (click)="copy(cipher.sshKey.privateKey, 'sshKeyPrivateKey', 'PrivateKey')"
+                  >
+                    <i class="bwi bwi-lg bwi-clone" aria-hidden="true"></i>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="col-12 form-group">
               <label for="sshKeyPublicKey">{{ "sshKeyPublicKey" | i18n }}</label>
               <div class="input-group">
                 <input

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -8958,6 +8958,9 @@
   "sshKeyFingerprint": {
     "message": "Fingerprint"
   },
+  "sshKeyPrivateKey": {
+    "message": "Private key"
+  },
   "sshKeyPublicKey": {
     "message": "Public key"
   },

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -69,6 +69,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   restorePromise: Promise<any>;
   checkPasswordPromise: Promise<number>;
   showPassword = false;
+  showPrivateKey = false;
   showTotpSeed = false;
   showCardNumber = false;
   showCardCode = false;
@@ -597,6 +598,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
         this.cipherId,
       );
     }
+  }
+
+  togglePrivateKey() {
+    this.showPrivateKey = !this.showPrivateKey;
   }
 
   toggleUriOptions(uri: LoginUriView) {

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -55,6 +55,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   showPasswordCount: boolean;
   showCardNumber: boolean;
   showCardCode: boolean;
+  showPrivateKey: boolean;
   canAccessPremium: boolean;
   showPremiumRequiredTotp: boolean;
   totpCode: string;
@@ -313,6 +314,10 @@ export class ViewComponent implements OnDestroy, OnInit {
         this.cipherId,
       );
     }
+  }
+
+  togglePrivateKey() {
+    this.showPrivateKey = !this.showPrivateKey;
   }
 
   async checkPassword() {

--- a/libs/common/src/vault/models/view/ssh-key.view.ts
+++ b/libs/common/src/vault/models/view/ssh-key.view.ts
@@ -16,8 +16,23 @@ export class SSHKeyView extends ItemView {
     }
   }
 
+  get maskedPrivateKey(): string {
+    let lines = this.privateKey.split("\n").filter((l) => l.trim() !== "");
+    lines = lines.map((l, i) => {
+      if (i === 0 || i === lines.length - 1) {
+        return l;
+      }
+      return this.maskLine(l);
+    });
+    return lines.join("\n");
+  }
+
+  private maskLine(line: string): string {
+    return "•".repeat(32);
+  }
+
   get subTitle(): string {
-    return null;
+    return this.keyFingerprint;
   }
 
   static fromJSON(obj: Partial<Jsonify<SSHKeyView>>): SSHKeyView {

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
@@ -6,6 +6,18 @@
   </bit-section-header>
   <bit-card>
     <bit-form-field>
+      <bit-label>{{ "sshPrivateKey" | i18n }}</bit-label>
+      <input id="privateKey" bitInput formControlName="privateKey" type="password" />
+      <button
+        type="button"
+        bitIconButton
+        bitSuffix
+        data-testid="toggle-password-visibility"
+        bitPasswordInputToggle
+      ></button>
+    </bit-form-field>
+
+    <bit-form-field>
       <bit-label>{{ "sshPublicKey" | i18n }}</bit-label>
       <input id="publicKey" bitInput formControlName="publicKey" />
     </bit-form-field>

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -4,6 +4,25 @@
   </bit-section-header>
   <bit-card class="[&_bit-form-field:last-of-type]:tw-mb-0">
     <bit-form-field>
+      <bit-label>{{ "sshPrivateKey" | i18n }}</bit-label>
+      <input readonly bitInput [value]="sshKey.privateKey" aria-readonly="true" type="password" />
+      <button
+        bitSuffix
+        type="button"
+        bitIconButton
+        bitPasswordInputToggle
+        data-testid="toggle-privateKey"
+      ></button>
+      <button
+        bitIconButton="bwi-clone"
+        bitSuffix
+        type="button"
+        [appCopyClick]="sshKey.privateKey"
+        showToast
+        [appA11yTitle]="'copyValue' | i18n"
+      ></button>
+    </bit-form-field>
+    <bit-form-field>
       <bit-label>{{ "sshPublicKey" | i18n }}</bit-label>
       <input readonly bitInput [value]="sshKey.publicKey" aria-readonly="true" />
       <button


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10406

## 📔 Objective

Add private key to view component and public key and fingerprint to add-edit component, to make the experience consistent with mobile. Additionally fix the autofill options on browser.

## 📸 Screenshots

https://github.com/user-attachments/assets/c4ec226d-2f53-4693-999b-22cc3c035f38


https://github.com/user-attachments/assets/2a97c5be-4dda-4ea4-8bd0-358b9e1b08cb


https://github.com/user-attachments/assets/2b9c2b5a-1d8e-4602-920e-8f92b744df58


https://github.com/user-attachments/assets/19d3a0a2-1ee2-4089-b2ac-c3491b86ce99



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
