### PR TITLE
Revert [PM-11312] Add "prevent screenshot" setting

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -419,23 +419,6 @@
                   "enableHardwareAccelerationDesc" | i18n
                 }}</small>
               </div>
-              <div class="form-group" *ngIf="!isLinux">
-                <div class="checkbox">
-                  <label for="allowScreenshots">
-                    <input
-                      id="allowScreenshots"
-                      type="checkbox"
-                      aria-describedby="allowScreenshotsHelp"
-                      formControlName="allowScreenshots"
-                      (change)="saveAllowScreenshots()"
-                    />
-                    {{ "allowScreenshots" | i18n }}
-                  </label>
-                </div>
-                <small id="allowScreenshotsHelp" class="help-block">{{
-                  "allowScreenshotsDesc" | i18n
-                }}</small>
-              </div>
               <div class="form-group" *ngIf="showDuckDuckGoIntegrationOption">
                 <div class="checkbox">
                   <label for="enableDuckDuckGoBrowserIntegration">

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -108,7 +108,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
       disabled: true,
     }),
     enableHardwareAcceleration: true,
-    allowScreenshots: false,
     enableDuckDuckGoBrowserIntegration: false,
     theme: [null as ThemeType | null],
     locale: [null as string | null],
@@ -274,7 +273,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
       enableHardwareAcceleration: await firstValueFrom(
         this.desktopSettingsService.hardwareAcceleration$,
       ),
-      allowScreenshots: await firstValueFrom(this.desktopSettingsService.allowScreenshots$),
       theme: await firstValueFrom(this.themeStateService.selectedTheme$),
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
     };
@@ -723,10 +721,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
     await this.desktopSettingsService.setHardwareAcceleration(
       this.form.value.enableHardwareAcceleration,
     );
-  }
-
-  async saveAllowScreenshots() {
-    await this.desktopSettingsService.setAllowScreenshots(this.form.value.allowScreenshots);
   }
 
   private async generateVaultTimeoutOptions(): Promise<VaultTimeoutOption[]> {

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3187,12 +3187,6 @@
   "textSends": {
     "message": "Text Sends"
   },
-  "allowScreenshots": {
-    "message": "Allow screen capture"
-  },
-  "allowScreenshotsDesc": {
-    "message": "Allow screen capture of the Bitwarden desktop application."
-  },
   "ssoError": {
     "message": "No free ports could be found for the sso login."
   },

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -69,13 +69,6 @@ export class WindowMain {
       this.logService.info("Render process reloaded");
     });
 
-    this.desktopSettingsService.allowScreenshots$.subscribe((allowed) => {
-      if (this.win == null) {
-        return;
-      }
-      this.win.setContentProtection(!allowed);
-    });
-
     return new Promise<void>((resolve, reject) => {
       try {
         if (!isMacAppStore() && !isSnapStore()) {
@@ -276,14 +269,6 @@ export class WindowMain {
         windowIsFocused: true,
       });
     });
-
-    firstValueFrom(this.desktopSettingsService.allowScreenshots$)
-      .then((allowScreenshots) => {
-        this.win.setContentProtection(!allowScreenshots);
-      })
-      .catch((e) => {
-        this.logService.error(e);
-      });
 
     if (this.createWindowCallback) {
       this.createWindowCallback(this.win);

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -71,10 +71,6 @@ const MINIMIZE_ON_COPY = new UserKeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "
   clearOn: [], // User setting, no need to clear
 });
 
-const ALLOW_SCREENSHOTS = new KeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "allowScreenshots", {
-  deserializer: (b) => b,
-});
-
 /**
  * Various settings for controlling application behavior specific to the desktop client.
  */
@@ -142,13 +138,6 @@ export class DesktopSettingsService {
    */
   browserIntegrationFingerprintEnabled$ =
     this.browserIntegrationFingerprintEnabledState.state$.pipe(map(Boolean));
-
-  private readonly allowScreenshotState = this.stateProvider.getGlobal(ALLOW_SCREENSHOTS);
-
-  /**
-   * The application setting for whether or not to allow screenshots of the app.
-   */
-  allowScreenshots$ = this.allowScreenshotState.state$.pipe(map(Boolean));
 
   private readonly minimizeOnCopyState = this.stateProvider.getActive(MINIMIZE_ON_COPY);
 
@@ -265,13 +254,5 @@ export class DesktopSettingsService {
    */
   async setMinimizeOnCopy(value: boolean, userId: UserId) {
     await this.stateProvider.getUser(userId, MINIMIZE_ON_COPY).update(() => value);
-  }
-
-  /**
-   * Sets the setting for whether or not the screenshot protection is enabled.
-   * @param value `true` if the screenshot protection is enabled, `false` if it is not.
-   */
-  async setAllowScreenshots(value: boolean) {
-    await this.allowScreenshotState.update(() => value);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11312

https://bitwarden.atlassian.net/browse/PM-13924

## 📔 Objective

This reverts the commit from https://github.com/bitwarden/clients/pull/10707 that introduced a setting to prevent screenshots.  We have had reports of users not able to view the desktop UI:

- https://github.com/bitwarden/clients/issues/11654
- https://www.reddit.com/r/Bitwarden/comments/1e5wzxq/bitwarden_desktop_app_not_opening_on_windows_10/

Users have confirmed with a build from this branch that reverting this feature resolves the issue for them.

We plan to follow up to make this feature disabled by default, as well as provide a way for users to disable it if they are no longer able to access the desktop when they do enable it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
