### PR TITLE
[PM-12724] - fix logic for showing new password

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
@@ -12,8 +12,8 @@
       >
     </bit-form-field>
     <bit-form-field>
-      <bit-label *ngIf="!originalSendView || !hasPassword">{{ "password" | i18n }}</bit-label>
-      <bit-label *ngIf="originalSendView && hasPassword">{{ "newPassword" | i18n }}</bit-label>
+      <bit-label *ngIf="!showNewPassword">{{ "password" | i18n }}</bit-label>
+      <bit-label *ngIf="showNewPassword">{{ "newPassword" | i18n }}</bit-label>
       <input bitInput type="password" formControlName="password" />
       <button
         data-testid="toggle-visibility-for-password"

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
@@ -12,8 +12,8 @@
       >
     </bit-form-field>
     <bit-form-field>
-      <bit-label *ngIf="!showNewPassword">{{ "password" | i18n }}</bit-label>
-      <bit-label *ngIf="showNewPassword">{{ "newPassword" | i18n }}</bit-label>
+      <bit-label *ngIf="!shouldShowNewPassword">{{ "password" | i18n }}</bit-label>
+      <bit-label *ngIf="shouldShowNewPassword">{{ "newPassword" | i18n }}</bit-label>
       <input bitInput type="password" formControlName="password" />
       <button
         data-testid="toggle-visibility-for-password"

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -53,8 +53,8 @@ export class SendOptionsComponent implements OnInit {
     hideEmail: [false as boolean],
   });
 
-  get showNewPassword(): boolean {
-    return this.config.mode === "edit" && this.originalSendView?.password !== null;
+  get shouldShowNewPassword(): boolean {
+    return this.originalSendView && this.originalSendView.password !== null;
   }
 
   get shouldShowCount(): boolean {

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -53,10 +53,8 @@ export class SendOptionsComponent implements OnInit {
     hideEmail: [false as boolean],
   });
 
-  get hasPassword(): boolean {
-    return (
-      this.sendOptionsForm.value.password !== null && this.sendOptionsForm.value.password !== ""
-    );
+  get showNewPassword(): boolean {
+    return this.config.mode === "edit" && this.originalSendView?.password !== null;
   }
 
   get shouldShowCount(): boolean {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12724

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes the logic for when to show "New Password" which should only occur when editing a send and if the send has an existing password.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
