### PR TITLE
[PM-13469] Added variant for autofill username field name

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -19,6 +19,7 @@ export class AutoFillConstants {
     "customer id",
     "login id",
     "login",
+    "loginusername",
     // German
     "benutzername",
     "benutzer name",


### PR DESCRIPTION
Autofill does not work on [Namecheap](https://www.namecheap.com/myaccount/login/), because their username input has name="LoginUserName". Bothered me since a long time.