### PR TITLE
[PM-12678] After Editing An Item Can No Longer Click On Vault Page

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -27,6 +27,7 @@ import {
   switchMap,
   takeUntil,
   tap,
+  withLatestFrom,
 } from "rxjs/operators";
 
 import {
@@ -476,15 +477,13 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     firstSetup$
       .pipe(
-        switchMap(() =>
-          combineLatest([this.route.queryParams, allCipherMap$, allCollections$, organization$]),
-        ),
+        switchMap(() => this.route.queryParams),
+        withLatestFrom(allCipherMap$, allCollections$, organization$),
         switchMap(async ([qParams, allCiphersMap, allCollections]) => {
           const cipherId = getCipherIdFromParams(qParams);
           if (!cipherId) {
             return;
           }
-
           const cipher = allCiphersMap[cipherId];
           const cipherCollections = allCollections.filter((c) =>
             cipher.collectionIds.includes(c.id),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12678](https://bitwarden.atlassian.net/browse/PM-12678)

## 📔 Objective

I was not able to replicate with the flow shown in the ticket description. However I was able to consistently replicate the bug with unassigned items. 
Updated the org vault firstSetup subscription to limit unnecessary calls from `refresh$` on `allCiphers` and `allCollections` 

NOTE: The screen recording below will show the `model-backdrop` element is no longer called. It will also show the unassigned item as `readOnly` on the next opening, that is a separate bug not related to this modal overlay. That bug will be addressed here: https://bitwarden.atlassian.net/browse/PM-10378

## 📸 Screenshots

https://github.com/user-attachments/assets/17a02c34-a9cc-4034-81f1-f3c28365e522

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12678]: https://bitwarden.atlassian.net/browse/PM-12678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ