### PR TITLE
Add logging for userkey / device trust rotation

### DIFF
--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.spec.ts
@@ -8,6 +8,7 @@ import { WebauthnRotateCredentialRequest } from "@bitwarden/common/auth/models/r
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendWithIdRequest } from "@bitwarden/common/tools/send/models/request/send-with-id.request";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
@@ -44,6 +45,7 @@ describe("KeyRotationService", () => {
   let mockConfigService: MockProxy<ConfigService>;
   let mockSyncService: MockProxy<SyncService>;
   let mockWebauthnLoginAdminService: MockProxy<WebauthnLoginAdminService>;
+  let mockLogService: MockProxy<LogService>;
 
   const mockUser = {
     id: "mockUserId" as UserId,
@@ -66,6 +68,7 @@ describe("KeyRotationService", () => {
     mockConfigService = mock<ConfigService>();
     mockSyncService = mock<SyncService>();
     mockWebauthnLoginAdminService = mock<WebauthnLoginAdminService>();
+    mockLogService = mock<LogService>();
 
     keyRotationService = new UserKeyRotationService(
       mockUserVerificationService,
@@ -80,6 +83,7 @@ describe("KeyRotationService", () => {
       mockEncryptService,
       mockSyncService,
       mockWebauthnLoginAdminService,
+      mockLogService,
     );
   });
 

--- a/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/auth/key-rotation/user-key-rotation.service.ts
@@ -8,6 +8,7 @@ import { VerificationType } from "@bitwarden/common/auth/enums/verification-type
 import { MasterPasswordVerification } from "@bitwarden/common/auth/types/verification";
 import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
 import { EncryptService } from "@bitwarden/common/platform/abstractions/encrypt.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { EncryptedString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -38,6 +39,7 @@ export class UserKeyRotationService {
     private encryptService: EncryptService,
     private syncService: SyncService,
     private webauthnLoginAdminService: WebauthnLoginAdminService,
+    private logService: LogService,
   ) {}
 
   /**
@@ -48,11 +50,14 @@ export class UserKeyRotationService {
     masterPassword: string,
     user: { id: UserId } & AccountInfo,
   ): Promise<void> {
+    this.logService.info("[Userkey rotation] Starting user key rotation...");
     if (!masterPassword) {
+      this.logService.info("[Userkey rotation] Invalid master password provided. Aborting!");
       throw new Error("Invalid master password");
     }
 
     if ((await this.syncService.getLastSync()) === null) {
+      this.logService.info("[Userkey rotation] Client was never synced. Aborting!");
       throw new Error(
         "The local vault is de-synced and the keys cannot be rotated. Please log out and log back in to resolve this issue.",
       );
@@ -74,6 +79,7 @@ export class UserKeyRotationService {
     const [newUserKey, newEncUserKey] = await this.cryptoService.makeUserKey(masterKey);
 
     if (!newUserKey || !newEncUserKey) {
+      this.logService.info("[Userkey rotation] User key could not be created. Aborting!");
       throw new Error("User key could not be created");
     }
 
@@ -91,6 +97,9 @@ export class UserKeyRotationService {
     // Note: We distribute the legacy key, but not all domains actually use it. If any of those
     // domains break their legacy support it will break the migration process for legacy users.
     const originalUserKey = await this.cryptoService.getUserKeyWithLegacySupport(user.id);
+    const isMasterKey =
+      (await firstValueFrom(this.cryptoService.userKey$(user.id))) != originalUserKey;
+    this.logService.info("[Userkey rotation] Is legacy user: " + isMasterKey);
 
     // Add re-encrypted data
     request.privateKey = await this.encryptPrivateKey(newUserKey, user.id);
@@ -151,10 +160,14 @@ export class UserKeyRotationService {
       request.webauthnKeys = rotatedWebauthnKeys;
     }
 
+    this.logService.info("[Userkey rotation] Posting user key rotation request to server");
     await this.apiService.postUserKeyUpdate(request);
+    this.logService.info("[Userkey rotation] Userkey rotation request posted to server");
 
     // TODO PM-2199: Add device trust rotation support to the user key rotation endpoint
+    this.logService.info("[Userkey rotation] Rotating device trust...");
     await this.deviceTrustService.rotateDevicesTrust(user.id, newUserKey, masterPasswordHash);
+    this.logService.info("[Userkey rotation] Device trust rotation completed");
   }
 
   private async encryptPrivateKey(

--- a/libs/common/src/auth/services/device-trust.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust.service.implementation.ts
@@ -175,6 +175,7 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     newUserKey: UserKey,
     masterPasswordHash: string,
   ): Promise<void> {
+    this.logService.info("[Device trust rotation] Rotating device trust...");
     if (!userId) {
       throw new Error("UserId is required. Cannot rotate device's trust.");
     }
@@ -183,11 +184,15 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     if (currentDeviceKey == null) {
       // If the current device doesn't have a device key available to it, then we can't
       // rotate any trust at all, so early return.
+      this.logService.info("[Device trust rotation] No device key available to rotate trust!");
       return;
     }
 
     // At this point of rotating their keys, they should still have their old user key in state
     const oldUserKey = await firstValueFrom(this.cryptoService.userKey$(userId));
+    if (oldUserKey == newUserKey) {
+      this.logService.info("[Device trust rotation] Old user key is the same as the new user key.");
+    }
 
     const deviceIdentifier = await this.appIdService.getAppId();
     const secretVerificationRequest = new SecretVerificationRequest();
@@ -229,7 +234,12 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     trustRequest.currentDevice = currentDeviceUpdateRequest;
     trustRequest.otherDevices = [];
 
+    this.logService.info(
+      "[Device trust rotation] Posting device trust update with current device:",
+      deviceIdentifier,
+    );
     await this.devicesApiService.updateTrust(trustRequest, deviceIdentifier);
+    this.logService.info("[Device trust rotation] Device trust update posted successfully.");
   }
 
   async getDeviceKey(userId: UserId): Promise<DeviceKey | null> {

--- a/libs/common/src/services/notifications.service.ts
+++ b/libs/common/src/services/notifications.service.ts
@@ -193,6 +193,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
         break;
       case NotificationType.LogOut:
         if (isAuthenticated) {
+          this.logService.info("[Notifications Service] Received logout notification");
           // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.logoutCallback("logoutNotification");


### PR DESCRIPTION
## 🎟️ Tracking

No specific ticket here. This is to debug tde key rotation issues.

## 📔 Objective

Add client-side logging needed to debug userkey rotation operations. Specifically, to userkey rotation service, notification service (for logout notifications) and device trust service.
_No sensitive data is logged._

These logs can then be provided by users or QA during screen recordings to better see what's going on.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
