### PR TITLE
[PM-13804] Add new Is-Prerelease header to requests

### DIFF
--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -3,7 +3,7 @@
 export type SharedFlags = {
   showPasswordless?: boolean;
   sdk?: boolean;
-  betaBuild?: boolean;
+  prereleaseBuild?: boolean;
 };
 
 // required to avoid linting errors when there are no flags

--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -3,6 +3,7 @@
 export type SharedFlags = {
   showPasswordless?: boolean;
   sdk?: boolean;
+  betaBuild?: boolean;
 };
 
 // required to avoid linting errors when there are no flags

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -126,6 +126,7 @@ import { AppIdService } from "../platform/abstractions/app-id.service";
 import { EnvironmentService } from "../platform/abstractions/environment.service";
 import { LogService } from "../platform/abstractions/log.service";
 import { PlatformUtilsService } from "../platform/abstractions/platform-utils.service";
+import { flagEnabled } from "../platform/misc/flags";
 import { Utils } from "../platform/misc/utils";
 import { SyncResponse } from "../platform/sync";
 import { UserId } from "../types/guid";
@@ -1843,44 +1844,20 @@ export class ApiService implements ApiServiceAbstraction {
     const requestUrl =
       apiUrl + Utils.normalizePath(pathParts[0]) + (pathParts.length > 1 ? `?${pathParts[1]}` : "");
 
-    const headers = new Headers({
-      "Device-Type": this.deviceType,
-    });
-    if (this.customUserAgent != null) {
-      headers.set("User-Agent", this.customUserAgent);
-    }
+    const [requestHeaders, requestBody] = await this.buildHeadersAndBody(
+      authed,
+      hasResponse,
+      alterHeaders,
+      body,
+    );
 
     const requestInit: RequestInit = {
       cache: "no-store",
       credentials: await this.getCredentials(),
       method: method,
     };
-
-    if (authed) {
-      const authHeader = await this.getActiveBearerToken();
-      headers.set("Authorization", "Bearer " + authHeader);
-    }
-    if (body != null) {
-      if (typeof body === "string") {
-        requestInit.body = body;
-        headers.set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
-      } else if (typeof body === "object") {
-        if (body instanceof FormData) {
-          requestInit.body = body;
-        } else {
-          headers.set("Content-Type", "application/json; charset=utf-8");
-          requestInit.body = JSON.stringify(body);
-        }
-      }
-    }
-    if (hasResponse) {
-      headers.set("Accept", "application/json");
-    }
-    if (alterHeaders != null) {
-      alterHeaders(headers);
-    }
-
-    requestInit.headers = headers;
+    requestInit.headers = requestHeaders;
+    requestInit.body = requestBody;
     const response = await this.fetch(new Request(requestUrl, requestInit));
 
     const responseType = response.headers.get("content-type");
@@ -1895,6 +1872,51 @@ export class ApiService implements ApiServiceAbstraction {
       const error = await this.handleError(response, false, authed);
       return Promise.reject(error);
     }
+  }
+
+  private async buildHeadersAndBody(
+    authed: boolean,
+    hasResponse: boolean,
+    body: any,
+    alterHeaders: (headers: Headers) => void,
+  ): Promise<[Headers, any]> {
+    let requestBody: any = null;
+    const headers = new Headers({
+      "Device-Type": this.deviceType,
+    });
+
+    if (flagEnabled("betaBuild")) {
+      headers.set("Is-Beta", "true");
+    }
+    if (this.customUserAgent != null) {
+      headers.set("User-Agent", this.customUserAgent);
+    }
+    if (hasResponse) {
+      headers.set("Accept", "application/json");
+    }
+    if (alterHeaders != null) {
+      alterHeaders(headers);
+    }
+    if (authed) {
+      const authHeader = await this.getActiveBearerToken();
+      headers.set("Authorization", "Bearer " + authHeader);
+    }
+
+    if (body != null) {
+      if (typeof body === "string") {
+        requestBody = body;
+        headers.set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+      } else if (typeof body === "object") {
+        if (body instanceof FormData) {
+          requestBody = body;
+        } else {
+          headers.set("Content-Type", "application/json; charset=utf-8");
+          requestBody = JSON.stringify(body);
+        }
+      }
+    }
+
+    return [headers, requestBody];
   }
 
   private async handleError(

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1885,8 +1885,8 @@ export class ApiService implements ApiServiceAbstraction {
       "Device-Type": this.deviceType,
     });
 
-    if (flagEnabled("betaBuild")) {
-      headers.set("Is-Beta", "true");
+    if (flagEnabled("prereleaseBuild")) {
+      headers.set("Is-Prerelease", "true");
     }
     if (this.customUserAgent != null) {
       headers.set("User-Agent", this.customUserAgent);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13804

## 📔 Objective

We want the ability to control feature flags based on whether the requesting client is a beta build or not.

To provide this context to LaunchDarkly, we must introduce a way for the clients to communicate that they are a beta to the server, where it can be used to build the LaunchDarkly context.

This will be done with an `Is-Prerelease` header on the request.

This PR adds that header to all API requests to our back-end based on whether the client-side `prereleaseBuild` flag is enabled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
