### PR TITLE
[PM-13675] Adjust browser autofill override instructions conditions and placement in the settings view

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill-v1.component.html
@@ -41,8 +41,19 @@
           </option>
         </select>
       </div>
-      <div class="box-footer" *ngIf="accountSwitcherEnabled && canOverrideBrowserAutofillSetting">
-        {{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}
+      <div class="box-footer" *ngIf="accountSwitcherEnabled || !canOverrideBrowserAutofillSetting">
+        <span *ngIf="accountSwitcherEnabled">{{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}</span>
+        <span *ngIf="!canOverrideBrowserAutofillSetting">
+          {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
+          <a
+            [attr.href]="disablePasswordManagerLink"
+            (click)="openDisablePasswordManagerLink($event)"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -86,7 +97,7 @@
         />
       </div>
     </div>
-    <div class="box-footer">
+    <div class="box-footer" *ngIf="canOverrideBrowserAutofillSetting">
       <span *ngIf="accountSwitcherEnabled">{{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}</span>
       {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
       <a

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -11,7 +11,7 @@
         <h2 bitTypography="h6">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
-        <bit-form-control>
+        <bit-form-control [disableMargin]="!enableInlineMenu">
           <input
             bitCheckbox
             id="show-inline-menu"
@@ -57,7 +57,11 @@
             {{ "showInlineMenuCardsLabel" | i18n }}
           </bit-label>
         </bit-form-control>
-        <bit-form-control *ngIf="enableInlineMenu" class="tw-ml-5">
+        <bit-form-control
+          *ngIf="enableInlineMenu"
+          class="tw-ml-5"
+          [disableMargin]="!canOverrideBrowserAutofillSetting"
+        >
           <input
             bitCheckbox
             id="show-autofill-suggestions-on-icon"
@@ -68,21 +72,8 @@
           <bit-label for="show-autofill-suggestions-on-icon">
             {{ "showInlineMenuOnIconSelectionLabel" | i18n }}
           </bit-label>
-          <bit-hint class="tw-text-sm" *ngIf="!canOverrideBrowserAutofillSetting">
-            {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
-            <a
-              bitLink
-              class="tw-no-underline"
-              rel="noreferrer"
-              target="_blank"
-              (click)="openURI($event, disablePasswordManagerURI)"
-              [attr.href]="disablePasswordManagerURI"
-            >
-              {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
-            </a>
-          </bit-hint>
         </bit-form-control>
-        <bit-form-control *ngIf="canOverrideBrowserAutofillSetting">
+        <bit-form-control *ngIf="canOverrideBrowserAutofillSetting" disableMargin>
           <input
             bitCheckbox
             id="overrideBrowserAutofill"
@@ -93,7 +84,7 @@
           <bit-label for="overrideBrowserAutofill">{{
             "overrideDefaultBrowserAutoFillSettings" | i18n
           }}</bit-label>
-          <bit-hint class="tw-text-sm">
+          <bit-hint class="tw-text-sm tw-mb-6">
             {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
             <a
               bitLink
@@ -107,6 +98,19 @@
             </a>
           </bit-hint>
         </bit-form-control>
+        <bit-hint *ngIf="!canOverrideBrowserAutofillSetting" class="tw-text-sm tw-mb-6">
+          {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
+          <a
+            bitLink
+            class="tw-no-underline"
+            rel="noreferrer"
+            target="_blank"
+            (click)="openURI($event, disablePasswordManagerURI)"
+            [attr.href]="disablePasswordManagerURI"
+          >
+            {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+          </a>
+        </bit-hint>
         <bit-form-control>
           <input
             bitCheckbox

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -11,7 +11,7 @@
         <h2 bitTypography="h6">{{ "autofillSuggestionsSectionTitle" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
-        <bit-form-control [disableMargin]="!enableInlineMenu">
+        <bit-form-control [disableMargin]="!enableInlineMenu && !canOverrideBrowserAutofillSetting">
           <input
             bitCheckbox
             id="show-inline-menu"
@@ -25,6 +25,22 @@
             class="tw-text-sm"
           >
             {{ "showInlineMenuOnFormFieldsDescAlt" | i18n }}
+          </bit-hint>
+          <bit-hint
+            *ngIf="!canOverrideBrowserAutofillSetting"
+            [class]="!enableInlineMenu ? 'tw-text-sm tw-mb-6' : 'tw-text-sm'"
+          >
+            {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
+            <a
+              bitLink
+              class="tw-no-underline"
+              rel="noreferrer"
+              target="_blank"
+              (click)="openURI($event, disablePasswordManagerURI)"
+              [attr.href]="disablePasswordManagerURI"
+            >
+              {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
+            </a>
           </bit-hint>
         </bit-form-control>
         <bit-form-control
@@ -57,11 +73,7 @@
             {{ "showInlineMenuCardsLabel" | i18n }}
           </bit-label>
         </bit-form-control>
-        <bit-form-control
-          *ngIf="enableInlineMenu"
-          class="tw-ml-5"
-          [disableMargin]="!canOverrideBrowserAutofillSetting"
-        >
+        <bit-form-control *ngIf="enableInlineMenu" class="tw-ml-5">
           <input
             bitCheckbox
             id="show-autofill-suggestions-on-icon"
@@ -73,7 +85,7 @@
             {{ "showInlineMenuOnIconSelectionLabel" | i18n }}
           </bit-label>
         </bit-form-control>
-        <bit-form-control *ngIf="canOverrideBrowserAutofillSetting" disableMargin>
+        <bit-form-control *ngIf="canOverrideBrowserAutofillSetting">
           <input
             bitCheckbox
             id="overrideBrowserAutofill"
@@ -84,7 +96,7 @@
           <bit-label for="overrideBrowserAutofill">{{
             "overrideDefaultBrowserAutoFillSettings" | i18n
           }}</bit-label>
-          <bit-hint class="tw-text-sm tw-mb-6">
+          <bit-hint class="tw-text-sm">
             {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
             <a
               bitLink
@@ -98,19 +110,6 @@
             </a>
           </bit-hint>
         </bit-form-control>
-        <bit-hint *ngIf="!canOverrideBrowserAutofillSetting" class="tw-text-sm tw-mb-6">
-          {{ "turnOffBrowserBuiltInPasswordManagerSettings" | i18n }}
-          <a
-            bitLink
-            class="tw-no-underline"
-            rel="noreferrer"
-            target="_blank"
-            (click)="openURI($event, disablePasswordManagerURI)"
-            [attr.href]="disablePasswordManagerURI"
-          >
-            {{ "turnOffBrowserBuiltInPasswordManagerSettingsLink" | i18n }}
-          </a>
-        </bit-hint>
         <bit-form-control>
           <input
             bitCheckbox


### PR DESCRIPTION
## 🎟️ Tracking

PM-13675

## 📔 Objective

With the new autofill [inline menu sub-options merged in](https://github.com/bitwarden/clients/pull/11260), there are some inconsistencies around the placement and display of the browser autofill override instructions between Firefox and other browsers (the former doesn't have an option/toggle for the override). This PR aims to make the placement and display of those instructions more consistent. 

## 📸 Screenshots

NOTE: The Submenu options are behind the `inline-menu-positioning-improvements` feature-flag

**Submenu options OFF**

| Chrome No Submenu (Before) | Chrome No Submenu (After) |
| --- | --- |
| ![before-chrome-nosub](https://github.com/user-attachments/assets/c8417f51-42de-4e11-abae-5b3fa5570aa8) | ![after-chrome-nosub](https://github.com/user-attachments/assets/a3ff133c-7b84-4c27-b045-93005a574c5a) |

| Firefox No Submenu (Before) | Firefox No Submenu (After) |
| --- | --- |
| ![before-firefox-nosub](https://github.com/user-attachments/assets/b11415f5-eaf2-40c0-875c-6ea71164f56d) | ![after-firefox-nosub](https://github.com/user-attachments/assets/7ef28e47-0466-4a39-b130-050b5ad20fb3) |

| Chrome No Submenu Refresh (Before) | Chrome No Submenu Refresh (After) |
| --- | --- |
| ![before-chrome-refresh-nosub](https://github.com/user-attachments/assets/ed41e9c1-7a2d-4a14-bc70-396bd30c1cfb) | ![after-chrome-refresh-nosub](https://github.com/user-attachments/assets/f5a44a7d-49f9-4048-8707-97dca370b9b1) |

| Firefox No Submenu Refresh (Before) | Firefox No Submenu Refresh (After) |
| --- | --- |
| ![before-firefox-refresh-nosub](https://github.com/user-attachments/assets/4a264fad-5661-43b1-b92b-e3b167d7155d) | ![after-firefox-refresh-nosub](https://github.com/user-attachments/assets/4e658e07-c696-4885-be2a-cc2c1dbca647) |

**Submenu options ON**

| Chrome Submenu (Before) | Chrome Submenu (After) |
| --- | --- |
| ![before-chrome-submenu](https://github.com/user-attachments/assets/6159914a-87a8-44ce-91aa-81e7acc32796) | ![after-chrome-submenu](https://github.com/user-attachments/assets/ed17e993-4d5c-41e5-9075-adfe19e5fec0) |

| Firefox Submenu (Before) | Firefox Submenu (After) |
| --- | --- |
| ![before-firefox-submenu](https://github.com/user-attachments/assets/b4936d08-cc38-4adf-b519-06f7b9353062) | ![after-firefox-submenu](https://github.com/user-attachments/assets/f9e2fde6-8f78-4b76-9b1e-fdb07fe6414a) |

| Chrome Submenu Refresh (Before) | Chrome Submenu Refresh (After) |
| --- | --- |
| ![before-chrome-refresh-submenu](https://github.com/user-attachments/assets/c4bf7124-096a-463e-9e6a-c4c06457f6a5) | ![after-chrome-refresh-submenu](https://github.com/user-attachments/assets/15d729d9-b85a-481c-8292-37c00d11f66d) |

| Firefox Submenu Refresh (Before) | Firefox Submenu Refresh (After) |
| --- | --- |
| ![before-firefox-refresh-submenu](https://github.com/user-attachments/assets/c89d32e5-36e6-454a-906c-1f0ab86045cf) | ![after-firefox-refresh-submenu](https://github.com/user-attachments/assets/636c7131-d65d-4cc4-98f8-ab95191b7298) |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
