### PR TITLE
[PM-13397] Heading level + Styling for generator components

### DIFF
--- a/libs/tools/generator/components/src/generator.module.ts
+++ b/libs/tools/generator/components/src/generator.module.ts
@@ -20,6 +20,7 @@ import {
   SectionHeaderComponent,
   SelectModule,
   ToggleGroupModule,
+  TypographyModule,
 } from "@bitwarden/components";
 import {
   createRandomizer,
@@ -55,6 +56,7 @@ const RANDOMIZER = new SafeInjectionToken<Randomizer>("Randomizer");
     SectionHeaderComponent,
     SelectModule,
     ToggleGroupModule,
+    TypographyModule,
   ],
   providers: [
     safeProvider({

--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -1,6 +1,6 @@
 <bit-section>
   <bit-section-header *ngIf="showHeader">
-    <h6 bitTypography="h6">{{ "options" | i18n }}</h6>
+    <h2 bitTypography="h6">{{ "options" | i18n }}</h2>
   </bit-section-header>
   <form class="box" [formGroup]="settings" class="tw-container">
     <div class="tw-mb-4">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13397](https://bitwarden.atlassian.net/browse/PM-13397)

## 📔 Objective

- Update the "Options" heading to be `h2` to follow the heading hierarchy of the page. 
- Import the `TypographyModule` so the proper styles from the component library are applied

## 📸 Screenshots

|Before|After|
|-|-|
|![Screenshot 2024-10-15 at 9 43 12 AM](https://github.com/user-attachments/assets/879895cb-a8ae-4f7c-84b6-0be7fdc925af)|![Screenshot 2024-10-15 at 9 42 30 AM](https://github.com/user-attachments/assets/bdae2645-5e5b-4d38-8cd5-92f1598744e5)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13397]: https://bitwarden.atlassian.net/browse/PM-13397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ