### PR TITLE
[PM-12727/12737] Adding copy for Add/Edit

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9265,5 +9265,11 @@
   },
   "editAccess": {
     "message": "Edit access"
+  },
+  "addAttachment": {
+    "message": "Add attachment"
+  },
+  "maxFileSizeSansPunctuation": {
+    "message": "Maximum file size is 500 MB"
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9271,5 +9271,8 @@
   },
   "maxFileSizeSansPunctuation": {
     "message": "Maximum file size is 500 MB"
+  },
+  "permanentlyDeleteAttachmentConfirmation": {
+    "message": "Are you sure you want to permanently delete this attachment?"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12727](https://bitwarden.atlassian.net/browse/PM-12727)
[PM-12737](https://bitwarden.atlassian.net/browse/PM-12737)

## 📔 Objective

Some copy was missed when porting over the add/edit component into the web vault
- Heading and size limit for attachments
- Warning message for deleting an attachment

## 📸 Screenshots

|Adding attachment|Deleting attachment|
|-|-|
|<img width="480" alt="Screenshot 2024-10-02 at 2 18 58 PM" src="https://github.com/user-attachments/assets/b19e7874-d110-4ac2-8127-52d625a19fee">|<img width="339" alt="Screenshot 2024-10-02 at 2 19 05 PM" src="https://github.com/user-attachments/assets/4fc023d9-1bee-4bbc-b9ab-adb41638e32d">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12727]: https://bitwarden.atlassian.net/browse/PM-12727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-12737]: https://bitwarden.atlassian.net/browse/PM-12737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ