### PR TITLE
Initialize SDK even when orgKeys is null

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -96,7 +96,7 @@ export class DefaultSdkService implements SdkService {
           let client: BitwardenClient;
 
           const createAndInitializeClient = async () => {
-            if (privateKey == null || userKey == null || orgKeys == null) {
+            if (privateKey == null || userKey == null) {
               return undefined;
             }
 
@@ -150,7 +150,7 @@ export class DefaultSdkService implements SdkService {
     kdfParams: KdfConfig,
     privateKey: EncryptedString,
     userKey: UserKey,
-    orgKeys: Record<OrganizationId, EncryptedOrganizationKeyData>,
+    orgKeys?: Record<OrganizationId, EncryptedOrganizationKeyData>,
   ) {
     await client.crypto().initialize_user_crypto({
       email: account.email,
@@ -169,9 +169,12 @@ export class DefaultSdkService implements SdkService {
             },
       privateKey,
     });
+
+    // We initialize the org crypto even if the org_keys are
+    // null to make sure any existing org keys are cleared.
     await client.crypto().initialize_org_crypto({
       organizationKeys: new Map(
-        Object.entries(orgKeys)
+        Object.entries(orgKeys ?? {})
           .filter(([_, v]) => v.type === "organization")
           .map(([k, v]) => [k, v.key]),
       ),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

When a user doesn't have any organization keys `orgKeys` will be null, which causes the SDK initialization step to be skipped. 

This PR changes it so the initialization is done even when `orgKeys` is null. Note that we still call `initialize_org_crypto` to make sure any keys that could already be there are cleared.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
