### PR TITLE
Add `@yao-pkg/pkg` to platform's renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -118,7 +118,8 @@
         "node-forge",
         "rxjs",
         "type-fest",
-        "typescript"
+        "typescript",
+        "@yao-pkg/pkg"
       ],
       "description": "Platform owned dependencies",
       "commitMessagePrefix": "[deps] Platform:",


### PR DESCRIPTION
## 🎟️ Tracking

[0]: https://bitwarden.atlassian.net/browse/PM-12624
[1]: https://github.com/bitwarden/clients/pull/11237

- Jira: [PM-12624][0]
- Parent PR: [`clients #11237`][1]

## 📔 Objective

On [#11237][1] renovate created a PR for the `@yao-pkg/pkg` dependency that
did not have a configured owner. `pkg` is a node build tool used to package
the CLI in `npm run dist` scripts. It makes sense that this would be a
platform owned dependency.

This commit updates the renovate configuration to assign `@yao-pkg/pkg` to
platform.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-12624]: https://bitwarden.atlassian.net/browse/PM-12624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ