### PR TITLE
[PM-739] Using a space at the beginning of otpauth:// generate a wrong OTP

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -329,6 +329,11 @@ export class AddEditComponent implements OnInit, OnDestroy {
       this.cipher.card.expYear = normalizeExpiryYearFormat(this.cipher.card.expYear);
     }
 
+    // trim whitespace from the TOTP field
+    if (this.cipher.type === this.cipherType.Login && this.cipher.login.totp) {
+      this.cipher.login.totp = this.cipher.login.totp.trim();
+    }
+
     if (this.cipher.name == null || this.cipher.name === "") {
       this.platformUtilsService.showToast(
         "error",

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.ts
@@ -125,7 +125,7 @@ export class LoginDetailsSectionComponent implements OnInit {
           Object.assign(cipher.login, {
             username: value.username,
             password: value.password,
-            totp: value.totp,
+            totp: value.totp.trim(),
           } as LoginView);
 
           return cipher;


### PR DESCRIPTION
## 🎟️ Tracking
[PM-739](https://bitwarden.atlassian.net/browse/PM-739)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Remove white space in the TOTP field
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/d012b26b-6fa9-44ca-b515-b4824b937a18


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
