### PR TITLE
[PM-12424] Add Retries to `get`

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -419,7 +419,7 @@ export default class MainBackground {
     this.logService = new ConsoleLogService(isDev);
     this.cryptoFunctionService = new WebCryptoFunctionService(self);
     this.keyGenerationService = new KeyGenerationService(this.cryptoFunctionService);
-    this.storageService = new BrowserLocalStorageService();
+    this.storageService = new BrowserLocalStorageService(this.logService);
 
     this.intraprocessMessagingSubject = new Subject<Message<Record<string, unknown>>>();
 

--- a/apps/browser/src/platform/services/browser-local-storage.service.ts
+++ b/apps/browser/src/platform/services/browser-local-storage.service.ts
@@ -1,8 +1,65 @@
-import AbstractChromeStorageService from "./abstractions/abstract-chrome-storage-api.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import AbstractChromeStorageService, {
+  SerializedValue,
+} from "./abstractions/abstract-chrome-storage-api.service";
 
 export default class BrowserLocalStorageService extends AbstractChromeStorageService {
-  constructor() {
+  constructor(private readonly logService: LogService) {
     super(chrome.storage.local);
+  }
+
+  override async get<T>(key: string): Promise<T> {
+    return await this.getWithRetries<T>(key, 0);
+  }
+
+  private async getWithRetries<T>(key: string, retryNum: number): Promise<T> {
+    // See: https://github.com/EFForg/privacybadger/pull/2980
+    const MAX_RETRIES = 5;
+    const WAIT_TIME = 200;
+
+    const store = await this.getStore(key);
+
+    if (store == null) {
+      if (retryNum >= MAX_RETRIES) {
+        throw new Error(`Failed to get a value for key '${key}', see logs for more details.`);
+      }
+
+      retryNum++;
+      this.logService.warning(`Retrying attempt to get value for key '${key}' in ${WAIT_TIME}ms`);
+      await new Promise<void>((resolve) => setTimeout(resolve, WAIT_TIME));
+      return await this.getWithRetries(key, retryNum);
+    }
+
+    // We have a store
+    return this.processGetObject<T>(store[key] as T | SerializedValue);
+  }
+
+  private async getStore(key: string) {
+    if (this.chromeStorageApi == null) {
+      this.logService.warning(
+        `chrome.storage.local was not initialized while retrieving key '${key}'.`,
+      );
+      return null;
+    }
+
+    return new Promise<{ [key: string]: unknown }>((resolve) => {
+      this.chromeStorageApi.get(key, (store) => {
+        if (chrome.runtime.lastError) {
+          this.logService.warning(`Failed to get value for key '${key}'`, chrome.runtime.lastError);
+          resolve(null);
+          return;
+        }
+
+        if (store == null) {
+          this.logService.warning(`Store was empty while retrieving value for key '${key}'`);
+          resolve(null);
+          return;
+        }
+
+        resolve(store);
+      });
+    });
   }
 
   async fillBuffer() {

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -304,7 +304,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: AbstractStorageService,
     useClass: BrowserLocalStorageService,
-    deps: [],
+    deps: [LogService],
   }),
   safeProvider({
     provide: AutofillServiceAbstraction,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12424

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add retries to our `get` operation on `chrome.storage.local`. Even will completely empty state `chrome.storage.local.get` should return an `{}` empty object store, so if it was null we shouldn't treat that as a `null` value that we have stored. We should treat it like an error. This is a similar workaround (EFForg/privacybadger#2980) privacy badger has implemented.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
