### PR TITLE
[PM-2094] Increase allowed focus time for windows hello

### DIFF
--- a/apps/desktop/desktop_native/core/src/biometric/windows.rs
+++ b/apps/desktop/desktop_native/core/src/biometric/windows.rs
@@ -169,7 +169,7 @@ fn random_challenge() -> [u8; 16] {
 
 /// Searches for a window that looks like a security prompt and set it as focused.
 ///
-/// Gives up after 1.5 seconds with a delay of 500ms between each try.
+/// Gives up after 4 seconds with a delay of 200ms between each try.
 fn focus_security_prompt() -> Result<()> {
     unsafe fn try_find_and_set_focus(
         class_name: windows::core::PCSTR,
@@ -183,8 +183,8 @@ fn focus_security_prompt() -> Result<()> {
     }
 
     let class_name = s!("Credential Dialog Xaml Host");
-    retry::retry_with_index(Fixed::from_millis(500), |current_try| {
-        if current_try > 3 {
+    retry::retry_with_index(Fixed::from_millis(200), |current_try| {
+        if current_try > 20 {
             return retry::OperationResult::Err(());
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2094
https://github.com/bitwarden/clients/issues/5287

## 📔 Objective

Bumps the frequency in which we attempt to focus the windows hello prompt, and increases the time we allow until the window must be present in an **attempt** to fix focusing behavior. The behavior some users were seeing has not been reproduces, so it could also be a case of the focusing logic not working.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
