### PR TITLE
[CL-451] Add option for full width chip select

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.html
+++ b/libs/components/src/chip-select/chip-select.component.html
@@ -1,17 +1,18 @@
 <div
   bitTypography="body2"
-  class="tw-inline-flex tw-items-center tw-rounded-full tw-max-w-52 tw-border-solid tw-border tw-border-text-muted"
+  class="tw-inline-flex tw-items-center tw-rounded-full tw-border-solid tw-border tw-border-text-muted"
   [ngClass]="[
     selectedOption
       ? 'tw-bg-text-muted tw-text-contrast tw-gap-1'
       : 'tw-bg-transparent tw-text-muted tw-gap-1.5',
     focusVisibleWithin() ? 'tw-ring-2 tw-ring-primary-500 tw-ring-offset-1' : '',
+    fullWidth ? 'tw-w-full' : 'tw-max-w-52',
   ]"
 >
   <!-- Primary button -->
   <button
     type="button"
-    class="fvw-target tw-inline-flex tw-gap-1.5 tw-items-center tw-bg-transparent hover:tw-bg-transparent tw-border-none tw-outline-none tw-max-w-full tw-py-1 tw-pl-3 last:tw-pr-3 tw-truncate tw-text-[inherit]"
+    class="fvw-target tw-inline-flex tw-gap-1.5 tw-items-center tw-justify-between tw-bg-transparent hover:tw-bg-transparent tw-border-none tw-outline-none tw-w-full tw-py-1 tw-pl-3 last:tw-pr-3 tw-truncate tw-text-[inherit]"
     [ngClass]="{
       'tw-cursor-not-allowed': disabled,
     }"
@@ -20,8 +21,10 @@
     [title]="label"
     #menuTrigger="menuTrigger"
   >
-    <i class="bwi !tw-text-[inherit]" [ngClass]="icon"></i>
-    <span class="tw-truncate">{{ label }}</span>
+    <span class="tw-inline-flex tw-items-center tw-gap-1.5 tw-truncate">
+      <i class="bwi !tw-text-[inherit]" [ngClass]="icon"></i>
+      <span class="tw-truncate">{{ label }}</span>
+    </span>
     <i
       *ngIf="!selectedOption"
       class="bwi"

--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -49,6 +49,9 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor {
   /** Disables the entire chip */
   @Input({ transform: booleanAttribute }) disabled = false;
 
+  /** Chip will stretch to full width of its container */
+  @Input({ transform: booleanAttribute }) fullWidth?: boolean;
+
   /**
    * We have `:focus-within` and `:focus-visible` but no `:focus-visible-within`
    */

--- a/libs/components/src/chip-select/chip-select.stories.ts
+++ b/libs/components/src/chip-select/chip-select.stories.ts
@@ -74,6 +74,44 @@ export const Default: Story = {
   },
 };
 
+export const FullWidth: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+    <div class="tw-w-40">
+      <bit-chip-select
+        placeholderText="Folder"
+        placeholderIcon="bwi-folder"
+        [options]="options"
+        [ngModel]="value"
+        fullWidth
+      ></bit-chip-select>
+    </div>
+    `,
+  }),
+  args: {
+    options: [
+      {
+        label: "Foo",
+        value: "foo",
+        icon: "bwi-folder",
+      },
+      {
+        label: "Bar",
+        value: "bar",
+        icon: "bwi-exclamation-triangle tw-text-danger",
+      },
+      {
+        label: "Baz",
+        value: "baz",
+        disabled: true,
+      },
+    ],
+  },
+};
+
 export const NestedOptions: Story = {
   ...Default,
   args: {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-451](https://bitwarden.atlassian.net/browse/CL-451)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the option to render the chip select as a full width variant, meaning it will stretch to fill its container.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-09-19 at 11 19 17 AM](https://github.com/user-attachments/assets/02389eff-1a66-4550-a3ec-af7cedf272c9)

See Storybook.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-451]: https://bitwarden.atlassian.net/browse/CL-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ