### PR TITLE
[PM-13878] default subaddress email to active account email

### DIFF
--- a/libs/tools/generator/components/src/subaddress-settings.component.ts
+++ b/libs/tools/generator/components/src/subaddress-settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
-import { BehaviorSubject, skip, Subject, takeUntil } from "rxjs";
+import { BehaviorSubject, map, skip, Subject, takeUntil, withLatestFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -53,9 +53,23 @@ export class SubaddressSettingsComponent implements OnInit, OnDestroy {
     const singleUserId$ = this.singleUserId$();
     const settings = await this.generatorService.settings(Generators.subaddress, { singleUserId$ });
 
-    settings.pipe(takeUntil(this.destroyed$)).subscribe((s) => {
-      this.settings.patchValue(s, { emitEvent: false });
-    });
+    settings
+      .pipe(
+        withLatestFrom(this.accountService.activeAccount$),
+        map(([settings, activeAccount]) => {
+          // if the subaddress isn't specified, copy it from
+          // the user's settings
+          if ((settings.subaddressEmail ?? "").length < 1) {
+            settings.subaddressEmail = activeAccount.email;
+          }
+
+          return settings;
+        }),
+        takeUntil(this.destroyed$),
+      )
+      .subscribe((s) => {
+        this.settings.patchValue(s, { emitEvent: false });
+      });
 
     // the first emission is the current value; subsequent emissions are updates
     settings.pipe(skip(1), takeUntil(this.destroyed$)).subscribe(this.onUpdated);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13878

## 📔 Objective

Fix regression: the subaddress email should default to the active account email

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
