### PR TITLE
PoC: Auth - Improved passkey MFA

### DIFF
--- a/apps/browser/src/auth/popup/two-factor.component.html
+++ b/apps/browser/src/auth/popup/two-factor.component.html
@@ -104,7 +104,24 @@
     <ng-container *ngIf="selectedProviderType === providerType.WebAuthn && webAuthnNewTab">
       <div class="content text-center" *ngIf="webAuthnNewTab">
         <p class="text-center">{{ "webAuthnNewTab" | i18n }}</p>
-        <button type="button" class="btn primary block" (click)="authWebAuthn()" appStopClick>
+        <button
+          bitButton
+          type="button"
+          buttonType="primary"
+          [block]="true"
+          (click)="authPasskey()"
+          appStopClick
+        >
+          {{ "Use passkey" }}
+        </button>
+        <button
+          bitButton
+          type="button"
+          buttonType="secondary"
+          [block]="true"
+          (click)="authWebAuthn()"
+          appStopClick
+        >
           {{ "webAuthnNewTabOpen" | i18n }}
         </button>
       </div>

--- a/libs/angular/src/auth/components/two-factor.component.ts
+++ b/libs/angular/src/auth/components/two-factor.component.ts
@@ -153,6 +153,7 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
       this.webAuthnSupported,
     );
     await this.init();
+    await this.authPasskey(); // auto launch passkey auth
   }
 
   ngOnDestroy(): void {
@@ -449,6 +450,96 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
     }
 
     this.emailPromise = null;
+  }
+
+  async authPasskey() {
+    const providerData: any = await this.twoFactorService.getProviders().then((providers) => {
+      return providers.get(this.selectedProviderType);
+    });
+
+    if (!this.webAuthnSupported) {
+      return;
+    }
+
+    // fix data foramts
+    const challenge = providerData.challenge.replace(/-/g, "+").replace(/_/g, "/");
+    providerData.challenge = Uint8Array.from(atob(challenge), (c) => c.charCodeAt(0));
+
+    providerData.allowCredentials.forEach((listItem: any) => {
+      // eslint-disable-next-line
+      const fixedId = listItem.id.replace(/\_/g, "/").replace(/\-/g, "+");
+      listItem.id = Uint8Array.from(atob(fixedId), (c) => c.charCodeAt(0));
+    });
+
+    // NOTE: This is a hack that to remove appid extension which is set by the server. The apppid extension is not supported in browsers
+    providerData.extensions = { uvm: true }; // TODO: Remove this and change the server so that it doesn't set extensions.
+
+    try {
+      const assertedCredential = (await navigator.credentials.get({
+        publicKey: providerData as any,
+      })) as PublicKeyCredential;
+
+      const response = assertedCredential.response as AuthenticatorAssertionResponse;
+
+      const authData = new Uint8Array(response.authenticatorData);
+      const clientDataJSON = new Uint8Array(response.clientDataJSON);
+      const rawId = new Uint8Array(assertedCredential.rawId);
+      const sig = new Uint8Array(response.signature);
+
+      const coerceToBase64Url = (thing: any) => {
+        // Array or ArrayBuffer to Uint8Array
+        if (Array.isArray(thing)) {
+          thing = Uint8Array.from(thing);
+        }
+
+        if (thing instanceof ArrayBuffer) {
+          thing = new Uint8Array(thing);
+        }
+
+        // Uint8Array to base64
+        if (thing instanceof Uint8Array) {
+          let str = "";
+          const len = thing.byteLength;
+
+          for (let i = 0; i < len; i++) {
+            str += String.fromCharCode(thing[i]);
+          }
+          thing = window.btoa(str);
+        }
+
+        if (typeof thing !== "string") {
+          throw new Error("could not coerce to string");
+        }
+
+        // base64 to base64url
+        // NOTE: "=" at the end of challenge is optional, strip it off here
+        thing = thing.replace(/\+/g, "-").replace(/\//g, "_").replace(/=*$/g, "");
+
+        return thing;
+      };
+
+      const data = {
+        id: assertedCredential.id,
+        rawId: coerceToBase64Url(rawId),
+        type: assertedCredential.type,
+        extensions: assertedCredential.getClientExtensionResults(),
+        response: {
+          authenticatorData: coerceToBase64Url(authData),
+          clientDataJson: coerceToBase64Url(clientDataJSON),
+          signature: coerceToBase64Url(sig),
+        },
+      };
+
+      this.token = JSON.stringify(data);
+      await this.submit();
+
+      // POC Code, this should not live here:
+
+      // From https://github.com/abergs/fido2-net-lib/blob/b487a1d47373ea18cd752b4988f7262035b7b54e/Demo/wwwroot/js/helpers.js#L34
+      // License: https://github.com/abergs/fido2-net-lib/blob/master/LICENSE.txt
+    } catch (e) {
+      return;
+    }
   }
 
   async authWebAuthn() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

**This PR is a PoC** to improve how we use passkeys for MFA. Earlier extensions was not able to use passkeys for a certain rpid (like bitwarden.com). This has been changed, extensions can now use passkeys for domains they have host permission for.

This means we can avoid the connector based flow and instead perform the passkey operation in the extension, which is a much more simplified UI.

I was not able to test in Firefox (due to what I think was an unrelated PostMessage error) - so we should confirm that this works in Firefox as well.

**Please note that this PR does currently not sign users in successfully** because we also need to tweak the passkey-options sent by our server to not include the appid extension by default.

AppID is used to support legacy U2F keys. If we want to we can still support appid in the connector flow for full backwards compatibility, but long term we probably want to upgrade those users to a use a modern passkey.  


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![CleanShot 2024-10-13 at 16 19 14@2x](https://github.com/user-attachments/assets/5b739d52-36fd-414d-b6f1-ba256043ccf1)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
