### PR TITLE
[PM-13669] Show disabled Sends within Send list view

### DIFF
--- a/libs/tools/send/send-ui/src/services/send-list-filters.service.spec.ts
+++ b/libs/tools/send/send-ui/src/services/send-list-filters.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from "@angular/core/testing";
 import { FormBuilder } from "@angular/forms";
-import { BehaviorSubject, first } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -44,16 +44,6 @@ describe("SendListFiltersService", () => {
 
   it("returns all send types", () => {
     expect(service.sendTypes.map((c) => c.value)).toEqual([SendType.File, SendType.Text]);
-  });
-
-  it("filters disabled sends", (done) => {
-    const sends = [{ disabled: true }, { disabled: false }, { disabled: true }] as SendView[];
-    service.filterFunction$.pipe(first()).subscribe((filterFunction) => {
-      expect(filterFunction(sends)).toEqual([sends[1]]);
-      done();
-    });
-
-    service.filterForm.patchValue({});
   });
 
   it("resets the filter form", () => {

--- a/libs/tools/send/send-ui/src/services/send-list-filters.service.ts
+++ b/libs/tools/send/send-ui/src/services/send-list-filters.service.ts
@@ -44,11 +44,6 @@ export class SendListFiltersService {
     map(
       (filters) => (sends: SendView[]) =>
         sends.filter((send) => {
-          // do not show disabled sends
-          if (send.disabled) {
-            return false;
-          }
-
           if (filters.sendType !== null && send.type !== filters.sendType) {
             return false;
           }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13669

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Show disabled Sends within Send list view

With #10192 we introduced the new send-list-filters, and filtered out any disabled sends. These still need to be shown as the the other clients still support enabling/disabling Sends

This will be removed once all clients use the same shared components.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
