### PR TITLE
[PM-12553][Defect] Delete Attachment button needs hover state.

### DIFF
--- a/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.html
+++ b/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.html
@@ -3,7 +3,6 @@
   buttonType="danger"
   size="small"
   type="button"
-  class="tw-border-none"
   [appA11yTitle]="'deleteAttachmentName' | i18n: attachment.fileName"
   [bitAction]="delete"
 ></button>

--- a/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.html
+++ b/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.html
@@ -3,6 +3,7 @@
   buttonType="danger"
   size="small"
   type="button"
+  class="tw-border-transparent"
   [appA11yTitle]="'deleteAttachmentName' | i18n: attachment.fileName"
   [bitAction]="delete"
 ></button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12553?atlOrigin=eyJpIjoiYjM2Y2QxYjc3MmIzNDhjY2I2MjhjYWQ5YzkwYWIzZWQiLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Replaces the `tw-border-none` class from the delete button which was preventing the button hover state from appearing. Added `tw-border-transparent` which works on both the `ps/extension-refresh` and `main` branches (allows hover state without showing a border when not hovered).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Main Not Hovered

![Screenshot 2024-09-30 at 12 32 17 PM](https://github.com/user-attachments/assets/537d5e45-2f86-43f5-8757-21f2835696be)

### Main Hovered

![Screenshot 2024-09-30 at 12 32 28 PM](https://github.com/user-attachments/assets/ba06a266-9657-4824-8566-aba441b51c0e)

### Extension Refresh Hovered

![Screenshot 2024-09-30 at 12 40 29 PM](https://github.com/user-attachments/assets/b54fc71a-8f84-4473-8c15-08ed968c8ea2)

### Extension Refresh Not Hovered

![Screenshot 2024-09-30 at 12 40 19 PM](https://github.com/user-attachments/assets/2357c0ac-69cf-4f17-9854-06912270fc97)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
