### PR TITLE
[PM-2410] convert timeout value substitutions to strings

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security-v1.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security-v1.component.ts
@@ -57,7 +57,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   availableVaultTimeoutActions: VaultTimeoutAction[] = [];
   vaultTimeoutOptions: VaultTimeoutOption[];
   vaultTimeoutPolicyCallout: Observable<{
-    timeout: { hours: number; minutes: number };
+    timeout: { hours: string; minutes: string };
     action: VaultTimeoutAction;
   }>;
   supportsBiometric: boolean;
@@ -105,8 +105,8 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         let timeout;
         if (policy.data?.minutes) {
           timeout = {
-            hours: Math.floor(policy.data?.minutes / 60),
-            minutes: policy.data?.minutes % 60,
+            hours: Math.floor(policy.data?.minutes / 60).toString(),
+            minutes: (policy.data?.minutes % 60).toString(),
           };
         }
         return { timeout: timeout, action: policy.data?.action };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2410

## 📔 Objective

Changes the types for the timeout obj to strings. Officially, the array of substitutions [only supports strings](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage#substitutions). 

## 📸 Screenshots

![Screenshot 2024-10-28 at 4 14 24 PM](https://github.com/user-attachments/assets/a89eacea-5019-4196-a052-e3d5ca3401ce)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
