### PR TITLE
[PM-14007] Only show CB client org exp when provider is Billable

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -264,7 +264,7 @@
 </bit-container>
 <ng-template #hideSubscription>
   <bit-container *ngIf="!loading">
-    <ng-container *ngIf="enableConsolidatedBilling$ | async; else consolidatedBillingDisabled">
+    <ng-container *ngIf="providerIsOnConsolidatedBilling; else providerIsNotOnConsolidatedBilling">
       <h2 bitTypography="h2">{{ "manageSubscription" | i18n }}</h2>
       <p bitTypography="body1" *ngIf="userOrg.isProviderUser; else isOrganizationOwner">
         {{ "manageSubscriptionFromThe" | i18n }}
@@ -281,7 +281,7 @@
       </ng-template>
       <ng-container *ngTemplateOutlet="setupSelfHost"></ng-container>
     </ng-container>
-    <ng-template #consolidatedBillingDisabled>
+    <ng-template #providerIsNotOnConsolidatedBilling>
       <div class="tw-flex tw-flex-col tw-items-center tw-text-info">
         <bit-icon [icon]="subscriptionHiddenIcon"></bit-icon>
         <p class="tw-font-bold">{{ "billingManagedByProvider" | i18n: userOrg.providerName }}</p>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-14007

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In determining the experience for a client organization subscription, I was only pivoting off of the `enable-consolidated-billing` feature flag, but that flag is enabled now in all environments, so it doesn't do anything. I needed to check the provider status as well to determine if the provider has been migrated or not.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/31cbf095-09e7-464a-b80f-5b04c3670953


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
