### PR TITLE
[PM-12718] Vault item - keyboard focus

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -17,7 +17,10 @@
     {{ description }}
   </div>
   <bit-item-group>
-    <cdk-virtual-scroll-viewport [itemSize]="ItemHeight">
+    <cdk-virtual-scroll-viewport
+      [itemSize]="ItemHeight"
+      class="tw-overflow-visible [&>.cdk-virtual-scroll-content-wrapper]:[contain:layout_style]"
+    >
       <bit-item *cdkVirtualFor="let cipher of ciphers">
         <button
           bit-item-content

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -19,8 +19,9 @@
   <bit-item-group>
     <cdk-virtual-scroll-viewport [itemSize]="ItemHeight">
       <bit-item *cdkVirtualFor="let cipher of ciphers">
-        <a
+        <button
           bit-item-content
+          type="button"
           (click)="onViewCipher(cipher)"
           [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
           class="{{ ItemHeightClass }}"
@@ -40,7 +41,7 @@
             [appA11yTitle]="'attachments' | i18n"
           ></i>
           <span slot="secondary">{{ cipher.subTitle }}</span>
-        </a>
+        </button>
         <ng-container slot="end">
           <bit-item-action *ngIf="showAutofillButton">
             <button


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12718](https://bitwarden.atlassian.net/browse/PM-12718)

## 📔 Objective

Vault items weren't keyboard focusable because they were an anchor tag without a `href`
- Refactored the element to be a button. This feels fine from an accessibility standpoint as the button could navigate _or_ display an action (password reprompt).
- The focus state is `outline` which doesn't display within the layout of the element. This caused the outline to be cut off by the container. I added some CSS to alter the `overflow` and `contain` properties of `cdk-virtual-scroll-viewport` element so that the outline can be shown via overflow. 
  ![Screenshot 2024-09-30 at 11 32 50 AM](https://github.com/user-attachments/assets/1cf3f4e0-357b-4408-9c47-b6a3e7625834)

  

## 📸 Screenshots

|Chrome|FireFox|Safari|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/56293d11-0a71-4828-a7dc-ca295b193a4b"/>|<video src="https://github.com/user-attachments/assets/077fff56-fb42-4357-b574-d9148cb62eee"/>|<video src="https://github.com/user-attachments/assets/ace79a59-145e-48e1-ae79-4d12f13649c4"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12718]: https://bitwarden.atlassian.net/browse/PM-12718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ