### PR TITLE
[PM-9876] Safari Passkeys Prompt is Not Triggered

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.register-content-scripts-polyfill.ts
+++ b/apps/browser/src/platform/browser/browser-api.register-content-scripts-polyfill.ts
@@ -43,23 +43,17 @@ function buildRegisterContentScriptsPolyfill() {
   function NestedProxy<T extends object>(target: T): T {
     return new Proxy(target, {
       get(target, prop) {
-        const propertyValue = target[prop as keyof T];
-
-        if (!propertyValue) {
+        if (!target[prop as keyof T]) {
           return;
         }
 
-        if (typeof propertyValue === "object") {
-          return NestedProxy<typeof propertyValue>(propertyValue);
-        }
-
-        if (typeof propertyValue !== "function") {
-          return propertyValue;
+        if (typeof target[prop as keyof T] !== "function") {
+          return NestedProxy(target[prop as keyof T] as object);
         }
 
         return (...arguments_: any[]) =>
           new Promise((resolve, reject) => {
-            propertyValue(...arguments_, (result: any) => {
+            (target[prop as keyof T] as CallableFunction)(...arguments_, (result: any) => {
               if (chrome.runtime.lastError) {
                 reject(new Error(chrome.runtime.lastError.message));
               } else {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9876

## 📔 Objective

Some changes made recently to facilitate upgrading to Typescript 5.3 have created an issue within Safari where the expected passkeys workflow is not triggering as expected. Modifications were made to the `browser-api.register-content-script-polyfill.ts` typings to ensure that Typescript 5.3 can compile as expected.

Those changes are reverted instead opting to use a casted `as` reference on the two areas that present problems in Typescript 5.3. [This fix can be seen on this JS playground link.](https://www.typescriptlang.org/play/?ts=5.3.3#code/CYUwxgNghgTiAEA3W8wAsYHsC2IBc8UAdgJ4DcAUBfPAGYCuRYALgJaZHwByIAzsyGAAFLAA8SAHgAq8EKIFFgveJgBGAK3DMAfAApmsAOYhmBKQEoz8AN7Ua8OM3oxOREAHd4IzOP1GTADQ2dvbwxsx+MOFBAA5YMebBoaGstPC6AIQGUSYA2nGYMYTKANYgJJhpUgC6ibbJyY7ORJQNNAC+VG3wqenMJDEglfDZ4fnxxfBlFVXV8BkAvAvwAEQMTGwcK3UhbU0u3HwCwmIkkWMFRVCl5cM1k2qaLOatbZ27ofucugB0f0b0XBEZi8AD6BGIJFytXgC20H2Sbk83mwrF4IF0ujgvEwEEQICCcCezEScKS3Xs5zyl0m0zuc2u8AAwlAINBVBAQAAxRgsdhEcy-f5RQEgYFgoJYvj0CCmQikUnackU+y9XToLC4H4wRhsLXQfgAURgWBgOxVDSJWl0SPgxtN6owOBA2t1rH112Y9swMB+uF4vCgxnMLwR3Xasgg6OVFpo2Nx+KlvBlJNesc66dDKvaWeS7QCuxzr3aQA)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
