### PR TITLE
[PM-13687] Update search state to show contextually relevant no results view messages

### DIFF
--- a/apps/browser/src/autofill/popup/fido2/fido2.component.html
+++ b/apps/browser/src/autofill/popup/fido2/fido2.component.html
@@ -49,17 +49,22 @@
       <!-- Display when no matching ciphers exist -->
       <ng-container *ngIf="!displayedCiphers.length">
         <bit-no-items class="tw-text-main" [icon]="noResultsIcon">
-          <ng-container slot="title">{{ "noMatchingLoginsForSite" | i18n }}</ng-container>
-          <ng-container slot="description">{{ "searchSavePasskeyNewLogin" | i18n }}</ng-container>
+          <ng-container slot="title">{{
+            (hasSearched ? "noItemsMatchSearch" : "noMatchingLoginsForSite") | i18n
+          }}</ng-container>
+          <ng-container slot="description">{{
+            (hasSearched ? "searchSavePasskeyNewLogin" : "clearFiltersOrTryAnother") | i18n
+          }}</ng-container>
+
           <button
             bitButton
             buttonType="primary"
             slot="button"
             type="button"
-            (click)="saveNewLogin()"
+            (click)="hasSearched ? clearSearch() : saveNewLogin()"
             [loading]="loading"
           >
-            {{ "savePasskeyNewLogin" | i18n }}
+            {{ (hasSearched ? "multiSelectClearAll" : "savePasskeyNewLogin") | i18n }}
           </button>
         </bit-no-items>
       </ng-container>
@@ -100,17 +105,22 @@
       <!-- Display when no matching ciphers exist -->
       <ng-container *ngIf="!displayedCiphers.length">
         <bit-no-items class="tw-text-main" [icon]="noResultsIcon">
-          <ng-container slot="title">{{ "noItemsMatchSearch" | i18n }}</ng-container>
-          <ng-container slot="description">{{ "clearFiltersOrTryAnother" | i18n }}</ng-container>
+          <ng-container slot="title">{{
+            (hasSearched ? "noItemsMatchSearch" : "noMatchingLoginsForSite") | i18n
+          }}</ng-container>
+          <ng-container slot="description">{{
+            (hasSearched ? "searchSavePasskeyNewLogin" : "clearFiltersOrTryAnother") | i18n
+          }}</ng-container>
+
           <button
             bitButton
             buttonType="primary"
             slot="button"
             type="button"
-            (click)="saveNewLogin()"
+            (click)="hasSearched ? clearSearch() : saveNewLogin()"
             [loading]="loading"
           >
-            {{ "savePasskeyNewLogin" | i18n }}
+            {{ (hasSearched ? "multiSelectClearAll" : "savePasskeyNewLogin") | i18n }}
           </button>
         </bit-no-items>
       </ng-container>


### PR DESCRIPTION
## 🎟️ Tracking

PM-13687

## 📔 Objective

Note: follow up from [PM-12368](https://github.com/bitwarden/clients/pull/11460)

When a user registers a new passkey via the extension popup and no login ciphers exist in the vault for that page, show a "No matching logins for this site" message with a search bar and button to save passkey as a new login. If the user searches from this view (or another view) and there are no login cipher matches for the search, display a "No items match your search" message with a button to clear search.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12368]: https://bitwarden.atlassian.net/browse/PM-12368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ