### PR TITLE
[PM-13312] Task scheduler loses event callback reference when popout opens

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -563,8 +563,8 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: ForegroundTaskSchedulerService,
-    useFactory: getBgService<ForegroundTaskSchedulerService>("taskSchedulerService"),
-    deps: [],
+    useClass: ForegroundTaskSchedulerService,
+    deps: [LogService, StateProvider],
   }),
   safeProvider({
     provide: AnonLayoutWrapperDataService,

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -563,7 +563,13 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: ForegroundTaskSchedulerService,
-    useClass: ForegroundTaskSchedulerService,
+    useFactory: (logService: LogService, stateProvider: StateProvider) => {
+      if (needsBackgroundInit) {
+        return getBgService<ForegroundTaskSchedulerService>("taskSchedulerService")();
+      }
+
+      return new ForegroundTaskSchedulerService(logService, stateProvider);
+    },
     deps: [LogService, StateProvider],
   }),
   safeProvider({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13312

## 📔 Objective

Usage of the `getBgService` reference within the Angular dependency structure for the browser extension popup is causing an issue with the `TaskSchedulerService` where a registered task handler method in the background script will be overwritten with a popup-based method. This causes a DeadObject issue within Firefox and other mv2 extension implementations. 

To resolve this, we need to remove usage of `getBgService` when instantiating the `TaskSchedulerService` for the popup.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
