### PR TITLE
[PM-13177] Fix Unassigned cipher collection assignment in AC

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -1249,6 +1249,8 @@ export class VaultComponent implements OnInit, OnDestroy {
         organizationId: this.organization?.id as OrganizationId,
         availableCollections,
         activeCollection: this.activeFilter?.selectedCollectionNode?.node,
+        isSingleCipherAdmin:
+          items.length === 1 && (this.organization?.canEditAllCiphers || items[0].isUnassigned),
       },
     });
 

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -113,6 +113,13 @@ export abstract class CipherService implements UserKeyRotationDataProvider<Ciphe
    * @returns A promise that resolves when the collections have been saved
    */
   saveCollectionsWithServer: (cipher: Cipher) => Promise<Cipher>;
+
+  /**
+   * Save the collections for a cipher with the server as an admin.
+   * Used for Unassigned ciphers or when the user only has admin access to the cipher (not assigned normally).
+   * @param cipher
+   */
+  saveCollectionsWithServerAdmin: (cipher: Cipher) => Promise<void>;
   /**
    * Bulk update collections for many ciphers with the server
    * @param orgId

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -858,6 +858,11 @@ export class CipherService implements CipherServiceAbstraction {
     return new Cipher(updated[cipher.id as CipherId], cipher.localData);
   }
 
+  async saveCollectionsWithServerAdmin(cipher: Cipher): Promise<void> {
+    const request = new CipherCollectionsRequest(cipher.collectionIds);
+    await this.apiService.putCipherCollectionsAdmin(cipher.id, request);
+  }
+
   /**
    * Bulk update collections for many ciphers with the server
    * @param orgId

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -64,6 +64,15 @@ export interface CollectionAssignmentParams {
    * removed from the ciphers upon submission.
    */
   activeCollection?: CollectionView;
+
+  /**
+   * Flag indicating if the user is performing the action as an admin on a SINGLE cipher. When true,
+   * the `/admin` endpoint will be used to update the cipher's collections. Required when updating
+   * ciphers an Admin does not normally have access to or for Unassigned ciphers.
+   *
+   * The bulk method already handles admin actions internally.
+   */
+  isSingleCipherAdmin?: boolean;
 }
 
 export enum CollectionAssignmentResult {
@@ -463,6 +472,10 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
     const { collections } = this.formGroup.getRawValue();
     cipherView.collectionIds = collections.map((i) => i.id as CollectionId);
     const cipher = await this.cipherService.encrypt(cipherView, this.activeUserId);
-    await this.cipherService.saveCollectionsWithServer(cipher);
+    if (this.params.isSingleCipherAdmin) {
+      await this.cipherService.saveCollectionsWithServerAdmin(cipher);
+    } else {
+      await this.cipherService.saveCollectionsWithServer(cipher);
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13177](https://bitwarden.atlassian.net/browse/PM-13177)

## 📔 Objective

Add logic to the Assign To Collections dialog to handle Unassigned ciphers and ciphers that an admin does not "normally" have access to when assigning ciphers in the Admin Console.

Previously, the AC would attempt to use the normal `/collections_v2` endpoint which did not properly support the above scenario. We already have an `collections/admin` endpoint that was in use by the old Collections dialog, so this is a drop in replacement.

## 📸 Screenshots


https://github.com/user-attachments/assets/61b99e13-34e1-452c-bd89-f4c6b253a1b5


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13177]: https://bitwarden.atlassian.net/browse/PM-13177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ