### PR TITLE
[PM-12743] a11y changes to make new drop down list for send and vault accessible

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
@@ -3,19 +3,19 @@
   {{ "new" | i18n }}
 </button>
 <bit-menu #itemOptions>
-  <a bitMenuItem (click)="newItemNavigate(cipherType.Login)">
+  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Login)">
     <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
     {{ "typeLogin" | i18n }}
   </a>
-  <a bitMenuItem (click)="newItemNavigate(cipherType.Card)">
+  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Card)">
     <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
     {{ "typeCard" | i18n }}
   </a>
-  <a bitMenuItem (click)="newItemNavigate(cipherType.Identity)">
+  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Identity)">
     <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
     {{ "typeIdentity" | i18n }}
   </a>
-  <a bitMenuItem (click)="newItemNavigate(cipherType.SecureNote)">
+  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.SecureNote)">
     <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
     {{ "note" | i18n }}
   </a>

--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
@@ -3,22 +3,22 @@
   {{ "new" | i18n }}
 </button>
 <bit-menu #itemOptions>
-  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Login)">
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(cipherType.Login)">
     <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
     {{ "typeLogin" | i18n }}
-  </a>
-  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Card)">
+  </button>
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(cipherType.Card)">
     <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
     {{ "typeCard" | i18n }}
-  </a>
-  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.Identity)">
+  </button>
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(cipherType.Identity)">
     <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
     {{ "typeIdentity" | i18n }}
-  </a>
-  <a bitMenuItem role="button" (click)="newItemNavigate(cipherType.SecureNote)">
+  </button>
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(cipherType.SecureNote)">
     <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
     {{ "note" | i18n }}
-  </a>
+  </button>
   <bit-menu-divider></bit-menu-divider>
   <button type="button" bitMenuItem (click)="openFolderDialog()">
     <i class="bwi bwi-folder" slot="start" aria-hidden="true"></i>

--- a/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
+++ b/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
@@ -3,11 +3,11 @@
   {{ (hideIcon ? "createSend" : "new") | i18n }}
 </button>
 <bit-menu #itemOptions>
-  <a type="button" bitMenuItem (click)="newItemNavigate(sendType.Text)">
+  <a role="button" bitMenuItem (click)="newItemNavigate(sendType.Text)">
     <i class="bwi bwi-file-text" slot="start" aria-hidden="true"></i>
     {{ "sendTypeText" | i18n }}
   </a>
-  <a type="button" bitMenuItem (click)="newItemNavigate(sendType.File)">
+  <a role="button" bitMenuItem (click)="newItemNavigate(sendType.File)">
     <i class="bwi bwi-file" slot="start" aria-hidden="true"></i>
     {{ "sendTypeFile" | i18n }}
     <button type="button" slot="end" *ngIf="hasNoPremium" bitBadge variant="success">

--- a/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
+++ b/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
@@ -3,15 +3,15 @@
   {{ (hideIcon ? "createSend" : "new") | i18n }}
 </button>
 <bit-menu #itemOptions>
-  <a role="button" bitMenuItem (click)="newItemNavigate(sendType.Text)">
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(sendType.Text)">
     <i class="bwi bwi-file-text" slot="start" aria-hidden="true"></i>
     {{ "sendTypeText" | i18n }}
-  </a>
-  <a role="button" bitMenuItem (click)="newItemNavigate(sendType.File)">
+  </button>
+  <button type="button" role="link" bitMenuItem (click)="newItemNavigate(sendType.File)">
     <i class="bwi bwi-file" slot="start" aria-hidden="true"></i>
     {{ "sendTypeFile" | i18n }}
     <button type="button" slot="end" *ngIf="hasNoPremium" bitBadge variant="success">
       {{ "premium" | i18n }}
     </button>
-  </a>
+  </button>
 </bit-menu>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12743

## 📔 Objective

 a11y changes to make new drop down list for send and vault accessible

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
