### PR TITLE
[PM-12527] [Defect] Remove unnecessary "General Information" Header in Organizat…

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -40,7 +40,7 @@
   *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
   class="tw-pt-6"
 >
-  <bit-section *ngIf="!createOrganization">
+  <bit-section [ngClass]="{ 'tw-hidden': !createOrganization }">
     <app-org-info
       (changedBusinessOwned)="changedOwnedBusiness()"
       [formGroup]="formGroup"

--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -41,16 +41,6 @@
   class="tw-pt-6"
 >
   <bit-section>
-    <app-org-info
-      (changedBusinessOwned)="changedOwnedBusiness()"
-      [formGroup]="formGroup"
-      [createOrganization]="createOrganization"
-      [isProvider]="!!providerId"
-      [acceptingSponsorship]="acceptingSponsorship"
-    >
-    </app-org-info>
-  </bit-section>
-  <bit-section>
     <h2 bitTypography="h2">{{ "chooseYourPlan" | i18n }}</h2>
     <bit-radio-group formControlName="productTier" [block]="true">
       <div *ngFor="let selectableProduct of selectableProducts" class="tw-mb-3">

--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -40,6 +40,16 @@
   *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
   class="tw-pt-6"
 >
+  <bit-section *ngIf="!createOrganization">
+    <app-org-info
+      (changedBusinessOwned)="changedOwnedBusiness()"
+      [formGroup]="formGroup"
+      [createOrganization]="createOrganization"
+      [isProvider]="!!providerId"
+      [acceptingSponsorship]="acceptingSponsorship"
+    >
+    </app-org-info>
+  </bit-section>
   <bit-section>
     <h2 bitTypography="h2">{{ "chooseYourPlan" | i18n }}</h2>
     <bit-radio-group formControlName="productTier" [block]="true">


### PR DESCRIPTION


## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12527

## 📔 Objective

Now that the checkbox for “This account is owned by a business” is no longer present, the “General Information” Header in the UI seems out of place. This should be removed in the organization upgrade flow (and was already removed from the organization creation flow)

## 📸 Screenshots

Before

![image](https://github.com/user-attachments/assets/03fc1072-2b4d-49d2-95a3-954dbdafdc76)

After

<img width="981" alt="image" src="https://github.com/user-attachments/assets/8ccba6a0-ebdf-4501-b8d1-a75f7fbf5317">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
