### PR TITLE
[PM-13658] Update copy of password history to generator history

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1913,11 +1913,11 @@
   "clearHistory": {
     "message": "Clear history"
   },
-  "noPasswordsToShow": {
-    "message": "No passwords to show"
+  "nothingToShow": {
+    "message": "Nothing to show"
   },
-  "noRecentlyGeneratedPassword": {
-    "message": "You haven't generated a password recently"
+  "nothingGeneratedRecently": {
+    "message": "You haven't generated anything recently"
   },
   "remove": {
     "message": "Remove"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1794,6 +1794,9 @@
   "passwordHistory": {
     "message": "Password history"
   },
+  "generatorHistory": {
+    "message": "Generator history"
+  },
   "back": {
     "message": "Back"
   },

--- a/apps/browser/src/tools/popup/generator/credential-generator-history.component.html
+++ b/apps/browser/src/tools/popup/generator/credential-generator-history.component.html
@@ -1,5 +1,5 @@
 <popup-page>
-  <popup-header slot="header" [pageTitle]="'passwordHistory' | i18n" showBackButton>
+  <popup-header slot="header" [pageTitle]="'generatorHistory' | i18n" showBackButton>
     <ng-container slot="end">
       <app-pop-out></app-pop-out>
     </ng-container>

--- a/apps/browser/src/tools/popup/generator/credential-generator.component.html
+++ b/apps/browser/src/tools/popup/generator/credential-generator.component.html
@@ -8,7 +8,7 @@
   <tools-credential-generator />
   <bit-item>
     <a type="button" bit-item-content routerLink="/generator-history">
-      {{ "passwordHistory" | i18n }}
+      {{ "generatorHistory" | i18n }}
       <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
     </a>
   </bit-item>

--- a/libs/tools/generator/components/src/empty-credential-history.component.html
+++ b/libs/tools/generator/components/src/empty-credential-history.component.html
@@ -1,7 +1,7 @@
 <div class="tw-flex tw-flex-col tw-h-full tw-justify-center">
   <div class="tw-text-center">
     <bit-icon [icon]="noCredentialsIcon" aria-hidden="true"></bit-icon>
-    <h2 bitTypography="h4" class="tw-mt-3">{{ "noPasswordsToShow" | i18n }}</h2>
-    <div>{{ "noRecentlyGeneratedPassword" | i18n }}</div>
+    <h2 bitTypography="h4" class="tw-mt-3">{{ "nothingToShow" | i18n }}</h2>
+    <div>{{ "nothingGeneratedRecently" | i18n }}</div>
   </div>
 </div>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13658

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Update the copy of buttons and titles to represent that the generator history supports all types and not just passwords/passphrases.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before
![image](https://github.com/user-attachments/assets/ab8fdf52-0926-4b55-a48a-0e3a44a35a57)
![image](https://github.com/user-attachments/assets/f4743096-b2de-4a39-a1ac-c549ee41e24a)

### After
![image](https://github.com/user-attachments/assets/14874fc8-940d-40ca-af3d-6ea7f261031a)
![image](https://github.com/user-attachments/assets/eaac3556-de71-4c95-a707-a95dfb2ec2e3)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
