### PR TITLE
[PM-13723] track history in generator components

### DIFF
--- a/libs/tools/generator/components/src/credential-generator.component.ts
+++ b/libs/tools/generator/components/src/credential-generator.component.ts
@@ -37,6 +37,7 @@ import {
   isUsernameAlgorithm,
   toCredentialGeneratorConfiguration,
 } from "@bitwarden/generator-core";
+import { GeneratorHistoryService } from "@bitwarden/generator-history";
 
 // constants used to identify navigation selections that are not
 // generator algorithms
@@ -51,6 +52,7 @@ const NONE_SELECTED = "none";
 export class CredentialGeneratorComponent implements OnInit, OnDestroy {
   constructor(
     private generatorService: CredentialGeneratorService,
+    private generatorHistoryService: GeneratorHistoryService,
     private toastService: ToastService,
     private logService: LogService,
     private i18nService: I18nService,
@@ -185,6 +187,12 @@ export class CredentialGeneratorComponent implements OnInit, OnDestroy {
         takeUntil(this.destroyed),
       )
       .subscribe((generated) => {
+        this.generatorHistoryService
+          .track(this.userId, generated.credential, generated.category, generated.generationDate)
+          .catch((e: unknown) => {
+            this.logService.error(e);
+          });
+
         // update subjects within the angular zone so that the
         // template bindings refresh immediately
         this.zone.run(() => {

--- a/libs/tools/generator/components/src/password-generator.component.ts
+++ b/libs/tools/generator/components/src/password-generator.component.ts
@@ -2,6 +2,7 @@ import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { Component, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output } from "@angular/core";
 import {
   BehaviorSubject,
+  catchError,
   distinctUntilChanged,
   filter,
   map,
@@ -14,7 +15,9 @@ import {
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { UserId } from "@bitwarden/common/types/guid";
+import { ToastService } from "@bitwarden/components";
 import { Option } from "@bitwarden/components/src/select/option";
 import {
   CredentialGeneratorService,
@@ -25,6 +28,7 @@ import {
   isPasswordAlgorithm,
   AlgorithmInfo,
 } from "@bitwarden/generator-core";
+import { GeneratorHistoryService } from "@bitwarden/generator-history";
 
 /** Options group for passwords */
 @Component({
@@ -34,6 +38,9 @@ import {
 export class PasswordGeneratorComponent implements OnInit, OnDestroy {
   constructor(
     private generatorService: CredentialGeneratorService,
+    private generatorHistoryService: GeneratorHistoryService,
+    private toastService: ToastService,
+    private logService: LogService,
     private i18nService: I18nService,
     private accountService: AccountService,
     private zone: NgZone,
@@ -101,10 +108,31 @@ export class PasswordGeneratorComponent implements OnInit, OnDestroy {
     // wire up the generator
     this.algorithm$
       .pipe(
+        filter((algorithm) => !!algorithm),
         switchMap((algorithm) => this.typeToGenerator$(algorithm.id)),
+        catchError((error: unknown, generator) => {
+          if (typeof error === "string") {
+            this.toastService.showToast({
+              message: error,
+              variant: "error",
+              title: "",
+            });
+          } else {
+            this.logService.error(error);
+          }
+
+          // continue with origin stream
+          return generator;
+        }),
         takeUntil(this.destroyed),
       )
       .subscribe((generated) => {
+        this.generatorHistoryService
+          .track(this.userId, generated.credential, generated.category, generated.generationDate)
+          .catch((e: unknown) => {
+            this.logService.error(e);
+          });
+
         // update subjects within the angular zone so that the
         // template bindings refresh immediately
         this.zone.run(() => {

--- a/libs/tools/generator/components/src/username-generator.component.ts
+++ b/libs/tools/generator/components/src/username-generator.component.ts
@@ -36,6 +36,7 @@ import {
   isUsernameAlgorithm,
   toCredentialGeneratorConfiguration,
 } from "@bitwarden/generator-core";
+import { GeneratorHistoryService } from "@bitwarden/generator-history";
 
 // constants used to identify navigation selections that are not
 // generator algorithms
@@ -57,6 +58,7 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
    */
   constructor(
     private generatorService: CredentialGeneratorService,
+    private generatorHistoryService: GeneratorHistoryService,
     private toastService: ToastService,
     private logService: LogService,
     private i18nService: I18nService,
@@ -156,6 +158,12 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
         takeUntil(this.destroyed),
       )
       .subscribe((generated) => {
+        this.generatorHistoryService
+          .track(this.userId, generated.credential, generated.category, generated.generationDate)
+          .catch((e: unknown) => {
+            this.logService.error(e);
+          });
+
         // update subjects within the angular zone so that the
         // template bindings refresh immediately
         this.zone.run(() => {

--- a/libs/tools/generator/extensions/history/src/generated-credential.ts
+++ b/libs/tools/generator/extensions/history/src/generated-credential.ts
@@ -1,6 +1,6 @@
 import { Jsonify } from "type-fest";
 
-import { GeneratorCategory } from "./options";
+import { CredentialAlgorithm } from "@bitwarden/generator-core";
 
 /** A credential generation result */
 export class GeneratedCredential {
@@ -14,7 +14,7 @@ export class GeneratedCredential {
    */
   constructor(
     readonly credential: string,
-    readonly category: GeneratorCategory,
+    readonly category: CredentialAlgorithm,
     generationDate: Date | number,
   ) {
     if (typeof generationDate === "number") {

--- a/libs/tools/generator/extensions/history/src/generator-history.abstraction.ts
+++ b/libs/tools/generator/extensions/history/src/generator-history.abstraction.ts
@@ -1,9 +1,9 @@
 import { Observable } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
+import { CredentialAlgorithm } from "@bitwarden/generator-core";
 
 import { GeneratedCredential } from "./generated-credential";
-import { GeneratorCategory } from "./options";
 
 /** Tracks the history of password generations.
  *  Each user gets their own store.
@@ -27,7 +27,7 @@ export abstract class GeneratorHistoryService {
   track: (
     userId: UserId,
     credential: string,
-    category: GeneratorCategory,
+    category: CredentialAlgorithm,
     date?: Date,
   ) => Promise<GeneratedCredential | null>;
 

--- a/libs/tools/generator/extensions/history/src/local-generator-history.service.ts
+++ b/libs/tools/generator/extensions/history/src/local-generator-history.service.ts
@@ -8,12 +8,13 @@ import { PaddedDataPacker } from "@bitwarden/common/tools/state/padded-data-pack
 import { SecretState } from "@bitwarden/common/tools/state/secret-state";
 import { UserKeyEncryptor } from "@bitwarden/common/tools/state/user-key-encryptor";
 import { UserId } from "@bitwarden/common/types/guid";
+import { CredentialAlgorithm } from "@bitwarden/generator-core";
 
 import { GeneratedCredential } from "./generated-credential";
 import { GeneratorHistoryService } from "./generator-history.abstraction";
 import { GENERATOR_HISTORY, GENERATOR_HISTORY_BUFFER } from "./key-definitions";
 import { LegacyPasswordHistoryDecryptor } from "./legacy-password-history-decryptor";
-import { GeneratorCategory, HistoryServiceOptions } from "./options";
+import { HistoryServiceOptions } from "./options";
 
 const OPTIONS_FRAME_SIZE = 2048;
 
@@ -33,7 +34,12 @@ export class LocalGeneratorHistoryService extends GeneratorHistoryService {
   private _credentialStates = new Map<UserId, SingleUserState<GeneratedCredential[]>>();
 
   /** {@link GeneratorHistoryService.track} */
-  track = async (userId: UserId, credential: string, category: GeneratorCategory, date?: Date) => {
+  track = async (
+    userId: UserId,
+    credential: string,
+    category: CredentialAlgorithm,
+    date?: Date,
+  ) => {
     const state = this.getCredentialState(userId);
     let result: GeneratedCredential = null;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13723

## 📔 Objective

Add an entry to the generator history log when the generator generates a new component.

This PR also doubles the size of the log to account for username entries.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
