### PR TITLE
[PM-12359] Fix typography of change shortcut section text

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -107,7 +107,7 @@
       </bit-section-header>
       <bit-item>
         <button bit-item-content type="button" (click)="openURI($event, browserShortcutsURI)">
-          <h3 bitTypography="h5">{{ "autofillKeyboardManagerShortcutsLabel" | i18n }}</h3>
+          <h3 bitTypography="body2">{{ "autofillKeyboardManagerShortcutsLabel" | i18n }}</h3>
           <bit-hint slot="secondary" class="tw-text-sm tw-whitespace-normal">
             {{ autofillKeyboardHelperText }}
           </bit-hint>


### PR DESCRIPTION
## 🎟️ Tracking

PM-12359

## 📔 Objective

> In the autofill settings page, the “Autofill shortcut” section shows “Manage shortcuts” text as larger, this makes the hierarchy of the page a bit funky. 

This PR fixes that

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![section-before](https://github.com/user-attachments/assets/cd985016-0164-49bc-b39a-11e6ef1d0390) | ![section-after](https://github.com/user-attachments/assets/483d414f-fd95-43ef-a17d-37e7e44ed451) |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
