### PR TITLE
Auth/AnonLayoutWrapperComponents - Add reset support for null values

### DIFF
--- a/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
+++ b/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
@@ -131,31 +131,35 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (data.pageTitle) {
-      this.pageTitle = this.handleStringOrTranslation(data.pageTitle);
+    // Null emissions are used to reset the page data as all fields are optional.
+
+    if (data.pageTitle !== undefined) {
+      this.pageTitle =
+        data.pageTitle !== null ? this.handleStringOrTranslation(data.pageTitle) : null;
     }
 
-    if (data.pageSubtitle) {
-      this.pageSubtitle = this.handleStringOrTranslation(data.pageSubtitle);
+    if (data.pageSubtitle !== undefined) {
+      this.pageSubtitle =
+        data.pageSubtitle !== null ? this.handleStringOrTranslation(data.pageSubtitle) : null;
     }
 
-    if (data.pageIcon) {
-      this.pageIcon = data.pageIcon;
+    if (data.pageIcon !== undefined) {
+      this.pageIcon = data.pageIcon !== null ? data.pageIcon : null;
     }
 
-    if (data.showReadonlyHostname != null) {
+    if (data.showReadonlyHostname !== undefined) {
       this.showReadonlyHostname = data.showReadonlyHostname;
     }
 
-    if (data.showAcctSwitcher != null) {
+    if (data.showAcctSwitcher !== undefined) {
       this.showAcctSwitcher = data.showAcctSwitcher;
     }
 
-    if (data.showBackButton != null) {
+    if (data.showBackButton !== undefined) {
       this.showBackButton = data.showBackButton;
     }
 
-    if (data.showLogo != null) {
+    if (data.showLogo !== undefined) {
       this.showLogo = data.showLogo;
     }
   }

--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
@@ -14,17 +14,17 @@ export interface AnonLayoutWrapperData {
    * If a string is provided, it will be presented as is (ex: Organization name)
    * If a Translation object (supports placeholders) is provided, it will be translated
    */
-  pageTitle?: string | Translation;
+  pageTitle?: string | Translation | null;
   /**
    * The optional subtitle of the page.
    * If a string is provided, it will be presented as is (ex: user's email)
    * If a Translation object (supports placeholders) is provided, it will be translated
    */
-  pageSubtitle?: string | Translation;
+  pageSubtitle?: string | Translation | null;
   /**
    * The optional icon to display on the page.
    */
-  pageIcon?: Icon;
+  pageIcon?: Icon | null;
   /**
    * Optional flag to either show the optional environment selector (false) or just a readonly hostname (true).
    */
@@ -114,19 +114,23 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (data.pageTitle) {
-      this.pageTitle = this.handleStringOrTranslation(data.pageTitle);
+    // Null emissions are used to reset the page data as all fields are optional.
+
+    if (data.pageTitle !== undefined) {
+      this.pageTitle =
+        data.pageTitle !== null ? this.handleStringOrTranslation(data.pageTitle) : null;
     }
 
-    if (data.pageSubtitle) {
-      this.pageSubtitle = this.handleStringOrTranslation(data.pageSubtitle);
+    if (data.pageSubtitle !== undefined) {
+      this.pageSubtitle =
+        data.pageSubtitle !== null ? this.handleStringOrTranslation(data.pageSubtitle) : null;
     }
 
-    if (data.pageIcon) {
-      this.pageIcon = data.pageIcon;
+    if (data.pageIcon !== undefined) {
+      this.pageIcon = data.pageIcon !== null ? data.pageIcon : null;
     }
 
-    if (data.showReadonlyHostname != null) {
+    if (data.showReadonlyHostname !== undefined) {
       this.showReadonlyHostname = data.showReadonlyHostname;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a but blocks https://github.com/bitwarden/clients/pull/10856

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To add support to the default and extension AnonLayoutWrapperComponents for removing previously set values by passing null. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Page subtitle removal demo:

https://github.com/user-attachments/assets/21babf30-aaa7-4bd0-b6d3-3a0f26b52a75



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
