### PR TITLE
[PM-11290] Fix safari not starting with sdk

### DIFF
--- a/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
+++ b/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
@@ -1,6 +1,8 @@
 import { SdkClientFactory } from "@bitwarden/common/platform/abstractions/sdk/sdk-client-factory";
 import type { BitwardenClient } from "@bitwarden/sdk-internal";
 
+import { BrowserApi } from "../../browser/browser-api";
+
 // https://stackoverflow.com/a/47880734
 const supported = (() => {
   try {
@@ -18,15 +20,33 @@ const supported = (() => {
   return false;
 })();
 
-async function load() {
+// Manifest v3 does not support dynamic imports in the service worker.
+if (BrowserApi.isManifestVersion(3)) {
   if (supported) {
     // eslint-disable-next-line no-console
     console.debug("WebAssembly is supported in this environment");
-    await import("./wasm");
+    import("./wasm");
   } else {
     // eslint-disable-next-line no-console
     console.debug("WebAssembly is not supported in this environment");
-    await import("./fallback");
+    import("./fallback");
+  }
+}
+
+// Manifest v2 expects dynamic imports to prevent timing issues.
+async function load() {
+  if (BrowserApi.isManifestVersion(3)) {
+    return;
+  }
+
+  if (supported) {
+    // eslint-disable-next-line no-console
+    console.debug("WebAssembly is supported in this environment");
+    import("./wasm");
+  } else {
+    // eslint-disable-next-line no-console
+    console.debug("WebAssembly is not supported in this environment");
+    import("./fallback");
   }
 }
 

--- a/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
+++ b/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
@@ -42,11 +42,11 @@ async function load() {
   if (supported) {
     // eslint-disable-next-line no-console
     console.debug("WebAssembly is supported in this environment");
-    import("./wasm");
+    await import("./wasm");
   } else {
     // eslint-disable-next-line no-console
     console.debug("WebAssembly is not supported in this environment");
-    import("./fallback");
+    await import("./fallback");
   }
 }
 

--- a/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
+++ b/apps/browser/src/platform/services/sdk/browser-sdk-client-factory.ts
@@ -18,14 +18,16 @@ const supported = (() => {
   return false;
 })();
 
-if (supported) {
-  // eslint-disable-next-line no-console
-  console.debug("WebAssembly is supported in this environment");
-  import("./wasm");
-} else {
-  // eslint-disable-next-line no-console
-  console.debug("WebAssembly is not supported in this environment");
-  import("./fallback");
+async function load() {
+  if (supported) {
+    // eslint-disable-next-line no-console
+    console.debug("WebAssembly is supported in this environment");
+    await import("./wasm");
+  } else {
+    // eslint-disable-next-line no-console
+    console.debug("WebAssembly is not supported in this environment");
+    await import("./fallback");
+  }
 }
 
 /**
@@ -37,6 +39,8 @@ export class BrowserSdkClientFactory implements SdkClientFactory {
   async createSdkClient(
     ...args: ConstructorParameters<typeof BitwardenClient>
   ): Promise<BitwardenClient> {
+    await load();
+
     return Promise.resolve((globalThis as any).init_sdk(...args));
   }
 }

--- a/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
+++ b/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 /* Begin PBXFileReference section */
 		03100CAE291891F4008E14EF /* encrypt-worker.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "encrypt-worker.js"; path = "../../../build/encrypt-worker.js"; sourceTree = "<group>"; };
 		5508DD7926051B5900A85C58 /* libswiftAppKit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftAppKit.tbd; path = usr/lib/swift/libswiftAppKit.tbd; sourceTree = SDKROOT; };
-		55BC93922CB4268A008CA4C6 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = /Users/oscar/Code/clients/apps/browser/build/assets; sourceTree = "<group>"; };
+		55BC93922CB4268A008CA4C6 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../../../build/assets; sourceTree = "<group>"; };
 		55E037482577FA6B00979016 /* desktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = desktop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		55E0374B2577FA6B00979016 /* desktop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = desktop.entitlements; sourceTree = "<group>"; };
 		55E0374C2577FA6B00979016 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };

--- a/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
+++ b/apps/browser/src/safari/desktop.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		03100CAF291891F4008E14EF /* encrypt-worker.js in Resources */ = {isa = PBXBuildFile; fileRef = 03100CAE291891F4008E14EF /* encrypt-worker.js */; };
+		55BC93932CB4268A008CA4C6 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 55BC93922CB4268A008CA4C6 /* assets */; };
 		55E0374D2577FA6B00979016 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E0374C2577FA6B00979016 /* AppDelegate.swift */; };
 		55E037502577FA6B00979016 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55E0374E2577FA6B00979016 /* Main.storyboard */; };
 		55E037522577FA6B00979016 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E037512577FA6B00979016 /* ViewController.swift */; };
@@ -54,6 +55,7 @@
 /* Begin PBXFileReference section */
 		03100CAE291891F4008E14EF /* encrypt-worker.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "encrypt-worker.js"; path = "../../../build/encrypt-worker.js"; sourceTree = "<group>"; };
 		5508DD7926051B5900A85C58 /* libswiftAppKit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftAppKit.tbd; path = usr/lib/swift/libswiftAppKit.tbd; sourceTree = SDKROOT; };
+		55BC93922CB4268A008CA4C6 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = /Users/oscar/Code/clients/apps/browser/build/assets; sourceTree = "<group>"; };
 		55E037482577FA6B00979016 /* desktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = desktop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		55E0374B2577FA6B00979016 /* desktop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = desktop.entitlements; sourceTree = "<group>"; };
 		55E0374C2577FA6B00979016 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 		55E0376F2577FA6F00979016 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				55BC93922CB4268A008CA4C6 /* assets */,
 				03100CAE291891F4008E14EF /* encrypt-worker.js */,
 				55E037702577FA6F00979016 /* popup */,
 				55E037712577FA6F00979016 /* background.js */,
@@ -270,6 +273,7 @@
 				55E0377A2577FA6F00979016 /* background.js in Resources */,
 				55E037792577FA6F00979016 /* popup in Resources */,
 				03100CAF291891F4008E14EF /* encrypt-worker.js in Resources */,
+				55BC93932CB4268A008CA4C6 /* assets in Resources */,
 				55E0377C2577FA6F00979016 /* notification in Resources */,
 				55E0377E2577FA6F00979016 /* vendor.js in Resources */,
 				55E0377D2577FA6F00979016 /* content in Resources */,

--- a/apps/browser/webpack.config.js
+++ b/apps/browser/webpack.config.js
@@ -316,6 +316,8 @@ const mainConfig = {
   },
   output: {
     filename: "[name].js",
+    chunkFilename: "assets/[name].js",
+    webassemblyModuleFilename: "assets/[modulehash].wasm",
     path: path.resolve(__dirname, "build"),
     clean: true,
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-11290

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We ran into some inconsistencies between how manifest v2 and v3 are handled in browsers. To resolve this we have a different flow for manifest v2 which dynamically imports, while v3 uses the sync importScripts.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
