### PR TITLE
[PM-13279] Adding a new cipher in the admin console

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault.component.ts
@@ -788,8 +788,8 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Edit the given cipher
-   * @param cipherView - The cipher to be edited
+   * Edit the given cipher or add a new cipher
+   * @param cipherView - When set, the cipher to be edited
    * @param cloneCipher - `true` when the cipher should be cloned.
    * Used in place of the `additionalComponentParameters`, as
    * the `editCipherIdV2` method has a differing implementation.
@@ -797,7 +797,7 @@ export class VaultComponent implements OnInit, OnDestroy {
    * the `AddEditComponent` to edit methods directly.
    */
   async editCipher(
-    cipher: CipherView,
+    cipher: CipherView | null,
     cloneCipher: boolean,
     additionalComponentParameters?: (comp: AddEditComponent) => void,
   ) {
@@ -805,7 +805,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async editCipherId(
-    cipher: CipherView,
+    cipher: CipherView | null,
     cloneCipher: boolean,
     additionalComponentParameters?: (comp: AddEditComponent) => void,
   ) {
@@ -827,7 +827,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     const defaultComponentParameters = (comp: AddEditComponent) => {
       comp.organization = this.organization;
       comp.organizationId = this.organization.id;
-      comp.cipherId = cipher.id;
+      comp.cipherId = cipher?.id;
       comp.onSavedCipher.pipe(takeUntil(this.destroy$)).subscribe(() => {
         modal.close();
         this.refresh();
@@ -866,10 +866,10 @@ export class VaultComponent implements OnInit, OnDestroy {
    * Edit a cipher using the new AddEditCipherDialogV2 component.
    * Only to be used behind the ExtensionRefresh feature flag.
    */
-  private async editCipherIdV2(cipher: CipherView, cloneCipher: boolean) {
+  private async editCipherIdV2(cipher: CipherView | null, cloneCipher: boolean) {
     const cipherFormConfig = await this.cipherFormConfigService.buildConfig(
       cloneCipher ? "clone" : "edit",
-      cipher.id as CipherId,
+      cipher?.id as CipherId | null,
     );
 
     await this.openVaultItemDialog("form", cipherFormConfig, cipher);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13279](https://bitwarden.atlassian.net/browse/PM-13279)

## 📔 Objective

The types for the `editCipher` method were a little misleading causing a runtime error. The `cipherView` parameter can be `null` when adding a cipher.
- Updated the corresponding types and all downstream logic to account for a `null` cipher value.

## 📸 Screenshots

|Admin Console - No Extension Refresh Flag| Admin Console with Extension Refresh Flag|
|-|-|
|<video src="https://github.com/user-attachments/assets/bdb923d4-ccdb-4b48-92e9-0b111fbe904d"/>|<video src="https://github.com/user-attachments/assets/6cb6816e-7b5c-4835-941c-5faad6a668ef"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13279]: https://bitwarden.atlassian.net/browse/PM-13279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ