### PR TITLE
[PM-14190] Replace history card with item component

### DIFF
--- a/libs/tools/generator/components/src/credential-generator-history.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history.component.html
@@ -1,7 +1,7 @@
 <bit-item *ngFor="let credential of credentials$ | async">
-  <div bit-item-content>
+  <bit-item-content>
     <bit-color-password class="tw-font-mono" [password]="credential.credential" />
-  </div>
+  </bit-item-content>
   <span slot="secondary" bitTypography="body2">
     {{ credential.generationDate | date: "medium" }}
   </span>

--- a/libs/tools/generator/components/src/credential-generator-history.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history.component.html
@@ -1,10 +1,10 @@
 <bit-item *ngFor="let credential of credentials$ | async">
   <bit-item-content>
     <bit-color-password class="tw-font-mono" [password]="credential.credential" />
+    <div class="tw-text-sm tw-text-muted" slot="secondary">
+      {{ credential.generationDate | date: "medium" }}
+    </div>
   </bit-item-content>
-  <span slot="secondary" bitTypography="body2">
-    {{ credential.generationDate | date: "medium" }}
-  </span>
   <ng-container slot="end">
     <bit-item-action>
       <button

--- a/libs/tools/generator/components/src/credential-generator-history.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history.component.html
@@ -1,7 +1,7 @@
 <bit-item *ngFor="let credential of credentials$ | async">
   <bit-item-content>
     <bit-color-password class="tw-font-mono" [password]="credential.credential" />
-    <div class="tw-text-sm tw-text-muted" slot="secondary">
+    <div slot="secondary">
       {{ credential.generationDate | date: "medium" }}
     </div>
   </bit-item-content>

--- a/libs/tools/generator/components/src/credential-generator-history.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history.component.html
@@ -1,23 +1,22 @@
-<bit-card *ngFor="let credential of credentials$ | async" class="tw-mb-2">
-  <div class="tw-flex tw-justify-between tw-items-center">
-    <div class="tw-flex tw-flex-col">
-      <bit-color-password
-        class="tw-font-mono"
-        [password]="credential.credential"
-      ></bit-color-password>
-      <span class="tw-text-muted" bitTypography="body1">{{
-        credential.generationDate | date: "medium"
-      }}</span>
-    </div>
-    <button
-      bitIconButton="bwi-clone"
-      bitSuffix
-      size="small"
-      type="button"
-      [appCopyClick]="credential.credential"
-      [ariaLabel]="'copyPassword' | i18n"
-      [appA11yTitle]="'copyPassword' | i18n"
-      showToast
-    ></button>
+<bit-item *ngFor="let credential of credentials$ | async">
+  <div bit-item-content>
+    <bit-color-password class="tw-font-mono" [password]="credential.credential" />
   </div>
-</bit-card>
+  <span slot="secondary" bitTypography="body2">
+    {{ credential.generationDate | date: "medium" }}
+  </span>
+  <ng-container slot="end">
+    <bit-item-action>
+      <button
+        type="button"
+        bitIconButton="bwi-clone"
+        [appCopyClick]="credential.credential"
+        [valueLabel]="getGeneratedValueText(credential)"
+        [appA11yTitle]="getCopyText(credential)"
+        showToast
+      >
+        {{ getCopyText(credential) }}
+      </button>
+    </bit-item-action>
+  </ng-container>
+</bit-item>

--- a/libs/tools/generator/components/src/credential-generator-history.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history.component.ts
@@ -8,14 +8,17 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
-  CardComponent,
   ColorPasswordModule,
   IconButtonModule,
+  ItemModule,
   NoItemsModule,
   SectionComponent,
   SectionHeaderComponent,
 } from "@bitwarden/components";
+import { CredentialGeneratorService } from "@bitwarden/generator-core";
 import { GeneratedCredential, GeneratorHistoryService } from "@bitwarden/generator-history";
+
+import { GeneratorModule } from "./generator.module";
 
 @Component({
   standalone: true,
@@ -28,9 +31,10 @@ import { GeneratedCredential, GeneratorHistoryService } from "@bitwarden/generat
     NoItemsModule,
     JslibModule,
     RouterLink,
-    CardComponent,
+    ItemModule,
     SectionComponent,
     SectionHeaderComponent,
+    GeneratorModule,
   ],
 })
 export class CredentialGeneratorHistoryComponent {
@@ -39,6 +43,7 @@ export class CredentialGeneratorHistoryComponent {
 
   constructor(
     private accountService: AccountService,
+    private generatorService: CredentialGeneratorService,
     private history: GeneratorHistoryService,
   ) {
     this.accountService.activeAccount$
@@ -53,8 +58,18 @@ export class CredentialGeneratorHistoryComponent {
       .pipe(
         takeUntilDestroyed(),
         switchMap((id) => id && this.history.credentials$(id)),
-        map((credentials) => credentials),
+        map((credentials) => credentials.filter((c) => (c.credential ?? "") !== "")),
       )
       .subscribe(this.credentials$);
+  }
+
+  protected getCopyText(credential: GeneratedCredential) {
+    const info = this.generatorService.algorithm(credential.category);
+    return info.copy;
+  }
+
+  protected getGeneratedValueText(credential: GeneratedCredential) {
+    const info = this.generatorService.algorithm(credential.category);
+    return info.generatedValue;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14190
https://bitwarden.atlassian.net/browse/PM-13998

## 📔 Objective

Improve credential generator history UX.

* Use `bit-item` for better visual consistency with other credential lists.
* Introduce dynamic copy text for consistency with main generator copy button.

## 📸 Screenshots

These screenshots do not have browser refresh stylesheets applied.

Generator history: 

<img width="364" alt="image" src="https://github.com/user-attachments/assets/89646749-517d-48f5-b73e-9b0ea654d144">

Example copy text (toast and tooltip/a11y):
<img width="444" alt="image" src="https://github.com/user-attachments/assets/5a07bc33-8caa-4467-8b80-9a7cdf2ce7ab">


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
