### PR TITLE
[PM-13398] embed counter into saved state so chrome always sends change notifications

### DIFF
--- a/libs/common/src/tools/state/user-state-subject.spec.ts
+++ b/libs/common/src/tools/state/user-state-subject.spec.ts
@@ -373,7 +373,11 @@ describe("UserStateSubject", () => {
       singleUserId$.next(SomeUser);
       await awaitAsync();
 
-      expect(state.nextMock).toHaveBeenCalledWith({ foo: "next" });
+      expect(state.nextMock).toHaveBeenCalledWith({
+        foo: "next",
+        // FIXME: don't leak this detail into the test
+        "$^$ALWAYS_UPDATE_KLUDGE_PROPERTY$^$": 0,
+      });
     });
 
     it("waits to evaluate `UserState.update` until singleUserEncryptor$ emits", async () => {
@@ -394,7 +398,13 @@ describe("UserStateSubject", () => {
       await awaitAsync();
 
       const encrypted = { foo: "encrypt(next)" };
-      expect(state.nextMock).toHaveBeenCalledWith({ id: null, secret: encrypted, disclosed: null });
+      expect(state.nextMock).toHaveBeenCalledWith({
+        id: null,
+        secret: encrypted,
+        disclosed: null,
+        // FIXME: don't leak this detail into the test
+        "$^$ALWAYS_UPDATE_KLUDGE_PROPERTY$^$": 0,
+      });
     });
 
     it("applies dynamic constraints", async () => {

--- a/libs/tools/generator/core/src/services/credential-generator.service.spec.ts
+++ b/libs/tools/generator/core/src/services/credential-generator.service.spec.ts
@@ -1163,7 +1163,11 @@ describe("CredentialGeneratorService", () => {
       await awaitAsync();
       const result = await firstValueFrom(stateProvider.getUserState$(SettingsKey, SomeUser));
 
-      expect(result).toEqual({ foo: "next value" });
+      expect(result).toEqual({
+        foo: "next value",
+        // FIXME: don't leak this detail into the test
+        "$^$ALWAYS_UPDATE_KLUDGE_PROPERTY$^$": 0,
+      });
     });
 
     it("waits for the user to become available", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13398

## 📔 Objective

Fixed length allowing negative values on Chrome extension. 

The root cause of this bug is that Firefox updates on every state save, whereas Chrome only updates when the value stored changes. (e.g. Chrome requires `{ foo: 1 }` to become `{ foo: 2 }` to trigger its storage changed event.)

## ♻️ Tech debt

The current mechanism is a stopgap for browser UI refresh. 

* It does not affect encrypted payloads, since their IVs vary the encrypted payload.
* It could be implemented properly as a new `ObjectKey` format.
* It could be extended into a [version vector](https://en.wikipedia.org/wiki/Version_vector) or [vector clock](https://en.wikipedia.org/wiki/Vector_clock) to provide distributed change detection.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
