### PR TITLE
[PM-11391] Browser Refresh - Fix TOTP timer

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -111,15 +111,13 @@
         aria-readonly="true"
         data-testid="login-totp"
       />
-      <button
+      <div
         *ngIf="isPremium$ | async"
         bitTotpCountdown
         [cipher]="cipher"
         bitSuffix
-        type="button"
         (sendCopyCode)="setTotpCopyCode($event)"
-        class="tw-cursor-default"
-      ></button>
+      ></div>
       <button
         bitIconButton="bwi-clone"
         bitSuffix

--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
@@ -6,7 +6,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { TypographyModule } from "@bitwarden/components";
 
 @Component({
-  selector: "button[bitTotpCountdown]:not(button[bitButton])",
+  selector: "[bitTotpCountdown]",
   templateUrl: "totp-countdown.component.html",
   standalone: true,
   imports: [CommonModule, TypographyModule],


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11391](https://bitwarden.atlassian.net/browse/PM-11391)

## 📔 Objective

Update the TOTP timer to be rendered as a `div` instead of a `button` to avoid unnecessary and conflicting styles.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/2e6838ca-b14f-4c94-8e75-5a37ef7dc1d1)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
