### PR TITLE
[PM-12360] Remove container padding for popup views

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -5,7 +5,7 @@
     </ng-container>
   </popup-header>
 
-  <div class="tw-bg-background-alt tw-p-2">
+  <div class="tw-bg-background-alt">
     <bit-section>
       <bit-section-header>
         <h2 bitTypography="h6">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
@@ -5,7 +5,7 @@
     </ng-container>
   </popup-header>
 
-  <div class="tw-bg-background-alt tw-p-2">
+  <div class="tw-bg-background-alt">
     <p>
       {{
         accountSwitcherEnabled ? ("excludedDomainsDescAlt" | i18n) : ("excludedDomainsDesc" | i18n)

--- a/apps/browser/src/autofill/popup/settings/notifications.component.html
+++ b/apps/browser/src/autofill/popup/settings/notifications.component.html
@@ -5,7 +5,7 @@
     </ng-container>
   </popup-header>
 
-  <div class="tw-bg-background-alt tw-p-2">
+  <div class="tw-bg-background-alt">
     <bit-section>
       <bit-section-header>
         <h2 bitTypography="h6">{{ "vaultSaveOptionsTitle" | i18n }}</h2>


### PR DESCRIPTION
## 🎟️ Tracking

PM-12360

## 📔 Objective

Remove extra padding from extension popup view containers for autofill settings, notification settings, and excluded domains settings

Note, changes are behind the browser refresh feature flag

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![autofill-before](https://github.com/user-attachments/assets/7c372c1c-6829-4113-85f6-6c82845081b8) | ![autofill-after](https://github.com/user-attachments/assets/802de26e-9df2-45fc-ace7-53a1a7f68ec4) |
| ![notifications-before](https://github.com/user-attachments/assets/c8054662-9f6c-4e96-afe7-91dfcd446b57) | ![notifications-after](https://github.com/user-attachments/assets/6cd65fdb-a701-4790-9d70-4f701311a133) |
| ![excluded-before](https://github.com/user-attachments/assets/da466c33-723a-41ec-a454-835b9cafcd07) | ![excluded-after](https://github.com/user-attachments/assets/302a471e-822c-494b-a58e-e11807cdb6d2) |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
