### PR TITLE
SRE-1060 Add usdev to additional regions config

### DIFF
--- a/apps/web/config/usdev.json
+++ b/apps/web/config/usdev.json
@@ -4,6 +4,15 @@
     "notifications": "https://notifications.usdev.bitwarden.pw",
     "scim": "https://scim.usdev.bitwarden.pw"
   },
+  "additionalRegions": [
+    {
+      "key": "USDEV",
+      "domain": "usdev.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.usdev.bitwarden.pw"
+      }
+    }
+  ],
   "flags": {
     "showPasswordless": true
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/SRE-1060

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This populates the web vault client `additionalRegions` configuration with USDEV environment details to fix an issue where the web vault defaults to self hosted region if one isn't explicitly defined. This issue was leading to an incorrect url being generated when enabling SCIM provisioning on an Organization in the USDEV environment. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
