### PR TITLE
[PM-12504] - hide create send button and send tab when sends are disabled

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -3,7 +3,9 @@ import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import {
   AvatarModule,
   BadgeModule,
@@ -316,6 +318,30 @@ export default {
               loading: "Loading",
               search: "Search",
             });
+          },
+        },
+        {
+          provide: PolicyService,
+          useFactory: () => {
+            return {
+              policyAppliesToActiveUser$: () => {
+                return {
+                  pipe: () => ({
+                    subscribe: () => ({}),
+                  }),
+                };
+              },
+            };
+          },
+        },
+        {
+          provide: SendService,
+          useFactory: () => {
+            return {
+              sends$: () => {
+                return { pipe: () => ({}) };
+              },
+            };
           },
         },
       ],

--- a/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
@@ -59,7 +59,7 @@ export class PopupTabNavigationComponent {
     ])
       .pipe(takeUntilDestroyed())
       .subscribe(([sends, policyAppliesToActiveUser]) => {
-        if (!policyAppliesToActiveUser && sends.length === 0) {
+        if (policyAppliesToActiveUser && sends.length === 0) {
           this.navButtons = this.navButtons.filter((b) => b.page !== "/tabs/send");
         }
       });

--- a/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
@@ -1,8 +1,13 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
+import { combineLatest } from "rxjs";
 
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { LinkModule } from "@bitwarden/components";
+import { SendItemsService } from "@bitwarden/send-ui";
 
 @Component({
   selector: "popup-tab-navigation",
@@ -40,4 +45,23 @@ export class PopupTabNavigationComponent {
       iconKeyActive: "cog-f",
     },
   ];
+
+  sendsDisabled = false;
+  protected sends$ = this.sendItemsService.filteredAndSortedSends$;
+
+  constructor(
+    private policyService: PolicyService,
+    private sendItemsService: SendItemsService,
+  ) {
+    combineLatest([
+      this.sendItemsService.filteredAndSortedSends$,
+      this.policyService.policyAppliesToActiveUser$(PolicyType.DisableSend),
+    ])
+      .pipe(takeUntilDestroyed())
+      .subscribe(([sends, policyAppliesToActiveUser]) => {
+        if (!policyAppliesToActiveUser && sends.length === 0) {
+          this.navButtons = this.navButtons.filter((b) => b.page !== "/tabs/send");
+        }
+      });
+  }
 }

--- a/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.ts
@@ -9,6 +9,33 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { LinkModule } from "@bitwarden/components";
 
+const allNavButtons = [
+  {
+    label: "Vault",
+    page: "/tabs/vault",
+    iconKey: "lock",
+    iconKeyActive: "lock-f",
+  },
+  {
+    label: "Generator",
+    page: "/tabs/generator",
+    iconKey: "generate",
+    iconKeyActive: "generate-f",
+  },
+  {
+    label: "Send",
+    page: "/tabs/send",
+    iconKey: "send",
+    iconKeyActive: "send-f",
+  },
+  {
+    label: "Settings",
+    page: "/tabs/settings",
+    iconKey: "cog",
+    iconKeyActive: "cog-f",
+  },
+];
+
 @Component({
   selector: "popup-tab-navigation",
   templateUrl: "popup-tab-navigation.component.html",
@@ -19,33 +46,7 @@ import { LinkModule } from "@bitwarden/components";
   },
 })
 export class PopupTabNavigationComponent {
-  navButtons = [
-    {
-      label: "Vault",
-      page: "/tabs/vault",
-      iconKey: "lock",
-      iconKeyActive: "lock-f",
-    },
-    {
-      label: "Generator",
-      page: "/tabs/generator",
-      iconKey: "generate",
-      iconKeyActive: "generate-f",
-    },
-    {
-      label: "Send",
-      page: "/tabs/send",
-      iconKey: "send",
-      iconKeyActive: "send-f",
-    },
-    {
-      label: "Settings",
-      page: "/tabs/settings",
-      iconKey: "cog",
-      iconKeyActive: "cog-f",
-    },
-  ];
-
+  navButtons = allNavButtons;
   constructor(
     private policyService: PolicyService,
     private sendService: SendService,
@@ -60,8 +61,8 @@ export class PopupTabNavigationComponent {
       )
       .subscribe((hasSends) => {
         this.navButtons = hasSends
-          ? this.navButtons
-          : this.navButtons.filter((b) => b.page !== "/tabs/send");
+          ? allNavButtons
+          : allNavButtons.filter((b) => b.page !== "/tabs/send");
       });
   }
 }

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.html
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.html
@@ -1,12 +1,20 @@
 <popup-page>
   <popup-header slot="header" [pageTitle]="'send' | i18n">
     <ng-container slot="end">
-      <tools-new-send-dropdown></tools-new-send-dropdown>
-
+      <tools-new-send-dropdown *ngIf="!sendsDisabled"></tools-new-send-dropdown>
       <app-pop-out></app-pop-out>
       <app-current-account></app-current-account>
     </ng-container>
   </popup-header>
+  <div slot="above-scroll-area" class="tw-p-4">
+    <bit-callout *ngIf="sendsDisabled" [title]="'sendDisabled' | i18n">
+      {{ "sendDisabledWarning" | i18n }}
+    </bit-callout>
+    <ng-container *ngIf="!sendsDisabled">
+      <tools-send-search></tools-send-search>
+      <app-send-list-filters></app-send-list-filters>
+    </ng-container>
+  </div>
 
   <div
     *ngIf="listState === sendState.Empty"
@@ -15,7 +23,7 @@
     <bit-no-items [icon]="noItemIcon" class="tw-text-main">
       <ng-container slot="title">{{ "sendsNoItemsTitle" | i18n }}</ng-container>
       <ng-container slot="description">{{ "sendsNoItemsMessage" | i18n }}</ng-container>
-      <tools-new-send-dropdown slot="button"></tools-new-send-dropdown>
+      <tools-new-send-dropdown *ngIf="!sendsDisabled" slot="button"></tools-new-send-dropdown>
     </bit-no-items>
   </div>
 
@@ -31,9 +39,4 @@
     </div>
     <app-send-list-items-container [headerText]="title | i18n" [sends]="sends$ | async" />
   </ng-container>
-
-  <div slot="above-scroll-area" class="tw-p-4" *ngIf="listState !== sendState.Empty">
-    <tools-send-search></tools-send-search>
-    <app-send-list-filters></app-send-list-filters>
-  </div>
 </popup-page>

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
@@ -7,6 +7,7 @@ import { of, BehaviorSubject } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
@@ -46,6 +47,7 @@ describe("SendV2Component", () => {
   let sendListFiltersServiceFilters$: BehaviorSubject<{ sendType: SendType | null }>;
   let sendItemsServiceEmptyList$: BehaviorSubject<boolean>;
   let sendItemsServiceNoFilteredResults$: BehaviorSubject<boolean>;
+  let policyService: MockProxy<PolicyService>;
 
   beforeEach(async () => {
     sendListFiltersServiceFilters$ = new BehaviorSubject({ sendType: null });
@@ -59,6 +61,9 @@ describe("SendV2Component", () => {
       ] as SendView[]),
       latestSearchText$: of(""),
     });
+
+    policyService = mock<PolicyService>();
+    policyService.policyAppliesToActiveUser$.mockReturnValue(of(true)); // Return `true` by default
 
     sendListFiltersService = new SendListFiltersService(mock(), new FormBuilder());
 
@@ -104,6 +109,7 @@ describe("SendV2Component", () => {
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: SendListFiltersService, useValue: sendListFiltersService },
         { provide: PopupRouterCacheService, useValue: mock<PopupRouterCacheService>() },
+        { provide: PolicyService, useValue: policyService },
       ],
     }).compileComponents();
 

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
@@ -5,8 +5,10 @@ import { RouterLink } from "@angular/router";
 import { combineLatest } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
-import { ButtonModule, Icons, NoItemsModule } from "@bitwarden/components";
+import { ButtonModule, CalloutModule, Icons, NoItemsModule } from "@bitwarden/components";
 import {
   NoSendsIcon,
   NewSendDropdownComponent,
@@ -31,6 +33,7 @@ export enum SendState {
   templateUrl: "send-v2.component.html",
   standalone: true,
   imports: [
+    CalloutModule,
     PopupPageComponent,
     PopupHeaderComponent,
     PopOutComponent,
@@ -61,9 +64,12 @@ export class SendV2Component implements OnInit, OnDestroy {
 
   protected noResultsIcon = Icons.NoResults;
 
+  protected sendsDisabled = false;
+
   constructor(
     protected sendItemsService: SendItemsService,
     protected sendListFiltersService: SendListFiltersService,
+    private policyService: PolicyService,
   ) {
     combineLatest([
       this.sendItemsService.emptyList$,
@@ -89,6 +95,13 @@ export class SendV2Component implements OnInit, OnDestroy {
         }
 
         this.listState = null;
+      });
+
+    this.policyService
+      .policyAppliesToActiveUser$(PolicyType.DisableSend)
+      .pipe(takeUntilDestroyed())
+      .subscribe((sendsDisabled) => {
+        this.sendsDisabled = !sendsDisabled;
       });
   }
 

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
@@ -101,7 +101,7 @@ export class SendV2Component implements OnInit, OnDestroy {
       .policyAppliesToActiveUser$(PolicyType.DisableSend)
       .pipe(takeUntilDestroyed())
       .subscribe((sendsDisabled) => {
-        this.sendsDisabled = !sendsDisabled;
+        this.sendsDisabled = sendsDisabled;
       });
   }
 

--- a/libs/angular/src/utils/extension-refresh-swap.ts
+++ b/libs/angular/src/utils/extension-refresh-swap.ts
@@ -23,7 +23,6 @@ export function extensionRefreshSwap(
     defaultComponent,
     refreshedComponent,
     async () => {
-      return true;
       const configService = inject(ConfigService);
       return configService.getFeatureFlag(FeatureFlag.ExtensionRefresh);
     },

--- a/libs/angular/src/utils/extension-refresh-swap.ts
+++ b/libs/angular/src/utils/extension-refresh-swap.ts
@@ -23,6 +23,7 @@ export function extensionRefreshSwap(
     defaultComponent,
     refreshedComponent,
     async () => {
+      return true;
       const configService = inject(ConfigService);
       return configService.getFeatureFlag(FeatureFlag.ExtensionRefresh);
     },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12504

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR implements the following requirements to the send list page and app tab nav for when sends are disabled:

1. remove the create send button
2. display callout
3. remove sends from tab if user has no sends

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|With existing send|Without existing send|
---|---
|![Screenshot 2024-09-20 at 3 51 59 PM](https://github.com/user-attachments/assets/a36e1738-ebd2-458e-82b3-9fef504b6c5a)|![Screenshot 2024-09-20 at 3 35 02 PM](https://github.com/user-attachments/assets/3df34540-b071-49b9-be0f-f936107add01)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
