### PR TITLE
[PM-12996] Updating UI Spacing for bit section header

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -1,5 +1,5 @@
 <bit-section *ngIf="ciphers?.length > 0 || description" [disableMargin]="disableSectionMargin">
-  <bit-section-header>
+  <bit-section-header class="tw-space-x-1">
     <h2 bitTypography="h6">
       {{ title }}
     </h2>

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -1,18 +1,20 @@
 <bit-section *ngIf="ciphers?.length > 0 || description" [disableMargin]="disableSectionMargin">
-  <bit-section-header class="tw-space-x-1">
-    <h2 bitTypography="h6">
-      {{ title }}
-    </h2>
-    <button
-      *ngIf="showRefresh"
-      bitIconButton="bwi-refresh"
-      type="button"
-      size="small"
-      (click)="onRefresh.emit()"
-      [appA11yTitle]="'refresh' | i18n"
-    ></button>
-    <span bitTypography="body2" slot="end">{{ ciphers.length }}</span>
-  </bit-section-header>
+  <div class="tw-ml-1">
+    <bit-section-header>
+      <h2 bitTypography="h6">
+        {{ title }}
+      </h2>
+      <button
+        *ngIf="showRefresh"
+        bitIconButton="bwi-refresh"
+        type="button"
+        size="small"
+        (click)="onRefresh.emit()"
+        [appA11yTitle]="'refresh' | i18n"
+      ></button>
+      <span bitTypography="body2" slot="end">{{ ciphers.length }}</span>
+    </bit-section-header>
+  </div>
   <div *ngIf="description" class="tw-text-muted tw-px-1 tw-mb-2" bitTypography="body2">
     {{ description }}
   </div>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12996

## 📔 Objective

Update UI to have more spacing to the left of the header where it's off.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/bf7ead52-4055-4181-8f20-876b08c077bf)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
