### PR TITLE
[PM-11393] Browser Refresh - Fix missing Autofill Options section in Web view

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -20,17 +20,15 @@ import { CollectionView } from "@bitwarden/common/vault/models/view/collection.v
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import {
   AsyncActionsModule,
-  SearchModule,
   ButtonModule,
-  IconButtonModule,
   DialogService,
+  IconButtonModule,
+  SearchModule,
   ToastService,
 } from "@bitwarden/components";
-import { TotpCaptureService } from "@bitwarden/vault";
 
 import { CipherViewComponent } from "../../../../../../../../libs/vault/src/cipher-view";
 import { PopOutComponent } from "../../../../../platform/popup/components/pop-out.component";
-import { BrowserTotpCaptureService } from "../../../services/browser-totp-capture.service";
 
 import { PopupFooterComponent } from "./../../../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "./../../../../../platform/popup/layout/popup-header.component";
@@ -41,7 +39,6 @@ import { VaultPopupAutofillService } from "./../../../services/vault-popup-autof
   selector: "app-view-v2",
   templateUrl: "view-v2.component.html",
   standalone: true,
-  providers: [{ provide: TotpCaptureService, useClass: BrowserTotpCaptureService }],
   imports: [
     CommonModule,
     SearchModule,

--- a/apps/browser/src/vault/popup/services/browser-totp-capture.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/browser-totp-capture.service.spec.ts
@@ -13,15 +13,10 @@ describe("BrowserTotpCaptureService", () => {
   let testBed: TestBed;
   let service: BrowserTotpCaptureService;
   let mockCaptureVisibleTab: jest.SpyInstance;
-  let createNewTabSpy: jest.SpyInstance;
 
   const validTotpUrl = "otpauth://totp/label?secret=123";
 
   beforeEach(() => {
-    const tabReturn = new Promise<chrome.tabs.Tab>((resolve) =>
-      resolve({ url: "google.com", active: true } as chrome.tabs.Tab),
-    );
-    createNewTabSpy = jest.spyOn(BrowserApi, "createNewTab").mockReturnValue(tabReturn);
     mockCaptureVisibleTab = jest.spyOn(BrowserApi, "captureVisibleTab");
     mockCaptureVisibleTab.mockResolvedValue("screenshot");
 
@@ -70,11 +65,5 @@ describe("BrowserTotpCaptureService", () => {
     const result = await service.captureTotpSecret();
 
     expect(result).toBeNull();
-  });
-
-  it("should call BrowserApi.createNewTab with a given loginURI", async () => {
-    await service.openAutofillNewTab("www.google.com");
-
-    expect(createNewTabSpy).toHaveBeenCalledWith("www.google.com");
   });
 });

--- a/apps/browser/src/vault/popup/services/browser-totp-capture.service.ts
+++ b/apps/browser/src/vault/popup/services/browser-totp-capture.service.ts
@@ -20,8 +20,4 @@ export class BrowserTotpCaptureService implements TotpCaptureService {
     }
     return null;
   }
-
-  async openAutofillNewTab(loginUri: string) {
-    await BrowserApi.createNewTab(loginUri);
-  }
 }

--- a/libs/vault/src/cipher-form/abstractions/totp-capture.service.ts
+++ b/libs/vault/src/cipher-form/abstractions/totp-capture.service.ts
@@ -1,9 +1,4 @@
 /**
- * TODO: PM-10727 - Rename and Refactor this service
- * This service is being used in both CipherForm and CipherView. Update this service to reflect that
- */
-
-/**
  * Service to capture TOTP secret from a client application.
  */
 export abstract class TotpCaptureService {
@@ -11,5 +6,4 @@ export abstract class TotpCaptureService {
    * Captures a TOTP secret and returns it as a string. Returns null if no TOTP secret was found.
    */
   abstract captureTotpSecret(): Promise<string | null>;
-  abstract openAutofillNewTab(loginUri: string): void;
 }

--- a/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.ts
+++ b/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.ts
@@ -2,17 +2,16 @@ import { CommonModule } from "@angular/common";
 import { Component, Input } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import {
   CardComponent,
   FormFieldModule,
+  IconButtonModule,
   SectionComponent,
   SectionHeaderComponent,
   TypographyModule,
-  IconButtonModule,
 } from "@bitwarden/components";
-
-import { TotpCaptureService } from "../../cipher-form";
 
 @Component({
   selector: "app-autofill-options-view",
@@ -32,9 +31,9 @@ import { TotpCaptureService } from "../../cipher-form";
 export class AutofillOptionsViewComponent {
   @Input() loginUris: LoginUriView[];
 
-  constructor(private totpCaptureService: TotpCaptureService) {}
+  constructor(private platformUtilsService: PlatformUtilsService) {}
 
-  async openWebsite(selectedUri: string) {
-    await this.totpCaptureService.openAutofillNewTab(selectedUri);
+  openWebsite(selectedUri: string) {
+    this.platformUtilsService.launchUri(selectedUri);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11393](https://bitwarden.atlassian.net/browse/PM-11393)

## 📔 Objective

The `AutofillOptionsSection` component was dependent on the `TotpCaptureService` which was not being provided in Web. We can make this dependency optional by using `PlatformUtilsService` instead of making the `TotpCaptureService` serve unrelated purposes. Without the dependency the `AutofillOptionsSection` component can now render without issue on Web.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/88bff8c0-8e9b-4b81-bbb1-b33618d4ff1d)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11393]: https://bitwarden.atlassian.net/browse/PM-11393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ