### PR TITLE
[PM-13854] update autofill label in browser

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -155,6 +155,10 @@
   "copyNotes": {
     "message": "Copy notes"
   },
+  "fill":{
+    "message": "Fill",
+    "description": "This string is used on the vault page to indicate autofilling. Horizontal space is limited in the interface here so try and keep translations as concise as possible."
+  },
   "autoFill": {
     "message": "Autofill"
   },

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -57,7 +57,7 @@
               [title]="'autofillTitle' | i18n: cipher.name"
               [attr.aria-label]="'autofillTitle' | i18n: cipher.name"
             >
-              {{ "autoFill" | i18n }}
+              {{ "fill" | i18n }}
             </button>
           </bit-item-action>
           <app-item-copy-actions [cipher]="cipher"></app-item-copy-actions>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13854](https://bitwarden.atlassian.net/browse/PM-13854)

## 📔 Objective

Update "autofill" label in browser to "fill" to fix horizontal spacing in the browser vault for long translations.

## 📸 Screenshots

![Screenshot 2024-10-24 at 10 45 26 AM](https://github.com/user-attachments/assets/891ffa23-5620-4609-9502-6bfd3513c966)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13854]: https://bitwarden.atlassian.net/browse/PM-13854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ