### PR TITLE
[PM-14160] Add getUserId and getOptionalUserId rxjs functions

### DIFF
--- a/libs/common/src/auth/services/account.service.ts
+++ b/libs/common/src/auth/services/account.service.ts
@@ -45,6 +45,24 @@ const LOGGED_OUT_INFO: AccountInfo = {
   name: undefined,
 };
 
+/**
+ * An rxjs map operator that extracts the UserId from an account, or throws if the account or UserId are null.
+ */
+export const getUserId = map<{ id: UserId | undefined }, UserId>((account) => {
+  if (account?.id == null) {
+    throw new Error("Null account or account ID");
+  }
+
+  return account.id;
+});
+
+/**
+ * An rxjs map operator that extracts the UserId from an account, or returns undefined if the account or UserId are null.
+ */
+export const getOptionalUserId = map<{ id: UserId | undefined }, UserId | undefined>(
+  (account) => account?.id ?? undefined,
+);
+
 export class AccountServiceImplementation implements InternalAccountService {
   private accountsState: GlobalState<Record<UserId, AccountInfo>>;
   private activeAccountIdState: GlobalState<UserId | undefined>;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14160

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add helper rxjs functions to help extract the active UserId from `accountService.activeAccount$`. As we deprecate `ActiveUserState` we'll need to access the active UserId much more frequently to pass it into services. 

These helpers were suggested [in Slack](https://bitwarden.slack.com/archives/C02LPDKPML6/p1728430298526159) for brevity and to provide descriptive error messages if a `UserId` is not present.

This is extracted from https://github.com/bitwarden/clients/pull/11738 so that I can remove Auth Team as a reviewer from that large PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
