### PR TITLE
[PM-14045] Scrolling content outside of iframe bounds breaks inline menu position

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -216,6 +216,7 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   getCurrentTabFrameId: ({ sender }: BackgroundSenderParam) => number;
   updateSubFrameData: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
   triggerSubFrameFocusInRebuild: ({ sender }: BackgroundSenderParam) => void;
+  shouldRepositionSubFrameInlineMenuOnScroll: ({ sender }: BackgroundSenderParam) => void;
   destroyAutofillInlineMenuListeners: ({
     message,
     sender,

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2598,12 +2598,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
   /**
    * Triggers on scroll of a frame within the tab. Will reposition the inline menu
-   * if the focused field is within a sub-frame.
+   * if the focused field is within a sub-frame and the inline menu is visible.
    *
    * @param sender - The sender of the message
    */
   private shouldRepositionSubFrameInlineMenuOnScroll(sender: chrome.runtime.MessageSender) {
-    if (!this.isFieldCurrentlyFocused || sender.tab.id !== this.focusedFieldData?.tabId) {
+    if (!this.isInlineMenuButtonVisible || sender.tab.id !== this.focusedFieldData?.tabId) {
       return false;
     }
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2596,6 +2596,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.repositionInlineMenu$.next(sender);
   }
 
+  /**
+   * Triggers on scroll of a frame within the tab. Will reposition the inline menu
+   * if the focused field is within a sub-frame.
+   *
+   * @param sender - The sender of the message
+   */
   private shouldRepositionSubFrameInlineMenuOnScroll(sender: chrome.runtime.MessageSender) {
     if (!this.isFieldCurrentlyFocused || sender.tab.id !== this.focusedFieldData?.tabId) {
       return false;

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -168,6 +168,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     getCurrentTabFrameId: ({ sender }) => this.getSenderFrameId(sender),
     updateSubFrameData: ({ message, sender }) => this.updateSubFrameData(message, sender),
     triggerSubFrameFocusInRebuild: ({ sender }) => this.triggerSubFrameFocusInRebuild(sender),
+    shouldRepositionSubFrameInlineMenuOnScroll: ({ sender }) =>
+      this.shouldRepositionSubFrameInlineMenuOnScroll(sender),
     destroyAutofillInlineMenuListeners: ({ message, sender }) =>
       this.triggerDestroyInlineMenuListeners(sender.tab, message.subFrameData.frameId),
     collectPageDetailsResponse: ({ message, sender }) => this.storePageDetails(message, sender),
@@ -2592,6 +2594,14 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.cancelInlineMenuFadeInAndPositionUpdate();
     this.rebuildSubFrameOffsets$.next(sender);
     this.repositionInlineMenu$.next(sender);
+  }
+
+  private shouldRepositionSubFrameInlineMenuOnScroll(sender: chrome.runtime.MessageSender) {
+    if (!this.isFieldCurrentlyFocused || sender.tab.id !== this.focusedFieldData?.tabId) {
+      return false;
+    }
+
+    return this.focusedFieldData.frameId > 0;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1699,6 +1699,7 @@ describe("AutofillOverlayContentService", () => {
     const repositionEvents = [EVENTS.SCROLL, EVENTS.RESIZE];
     repositionEvents.forEach((repositionEvent) => {
       it(`sends a message trigger overlay reposition message to the background when a ${repositionEvent} event occurs`, async () => {
+        sendExtensionMessageSpy.mockResolvedValueOnce(true);
         globalThis.dispatchEvent(new Event(repositionEvent));
         await flushPromises();
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1571,14 +1571,35 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       AUTOFILL_OVERLAY_HANDLE_REPOSITION,
     );
 
-    const eventTargetDoesNotContainFocusedField = (element: Element) =>
-      typeof element?.contains === "function" && !element.contains(this.mostRecentlyFocusedField);
+    const eventTargetContainsFocusedField = (eventTarget: Element | Document) => {
+      if (!eventTarget || !this.mostRecentlyFocusedField) {
+        return false;
+      }
+
+      const activeElement = (eventTarget as Document).activeElement;
+      if (activeElement) {
+        return (
+          activeElement === this.mostRecentlyFocusedField ||
+          activeElement.contains(this.mostRecentlyFocusedField)
+        );
+      }
+
+      if (typeof eventTarget.contains !== "function") {
+        return false;
+      }
+      return (
+        eventTarget === this.mostRecentlyFocusedField ||
+        eventTarget.contains(this.mostRecentlyFocusedField)
+      );
+    };
     const scrollHandler = this.useEventHandlersMemo(
-      throttle((event) => {
-        if (eventTargetDoesNotContainFocusedField(event.target as Element)) {
-          return;
+      throttle(async (event) => {
+        if (
+          eventTargetContainsFocusedField(event.target) ||
+          (await this.shouldRepositionSubFrameInlineMenuOnScroll())
+        ) {
+          repositionHandler(event);
         }
-        repositionHandler(event);
       }, 50),
       AUTOFILL_OVERLAY_HANDLE_SCROLL,
     );
@@ -1589,6 +1610,10 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     });
     globalThis.addEventListener(EVENTS.RESIZE, repositionHandler);
   }
+
+  private shouldRepositionSubFrameInlineMenuOnScroll = async () => {
+    return await this.sendExtensionMessage("shouldRepositionSubFrameInlineMenuOnScroll");
+  };
 
   /**
    * Removes the listeners that facilitate repositioning


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14045

## 📔 Objective

A regression with how the inline menu repositions itself for iframe content has been identified. When an form within an iframe has an parent frame that overflows the viewport, it’s possible to scroll that parent frame and misalign the inline menu. We need to account for scroll events that happen outside of iframes when triggering an inline menu re-position. 

This can be observed very easily on a page such as https://webtests.dev/forms/login/iframe-login/ if you attempt to scroll from the navigation bar when the screen is presented at a very small height. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
