### PR TITLE
[PM-12548] Fido2 scripts should not load when user is logged out

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -1484,9 +1484,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   }
 
   /**
-   * Gets the user's authentication status from the auth service. If the user's authentication
-   * status has changed, the inline menu button's authentication status will be updated
-   * and the inline menu list's ciphers will be updated.
+   * Gets the user's authentication status from the auth service.
    */
   private async getAuthStatus() {
     return await firstValueFrom(this.authService.activeAccountStatus$);

--- a/apps/browser/src/autofill/fido2/background/abstractions/fido2.background.ts
+++ b/apps/browser/src/autofill/fido2/background/abstractions/fido2.background.ts
@@ -45,7 +45,6 @@ type Fido2BackgroundExtensionMessageHandlers = {
 
 interface Fido2Background {
   init(): void;
-  injectFido2ContentScriptsInAllTabs(): Promise<void>;
 }
 
 export {

--- a/apps/browser/src/autofill/fido2/background/fido2.background.ts
+++ b/apps/browser/src/autofill/fido2/background/fido2.background.ts
@@ -1,6 +1,8 @@
-import { firstValueFrom, startWith } from "rxjs";
+import { firstValueFrom, startWith, Subscription } from "rxjs";
 import { pairwise } from "rxjs/operators";
 
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Fido2ActiveRequestManager } from "@bitwarden/common/platform/abstractions/fido2/fido2-active-request-manager.abstraction";
@@ -29,6 +31,7 @@ import {
 } from "./abstractions/fido2.background";
 
 export class Fido2Background implements Fido2BackgroundInterface {
+  private currentAuthStatus$: Subscription;
   private abortManager = new AbortManager();
   private fido2ContentScriptPortsSet = new Set<chrome.runtime.Port>();
   private registeredContentScripts: browser.contentScripts.RegisteredContentScript;
@@ -55,6 +58,7 @@ export class Fido2Background implements Fido2BackgroundInterface {
     private vaultSettingsService: VaultSettingsService,
     private scriptInjectorService: ScriptInjectorService,
     private configService: ConfigService,
+    private authService: AuthService,
   ) {}
 
   /**
@@ -68,12 +72,32 @@ export class Fido2Background implements Fido2BackgroundInterface {
     this.vaultSettingsService.enablePasskeys$
       .pipe(startWith(undefined), pairwise())
       .subscribe(([previous, current]) => this.handleEnablePasskeysUpdate(previous, current));
+    this.currentAuthStatus$ = this.authService.activeAccountStatus$
+      .pipe(startWith(undefined), pairwise())
+      .subscribe(([_previous, current]) => this.handleAuthStatusUpdate(current));
+  }
+
+  /**
+   * Handles initializing the FIDO2 content scripts based on the current
+   * authentication status. We only want to inject the FIDO2 content scripts
+   * if the user is logged in.
+   *
+   * @param authStatus - The current authentication status.
+   */
+  private async handleAuthStatusUpdate(authStatus: AuthenticationStatus) {
+    if (authStatus === AuthenticationStatus.LoggedOut) {
+      return;
+    }
+
+    const enablePasskeys = await this.isPasskeySettingEnabled();
+    await this.handleEnablePasskeysUpdate(enablePasskeys, enablePasskeys);
+    this.currentAuthStatus$.unsubscribe();
   }
 
   /**
    * Injects the FIDO2 content and page script into all existing browser tabs.
    */
-  async injectFido2ContentScriptsInAllTabs() {
+  private async injectFido2ContentScriptsInAllTabs() {
     const tabs = await BrowserApi.tabsQuery({});
 
     for (let index = 0; index < tabs.length; index++) {
@@ -83,6 +107,13 @@ export class Fido2Background implements Fido2BackgroundInterface {
         void this.injectFido2ContentScripts(tab);
       }
     }
+  }
+
+  /**
+   * Gets the user's authentication status from the auth service.
+   */
+  private async getAuthStatus() {
+    return await firstValueFrom(this.authService.activeAccountStatus$);
   }
 
   /**
@@ -98,12 +129,16 @@ export class Fido2Background implements Fido2BackgroundInterface {
     previousEnablePasskeysSetting: boolean,
     enablePasskeys: boolean,
   ) {
-    this.fido2ActiveRequestManager.removeAllActiveRequests();
-    await this.updateContentScriptRegistration();
+    if ((await this.getAuthStatus()) === AuthenticationStatus.LoggedOut) {
+      return;
+    }
 
     if (previousEnablePasskeysSetting === undefined) {
       return;
     }
+
+    this.fido2ActiveRequestManager.removeAllActiveRequests();
+    await this.updateContentScriptRegistration();
 
     this.destroyLoadedFido2ContentScripts();
     if (enablePasskeys) {

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script-append.mv2.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script-append.mv2.ts
@@ -9,6 +9,7 @@
 
   const script = globalContext.document.createElement("script");
   script.src = chrome.runtime.getURL("content/fido2-page-script.js");
+  script.async = false;
 
   const scriptInsertionPoint =
     globalContext.document.head || globalContext.document.documentElement;

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script-delay-append.mv2.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script-delay-append.mv2.ts
@@ -9,6 +9,7 @@
 
   const script = globalContext.document.createElement("script");
   script.src = chrome.runtime.getURL("content/fido2-page-script.js");
+  script.async = false;
 
   // We are ensuring that the script injection is delayed in the event that we are loading
   // within an iframe element. This prevents an issue with web mail clients that load content

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
@@ -4,7 +4,11 @@ import { MessageType } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 (function (globalContext) {
-  globalContext.document.currentScript.parentNode.removeChild(globalContext.document.currentScript);
+  if (globalContext.document.currentScript) {
+    globalContext.document.currentScript.parentNode.removeChild(
+      globalContext.document.currentScript,
+    );
+  }
 
   const shouldExecuteContentScript =
     globalContext.document.contentType === "text/html" &&

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
@@ -4,6 +4,8 @@ import { MessageType } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 (function (globalContext) {
+  globalContext.document.currentScript.parentNode.removeChild(globalContext.document.currentScript);
+
   const shouldExecuteContentScript =
     globalContext.document.contentType === "text/html" &&
     (globalContext.document.location.protocol === "https:" ||

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1104,6 +1104,7 @@ export default class MainBackground {
         this.vaultSettingsService,
         this.scriptInjectorService,
         this.configService,
+        this.authService,
       );
 
       const lockService = new DefaultLockService(this.accountService, this.vaultTimeoutService);
@@ -1119,7 +1120,6 @@ export default class MainBackground {
         this.messagingService,
         this.logService,
         this.configService,
-        this.fido2Background,
         messageListener,
         this.accountService,
         lockService,

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -21,7 +21,6 @@ import {
   openTwoFactorAuthPopout,
 } from "../auth/popup/utils/auth-popout-window";
 import { LockedVaultPendingNotificationsData } from "../autofill/background/abstractions/notification.background";
-import { Fido2Background } from "../autofill/fido2/background/abstractions/fido2.background";
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
 import { BrowserApi } from "../platform/browser/browser-api";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
@@ -46,7 +45,6 @@ export default class RuntimeBackground {
     private messagingService: MessagingService,
     private logService: LogService,
     private configService: ConfigService,
-    private fido2Background: Fido2Background,
     private messageListener: MessageListener,
     private accountService: AccountService,
     private readonly lockService: LockService,
@@ -365,7 +363,6 @@ export default class RuntimeBackground {
 
   private async checkOnInstalled() {
     setTimeout(async () => {
-      void this.fido2Background.injectFido2ContentScriptsInAllTabs();
       void this.autofillService.loadAutofillScriptsOnInstall();
 
       if (this.onInstalledReason != null) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12548

## 📔 Objective

The content scripts used to override the Webauthn  API are being injected when a user is in a logged out state. This problem introduces an issue where we break the default Webauthn API since an un-authed user cannot respond to the overriden Webauthn API call in any manner.

The changes in this PR address that problem by reworking how we handle injecting the fido2 content scripts on load of the extension. Effectively, we should only be injecting those scripts if the user is logged in or shortly after the user logs into the browser extension.

Resolves https://github.com/bitwarden/clients/issues/11199#issuecomment-2395593752

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
