### PR TITLE
[PM-12622] Check that readOnly is falsy not only null

### DIFF
--- a/libs/angular/src/admin-console/components/collections.component.ts
+++ b/libs/angular/src/admin-console/components/collections.component.ts
@@ -72,7 +72,7 @@ export class CollectionsComponent implements OnInit {
         if (this.organization.canEditAllCiphers) {
           return !!(c as any).checked;
         } else {
-          return !!(c as any).checked && c.readOnly == null;
+          return !!(c as any).checked && !c.readOnly;
         }
       })
       .map((c) => c.id);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12622](https://bitwarden.atlassian.net/browse/PM-12622)

## 📔 Objective

When selecting collections for assignment, ensure we check that `readOnly` is falsy, not only `== null`. 

#11207 cleaned up the collections observable in the org vault which was originally setting `readOnly` to `null` via the sync'd collections (which implied `false`). Now that its being properly set to `false`, using `== null` caused the collection dialog to believe every collection was readonly and cleared them all.

## 📸 Screenshots


https://github.com/user-attachments/assets/8770c088-338b-4262-a515-2b884781a648


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12622]: https://bitwarden.atlassian.net/browse/PM-12622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ