### PR TITLE
Fix IPC proxy selection in prod when using ELECTRON_IS_DEV

### DIFF
--- a/apps/desktop/src/main/native-messaging.main.ts
+++ b/apps/desktop/src/main/native-messaging.main.ts
@@ -331,7 +331,7 @@ export class NativeMessagingMain {
     const ext = process.platform === "win32" ? ".exe" : "";
 
     if (isDev()) {
-      return path.join(
+      const devPath = path.join(
         this.appPath,
         "..",
         "desktop_native",
@@ -339,6 +339,12 @@ export class NativeMessagingMain {
         "debug",
         `desktop_proxy${ext}`,
       );
+
+      // isDev() returns true when using a production build with ELECTRON_IS_DEV=1,
+      // so we need to fall back to the prod binary if the dev binary doesn't exist.
+      if (existsSync(devPath)) {
+        return devPath;
+      }
     }
 
     return path.join(path.dirname(this.exePath), `desktop_proxy${ext}`);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

When running the desktop app in dev mode, we force the selection of IPC proxy binary to be the `target/debug` artifacts. This is fine when using `npm run electron`, but will fail when using the production builds and setting the ELECTRON_IS_DEV=1 environment variable.

By changing the behavior to check if the debug artifact exists first and falling back to the prod artifact, we allow this to work regardless of how the `isDev` flag got activated.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
