### PR TITLE
[CL-439] Improve keyboard and visual a11y for chip select

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.html
+++ b/libs/components/src/chip-select/chip-select.component.html
@@ -52,10 +52,12 @@
         type="button"
         bitMenuItem
         (click)="viewOption(parent, $event)"
-        [title]="parent.label ? ('backTo' | i18n: parent.label) : ('back' | i18n)"
+        [title]="
+          parent.label ? ('backTo' | i18n: parent.label) : ('backTo' | i18n: placeholderText)
+        "
       >
         <i slot="start" class="bwi bwi-angle-left" aria-hidden="true"></i>
-        {{ parent.label ? ("backTo" | i18n: parent.label) : ("back" | i18n) }}
+        {{ parent.label ? ("backTo" | i18n: parent.label) : ("backTo" | i18n: placeholderText) }}
       </button>
 
       <button
@@ -76,6 +78,7 @@
       (click)="option.children?.length ? viewOption(option, $event) : selectOption(option, $event)"
       [disabled]="option.disabled"
       [title]="option.label"
+      [attr.aria-haspopup]="option.children?.length ? 'menu' : null"
     >
       <i
         *ngIf="option.icon"

--- a/libs/components/src/chip-select/chip-select.component.html
+++ b/libs/components/src/chip-select/chip-select.component.html
@@ -52,12 +52,10 @@
         type="button"
         bitMenuItem
         (click)="viewOption(parent, $event)"
-        [title]="
-          parent.label ? ('backTo' | i18n: parent.label) : ('backTo' | i18n: placeholderText)
-        "
+        [title]="'backTo' | i18n: parent.label ?? placeholderText"
       >
         <i slot="start" class="bwi bwi-angle-left" aria-hidden="true"></i>
-        {{ parent.label ? ("backTo" | i18n: parent.label) : ("backTo" | i18n: placeholderText) }}
+        {{ "backTo" | i18n: parent.label ?? placeholderText }}
       </button>
 
       <button

--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnDestroy,
   QueryList,
+  ViewChild,
   ViewChildren,
   booleanAttribute,
   signal,
@@ -15,7 +16,7 @@ import { Subject, takeUntil } from "rxjs";
 import { compareValues } from "../../../common/src/platform/misc/compare-values";
 import { ButtonModule } from "../button";
 import { IconButtonModule } from "../icon-button";
-import { MenuItemDirective, MenuModule } from "../menu";
+import { MenuComponent, MenuItemDirective, MenuModule } from "../menu";
 import { Option } from "../select/option";
 import { SharedModule } from "../shared";
 import { TypographyModule } from "../typography";
@@ -42,6 +43,7 @@ export type ChipSelectOption<T> = Option<T> & {
 export class ChipSelectComponent<T = unknown>
   implements ControlValueAccessor, AfterViewInit, OnDestroy
 {
+  @ViewChild(MenuComponent) menu: MenuComponent;
   @ViewChildren(MenuItemDirective) menuItems: QueryList<MenuItemDirective>;
 
   /** Text to show when there is no selected option */
@@ -166,11 +168,13 @@ export class ChipSelectComponent<T = unknown>
   }
 
   ngAfterViewInit() {
-    this.menuItems.changes
-      .pipe(takeUntil(this.destroyed$))
-      .subscribe((next: QueryList<MenuItemDirective>) => {
-        next.first.focus();
-      });
+    /**
+     * menuItems will change when the user navigates into or out of a submenu. when that happens, we want to
+     * direct their focus to the first item in the new menu
+     */
+    this.menuItems.changes.pipe(takeUntil(this.destroyed$)).subscribe(() => {
+      this.menu.keyManager.setFirstItemActive();
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-439](https://bitwarden.atlassian.net/browse/CL-439)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
A11y already present:
- Chip announces it is a button for a menu
- Users can navigate menu with up/down arrow keys
- X button on the chip announces as "Remove { label }"

A11y implemented in this PR:
- [x] Keyboard focus moves to first item in menu when navigating between submenus
- [x] Menu items that are submenus now announce that they are a submenu 
- [x] "Back" button that goes to the root chip menu now says "Back to {root}"

Not being implemented:
- Chip menu and submenus announce the number of items -- we would need to switch our menu component to use list semantic elements, which we should do, but it's out of scope for this. Ticket here: [CL-452](https://bitwarden.atlassian.net/browse/CL-452)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
View the stories for the Chip Select in Storybook (specifically the nested items story) to play with the keyboard nav and screenreader support.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-439]: https://bitwarden.atlassian.net/browse/CL-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CL-452]: https://bitwarden.atlassian.net/browse/CL-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ