### PR TITLE
Auth/PM-13103 - Fix Users with Frameless Duo 2FA not being able to login

### DIFF
--- a/apps/web/src/connectors/duo-redirect.ts
+++ b/apps/web/src/connectors/duo-redirect.ts
@@ -54,8 +54,10 @@ function redirectToDuoFrameless(redirectUrl: string) {
 
   if (
     validateUrl.protocol !== "https:" ||
-    !validateUrl.hostname.endsWith("duosecurity.com") ||
-    !validateUrl.hostname.endsWith("duofederal.com")
+    !(
+      validateUrl.hostname.endsWith("duosecurity.com") ||
+      validateUrl.hostname.endsWith("duofederal.com")
+    )
   ) {
     throw new Error("Invalid redirect URL");
   }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13103

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To fix users with frameless Duo 2FA from not being able to login. The existing logic failed because the construction of the previous check would reject all URLs.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Info: I temporarily mocked one of the known failing redirects to prove that the `Invalid redirect URL` error would not be thrown after the logic change. 

https://github.com/user-attachments/assets/7a56b55f-61fe-44e8-81e7-62d64469f887


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
