### PR TITLE
[PM-14182] colorize password history

### DIFF
--- a/libs/tools/generator/components/src/credential-generator-history.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history.component.html
@@ -1,7 +1,10 @@
 <bit-card *ngFor="let credential of credentials$ | async" class="tw-mb-2">
   <div class="tw-flex tw-justify-between tw-items-center">
     <div class="tw-flex tw-flex-col">
-      <h2 bitTypography="h6">{{ credential.credential }}</h2>
+      <bit-color-password
+        class="tw-font-mono"
+        [password]="credential.credential"
+      ></bit-color-password>
       <span class="tw-text-muted" bitTypography="body1">{{
         credential.generationDate | date: "medium"
       }}</span>

--- a/libs/tools/generator/components/src/credential-generator-history.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history.component.ts
@@ -9,6 +9,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { UserId } from "@bitwarden/common/types/guid";
 import {
   CardComponent,
+  ColorPasswordModule,
   IconButtonModule,
   NoItemsModule,
   SectionComponent,
@@ -21,6 +22,7 @@ import { GeneratedCredential, GeneratorHistoryService } from "@bitwarden/generat
   selector: "bit-credential-generator-history",
   templateUrl: "credential-generator-history.component.html",
   imports: [
+    ColorPasswordModule,
     CommonModule,
     IconButtonModule,
     NoItemsModule,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14182

## 📔 Objective

Add character highlighting to password history

## 📸 Screenshots

All passwords in the following screenshot were generated in a test environment.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/f4c98b60-f202-4e99-8b96-dd2f710f62c0">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
