### PR TITLE
increase minimum number of words on passphrases to 6

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/password-generator.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/password-generator.component.html
@@ -60,7 +60,7 @@
     <div class="tw-grid tw-grid-cols-12 tw-gap-4">
       <bit-form-field class="tw-col-span-6">
         <bit-label>{{ "minimumNumberOfWords" | i18n }}</bit-label>
-        <input bitInput type="number" min="3" max="20" formControlName="minNumberWords" />
+        <input bitInput type="number" min="6" max="20" formControlName="minNumberWords" />
       </bit-form-field>
     </div>
     <bit-form-control>

--- a/libs/tools/generator/core/src/data/default-passphrase-boundaries.ts
+++ b/libs/tools/generator/core/src/data/default-passphrase-boundaries.ts
@@ -1,6 +1,6 @@
 function initializeBoundaries() {
   const numWords = Object.freeze({
-    min: 3,
+    min: 6,
     max: 20,
   });
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8689

## 📔 Objective

Increase entropy of generated passphrases.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
