### PR TITLE
[PM-12070] FormField readonly shift

### DIFF
--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -87,8 +87,7 @@
       [ngClass]="{
         'tw-border-secondary-300/50 tw-border-b tw-pb-[3px]':
           !disableReadOnlyBorder && !defaultContentIsFocused(),
-        'tw-border-b-2 tw-border-transparent tw-pb-[4px]':
-          disableReadOnlyBorder && !defaultContentIsFocused(),
+        'tw-border-transparent tw-pb-[4px]': disableReadOnlyBorder && !defaultContentIsFocused(),
         'tw-border-b-2 tw-border-primary-600': defaultContentIsFocused(),
       }"
     >


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12070](https://bitwarden.atlassian.net/browse/PM-12070)

## 📔 Objective

### Issue:

Using the `disableReadOnlyBorder` attribute of the form field causes a shift when the field is focused in the extension but **not** in Storybook.

I'm kind of dumbfounded by this one, but I'll retrace my steps for the history books. Having `ngClass` and two conditionals within it with the same class (`tw-border-b-2`) is behaving differently in storybook versus the extension.

My hypothesis is that tailwind is recognizing that `tw-border-b-2` is defined in both and is filtering one of them out because it isn't present in the class name. To support this, if you change one of the `tw-border-b-2` to be a different numeric value: `tw-border-b-3` then it will be present in the class name as expected.

I can't find any root cause for this to work differently between the applications. Everything in the tailwind configuration looks accurate, and I time boxed myself from digging way to deep into the tailwind source code.

The fix was simple here as I don't believe `tw-border-b-2` is needed for readonly fields when they're not focused.

#### Storybook:

In storybook, when the field is unfocused there is a total of 4px of padding, but the `tw-border-b-2` isn't present in the class name. When the field is focused, padding is decreased and `tw-border-b-2` is applied to maintain the visual 4 pixels. 

|Storybook unfocused|Storybook focused|
|-|-|
|![storybook-unfocused](https://github.com/user-attachments/assets/f9991480-4b1a-4f19-ab34-781fbf54ea54)|![storybook-focused](https://github.com/user-attachments/assets/dfa747d8-6db4-4dee-91c3-12b3862965fd)|

#### Extension

In the extension, when the field is focused `tw-border-b-2` is present as you'd expect by the `ngClass` logic but it results in 6 pixels of visual space. When the field is focused, `tw-border-b-2` is still present but padding is decreased to 2 pixels, cause the "shift" from 6 pixels of height down to 4 pixels.

|Extension Unfocused|Extension Focused|
|-|-|
|![extension-unfocused](https://github.com/user-attachments/assets/e1162df7-47ce-47d2-9219-0359b0ad4d35)|![extension-focused](https://github.com/user-attachments/assets/b5cffdfa-4a34-4cda-a0fd-f4a27025e9c7)|

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-12070]: https://bitwarden.atlassian.net/browse/PM-12070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ