### PR TITLE
PM-11606 | self host billing page radio buttons fix

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
@@ -65,7 +65,7 @@
       {{ "launchCloudSubscription" | i18n }}
     </a>
     <form [formGroup]="form">
-      <bit-radio-group formControlName="updateMethod">
+      <bit-radio-group formControlName="updateMethod" [block]="true">
         <h2 class="mt-5">
           {{ "licenseAndBillingManagement" | i18n }}
         </h2>
@@ -73,7 +73,6 @@
           id="automatic-sync"
           [value]="licenseOptions.SYNC"
           [disabled]="disableLicenseSyncControl"
-          class="tw-block"
           *ngIf="showAutomaticSyncAndManualUpload"
         >
           <bit-label
@@ -94,29 +93,31 @@
           </bit-hint>
         </bit-radio-button>
         <ng-container *ngIf="updateMethod === licenseOptions.SYNC">
-          <button
-            bitButton
-            buttonType="secondary"
-            type="button"
-            (click)="manageBillingSyncSelfHosted()"
-          >
-            {{ "manageBillingSync" | i18n }}
-          </button>
-          <button
-            bitButton
-            buttonType="primary"
-            type="button"
-            [bitAction]="syncLicense"
-            [disabled]="!billingSyncEnabled"
-          >
-            {{ "syncLicense" | i18n }}
-          </button>
+          <div class="tw-mt-6">
+            <button
+              bitButton
+              buttonType="secondary"
+              type="button"
+              (click)="manageBillingSyncSelfHosted()"
+            >
+              {{ "manageBillingSync" | i18n }}
+            </button>
+            <button
+              bitButton
+              buttonType="primary"
+              type="button"
+              [bitAction]="syncLicense"
+              [disabled]="!billingSyncEnabled"
+            >
+              {{ "syncLicense" | i18n }}
+            </button>
+          </div>
         </ng-container>
 
         <bit-radio-button
           id="manual-upload"
           [value]="licenseOptions.UPLOAD"
-          class="tw-mt-6 tw-block"
+          class="tw-mt-6"
           *ngIf="showAutomaticSyncAndManualUpload"
         >
           <bit-label>{{ "manualUpload" | i18n }}</bit-label>
@@ -128,7 +129,7 @@
           <bit-label class="tw-mb-6 tw-block" *ngIf="!showAutomaticSyncAndManualUpload">
             {{ "licenseAndBillingManagementDesc" | i18n }}
           </bit-label>
-          <h3 *ngIf="showAutomaticSyncAndManualUpload" class="tw-font-semibold">
+          <h3 *ngIf="showAutomaticSyncAndManualUpload" class="tw-font-semibold tw-mt-6">
             {{ "uploadLicense" | i18n }}
           </h3>
           <app-update-license


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-11606](https://bitwarden.atlassian.net/browse/PM-11606)

## 📔 Objective
When selecting the "automatic sync" radio button, the "manual upload" button was rendering inline to the two buttons below the "automatic sync" radio button. There's also some spacing updates here to give some breathing room. 

![image-20240903-153035](https://github.com/user-attachments/assets/25615259-cbb6-4617-9717-1b525abeed4e)


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| automatic sync selected | manual upload selected |
|--------|--------|
| <img width="1628" alt="Screenshot 2024-09-27 at 10 17 02 AM" src="https://github.com/user-attachments/assets/f57b1b52-e9b2-4baf-b273-af2f8e7d9f8d"> | <img width="1629" alt="Screenshot 2024-09-27 at 10 17 23 AM" src="https://github.com/user-attachments/assets/003bdb21-bc4f-4e2b-b3cc-eef3877f495f"> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11606]: https://bitwarden.atlassian.net/browse/PM-11606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ