### PR TITLE
[PM-13806] Bugfix - Do not redirect after saving changes to excluded domains

### DIFF
--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
@@ -11,7 +11,7 @@
         accountSwitcherEnabled ? ("excludedDomainsDescAlt" | i18n) : ("excludedDomainsDesc" | i18n)
       }}
     </p>
-    <bit-section>
+    <bit-section *ngIf="!isLoading">
       <bit-section-header>
         <h2 bitTypography="h6">{{ "domainsTitle" | i18n }}</h2>
         <span bitTypography="body2" slot="end">{{ excludedDomainsState?.length || 0 }}</span>
@@ -57,7 +57,13 @@
     </bit-section>
   </div>
   <popup-footer slot="footer">
-    <button bitButton buttonType="primary" type="submit" (click)="saveChanges()">
+    <button
+      bitButton
+      buttonType="primary"
+      type="submit"
+      [disabled]="dataIsPristine"
+      (click)="saveChanges()"
+    >
       {{ "save" | i18n }}
     </button>
   </popup-footer>


### PR DESCRIPTION
## 🎟️ Tracking

PM-13806

## 📔 Objective

Currently, when saving an excluded domain in the notification settings menu, the user it navigated back to the notification settings menu. If they then try to navigate back using the back arrow in the top nav, they will go back to the excluded domains settings, which will navigate back to the notification settings (in a navigation loop).

This PR eliminates the redirect on save behaviour and resolves some hidden state issues on excluded domains updates.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
