### PR TITLE
[PM-12721] - add copy button to send options password field

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
@@ -34,7 +34,7 @@
         type="button"
         bitIconButton="bwi-clone"
         bitSuffix
-        [appA11yTitle]="'copyValue' | i18n"
+        [appA11yTitle]="'passwordCopied' | i18n"
         [appCopyClick]="sendOptionsForm.get('password').value"
         showToast
       ></button>

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
@@ -34,7 +34,8 @@
         type="button"
         bitIconButton="bwi-clone"
         bitSuffix
-        [appA11yTitle]="'passwordCopied' | i18n"
+        [appA11yTitle]="'copyPassword' | i18n"
+        [valueLabel]="'password' | i18n"
         [appCopyClick]="sendOptionsForm.get('password').value"
         showToast
       ></button>

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
@@ -30,6 +30,14 @@
         (click)="generatePassword()"
         data-testid="generate-password"
       ></button>
+      <button
+        type="button"
+        bitIconButton="bwi-clone"
+        bitSuffix
+        [appA11yTitle]="'copyValue' | i18n"
+        [appCopyClick]="sendOptionsForm.get('password').value"
+        showToast
+      ></button>
       <bit-hint>{{ "sendPasswordDescV2" | i18n }}</bit-hint>
     </bit-form-field>
     <bit-form-control *ngIf="!disableHideEmail">


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12721

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a copy button to the send options password field

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-09-27 at 10 29 38 AM](https://github.com/user-attachments/assets/950085d5-e5d9-44a4-a98f-cfd94eadc637)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
