### PR TITLE
Check run earlier during setup

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -41,6 +41,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     outputs:
       repo_url: ${{ steps.gen_vars.outputs.repo_url }}
       adj_build_number: ${{ steps.gen_vars.outputs.adj_build_number }}
@@ -236,7 +238,6 @@ jobs:
     needs:
       - setup
       - locales-test
-      - check-run
     env:
       _BUILD_NUMBER: ${{ needs.setup.outputs.adj_build_number }}
       _NODE_VERSION: ${{ needs.setup.outputs.node_version }}

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -42,6 +42,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     outputs:
       package_version: ${{ steps.retrieve-package-version.outputs.package_version }}
       node_version: ${{ steps.retrieve-node-version.outputs.node_version }}
@@ -398,7 +400,6 @@ jobs:
       - cli
       - cli-windows
       - snap
-      - check-run
     steps:
       - name: Check if any job failed
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -40,6 +40,8 @@ jobs:
   electron-verify:
     name: Verify Electron Version
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,6 +63,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     outputs:
       package_version: ${{ steps.retrieve-version.outputs.package_version }}
       release_channel: ${{ steps.release-channel.outputs.channel }}
@@ -251,7 +255,6 @@ jobs:
     runs-on: windows-2022
     needs:
       - setup
-      - check-run
     defaults:
       run:
         shell: pwsh
@@ -464,7 +467,6 @@ jobs:
     runs-on: macos-13
     needs:
       - setup
-      - check-run
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
       _NODE_VERSION: ${{ needs.setup.outputs.node_version }}

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -44,6 +44,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     outputs:
       version: ${{ steps.version.outputs.value }}
       node_version: ${{ steps.retrieve-node-version.outputs.node_version }}
@@ -67,7 +69,8 @@ jobs:
   build-artifacts:
     name: Build artifacts
     runs-on: ubuntu-22.04
-    needs: setup
+    needs:
+      - setup
     env:
       _VERSION: ${{ needs.setup.outputs.version }}
       _NODE_VERSION: ${{ needs.setup.outputs.node_version }}
@@ -151,7 +154,6 @@ jobs:
     needs:
       - setup
       - build-artifacts
-      - check-run
     strategy:
       fail-fast: false
       matrix:
@@ -264,7 +266,6 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs:
       - build-artifacts
-      - check-run
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repo
@@ -302,7 +303,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - build-artifacts
-      - check-run
     steps:
       - name: Login to Azure - CI Subscription
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to earlier check run changes.

## 📔 Objective

To drive awareness of the need for the check run, just require it across the common setup job all the builds use, this way it's checked early and at the first time code is checked out.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
