### PR TITLE
[PM-13350] Fix sorting on weak-password report

### DIFF
--- a/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.html
@@ -39,7 +39,7 @@
             <th bitCell bitSortable="organizationId" *ngIf="!isAdminConsoleActive">
               {{ "owner" | i18n }}
             </th>
-            <th bitCell class="tw-text-right" bitSortable="reportValue" default>
+            <th bitCell class="tw-text-right" bitSortable="score" default>
               {{ "weakness" | i18n }}
             </th>
           </tr>

--- a/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
@@ -15,7 +15,7 @@ import { PasswordRepromptService } from "@bitwarden/vault";
 import { CipherReportComponent } from "./cipher-report.component";
 
 type ReportScore = { label: string; badgeVariant: BadgeVariant };
-type ReportResult = CipherView & { reportValue: ReportScore };
+type ReportResult = CipherView & { score: number; reportValue: ReportScore };
 
 @Component({
   selector: "app-weak-passwords-report",
@@ -100,7 +100,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
       if (result.score != null && result.score <= 2) {
         const scoreValue = this.scoreKey(result.score);
-        const row = { ...ciph, reportValue: scoreValue } as ReportResult;
+        const row = { ...ciph, score: result.score, reportValue: scoreValue } as ReportResult;
         this.weakPasswordCiphers.push(row);
       }
     });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13350

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix the sorting by weakness on the weak-password report. The `bitSortable` does not support sorting by object/object-key so I had to add the scoring to the result row as an independent property.

Change will need to be 🍒 ⛏️ 'ed to `rc`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
