### PR TITLE
[PM-11131] Prevent duplicated sr labels on form field icon buttons

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -10,6 +10,7 @@ import {
 } from "@angular/forms";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
+import { A11yTitleDirective } from "@bitwarden/angular/src/directives/a11y-title.directive";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { AsyncActionsModule } from "../async-actions";
@@ -50,6 +51,7 @@ export default {
         TextFieldModule,
         BadgeModule,
       ],
+      declarations: [A11yTitleDirective],
       providers: [
         {
           provide: I18nService,
@@ -237,7 +239,7 @@ export const Readonly: Story = {
         <bit-label>Input</bit-label>
         <input bitInput type="password" value="Foobar" [readonly]="true" />
         <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
-        <button type="button" bitSuffix bitIconButton="bwi-clone" aria-label="Clone"></button>
+        <button type="button" bitSuffix bitIconButton="bwi-clone" [appA11yTitle]="'Clone Input'"></button>
       </bit-form-field>
 
       <bit-form-field>
@@ -258,7 +260,7 @@ export const Readonly: Story = {
               <bit-label>Input</bit-label>
               <input bitInput type="password" value="Foobar" readonly />
               <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
-              <button type="button" bitSuffix bitIconButton="bwi-clone" aria-label="Clone"></button>
+              <button type="button" bitSuffix bitIconButton="bwi-clone" [appA11yTitle]="'Clone Input'"></button>
             </bit-form-field>
 
             <bit-form-field>
@@ -302,14 +304,14 @@ export const ButtonInputGroup: Story = {
       <bit-form-field>
         <bit-label>
           Label
-          <a href="#" slot="end" bitLink>
+          <a href="#" slot="end" bitLink [appA11yTitle]="'More info'">
             <i class="bwi bwi-question-circle" aria-hidden="true"></i>
           </a>
         </bit-label>
-        <button bitPrefix bitIconButton="bwi-star" aria-label="Favorite"></button>
+        <button bitPrefix bitIconButton="bwi-star" [appA11yTitle]="'Favorite Label'"></button>
         <input bitInput placeholder="Placeholder" />
-        <button bitSuffix bitIconButton="bwi-eye" aria-label="Hide"></button>
-        <button bitSuffix bitIconButton="bwi-clone" aria-label="Clone"></button>
+        <button bitSuffix bitIconButton="bwi-eye" [appA11yTitle]="'Hide Label'"></button>
+        <button bitSuffix bitIconButton="bwi-clone" [appA11yTitle]="'Clone Label'"></button>
         <button bitSuffix bitLink>
           Apply
         </button>
@@ -325,10 +327,10 @@ export const DisabledButtonInputGroup: Story = {
     template: /*html*/ `
       <bit-form-field>
         <bit-label>Label</bit-label>
-        <button bitPrefix bitIconButton="bwi-star" disabled aria-label="Favorite"></button>
+        <button bitPrefix bitIconButton="bwi-star" disabled [appA11yTitle]="'Favorite Label'"></button>
         <input bitInput placeholder="Placeholder" disabled />
-        <button bitSuffix bitIconButton="bwi-eye" disabled aria-label="Hide"></button>
-        <button bitSuffix bitIconButton="bwi-clone" disabled aria-label="Clone"></button>
+        <button bitSuffix bitIconButton="bwi-eye" disabled [appA11yTitle]="'Hide Label'"></button>
+        <button bitSuffix bitIconButton="bwi-clone" disabled [appA11yTitle]="'Clone Label'"></button>
         <button bitSuffix bitLink disabled>
           Apply
         </button>
@@ -345,8 +347,8 @@ export const PartiallyDisabledButtonInputGroup: Story = {
       <bit-form-field>
         <bit-label>Label</bit-label>
         <input bitInput placeholder="Placeholder" disabled />
-        <button bitSuffix bitIconButton="bwi-eye" aria-label="Hide"></button>
-        <button bitSuffix bitIconButton="bwi-clone" aria-label="Clone"></button>
+        <button bitSuffix bitIconButton="bwi-eye" [appA11yTitle]="'Hide Label'"></button>
+        <button bitSuffix bitIconButton="bwi-clone" [appA11yTitle]="'Clone Label'"></button>
         <button bitSuffix bitLink disabled>
           Apply
         </button>

--- a/libs/components/src/form-field/prefix.directive.ts
+++ b/libs/components/src/form-field/prefix.directive.ts
@@ -1,34 +1,20 @@
-import { AfterContentInit, Directive, HostBinding, Input, OnInit, Optional } from "@angular/core";
+import { Directive, HostBinding, Input, OnInit, Optional } from "@angular/core";
 
 import { BitIconButtonComponent } from "../icon-button/icon-button.component";
-
-import { BitFormFieldComponent } from "./form-field.component";
 
 @Directive({
   selector: "[bitPrefix]",
 })
-export class BitPrefixDirective implements OnInit, AfterContentInit {
+export class BitPrefixDirective implements OnInit {
   @HostBinding("class") @Input() get classList() {
     return ["tw-text-muted"];
   }
 
-  @HostBinding("attr.aria-describedby")
-  protected ariaDescribedBy: string;
-
-  constructor(
-    @Optional() private parentFormField: BitFormFieldComponent,
-    @Optional() private iconButtonComponent: BitIconButtonComponent,
-  ) {}
+  constructor(@Optional() private iconButtonComponent: BitIconButtonComponent) {}
 
   ngOnInit() {
     if (this.iconButtonComponent) {
       this.iconButtonComponent.size = "small";
-    }
-  }
-
-  ngAfterContentInit() {
-    if (this.parentFormField?.label?.id) {
-      this.ariaDescribedBy = this.parentFormField.label.id;
     }
   }
 }

--- a/libs/components/src/form-field/suffix.directive.ts
+++ b/libs/components/src/form-field/suffix.directive.ts
@@ -1,34 +1,20 @@
-import { AfterContentInit, Directive, HostBinding, Input, OnInit, Optional } from "@angular/core";
+import { Directive, HostBinding, Input, OnInit, Optional } from "@angular/core";
 
 import { BitIconButtonComponent } from "../icon-button/icon-button.component";
-
-import { BitFormFieldComponent } from "./form-field.component";
 
 @Directive({
   selector: "[bitSuffix]",
 })
-export class BitSuffixDirective implements OnInit, AfterContentInit {
+export class BitSuffixDirective implements OnInit {
   @HostBinding("class") @Input() get classList() {
     return ["tw-text-muted"];
   }
 
-  @HostBinding("attr.aria-describedby")
-  protected ariaDescribedBy: string;
-
-  constructor(
-    @Optional() private parentFormField: BitFormFieldComponent,
-    @Optional() private iconButtonComponent: BitIconButtonComponent,
-  ) {}
+  constructor(@Optional() private iconButtonComponent: BitIconButtonComponent) {}
 
   ngOnInit() {
     if (this.iconButtonComponent) {
       this.iconButtonComponent.size = "small";
-    }
-  }
-
-  ngAfterContentInit() {
-    if (this.parentFormField?.label?.id) {
-      this.ariaDescribedBy = this.parentFormField.label.id;
     }
   }
 }

--- a/libs/components/src/form/forms.mdx
+++ b/libs/components/src/form/forms.mdx
@@ -152,6 +152,12 @@ If a checkbox group has more than 4 options a
   helper text.
   - **Example:** "Billing Email is required if owned by a business".
 
+### Icon Buttons in Form Fields
+
+When adding prefix or suffix icon buttons to a form field, be sure to use the `appA11yTitle`
+directive to provide a label for screenreaders. Typically, the label should follow this pattern:
+`{Action} {field label}`, i.e. "Copy username".
+
 ### Form Field Errors
 
 - When a resting field is filled out, validation is triggered when the user de-focuses the field


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-11131](https://bitwarden.atlassian.net/browse/PM-11131)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Originally, when we updated the prefix and suffix directives, we added in an automatic `aria-describedby` assignment that referenced the form field label. The idea was that this would help provide context for what the button was associated with. However, when implementing it in the browser extension, we ran into issues where a button with an `ngIf` on it would not get the `aria-describedby` applied properly due to either race conditions or lifecycle event ordering within Angular. The simplest solution is to remove the `aria-describedby` from the prefix and suffix directives and move the label/context responsibility to the implementation, which already is using the `appA11yTitle` directive to apply a label.

This PR also updates the documentation and storybook code to more accurately reflect the usage of `appA11yTitle`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Test in Storybook with screenreader on. You can also pull down this branch and run the extension with the screenreader on to ensure that the existing labels work as expected.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11131]: https://bitwarden.atlassian.net/browse/PM-11131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ