### PR TITLE
[PM-8582] Improve search performance in Safari

### DIFF
--- a/libs/components/src/search/search.component.html
+++ b/libs/components/src/search/search.component.html
@@ -10,7 +10,7 @@
   <input
     #input
     bitInput
-    type="search"
+    [type]="inputType"
     [id]="id"
     [placeholder]="placeholder ?? ('search' | i18n)"
     class="tw-rounded-l tw-pl-9"

--- a/libs/components/src/search/search.component.ts
+++ b/libs/components/src/search/search.component.ts
@@ -1,6 +1,8 @@
 import { Component, ElementRef, Input, ViewChild } from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
+import { isBrowserSafariApi } from "@bitwarden/platform";
+
 import { FocusableElement } from "../shared/focusable-element";
 
 let nextId = 0;
@@ -28,6 +30,8 @@ export class SearchComponent implements ControlValueAccessor, FocusableElement {
 
   protected id = `search-id-${nextId++}`;
   protected searchText: string;
+  // Use `type="text"` for Safari to improve rendering performance
+  protected inputType = isBrowserSafariApi() ? ("text" as const) : ("search" as const);
 
   @Input() disabled: boolean;
   @Input() placeholder: string;

--- a/libs/components/tsconfig.json
+++ b/libs/components/tsconfig.json
@@ -20,7 +20,8 @@
     "lib": ["es2020", "dom"],
     "paths": {
       "@bitwarden/common/*": ["../common/src/*"],
-      "@bitwarden/angular/*": ["../angular/src/*"]
+      "@bitwarden/angular/*": ["../angular/src/*"],
+      "@bitwarden/platform": ["../platform/src"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8582](https://bitwarden.atlassian.net/browse/PM-8582)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR addresses poor performance in Safari, observed in the browser extension refresh. We don't quite know why, but using `type="search"` for a search input causes rendering lag in Safari. Our existing extension code conditionally uses `type="text"` for Safari, so we are implementing the same logic for the component library Search component. Note that this will also apply to Safari web.

I was unable to reproduce the poor performance in Safari version 17.6, but it has been reproduced in 17.5. While this change helps mitigate the poor performance, it does not entirely eliminate it in version 17.5. Since it looks like more recent versions of Safari perform better, we expect this issue to lessen as more people update Safari.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8582]: https://bitwarden.atlassian.net/browse/PM-8582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ