### PR TITLE
[PM-12052] Remove border styles from custom field delete

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
@@ -38,7 +38,7 @@
         *ngIf="variant === 'edit'"
         type="button"
         buttonType="danger"
-        class="tw-border-0 tw-ml-auto"
+        class="tw-ml-auto"
         bitIconButton="bwi-trash"
         [appA11yTitle]="'deleteCustomField' | i18n: customFieldForm.value.label"
         (click)="removeField()"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12052](https://bitwarden.atlassian.net/browse/PM-12052)

## 📔 Objective

- The delete button for custom fields doesn't show a border on hover because of an applied `border-0` class.
  - This must have been me trying to match the extension refresh designs. Removing the border class here, on the `ps/extension-refresh` branch the component displays as it should. 

## 📸 Screenshots

Same change, but on `ps/extension-refresh` showing the hover state:
![Screenshot 2024-09-19 at 10 40 59 AM](https://github.com/user-attachments/assets/a974a69a-ff6a-41d4-b3fa-f54656f84a3f)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12052]: https://bitwarden.atlassian.net/browse/PM-12052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ