### PR TITLE
Removed unused twoFactorProviders property references

### DIFF
--- a/libs/auth/src/common/login-strategies/login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/login.strategy.spec.ts
@@ -360,7 +360,6 @@ describe("LoginStrategy", () => {
     it("rejects login if 2FA is required", async () => {
       // Sample response where TOTP 2FA required
       const tokenResponse = new IdentityTwoFactorResponse({
-        TwoFactorProviders: ["0"],
         TwoFactorProviders2: { 0: null },
         error: "invalid_grant",
         error_description: "Two factor required.",
@@ -393,7 +392,6 @@ describe("LoginStrategy", () => {
         "BwSsoEmail2FaSessionToken_CfDJ8AMrVzKqBFpKqzzsahUx8ubIi9AhHm6aLHDLpCUYc3QV3qC14iuSVkNg57Q7-kGQUn1z87bGY1WP58jFMNJ6ndaurIgQWNfPNN4DG-dBhvzarOAZ0RKY5oKT5futWm6_k9NMMGd8PcGGHg5Pq1_koOIwRtiXO3IpD-bemB7m8oEvbj__JTQP3Mcz-UediFlCbYBKU3wyIiBL_tF8hW5D4RAUa5ZzXIuauJiiCdDS7QOzBcqcusVAPGFfKjfIdAwFfKSOYd5KmYrhK7Y7ymjweP_igPYKB5aMfcVaYr5ux-fdffeJTGqtJorwNjLUYNv7KA";
 
       const tokenResponse = new IdentityTwoFactorResponse({
-        TwoFactorProviders: ["1"],
         TwoFactorProviders2: { "1": { Email: "k***@bitwarden.com" } },
         error: "invalid_grant",
         error_description: "Two factor required.",

--- a/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
@@ -246,7 +246,6 @@ describe("PasswordLoginStrategy", () => {
     tokenService.decodeAccessToken.mockResolvedValue({ sub: userId });
 
     const token2FAResponse = new IdentityTwoFactorResponse({
-      TwoFactorProviders: ["0"],
       TwoFactorProviders2: { 0: null },
       error: "invalid_grant",
       error_description: "Two factor required.",

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
@@ -199,7 +199,6 @@ describe("LoginStrategyService", () => {
     const credentials = new PasswordLoginCredentials("EMAIL", "MASTER_PASSWORD");
     apiService.postIdentityToken.mockResolvedValueOnce(
       new IdentityTwoFactorResponse({
-        TwoFactorProviders: ["0"],
         TwoFactorProviders2: { 0: null },
         error: "invalid_grant",
         error_description: "Two factor required.",
@@ -258,7 +257,6 @@ describe("LoginStrategyService", () => {
     const credentials = new PasswordLoginCredentials("EMAIL", "MASTER_PASSWORD");
     apiService.postIdentityToken.mockResolvedValue(
       new IdentityTwoFactorResponse({
-        TwoFactorProviders: ["0"],
         TwoFactorProviders2: { 0: null },
         error: "invalid_grant",
         error_description: "Two factor required.",

--- a/libs/common/src/auth/models/response/identity-two-factor.response.ts
+++ b/libs/common/src/auth/models/response/identity-two-factor.response.ts
@@ -4,8 +4,6 @@ import { TwoFactorProviderType } from "../../enums/two-factor-provider-type";
 import { MasterPasswordPolicyResponse } from "./master-password-policy.response";
 
 export class IdentityTwoFactorResponse extends BaseResponse {
-  // contains available two-factor providers
-  twoFactorProviders: TwoFactorProviderType[];
   // a map of two-factor providers to necessary data for completion
   twoFactorProviders2: Record<TwoFactorProviderType, Record<string, string>>;
   captchaToken: string;
@@ -16,7 +14,6 @@ export class IdentityTwoFactorResponse extends BaseResponse {
   constructor(response: any) {
     super(response);
     this.captchaToken = this.getResponseProperty("CaptchaBypassToken");
-    this.twoFactorProviders = this.getResponseProperty("TwoFactorProviders");
     this.twoFactorProviders2 = this.getResponseProperty("TwoFactorProviders2");
     this.masterPasswordPolicy = new MasterPasswordPolicyResponse(
       this.getResponseProperty("MasterPasswordPolicy"),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13850

## 📔 Objective

We currently send back both a `twoFactorProviders` and `twoFactorProviders2` property on the authentication response when 2FA is required.

The `twoFactorProviders2` is used by the client, but the `twoFactorProviders` is no longer used.

This PR removes all client references to the unused property, so that we can follow up with a change to remove it from the server as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
