### PR TITLE
[PM-12395] - hide free bitwarden families button when not available

### DIFF
--- a/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/more-from-bitwarden-page-v2.component.ts
@@ -38,7 +38,7 @@ export class MoreFromBitwardenPageV2Component {
     private organizationService: OrganizationService,
   ) {
     this.canAccessPremium$ = billingAccountProfileStateService.hasPremiumFromAnySource$;
-    this.familySponsorshipAvailable$ = this.organizationService.canManageSponsorships$;
+    this.familySponsorshipAvailable$ = this.organizationService.familySponsorshipAvailable$;
   }
 
   async openFreeBitwardenFamiliesPage() {

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -117,6 +117,10 @@ export abstract class OrganizationService {
    * Emits true if the user can create or manage a Free Bitwarden Families sponsorship.
    */
   canManageSponsorships$: Observable<boolean>;
+  /**
+   * Emits true if any of the user's organizations have a Free Bitwarden Families sponsorship available.
+   */
+  familySponsorshipAvailable$: Observable<boolean>;
   hasOrganizations: () => Promise<boolean>;
   get$: (id: string) => Observable<Organization | undefined>;
   get: (id: string) => Promise<Organization>;

--- a/libs/common/src/admin-console/services/organization/organization.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization.service.ts
@@ -88,6 +88,10 @@ export class OrganizationService implements InternalOrganizationServiceAbstracti
     mapToBooleanHasAnyOrganizations(),
   );
 
+  familySponsorshipAvailable$ = this.organizations$.pipe(
+    map((orgs) => orgs.some((o) => o.familySponsorshipAvailable)),
+  );
+
   async hasOrganizations(): Promise<boolean> {
     return await firstValueFrom(this.organizations$.pipe(mapToBooleanHasAnyOrganizations()));
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12395

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where the "Free Bitwarden Families" button was showing in the browser extension for enterprise users even when it wasn't available.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
