### PR TITLE
use latest configuration name when generating send passwords

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -102,7 +102,7 @@ export class SendOptionsComponent implements OnInit {
 
   generatePassword = async () => {
     const generatedCredential = await firstValueFrom(
-      this.generatorService.generate$(Generators.Password),
+      this.generatorService.generate$(Generators.password),
     );
 
     this.sendOptionsForm.patchValue({


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Fix the broken build. Root cause:

* f1ac1d44e3ad8fec22b3bf8ac139b71b87d7d10d introduced password generation to the send UI
* 433ae13513c684e1784a793079a9ecc755e2554e updated the configuration name to be lowercase

And there was a wildly coincidental merge of these within 2 hours of each other. 🙃 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
