### PR TITLE
Update Is-Prerelease header to be integer instead of string

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1886,7 +1886,7 @@ export class ApiService implements ApiServiceAbstraction {
     });
 
     if (flagEnabled("prereleaseBuild")) {
-      headers.set("Is-Prerelease", "true");
+      headers.set("Is-Prerelease", "1");
     }
     if (this.customUserAgent != null) {
       headers.set("User-Agent", this.customUserAgent);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13804

## 📔 Objective

In [discussion](https://github.com/bitwarden/server/pull/4994#pullrequestreview-2421469231) on the consuming server PR for this change, we determined it would be better to serve this header as an integer (0/1) instead of string (`true`/`false`) for a boolean representation.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
