### PR TITLE
[PM-13132] Generators - Web Dialog Margins

### DIFF
--- a/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.html
+++ b/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.html
@@ -6,6 +6,7 @@
     <vault-cipher-form-generator
       [type]="params.type"
       (valueGenerated)="onValueGenerated($event)"
+      disableMargin
     ></vault-cipher-form-generator>
   </ng-container>
   <ng-container bitDialogFooter>

--- a/libs/tools/generator/components/src/passphrase-settings.component.html
+++ b/libs/tools/generator/components/src/passphrase-settings.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<bit-section [disableMargin]="disableMargin">
   <bit-section-header *ngIf="showHeader">
     <h6 bitTypography="h6">{{ "options" | i18n }}</h6>
   </bit-section-header>

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { OnInit, Input, Output, EventEmitter, Component, OnDestroy } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 import { BehaviorSubject, skip, takeUntil, Subject } from "rxjs";
@@ -46,6 +47,9 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
   /** When `true`, an options header is displayed by the component. Otherwise, the header is hidden. */
   @Input()
   showHeader: boolean = true;
+
+  /** Removes bottom margin from `bit-section` */
+  @Input({ transform: coerceBooleanProperty }) disableMargin = false;
 
   /** Emits settings updates and completes if the settings become unavailable.
    * @remarks this does not emit the initial settings. If you would like

--- a/libs/tools/generator/components/src/password-generator.component.html
+++ b/libs/tools/generator/components/src/password-generator.component.html
@@ -32,6 +32,7 @@
   class="tw-mt-6"
   *ngIf="(algorithm$ | async)?.id === 'password'"
   [userId]="this.userId$ | async"
+  [disableMargin]="disableMargin"
   (onUpdated)="generate$.next()"
 />
 <tools-passphrase-settings
@@ -39,4 +40,5 @@
   *ngIf="(algorithm$ | async)?.id === 'passphrase'"
   [userId]="this.userId$ | async"
   (onUpdated)="generate$.next()"
+  [disableMargin]="disableMargin"
 />

--- a/libs/tools/generator/components/src/password-generator.component.ts
+++ b/libs/tools/generator/components/src/password-generator.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { Component, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output } from "@angular/core";
 import {
   BehaviorSubject,
@@ -44,6 +45,9 @@ export class PasswordGeneratorComponent implements OnInit, OnDestroy {
    */
   @Input()
   userId: UserId | null;
+
+  /** Removes bottom margin, passed to downstream components */
+  @Input({ transform: coerceBooleanProperty }) disableMargin = false;
 
   /** tracks the currently selected credential type */
   protected credentialType$ = new BehaviorSubject<PasswordAlgorithm>(null);

--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<bit-section [disableMargin]="disableMargin">
   <bit-section-header *ngIf="showHeader">
     <h2 bitTypography="h6">{{ "options" | i18n }}</h2>
   </bit-section-header>

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { OnInit, Input, Output, EventEmitter, Component, OnDestroy } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 import { BehaviorSubject, takeUntil, Subject, map, filter, tap, debounceTime, skip } from "rxjs";
@@ -54,6 +55,9 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
   /** Number of milliseconds to wait before accepting user input. */
   @Input()
   waitMs: number = 100;
+
+  /** Removes bottom margin from `bit-section` */
+  @Input({ transform: coerceBooleanProperty }) disableMargin = false;
 
   /** Emits settings updates and completes if the settings become unavailable.
    * @remarks this does not emit the initial settings. If you would like

--- a/libs/tools/generator/components/src/username-generator.component.html
+++ b/libs/tools/generator/components/src/username-generator.component.html
@@ -17,11 +17,11 @@
     </button>
   </div>
 </bit-card>
-<bit-section>
+<bit-section [disableMargin]="disableMargin">
   <bit-section-header>
     <h6 bitTypography="h6">{{ "options" | i18n }}</h6>
   </bit-section-header>
-  <div class="tw-mb-4">
+  <div [ngClass]="{ 'tw-mb-4': !disableMargin }">
     <bit-card>
       <form class="box" [formGroup]="credential" class="tw-container">
         <bit-form-field>

--- a/libs/tools/generator/components/src/username-generator.component.ts
+++ b/libs/tools/generator/components/src/username-generator.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { Component, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
 import {
@@ -56,6 +57,9 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
   /** Emits credentials created from a generation request. */
   @Output()
   readonly onGenerated = new EventEmitter<GeneratedCredential>();
+
+  /** Removes bottom margin from internal elements */
+  @Input({ transform: coerceBooleanProperty }) disableMargin = false;
 
   /** Tracks the selected generation algorithm */
   protected credential = this.formBuilder.group({

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
@@ -1,8 +1,10 @@
 <tools-password-generator
   *ngIf="type === 'password'"
+  [disableMargin]="disableMargin"
   (onGenerated)="onCredentialGenerated($event)"
 ></tools-password-generator>
 <tools-username-generator
   *ngIf="type === 'username'"
+  [disableMargin]="disableMargin"
   (onGenerated)="onCredentialGenerated($event)"
 ></tools-username-generator>

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { CommonModule } from "@angular/common";
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
@@ -20,6 +21,9 @@ export class CipherFormGeneratorComponent {
    */
   @Input({ required: true })
   type: "password" | "username";
+
+  /** Removes bottom margin of internal sections */
+  @Input({ transform: coerceBooleanProperty }) disableMargin = false;
 
   /**
    * Emits an event when a new value is generated.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13132](https://bitwarden.atlassian.net/browse/PM-13132)

## 📔 Objective

- A little bit of drilling because of the component hierarchy. Adding a `disableMargin` Input to be passed down the component tree to remove the margin from applicable `bit-section` elements in the web dialog implementation. 

## 📸 Screenshots

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/c48357fd-b476-4c43-af9c-13aada6f7cc2" />|<video src="https://github.com/user-attachments/assets/2802dcad-4768-44ad-aa70-c5ee9ee5cf91" />|



## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13132]: https://bitwarden.atlassian.net/browse/PM-13132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ