### PR TITLE
[PM-14653] Delete Unassigned Ciphers 

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -466,7 +466,14 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
    * Helper method to delete cipher.
    */
   private async deleteCipher(): Promise<void> {
-    const asAdmin = this.organization?.canEditAllCiphers;
+    const cipherIsUnassigned =
+      !this.cipher.collectionIds || this.cipher.collectionIds?.length === 0;
+
+    // Delete the cipher as an admin when:
+    // - the organization allows for owners/admins to manage all collections/items
+    // - the cipher is unassigned
+    const asAdmin = this.organization?.canEditAllCiphers || cipherIsUnassigned;
+
     if (this.cipher.isDeleted) {
       await this.cipherService.deleteWithServer(this.cipher.id, asAdmin);
     } else {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14653](https://bitwarden.atlassian.net/browse/PM-14653)

## 📔 Objective

When a cipher is unassigned in the Admin Console it needs to be deleted with admin privileges. Without passing the admin flag, the delete request comes back as a 404 as the user does not have direct access to it.

#### Notes 
- This bug only occurs when the `Owners and admins can manage all collections and items` setting is disabled.
- Parallel PR that fixes this when the extension refresh is disabled: #11927

## 📸 Screenshots

|Before (error) | After (success)|
|-|-|
|<video src="https://github.com/user-attachments/assets/831cf04e-ff51-4370-88a9-08af0bc37a8f" /> | <video src="https://github.com/user-attachments/assets/f731bb9b-63c8-484e-a62f-20a25efcdf74" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14653]: https://bitwarden.atlassian.net/browse/PM-14653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ