### PR TITLE
[PM-13708] Fix: Add TOTP import support to KeePassX CSV importer

### DIFF
--- a/libs/importer/spec/keepassx-csv-importer.spec.ts
+++ b/libs/importer/spec/keepassx-csv-importer.spec.ts
@@ -1,0 +1,42 @@
+import { KeePassXCsvImporter } from "../src/importers";
+
+import { keepassxTestData } from "./test-data/keepassx-csv/testdata.csv";
+
+describe("KeePassX CSV Importer", () => {
+  let importer: KeePassXCsvImporter;
+
+  beforeEach(() => {
+    importer = new KeePassXCsvImporter();
+  });
+
+  describe("given login data", () => {
+    it("should parse login data when provided valid CSV", async () => {
+      const result = await importer.parse(keepassxTestData);
+      expect(result != null).toBe(true);
+
+      const cipher = result.ciphers.shift();
+      expect(cipher.name).toEqual("Example Entry");
+      expect(cipher.login.username).toEqual("testuser");
+      expect(cipher.login.password).toEqual("password123");
+      expect(cipher.login.uris.length).toEqual(1);
+      const uriView = cipher.login.uris.shift();
+      expect(uriView.uri).toEqual("https://example.com");
+      expect(cipher.notes).toEqual("Some notes");
+    });
+
+    it("should import TOTP when present in the CSV", async () => {
+      const result = await importer.parse(keepassxTestData);
+      expect(result != null).toBe(true);
+
+      const cipher = result.ciphers.pop();
+      expect(cipher.name).toEqual("Another Entry");
+      expect(cipher.login.username).toEqual("anotheruser");
+      expect(cipher.login.password).toEqual("anotherpassword");
+      expect(cipher.login.uris.length).toEqual(1);
+      const uriView = cipher.login.uris.shift();
+      expect(uriView.uri).toEqual("https://another.com");
+      expect(cipher.notes).toEqual("Another set of notes");
+      expect(cipher.login.totp).toEqual("otpauth://totp/Another?secret=ABCD1234EFGH5678");
+    });
+  });
+});

--- a/libs/importer/spec/test-data/keepassx-csv/testdata.csv.ts
+++ b/libs/importer/spec/test-data/keepassx-csv/testdata.csv.ts
@@ -1,0 +1,3 @@
+export const keepassxTestData = `Title,Username,Password,URL,Notes,TOTP
+Example Entry,testuser,password123,https://example.com,Some notes,
+Another Entry,anotheruser,anotherpassword,https://another.com,Another set of notes,otpauth://totp/Another?secret=ABCD1234EFGH5678`;

--- a/libs/importer/src/importers/keepassx-csv-importer.ts
+++ b/libs/importer/src/importers/keepassx-csv-importer.ts
@@ -30,6 +30,8 @@ export class KeePassXCsvImporter extends BaseImporter implements Importer {
       cipher.login.username = this.getValueOrDefault(value.Username);
       cipher.login.password = this.getValueOrDefault(value.Password);
       cipher.login.uris = this.makeUriArray(value.URL);
+      cipher.login.totp = this.getValueOrDefault(value.TOTP);
+
       this.cleanupCipher(cipher);
       result.ciphers.push(cipher);
     });


### PR DESCRIPTION
### Fixes
Fixes #11522 - Keepass CSV import doesn't include TOTP

### Description
This pull request resolves an issue where TOTP fields were not imported from KeePass CSV files into Bitwarden vault entries. The `keepassx-csv-importer` was modified to parse and include TOTP fields during the import process. Unit tests were also added to ensure TOTP values are handled correctly.

### Changes
- Updated `keepassx-csv-importer` to support TOTP field import.
- Added unit tests for TOTP parsing in `libs/importer/spec/keepassx-csv-importer.spec.ts`.

