### PR TITLE
[PM-14054] Fixing scroll-based repositioning of inline menu when inline menu is focused

### DIFF
--- a/apps/browser/src/autofill/content/bootstrap-autofill-overlay-menu.ts
+++ b/apps/browser/src/autofill/content/bootstrap-autofill-overlay-menu.ts
@@ -21,6 +21,7 @@ import AutofillInit from "./autofill-init";
       domQueryService,
       domElementVisibilityService,
       inlineMenuFieldQualificationService,
+      inlineMenuContentService,
     );
 
     windowContext.bitwardenAutofillInit = new AutofillInit(

--- a/apps/browser/src/autofill/content/bootstrap-autofill-overlay.ts
+++ b/apps/browser/src/autofill/content/bootstrap-autofill-overlay.ts
@@ -24,6 +24,7 @@ import AutofillInit from "./autofill-init";
       domQueryService,
       domElementVisibilityService,
       inlineMenuFieldQualificationService,
+      inlineMenuContentService,
     );
 
     windowContext.bitwardenAutofillInit = new AutofillInit(

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1,4 +1,4 @@
-import { mock } from "jest-mock-extended";
+import { mock, MockProxy } from "jest-mock-extended";
 
 import { EVENTS } from "@bitwarden/common/autofill/constants";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -13,6 +13,7 @@ import {
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
 import AutofillPageDetails from "../models/autofill-page-details";
+import { AutofillInlineMenuContentService } from "../overlay/inline-menu/abstractions/autofill-inline-menu-content.service";
 import { createAutofillFieldMock } from "../spec/autofill-mocks";
 import {
   flushPromises,
@@ -35,6 +36,7 @@ describe("AutofillOverlayContentService", () => {
   let domElementVisibilityService: DomElementVisibilityService;
   let autofillInit: AutofillInit;
   let inlineMenuFieldQualificationService: InlineMenuFieldQualificationService;
+  let inlineMenuContentService: MockProxy<AutofillInlineMenuContentService>;
   let autofillOverlayContentService: AutofillOverlayContentService;
   let sendExtensionMessageSpy: jest.SpyInstance;
   const sendResponseSpy = jest.fn();
@@ -44,10 +46,12 @@ describe("AutofillOverlayContentService", () => {
     inlineMenuFieldQualificationService = new InlineMenuFieldQualificationService();
     domQueryService = new DomQueryService();
     domElementVisibilityService = new DomElementVisibilityService();
+    inlineMenuContentService = mock<AutofillInlineMenuContentService>();
     autofillOverlayContentService = new AutofillOverlayContentService(
       domQueryService,
       domElementVisibilityService,
       inlineMenuFieldQualificationService,
+      inlineMenuContentService,
     );
     autofillInit = new AutofillInit(
       domQueryService,

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -28,6 +28,7 @@ import {
 } from "../enums/autofill-overlay.enum";
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
+import { AutofillInlineMenuContentService } from "../overlay/inline-menu/abstractions/autofill-inline-menu-content.service";
 import { ElementWithOpId, FillableFormFieldElement, FormFieldElement } from "../types";
 import {
   currentlyInSandboxedIframe,
@@ -155,6 +156,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     private domQueryService: DomQueryService,
     private domElementVisibilityService: DomElementVisibilityService,
     private inlineMenuFieldQualificationService: InlineMenuFieldQualificationService,
+    private inlineMenuContentService?: AutofillInlineMenuContentService,
   ) {}
 
   /**
@@ -1580,7 +1582,8 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       if (activeElement) {
         return (
           activeElement === this.mostRecentlyFocusedField ||
-          activeElement.contains(this.mostRecentlyFocusedField)
+          activeElement.contains(this.mostRecentlyFocusedField) ||
+          this.inlineMenuContentService?.isElementInlineMenu(activeElement as HTMLElement)
         );
       }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14054

## 📔 Objective

Fixing another edge case encountered when triggering scroll based repositioning. When the inline menu is focused in some manner, it is possible for reposition events to be ignored at the top level frame of a page. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
