### PR TITLE
[PM-13996] Add warning dialog when clearing generator history

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1794,6 +1794,12 @@
   "passwordHistory": {
     "message": "Password history"
   },
+  "clearGeneratorHistoryTitle": {
+    "message": "Clear generator history"
+  },
+  "cleargGeneratorHistoryDescription": {
+    "message": "If you continue, all entries will be permanently deleted from generator's history. Are you sure you want to continue?"
+  },
   "back": {
     "message": "Back"
   },

--- a/apps/browser/src/tools/popup/generator/credential-generator-history.component.ts
+++ b/apps/browser/src/tools/popup/generator/credential-generator-history.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject, distinctUntilChanged, firstValueFrom, map, switchMap }
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
-import { ButtonModule, ContainerComponent } from "@bitwarden/components";
+import { ButtonModule, ContainerComponent, DialogService } from "@bitwarden/components";
 import {
   CredentialGeneratorHistoryComponent as CredentialGeneratorHistoryToolsComponent,
   EmptyCredentialHistoryComponent,
@@ -42,6 +42,7 @@ export class CredentialGeneratorHistoryComponent {
   constructor(
     private accountService: AccountService,
     private history: GeneratorHistoryService,
+    private dialogService: DialogService,
   ) {
     this.accountService.activeAccount$
       .pipe(
@@ -61,6 +62,16 @@ export class CredentialGeneratorHistoryComponent {
   }
 
   clear = async () => {
-    await this.history.clear(await firstValueFrom(this.userId$));
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "clearGeneratorHistoryTitle" },
+      content: { key: "cleargGeneratorHistoryDescription" },
+      type: "warning",
+      acceptButtonText: { key: "clearHistory" },
+      cancelButtonText: { key: "cancel" },
+    });
+
+    if (confirmed) {
+      await this.history.clear(await firstValueFrom(this.userId$));
+    }
   };
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13996

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add a warning dialog for the user to confirm they, want to delete the generator history.

@danielleflinn I went with "removing entries" instead of "removing credentials"

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![image](https://github.com/user-attachments/assets/d80db3c6-bae0-47eb-8624-1d4e3aac478d)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
