### PR TITLE
[PM-13145] TOTP Code - monospace font

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -111,6 +111,7 @@
         [value]="totpCodeCopyObj?.totpCodeFormatted || '*** ***'"
         aria-readonly="true"
         data-testid="login-totp"
+        class="tw-font-mono"
       />
       <div
         *ngIf="isPremium$ | async"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13145](https://bitwarden.atlassian.net/browse/PM-13145)

## 📔 Objective

Kyra found that the TOTP code should also be monospcae font, which I missed in https://github.com/bitwarden/clients/pull/11764

## 📸 Screenshots

|Web|Browser
|-|-|
|![Screenshot 2024-11-04 at 8 51 04 AM](https://github.com/user-attachments/assets/41504d39-43ae-4144-aaf1-0a92f8f80526)|![Screenshot 2024-11-04 at 8 52 38 AM](https://github.com/user-attachments/assets/0d356b78-b0cd-42b3-8938-5ec3f403cd04)|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13145]: https://bitwarden.atlassian.net/browse/PM-13145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ