### PR TITLE
[PM-12776] Draggable Items within a dialog

### DIFF
--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -223,8 +223,8 @@ summary.tw-list-none::-webkit-details-marker {
 
 /**
  * Bootstrap uses z-index: 1050 for modals, dialogs and drag-and-drop previews should appear above them.
- * Remove once bootstrap is removed from our codebase.
- * CL-XYZ
+ * Remove once bootstrap these styles should revisited to ensure that overlays display properly over other content.
+ * CL-483
  */
 .cdk-drag-preview,
 .cdk-overlay-container,

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -1,9 +1,9 @@
 @import "./reset.css";
 
-/** 
-  Note that the value of the *-600 colors is currently equivalent to the value 
+/**
+  Note that the value of the *-600 colors is currently equivalent to the value
   of the *-500 variant of that color. This is a temporary change to make BW-42
-  updates easier. 
+  updates easier.
 
   TODO remove comment when the color palette portion of BW-42 is completed.
 */
@@ -196,7 +196,7 @@
 @import "./toast/toast.tokens.css";
 @import "./toast/toastr.css";
 
-/** 
+/**
  * tw-break-words does not work with table cells:
  * https://github.com/tailwindlabs/tailwindcss/issues/835
  */
@@ -204,7 +204,7 @@ td.tw-break-words {
   overflow-wrap: anywhere;
 }
 
-/** 
+/**
  * tw-list-none hides summary arrow in Firefox & Chrome but not Safari:
  * https://github.com/tailwindlabs/tailwindcss/issues/924#issuecomment-915509785
  */
@@ -213,7 +213,7 @@ summary.tw-list-none::-webkit-details-marker {
   display: none;
 }
 
-/** 
+/**
  * Arbitrary values can't be used with `text-align`:
  * https://github.com/tailwindlabs/tailwindcss/issues/802#issuecomment-849013311
  */
@@ -222,10 +222,11 @@ summary.tw-list-none::-webkit-details-marker {
 }
 
 /**
- * Bootstrap uses z-index: 1050 for modals, dialogs should appear above them.
+ * Bootstrap uses z-index: 1050 for modals, dialogs and drag-and-drop previews should appear above them.
  * Remove once bootstrap is removed from our codebase.
  * CL-XYZ
  */
+.cdk-drag-preview,
 .cdk-overlay-container,
 .cdk-global-overlay-wrapper,
 .cdk-overlay-connected-position-bounding-box,

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -223,7 +223,7 @@ summary.tw-list-none::-webkit-details-marker {
 
 /**
  * Bootstrap uses z-index: 1050 for modals, dialogs and drag-and-drop previews should appear above them.
- * Remove once bootstrap these styles should revisited to ensure that overlays display properly over other content.
+ * When bootstrap is removed, test if these styles are still needed and that overlays display properly over other content.
  * CL-483
  */
 .cdk-drag-preview,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12776](https://bitwarden.atlassian.net/browse/PM-12776)

## 📔 Objective

### Issue

The default `z-index` of draggable items from the CDK is 1000. There is a z-index of 2000 set for the dialog component causing the draggable preview to show up behind the dialog.

### Fix

Add the `cdk-drag-preview` class to the same styles as the dialog so they have the same z-index and thus the draggable item will display on top of the dialog. 

## 📸 Screenshots

| Web Vault | Browser (no change here, just validation it still works)|
|-|-|
|<video src="https://github.com/user-attachments/assets/3facef3c-aa83-46a5-97cf-d05a3c987caf" />|<video src="https://github.com/user-attachments/assets/526ae711-73ce-47b8-b10d-9e9a2123bae0" />|



## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12776]: https://bitwarden.atlassian.net/browse/PM-12776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ