### PR TITLE
[PM-13907] [PM-13849] Browser Refresh - Improve launch login UX

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -574,6 +574,15 @@
   "launchWebsite": {
     "message": "Launch website"
   },
+  "launchWebsiteName": {
+    "message": "Launch website $ITEMNAME$",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret item"
+      }
+    }
+  },
   "website": {
     "message": "Website"
   },

--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
@@ -17,9 +17,6 @@
           {{ "fillAndSave" | i18n }}
         </button>
       </ng-container>
-      <button type="button" bitMenuItem *ngIf="this.canLaunch" (click)="launchCipher()">
-        {{ "launchWebsite" | i18n }}
-      </button>
     </ng-container>
     <button type="button" bitMenuItem (click)="toggleFavorite()">
       {{ favoriteText | i18n }}

--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -18,8 +18,6 @@ import {
 } from "@bitwarden/components";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
-import { BrowserApi } from "../../../../../platform/browser/browser-api";
-import BrowserPopupUtils from "../../../../../platform/popup/browser-popup-utils";
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { AddEditQueryParams } from "../add-edit/add-edit-v2.component";
 
@@ -80,30 +78,6 @@ export class ItemMoreOptionsComponent {
 
   async doAutofillAndSave() {
     await this.vaultPopupAutofillService.doAutofillAndSave(this.cipher, false);
-  }
-
-  /**
-   * Determines if the login cipher can be launched in a new browser tab.
-   */
-  get canLaunch() {
-    return this.cipher.type === CipherType.Login && this.cipher.login.canLaunch;
-  }
-
-  /**
-   * Launches the login cipher in a new browser tab.
-   */
-  async launchCipher() {
-    if (!this.canLaunch) {
-      return;
-    }
-
-    await this.cipherService.updateLastLaunchedDate(this.cipher.id);
-
-    await BrowserApi.createNewTab(this.cipher.login.launchUri);
-
-    if (BrowserPopupUtils.inPopup(window)) {
-      BrowserApi.closePopup(window);
-    }
   }
 
   /**

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -28,6 +28,7 @@
           bit-item-content
           type="button"
           (click)="onViewCipher(cipher)"
+          (dblclick)="launchCipher(cipher)"
           [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
           class="{{ ItemHeightClass }}"
         >

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -60,6 +60,16 @@
               {{ "autoFill" | i18n }}
             </button>
           </bit-item-action>
+          <bit-item-action *ngIf="!showAutofillButton && cipher.canLaunch">
+            <button
+              type="button"
+              bitIconButton="bwi-external-link"
+              size="small"
+              (click)="launchCipher(cipher)"
+              [attr.aria-label]="'launchWebsiteName' | i18n: cipher.name"
+              [title]="'launchWebsiteName' | i18n: cipher.name"
+            ></button>
+          </bit-item-action>
           <app-item-copy-actions [cipher]="cipher"></app-item-copy-actions>
           <app-item-more-options
             [cipher]="cipher"

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -53,6 +53,12 @@ export class VaultListItemsContainerComponent {
   protected ItemHeight = BitItemHeight;
 
   /**
+   * Timeout used to add a small delay when selecting a cipher to allow for double click to launch
+   * @private
+   */
+  private viewCipherTimeout: number | null;
+
+  /**
    * The list of ciphers to display.
    */
   @Input()
@@ -124,6 +130,12 @@ export class VaultListItemsContainerComponent {
       return;
     }
 
+    // If there is a view action pending, clear it
+    if (this.viewCipherTimeout != null) {
+      window.clearTimeout(this.viewCipherTimeout);
+      this.viewCipherTimeout = null;
+    }
+
     await this.cipherService.updateLastLaunchedDate(cipher.id);
 
     await BrowserApi.createNewTab(cipher.login.launchUri);
@@ -138,13 +150,28 @@ export class VaultListItemsContainerComponent {
   }
 
   async onViewCipher(cipher: PopupCipherView) {
-    const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
-    if (!repromptPassed) {
+    // We already have a view action in progress, don't start another
+    if (this.viewCipherTimeout != null) {
       return;
     }
 
-    await this.router.navigate(["/view-cipher"], {
-      queryParams: { cipherId: cipher.id, type: cipher.type },
-    });
+    // Wrap in a timeout to allow for double click to launch
+    this.viewCipherTimeout = window.setTimeout(
+      async () => {
+        try {
+          const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
+          if (!repromptPassed) {
+            return;
+          }
+          await this.router.navigate(["/view-cipher"], {
+            queryParams: { cipherId: cipher.id, type: cipher.type },
+          });
+        } finally {
+          // Ensure the timeout is always cleared
+          this.viewCipherTimeout = null;
+        }
+      },
+      cipher.canLaunch ? 200 : 0,
+    );
   }
 }

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -5,6 +5,8 @@ import { Router, RouterLink } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeModule,
   BitItemHeight,
@@ -18,6 +20,8 @@ import {
 } from "@bitwarden/components";
 import { OrgIconDirective, PasswordRepromptService } from "@bitwarden/vault";
 
+import { BrowserApi } from "../../../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../../../platform/popup/browser-popup-utils";
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { PopupCipherView } from "../../../views/popup-cipher.view";
 import { ItemCopyActionsComponent } from "../item-copy-action/item-copy-actions.component";
@@ -108,8 +112,26 @@ export class VaultListItemsContainerComponent {
     private i18nService: I18nService,
     private vaultPopupAutofillService: VaultPopupAutofillService,
     private passwordRepromptService: PasswordRepromptService,
+    private cipherService: CipherService,
     private router: Router,
   ) {}
+
+  /**
+   * Launches the login cipher in a new browser tab.
+   */
+  async launchCipher(cipher: CipherView) {
+    if (!cipher.canLaunch) {
+      return;
+    }
+
+    await this.cipherService.updateLastLaunchedDate(cipher.id);
+
+    await BrowserApi.createNewTab(cipher.login.launchUri);
+
+    if (BrowserPopupUtils.inPopup(window)) {
+      BrowserApi.closePopup(window);
+    }
+  }
 
   async doAutofill(cipher: PopupCipherView) {
     await this.vaultPopupAutofillService.doAutofill(cipher);

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -2,9 +2,8 @@ import { View } from "../../../models/view/view";
 import { InitializerMetadata } from "../../../platform/interfaces/initializer-metadata.interface";
 import { InitializerKey } from "../../../platform/services/cryptography/initializer-key";
 import { DeepJsonify } from "../../../types/deep-jsonify";
-import { LinkedIdType } from "../../enums";
+import { CipherType, LinkedIdType } from "../../enums";
 import { CipherRepromptType } from "../../enums/cipher-reprompt-type";
-import { CipherType } from "../../enums/cipher-type";
 import { LocalData } from "../data/local.data";
 import { Cipher } from "../domain/cipher";
 
@@ -130,6 +129,13 @@ export class CipherView implements View, InitializerMetadata {
     return (
       this.organizationId != null && (this.collectionIds == null || this.collectionIds.length === 0)
     );
+  }
+
+  /**
+   * Determines if the cipher can be launched in a new browser tab.
+   */
+  get canLaunch(): boolean {
+    return this.type === CipherType.Login && this.login.canLaunch;
   }
 
   linkedFieldValue(id: LinkedIdType) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13907](https://bitwarden.atlassian.net/browse/PM-13907)
[PM-13849](https://bitwarden.atlassian.net/browse/PM-13849)

## 📔 Objective

Add external link icon to Login items in the Vault for the Favorites and All Items lists. Also re-adds double click to launch support for Login items.

## 📸 Screenshots

https://github.com/user-attachments/assets/b946659d-f5fd-4a24-94b7-aa8730bddd87


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13907]: https://bitwarden.atlassian.net/browse/PM-13907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-13849]: https://bitwarden.atlassian.net/browse/PM-13849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ