### PR TITLE
[PM-12600] prevent verified user from deleting their account

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -10,7 +10,17 @@ import {
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { Router } from "@angular/router";
-import { catchError, filter, firstValueFrom, map, of, Subject, takeUntil, timeout } from "rxjs";
+import {
+  catchError,
+  filter,
+  firstValueFrom,
+  map,
+  of,
+  Subject,
+  takeUntil,
+  timeout,
+  withLatestFrom,
+} from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
@@ -22,6 +32,7 @@ import { NotificationsService } from "@bitwarden/common/abstractions/notificatio
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
 import { VaultTimeoutService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout.service";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -154,6 +165,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private stateEventRunnerService: StateEventRunnerService,
     private accountService: AccountService,
     private sdkService: SdkService,
+    private organizationService: OrganizationService,
   ) {
     if (flagEnabled("sdk")) {
       // Warn if the SDK for some reason can't be initialized
@@ -308,7 +320,8 @@ export class AppComponent implements OnInit, OnDestroy {
             break;
           }
           case "deleteAccount":
-            DeleteAccountComponent.open(this.dialogService);
+            // check if can delete account
+            await this.deleteAccount();
             break;
           case "openPasswordHistory":
             await this.openModal<PasswordGeneratorHistoryComponent>(
@@ -861,5 +874,29 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     this.messagingService.send(message, { code: code, state: receivedState });
+  }
+
+  private async deleteAccount() {
+    await firstValueFrom(
+      this.configService.getFeatureFlag$(FeatureFlag.AccountDeprovisioning).pipe(
+        withLatestFrom(this.organizationService.organizations$),
+        map(async ([accountDeprovisioningEnabled, organization]) => {
+          if (
+            accountDeprovisioningEnabled &&
+            organization.some((o) => o.userIsManagedByOrganization === true)
+          ) {
+            await this.dialogService.openSimpleDialog({
+              title: { key: "cannotDeleteAccount" },
+              content: { key: "cannotDeleteAccountDesc" },
+              cancelButtonText: null,
+              acceptButtonText: { key: "close" },
+              type: "danger",
+            });
+          } else {
+            DeleteAccountComponent.open(this.dialogService);
+          }
+        }),
+      ),
+    );
   }
 }

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -320,7 +320,6 @@ export class AppComponent implements OnInit, OnDestroy {
             break;
           }
           case "deleteAccount":
-            // check if can delete account
             await this.deleteAccount();
             break;
           case "openPasswordHistory":

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1651,6 +1651,12 @@
   "deleteAccountWarning": {
     "message": "Deleting your account is permanent. It cannot be undone."
   },
+  "cannotDeleteAccount":{
+    "message": "Cannot delete account"
+  },
+  "cannotDeleteAccountDesc":{
+    "message": "This action cannot be completed because your account is owned by an organization. Contact your organization administrator for additional details."
+  },
   "accountDeleted": {
     "message": "Account deleted"
   },


### PR DESCRIPTION
## 🎟️ Tracking
server PR: https://github.com/bitwarden/server/pull/4932

[PM-12600](https://bitwarden.atlassian.net/browse/PM-12600)

## 📔 Objective

This PR adds a check for if a user is managed by an organization before deleting and shows a simple dialog if they are, preventing the deletion.

## 📸 Screenshots

<img width="441" alt="Screenshot 2024-10-23 at 10 39 26 AM" src="https://github.com/user-attachments/assets/ac04bcab-0924-4277-9890-6f4feed5779c">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12600]: https://bitwarden.atlassian.net/browse/PM-12600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ