### PR TITLE
[CL-459] Fix chip behavior when opening menu while item is selected

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -108,13 +108,20 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor, A
     return this.selectedOption?.icon || this.placeholderIcon;
   }
 
-  protected handleMenuClosed(): void {
-    /** Update the rendered options for next time the menu is opened */
+  /**
+   * Set the rendered options based on whether or not an option is already selected, so that the correct
+   * submenu displays.
+   */
+  protected setOrResetRenderedOptions(): void {
     this.renderedOptions = this.selectedOption
       ? this.selectedOption.children?.length > 0
         ? this.selectedOption
         : this.getParent(this.selectedOption)
       : this.rootTree;
+  }
+
+  protected handleMenuClosed(): void {
+    this.setOrResetRenderedOptions();
   }
 
   protected selectOption(option: ChipSelectOption<T>, _event: MouseEvent) {
@@ -202,6 +209,7 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor, A
   /** Implemented as part of NG_VALUE_ACCESSOR */
   writeValue(obj: T): void {
     this.selectedOption = this.findOption(this.rootTree, obj);
+    this.setOrResetRenderedOptions();
   }
 
   /** Implemented as part of NG_VALUE_ACCESSOR */

--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -111,7 +111,7 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor, A
   protected handleMenuClosed(): void {
     /** Update the rendered options for next time the menu is opened */
     this.renderedOptions = this.selectedOption
-      ? this.selectedOption.children.length > 0
+      ? this.selectedOption.children?.length > 0
         ? this.selectedOption
         : this.getParent(this.selectedOption)
       : this.rootTree;

--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -109,7 +109,12 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor, A
   }
 
   protected handleMenuClosed(): void {
-    this.renderedOptions = this.selectedOption ?? this.rootTree;
+    /** Update the rendered options for next time the menu is opened */
+    this.renderedOptions = this.selectedOption
+      ? this.selectedOption.children.length > 0
+        ? this.selectedOption
+        : this.getParent(this.selectedOption)
+      : this.rootTree;
   }
 
   protected selectOption(option: ChipSelectOption<T>, _event: MouseEvent) {
@@ -197,11 +202,6 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor, A
   /** Implemented as part of NG_VALUE_ACCESSOR */
   writeValue(obj: T): void {
     this.selectedOption = this.findOption(this.rootTree, obj);
-
-    /** Update the rendered options for next time the menu is opened */
-    this.renderedOptions = this.selectedOption
-      ? this.getParent(this.selectedOption)
-      : this.rootTree;
   }
 
   /** Implemented as part of NG_VALUE_ACCESSOR */


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-459](https://bitwarden.atlassian.net/browse/CL-459)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR ensures that the chip select has the following behavior:

- [x] Open the chip menu and navigate through the submenus without selecting anything. Click out of / close the chip menu. Reopen it. It should display the root menu regardless of where you left off.
- [x] Open the chip menu and select an item that does not have any children. Reopen it. It should display the menu that contains the item you selected.
- [x] Open the chip menu and navigate to a submenu. Select the "view items" option for this submenu. Reopen the chip menu. It should display the submenu where you selected "view items."

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/4a9f8661-ed3c-472f-93de-c8d1d3b2af2d



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-459]: https://bitwarden.atlassian.net/browse/CL-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ