### PR TITLE
[PM-12971] - close safari default extension on pop out

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -58,11 +58,36 @@ export class BrowserApi {
   }
 
   static async createWindow(options: chrome.windows.CreateData): Promise<chrome.windows.Window> {
-    return new Promise((resolve) =>
-      chrome.windows.create(options, (window) => {
-        resolve(window);
-      }),
-    );
+    return new Promise((resolve) => {
+      chrome.windows.create(options, async (newWindow) => {
+        if (!BrowserApi.isSafariApi) {
+          return resolve(newWindow);
+        }
+        // Safari doesn't close the default extension popup when a new window is created so we need to
+        // manually trigger the close by focusing the main window after the new window is created
+        const allWindows = await new Promise<chrome.windows.Window[]>((resolve) => {
+          chrome.windows.getAll({ windowTypes: ["normal"] }, (windows) => resolve(windows));
+        });
+
+        const mainWindow = allWindows.find((window) => window.id !== newWindow.id);
+
+        // No main window found, resolve the new window
+        if (!mainWindow) {
+          return resolve(newWindow);
+        }
+        // Focus the main window to close the extension popup
+        if (mainWindow && mainWindow.id) {
+          chrome.windows.update(mainWindow.id, { focused: true }, () => {
+            // Refocus the newly created window
+            if (newWindow.id) {
+              chrome.windows.update(newWindow.id, { focused: true }, () => {
+                resolve(newWindow);
+              });
+            }
+          });
+        }
+      });
+    });
   }
 
   /**

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -75,7 +75,7 @@ export class BrowserApi {
         if (mainWindow == null || !mainWindow.id) {
           return resolve(newWindow);
         }
-        
+
         // Focus the main window to close the extension popup
         chrome.windows.update(mainWindow.id, { focused: true }, () => {
           // Refocus the newly created window
@@ -88,7 +88,6 @@ export class BrowserApi {
             resolve(mainWindow);
           }
         });
-        
       });
     });
   }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -72,20 +72,23 @@ export class BrowserApi {
         const mainWindow = allWindows.find((window) => window.id !== newWindow.id);
 
         // No main window found, resolve the new window
-        if (!mainWindow) {
+        if (mainWindow == null || !mainWindow.id) {
           return resolve(newWindow);
         }
+        
         // Focus the main window to close the extension popup
-        if (mainWindow && mainWindow.id) {
-          chrome.windows.update(mainWindow.id, { focused: true }, () => {
-            // Refocus the newly created window
-            if (newWindow.id) {
-              chrome.windows.update(newWindow.id, { focused: true }, () => {
-                resolve(newWindow);
-              });
-            }
-          });
-        }
+        chrome.windows.update(mainWindow.id, { focused: true }, () => {
+          // Refocus the newly created window
+          if (newWindow.id) {
+            chrome.windows.update(newWindow.id, { focused: true }, () => {
+              resolve(newWindow);
+            });
+          } else {
+            // Is this what you'd want in this situation?
+            resolve(mainWindow);
+          }
+        });
+        
       });
     });
   }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -79,14 +79,9 @@ export class BrowserApi {
         // Focus the main window to close the extension popup
         chrome.windows.update(mainWindow.id, { focused: true }, () => {
           // Refocus the newly created window
-          if (newWindow.id) {
-            chrome.windows.update(newWindow.id, { focused: true }, () => {
-              resolve(newWindow);
-            });
-          } else {
-            // Is this what you'd want in this situation?
-            resolve(mainWindow);
-          }
+          chrome.windows.update(newWindow.id, { focused: true }, () => {
+            resolve(newWindow);
+          });
         });
       });
     });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12971

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a bug where, in Safari, after "popping out" the extension in a new window/ the original window would persist until the user clicked on the main window.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
