### PR TITLE
[PM-13454] - Health report raw data and member count to uri

### DIFF
--- a/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
+++ b/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
@@ -3,6 +3,9 @@
   <bit-tab label="Raw Data">
     <tools-password-health></tools-password-health>
   </bit-tab>
+  <bit-tab label="Raw Data + members">
+    <tools-password-health-members></tools-password-health-members>
+  </bit-tab>
   <!-- <bit-tab label="{{ 'allApplicationsWithCount' | i18n: apps.length }}">
     <h2 bitTypography="h2">{{ "allApplications" | i18n }}</h2>
     <tools-application-table></tools-application-table>

--- a/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
+++ b/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
@@ -6,6 +6,9 @@
   <bit-tab label="Raw Data + members">
     <tools-password-health-members></tools-password-health-members>
   </bit-tab>
+  <bit-tab label="Raw Data + members + uri">
+    <tools-password-health-members-uri></tools-password-health-members-uri>
+  </bit-tab>
   <!-- <bit-tab label="{{ 'allApplicationsWithCount' | i18n: apps.length }}">
     <h2 bitTypography="h2">{{ "allApplications" | i18n }}</h2>
     <tools-application-table></tools-application-table>

--- a/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
+++ b/apps/web/src/app/tools/access-intelligence/access-intelligence.component.html
@@ -6,7 +6,7 @@
   <bit-tab label="Raw Data + members">
     <tools-password-health-members></tools-password-health-members>
   </bit-tab>
-  <bit-tab label="Raw Data + members + uri">
+  <bit-tab label="Raw Data + uri">
     <tools-password-health-members-uri></tools-password-health-members-uri>
   </bit-tab>
   <!-- <bit-tab label="{{ 'allApplicationsWithCount' | i18n: apps.length }}">

--- a/apps/web/src/app/tools/access-intelligence/access-intelligence.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/access-intelligence.component.ts
@@ -11,6 +11,7 @@ import { HeaderModule } from "../../layouts/header/header.module";
 
 import { ApplicationTableComponent } from "./application-table.component";
 import { NotifiedMembersTableComponent } from "./notified-members-table.component";
+import { PasswordHealthMembersComponent } from "./password-health-members.component";
 import { PasswordHealthComponent } from "./password-health.component";
 
 export enum AccessIntelligenceTabType {
@@ -28,6 +29,7 @@ export enum AccessIntelligenceTabType {
     JslibModule,
     HeaderModule,
     PasswordHealthComponent,
+    PasswordHealthMembersComponent,
     NotifiedMembersTableComponent,
     TabsModule,
   ],

--- a/apps/web/src/app/tools/access-intelligence/access-intelligence.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/access-intelligence.component.ts
@@ -11,6 +11,7 @@ import { HeaderModule } from "../../layouts/header/header.module";
 
 import { ApplicationTableComponent } from "./application-table.component";
 import { NotifiedMembersTableComponent } from "./notified-members-table.component";
+import { PasswordHealthMembersURIComponent } from "./password-health-members-uri.component";
 import { PasswordHealthMembersComponent } from "./password-health-members.component";
 import { PasswordHealthComponent } from "./password-health.component";
 
@@ -30,6 +31,7 @@ export enum AccessIntelligenceTabType {
     HeaderModule,
     PasswordHealthComponent,
     PasswordHealthMembersComponent,
+    PasswordHealthMembersURIComponent,
     NotifiedMembersTableComponent,
     TabsModule,
   ],

--- a/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.html
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.html
@@ -1,0 +1,55 @@
+<bit-container>
+  <p>{{ "passwordsReportDesc" | i18n }}</p>
+  <div *ngIf="loading">
+    <i
+      class="bwi bwi-spinner bwi-spin tw-text-muted"
+      title="{{ 'loading' | i18n }}"
+      aria-hidden="true"
+    ></i>
+    <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  </div>
+  <div class="tw-mt-4" *ngIf="!loading">
+    <bit-table [dataSource]="dataSource">
+      <ng-container header>
+        <tr bitRow>
+          <th bitCell bitSortable="hostURI">{{ "application" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "weakness" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "timesReused" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "timesExposed" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "totalMembers" | i18n }}</th>
+        </tr>
+      </ng-container>
+      <ng-template body let-rows$>
+        <tr bitRow *ngFor="let r of rows$ | async">
+          <td bitCell>
+            <ng-container>
+              <span>{{ r.hostURI }}</span>
+            </ng-container>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span
+              bitBadge
+              *ngIf="passwordStrengthMap.has(r.id)"
+              [variant]="passwordStrengthMap.get(r.id)[1]"
+            >
+              {{ passwordStrengthMap.get(r.id)[0] | i18n }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span bitBadge *ngIf="passwordUseMap.has(r.login.password)" variant="warning">
+              {{ "reusedXTimes" | i18n: passwordUseMap.get(r.login.password) }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span bitBadge *ngIf="exposedPasswordMap.has(r.id)" variant="warning">
+              {{ "exposedXTimes" | i18n: exposedPasswordMap.get(r.id) }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right" data-testid="total-membership">
+            {{ totalMembersMap.get(r.id) || 0 }}
+          </td>
+        </tr>
+      </ng-template>
+    </bit-table>
+  </div>
+</bit-container>

--- a/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.html
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.html
@@ -16,7 +16,6 @@
           <th bitCell class="tw-text-right">{{ "weakness" | i18n }}</th>
           <th bitCell class="tw-text-right">{{ "timesReused" | i18n }}</th>
           <th bitCell class="tw-text-right">{{ "timesExposed" | i18n }}</th>
-          <th bitCell class="tw-text-right">{{ "totalMembers" | i18n }}</th>
         </tr>
       </ng-container>
       <ng-template body let-rows$>
@@ -44,9 +43,6 @@
             <span bitBadge *ngIf="exposedPasswordMap.has(r.id)" variant="warning">
               {{ "exposedXTimes" | i18n: exposedPasswordMap.get(r.id) }}
             </span>
-          </td>
-          <td bitCell class="tw-text-right" data-testid="total-membership">
-            {{ totalMembersMap.get(r.id) || 0 }}
           </td>
         </tr>
       </ng-template>

--- a/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.ts
@@ -29,8 +29,6 @@ import { OrganizationBadgeModule } from "../../vault/individual-vault/organizati
 // eslint-disable-next-line no-restricted-imports
 import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
 
-import { userData } from "./password-health.mock";
-
 @Component({
   standalone: true,
   selector: "tools-password-health-members-uri",
@@ -56,8 +54,6 @@ export class PasswordHealthMembersURIComponent implements OnInit {
   exposedPasswordMap = new Map<string, number>();
 
   dataSource = new TableDataSource<CipherView>();
-
-  totalMembersMap = new Map<string, number>();
 
   reportCiphers: (CipherView & { hostURI: string })[] = [];
   reportCipherURIs: string[] = [];
@@ -91,17 +87,6 @@ export class PasswordHealthMembersURIComponent implements OnInit {
         switchMap(() => from(this.setCiphers())),
       )
       .subscribe();
-
-    // mock data - will be replaced with actual data
-    userData.forEach((user) => {
-      user.cipherIds.forEach((cipherId: string) => {
-        if (this.totalMembersMap.has(cipherId)) {
-          this.totalMembersMap.set(cipherId, (this.totalMembersMap.get(cipherId) || 0) + 1);
-        } else {
-          this.totalMembersMap.set(cipherId, 1);
-        }
-      });
-    });
   }
 
   async setCiphers() {

--- a/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members-uri.component.ts
@@ -1,0 +1,246 @@
+import { CommonModule } from "@angular/common";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { from, map, switchMap, tap } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AuditService } from "@bitwarden/common/abstractions/audit.service";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  BadgeModule,
+  BadgeVariant,
+  ContainerComponent,
+  TableDataSource,
+  TableModule,
+} from "@bitwarden/components";
+
+// eslint-disable-next-line no-restricted-imports
+import { HeaderModule } from "../../layouts/header/header.module";
+// eslint-disable-next-line no-restricted-imports
+import { OrganizationBadgeModule } from "../../vault/individual-vault/organization-badge/organization-badge.module";
+// eslint-disable-next-line no-restricted-imports
+import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
+
+import { userData } from "./password-health.mock";
+
+@Component({
+  standalone: true,
+  selector: "tools-password-health-members-uri",
+  templateUrl: "password-health-members-uri.component.html",
+  imports: [
+    BadgeModule,
+    OrganizationBadgeModule,
+    CommonModule,
+    ContainerComponent,
+    PipesModule,
+    JslibModule,
+    HeaderModule,
+    TableModule,
+  ],
+})
+export class PasswordHealthMembersURIComponent implements OnInit {
+  passwordStrengthMap = new Map<string, [string, BadgeVariant]>();
+
+  weakPasswordCiphers: CipherView[] = [];
+
+  passwordUseMap = new Map<string, number>();
+
+  exposedPasswordMap = new Map<string, number>();
+
+  dataSource = new TableDataSource<CipherView>();
+
+  totalMembersMap = new Map<string, number>();
+
+  reportCiphers: (CipherView & { hostURI: string })[] = [];
+  reportCipherURIs: string[] = [];
+
+  organization: Organization;
+
+  loading = true;
+
+  private destroyRef = inject(DestroyRef);
+
+  constructor(
+    protected cipherService: CipherService,
+    protected passwordStrengthService: PasswordStrengthServiceAbstraction,
+    protected organizationService: OrganizationService,
+    protected auditService: AuditService,
+    protected i18nService: I18nService,
+    protected activatedRoute: ActivatedRoute,
+  ) {}
+
+  ngOnInit() {
+    this.activatedRoute.paramMap
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        map((params) => params.get("organizationId")),
+        switchMap((organizationId) => {
+          return from(this.organizationService.get(organizationId));
+        }),
+        tap((organization) => {
+          this.organization = organization;
+        }),
+        switchMap(() => from(this.setCiphers())),
+      )
+      .subscribe();
+
+    // mock data - will be replaced with actual data
+    userData.forEach((user) => {
+      user.cipherIds.forEach((cipherId: string) => {
+        if (this.totalMembersMap.has(cipherId)) {
+          this.totalMembersMap.set(cipherId, (this.totalMembersMap.get(cipherId) || 0) + 1);
+        } else {
+          this.totalMembersMap.set(cipherId, 1);
+        }
+      });
+    });
+  }
+
+  async setCiphers() {
+    const allCiphers = await this.cipherService.getAllFromApiForOrganization(this.organization.id);
+    // const allCiphers = cipherData;
+    allCiphers.forEach(async (cipher) => {
+      this.findWeakPassword(cipher);
+      this.findReusedPassword(cipher);
+      await this.findExposedPassword(cipher);
+    });
+    this.dataSource.data = this.reportCiphers;
+    this.loading = false;
+
+    // const reportIssues = allCiphers.map((c) => {
+    //   if (this.passwordStrengthMap.has(c.id)) {
+    //     return c;
+    //   }
+
+    //   if (this.passwordUseMap.has(c.id)) {
+    //     return c;
+    //   }
+
+    //   if (this.exposedPasswordMap.has(c.id)) {
+    //     return c;
+    //   }
+    // });
+  }
+
+  protected checkForExistingCipher(ciph: CipherView) {
+    ciph.trimmedURIs.forEach((uri: string) => {
+      if (!this.reportCipherURIs.includes(uri)) {
+        this.reportCiphers.push({ ...ciph, hostURI: uri } as CipherView & { hostURI: string });
+      }
+    });
+  }
+
+  protected async findExposedPassword(cipher: CipherView) {
+    const { type, login, isDeleted, edit, viewPassword, id } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    const exposedCount = await this.auditService.passwordLeaked(login.password);
+    if (exposedCount > 0) {
+      this.exposedPasswordMap.set(id, exposedCount);
+      this.checkForExistingCipher(cipher);
+    }
+  }
+
+  protected findReusedPassword(cipher: CipherView) {
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    if (this.passwordUseMap.has(login.password)) {
+      this.passwordUseMap.set(login.password, this.passwordUseMap.get(login.password) || 0 + 1);
+    } else {
+      this.passwordUseMap.set(login.password, 1);
+    }
+
+    this.checkForExistingCipher(cipher);
+  }
+
+  protected findWeakPassword(cipher: CipherView): void {
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    const hasUserName = this.isUserNameNotEmpty(cipher);
+    let userInput: string[] = [];
+    if (hasUserName) {
+      const atPosition = login.username.indexOf("@");
+      if (atPosition > -1) {
+        userInput = userInput
+          .concat(
+            login.username
+              .substring(0, atPosition)
+              .trim()
+              .toLowerCase()
+              .split(/[^A-Za-z0-9]/),
+          )
+          .filter((i) => i.length >= 3);
+      } else {
+        userInput = login.username
+          .trim()
+          .toLowerCase()
+          .split(/[^A-Za-z0-9]/)
+          .filter((i) => i.length >= 3);
+      }
+    }
+    const { score } = this.passwordStrengthService.getPasswordStrength(
+      login.password,
+      null,
+      userInput.length > 0 ? userInput : null,
+    );
+
+    if (score != null && score <= 2) {
+      this.passwordStrengthMap.set(cipher.id, this.scoreKey(score));
+      this.checkForExistingCipher(cipher);
+    }
+  }
+
+  private isUserNameNotEmpty(c: CipherView): boolean {
+    return !Utils.isNullOrWhitespace(c.login.username);
+  }
+
+  private scoreKey(score: number): [string, BadgeVariant] {
+    switch (score) {
+      case 4:
+        return ["strong", "success"];
+      case 3:
+        return ["good", "primary"];
+      case 2:
+        return ["weak", "warning"];
+      default:
+        return ["veryWeak", "danger"];
+    }
+  }
+}

--- a/apps/web/src/app/tools/access-intelligence/password-health-members.component.html
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members.component.html
@@ -1,0 +1,61 @@
+<bit-container>
+  <p>{{ "passwordsReportDesc" | i18n }}</p>
+  <div *ngIf="loading">
+    <i
+      class="bwi bwi-spinner bwi-spin tw-text-muted"
+      title="{{ 'loading' | i18n }}"
+      aria-hidden="true"
+    ></i>
+    <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  </div>
+  <div class="tw-mt-4" *ngIf="!loading">
+    <bit-table [dataSource]="dataSource">
+      <ng-container header>
+        <tr bitRow>
+          <th bitCell></th>
+          <th bitCell bitSortable="name">{{ "name" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "weakness" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "timesReused" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "timesExposed" | i18n }}</th>
+          <th bitCell class="tw-text-right">{{ "totalMembers" | i18n }}</th>
+        </tr>
+      </ng-container>
+      <ng-template body let-rows$>
+        <tr bitRow *ngFor="let r of rows$ | async">
+          <td bitCell>
+            <app-vault-icon [cipher]="r"></app-vault-icon>
+          </td>
+          <td bitCell>
+            <ng-container>
+              <span>{{ r.name }}</span>
+            </ng-container>
+            <br />
+            <small>{{ r.subTitle }}</small>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span
+              bitBadge
+              *ngIf="passwordStrengthMap.has(r.id)"
+              [variant]="passwordStrengthMap.get(r.id)[1]"
+            >
+              {{ passwordStrengthMap.get(r.id)[0] | i18n }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span bitBadge *ngIf="passwordUseMap.has(r.login.password)" variant="warning">
+              {{ "reusedXTimes" | i18n: passwordUseMap.get(r.login.password) }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right">
+            <span bitBadge *ngIf="exposedPasswordMap.has(r.id)" variant="warning">
+              {{ "exposedXTimes" | i18n: exposedPasswordMap.get(r.id) }}
+            </span>
+          </td>
+          <td bitCell class="tw-text-right" data-testid="total-membership">
+            {{ totalMembersMap.get(r.id) || 0 }}
+          </td>
+        </tr>
+      </ng-template>
+    </bit-table>
+  </div>
+</bit-container>

--- a/apps/web/src/app/tools/access-intelligence/password-health-members.component.spec.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members.component.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, convertToParamMap } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { AuditService } from "@bitwarden/common/abstractions/audit.service";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength/password-strength.service.abstraction";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { TableModule } from "@bitwarden/components";
+import { TableBodyDirective } from "@bitwarden/components/src/table/table.component";
+
+import { LooseComponentsModule } from "../../shared/loose-components.module";
+import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
+// eslint-disable-next-line no-restricted-imports
+import { cipherData } from "../reports/pages/reports-ciphers.mock";
+
+import { PasswordHealthMembersComponent } from "./password-health-members.component";
+import { PasswordHealthComponent } from "./password-health.component";
+
+describe("PasswordHealthMembersComponent", () => {
+  let component: PasswordHealthMembersComponent;
+  let fixture: ComponentFixture<PasswordHealthMembersComponent>;
+  let cipherServiceMock: MockProxy<CipherService>;
+  let passwordStrengthService: MockProxy<PasswordStrengthServiceAbstraction>;
+  let organizationService: MockProxy<OrganizationService>;
+  let auditServiceMock: MockProxy<AuditService>;
+  const activeRouteParams = convertToParamMap({ organizationId: "orgId1" });
+
+  beforeEach(async () => {
+    passwordStrengthService = mock<PasswordStrengthServiceAbstraction>();
+    auditServiceMock = mock<AuditService>();
+    organizationService = mock<OrganizationService>({
+      get: jest.fn().mockResolvedValue({ id: "orgId1" } as Organization),
+    });
+    cipherServiceMock = mock<CipherService>({
+      getAllFromApiForOrganization: jest.fn().mockResolvedValue(cipherData),
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [PasswordHealthComponent, PipesModule, TableModule, LooseComponentsModule],
+      declarations: [TableBodyDirective],
+      providers: [
+        { provide: CipherService, useValue: cipherServiceMock },
+        { provide: PasswordStrengthServiceAbstraction, useValue: passwordStrengthService },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: I18nService, useValue: mock<I18nService>() },
+        { provide: AuditService, useValue: auditServiceMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(activeRouteParams),
+            url: of([]),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PasswordHealthMembersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should initialize component", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should format URIs to hostnames", () => {
+    const ciphers = [
+      {
+        login: {
+          uris: [{ uri: "https://example.com/path" }, { uri: "http://another-example.com" }],
+        },
+      },
+      {
+        login: {
+          uris: [
+            { uri: "ftp://ftp.example.com/resource" },
+            { uri: "example.site.com" },
+            { uri: "example site" },
+          ],
+        },
+      },
+    ];
+
+    const formattedCiphers = component.formatUrisToHostnames(ciphers);
+
+    expect(formattedCiphers[0].login.uris[0].uri).toBe("example.com");
+    expect(formattedCiphers[0].login.uris[1].uri).toBe("another-example.com");
+    expect(formattedCiphers[1].login.uris[0].uri).toBe("ftp.example.com");
+    expect(formattedCiphers[1].login.uris[1].uri).toBe("example.site.com");
+    expect(formattedCiphers[1].login.uris[2].uri).toBe("example site");
+  });
+
+  it("should handle ciphers with no URIs", () => {
+    const ciphers = [
+      {
+        login: {
+          uris: [] as { uri: string }[],
+        },
+      },
+    ];
+
+    const formattedCiphers = component.formatUrisToHostnames(ciphers);
+
+    expect(formattedCiphers[0].login.uris.length).toBe(0);
+  });
+
+  it("should handle ciphers with null or undefined URIs", () => {
+    const ciphers = [
+      {
+        login: {
+          uris: null as { uri: string }[] | null,
+        },
+      },
+      {
+        login: {
+          uris: undefined,
+        },
+      },
+    ];
+
+    const formattedCiphers = component.formatUrisToHostnames(ciphers);
+
+    expect(formattedCiphers[0].login.uris).toBeNull();
+    expect(formattedCiphers[1].login.uris).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
@@ -108,7 +108,7 @@ export class PasswordHealthMembersComponent implements OnInit {
 
   async setCiphers() {
     // const allCiphers = await this.cipherService.getAllFromApiForOrganization(this.organization.id);
-    const allCiphers = cipherData;
+    const allCiphers = this.formatUrisToHostnames(cipherData);
     allCiphers.forEach(async (cipher) => {
       this.findWeakPassword(cipher);
       this.findReusedPassword(cipher);
@@ -130,6 +130,16 @@ export class PasswordHealthMembersComponent implements OnInit {
     //     return c;
     //   }
     // });
+  }
+
+  formatUrisToHostnames(ciphers: any[]) {
+    const allCiphers = cipherData;
+    allCiphers.map((cipher) => {
+      const uris = cipher.login?.uris ?? [];
+      uris.map((u: { uri: string }) => (u.uri = Utils.getHostname(u.uri)));
+      // console.log(`modified uris: ${JSON.stringify(uris)}`);
+    });
+    return allCiphers;
   }
 
   protected checkForExistingCipher(ciph: CipherView) {

--- a/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
@@ -1,0 +1,247 @@
+import { CommonModule } from "@angular/common";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { from, map, switchMap, tap } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AuditService } from "@bitwarden/common/abstractions/audit.service";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  BadgeModule,
+  BadgeVariant,
+  ContainerComponent,
+  TableDataSource,
+  TableModule,
+} from "@bitwarden/components";
+
+// eslint-disable-next-line no-restricted-imports
+import { HeaderModule } from "../../layouts/header/header.module";
+// eslint-disable-next-line no-restricted-imports
+import { OrganizationBadgeModule } from "../../vault/individual-vault/organization-badge/organization-badge.module";
+// eslint-disable-next-line no-restricted-imports
+import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
+// eslint-disable-next-line no-restricted-imports
+import { cipherData } from "../reports/pages/reports-ciphers.mock";
+
+import { userData } from "./password-health.mock";
+
+@Component({
+  standalone: true,
+  selector: "tools-password-health-members",
+  templateUrl: "password-health-members.component.html",
+  imports: [
+    BadgeModule,
+    OrganizationBadgeModule,
+    CommonModule,
+    ContainerComponent,
+    PipesModule,
+    JslibModule,
+    HeaderModule,
+    TableModule,
+  ],
+})
+export class PasswordHealthMembersComponent implements OnInit {
+  passwordStrengthMap = new Map<string, [string, BadgeVariant]>();
+
+  weakPasswordCiphers: CipherView[] = [];
+
+  passwordUseMap = new Map<string, number>();
+
+  exposedPasswordMap = new Map<string, number>();
+
+  dataSource = new TableDataSource<CipherView>();
+
+  totalMembersMap = new Map<string, number>();
+
+  reportCiphers: CipherView[] = [];
+  reportCipherIds: string[] = [];
+
+  organization: Organization;
+
+  loading = true;
+
+  private destroyRef = inject(DestroyRef);
+
+  constructor(
+    protected cipherService: CipherService,
+    protected passwordStrengthService: PasswordStrengthServiceAbstraction,
+    protected organizationService: OrganizationService,
+    protected auditService: AuditService,
+    protected i18nService: I18nService,
+    protected activatedRoute: ActivatedRoute,
+  ) {}
+
+  ngOnInit() {
+    this.activatedRoute.paramMap
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        map((params) => params.get("organizationId")),
+        switchMap((organizationId) => {
+          return from(this.organizationService.get(organizationId));
+        }),
+        tap((organization) => {
+          this.organization = organization;
+        }),
+        switchMap(() => from(this.setCiphers())),
+      )
+      .subscribe();
+
+    // mock data - will be replaced with actual data
+    userData.forEach((user) => {
+      user.cipherIds.forEach((cipherId: string) => {
+        if (this.totalMembersMap.has(cipherId)) {
+          this.totalMembersMap.set(cipherId, (this.totalMembersMap.get(cipherId) || 0) + 1);
+        } else {
+          this.totalMembersMap.set(cipherId, 1);
+        }
+      });
+    });
+  }
+
+  async setCiphers() {
+    // const allCiphers = await this.cipherService.getAllFromApiForOrganization(this.organization.id);
+    const allCiphers = cipherData;
+    allCiphers.forEach(async (cipher) => {
+      this.findWeakPassword(cipher);
+      this.findReusedPassword(cipher);
+      await this.findExposedPassword(cipher);
+    });
+    this.dataSource.data = this.reportCiphers;
+    this.loading = false;
+
+    // const reportIssues = allCiphers.map((c) => {
+    //   if (this.passwordStrengthMap.has(c.id)) {
+    //     return c;
+    //   }
+
+    //   if (this.passwordUseMap.has(c.id)) {
+    //     return c;
+    //   }
+
+    //   if (this.exposedPasswordMap.has(c.id)) {
+    //     return c;
+    //   }
+    // });
+  }
+
+  protected checkForExistingCipher(ciph: CipherView) {
+    if (!this.reportCipherIds.includes(ciph.id)) {
+      this.reportCipherIds.push(ciph.id);
+      this.reportCiphers.push(ciph);
+    }
+  }
+
+  protected async findExposedPassword(cipher: CipherView) {
+    const { type, login, isDeleted, edit, viewPassword, id } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    const exposedCount = await this.auditService.passwordLeaked(login.password);
+    if (exposedCount > 0) {
+      this.exposedPasswordMap.set(id, exposedCount);
+      this.checkForExistingCipher(cipher);
+    }
+  }
+
+  protected findReusedPassword(cipher: CipherView) {
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    if (this.passwordUseMap.has(login.password)) {
+      this.passwordUseMap.set(login.password, this.passwordUseMap.get(login.password) || 0 + 1);
+    } else {
+      this.passwordUseMap.set(login.password, 1);
+    }
+
+    this.checkForExistingCipher(cipher);
+  }
+
+  protected findWeakPassword(cipher: CipherView): void {
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return;
+    }
+
+    const hasUserName = this.isUserNameNotEmpty(cipher);
+    let userInput: string[] = [];
+    if (hasUserName) {
+      const atPosition = login.username.indexOf("@");
+      if (atPosition > -1) {
+        userInput = userInput
+          .concat(
+            login.username
+              .substring(0, atPosition)
+              .trim()
+              .toLowerCase()
+              .split(/[^A-Za-z0-9]/),
+          )
+          .filter((i) => i.length >= 3);
+      } else {
+        userInput = login.username
+          .trim()
+          .toLowerCase()
+          .split(/[^A-Za-z0-9]/)
+          .filter((i) => i.length >= 3);
+      }
+    }
+    const { score } = this.passwordStrengthService.getPasswordStrength(
+      login.password,
+      null,
+      userInput.length > 0 ? userInput : null,
+    );
+
+    if (score != null && score <= 2) {
+      this.passwordStrengthMap.set(cipher.id, this.scoreKey(score));
+      this.checkForExistingCipher(cipher);
+    }
+  }
+
+  private isUserNameNotEmpty(c: CipherView): boolean {
+    return !Utils.isNullOrWhitespace(c.login.username);
+  }
+
+  private scoreKey(score: number): [string, BadgeVariant] {
+    switch (score) {
+      case 4:
+        return ["strong", "success"];
+      case 3:
+        return ["good", "primary"];
+      case 2:
+        return ["weak", "warning"];
+      default:
+        return ["veryWeak", "danger"];
+    }
+  }
+}

--- a/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health-members.component.ts
@@ -133,11 +133,10 @@ export class PasswordHealthMembersComponent implements OnInit {
   }
 
   formatUrisToHostnames(ciphers: any[]) {
-    const allCiphers = cipherData;
+    const allCiphers = ciphers;
     allCiphers.map((cipher) => {
       const uris = cipher.login?.uris ?? [];
       uris.map((u: { uri: string }) => (u.uri = Utils.getHostname(u.uri)));
-      // console.log(`modified uris: ${JSON.stringify(uris)}`);
     });
     return allCiphers;
   }

--- a/apps/web/src/app/tools/access-intelligence/password-health.mock.ts
+++ b/apps/web/src/app/tools/access-intelligence/password-health.mock.ts
@@ -1,0 +1,66 @@
+export const userData: any[] = [
+  {
+    userName: "David Brent",
+    email: "david.brent@wernhamhogg.uk",
+    usesKeyConnector: true,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228ab1",
+      "cbea34a8-bde4-46ad-9d19-b05001228ab2",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+      "cbea34a8-bde4-46ad-9d19-b05001227nm5",
+    ],
+  },
+  {
+    userName: "Tim Canterbury",
+    email: "tim.canterbury@wernhamhogg.uk",
+    usesKeyConnector: false,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228ab2",
+      "cbea34a8-bde4-46ad-9d19-b05001228cd3",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+      "cbea34a8-bde4-46ad-9d19-b05001227nm5",
+    ],
+  },
+  {
+    userName: "Gareth Keenan",
+    email: "gareth.keenan@wernhamhogg.uk",
+    usesKeyConnector: true,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228cd3",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+      "cbea34a8-bde4-46ad-9d19-b05001227nm5",
+      "cbea34a8-bde4-46ad-9d19-b05001227nm7",
+    ],
+  },
+  {
+    userName: "Dawn Tinsley",
+    email: "dawn.tinsley@wernhamhogg.uk",
+    usesKeyConnector: true,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228ab2",
+      "cbea34a8-bde4-46ad-9d19-b05001228cd3",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+    ],
+  },
+  {
+    userName: "Keith Bishop",
+    email: "keith.bishop@wernhamhogg.uk",
+    usesKeyConnector: false,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228ab1",
+      "cbea34a8-bde4-46ad-9d19-b05001228cd3",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+      "cbea34a8-bde4-46ad-9d19-b05001227nm5",
+    ],
+  },
+  {
+    userName: "Chris Finch",
+    email: "chris.finch@wernhamhogg.uk",
+    usesKeyConnector: true,
+    cipherIds: [
+      "cbea34a8-bde4-46ad-9d19-b05001228ab2",
+      "cbea34a8-bde4-46ad-9d19-b05001228cd3",
+      "cbea34a8-bde4-46ad-9d19-b05001228xy4",
+    ],
+  },
+];

--- a/apps/web/src/app/tools/reports/pages/reports-ciphers.mock.ts
+++ b/apps/web/src/app/tools/reports/pages/reports-ciphers.mock.ts
@@ -12,6 +12,14 @@ export const cipherData: any[] = [
     organizationUseTotp: false,
     login: {
       password: "123",
+      hasUris: true,
+      uris: [
+        { uri: "https://www.google.com" },
+        { uri: "https://www.google.com/accounts" },
+        { uri: "https://www.accounts.google.com" },
+        { uri: "https://accounts.google.com" },
+        { uri: "accounts.google.com/all" },
+      ],
     },
     edit: false,
     viewPassword: true,

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -132,6 +132,10 @@ export class CipherView implements View, InitializerMetadata {
     );
   }
 
+  get trimmedURIs(): string[] {
+    return this.login?.uris?.map((u) => u.uri.replace(/(^\w+:|^)\/\//, "")) || [];
+  }
+
   linkedFieldValue(id: LinkedIdType) {
     const linkedFieldOption = this.linkedFieldOptions?.get(id);
     if (linkedFieldOption == null) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13454

## 📔 Objective

This PR adds a new component that displays the list of ciphers split up by host.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-10-16 at 4 57 39 PM](https://github.com/user-attachments/assets/36700a8b-980c-44fa-b06e-eb9398df3645)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
