### PR TITLE
[PM-13813] - fix voiceover on send created screen

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
+++ b/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
@@ -15,7 +15,9 @@
       class="tw-flex tw-bg-background-alt tw-flex-col tw-justify-center tw-items-center tw-gap-2 tw-h-full tw-px-5"
     >
       <bit-icon [icon]="sendCreatedIcon"></bit-icon>
-      <h3 class="tw-font-semibold">{{ "createdSendSuccessfully" | i18n }}</h3>
+      <h3 tabindex="0" appAutofocus class="tw-font-semibold">
+        {{ "createdSendSuccessfully" | i18n }}
+      </h3>
       <p class="tw-text-center">
         {{ formatExpirationDate() }}
       </p>

--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
@@ -6,7 +6,7 @@
   <bit-card>
     <bit-form-field>
       <bit-label>{{ "name" | i18n }}</bit-label>
-      <input bitInput type="text" formControlName="name" />
+      <input appAutofocus bitInput type="text" formControlName="name" />
     </bit-form-field>
 
     <tools-send-text-details


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13813

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where screen readers weren't reading the send created success text. Adding an autofocus and tabindex allows for the text to be focused.

As a bonus autofocus was also added to the `name` input in the the send details form to improve the ux

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
