### PR TITLE
[PM-14198] zero minimums when the character category is disabled

### DIFF
--- a/libs/tools/generator/core/src/policies/constraints.ts
+++ b/libs/tools/generator/core/src/policies/constraints.ts
@@ -2,6 +2,7 @@ import { Constraint } from "@bitwarden/common/tools/types";
 
 import { sum } from "../util";
 
+const Zero: Constraint<number> = { min: 0, max: 0 };
 const AtLeastOne: Constraint<number> = { min: 1 };
 const RequiresTrue: Constraint<boolean> = { requiredValue: true };
 
@@ -159,6 +160,7 @@ export {
   enforceConstant,
   readonlyTrueWhen,
   fitLength,
+  Zero,
   AtLeastOne,
   RequiresTrue,
 };

--- a/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.spec.ts
+++ b/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPasswordBoundaries, DefaultPasswordGenerationOptions, Policies } from "../data";
 
-import { AtLeastOne } from "./constraints";
+import { AtLeastOne, Zero } from "./constraints";
 import { DynamicPasswordPolicyConstraints } from "./dynamic-password-policy-constraints";
 
 describe("DynamicPasswordPolicyConstraints", () => {
@@ -207,7 +207,7 @@ describe("DynamicPasswordPolicyConstraints", () => {
       expect(calibrated.constraints.minNumber).toEqual(dynamic.constraints.minNumber);
     });
 
-    it("disables the minNumber constraint when the state's number flag is false", () => {
+    it("outputs the zero constraint when the state's number flag is false", () => {
       const dynamic = new DynamicPasswordPolicyConstraints(Policies.Password.disabledValue);
       const state = {
         ...DefaultPasswordGenerationOptions,
@@ -216,7 +216,7 @@ describe("DynamicPasswordPolicyConstraints", () => {
 
       const calibrated = dynamic.calibrate(state);
 
-      expect(calibrated.constraints.minNumber).toBeUndefined();
+      expect(calibrated.constraints.minNumber).toEqual(Zero);
     });
 
     it("outputs the minSpecial constraint when the state's special flag is true", () => {
@@ -231,7 +231,7 @@ describe("DynamicPasswordPolicyConstraints", () => {
       expect(calibrated.constraints.minSpecial).toEqual(dynamic.constraints.minSpecial);
     });
 
-    it("disables the minSpecial constraint when the state's special flag is false", () => {
+    it("outputs the zero constraint when the state's special flag is false", () => {
       const dynamic = new DynamicPasswordPolicyConstraints(Policies.Password.disabledValue);
       const state = {
         ...DefaultPasswordGenerationOptions,
@@ -240,23 +240,7 @@ describe("DynamicPasswordPolicyConstraints", () => {
 
       const calibrated = dynamic.calibrate(state);
 
-      expect(calibrated.constraints.minSpecial).toBeUndefined();
-    });
-
-    it("copies the minimum length constraint", () => {
-      const dynamic = new DynamicPasswordPolicyConstraints(Policies.Password.disabledValue);
-
-      const calibrated = dynamic.calibrate(DefaultPasswordGenerationOptions);
-
-      expect(calibrated.constraints.minSpecial).toBeUndefined();
-    });
-
-    it("overrides the minimum length constraint when it is less than the sum of the state's minimums", () => {
-      const dynamic = new DynamicPasswordPolicyConstraints(Policies.Password.disabledValue);
-
-      const calibrated = dynamic.calibrate(DefaultPasswordGenerationOptions);
-
-      expect(calibrated.constraints.minSpecial).toBeUndefined();
+      expect(calibrated.constraints.minSpecial).toEqual(Zero);
     });
   });
 });

--- a/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.ts
+++ b/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.ts
@@ -7,7 +7,7 @@ import {
 import { DefaultPasswordBoundaries } from "../data";
 import { PasswordGeneratorPolicy, PasswordGeneratorSettings } from "../types";
 
-import { atLeast, atLeastSum, maybe, readonlyTrueWhen, AtLeastOne } from "./constraints";
+import { atLeast, atLeastSum, maybe, readonlyTrueWhen, AtLeastOne, Zero } from "./constraints";
 import { PasswordPolicyConstraints } from "./password-policy-constraints";
 
 /** Creates state constraints by blending policy and password settings. */
@@ -68,8 +68,8 @@ export class DynamicPasswordPolicyConstraints
       ...this.constraints,
       minLowercase: maybe<number>(lowercase, this.constraints.minLowercase ?? AtLeastOne),
       minUppercase: maybe<number>(uppercase, this.constraints.minUppercase ?? AtLeastOne),
-      minNumber: maybe<number>(number, this.constraints.minNumber),
-      minSpecial: maybe<number>(special, this.constraints.minSpecial),
+      minNumber: maybe<number>(number, this.constraints.minNumber) ?? Zero,
+      minSpecial: maybe<number>(special, this.constraints.minSpecial) ?? Zero,
     };
 
     // lower bound of length must always at least fit its sub-lengths


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14198

## 📔 Objective

Fix negative number entries not resetting to zero when the cursor moves away.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
