### PR TITLE
[CL-448] Selectively apply styled scrollbar

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -12,7 +12,7 @@
     <ng-content select="[slot=above-scroll-area]"></ng-content>
   </div>
   <div
-    class="tw-max-w-screen-sm tw-mx-auto tw-overflow-y-auto tw-flex tw-flex-col tw-w-full tw-h-full"
+    class="tw-max-w-screen-sm tw-mx-auto tw-overflow-y-auto tw-flex tw-flex-col tw-w-full tw-h-full tw-styled-scrollbar"
     (scroll)="handleScroll($event)"
     [ngClass]="{ 'tw-invisible': loading }"
   >

--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -4,23 +4,23 @@
 
 @import "../../../../../libs/components/src/tw-theme.css";
 
-@layer base {
-  /* Chrome & Safari support */
-  ::-webkit-scrollbar {
+@layer components {
+  /* Chrome / Safari support */
+  .tw-styled-scrollbar::-webkit-scrollbar {
     @apply tw-overflow-auto;
   }
-  ::-webkit-scrollbar-thumb {
+  .tw-styled-scrollbar::-webkit-scrollbar-thumb {
     @apply tw-bg-secondary-500 tw-rounded-lg tw-border-4 tw-border-solid tw-border-transparent tw-bg-clip-content;
   }
-  ::-webkit-scrollbar-track {
+  .tw-styled-scrollbar::-webkit-scrollbar-track {
     @apply tw-bg-background-alt;
   }
-  ::-webkit-scrollbar-thumb:hover {
+  .tw-styled-scrollbar::-webkit-scrollbar-thumb:hover {
     @apply tw-bg-secondary-600;
   }
 
   /* FireFox support */
-  * {
+  .tw-styled-scrollbar {
     @supports (-moz-appearance: none) {
       scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background-alt));
     }

--- a/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-v2.component.html
@@ -54,7 +54,11 @@
       </div>
     </div>
 
-    <div *ngIf="vaultState === null" cdkVirtualScrollingElement class="tw-h-full tw-p-3">
+    <div
+      *ngIf="vaultState === null"
+      cdkVirtualScrollingElement
+      class="tw-h-full tw-p-3 tw-styled-scrollbar"
+    >
       <app-autofill-vault-list-items></app-autofill-vault-list-items>
       <app-vault-list-items-container
         [title]="'favorites' | i18n"


### PR DESCRIPTION
## 🎟️ Tracking

[CL-488](https://bitwarden.atlassian.net/browse/CL-448)

## 📔 Objective

Migrate the globally applied scrollbar styles to a custom tailwind class. That way it can be applied selectively to specific elements. 
- In this case the popup page and the `vault-v2`. The `vault-v2` component uses the popup page but has it's own scroll container. 
- `tw-styled-scrollbar` isn't very creative but is unique and will probably never be added to tailwind
- This could have also been a plugin but I opted to stay in the CSS realm. I can go either way!

## Screenshots

|Vault Items| Generic Popup Page | Select dropdown with browser default scrollbar|
|-|-|-|
|<img width="379" alt="Screenshot 2024-09-25 at 2 13 50 PM" src="https://github.com/user-attachments/assets/a0fb4a81-9679-4add-9651-5c23dbd8e295">|<img width="387" alt="Screenshot 2024-09-25 at 2 14 14 PM" src="https://github.com/user-attachments/assets/f877fef9-dcc0-45e1-acbc-c74736c6f6fa">|<img width="386" alt="Screenshot 2024-09-25 at 2 14 40 PM" src="https://github.com/user-attachments/assets/aaa0e027-dc7c-4ce6-8afe-12e5644a61e2">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
