### PR TITLE
[PM-12024] Move Lock All To Happen in Background

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule, Location } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
-import { Subject, firstValueFrom, map, of, startWith, switchMap, takeUntil } from "rxjs";
+import { Subject, firstValueFrom, map, of, startWith, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { LockService } from "@bitwarden/auth/common";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
 import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -70,6 +71,7 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private authService: AuthService,
     private configService: ConfigService,
+    private lockService: LockService,
   ) {}
 
   get accountLimit() {
@@ -131,26 +133,8 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
 
   async lockAll() {
     this.loading = true;
-    this.availableAccounts$
-      .pipe(
-        map((accounts) =>
-          accounts
-            .filter((account) => account.id !== this.specialAddAccountId)
-            .sort((a, b) => (a.isActive ? -1 : b.isActive ? 1 : 0)) // Log out of the active account first
-            .map((account) => account.id),
-        ),
-        switchMap(async (accountIds) => {
-          if (accountIds.length === 0) {
-            return;
-          }
-
-          // Must lock active (first) account first, then order doesn't matter
-          await this.vaultTimeoutService.lock(accountIds.shift());
-          await Promise.all(accountIds.map((id) => this.vaultTimeoutService.lock(id)));
-        }),
-        takeUntil(this.destroy$),
-      )
-      .subscribe(() => this.router.navigate(["lock"]));
+    await this.lockService.lockAll();
+    await this.router.navigate(["lock"]);
   }
 
   async logOut(userId: UserId) {

--- a/apps/browser/src/auth/popup/accounts/foreground-lock.service.ts
+++ b/apps/browser/src/auth/popup/accounts/foreground-lock.service.ts
@@ -1,0 +1,32 @@
+import { filter, firstValueFrom } from "rxjs";
+
+import { LockService } from "@bitwarden/auth/common";
+import {
+  CommandDefinition,
+  MessageListener,
+  MessageSender,
+} from "@bitwarden/common/platform/messaging";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
+const LOCK_ALL_FINISHED = new CommandDefinition<{ requestId: string }>("lockAllFinished");
+const LOCK_ALL = new CommandDefinition<{ requestId: string }>("lockAll");
+
+export class ForegroundLockService implements LockService {
+  constructor(
+    private readonly messageSender: MessageSender,
+    private readonly messageListener: MessageListener,
+  ) {}
+
+  async lockAll(): Promise<void> {
+    const requestId = Utils.newGuid();
+    const finishMessage = firstValueFrom(
+      this.messageListener
+        .messages$(LOCK_ALL_FINISHED)
+        .pipe(filter((m) => m.requestId === requestId)),
+    );
+
+    this.messageSender.send(LOCK_ALL, { requestId });
+
+    await finishMessage;
+  }
+}

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -9,6 +9,7 @@ import {
   AuthRequestService,
   LoginEmailServiceAbstraction,
   LogoutReason,
+  DefaultLockService,
 } from "@bitwarden/auth/common";
 import { ApiService as ApiServiceAbstraction } from "@bitwarden/common/abstractions/api.service";
 import { AuditService as AuditServiceAbstraction } from "@bitwarden/common/abstractions/audit.service";
@@ -1065,6 +1066,9 @@ export default class MainBackground {
         this.scriptInjectorService,
         this.configService,
       );
+
+      const lockService = new DefaultLockService(this.accountService, this.vaultTimeoutService);
+
       this.runtimeBackground = new RuntimeBackground(
         this,
         this.autofillService,
@@ -1079,6 +1083,7 @@ export default class MainBackground {
         this.fido2Background,
         messageListener,
         this.accountService,
+        lockService,
       );
       this.nativeMessagingBackground = new NativeMessagingBackground(
         this.cryptoService,

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -1,5 +1,6 @@
 import { firstValueFrom, map, mergeMap, of, switchMap } from "rxjs";
 
+import { LockService } from "@bitwarden/auth/common";
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AutofillOverlayVisibility, ExtensionCommand } from "@bitwarden/common/autofill/constants";
@@ -48,6 +49,7 @@ export default class RuntimeBackground {
     private fido2Background: Fido2Background,
     private messageListener: MessageListener,
     private accountService: AccountService,
+    private readonly lockService: LockService,
   ) {
     // onInstalled listener must be wired up before anything else, so we do it in the ctor
     chrome.runtime.onInstalled.addListener((details: any) => {
@@ -244,6 +246,12 @@ export default class RuntimeBackground {
         break;
       case "lockVault":
         await this.main.vaultTimeoutService.lock(msg.userId);
+        break;
+      case "lockAll":
+        {
+          await this.lockService.lockAll();
+          this.messagingService.send("lockAllFinished", { requestId: msg.requestId });
+        }
         break;
       case "logout":
         await this.main.logout(msg.expired, msg.userId);

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -17,7 +17,7 @@ import {
 } from "@bitwarden/angular/services/injection-tokens";
 import { JslibServicesModule } from "@bitwarden/angular/services/jslib-services.module";
 import { AnonLayoutWrapperDataService } from "@bitwarden/auth/angular";
-import { PinServiceAbstraction } from "@bitwarden/auth/common";
+import { LockService, PinServiceAbstraction } from "@bitwarden/auth/common";
 import { EventCollectionService as EventCollectionServiceAbstraction } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { NotificationsService } from "@bitwarden/common/abstractions/notifications.service";
 import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout.service";
@@ -91,6 +91,7 @@ import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
+import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock.service";
 import { ExtensionAnonLayoutWrapperDataService } from "../../auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper-data.service";
 import { AutofillService as AutofillServiceAbstraction } from "../../autofill/services/abstractions/autofill.service";
 import AutofillService from "../../autofill/services/autofill.service";
@@ -559,6 +560,11 @@ const safeProviders: SafeProvider[] = [
     provide: AnonLayoutWrapperDataService,
     useClass: ExtensionAnonLayoutWrapperDataService,
     deps: [],
+  }),
+  safeProvider({
+    provide: LockService,
+    useClass: ForegroundLockService,
+    deps: [MessageSender, MessageListener],
   }),
 ];
 

--- a/libs/auth/src/common/services/accounts/lock.service.ts
+++ b/libs/auth/src/common/services/accounts/lock.service.ts
@@ -1,0 +1,47 @@
+import { combineLatest, firstValueFrom, map } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { VaultTimeoutService } from "@bitwarden/common/services/vault-timeout/vault-timeout.service";
+import { UserId } from "@bitwarden/common/types/guid";
+
+export abstract class LockService {
+  /**
+   * Locks all accounts.
+   */
+  abstract lockAll(): Promise<void>;
+}
+
+export class DefaultLockService implements LockService {
+  constructor(
+    private readonly accountService: AccountService,
+    private readonly vaultTimeoutService: VaultTimeoutService,
+  ) {}
+
+  async lockAll() {
+    const accounts = await firstValueFrom(
+      combineLatest([this.accountService.activeAccount$, this.accountService.accounts$]).pipe(
+        map(([activeAccount, accounts]) => {
+          const otherAccounts = Object.keys(accounts) as UserId[];
+
+          if (activeAccount == null) {
+            return { activeAccount: null, otherAccounts: otherAccounts };
+          }
+
+          return {
+            activeAccount: activeAccount.id,
+            otherAccounts: otherAccounts.filter((accountId) => accountId !== activeAccount.id),
+          };
+        }),
+      ),
+    );
+
+    // Always prefer to do the active account first
+    if (accounts.activeAccount != null) {
+      await this.vaultTimeoutService.lock(accounts.activeAccount);
+    }
+
+    for (const otherAccount of accounts.otherAccounts) {
+      await this.vaultTimeoutService.lock(otherAccount);
+    }
+  }
+}

--- a/libs/auth/src/common/services/index.ts
+++ b/libs/auth/src/common/services/index.ts
@@ -4,3 +4,4 @@ export * from "./login-strategies/login-strategy.service";
 export * from "./user-decryption-options/user-decryption-options.service";
 export * from "./auth-request/auth-request.service";
 export * from "./register-route.service";
+export * from "./accounts/lock.service";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Refactor `lockAll` for browser to be a single action that is sent to the background and have all the locks on users happen serially. I'm not completely sure what made firefox fall apart from the original code or why this fixes it but it does for me 🤷.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
