### PR TITLE
[PM-14221] Fix extension autofilling instead of viewing

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -5,6 +5,7 @@ import { Subject } from "rxjs";
 
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AUTOFILL_ID } from "@bitwarden/common/autofill/constants";
 import { EventType } from "@bitwarden/common/enums";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -33,6 +34,7 @@ describe("ViewV2Component", () => {
   const params$ = new Subject();
   const mockNavigate = jest.fn();
   const collect = jest.fn().mockResolvedValue(null);
+  const doAutofill = jest.fn();
 
   const mockCipher = {
     id: "122-333-444",
@@ -41,7 +43,7 @@ describe("ViewV2Component", () => {
   };
 
   const mockVaultPopupAutofillService = {
-    doAutofill: jest.fn(),
+    doAutofill,
   };
   const mockUserId = Utils.newGuid() as UserId;
   const accountService: FakeAccountService = mockAccountServiceWith(mockUserId);
@@ -54,6 +56,7 @@ describe("ViewV2Component", () => {
   beforeEach(async () => {
     mockNavigate.mockClear();
     collect.mockClear();
+    doAutofill.mockClear();
 
     await TestBed.configureTestingModule({
       imports: [ViewV2Component],
@@ -147,6 +150,14 @@ describe("ViewV2Component", () => {
         false,
         undefined,
       );
+    }));
+
+    it('invokes `doAutofill` when action="AUTOFILL_ID"', fakeAsync(() => {
+      params$.next({ action: AUTOFILL_ID });
+
+      flush(); // Resolve all promises
+
+      expect(doAutofill).toHaveBeenCalledOnce();
     }));
   });
 });

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -100,7 +100,7 @@ export class ViewV2Component {
         switchMap(async (cipher) => {
           this.cipher = cipher;
           this.headerText = this.setHeader(cipher.type);
-          if (this.loadAction === AUTOFILL_ID || this.loadAction === SHOW_AUTOFILL_BUTTON) {
+          if (this.loadAction === AUTOFILL_ID) {
             await this.vaultPopupAutofillService.doAutofill(this.cipher);
           }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14221](https://bitwarden.atlassian.net/browse/PM-14221)

## 📔 Objective

Removes the check for `SHOW_AUTOFILL_BUTTON` in `view-v2.component.` This stops the extension from autofilling and closing when a user clicks the "view" button on the autofill component. 
- From my testing the `AUTOFILL_ID` check is still needed for when a cipher has master password reprompt set 

## 📸 Screenshots

View action from autofill and verification that master password reprompt still works: 
<video src="https://github.com/user-attachments/assets/b4318eca-3dda-46ed-8931-32d8dc550728" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14221]: https://bitwarden.atlassian.net/browse/PM-14221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ