### PR TITLE
[AC-2617] Loading "Collections" Text on slow load of Org Header

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
@@ -122,7 +122,9 @@ export class VaultHeaderComponent implements OnInit {
       return this.i18nService.t("unassigned");
     }
 
-    return `${this.organization?.name} ${headerType}`;
+    return this.organization?.name
+      ? `${this.organization?.name} ${headerType}`
+      : this.i18nService.t("collections");
   }
 
   get icon() {


### PR DESCRIPTION
## 🎟️ Tracking

[AC-2617](https://bitwarden.atlassian.net/browse/AC-2617)

## 📔 Objective

When switching between a page to collections in org vault (e.g. settings > Collections), if the users internet is slow to load the org data, "undefined" will show in the header until org is loaded. 
Added placeholder text of "Collections" while loading

## 📸 Screen Recording

https://github.com/user-attachments/assets/c698b785-60e1-4e76-8eda-b28899bf18b5

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[AC-2617]: https://bitwarden.atlassian.net/browse/AC-2617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ