### PR TITLE
[CL-477] Remove focus styles for readonly input

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -306,7 +306,7 @@ input[type="password"]::-ms-reveal {
 // contrast against the background, so its inversion is also still readable)
 // and suppress user selection for most elements (to make it more app-like)
 
-::selection {
+:not(bit-form-field input)::selection {
   @include themify($themes) {
     color: themed("backgroundColor");
     background-color: themed("primaryAccentColor");

--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -75,20 +75,15 @@
   <div class="tw-w-full tw-relative">
     <label
       class="tw-flex tw-gap-1 tw-text-sm tw-text-muted tw-mb-0 tw-max-w-full"
-      [ngClass]="
-        defaultContentIsFocused() ? 'tw-text-primary-600 tw-font-semibold' : 'tw-text-muted'
-      "
       [attr.for]="input.labelForId"
     >
       <ng-container *ngTemplateOutlet="labelContent"></ng-container>
     </label>
     <div
-      class="tw-gap-1 tw-flex tw-min-h-[1.85rem] tw-pb-[2px] tw-border-0 tw-border-solid"
+      class="tw-gap-1 tw-flex tw-min-h-[1.85rem] tw-border-0 tw-border-solid"
       [ngClass]="{
-        'tw-border-secondary-300/50 tw-border-b tw-pb-[3px]':
-          !disableReadOnlyBorder && !defaultContentIsFocused(),
-        'tw-border-transparent tw-pb-[4px]': disableReadOnlyBorder && !defaultContentIsFocused(),
-        'tw-border-b-2 tw-border-primary-600': defaultContentIsFocused(),
+        'tw-border-secondary-300/50 tw-border-b tw-pb-[2px]': !disableReadOnlyBorder,
+        'tw-border-transparent tw-pb-[3px]': disableReadOnlyBorder,
       }"
     >
       <div
@@ -98,7 +93,9 @@
       >
         <ng-container *ngTemplateOutlet="prefixContent"></ng-container>
       </div>
-      <div class="default-content tw-w-full tw-pb-0 tw-relative [&>*]:tw-p-0">
+      <div
+        class="default-content tw-w-full tw-pb-0 tw-relative [&>*]:tw-p-0 [&>*::selection]:tw-bg-primary-700 [&>*::selection]:tw-text-contrast"
+      >
         <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
       </div>
       <div


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-477](https://bitwarden.atlassian.net/browse/CL-477)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the focus indicators from the readonly input fields, and adds custom selection styling to the readonly input.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
With flag off (existing selection styling unchanged):

https://github.com/user-attachments/assets/b4aed71a-bfd9-467c-b791-d7716055d117

With flag on (new selection styling):

https://github.com/user-attachments/assets/1f8c9e4e-0698-4fc5-b4e3-57ec43bbfb71

Storybook:

https://github.com/user-attachments/assets/7669eca6-52e3-43cb-8a9b-78e621e4d1a1





## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-477]: https://bitwarden.atlassian.net/browse/CL-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ