### PR TITLE
[PM-12751] Added home to plugs to allow access to home directory

### DIFF
--- a/apps/cli/stores/snap/snapcraft.yaml
+++ b/apps/cli/stores/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ apps:
     command: bw
     environment:
       XDG_CONFIG_HOME: $SNAP_USER_DATA
-    plugs: [network, network-bind, desktop]
+    plugs: [network, network-bind, desktop, home]
 parts:
   bw:
     plugin: dump


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12751
https://github.com/bitwarden/clients/issues/11280.

## 📔 Objective

Fix https://github.com/bitwarden/clients/issues/11280. The bw snap cannot read/write to disk as it does not have
the home directory access enabled in its confinement.

https://snapcraft.io/docs/home-interface

Note that I don't have the machinery to test the solution, so this PR is to point you in the right direction of fixing the issue.

