### PR TITLE
Fix click on copy send link and delete send buttons

### DIFF
--- a/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
+++ b/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
@@ -30,28 +30,28 @@
         <span slot="secondary">
           {{ "deletionDate" | i18n }}:&nbsp;{{ send.deletionDate | date: "mediumDate" }}
         </span>
-        <ng-container slot="end">
-          <bit-item-action>
-            <button
-              class="tw-p-1"
-              bitIconButton="bwi-clone"
-              size="small"
-              type="button"
-              (click)="copySendLink(send)"
-              appA11yTitle="{{ 'copyLink' | i18n }} - {{ send.name }}"
-            ></button>
-          </bit-item-action>
-          <bit-item-action>
-            <button
-              bitIconButton="bwi-trash"
-              size="small"
-              type="button"
-              (click)="deleteSend(send)"
-              appA11yTitle="{{ 'delete' | i18n }} - {{ send.name }}"
-            ></button>
-          </bit-item-action>
-        </ng-container>
       </button>
+      <ng-container slot="end">
+        <bit-item-action>
+          <button
+            class="tw-p-1"
+            bitIconButton="bwi-clone"
+            size="small"
+            type="button"
+            (click)="copySendLink(send)"
+            appA11yTitle="{{ 'copyLink' | i18n }} - {{ send.name }}"
+          ></button>
+        </bit-item-action>
+        <bit-item-action>
+          <button
+            bitIconButton="bwi-trash"
+            size="small"
+            type="button"
+            (click)="deleteSend(send)"
+            appA11yTitle="{{ 'delete' | i18n }} - {{ send.name }}"
+          ></button>
+        </bit-item-action>
+      </ng-container>
     </bit-item>
   </bit-item-group>
 </bit-section>


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While reviewing and testing https://github.com/bitwarden/clients/pull/11002 I noticed that clicking on the copy send link and delete send buttons within the send list view, would also navigate to the selected Send's edit page. 

The area to display the button was also the click area to trigger navigating to `/edit-send`. Scoping the front part of the area to navigate to edit and the buttons on the end to their actions fixes this.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
