### PR TITLE
[BEEEP][PM-14388] Better dev experience on desktop-browser IPC

### DIFF
--- a/apps/desktop/desktop_native/core/src/ipc/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/mod.rs
@@ -31,7 +31,7 @@ pub fn path(name: &str) -> std::path::PathBuf {
         format!(r"\\.\pipe\{hash_b64}.app.{name}").into()
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
     {
         let mut home = dirs::home_dir().unwrap();
 
@@ -51,6 +51,13 @@ pub fn path(name: &str) -> std::path::PathBuf {
         // The tmp directory might not exist, so create it
         let _ = std::fs::create_dir_all(&tmp);
         tmp.join(format!("app.{name}"))
+    }
+
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    {
+        // When running in debug mode, we use the tmp dir because the app is not sandboxed
+        let dir = std::env::temp_dir();
+        dir.join(format!("app.{name}"))
     }
 
     #[cfg(target_os = "linux")]

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -626,7 +626,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
   async saveBrowserIntegration() {
     if (
       ipc.platform.deviceType === DeviceType.MacOsDesktop &&
-      !this.platformUtilsService.isMacAppStore()
+      !this.platformUtilsService.isMacAppStore() &&
+      !ipc.platform.isDev
     ) {
       await this.dialogService.openSimpleDialog({
         title: { key: "browserIntegrationUnsupportedTitle" },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14388

## 📔 Objective

This PR tries to improve developer experience on desktop-browser integration by removing some unnecessary steps.

- Allow enabling biometric integration on desktop MacOS, even if the app is not an appstore build, when using dev mode. This should make it much faster to test changes here, without waiting for a full build+signing.
- When building the IPC code in debug mode, use a TMP directory instead of the App Groups folder. As the app won't be codesigned, using App Groups leads to a lot of popups asking for access to that folder.
- Try to detect any bitwarden extension installed in the chrome based browsers and add their extension to the allowlist. This is to make it easier to test dev builds of the browser extension, which generates a random extension id per user. Previously devs had to manually patch the manifest file, but this should be done automatically for them now.
- Reorganized the Linux browser detection a bit to make it look closer to what we do for Mac and Windows. This should make it easier to add other chrome-based browsers in the future. It also revealed that we weren't deleting the manifest from chromium before, that's fixed

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
