### PR TITLE
Fix RegistrationStartComponent typo

### DIFF
--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
@@ -91,7 +91,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
     private router: Router,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
   ) {
-    this.isSelfHost = platformUtilsService.isSelfHost();
+    this.isSelfHost = this.platformUtilsService.isSelfHost();
   }
 
   async ngOnInit() {


### PR DESCRIPTION
Fixes a typo where we missed the `this` keyword.
