### PR TITLE
[PM-12281] [PM-12301] [PM-12306] Defects on Move Delete Item to Can Manage

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -156,12 +156,7 @@
       <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
       {{ "restore" | i18n }}
     </button>
-    <button
-      bitMenuItem
-      *ngIf="canEditCipher || !vaultBulkManagementActionEnabled"
-      (click)="deleteCipher()"
-      type="button"
-    >
+    <button bitMenuItem *ngIf="canManageCollection" (click)="deleteCipher()" type="button">
       <span class="tw-text-danger">
         <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
         {{ (cipher.isDeleted ? "permanentlyDelete" : "delete") | i18n }}

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
@@ -36,6 +36,7 @@ export class VaultCipherRowComponent implements OnInit {
   @Input() viewingOrgVault: boolean;
   @Input() canEditCipher: boolean;
   @Input() vaultBulkManagementActionEnabled: boolean;
+  @Input() canManageCollection: boolean;
 
   @Output() onEvent = new EventEmitter<VaultItemEvent>();
 

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -74,7 +74,7 @@
               {{ "restoreSelected" | i18n }}
             </button>
             <button
-              *ngIf="deleteAllowed || showBulkTrashOptions"
+              *ngIf="showDelete() || showBulkTrashOptions"
               type="button"
               bitMenuItem
               (click)="bulkDelete()"
@@ -132,6 +132,7 @@
           [collections]="allCollections"
           [checked]="selection.isSelected(item)"
           [canEditCipher]="canEditCipher(item.cipher) && vaultBulkManagementActionEnabled"
+          [canManageCollection]="canManageCollection(item.cipher)"
           [vaultBulkManagementActionEnabled]="vaultBulkManagementActionEnabled"
           (checkedToggled)="selection.toggle(item)"
           (onEvent)="event($event)"

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -216,8 +216,13 @@ export class VaultItemsComponent {
   }
 
   protected canManageCollection(cipher: CipherView) {
-    if (cipher.organizationId == null) {
-      return true;
+    // If the cipher is not part of an organization (personal item) or has no collections, user can manage it
+    if (
+      cipher.organizationId == null ||
+      !cipher.collectionIds ||
+      cipher.collectionIds.length === 0
+    ) {
+      return cipher.edit;
     }
 
     // Check for admin access in AC vault

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -47,6 +47,7 @@ export class VaultItemsComponent {
   @Input() addAccessStatus: number;
   @Input() addAccessToggle: boolean;
   @Input() vaultBulkManagementActionEnabled = false;
+  @Input() activeCollection: CollectionView | undefined;
 
   private _ciphers?: CipherView[] = [];
   @Input() get ciphers(): CipherView[] {
@@ -214,6 +215,33 @@ export class VaultItemsComponent {
     return (organization.canEditAllCiphers && this.viewingOrgVault) || cipher.edit;
   }
 
+  protected canManageCollection(cipher: CipherView) {
+    if (cipher.organizationId == null) {
+      return true;
+    }
+
+    // Check for admin access in AC vault
+    if (this.showAdminActions) {
+      const organization = this.allOrganizations.find((o) => o.id === cipher.organizationId);
+
+      if (organization?.permissions.editAnyCollection) {
+        return true;
+      }
+
+      if (organization?.allowAdminAccessToAllCollectionItems && organization.isAdmin) {
+        return true;
+      }
+    }
+
+    if (this.activeCollection) {
+      return this.activeCollection.manage === true;
+    }
+
+    return this.allCollections
+      .filter((c) => cipher.collectionIds.includes(c.id))
+      .some((collection) => collection.manage);
+  }
+
   private refreshItems() {
     const collections: VaultItem[] = this.collections.map((collection) => ({ collection }));
     const ciphers: VaultItem[] = this.ciphers.map((cipher) => ({ cipher }));
@@ -289,19 +317,16 @@ export class VaultItemsComponent {
 
     const hasPersonalItems = this.hasPersonalItems();
     const uniqueCipherOrgIds = this.getUniqueOrganizationIds();
-    const organizations = Array.from(uniqueCipherOrgIds, (orgId) =>
-      this.allOrganizations.find((o) => o.id === orgId),
-    );
 
-    const canEditOrManageAllCiphers =
-      organizations.length > 0 && organizations.every((org) => org?.canEditAllCiphers);
+    const canManageCollectionCiphers = this.selection.selected
+      .filter((item) => item.cipher)
+      .every(({ cipher }) => this.canManageCollection(cipher));
 
     const canDeleteCollections = this.selection.selected
       .filter((item) => item.collection)
       .every((item) => item.collection && this.canDeleteCollection(item.collection));
 
-    const userCanDeleteAccess =
-      (canEditOrManageAllCiphers || this.allCiphersHaveEditAccess()) && canDeleteCollections;
+    const userCanDeleteAccess = canManageCollectionCiphers && canDeleteCollections;
 
     if (
       userCanDeleteAccess ||

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.html
@@ -994,7 +994,7 @@
             (click)="delete()"
             class="btn btn-outline-danger"
             appA11yTitle="{{ (cipher.isDeleted ? 'permanentlyDelete' : 'delete') | i18n }}"
-            *ngIf="editMode && !cloneMode && !(!cipher.edit && editMode)"
+            *ngIf="editMode && !cloneMode && canDeleteCipher"
             [disabled]="$any(deleteBtn).loading"
             [appApiAction]="deletePromise"
           >

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -732,6 +732,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async editCipherId(id: string, cloneMode?: boolean) {
+    let cipherView: CipherView | null = null;
     const cipher = await this.cipherService.get(id);
 
     if (
@@ -750,16 +751,22 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     // Decrypt the cipher.
-    const cipherView = await cipher.decrypt(
-      await this.cipherService.getKeyForCipherKeyDecryption(cipher, this.activeUserId),
-    );
+    if (cipher) {
+      cipherView = await cipher.decrypt(
+        await this.cipherService.getKeyForCipherKeyDecryption(cipher, this.activeUserId),
+      );
+    }
 
     const [modal, childComponent] = await this.modalService.openViewRef(
       AddEditComponent,
       this.cipherAddEditModalRef,
       (comp) => {
         comp.cipherId = id;
-        comp.canDeleteCipher = this.canDeleteCipher(cipherView);
+
+        if (cipherView) {
+          comp.canDeleteCipher = this.canDeleteCipher(cipherView);
+        }
+
         comp.onSavedCipher.pipe(takeUntil(this.destroy$)).subscribe(() => {
           modal.close();
           this.refresh();

--- a/apps/web/src/app/vault/individual-vault/view.component.html
+++ b/apps/web/src/app/vault/individual-vault/view.component.html
@@ -22,7 +22,7 @@
         buttonType="danger"
         [appA11yTitle]="'delete' | i18n"
         [bitAction]="delete"
-        [disabled]="!cipher.edit"
+        [disabled]="params.disableDelete"
       >
         <i class="bwi bwi-trash bwi-lg bwi-fw" aria-hidden="true"></i>
       </button>

--- a/apps/web/src/app/vault/individual-vault/view.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/view.component.spec.ts
@@ -36,6 +36,7 @@ describe("ViewComponent", () => {
 
   const mockParams: ViewCipherDialogParams = {
     cipher: mockCipher,
+    canDeleteCipher: true,
   };
 
   beforeEach(async () => {

--- a/apps/web/src/app/vault/individual-vault/view.component.ts
+++ b/apps/web/src/app/vault/individual-vault/view.component.ts
@@ -36,6 +36,11 @@ export interface ViewCipherDialogParams {
    * If true, the edit button will be disabled in the dialog.
    */
   disableEdit?: boolean;
+
+  /**
+   * If true, the delete button will be disabled in the dialog.
+   */
+  disableDelete?: boolean;
 }
 
 export enum ViewCipherDialogResult {

--- a/apps/web/src/app/vault/org-vault/vault.component.html
+++ b/apps/web/src/app/vault/org-vault/vault.component.html
@@ -70,6 +70,7 @@
       [viewingOrgVault]="true"
       [addAccessStatus]="addAccessStatus$ | async"
       [addAccessToggle]="showAddAccessToggle"
+      [activeCollection]="selectedCollection?.node"
     >
     </app-vault-items>
     <ng-container *ngIf="!performingInitialLoad && isEmpty">

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -803,8 +803,12 @@ export class VaultComponent implements OnInit, OnDestroy {
     const defaultComponentParameters = (comp: AddEditComponent) => {
       comp.organization = this.organization;
       comp.organizationId = this.organization.id;
-      comp.cipherId = cipher.id;
-      comp.canDeleteCipher = this.canDeleteCipher(cipher);
+      comp.cipherId = cipher?.id;
+
+      if (cipher) {
+        comp.canDeleteCipher = this.canDeleteCipher(cipher);
+      }
+
       comp.onSavedCipher.pipe(takeUntil(this.destroy$)).subscribe(() => {
         modal.close();
         this.refresh();

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -1331,9 +1331,13 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     const activeCollection = this.selectedCollection?.node;
-
     if (activeCollection) {
       return activeCollection.manage === true;
+    }
+
+    // If collectionIds is empty or null, it means the cipher is unassigned
+    if (!cipher.collectionIds || cipher.collectionIds.length === 0) {
+      return cipher.edit;
     }
 
     return this.allCollections

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -48,6 +48,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   @Input() type: CipherType;
   @Input() collectionIds: string[];
   @Input() organizationId: string = null;
+  @Input() canDeleteCipher: boolean;
   @Output() onSavedCipher = new EventEmitter<CipherView>();
   @Output() onDeletedCipher = new EventEmitter<CipherView>();
   @Output() onRestoredCipher = new EventEmitter<CipherView>();

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -48,7 +48,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   @Input() type: CipherType;
   @Input() collectionIds: string[];
   @Input() organizationId: string = null;
-  @Input() canDeleteCipher: boolean;
+  @Input() canDeleteCipher: boolean = false;
   @Output() onSavedCipher = new EventEmitter<CipherView>();
   @Output() onDeletedCipher = new EventEmitter<CipherView>();
   @Output() onRestoredCipher = new EventEmitter<CipherView>();


### PR DESCRIPTION
## 🎟️ Tracking
[PM-12281](https://bitwarden.atlassian.net/browse/PM-12281)
[PM-12301](https://bitwarden.atlassian.net/browse/PM-12301)
[PM-12306](https://bitwarden.atlassian.net/browse/PM-12306)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Currently, users with Can Edit permissions can delete items within the collection. This should be updated so that only users with the Can Manage permission can delete items within a collection. This applies to the web client; a different PR would handle the other clients.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/ee0eb13d-0956-474b-8874-e9336bc8dd66


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12281]: https://bitwarden.atlassian.net/browse/PM-12281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-12301]: https://bitwarden.atlassian.net/browse/PM-12301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-12306]: https://bitwarden.atlassian.net/browse/PM-12306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ