### PR TITLE
[PM-11681] Fix fido2 cipher row component subname not having proper layout/styling

### DIFF
--- a/apps/browser/src/autofill/popup/fido2/fido2-cipher-row.component.html
+++ b/apps/browser/src/autofill/popup/fido2/fido2-cipher-row.component.html
@@ -15,7 +15,9 @@
         class="bwi bwi-collection text-muted"
       ></i>
     </span>
-    <span class="detail" *ngIf="getSubName(cipher)">{{ getSubName(cipher) }}</span>
-    <span *ngIf="cipher.subTitle" slot="secondary">{{ cipher.subTitle }}</span>
+    <ng-container slot="secondary">
+      <div *ngIf="getSubName(cipher)">{{ getSubName(cipher) }}</div>
+      <div *ngIf="cipher.subTitle">{{ cipher.subTitle }}</div>
+    </ng-container>
   </button>
 </bit-item>


### PR DESCRIPTION
## 🎟️ Tracking

PM-11681

## 📔 Objective

Fix fido2 cipher row component subname not having proper layout/styling

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-10-03 at 1 06 41 PM](https://github.com/user-attachments/assets/c9e911a2-96ba-4d2a-8aa9-226425029549) | ![Screenshot 2024-10-03 at 1 04 28 PM](https://github.com/user-attachments/assets/eacb7184-a0a9-4fc6-af02-d8dcf2e70325) | 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
