### PR TITLE
[PM-13016] Browser default match detection

### DIFF
--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
@@ -58,6 +58,13 @@ describe("UriOptionComponent", () => {
     expect(component["uriMatchOptions"][0].label).toBe("default");
   });
 
+  it("should update the default uri match strategy label when it is domain", () => {
+    component.defaultMatchDetection = UriMatchStrategy.Domain;
+    fixture.detectChanges();
+
+    expect(component["uriMatchOptions"][0].label).toBe("defaultLabel baseDomain");
+  });
+
   it("should update the default uri match strategy label", () => {
     component.defaultMatchDetection = UriMatchStrategy.Exact;
     fixture.detectChanges();

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -84,7 +84,7 @@ export class UriOptionComponent implements ControlValueAccessor {
   @Input({ required: true })
   set defaultMatchDetection(value: UriMatchStrategySetting) {
     // The default selection has a value of `null` avoid showing "Default (Default)"
-    if (!value) {
+    if (value === null) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13016](https://bitwarden.atlassian.net/browse/PM-13016)

## 📔 Objective

- The `UriMatchStrategy` for Domain was 0 and hitting the conditional and thus returning early and not showing the `Domain` on the browser.
- Note: No change to the web implementation, the video below just shows that the value is still hidden.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/99bcb787-7dd1-43d0-a8ad-47737b2207b5" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13016]: https://bitwarden.atlassian.net/browse/PM-13016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ