### PR TITLE
Auth/PM-13945 - Extension - Fix TDE User with MP can't navigate to Lock Screen

### DIFF
--- a/libs/angular/src/auth/functions/unauth-ui-refresh-redirect.ts
+++ b/libs/angular/src/auth/functions/unauth-ui-refresh-redirect.ts
@@ -16,7 +16,12 @@ export function unauthUiRefreshRedirect(redirectUrl: string): () => Promise<bool
       FeatureFlag.UnauthenticatedExtensionUIRefresh,
     );
     if (shouldRedirect) {
-      return router.parseUrl(redirectUrl);
+      const currentNavigation = router.getCurrentNavigation();
+      const queryParams = currentNavigation?.extras?.queryParams || {};
+
+      // Preserve query params when redirecting as it is likely that the refreshed component
+      // will be consuming the same query params.
+      return router.createUrlTree([redirectUrl], { queryParams });
     } else {
       return true;
     }

--- a/libs/angular/src/utils/extension-refresh-redirect.ts
+++ b/libs/angular/src/utils/extension-refresh-redirect.ts
@@ -12,9 +12,15 @@ export function extensionRefreshRedirect(redirectUrl: string): () => Promise<boo
   return async () => {
     const configService = inject(ConfigService);
     const router = inject(Router);
+
     const shouldRedirect = await configService.getFeatureFlag(FeatureFlag.ExtensionRefresh);
     if (shouldRedirect) {
-      return router.parseUrl(redirectUrl);
+      const currentNavigation = router.getCurrentNavigation();
+      const queryParams = currentNavigation?.extras?.queryParams || {};
+
+      // Preserve query params when redirecting as it is likely that the refreshed component
+      // will be consuming the same query params.
+      return router.createUrlTree([redirectUrl], { queryParams });
     } else {
       return true;
     }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13945

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To allow a browser extension TDE user with a MP to access the lock screen so they can decrypt their vault. 

Further context:
The Extension Refresh redirects should persist the query params as we use query params to execute guard logic (e.g., `lockGuard`). The loss of the `from: login-initiated` query param after the redirect to the `lockV2` route prevented navigation to the lock screen.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/a2664e7d-faf8-40ee-a8d1-ba6562ea9ea7




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
