### PR TITLE
PM-12102 | Fix LastPass importer not properly de-encrypting URLs

### DIFF
--- a/libs/importer/src/importers/lastpass/access/services/parser.ts
+++ b/libs/importer/src/importers/lastpass/access/services/parser.ts
@@ -68,7 +68,7 @@ export class Parser {
               encryptionKey,
               placeholder,
             )
-          : this.decodeHexLoose(Utils.fromBufferToUtf8(urlEncoded)).toString();
+          : Utils.fromBufferToUtf8(this.decodeHexLoose(Utils.fromBufferToUtf8(urlEncoded)));
 
       // Ignore "group" accounts. They have no credentials.
       if (url == "http://group") {

--- a/libs/importer/src/importers/lastpass/access/services/parser.ts
+++ b/libs/importer/src/importers/lastpass/access/services/parser.ts
@@ -22,7 +22,7 @@ export class Parser {
   /*
   May return null when the chunk does not represent an account.
   All secure notes are ACCTs but not all of them store account information.
-  
+
   TODO: Add a test for the folder case!
   TODO: Add a test case that covers secure note account!
   */
@@ -60,9 +60,15 @@ export class Parser {
 
       // 3: url
       step = 3;
-      let url = Utils.fromBufferToUtf8(
-        this.decodeHexLoose(Utils.fromBufferToUtf8(this.readItem(reader))),
-      );
+      const urlEncoded = this.readItem(reader);
+      let url =
+        urlEncoded.length > 0 && urlEncoded[0] === 33 // 33 = '!'
+          ? await this.cryptoUtils.decryptAes256PlainWithDefault(
+              urlEncoded,
+              encryptionKey,
+              placeholder,
+            )
+          : this.decodeHexLoose(Utils.fromBufferToUtf8(urlEncoded)).toString();
 
       // Ignore "group" accounts. They have no credentials.
       if (url == "http://group") {

--- a/libs/importer/src/importers/lastpass/access/services/parser.ts
+++ b/libs/importer/src/importers/lastpass/access/services/parser.ts
@@ -63,12 +63,14 @@ export class Parser {
       const urlEncoded = this.readItem(reader);
       let url =
         urlEncoded.length > 0 && urlEncoded[0] === 33 // 33 = '!'
-          ? await this.cryptoUtils.decryptAes256PlainWithDefault(
+          ? // URL is encrypted
+            await this.cryptoUtils.decryptAes256PlainWithDefault(
               urlEncoded,
               encryptionKey,
               placeholder,
             )
-          : Utils.fromBufferToUtf8(this.decodeHexLoose(Utils.fromBufferToUtf8(urlEncoded)));
+          : // URL is not encrypted
+            Utils.fromBufferToUtf8(this.decodeHexLoose(Utils.fromBufferToUtf8(urlEncoded)));
 
       // Ignore "group" accounts. They have no credentials.
       if (url == "http://group") {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12102

Closes #11051

## 📔 Objective

LastPass encrypts URLs of items in their vault. When importing, they need to be decrypted to appear properly.

I used [this code](https://github.com/detunized/password-manager-access/commit/213e966bb651e9323f5508c79568809da7a6ab83#diff-bef5fc4c400af83e7b83a90460331c45ad3be3db95756ac60597f4ba430a909fR52) as reference for my implementation.

## 📸 Screenshots

Before:

![image](https://github.com/user-attachments/assets/9008b307-0e0c-47e0-9f10-c11345c03768)

After:

<img width="272" alt="image" src="https://github.com/user-attachments/assets/3e9e6d6d-64ad-4925-b77b-750687d525d6">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
