### PR TITLE
[PM-12355] Password Toggle Order

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -37,15 +37,6 @@
         data-testid="login-password"
       />
       <button
-        *ngIf="cipher.viewPassword"
-        bitSuffix
-        type="button"
-        bitIconButton
-        bitPasswordInputToggle
-        data-testid="toggle-password"
-        (toggledChange)="pwToggleValue($event)"
-      ></button>
-      <button
         *ngIf="cipher.viewPassword && passwordRevealed"
         bitIconButton="bwi-numbered-list"
         bitSuffix
@@ -55,6 +46,15 @@
         [attr.aria-expanded]="showPasswordCount"
         appStopClick
         (click)="togglePasswordCount()"
+      ></button>
+      <button
+        *ngIf="cipher.viewPassword"
+        bitSuffix
+        type="button"
+        bitIconButton
+        bitPasswordInputToggle
+        data-testid="toggle-password"
+        (toggledChange)="pwToggleValue($event)"
       ></button>
       <button
         *ngIf="cipher.viewPassword"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12355](https://bitwarden.atlassian.net/browse/PM-12355)

## 📔 Objective

Move the password count to display before the password toggle. The password count used to force the password toggle out from underneath the users mouse.

## 📸 Screenshots

Admin Console, Password Manager, Extension
<video src="https://github.com/user-attachments/assets/b73cba45-b52b-4c40-8d1f-b059b037aca2" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12355]: https://bitwarden.atlassian.net/browse/PM-12355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ