### PR TITLE
[PM-13399] Generate & Copy wrapping

### DIFF
--- a/libs/tools/generator/components/src/credential-generator.component.html
+++ b/libs/tools/generator/components/src/credential-generator.component.html
@@ -15,7 +15,7 @@
   <div class="tw-grow tw-flex tw-items-center">
     <bit-color-password class="tw-font-mono" [password]="value$ | async"></bit-color-password>
   </div>
-  <div class="tw-space-x-1">
+  <div class="tw-flex tw-items-center tw-space-x-1">
     <button type="button" bitIconButton="bwi-generate" buttonType="main" (click)="generate$.next()">
       {{ "generatePassword" | i18n }}
     </button>

--- a/libs/tools/generator/components/src/password-generator.component.html
+++ b/libs/tools/generator/components/src/password-generator.component.html
@@ -13,7 +13,7 @@
   <div class="tw-grow tw-flex tw-items-center">
     <bit-color-password class="tw-font-mono" [password]="value$ | async"></bit-color-password>
   </div>
-  <div class="tw-space-x-1">
+  <div class="tw-flex tw-items-center tw-space-x-1">
     <button type="button" bitIconButton="bwi-generate" buttonType="main" (click)="generate$.next()">
       {{ "generatePassword" | i18n }}
     </button>

--- a/libs/tools/generator/components/src/username-generator.component.html
+++ b/libs/tools/generator/components/src/username-generator.component.html
@@ -2,7 +2,7 @@
   <div class="tw-grow tw-flex tw-items-center">
     <bit-color-password class="tw-font-mono" [password]="value$ | async"></bit-color-password>
   </div>
-  <div class="tw-space-x-1">
+  <div class="tw-flex tw-items-center tw-space-x-1">
     <button type="button" bitIconButton="bwi-generate" buttonType="main" (click)="generate$.next()">
       {{ "generatePassword" | i18n }}
     </button>


### PR DESCRIPTION

## 🎟️ Tracking

[PM-13399](https://bitwarden.atlassian.net/browse/PM-13399)

## 📔 Objective

Fix wrapping of the copy and generate buttons by making their container a flex container. Flex containers do not wrap their children by default. 

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/3af860da-404f-47ed-a143-1935b5a2beb9" />|<video src="https://github.com/user-attachments/assets/7bd41a1c-b82a-4db3-b505-cf0015f84704" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13399]: https://bitwarden.atlassian.net/browse/PM-13399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ