### PR TITLE
[PM-12717][Defect] Cloning item takes you back to original item's view modal after saving

### DIFF
--- a/apps/web/src/app/vault/individual-vault/add-edit-v2.component.ts
+++ b/apps/web/src/app/vault/individual-vault/add-edit-v2.component.ts
@@ -29,6 +29,7 @@ import { AttachmentsV2Component } from "./attachments-v2.component";
 export enum AddEditCipherDialogResult {
   Edited = "edited",
   Added = "added",
+  Cloned = "cloned",
   Canceled = "canceled",
 }
 
@@ -153,11 +154,17 @@ export class AddEditComponentV2 implements OnInit {
    * @param cipherView The cipher view that was saved.
    */
   async onCipherSaved(cipherView: CipherView) {
+    let action: AddEditCipherDialogResult;
+
+    if (this.config.mode === "add") {
+      action = AddEditCipherDialogResult.Added;
+    } else if (this.config.mode === "clone") {
+      action = AddEditCipherDialogResult.Cloned;
+    } else {
+      action = AddEditCipherDialogResult.Edited;
+    }
     this.dialogRef.close({
-      action:
-        this.config.mode === "add"
-          ? AddEditCipherDialogResult.Added
-          : AddEditCipherDialogResult.Edited,
+      action,
       id: cipherView.id as CipherId,
     });
   }

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -793,17 +793,20 @@ export class VaultComponent implements OnInit, OnDestroy {
     const result: AddEditCipherDialogCloseResult = await firstValueFrom(dialogRef.closed);
 
     /**
-     * Refresh the vault if the dialog was closed by adding, editing, or deleting a cipher.
+     * Show the cloned cipher in the vault.
      */
-    if (result?.action === AddEditCipherDialogResult.Edited) {
+    if (result?.action === AddEditCipherDialogResult.Cloned) {
       this.refresh();
     }
 
     /**
-     * View the cipher if the dialog was closed by editing the cipher.
+     * View the cipher if the dialog was closed by editing or cloning the cipher.
      */
-    if (result?.action === AddEditCipherDialogResult.Edited) {
-      this.go({ itemId: cipher.id, action: "view" });
+    if (
+      result?.action === AddEditCipherDialogResult.Edited ||
+      result?.action === AddEditCipherDialogResult.Cloned
+    ) {
+      this.go({ itemId: result.id, action: "view" });
       return;
     }
 
@@ -1018,7 +1021,9 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     const component = await this.editCipher(cipher, true);
-    component.cloneMode = true;
+    if (component) {
+      component.cloneMode = true;
+    }
   }
 
   async restore(c: CipherView): Promise<boolean> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12717?atlOrigin=eyJpIjoiNzI3OTU0OGQyNTZiNDY3Njg1NmM2MzNlMzJkNDNmYTciLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After cloning a cipher the view dialog would open with the original cipher. This PR introduces a `Cloned` action as an available result of closing the `AddEditV2Component` component. The view dialog will now use the newly created (cloned) cipher ID, and refresh the vault to show the cloned item in the list immediately.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
