### PR TITLE
The get started banner will show even though the user has completed tasks

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
@@ -52,8 +52,6 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
   isNewAccount: boolean;
   private readonly onboardingReleaseDate = new Date("2024-04-02");
 
-  protected currentTasks: VaultOnboardingTasks;
-
   protected onboardingTasks$: Observable<VaultOnboardingTasks>;
   protected showOnboarding = false;
   protected extensionRefreshEnabled = false;
@@ -85,6 +83,7 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
         importData: this.ciphers.length > 0,
         installExtension: currentTasks.installExtension,
       };
+      if (!Object.values(updatedTasks).includes(false)) {this.showOnboarding = false;}
       await this.vaultOnboardingService.setVaultOnboardingTasks(updatedTasks);
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/10943

## 📔 Objective

This PR addresses the issue of a race condition. The tasks get updated from the backend sync call, but this is a race condition. When ngOnChanges runs, it will have the current updates, but we never trigger showOnboarding again to set it to false. This fixes that.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/f7bce53c-33c2-4976-b343-dadb2ec45479)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
