### PR TITLE
[PM-11438] - Add padding to new org input

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -11,7 +11,7 @@
   <form [formGroup]="selfHostedForm" [bitSubmit]="submit">
     <bit-form-field>
       <bit-label>{{ "licenseFile" | i18n }}</bit-label>
-      <div>
+      <div class="tw-pt-2 tw-pb-1">
         <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
           {{ "chooseFile" | i18n }}
         </button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11438

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the appropriate padding on the input button for the new organization license field.

### Note

This was previously attempted in https://github.com/bitwarden/clients/pull/10982 but the appropriate commit didn't make it in.

## 📸 Screenshots

|Before|After|
---|---
|<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-09-10 at 3 44 34 PM](https://github.com/user-attachments/assets/5db8beff-1101-49aa-be0c-937fc3d919ec)|![Screenshot 2024-09-10 at 3 44 04 PM](https://github.com/user-attachments/assets/0d808606-dfd4-4ca0-8667-412b49d8360f)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
