### PR TITLE
[PM-14043] Update size of toggle group label to fit more content

### DIFF
--- a/libs/components/src/toggle-group/toggle.component.ts
+++ b/libs/components/src/toggle-group/toggle.component.ts
@@ -59,6 +59,7 @@ export class ToggleComponent<TValue> implements AfterContentChecked {
       "tw-leading-5",
       "tw-transition",
       "tw-text-center",
+      "tw-text-sm",
       "tw-border-primary-600",
       "!tw-text-primary-600",
       "tw-border-solid",
@@ -85,7 +86,7 @@ export class ToggleComponent<TValue> implements AfterContentChecked {
       "peer-checked/toggle-input:tw-border-primary-600",
       "peer-checked/toggle-input:!tw-text-contrast",
       "tw-py-1.5",
-      "tw-px-4",
+      "tw-px-3",
 
       // Fix for bootstrap styles that add bottom margin
       "!tw-mb-0",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-14043](https://bitwarden.atlassian.net/browse/PM-14043)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the font size of the toggle group to match the design spec (should match `body2` typography variant), and reduces the x padding on the label to give more horizontal space to longer words.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| ![Screenshot 2024-11-06 at 11 31 02 AM](https://github.com/user-attachments/assets/005f700b-7904-4562-ac31-7f498cf9c3f9) | ![Screenshot 2024-11-06 at 11 27 43 AM](https://github.com/user-attachments/assets/15703b17-56fb-4cdb-8164-c9d7e998cd14) |



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14043]: https://bitwarden.atlassian.net/browse/PM-14043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ