### PR TITLE
Allow `build-*` workflows to be ran on demand on any git ref

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,38 @@
+---
+name: Build all
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
+
+jobs:
+  build-browser:
+    name: Browser build
+    uses: ./.github/workflows/build-browser.yml
+    secrets: inherit
+    with:
+      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
+
+  build-cli:
+    name: CLI build
+    uses: ./.github/workflows/build-cli.yml
+    secrets: inherit
+    with:
+      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
+
+  build-desktop:
+    name: Desktop build
+    uses: ./.github/workflows/build-desktop.yml
+    secrets: inherit
+    with:
+      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
+
+  build-web:
+    name: Web build
+    uses: ./.github/workflows/build-web.yml
+    secrets: inherit
+    with:
+      checkout_ref: ${{ inputs.checkout_ref || github.ref }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -2,6 +2,7 @@
 name: Build all
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       checkout_ref:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -2,7 +2,6 @@
 name: Build all
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       checkout_ref:

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -25,9 +25,15 @@ on:
       - '!*.txt'
       - '.github/workflows/build-browser.yml'
   workflow_call:
-    inputs: {}
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
 
 defaults:
   run:
@@ -44,6 +50,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Get Package Version
         id: gen_vars
@@ -74,6 +82,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Testing locales - extName length
         run: |
@@ -112,6 +122,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -255,6 +267,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -368,6 +382,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Login to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0

--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -190,6 +190,7 @@ jobs:
           name: dist-opera-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-opera.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Opera MV3 artifact (DO NOT USE FOR PROD)
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -197,6 +198,7 @@ jobs:
           name: DO-NOT-USE-FOR-PROD-dist-opera-MV3-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-opera-mv3.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Chrome MV3 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -204,6 +206,7 @@ jobs:
           name: dist-chrome-MV3-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-chrome-mv3.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Chrome MV3 Beta artifact (DO NOT USE FOR PROD)
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -211,6 +214,7 @@ jobs:
           name: DO-NOT-USE-FOR-PROD-dist-chrome-MV3-beta-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-chrome-mv3-beta.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Firefox artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -218,6 +222,7 @@ jobs:
           name: dist-firefox-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-firefox.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Firefox MV3 artifact (DO NOT USE FOR PROD)
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -225,6 +230,7 @@ jobs:
           name: DO-NOT-USE-FOR-PROD-dist-firefox-MV3-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-firefox-mv3.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Edge artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -232,6 +238,7 @@ jobs:
           name: dist-edge-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-edge.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Edge MV3 artifact (DO NOT USE FOR PROD)
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -239,6 +246,7 @@ jobs:
           name: DO-NOT-USE-FOR-PROD-dist-edge-MV3-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/dist/dist-edge-mv3.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload browser source
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -246,6 +254,7 @@ jobs:
           name: browser-source-${{ env._BUILD_NUMBER }}.zip
           path: browser-source.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload coverage artifact
         if: false
@@ -254,6 +263,7 @@ jobs:
           name: coverage-${{ env._BUILD_NUMBER }}.zip
           path: browser-source/apps/browser/coverage/coverage-${{ env._BUILD_NUMBER }}.zip
           if-no-files-found: error
+          overwrite: true
 
   build-safari:
     name: Build Safari
@@ -371,6 +381,7 @@ jobs:
           name: dist-safari-${{ env._BUILD_NUMBER }}.zip
           path: apps/browser/dist/dist-safari.zip
           if-no-files-found: error
+          overwrite: true
 
   crowdin-push:
     name: Crowdin Push

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -147,6 +147,7 @@ jobs:
           name: bw${{ matrix.license_type.artifact_prefix }}-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
           path: apps/cli/dist/bw${{ matrix.license_type.artifact_prefix }}-${{ env.LOWER_RUNNER_OS }}-${{ env._PACKAGE_VERSION }}.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload unix checksum asset
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -154,6 +155,7 @@ jobs:
           name: bw${{ matrix.license_type.artifact_prefix }}-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
           path: apps/cli/dist/bw${{ matrix.license_type.artifact_prefix }}-${{ env.LOWER_RUNNER_OS }}-sha256-${{ env._PACKAGE_VERSION }}.txt
           if-no-files-found: error
+          overwrite: true
 
   cli-windows:
     name: "windows - ${{ matrix.license_type.readable }}"
@@ -288,6 +290,7 @@ jobs:
           name: bw${{ matrix.license_type.artifact_prefix }}-windows-${{ env._PACKAGE_VERSION }}.zip
           path: apps/cli/dist/bw${{ matrix.license_type.artifact_prefix }}-windows-${{ env._PACKAGE_VERSION }}.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload windows checksum asset
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -295,6 +298,7 @@ jobs:
           name: bw${{ matrix.license_type.artifact_prefix }}-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           path: apps/cli/dist/bw${{ matrix.license_type.artifact_prefix }}-windows-sha256-${{ env._PACKAGE_VERSION }}.txt
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Chocolatey asset
         if: matrix.license_type.build_prefix == 'bit'
@@ -303,6 +307,7 @@ jobs:
           name: bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
           path: apps/cli/dist/chocolatey/bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
           if-no-files-found: error
+          overwrite: true
 
       - name: Zip NPM Build Artifact
         run: Get-ChildItem -Path .\build | Compress-Archive -DestinationPath .\bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
@@ -314,6 +319,7 @@ jobs:
           name: bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
           path: apps/cli/bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
           if-no-files-found: error
+          overwrite: true
 
   snap:
     name: Build Snap
@@ -385,6 +391,7 @@ jobs:
           name: bw_${{ env._PACKAGE_VERSION }}_amd64.snap
           path: apps/cli/dist/snap/bw_${{ env._PACKAGE_VERSION }}_amd64.snap
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload snap checksum asset
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -392,6 +399,7 @@ jobs:
           name: bw-snap-sha256-${{ env._PACKAGE_VERSION }}.txt
           path: apps/cli/dist/snap/bw-snap-sha256-${{ env._PACKAGE_VERSION }}.txt
           if-no-files-found: error
+          overwrite: true
 
 
   check-failures:

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -27,8 +27,16 @@ on:
       - '!*.txt'
       - '.github/workflows/build-cli.yml'
       - 'bitwarden_license/bit-cli/**'
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
 
 defaults:
   run:
@@ -44,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Get Package Version
         id: retrieve-package-version
@@ -85,6 +95,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup Unix Vars
         run: |
@@ -163,6 +175,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Setup Windows builder
         run: |
@@ -289,7 +303,7 @@ jobs:
           name: bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
           path: apps/cli/dist/chocolatey/bitwarden-cli.${{ env._PACKAGE_VERSION }}.nupkg
           if-no-files-found: error
-      
+
       - name: Zip NPM Build Artifact
         run: Get-ChildItem -Path .\build | Compress-Archive -DestinationPath .\bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
 
@@ -313,6 +327,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Print environment
         run: |

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -212,6 +212,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-amd64.deb
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-amd64.deb
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .rpm artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -219,6 +220,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.rpm
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.rpm
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .freebsd artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -226,6 +228,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .snap artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -233,6 +236,7 @@ jobs:
           name: bitwarden_${{ env._PACKAGE_VERSION }}_amd64.snap
           path: apps/desktop/dist/bitwarden_${{ env._PACKAGE_VERSION }}_amd64.snap
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .AppImage artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -240,6 +244,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.AppImage
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.AppImage
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload auto-update artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -247,6 +252,7 @@ jobs:
           name: ${{ needs.setup.outputs.release_channel }}-linux.yml
           path: apps/desktop/dist/${{ needs.setup.outputs.release_channel }}-linux.yml
           if-no-files-found: error
+          overwrite: true
 
 
   windows:
@@ -372,6 +378,7 @@ jobs:
           name: Bitwarden-Portable-${{ env._PACKAGE_VERSION }}.exe
           path: apps/desktop/dist/Bitwarden-Portable-${{ env._PACKAGE_VERSION }}.exe
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload installer exe artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -379,6 +386,7 @@ jobs:
           name: Bitwarden-Installer-${{ env._PACKAGE_VERSION }}.exe
           path: apps/desktop/dist/nsis-web/Bitwarden-Installer-${{ env._PACKAGE_VERSION }}.exe
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload appx ia32 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -386,6 +394,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-ia32.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-ia32.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload store appx ia32 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -393,6 +402,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-ia32-store.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-ia32-store.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload NSIS ia32 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -400,6 +410,7 @@ jobs:
           name: bitwarden-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z
           path: apps/desktop/dist/nsis-web/bitwarden-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload appx x64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -407,6 +418,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x64.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x64.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload store appx x64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -414,6 +426,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x64-store.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x64-store.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload NSIS x64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -421,6 +434,7 @@ jobs:
           name: bitwarden-${{ env._PACKAGE_VERSION }}-x64.nsis.7z
           path: apps/desktop/dist/nsis-web/bitwarden-${{ env._PACKAGE_VERSION }}-x64.nsis.7z
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload appx ARM64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -428,6 +442,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload store appx ARM64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -435,6 +450,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64-store.appx
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64-store.appx
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload NSIS ARM64 artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -442,6 +458,7 @@ jobs:
           name: bitwarden-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
           path: apps/desktop/dist/nsis-web/bitwarden-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -449,6 +466,7 @@ jobs:
           name: bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
           path: apps/desktop/dist/chocolatey/bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload auto-update artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -456,6 +474,7 @@ jobs:
           name: ${{ needs.setup.outputs.release_channel }}.yml
           path: apps/desktop/dist/nsis-web/${{ needs.setup.outputs.release_channel }}.yml
           if-no-files-found: error
+          overwrite: true
 
 
   macos-build:
@@ -818,6 +837,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal-mac.zip
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal-mac.zip
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .dmg artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -825,6 +845,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload .dmg blockmap artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -832,6 +853,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg.blockmap
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg.blockmap
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload auto-update artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
@@ -1044,6 +1066,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.pkg
           path: apps/desktop/dist/mas-universal/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.pkg
           if-no-files-found: error
+          overwrite: true
 
       - name: Deploy to TestFlight
         id: testflight-deploy
@@ -1282,6 +1305,7 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-masdev-universal.zip
           path: apps/desktop/dist/mas-dev-universal/Bitwarden-${{ env._PACKAGE_VERSION }}-masdev-universal.zip
           if-no-files-found: error
+          overwrite: true
 
 
   crowdin-push:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -25,8 +25,16 @@ on:
       - '!*.md'
       - '!*.txt'
       - '.github/workflows/build-desktop.yml'
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
 
 defaults:
   run:
@@ -39,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Verify
         run: |
@@ -68,6 +78,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Get Package Version
         id: retrieve-version
@@ -141,6 +153,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -250,6 +264,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -456,6 +472,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -601,7 +619,8 @@ jobs:
     needs: setup
     uses: ./.github/workflows/build-browser.yml
     secrets: inherit
-
+    with:
+      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
@@ -620,6 +639,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -837,6 +858,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -1082,6 +1105,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -1271,6 +1296,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Login to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -27,8 +27,16 @@ on:
       - '.github/workflows/build-web.yml'
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
+      checkout_ref:
+        required: false
+        type: string
       custom_tag_extension:
         description: "Custom image tag extension"
         required: false
@@ -46,6 +54,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Get GitHub sha as version
         id: version
@@ -92,6 +102,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -158,6 +170,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Check Branch to Publish
         env:
@@ -256,6 +270,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Login to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12022

## 📔 Objective

- Streamline the community PR handling process by getting rid of the "Clone PR" stage. This is achieved by doing the following:
  - Allow `build-*.yml` workflows to run on manual dispatch. Add an input parameter called `checkout_ref` that allows the actor to manually specify any commit hash, tag, or branch to run the workflow against. This can be used with a commit hash from a 3rd-party fork.
  - Create an umbrella `build-all.yml` workflow that can run on manual dispatch. This workflow simply calls all other `build-*.yml` workflows.

With this approach, instead of going through the lengthy and wasteful process of rehoming the community PR branch via a Clone PR, a Bitwarden developer can simply manually run the build workflows (all or just a few specific ones) on the community PR branch. Then, they can include the link to the corresponding artifacts in the QA testing notes.

Because the trigger of the workflow is not a `pull_request` event, but a `workflow_dispatch` event, the corresponding run will have full access to secrets. While this is risky, it's not inherently any less secure than the current Clone PR process, which is just a messy workaround for doing the same thing -- triggering build workflows with elevated privileges on a PR branch from an outside fork.

## 📸 Screenshots

- Running all build workflows for a specific git ref (in this case, the latest commit on [this community PR](https://github.com/bitwarden/clients/pull/10967)):

<img width="853" alt="image" src="https://github.com/user-attachments/assets/b56fe3ec-fd0b-46c6-b995-77b5dc030e13">

(once this is merged, you will be able to do this from GitHub Web as well)

- [Run in progress](https://github.com/bitwarden/clients/actions/runs/11017002874):

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/de3c3f46-5d52-45ec-9efa-84c5eb31ebe4">

(as you can see, all jobs are running despite the target being a branch from an outside fork)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
