### PR TITLE
[PM-13271] Remove unused ci:coverage from gulpfile

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -168,10 +168,6 @@ jobs:
         run: npm run dist:chrome:beta
         working-directory: browser-source/apps/browser
 
-      - name: Gulp
-        run: gulp ci
-        working-directory: browser-source/apps/browser
-
       - name: Upload Opera artifact
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
@@ -233,14 +229,6 @@ jobs:
         with:
           name: browser-source-${{ env._BUILD_NUMBER }}.zip
           path: browser-source.zip
-          if-no-files-found: error
-
-      - name: Upload coverage artifact
-        if: false
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-        with:
-          name: coverage-${{ env._BUILD_NUMBER }}.zip
-          path: browser-source/apps/browser/coverage/coverage-${{ env._BUILD_NUMBER }}.zip
           if-no-files-found: error
 
   build-safari:

--- a/apps/browser/gulpfile.js
+++ b/apps/browser/gulpfile.js
@@ -14,7 +14,6 @@ const betaBuild = process.env.BETA_BUILD === "1";
 const paths = {
   build: "./build/",
   dist: "./dist/",
-  coverage: "./coverage/",
   node_modules: "./node_modules/",
   popupDir: "./src/popup/",
   cssDir: "./src/popup/css/",
@@ -276,17 +275,6 @@ function stdOutProc(proc) {
   proc.stderr.on("data", (data) => console.error(data.toString()));
 }
 
-async function ciCoverage(cb) {
-  const { default: zip } = await import("gulp-zip");
-  const { default: filter } = await import("gulp-filter");
-
-  return gulp
-    .src(paths.coverage + "**/*")
-    .pipe(filter(["**", "!coverage/coverage*.zip"]))
-    .pipe(zip(`coverage${buildString()}.zip`))
-    .pipe(gulp.dest(paths.coverage));
-}
-
 function applyBetaLabels(manifest) {
   manifest.name = "Bitwarden Password Manager BETA";
   manifest.short_name = "Bitwarden BETA";
@@ -320,5 +308,3 @@ exports["dist:safari:mas"] = distSafariMas;
 exports["dist:safari:masdev"] = distSafariMasDev;
 exports["dist:safari:dmg"] = distSafariDmg;
 exports.dist = gulp.parallel(distFirefox, distChrome, distOpera, distEdge);
-exports["ci:coverage"] = ciCoverage;
-exports.ci = ciCoverage;

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -26,7 +26,6 @@
     "dist:safari:masdev": "npm run build:prod && gulp dist:safari:masdev",
     "dist:safari:dmg": "npm run build:prod && gulp dist:safari:dmg",
     "test": "jest",
-    "test:coverage": "jest --coverage --coverageDirectory=coverage",
     "test:watch": "jest --watch",
     "test:watch:all": "jest --watchAll"
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-13271

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Part of the browser build script refactor effort.

Remove the gulp coverage report since we now use jest, and coverage is handled through the root coverage report which is done in a different script.

Supersedes https://github.com/bitwarden/clients/pull/4781.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
