### PR TITLE
[CL-481] Style updates for bit-item, bit-card, and primary-100

### DIFF
--- a/libs/components/src/card/card.component.ts
+++ b/libs/components/src/card/card.component.ts
@@ -9,7 +9,7 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class:
-      "tw-box-border tw-block tw-bg-background tw-text-main tw-border-solid tw-border-b tw-border-0 tw-border-b-secondary-300 [&:not(bit-layout_*)]:tw-rounded-lg tw-py-4 tw-px-3",
+      "tw-box-border tw-block tw-bg-background tw-text-main tw-border-solid tw-border-b tw-border-0 tw-border-b-secondary-300 [&:not(bit-layout_*)]:tw-rounded-lg [&:not(bit-layout_*)]:tw-border-b-shadow tw-py-4 tw-px-3",
   },
 })
 export class CardComponent {}

--- a/libs/components/src/item/item.component.html
+++ b/libs/components/src/item/item.component.html
@@ -3,7 +3,7 @@
   [ngClass]="
     focusVisibleWithin()
       ? 'tw-z-10 tw-rounded tw-outline-none tw-ring tw-ring-primary-600 tw-border-transparent'
-      : 'tw-border-b-secondary-300 [&:has(.item-main-content_button:hover,.item-main-content_a:hover)]:tw-border-b-transparent'
+      : 'tw-border-b-shadow'
   "
 >
   <bit-item-action class="item-main-content tw-block tw-flex-1 tw-overflow-hidden">

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -2,6 +2,7 @@
 
 :root {
   --color-transparent-hover: rgb(0 0 0 / 0.02);
+  --color-shadow: 168 179 200;
 
   --color-background: 255 255 255;
   --color-background-alt: 243 246 249;
@@ -56,6 +57,7 @@
 
 .theme_dark {
   --color-transparent-hover: rgb(255 255 255 / 0.02);
+  --color-shadow: 0 0 0;
 
   --color-background: 32 39 51;
   --color-background-alt: 18 26 39;
@@ -63,7 +65,7 @@
   --color-background-alt3: 48 57 70;
   --color-background-alt4: 18 26 39;
 
-  --color-primary-100: 2 15 102;
+  --color-primary-100: 26 39 78;
   --color-primary-300: 26 65 172;
   --color-primary-600: 101 171 255;
   --color-primary-700: 170 195 239;

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -23,6 +23,7 @@ module.exports = {
       },
       current: colors.current,
       black: colors.black,
+      shadow: rgba("--color-shadow"),
       primary: {
         100: rgba("--color-primary-100"),
         300: rgba("--color-primary-300"),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-481](https://bitwarden.atlassian.net/browse/CL-481)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR:
- Updates the color of `primary-100` in dark mode
- Displays the `bit-item` border on hover
- Switches `bit-card` and `bit-item` to use a new `shadow` color for their bottom borders. The `shadow` color ensures that the item and card look "popped out" instead of "sunken in". The only exclusion is when `bit-card` is used within `bit-layout`, because its border transforms from a bottom shadow to a divider and thus should remain light-colored in dark mode.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="583" alt="Screenshot 2024-10-09 at 12 14 08 PM" src="https://github.com/user-attachments/assets/fd0af3d8-b7e8-4a1b-9774-6358dd680334">

<img width="583" alt="Screenshot 2024-10-09 at 12 14 42 PM" src="https://github.com/user-attachments/assets/a1e9c89b-eafa-4f81-82e8-2191d1ed7fb8">

<img width="583" alt="Screenshot 2024-10-09 at 12 14 46 PM" src="https://github.com/user-attachments/assets/6aa73830-33c7-4b5f-a25d-dcafdea05be7">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-481]: https://bitwarden.atlassian.net/browse/CL-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ