### PR TITLE
Fix log service not binding this

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1340,7 +1340,7 @@ export default class MainBackground {
       }
 
       if (!supported) {
-        this.sdkService.failedToInitialize().catch(this.logService.error);
+        this.sdkService.failedToInitialize().catch((e) => this.logService.error(e));
       }
     }
 

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -81,7 +81,7 @@ export class AppComponent implements OnInit, OnDestroy {
         .subscribe((supported) => {
           if (!supported) {
             this.logService.debug("SDK is not supported");
-            this.sdkService.failedToInitialize().catch(this.logService.error);
+            this.sdkService.failedToInitialize().catch((e) => this.logService.error(e));
           } else {
             this.logService.debug("SDK is supported");
           }

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -858,7 +858,7 @@ export class ServiceContainer {
       }
 
       if (!supported) {
-        this.sdkService.failedToInitialize().catch(this.logService.error);
+        this.sdkService.failedToInitialize().catch((e) => this.logService.error(e));
       }
     }
   }

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -167,7 +167,7 @@ export class AppComponent implements OnInit, OnDestroy {
         .subscribe((supported) => {
           if (!supported) {
             this.logService.debug("SDK is not supported");
-            this.sdkService.failedToInitialize().catch(this.logService.error);
+            this.sdkService.failedToInitialize().catch((e) => this.logService.error(e));
           } else {
             this.logService.debug("SDK is supported");
           }

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -105,7 +105,7 @@ export class AppComponent implements OnDestroy, OnInit {
         .subscribe((supported) => {
           if (!supported) {
             this.logService.debug("SDK is not supported");
-            this.sdkService.failedToInitialize().catch(this.logService.error);
+            this.sdkService.failedToInitialize().catch((e) => this.logService.error(e));
           } else {
             this.logService.debug("SDK is supported");
           }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13685

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We ran into a ```Unhandled error in angular Error: Uncaught (in promise): TypeError: Cannot read properties of undefined (reading 'write') TypeError: Cannot read properties of undefined (reading 'write')``` due to log service losing `this`. Fixed by using the arrow function. 🤦 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
