### PR TITLE
Add logging for decryption failures

### DIFF
--- a/libs/common/src/platform/enums/encryption-type.enum.ts
+++ b/libs/common/src/platform/enums/encryption-type.enum.ts
@@ -8,6 +8,20 @@ export enum EncryptionType {
   Rsa2048_OaepSha1_HmacSha256_B64 = 6,
 }
 
+const EncryptionTypeNames = {
+  [EncryptionType.AesCbc256_B64]: "AesCbc256_B64",
+  [EncryptionType.AesCbc128_HmacSha256_B64]: "AesCbc128_HmacSha256_B64",
+  [EncryptionType.AesCbc256_HmacSha256_B64]: "AesCbc256_HmacSha256_B64",
+  [EncryptionType.Rsa2048_OaepSha256_B64]: "Rsa2048_OaeppSha256_B64",
+  [EncryptionType.Rsa2048_OaepSha1_B64]: "Rsa2048_OaepSha1_B64",
+  [EncryptionType.Rsa2048_OaepSha256_HmacSha256_B64]: "Rsa2048_OaepSha256_HmacSha256_B64",
+  [EncryptionType.Rsa2048_OaepSha1_HmacSha256_B64]: "Rsa2048_OaepSha1_HmacSha256_B64",
+};
+
+export function encryptionTypeToString(encryptionType: EncryptionType): string {
+  return EncryptionTypeNames[encryptionType];
+}
+
 /** The expected number of parts to a serialized EncString of the given encryption type.
  * For example, an EncString of type AesCbc256_B64 will have 2 parts, and an EncString of type
  * AesCbc128_HmacSha256_B64 will have 3 parts.

--- a/libs/common/src/platform/enums/encryption-type.enum.ts
+++ b/libs/common/src/platform/enums/encryption-type.enum.ts
@@ -8,19 +8,9 @@ export enum EncryptionType {
   Rsa2048_OaepSha1_HmacSha256_B64 = 6,
 }
 
-const EncryptionTypeNames = {
-  [EncryptionType.AesCbc256_B64]: "AesCbc256_B64",
-  [EncryptionType.AesCbc128_HmacSha256_B64]: "AesCbc128_HmacSha256_B64",
-  [EncryptionType.AesCbc256_HmacSha256_B64]: "AesCbc256_HmacSha256_B64",
-  [EncryptionType.Rsa2048_OaepSha256_B64]: "Rsa2048_OaeppSha256_B64",
-  [EncryptionType.Rsa2048_OaepSha1_B64]: "Rsa2048_OaepSha1_B64",
-  [EncryptionType.Rsa2048_OaepSha256_HmacSha256_B64]: "Rsa2048_OaepSha256_HmacSha256_B64",
-  [EncryptionType.Rsa2048_OaepSha1_HmacSha256_B64]: "Rsa2048_OaepSha1_HmacSha256_B64",
-};
-
 export function encryptionTypeToString(encryptionType: EncryptionType): string {
-  if (encryptionType in EncryptionTypeNames) {
-    return EncryptionTypeNames[encryptionType];
+  if (encryptionType in EncryptionType) {
+    return EncryptionType[encryptionType];
   } else {
     return "Unknown encryption type " + encryptionType;
   }

--- a/libs/common/src/platform/enums/encryption-type.enum.ts
+++ b/libs/common/src/platform/enums/encryption-type.enum.ts
@@ -19,7 +19,11 @@ const EncryptionTypeNames = {
 };
 
 export function encryptionTypeToString(encryptionType: EncryptionType): string {
-  return EncryptionTypeNames[encryptionType];
+  if (encryptionType in EncryptionTypeNames) {
+    return EncryptionTypeNames[encryptionType];
+  } else {
+    return "Unknown encryption type " + encryptionType;
+  }
 }
 
 /** The expected number of parts to a serialized EncString of the given encryption type.


### PR DESCRIPTION
## 🎟️ Tracking

-

## 📔 Objective

Improve the logging around encryption failures. Again no sensitive data is logged. Just encryption key types (i.e their algorithm). This allows us to better see what's going wrong (i.e instead of seeing "encryption type mismatch", we can see which encryption types are expected for the key / encstring).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
