### PR TITLE
[PM-13187] Hide "Assign To Collections" when the user has no orgs

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
@@ -28,7 +28,7 @@
       <a bitMenuItem (click)="clone()">
         {{ "clone" | i18n }}
       </a>
-      <a bitMenuItem (click)="conditionallyNavigateToAssignCollections()">
+      <a bitMenuItem *ngIf="hasOrganizations" (click)="conditionallyNavigateToAssignCollections()">
         {{ "assignToCollections" | i18n }}
       </a>
     </ng-container>

--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from "@angular/common";
-import { booleanAttribute, Component, Input } from "@angular/core";
+import { booleanAttribute, Component, Input, OnInit } from "@angular/core";
 import { Router, RouterModule } from "@angular/router";
 import { firstValueFrom, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -29,7 +30,7 @@ import { AddEditQueryParams } from "../add-edit/add-edit-v2.component";
   templateUrl: "./item-more-options.component.html",
   imports: [ItemModule, IconButtonModule, MenuModule, CommonModule, JslibModule, RouterModule],
 })
-export class ItemMoreOptionsComponent {
+export class ItemMoreOptionsComponent implements OnInit {
   @Input({
     required: true,
   })
@@ -44,6 +45,9 @@ export class ItemMoreOptionsComponent {
 
   protected autofillAllowed$ = this.vaultPopupAutofillService.autofillAllowed$;
 
+  /** Boolean dependent on the current user having access to an organization */
+  protected hasOrganizations = false;
+
   constructor(
     private cipherService: CipherService,
     private passwordRepromptService: PasswordRepromptService,
@@ -53,7 +57,12 @@ export class ItemMoreOptionsComponent {
     private i18nService: I18nService,
     private vaultPopupAutofillService: VaultPopupAutofillService,
     private accountService: AccountService,
+    private organizationService: OrganizationService,
   ) {}
+
+  async ngOnInit(): Promise<void> {
+    this.hasOrganizations = await this.organizationService.hasOrganizations();
+  }
 
   get canEdit() {
     return this.cipher.edit;

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
@@ -92,7 +92,7 @@ export class VaultCipherRowComponent implements OnInit {
   }
 
   protected get showAssignToCollections() {
-    return this.canEditCipher && !this.cipher.isDeleted;
+    return this.organizations?.length && this.canEditCipher && !this.cipher.isDeleted;
   }
 
   protected get showClone() {

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -299,6 +299,11 @@ export class VaultItemsComponent {
       return false;
     }
 
+    // When the user doesn't belong to an organization, hide assign to collections
+    if (this.allOrganizations.length === 0) {
+      return false;
+    }
+
     if (this.selection.selected.length === 0) {
       return true;
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13187](https://bitwarden.atlassian.net/browse/PM-13187)

## 📔 Objective

When a user is not a part of an organization, the "Assign To Collection" option should be hidden in both the web vault and browser.
- Note: The "Assign To Collections" option on the web is _not_ behind the extension refresh feature flag

## 📸 Screenshots

|Web|Browser|
|-|-|
|<img width="377" alt="browser" src="https://github.com/user-attachments/assets/333abd34-d85a-4e96-a684-12ab4dcd87b6">|<img width="1779" alt="web" src="https://github.com/user-attachments/assets/e5cd0b51-c11d-4de9-a874-556d36ad7e30">|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13187]: https://bitwarden.atlassian.net/browse/PM-13187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ