### PR TITLE
[CL-469] ScrollBar Styles

### DIFF
--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -5,24 +5,22 @@
 @import "../../../../../libs/components/src/tw-theme.css";
 
 @layer components {
-  /* Chrome / Safari support */
-  .tw-styled-scrollbar::-webkit-scrollbar {
+  /** Safari Support */
+  html.browser_safari .tw-styled-scrollbar::-webkit-scrollbar {
     @apply tw-overflow-auto;
   }
-  .tw-styled-scrollbar::-webkit-scrollbar-thumb {
+  html.browser_safari .tw-styled-scrollbar::-webkit-scrollbar-thumb {
     @apply tw-bg-secondary-500 tw-rounded-lg tw-border-4 tw-border-solid tw-border-transparent tw-bg-clip-content;
   }
-  .tw-styled-scrollbar::-webkit-scrollbar-track {
+  html.browser_safari .tw-styled-scrollbar::-webkit-scrollbar-track {
     @apply tw-bg-background-alt;
   }
-  .tw-styled-scrollbar::-webkit-scrollbar-thumb:hover {
+  html.browser_safari .tw-styled-scrollbar::-webkit-scrollbar-thumb:hover {
     @apply tw-bg-secondary-600;
   }
 
-  /* FireFox support */
-  .tw-styled-scrollbar {
-    @supports (-moz-appearance: none) {
-      scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background-alt));
-    }
+  /* FireFox & Chrome support */
+  html:not(.browser_safari) .tw-styled-scrollbar {
+    scrollbar-color: rgb(var(--color-secondary-500)) rgb(var(--color-background-alt));
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[CL-469](https://bitwarden.atlassian.net/browse/CL-469)

## 📔 Objective

Implements scrollbar styles specific to browsers. See the comments in [CL-469](https://bitwarden.atlassian.net/browse/CL-469) for the options/discussion.
- Chrome and FireFox support the scrollbar-color CSS attribute that respects the macOS setting for only showing a scrollbar when scrolling
- Safari needs webkit specific styling which does not respect the macOS scrollbar settings

## 📸 Screenshots

|Chrome|FireFox|Safari|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/dd71e033-fb83-4aaf-a0e1-460a15532472"/>|<video src="https://github.com/user-attachments/assets/f7edaa4f-cbe0-4ed9-b97a-7557655be593"/>|<video src="https://github.com/user-attachments/assets/c3e9e0ce-c6a5-4051-ac18-9ac8e2be7e5b"/>|


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-469]: https://bitwarden.atlassian.net/browse/CL-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-469]: https://bitwarden.atlassian.net/browse/CL-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ