### PR TITLE
[CL-455] Do not use responsive margin for sections in dialogs or extension

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -37,7 +37,7 @@ class ExtensionContainerComponent {}
 @Component({
   selector: "vault-placeholder",
   template: `
-    <bit-section disableMargin>
+    <bit-section>
       <bit-item-group aria-label="Mock Vault Items">
         <bit-item *ngFor="let item of data; index as i">
           <button bit-item-content>

--- a/libs/components/src/section/section.component.ts
+++ b/libs/components/src/section/section.component.ts
@@ -9,7 +9,7 @@ import { Component, Input } from "@angular/core";
   template: `
     <section
       [ngClass]="{
-        'tw-mb-6 md:tw-mb-12': !disableMargin,
+        'tw-mb-6 [&:not(bit-dialog_*):not(popup-page_*)]:md:tw-mb-12': !disableMargin,
       }"
     >
       <ng-content></ng-content>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-455](https://bitwarden.atlassian.net/browse/CL-455)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The section has a breakpoint for applying more bottom margin at larger screen sizes. This PR conditionally applies that breakpoint so that it does not affect sections within dialogs or sections within the browser extension. At this time, design has no expectation that we would want to support wide views of the extension with the larger margin.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Check Storybook for behavior:
- Section story will show the increased bottom margin at large screen sizes, and less margin at small screen sizes
- Dialog story "With Cards" shows sections being used with the small margin
- Popup layout "Popup Page" story shows a section being used with the small margin

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-455]: https://bitwarden.atlassian.net/browse/CL-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ