### PR TITLE
Update the publisher name to Bitwarden Inc

### DIFF
--- a/apps/browser/store/windows/AppxManifest.xml
+++ b/apps/browser/store/windows/AppxManifest.xml
@@ -12,7 +12,7 @@
 
   <Properties>
     <DisplayName>Bitwarden Password Manager</DisplayName>
-    <PublisherDisplayName>8bit Solutions LLC</PublisherDisplayName>
+    <PublisherDisplayName>Bitwarden Inc</PublisherDisplayName>
     <Logo>Assets/icon_50.png</Logo>
   </Properties>
 

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -162,7 +162,7 @@
     "applicationId": "bitwardendesktop",
     "identityName": "8bitSolutionsLLC.bitwardendesktop",
     "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",
-    "publisherDisplayName": "8bit Solutions LLC",
+    "publisherDisplayName": "Bitwarden Inc",
     "languages": [
       "en-US",
       "af",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The legal info on the windows store account was updated from `8bit Solutions LLC` to `Bitwarden Inc`. I believe these updates are necessary to match that change for future app releases.