### PR TITLE
[CL-458] Exclude badges from truncation and vertically center content

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/attachments/open-attachments/open-attachments.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/attachments/open-attachments/open-attachments.component.html
@@ -1,11 +1,9 @@
 <bit-item>
   <button bit-item-content type="button" (click)="openAttachments()">
-    <p class="tw-m-0">
-      {{ "attachments" | i18n }}
-      <span *ngIf="!canAccessAttachments" bitBadge variant="success" class="tw-ml-2">
-        {{ "premium" | i18n }}
-      </span>
-    </p>
+    {{ "attachments" | i18n }}
+    <span *ngIf="!canAccessAttachments" bitBadge variant="success" slot="default-trailing">
+      {{ "premium" | i18n }}
+    </span>
     <ng-container slot="end">
       <i class="bwi bwi-popout" aria-hidden="true" *ngIf="openAttachmentsInPopout"></i>
       <i class="bwi bwi-angle-right" aria-hidden="true" *ngIf="!openAttachmentsInPopout"></i>

--- a/apps/web/src/app/vault/individual-vault/add-edit-v2.component.html
+++ b/apps/web/src/app/vault/individual-vault/add-edit-v2.component.html
@@ -12,12 +12,10 @@
     >
       <bit-item slot="attachment-button">
         <button bit-item-content type="button" (click)="openAttachmentsDialog()">
-          <p class="tw-m-0">
-            {{ "attachments" | i18n }}
-            <span *ngIf="!canAccessAttachments" bitBadge variant="success" class="tw-ml-2">
-              {{ "premium" | i18n }}
-            </span>
-          </p>
+          {{ "attachments" | i18n }}
+          <span *ngIf="!canAccessAttachments" bitBadge variant="success" slot="default-trailing">
+            {{ "premium" | i18n }}
+          </span>
           <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
         </button>
       </bit-item>

--- a/libs/components/src/item/item-content.component.html
+++ b/libs/components/src/item/item-content.component.html
@@ -2,8 +2,16 @@
   <ng-content select="[slot=start]"></ng-content>
 
   <div class="tw-flex tw-flex-col tw-items-start tw-text-start tw-w-full tw-truncate [&_p]:tw-mb-0">
-    <div class="tw-text-main tw-text-base tw-w-full tw-truncate">
-      <ng-content></ng-content>
+    <div
+      bitTypography="body2"
+      class="tw-text-main tw-truncate tw-inline-flex tw-items-center tw-gap-1.5 tw-w-full"
+    >
+      <div class="tw-truncate">
+        <ng-content></ng-content>
+      </div>
+      <div class="tw-flex-grow">
+        <ng-content select="[slot=default-trailing]"></ng-content>
+      </div>
     </div>
     <div class="tw-text-muted tw-text-sm tw-w-full tw-truncate">
       <ng-content select="[slot=secondary]"></ng-content>

--- a/libs/components/src/item/item.mdx
+++ b/libs/components/src/item/item.mdx
@@ -55,12 +55,13 @@ The content can be a button, anchor, or static container.
 
 `bit-item-content` contains the following slots to help position the content:
 
-| Slot               | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| default            | primary text or arbitrary content; fan favorite     |
-| `slot="secondary"` | supporting text; under the default slot             |
-| `slot="start"`     | commonly an icon or avatar; before the default slot |
-| `slot="end"`       | commonly an icon; after the default slot            |
+| Slot                      | Description                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| default                   | primary text or arbitrary content; fan favorite                                                           |
+| `slot="secondary"`        | supporting text; under the default slot                                                                   |
+| `slot="start"`            | commonly an icon or avatar; before the default slot                                                       |
+| `slot="default-trailing"` | commonly a badge; default content that should not be truncated and is placed right after the default slot |
+| `slot="end"`              | commonly an icon; placed at the far end after the default slot                                            |
 
 - Note: There is also an `end` slot within `bit-item` itself. Place
   [interactive secondary actions](#secondary-actions) there, and place non-interactive content (such
@@ -71,6 +72,7 @@ The content can be a button, anchor, or static container.
   <button bit-item-content type="button">
     <bit-avatar slot="start" text="Foo"></bit-avatar>
     foo@bitwarden.com
+    <span bitBadge variant="primary" slot="default-trailing">Auto-fill</span>
     <ng-container slot="secondary">
       <div>Bitwarden.com</div>
       <div><em>locked</em></div>

--- a/libs/components/src/item/item.stories.ts
+++ b/libs/components/src/item/item.stories.ts
@@ -322,6 +322,30 @@ export const SingleActionList: Story = {
   }),
 };
 
+export const SingleActionWithBadge: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-item-group aria-label="Single Action With Badge">
+        <bit-item>
+          <a bit-item-content href="#">
+            Foobar
+            <span bitBadge variant="primary" slot="default-trailing">Auto-fill</span>
+            <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
+          </a>          
+        </bit-item>
+        <bit-item>
+          <a bit-item-content href="#">
+            Helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo!
+            <span bitBadge variant="primary" slot="default-trailing">Auto-fill</span>
+            <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
+          </a>          
+        </bit-item>
+      </bit-item-group>
+    `,
+  }),
+};
+
 export const VirtualScrolling: Story = {
   render: (_args) => ({
     props: {
@@ -329,7 +353,7 @@ export const VirtualScrolling: Story = {
     },
     template: /*html*/ `
       <cdk-virtual-scroll-viewport [itemSize]="46" class="tw-h-[500px]">
-        <bit-item-group aria-label="Single Action List">
+        <bit-item-group aria-label="Virtual Scrolling">
           <bit-item *cdkVirtualFor="let item of data">
             <button bit-item-content>
               <i slot="start" class="bwi bwi-globe tw-text-3xl tw-text-muted" aria-hidden="true"></i>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-458](https://bitwarden.atlassian.net/browse/CL-458)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR vertically centers the content of the `default` slot of the `bit-item-content` component so that badges and text line up vertically. (Note that the badge looks a bit off here on `main` but will look correct once the extension refresh feature branch is merged in.) This PR also moves the badge outside of the truncation of the default content to align better with UI expectations, by introducing a new content slot. The two usages of `bit-item-content` with badges have been updated to use the new slot.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="725" alt="Screenshot 2024-09-27 at 9 48 44 AM" src="https://github.com/user-attachments/assets/24317b60-ed18-4347-8c85-bb1f8a9782fe">

<img width="387" alt="Screenshot 2024-09-27 at 9 53 20 AM" src="https://github.com/user-attachments/assets/b3c39810-8781-4cfc-bec6-3045247e420c">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-458]: https://bitwarden.atlassian.net/browse/CL-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ