### PR TITLE
[PM-14495] Web - Autofill from the extension no longer works

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -11,7 +11,7 @@
 -->
 
 <form [bitSubmit]="submit" [formGroup]="formGroup">
-  <ng-container *ngIf="loginUiState === LoginUiState.EMAIL_ENTRY">
+  <div [ngClass]="{ 'tw-invisible tw-h-0': loginUiState !== LoginUiState.EMAIL_ENTRY }">
     <!-- Email Address input -->
     <bit-form-field>
       <bit-label>{{ "emailAddress" | i18n }}</bit-label>
@@ -82,9 +82,9 @@
         </button>
       </ng-container>
     </div>
-  </ng-container>
+  </div>
 
-  <ng-container *ngIf="loginUiState === LoginUiState.MASTER_PASSWORD_ENTRY">
+  <div [ngClass]="{ 'tw-invisible tw-h-0': loginUiState !== LoginUiState.MASTER_PASSWORD_ENTRY }">
     <!-- Master Password input -->
     <bit-form-field class="!tw-mb-1">
       <bit-label>{{ "masterPass" | i18n }}</bit-label>
@@ -140,5 +140,5 @@
         </button>
       </ng-container>
     </div>
-  </ng-container>
+  </div>
 </form>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-14495?atlOrigin=eyJpIjoiZjg1ODEwYWM0ZWJhNGYzMTgyZTAxZjU1YWQ0NDhlMTkiLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Uses `divs` with conditional `tw-invisible tw-h-0` classes to show hide the email entry and MP entry states of the new login component (instead of `ng-container *ngIf`). This allows autofill via the extension  to work while logging in to the web by keeping both email and MP fields in the DOM. Without this, autofill needed to be applied twice (once for the email state, once for the MP entry state).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Before (`main`)

https://github.com/user-attachments/assets/6c6007f0-c502-4128-b593-3fb58e8fafd7

### After

https://github.com/user-attachments/assets/c19afcd0-7517-40ae-a4b1-a5f94b4ecd3f


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
