### PR TITLE
[PM-12505] - add delete send button to footer

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2370,6 +2370,10 @@
     "message": "Are you sure you want to delete this Send?",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "deleteSendPermanentConfirmation": {
+    "message": "Are you sure you want to permanently delete this Send?",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
   "editSend": {
     "message": "Edit Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
@@ -17,7 +17,7 @@
       *ngIf="config?.mode !== 'add'"
       type="button"
       buttonType="danger"
-      class="tw-border-0 tw-ml-auto bwi-lg"
+      class="tw-ml-auto bwi-lg"
       bitIconButton="bwi-trash"
       [bitAction]="deleteSend"
       appA11yTitle="{{ 'delete' | i18n }}"

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
@@ -19,7 +19,7 @@
       buttonType="danger"
       class="tw-border-0 tw-ml-auto bwi-lg"
       bitIconButton="bwi-trash"
-      (click)="deleteSend()"
+      [bitAction]="deleteSend"
       appA11yTitle="{{ 'delete' | i18n }}"
     ></button>
   </popup-footer>

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
@@ -13,5 +13,14 @@
     <button bitButton type="submit" form="sendForm" buttonType="primary" #submitBtn>
       {{ "save" | i18n }}
     </button>
+    <button
+      *ngIf="config?.mode !== 'add'"
+      type="button"
+      buttonType="danger"
+      class="tw-border-0 tw-ml-auto bwi-lg"
+      bitIconButton="bwi-trash"
+      (click)="deleteSend()"
+      appA11yTitle="{{ 'delete' | i18n }}"
+    ></button>
   </popup-footer>
 </popup-page>

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -107,7 +107,7 @@ export class SendAddEditComponent {
   async deleteSend() {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "deleteSend" },
-      content: { key: "deleteSendConfirmation" },
+      content: { key: "deleteSendPermanentConfirmation" },
       type: "warning",
     });
 

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -104,7 +104,7 @@ export class SendAddEditComponent {
     this.location.back();
   }
 
-  async deleteSend() {
+  deleteSend = async () => {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "deleteSend" },
       content: { key: "deleteSendPermanentConfirmation" },
@@ -133,7 +133,7 @@ export class SendAddEditComponent {
       title: null,
       message: this.i18nService.t("deletedSend"),
     });
-  }
+  };
 
   /**
    * Subscribes to the route query parameters and builds the configuration based on the parameters.

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -112,10 +112,19 @@ export class SendAddEditComponent {
     });
 
     if (!confirmed) {
-      return false;
+      return;
     }
 
-    await this.sendApiService.delete(this.config.originalSend?.id);
+    try {
+      await this.sendApiService.delete(this.config.originalSend?.id);
+    } catch (e) {
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: e.message,
+      });
+      return;
+    }
 
     this.location.back();
 

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -8,8 +8,16 @@ import { map, switchMap } from "rxjs";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
+import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendId } from "@bitwarden/common/types/guid";
-import { AsyncActionsModule, ButtonModule, SearchModule } from "@bitwarden/components";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  DialogService,
+  IconButtonModule,
+  SearchModule,
+  ToastService,
+} from "@bitwarden/components";
 import {
   DefaultSendFormConfigService,
   SendFormConfig,
@@ -58,6 +66,7 @@ export type AddEditQueryParams = Partial<Record<keyof QueryParams, string>>;
     JslibModule,
     FormsModule,
     ButtonModule,
+    IconButtonModule,
     PopupPageComponent,
     PopupHeaderComponent,
     PopupFooterComponent,
@@ -81,6 +90,9 @@ export class SendAddEditComponent {
     private location: Location,
     private i18nService: I18nService,
     private addEditFormConfigService: SendFormConfigService,
+    private sendApiService: SendApiService,
+    private toastService: ToastService,
+    private dialogService: DialogService,
   ) {
     this.subscribeToParams();
   }
@@ -90,6 +102,28 @@ export class SendAddEditComponent {
    */
   onSendSaved() {
     this.location.back();
+  }
+
+  async deleteSend() {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "deleteSend" },
+      content: { key: "deleteSendConfirmation" },
+      type: "warning",
+    });
+
+    if (!confirmed) {
+      return false;
+    }
+
+    await this.sendApiService.delete(this.config.originalSend?.id);
+
+    this.location.back();
+
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("deletedSend"),
+    });
   }
 
   /**

--- a/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.ts
+++ b/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.ts
@@ -64,7 +64,7 @@ export class SendListItemsContainerComponent {
   async deleteSend(s: SendView): Promise<boolean> {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "deleteSend" },
-      content: { key: "deleteSendConfirmation" },
+      content: { key: "deleteSendPermanentConfirmation" },
       type: "warning",
     });
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12505
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the delete button to the footer of the edit send page.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/6d1e657e-7816-4564-b5d5-58311b2c92dc



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
