### PR TITLE
[PM-13947] - guard against call to undefined onSubmit

### DIFF
--- a/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
@@ -35,7 +35,7 @@ export class PaymentV2Component implements OnInit, OnDestroy {
   /** The payment method selected by default when the component renders. */
   @Input() private initialPaymentMethod: PaymentMethodType = PaymentMethodType.Card;
   /** If provided, will be invoked with the tokenized payment source during form submission. */
-  @Input() protected onSubmit?: (request: TokenizedPaymentSourceRequest) => Promise<void>;
+  @Input() protected onSubmit: (request: TokenizedPaymentSourceRequest) => Promise<void>;
 
   @Output() submitted = new EventEmitter<PaymentMethodType>();
 
@@ -93,7 +93,7 @@ export class PaymentV2Component implements OnInit, OnDestroy {
 
   protected submit = async () => {
     const { type, token } = await this.tokenize();
-    await this.onSubmit({ type, token });
+    await this.onSubmit?.({ type, token });
     this.submitted.emit(type);
   };
 

--- a/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment-v2.component.ts
@@ -35,7 +35,7 @@ export class PaymentV2Component implements OnInit, OnDestroy {
   /** The payment method selected by default when the component renders. */
   @Input() private initialPaymentMethod: PaymentMethodType = PaymentMethodType.Card;
   /** If provided, will be invoked with the tokenized payment source during form submission. */
-  @Input() protected onSubmit: (request: TokenizedPaymentSourceRequest) => Promise<void>;
+  @Input() protected onSubmit?: (request: TokenizedPaymentSourceRequest) => Promise<void>;
 
   @Output() submitted = new EventEmitter<PaymentMethodType>();
 

--- a/apps/web/src/app/billing/shared/verify-bank-account/verify-bank-account.component.ts
+++ b/apps/web/src/app/billing/shared/verify-bank-account/verify-bank-account.component.ts
@@ -35,7 +35,7 @@ export class VerifyBankAccountComponent {
       this.formGroup.value.amount1,
       this.formGroup.value.amount2,
     );
-    await this.onSubmit(request);
+    await this.onSubmit?.(request);
     this.submitted.emit();
   };
 }

--- a/libs/angular/src/billing/components/manage-tax-information/manage-tax-information.component.ts
+++ b/libs/angular/src/billing/components/manage-tax-information/manage-tax-information.component.ts
@@ -46,7 +46,7 @@ export class ManageTaxInformationComponent implements OnInit, OnDestroy {
     if (this.formGroup.invalid) {
       return;
     }
-    await this.onSubmit(this.taxInformation);
+    await this.onSubmit?.(this.taxInformation);
     this.taxInformationUpdated.emit();
   };
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13947

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While I was unable to reproduce the issue in the ticket I found a couple places where calling `this.onSubmit` could result in an error if `onSubmit` was not provided. This PR adds a guard against this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
