### PR TITLE
[PM-13952] Fix totp import on Dashlane csv importer

### DIFF
--- a/libs/importer/spec/dashlane-csv-importer.spec.ts
+++ b/libs/importer/spec/dashlane-csv-importer.spec.ts
@@ -2,6 +2,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 
 import { DashlaneCsvImporter } from "../src/importers";
 
+import { credentialsData_otpUrl } from "./test-data/dashlane-csv/credentials-otpurl.csv";
 import { credentialsData } from "./test-data/dashlane-csv/credentials.csv";
 import { identityData } from "./test-data/dashlane-csv/id.csv";
 import { multiplePersonalInfoData } from "./test-data/dashlane-csv/multiple-personal-info.csv";
@@ -28,6 +29,14 @@ describe("Dashlane CSV Importer", () => {
     const uriView = cipher.login.uris.shift();
     expect(uriView.uri).toEqual("https://www.example.com");
     expect(cipher.notes).toEqual("some note for example.com");
+  });
+
+  it("should parse login with totp when given otpUrl instead of otpSecret", async () => {
+    const result = await importer.parse(credentialsData_otpUrl);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.login.totp).toEqual("anotherTOTPSeed");
   });
 
   it("should parse an item and create a folder", async () => {

--- a/libs/importer/spec/test-data/dashlane-csv/credentials-otpurl.csv.ts
+++ b/libs/importer/spec/test-data/dashlane-csv/credentials-otpurl.csv.ts
@@ -1,0 +1,2 @@
+export const credentialsData_otpUrl = `username,username2,username3,title,password,note,url,category,otpUrl
+jdoe,,,example.com,somePassword,some note for example.com,https://www.example.com,Entertainment,anotherTOTPSeed`;

--- a/libs/importer/src/importers/dashlane/dashlane-csv-importer.ts
+++ b/libs/importer/src/importers/dashlane/dashlane-csv-importer.ts
@@ -119,7 +119,7 @@ export class DashlaneCsvImporter extends BaseImporter implements Importer {
     cipher.notes = row.note;
     cipher.login.username = row.username;
     cipher.login.password = row.password;
-    cipher.login.totp = row.otpSecret;
+    cipher.login.totp = Object.keys(row).includes("otpUrl") ? row.otpUrl : row.otpSecret;
     cipher.login.uris = this.makeUriArray(row.url);
 
     this.importUnmappedFields(cipher, row, _mappedCredentialsColumns);

--- a/libs/importer/src/importers/dashlane/types/dashlane-csv-types.ts
+++ b/libs/importer/src/importers/dashlane/types/dashlane-csv-types.ts
@@ -8,7 +8,8 @@ export class CredentialsRecord {
   note: string;
   url: string;
   category: string;
-  otpSecret: string;
+  otpSecret?: string;
+  otpUrl?: string; // Likely introduced by Dashlane as a replacement for `otpSecret`
 }
 
 export class PaymentsRecord {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13952

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Within credentials.csv  the column `otpSecret` got replaced with `otpUrl`. This adds support for both of them, in case a user tries to import from an older source.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
