### PR TITLE
[PM-11920] Remove platformUtilService.showToast call

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
@@ -105,6 +105,11 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
 
   copyDnsTxt(): void {
     this.orgDomainService.copyDnsTxt(this.txtCtrl.value);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("valueCopied", this.i18nService.t("dnsTxtRecord")),
+    });
   }
 
   // End Form methods

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
@@ -101,6 +101,11 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
 
   copyDnsTxt(dnsTxt: string): void {
     this.orgDomainService.copyDnsTxt(dnsTxt);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("valueCopied", this.i18nService.t("dnsTxtRecord")),
+    });
   }
 
   async verifyDomain(orgDomainId: string, domainName: string): Promise<void> {

--- a/libs/common/src/admin-console/services/organization-domain/org-domain.service.spec.ts
+++ b/libs/common/src/admin-console/services/organization-domain/org-domain.service.spec.ts
@@ -180,6 +180,5 @@ describe("Org Domain Service", () => {
   it("copyDnsTxt copies DNS TXT to clipboard and shows toast", () => {
     orgDomainService.copyDnsTxt("fakeTxt");
     expect(jest.spyOn(platformUtilService, "copyToClipboard")).toHaveBeenCalled();
-    expect(jest.spyOn(platformUtilService, "showToast")).toHaveBeenCalled();
   });
 });

--- a/libs/common/src/admin-console/services/organization-domain/org-domain.service.ts
+++ b/libs/common/src/admin-console/services/organization-domain/org-domain.service.ts
@@ -23,11 +23,6 @@ export class OrgDomainService implements OrgDomainInternalServiceAbstraction {
 
   copyDnsTxt(dnsTxt: string): void {
     this.platformUtilsService.copyToClipboard(dnsTxt);
-    this.platformUtilsService.showToast(
-      "success",
-      null,
-      this.i18nService.t("valueCopied", this.i18nService.t("dnsTxtRecord")),
-    );
   }
 
   upsert(orgDomains: OrganizationDomainResponse[]): void {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11920](https://bitwarden.atlassian.net/browse/PM-11920)

## 📔 Objective

This PR removes the deprecated call to `platformUtilsService.showToast` function in the `org-domain.service` and refactors the `domain-add-edit-dialog` and `domain-verification.component` to use the ToastService to show toasts when copying the DNS text.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11920]: https://bitwarden.atlassian.net/browse/PM-11920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ