### PR TITLE
[PM-14001] do not store last value when it is 0

### DIFF
--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -171,10 +171,10 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
     this.minNumber.valueChanges
       .pipe(
         map((value) => [value, value > 0] as const),
-        tap(([value]) => (lastMinNumber = this.numbers.value ? value : lastMinNumber)),
+        tap(([value, checkNumbers]) => (lastMinNumber = checkNumbers ? value : lastMinNumber)),
         takeUntil(this.destroyed$),
       )
-      .subscribe(([, checked]) => this.numbers.setValue(checked, { emitEvent: false }));
+      .subscribe(([, checkNumbers]) => this.numbers.setValue(checkNumbers, { emitEvent: false }));
 
     let lastMinSpecial = 1;
     this.special.valueChanges
@@ -188,10 +188,10 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
     this.minSpecial.valueChanges
       .pipe(
         map((value) => [value, value > 0] as const),
-        tap(([value]) => (lastMinSpecial = this.special.value ? value : lastMinSpecial)),
+        tap(([value, checkSpecial]) => (lastMinSpecial = checkSpecial ? value : lastMinSpecial)),
         takeUntil(this.destroyed$),
       )
-      .subscribe(([, checked]) => this.special.setValue(checked, { emitEvent: false }));
+      .subscribe(([, checkSpecial]) => this.special.setValue(checkSpecial, { emitEvent: false }));
 
     // `onUpdated` depends on `settings` because the UserStateSubject is asynchronous;
     // subscribing directly to `this.settings.valueChanges` introduces a race condition.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14001

## 📔 Objective

Fix a bug caused by the logic that saved the user's last value when deselecting a character class. The logic read the current value of the checkbox to determine whether the value was saveable, which was incorrect when setting the value manually to 0.

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
