### PR TITLE
[PM-11409] prevent managed user from leaving organization

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
-import { combineLatest, map, Observable, Subject, takeUntil } from "rxjs";
+import { combineLatest, map, Observable, of, Subject, switchMap, takeUntil } from "rxjs";
 
 import {
   OrganizationUserApiService,
@@ -8,11 +8,14 @@ import {
 import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -38,6 +41,8 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
+  userIsManaged$: Observable<boolean>;
+
   constructor(
     @Inject(OptionsInput) protected organization$: Observable<OrganizationFilter>,
     private platformUtilsService: PlatformUtilsService,
@@ -53,6 +58,8 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
     private resetPasswordService: OrganizationUserResetPasswordService,
     private userVerificationService: UserVerificationService,
     private toastService: ToastService,
+    private configService: ConfigService,
+    private organizationService: OrganizationService,
   ) {}
 
   async ngOnInit() {
@@ -60,23 +67,39 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
       map((policies) => policies.filter((policy) => policy.type === PolicyType.ResetPassword)),
     );
 
+    const managingOrg$ = this.configService
+      .getFeatureFlag$(FeatureFlag.AccountDeprovisioning)
+      .pipe(
+        switchMap((isAccountDeprovisioningEnabled) =>
+          isAccountDeprovisioningEnabled
+            ? this.organizationService.organizations$.pipe(
+                map((organizations) =>
+                  organizations.find((o) => o.userIsManagedByOrganization === true),
+                ),
+              )
+            : of(null),
+        ),
+      );
+
     combineLatest([
       this.organization$,
       resetPasswordPolicies$,
       this.userDecryptionOptionsService.userDecryptionOptions$,
+      managingOrg$,
     ])
       .pipe(takeUntil(this.destroy$))
-      .subscribe(([organization, resetPasswordPolicies, decryptionOptions]) => {
+      .subscribe(([organization, resetPasswordPolicies, decryptionOptions, managingOrg]) => {
         this.organization = organization;
         this.resetPasswordPolicy = resetPasswordPolicies.find(
           (p) => p.organizationId === organization.id,
         );
 
-        // A user can leave an organization if they are NOT using TDE and Key Connector, or they have a master password.
+        // A user can leave an organization if they are NOT a managed user and they are NOT using TDE and Key Connector, or they have a master password.
         this.showLeaveOrgOption =
-          (decryptionOptions.trustedDeviceOption == undefined &&
+          managingOrg.id !== organization.id &&
+          ((decryptionOptions.trustedDeviceOption == undefined &&
             decryptionOptions.keyConnectorOption == undefined) ||
-          decryptionOptions.hasMasterPassword;
+            decryptionOptions.hasMasterPassword);
 
         // Hide the 3 dot menu if the user has no available actions
         this.hideMenu =

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
@@ -94,7 +94,7 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
 
         // A user can leave an organization if they are NOT a managed user and they are NOT using TDE and Key Connector, or they have a master password.
         this.showLeaveOrgOption =
-          managingOrg.id !== organization.id &&
+          managingOrg?.id !== organization.id &&
           ((decryptionOptions.trustedDeviceOption == undefined &&
             decryptionOptions.keyConnectorOption == undefined) ||
             decryptionOptions.hasMasterPassword);

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
@@ -41,8 +41,6 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  userIsManaged$: Observable<boolean>;
-
   constructor(
     @Inject(OptionsInput) protected organization$: Observable<OrganizationFilter>,
     private platformUtilsService: PlatformUtilsService,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11409

## 📔 Objective

This PR hides the leave option for the managing organization that a manged user belongs to.

## 📸 Screenshots
Organization that does **not** manage this user
![image](https://github.com/user-attachments/assets/2d03fb7f-0191-411c-aec3-054e85c5b67f)

Organization that **does** manage this user (cannot leave)
![image](https://github.com/user-attachments/assets/5264047b-226a-49eb-b353-c96773d34aaf)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
