### PR TITLE
[CL-448] Scrollbar Styles

### DIFF
--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -13,7 +13,7 @@
     @apply tw-bg-secondary-500 tw-rounded-lg tw-border-4 tw-border-solid tw-border-transparent tw-bg-clip-content;
   }
   ::-webkit-scrollbar-track {
-    @apply tw-bg-background;
+    @apply tw-bg-background-alt;
   }
   ::-webkit-scrollbar-thumb:hover {
     @apply tw-bg-secondary-600;
@@ -22,7 +22,7 @@
   /* FireFox support */
   * {
     @supports (-moz-appearance: none) {
-      scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background));
+      scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background-alt));
     }
   }
 }

--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -3,3 +3,26 @@
 @tailwind utilities;
 
 @import "../../../../../libs/components/src/tw-theme.css";
+
+@layer base {
+  /* Chrome & Safari support */
+  ::-webkit-scrollbar {
+    @apply tw-overflow-auto;
+  }
+  ::-webkit-scrollbar-thumb {
+    @apply tw-bg-secondary-500 tw-rounded-lg tw-border-4 tw-border-solid tw-border-transparent tw-bg-clip-content;
+  }
+  ::-webkit-scrollbar-track {
+    @apply tw-bg-background;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    @apply tw-bg-secondary-600;
+  }
+
+  /* FireFox support */
+  * {
+    @supports (-moz-appearance: none) {
+      scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background));
+    }
+  }
+}

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -167,5 +167,31 @@ module.exports = {
         addVariant(state, [`&:${state}`, `&.test-${state}`]);
       }
     }),
+    plugin(function ({ addBase }) {
+      addBase({
+        // Chrome & Safari support
+        "::-webkit-scrollbar": {
+          overflow: "auto",
+        },
+        "::-webkit-scrollbar-thumb": {
+          border: "4px solid transparent",
+          "background-clip": "content-box",
+          "border-radius": "10px",
+          "background-color": "rgb(var(--color-secondary-500))",
+        },
+        "::-webkit-scrollbar-track": {
+          "background-color": "rgb(var(--color-background))",
+        },
+        "::-webkit-scrollbar-thumb:hover": {
+          "background-color": "rgb(var(--color-secondary-600))",
+        },
+        // FireFox support
+        "*": {
+          "@supports (-moz-appearance:none)": {
+            "scrollbar-color": "rgb(var(--color-secondary-500)) rgb(var(--color-background))",
+          },
+        },
+      });
+    }),
   ],
 };

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -167,31 +167,5 @@ module.exports = {
         addVariant(state, [`&:${state}`, `&.test-${state}`]);
       }
     }),
-    plugin(function ({ addBase }) {
-      addBase({
-        // Chrome & Safari support
-        "::-webkit-scrollbar": {
-          overflow: "auto",
-        },
-        "::-webkit-scrollbar-thumb": {
-          border: "4px solid transparent",
-          "background-clip": "content-box",
-          "border-radius": "10px",
-          "background-color": "rgb(var(--color-secondary-500))",
-        },
-        "::-webkit-scrollbar-track": {
-          "background-color": "rgb(var(--color-background))",
-        },
-        "::-webkit-scrollbar-thumb:hover": {
-          "background-color": "rgb(var(--color-secondary-600))",
-        },
-        // FireFox support
-        "*": {
-          "@supports (-moz-appearance:none)": {
-            "scrollbar-color": "rgb(var(--color-secondary-500)) rgb(var(--color-background))",
-          },
-        },
-      });
-    }),
   ],
 };


### PR DESCRIPTION
## 🎟️ Tracking

[CL-448](https://bitwarden.atlassian.net/browse/CL-448)

## 📔 Objective

Add custom styles for scrollbar in the Tailwind Configuration
- FireFox doesn't support the `webkit` prefix, I used [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) instead. The only downside is it doesn't support the hover styles.
- Safari doesn't seem to respond when the system theme is transitioned for the browser. That's why there is a separate video for light/dark below

## 📸 Screenshots

### Outdated see below https://github.com/bitwarden/clients/pull/11111#discussion_r1765373150

|Chrome|Safari Light|Safari Dark|FireFox|
|-|-|-|-|
|<video src="https://github.com/user-attachments/assets/11a8403f-9a62-451a-853e-a2c3b2a678b8"/>|<video src="https://github.com/user-attachments/assets/6899be72-7f87-48ad-a949-715ad5b1d492" />|<video src="https://github.com/user-attachments/assets/9fb9ece5-da25-4700-8772-8cd5dd5dc3f4" />|<video src="https://github.com/user-attachments/assets/07e89af6-4991-4036-9319-41eb15eb0924" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-448]: https://bitwarden.atlassian.net/browse/CL-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ