### PR TITLE
[PM-13896] Browser Refresh - Avoid sorting items when a search term is applied

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -277,6 +277,10 @@ describe("VaultPopupItemsService", () => {
   });
 
   describe("remainingCiphers$", () => {
+    beforeEach(() => {
+      searchService.isSearchable.mockImplementation(async (text) => text.length > 2);
+    });
+
     it("should exclude autofill and favorite ciphers", (done) => {
       service.remainingCiphers$.subscribe((ciphers) => {
         // 2 autofill ciphers, 2 favorite ciphers = 6 remaining ciphers to show
@@ -285,9 +289,17 @@ describe("VaultPopupItemsService", () => {
       });
     });
 
-    it("should sort by last used then by name", (done) => {
-      service.remainingCiphers$.subscribe((ciphers) => {
+    it("should sort by last used then by name by default", (done) => {
+      service.remainingCiphers$.subscribe(() => {
         expect(cipherServiceMock.getLocaleSortingFunction).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it("should NOT sort by last used then by name when search text is applied", (done) => {
+      service.applyFilter("Login");
+      service.remainingCiphers$.subscribe(() => {
+        expect(cipherServiceMock.getLocaleSortingFunction).not.toHaveBeenCalled();
         done();
       });
     });

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -6,7 +6,6 @@ import {
   distinctUntilChanged,
   distinctUntilKeyChanged,
   filter,
-  from,
   map,
   merge,
   MonoTypeOperatorFunction,
@@ -111,6 +110,14 @@ export class VaultPopupItemsService {
     ),
   );
 
+  /**
+   * Observable that indicates whether there is search text present that is searchable.
+   * @private
+   */
+  private _hasSearchText$ = this._searchText$.pipe(
+    switchMap((searchText) => this.searchService.isSearchable(searchText)),
+  );
+
   private _filteredCipherList$: Observable<PopupCipherView[]> = combineLatest([
     this._activeCipherList$,
     this._searchText$,
@@ -179,7 +186,11 @@ export class VaultPopupItemsService {
         (cipher) => !autoFillCiphers.includes(cipher) && !favoriteCiphers.includes(cipher),
       ),
     ),
-    map((ciphers) => ciphers.sort(this.cipherService.getLocaleSortingFunction())),
+    withLatestFrom(this._hasSearchText$),
+    map(([ciphers, hasSearchText]) =>
+      // Do not sort alphabetically when there is search text, default to the search service scoring
+      hasSearchText ? ciphers : ciphers.sort(this.cipherService.getLocaleSortingFunction()),
+    ),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
@@ -192,19 +203,14 @@ export class VaultPopupItemsService {
   ).pipe(startWith(true), distinctUntilChanged(), shareReplay({ refCount: false, bufferSize: 1 }));
 
   /**
-   * Observable that indicates whether a filter is currently applied to the ciphers.
+   * Observable that indicates whether a filter or search text is currently applied to the ciphers.
    */
   hasFilterApplied$ = combineLatest([
-    this._searchText$,
+    this._hasSearchText$,
     this.vaultPopupListFiltersService.filters$,
   ]).pipe(
-    switchMap(([searchText, filters]) => {
-      return from(this.searchService.isSearchable(searchText)).pipe(
-        map(
-          (isSearchable) =>
-            isSearchable || Object.values(filters).some((filter) => filter !== null),
-        ),
-      );
+    map(([hasSearchText, filters]) => {
+      return hasSearchText || Object.values(filters).some((filter) => filter !== null);
     }),
   );
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13896](https://bitwarden.atlassian.net/browse/PM-13896)

## 📔 Objective

Do not sort "All Items" section by name when a search term is applied. Default to sorting by the search score handled by the `searchService` to keep the existing extension search behavior.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/13f8d7a6-9be8-4523-8d04-169ff555a168)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13896]: https://bitwarden.atlassian.net/browse/PM-13896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ