### PR TITLE
[PM-13645] Fix invite counter to check remaining number of seats in plan

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -27,10 +27,10 @@
               <bit-label>{{ "email" | i18n }}</bit-label>
               <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
               <bit-hint *ngIf="remainingSeats > 1; else singleSeat">{{
-                "inviteMultipleEmailDesc" | i18n: (remainingSeats$ | async)
+                "inviteMultipleEmailDesc" | i18n: remainingSeats
               }}</bit-hint>
               <ng-template #singleSeat>
-                <bit-hint>{{ "inviteSingleEmailDesc" | i18n: (remainingSeats$ | async) }}</bit-hint>
+                <bit-hint>{{ "inviteSingleEmailDesc" | i18n: remainingSeats }}</bit-hint>
               </ng-template>
             </bit-form-field>
           </ng-container>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -23,14 +23,15 @@
         <bit-tab [label]="'role' | i18n">
           <ng-container *ngIf="!editMode">
             <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
-            <bit-form-field>
+            <bit-form-field *ngIf="remainingSeats$ | async as remainingSeats">
               <bit-label>{{ "email" | i18n }}</bit-label>
               <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
-              <bit-hint>{{
-                "inviteMultipleEmailDesc"
-                  | i18n
-                    : (organization.productTierType === ProductTierType.TeamsStarter ? "10" : "20")
+              <bit-hint *ngIf="remainingSeats > 1; else singleSeat">{{
+                "inviteMultipleEmailDesc" | i18n: (remainingSeats$ | async)
               }}</bit-hint>
+              <ng-template #singleSeat>
+                <bit-hint>{{ "inviteSingleEmailDesc" | i18n: (remainingSeats$ | async) }}</bit-hint>
+              </ng-template>
             </bit-form-field>
           </ng-container>
           <bit-radio-group formControlName="type">

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -89,6 +89,7 @@ export class MemberDialogComponent implements OnDestroy {
   PermissionMode = PermissionMode;
   showNoMasterPasswordWarning = false;
   isOnSecretsManagerStandalone: boolean;
+  remainingSeats$: Observable<number>;
 
   protected organization$: Observable<Organization>;
   protected collectionAccessItems: AccessItemView[] = [];
@@ -250,6 +251,10 @@ export class MemberDialogComponent implements OnDestroy {
 
         this.loading = false;
       });
+
+    this.remainingSeats$ = this.organization$.pipe(
+      map((organization) => organization.seats - this.params.numConfirmedMembers),
+    );
   }
 
   private setFormValidators(organization: Organization) {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3162,6 +3162,9 @@
       }
     }
   },
+  "inviteSingleEmailDesc": {
+    "message": "You have 1 invite remaining."
+  },
   "userUsingTwoStep": {
     "message": "This user is using two-step login to protect their account."
   },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13645](https://bitwarden.atlassian.net/browse/PM-13645)
## 📔 Objective

This PR fixes the hint message for the email field when inviting new members to an organization to calculate how many seats remain in an org.

## 📸 Screenshots

<img width="648" alt="Screenshot 2024-10-16 at 10 15 34 AM" src="https://github.com/user-attachments/assets/babdb5d7-7727-438c-a811-59399b053bf9">
<img width="655" alt="Screenshot 2024-10-16 at 10 15 12 AM" src="https://github.com/user-attachments/assets/3aed2d0b-3aca-4585-b449-ea341273a279">



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13645]: https://bitwarden.atlassian.net/browse/PM-13645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ