### PR TITLE
[PM-12738] Show Premium dialog when accessing attachments

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -207,6 +207,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     private accountService: AccountService,
     private router: Router,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private premiumUpgradeService: PremiumUpgradePromptService,
   ) {
     this.updateTitle();
   }
@@ -297,6 +298,13 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   };
 
   openAttachmentsDialog = async () => {
+    const canAccessAttachments = await firstValueFrom(this.canAccessAttachments$);
+
+    if (!canAccessAttachments) {
+      await this.premiumUpgradeService.promptForPremium();
+      return;
+    }
+
     const dialogRef = this.dialogService.open<AttachmentDialogCloseResult, { cipherId: CipherId }>(
       AttachmentsV2Component,
       {

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -611,6 +611,12 @@ export class VaultComponent implements OnInit, OnDestroy {
     const result = await lastValueFrom(this.vaultItemDialogRef.closed);
     this.vaultItemDialogRef = undefined;
 
+    // When the dialog is closed for a premium upgrade, return early as the user
+    // should be navigated to the subscription settings elsewhere
+    if (result === VaultItemDialogResult.PremiumUpgrade) {
+      return;
+    }
+
     // If the dialog was closed by deleting the cipher, refresh the vault.
     if (result === VaultItemDialogResult.Deleted || result === VaultItemDialogResult.Saved) {
       this.refresh();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12738](https://bitwarden.atlassian.net/browse/PM-12738)

## 📔 Objective

- Adds a premium check when trying to access attachments in the `VaultItemDialogComponent`

## 📸 Screenshots

| Premium Dialog from Edit dialog |
|-|
|<video src="https://github.com/user-attachments/assets/5d3f5935-d738-43af-b10e-18276a4f7abb"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12738]: https://bitwarden.atlassian.net/browse/PM-12738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ