### PR TITLE
[PM-13736] - fix send options viewsLeft

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -27,16 +27,16 @@ import { SendFormContainer } from "../../send-form-container";
   templateUrl: "./send-options.component.html",
   standalone: true,
   imports: [
+    CardComponent,
+    CheckboxModule,
+    CommonModule,
+    FormFieldModule,
+    IconButtonModule,
+    JslibModule,
+    ReactiveFormsModule,
     SectionComponent,
     SectionHeaderComponent,
     TypographyModule,
-    JslibModule,
-    CardComponent,
-    FormFieldModule,
-    ReactiveFormsModule,
-    IconButtonModule,
-    CheckboxModule,
-    CommonModule,
   ],
 })
 export class SendOptionsComponent implements OnInit {
@@ -61,10 +61,12 @@ export class SendOptionsComponent implements OnInit {
     return this.config.mode === "edit" && this.sendOptionsForm.value.maxAccessCount !== null;
   }
 
-  get viewsLeft(): number {
-    return this.sendOptionsForm.value.maxAccessCount
-      ? this.sendOptionsForm.value.maxAccessCount - this.sendOptionsForm.value.accessCount
-      : 0;
+  get viewsLeft() {
+    return String(
+      this.sendOptionsForm.value.maxAccessCount
+        ? this.sendOptionsForm.value.maxAccessCount - this.sendOptionsForm.value.accessCount
+        : 0,
+    );
   }
 
   constructor(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13736

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a bug where in Safari the `n Views Left` translation was not inserting `n` into the message. This appears to be due to the fact that Safari doesn't handle interpolating numbers into strings within the translation service.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
