### PR TITLE
[CL-275] Update link styles

### DIFF
--- a/libs/components/src/link/link.directive.ts
+++ b/libs/components/src/link/link.directive.ts
@@ -8,7 +8,7 @@ const linkStyles: Record<LinkType, string[]> = {
     "hover:!tw-text-primary-700",
     "focus-visible:before:tw-ring-primary-600",
   ],
-  secondary: ["!tw-text-main", "hover:!tw-text-main", "focus-visible:before:tw-ring-primary-700"],
+  secondary: ["!tw-text-main", "hover:!tw-text-main", "focus-visible:before:tw-ring-primary-600"],
   contrast: [
     "!tw-text-contrast",
     "hover:!tw-text-contrast",

--- a/libs/components/src/link/link.directive.ts
+++ b/libs/components/src/link/link.directive.ts
@@ -5,34 +5,23 @@ export type LinkType = "primary" | "secondary" | "contrast" | "light";
 const linkStyles: Record<LinkType, string[]> = {
   primary: [
     "!tw-text-primary-600",
-    "hover:!tw-text-primary-600",
-    "focus-visible:before:tw-ring-primary-700",
-    "disabled:!tw-text-primary-600/60",
+    "hover:!tw-text-primary-700",
+    "focus-visible:before:tw-ring-primary-600",
   ],
-  secondary: [
-    "!tw-text-main",
-    "hover:!tw-text-main",
-    "focus-visible:before:tw-ring-primary-700",
-    "disabled:!tw-text-muted/60",
-  ],
+  secondary: ["!tw-text-main", "hover:!tw-text-main", "focus-visible:before:tw-ring-primary-700"],
   contrast: [
     "!tw-text-contrast",
     "hover:!tw-text-contrast",
     "focus-visible:before:tw-ring-text-contrast",
-    "disabled:!tw-text-contrast/60",
   ],
-  light: [
-    "!tw-text-alt2",
-    "hover:!tw-text-alt2",
-    "focus-visible:before:tw-ring-text-alt2",
-    "disabled:!tw-text-alt2/60",
-  ],
+  light: ["!tw-text-alt2", "hover:!tw-text-alt2", "focus-visible:before:tw-ring-text-alt2"],
 };
 
 const commonStyles = [
   "tw-text-unset",
   "tw-leading-none",
-  "tw-p-0",
+  "tw-px-0",
+  "tw-py-0.5",
   "tw-font-semibold",
   "tw-bg-transparent",
   "tw-border-0",
@@ -43,6 +32,9 @@ const commonStyles = [
   "hover:tw-decoration-1",
   "disabled:tw-no-underline",
   "disabled:tw-cursor-not-allowed",
+  "disabled:!tw-text-secondary-300",
+  "disabled:hover:!tw-text-secondary-300",
+  "disabled:hover:tw-no-underline",
   "focus-visible:tw-outline-none",
   "focus-visible:tw-underline",
   "focus-visible:tw-decoration-1",

--- a/libs/components/src/link/link.mdx
+++ b/libs/components/src/link/link.mdx
@@ -10,23 +10,30 @@ import { LinkModule } from "@bitwarden/components";
 
 # Link / Text button
 
-Text Links and Buttons use the `primary-600` color and can use either the `<a>` or `<button>` tags.
-Choose which based on the action the button takes:
+Text Links and Buttons can use either the `<a>` or `<button>` tags. Choose which based on the action
+the button takes:
 
 - if navigating to a new page, use a `<a>`
-- if taking an action on the current page use a `<button>`
+- if taking an action on the current page, use a `<button>`
 
 Text buttons or links are most commonly used in paragraphs of text or in forms to customize actions
 or show/hide additional form options.
 
 <Primary />
-<Controls />
+
+## Variants
+
+You can use one of the following variants by providing it as the `linkType` input:
+
+- `primary` - most common, uses brand color
+- `secondary` - matches the main text color
+- `contrast` - for high contrast against a dark background (or a light background in dark mode)
+- `light` - always a light color, even in dark mode
 
 ## Sizes
 
-There are 2 sizes for the component: default and small.
-
-Default uses `text-base` and small uses `text-xs`
+If you want to display a link with a smaller text size, apply the `tw-text-sm` class. This will
+match the `body2` variant of the Typography directive.
 
 ## With icons
 
@@ -40,4 +47,5 @@ show/hide additional content.
 
 ## Accessibility
 
-Make sure to only use the Link on backgrounds that maintain the WCAG color contrast ratios.
+- Make sure to only use the Link on backgrounds that maintain the WCAG color contrast ratios.
+- Be sure to select the correct element type (anchor or button) for the intended action.

--- a/libs/components/src/link/link.stories.ts
+++ b/libs/components/src/link/link.stories.ts
@@ -26,10 +26,41 @@ export default {
 
 type Story = StoryObj<ButtonLinkDirective>;
 
+export const Default: Story = {
+  render: () => ({
+    template: /*html*/ `
+      <div class="tw-flex tw-gap-4 tw-p-2 tw-mb-6">
+        <a bitLink linkType="primary" href="#">Primary</a>
+        <a bitLink linkType="primary" href="#" class="tw-test-hover">Primary</a>
+        <a bitLink linkType="primary" href="#" class="tw-test-focus-visible">Primary</a>
+        <a bitLink linkType="primary" href="#" class="tw-test-hover tw-test-focus-visible">Primary</a>
+      </div>
+      <div class="tw-flex tw-gap-4 tw-p-2 tw-mb-6">
+        <a bitLink linkType="secondary" href="#">Secondary</a>
+        <a bitLink linkType="secondary" href="#" class="tw-test-hover">Secondary</a>
+        <a bitLink linkType="secondary" href="#" class="tw-test-focus-visible">Secondary</a>
+        <a bitLink linkType="secondary" href="#" class="tw-test-hover tw-test-focus-visible">Secondary</a>
+      </div>
+      <div class="tw-flex tw-gap-4 tw-p-2 tw-mb-6 tw-bg-primary-600">
+        <a bitLink linkType="contrast" href="#">Contrast</a>
+        <a bitLink linkType="contrast" href="#" class="tw-test-hover">Contrast</a>
+        <a bitLink linkType="contrast" href="#" class="tw-test-focus-visible">Contrast</a>
+        <a bitLink linkType="contrast" href="#" class="tw-test-hover tw-test-focus-visible">Contrast</a>
+      </div>
+      <div class="tw-flex tw-gap-4 tw-p-2 tw-mb-6 tw-bg-primary-600">
+        <a bitLink linkType="light" href="#">Light</a>
+        <a bitLink linkType="light" href="#" class="tw-test-hover">Light</a>
+        <a bitLink linkType="light" href="#" class="tw-test-focus-visible">Light</a>
+        <a bitLink linkType="light" href="#" class="tw-test-hover tw-test-focus-visible">Light</a>
+      </div>
+    `,
+  }),
+};
+
 export const Buttons: Story = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
     <div class="tw-p-2" [ngClass]="{ 'tw-bg-transparent': linkType != 'contrast', 'tw-bg-primary-600': linkType === 'contrast' }">
       <div class="tw-block tw-p-2">
         <button bitLink [linkType]="linkType">Button</button>
@@ -60,7 +91,7 @@ export const Buttons: Story = {
 export const Anchors: StoryObj<AnchorLinkDirective> = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
     <div class="tw-p-2" [ngClass]="{ 'tw-bg-transparent': linkType != 'contrast', 'tw-bg-primary-600': linkType === 'contrast' }">
       <div class="tw-block tw-p-2">
         <a bitLink [linkType]="linkType" href="#">Anchor</a>
@@ -91,7 +122,7 @@ export const Anchors: StoryObj<AnchorLinkDirective> = {
 export const Inline: Story = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
       <span class="tw-text-main">
         On the internet paragraphs often contain <a bitLink href="#">inline links</a>, but few know that <button bitLink>buttons</button> can be used for similar purposes.
       </span>
@@ -105,7 +136,7 @@ export const Inline: Story = {
 export const Disabled: Story = {
   render: (args) => ({
     props: args,
-    template: `
+    template: /*html*/ `
       <button bitLink disabled linkType="primary" class="tw-mr-2">Primary</button>
       <button bitLink disabled linkType="secondary" class="tw-mr-2">Secondary</button>
       <div class="tw-bg-primary-600 tw-p-2 tw-inline-block">


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-275](https://bitwarden.atlassian.net/browse/CL-275)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the styles for the Link component to match the new extension refresh spec.

- [x] Update disabled state color for all variants to `secondary-300`
- [x] Update top and bottom padding to 2px
- [x]  Update focus ring color for primary and secondary variants to `primary-600`
- [x] Update hover color for primary variant to `primary-700`
- [x] Update documentation page
- [x] Add story with pseudo-selectors

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![Screenshot 2024-09-20 at 4 05 39 PM](https://github.com/user-attachments/assets/79a255d1-3959-4f39-91aa-35bbf07d76e9)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-275]: https://bitwarden.atlassian.net/browse/CL-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ