### PR TITLE
[PM-12528] AC Fix Collection Refresh

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -11,7 +11,6 @@ import { ActivatedRoute, Params, Router } from "@angular/router";
 import {
   BehaviorSubject,
   combineLatest,
-  defer,
   firstValueFrom,
   lastValueFrom,
   Observable,
@@ -284,29 +283,9 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.currentSearchText$ = this.route.queryParams.pipe(map((queryParams) => queryParams.search));
 
     this.allCollectionsWithoutUnassigned$ = this.refresh$.pipe(
-      switchMap(() =>
-        combineLatest([
-          organizationId$.pipe(switchMap((orgId) => this.collectionAdminService.getAll(orgId))),
-          defer(() => this.collectionService.getAllDecrypted()),
-        ]),
-      ),
-      map(([adminCollections, syncCollections]) => {
-        const syncCollectionDict = Object.fromEntries(syncCollections.map((c) => [c.id, c]));
-
-        return adminCollections.map((collection) => {
-          const currentId: any = collection.id;
-
-          const match = syncCollectionDict[currentId];
-
-          if (match) {
-            collection.manage = match.manage;
-            collection.readOnly = match.readOnly;
-            collection.hidePasswords = match.hidePasswords;
-          }
-          return collection;
-        });
-      }),
-      shareReplay({ refCount: true, bufferSize: 1 }),
+      switchMap(() => organizationId$),
+      switchMap((orgId) => this.collectionAdminService.getAll(orgId)),
+      shareReplay({ refCount: false, bufferSize: 1 }),
     );
 
     this.editableCollections$ = this.allCollectionsWithoutUnassigned$.pipe(

--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -283,10 +283,13 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     this.currentSearchText$ = this.route.queryParams.pipe(map((queryParams) => queryParams.search));
 
-    this.allCollectionsWithoutUnassigned$ = combineLatest([
-      organizationId$.pipe(switchMap((orgId) => this.collectionAdminService.getAll(orgId))),
-      defer(() => this.collectionService.getAllDecrypted()),
-    ]).pipe(
+    this.allCollectionsWithoutUnassigned$ = this.refresh$.pipe(
+      switchMap(() =>
+        combineLatest([
+          organizationId$.pipe(switchMap((orgId) => this.collectionAdminService.getAll(orgId))),
+          defer(() => this.collectionService.getAllDecrypted()),
+        ]),
+      ),
       map(([adminCollections, syncCollections]) => {
         const syncCollectionDict = Object.fromEntries(syncCollections.map((c) => [c.id, c]));
 
@@ -367,7 +370,6 @@ export class VaultComponent implements OnInit, OnDestroy {
       map((ciphers) => {
         return Object.fromEntries(ciphers.map((c) => [c.id, c]));
       }),
-      shareReplay({ refCount: true, bufferSize: 1 }),
     );
 
     const nestedCollections$ = allCollections$.pipe(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12528](https://bitwarden.atlassian.net/browse/PM-12528)

## 📔 Objective

Make `allCollectionsWithoutUnassigned$` depend on the `refresh$` subject so that any emissions from `refresh$` force the `allCollectionsWithoutUnassigned$` to refetch collections from the API. 

Additionally, clean up the `allCollectionsWithoutUnassigned$` observable as it no longer needs to "marry" sync data with the collections from API. The API now includes permission details in the response.

Some background: #11092 added a new subscription to the `allCollectionsWithoutUnassigned$` observable in order to access collections when the route parameters updated. This had the unintended side effect of keeping the subscription alive which never allowed the `refCount` of the `shareReplay` to drop to 0 which would clear the list of collections. This prevented the collections from reloading when requested with `refresh$`.

## 📸 Screenshots


https://github.com/user-attachments/assets/f4d3da86-6c36-4ba0-b213-e0b72885fb8b



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12528]: https://bitwarden.atlassian.net/browse/PM-12528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ