### PR TITLE
Auth/PM-14361 - Fix missed translation key updates for loginWithPasskey changing to logInWithPasskey

### DIFF
--- a/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="large" [loading]="loading$ | async">
     <span bitDialogTitle
-      >{{ "loginWithPasskey" | i18n }}
+      >{{ "logInWithPasskey" | i18n }}
       <span class="tw-text-sm tw-normal-case tw-text-muted">{{ "newPasskey" | i18n }}</span>
     </span>
     <ng-container bitDialogContent>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
@@ -1,5 +1,5 @@
 <h2 bitTypography="h2">
-  {{ "loginWithPasskey" | i18n }}
+  {{ "logInWithPasskey" | i18n }}
   <ng-container *ngIf="hasData">
     <span
       *ngIf="requireSsoPolicyEnabled"
@@ -89,7 +89,7 @@
     *ngIf="!hasCredentials"
     type="button"
     bitButton
-    [attr.aria-label]="('enable' | i18n) + ' ' + ('loginWithPasskey' | i18n)"
+    [attr.aria-label]="('enable' | i18n) + ' ' + ('logInWithPasskey' | i18n)"
     [disabled]="loading"
     (click)="createCredential()"
   >

--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -104,7 +104,7 @@ const routes: Routes = [
       {
         path: "login-with-passkey",
         component: LoginViaWebAuthnComponent,
-        data: { titleId: "loginWithPasskey" } satisfies RouteDataProperties,
+        data: { titleId: "logInWithPasskey" } satisfies RouteDataProperties,
       },
       {
         path: "admin-approval-requested",


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14361

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
 In PM-8111 (https://github.com/bitwarden/clients/pull/10856), the `loginWithPasskey` web translation was changed to be `logInWithPasskey` but the usages were not updated. This updates the usages to point to the new translation key.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="864" alt="image" src="https://github.com/user-attachments/assets/ed8ef091-f923-482f-b671-13f569cf9fcb">

<img width="734" alt="image" src="https://github.com/user-attachments/assets/86a73740-5d44-48cf-8dfa-918fbc72b465">

<img width="457" alt="image" src="https://github.com/user-attachments/assets/4b3e85cb-766f-43b7-9961-7381b831f0a4">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
