### PR TITLE
[PM-12718] Keyboard accessible trash links

### DIFF
--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
@@ -7,14 +7,15 @@
   </bit-section-header>
   <bit-item-group>
     <bit-item *ngFor="let cipher of ciphers">
-      <a
+      <button
         bit-item-content
+        type="button"
         [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
         (click)="onViewCipher(cipher)"
       >
         <app-vault-icon slot="start" [cipher]="cipher"></app-vault-icon>
         <span data-testid="item-name">{{ cipher.name }}</span>
-      </a>
+      </button>
       <ng-container slot="end" *ngIf="cipher.edit">
         <bit-item-action>
           <button


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12718](https://bitwarden.atlassian.net/browse/PM-12718)

## 📔 Objective

I was so focused on the virtual scrolling fixes in https://github.com/bitwarden/clients/pull/11338, that I forgot about the trash page completely. 
- Updating the trash page to use a `button` element rather than anchor element. An anchor without an `href` attribute is not keyboard accessible. 

## 📸 Screenshots

|Trash Page|
|-|
|<video src="https://github.com/user-attachments/assets/aa62abfc-e4e1-475e-b733-5f883c27be62"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12718]: https://bitwarden.atlassian.net/browse/PM-12718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ