### PR TITLE
Revert "[PM-13645] Fix invite counter to check remaining number of seats in plan"

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -23,15 +23,14 @@
         <bit-tab [label]="'role' | i18n">
           <ng-container *ngIf="!editMode">
             <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
-            <bit-form-field *ngIf="remainingSeats$ | async as remainingSeats">
+            <bit-form-field>
               <bit-label>{{ "email" | i18n }}</bit-label>
               <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
-              <bit-hint *ngIf="remainingSeats > 1; else singleSeat">{{
-                "inviteMultipleEmailDesc" | i18n: remainingSeats
+              <bit-hint>{{
+                "inviteMultipleEmailDesc"
+                  | i18n
+                    : (organization.productTierType === ProductTierType.TeamsStarter ? "10" : "20")
               }}</bit-hint>
-              <ng-template #singleSeat>
-                <bit-hint>{{ "inviteSingleEmailDesc" | i18n: remainingSeats }}</bit-hint>
-              </ng-template>
             </bit-form-field>
           </ng-container>
           <bit-radio-group formControlName="type">

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -89,7 +89,6 @@ export class MemberDialogComponent implements OnDestroy {
   PermissionMode = PermissionMode;
   showNoMasterPasswordWarning = false;
   isOnSecretsManagerStandalone: boolean;
-  remainingSeats$: Observable<number>;
 
   protected organization$: Observable<Organization>;
   protected collectionAccessItems: AccessItemView[] = [];
@@ -251,10 +250,6 @@ export class MemberDialogComponent implements OnDestroy {
 
         this.loading = false;
       });
-
-    this.remainingSeats$ = this.organization$.pipe(
-      map((organization) => organization.seats - this.params.numConfirmedMembers),
-    );
   }
 
   private setFormValidators(organization: Organization) {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3218,9 +3218,6 @@
       }
     }
   },
-  "inviteSingleEmailDesc": {
-    "message": "You have 1 invite remaining."
-  },
   "userUsingTwoStep": {
     "message": "This user is using two-step login to protect their account."
   },


### PR DESCRIPTION
Reverts bitwarden/clients#11577

This fix uncovered an issue where the organization seat count (among other properties) are not being updated when the subscription is updated. This will be pulled until the existing issue is resolved in [PM-14368](https://bitwarden.atlassian.net/browse/PM-14368) as the issue is a blocker.