### PR TITLE
[PM-14533] Update enabled state of Organization Name

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -123,20 +123,22 @@ export class AccountComponent implements OnInit, OnDestroy {
         this.canEditSubscription = organization.canEditSubscription;
         this.canUseApi = organization.useApi;
 
-        // Update disabled states - reactive forms prefers not using disabled attribute
         // Disabling these fields for self hosted orgs is deprecated
         // This block can be completely removed as part of
         // https://bitwarden.atlassian.net/browse/PM-10863
         if (!this.limitCollectionCreationDeletionSplitFeatureFlagIsEnabled) {
           if (!this.selfHosted) {
-            this.formGroup.get("orgName").enable();
             this.collectionManagementFormGroup.get("limitCollectionCreationDeletion").enable();
             this.collectionManagementFormGroup.get("allowAdminAccessToAllCollectionItems").enable();
           }
         }
 
-        if (!this.selfHosted && this.canEditSubscription) {
-          this.formGroup.get("billingEmail").enable();
+        // Update disabled states - reactive forms prefers not using disabled attribute
+        if (!this.selfHosted) {
+          this.formGroup.get("orgName").enable();
+          if (this.canEditSubscription) {
+            this.formGroup.get("billingEmail").enable();
+          }
         }
 
         // Org Response


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14533


## 📔 Objective

> Fix a small oversight with the enabled state of the Organization Name field when the `pm-10863-limit-collection-creation-deletion-split` flag is **on**


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
