### PR TITLE
[PM-13950] Do not do browser extension permission check if the Show autofill suggestions setting is being turned off

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -219,7 +219,11 @@ export class AutofillComponent implements OnInit {
         : AutofillOverlayVisibility.Off;
 
     await this.autofillSettingsService.setInlineMenuVisibility(newInlineMenuVisibilityValue);
-    await this.requestPrivacyPermission();
+
+    // No need to initiate browser permission request if a feature is being turned off
+    if (newInlineMenuVisibilityValue !== AutofillOverlayVisibility.Off) {
+      await this.requestPrivacyPermission();
+    }
   }
 
   async updateAutofillOnPageLoad() {


### PR DESCRIPTION
## 🎟️ Tracking

PM-13950

## 📔 Objective

Do not do browser extension permission check if the Show autofill suggestions setting is being turned off

## Screencap

https://github.com/user-attachments/assets/5adfb07d-e328-4312-ac61-1f9ad92f68b7

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
