### PR TITLE
Tools/pm 14838/convert settings

### DIFF
--- a/libs/tools/generator/core/src/data/generators.ts
+++ b/libs/tools/generator/core/src/data/generators.ts
@@ -25,11 +25,6 @@ import {
 import { CatchallConstraints } from "../policies/catchall-constraints";
 import { SubaddressConstraints } from "../policies/subaddress-constraints";
 import {
-  EFF_USERNAME_SETTINGS,
-  PASSPHRASE_SETTINGS,
-  PASSWORD_SETTINGS,
-} from "../strategies/storage";
-import {
   CatchallGenerationOptions,
   CredentialGenerator,
   CredentialGeneratorConfiguration,
@@ -76,7 +71,23 @@ const PASSPHRASE = Object.freeze({
       },
       wordSeparator: { maxLength: 1 },
     },
-    account: PASSPHRASE_SETTINGS,
+    account: {
+      key: "passphraseGeneratorSettings",
+      target: "object",
+      format: "plain",
+      classifier: new PublicClassifier<PassphraseGenerationOptions>([
+        "numWords",
+        "wordSeparator",
+        "capitalize",
+        "includeNumber",
+      ]),
+      state: GENERATOR_DISK,
+      initial: DefaultPassphraseGenerationOptions,
+      options: {
+        deserializer: (value) => value,
+        clearOn: ["logout"],
+      },
+    } satisfies ObjectKey<PassphraseGenerationOptions>,
   },
   policy: {
     type: PolicyType.PasswordGenerator,
@@ -126,7 +137,29 @@ const PASSWORD = Object.freeze({
         max: DefaultPasswordBoundaries.minSpecialCharacters.max,
       },
     },
-    account: PASSWORD_SETTINGS,
+    account: {
+      key: "passwordGeneratorSettings",
+      target: "object",
+      format: "plain",
+      classifier: new PublicClassifier<PasswordGenerationOptions>([
+        "length",
+        "ambiguous",
+        "uppercase",
+        "minUppercase",
+        "lowercase",
+        "minLowercase",
+        "number",
+        "minNumber",
+        "special",
+        "minSpecial",
+      ]),
+      state: GENERATOR_DISK,
+      initial: DefaultPasswordGenerationOptions,
+      options: {
+        deserializer: (value) => value,
+        clearOn: ["logout"],
+      },
+    } satisfies ObjectKey<PasswordGenerationOptions>,
   },
   policy: {
     type: PolicyType.PasswordGenerator,
@@ -164,7 +197,21 @@ const USERNAME = Object.freeze({
   settings: {
     initial: DefaultEffUsernameOptions,
     constraints: {},
-    account: EFF_USERNAME_SETTINGS,
+    account: {
+      key: "effUsernameGeneratorSettings",
+      target: "object",
+      format: "plain",
+      classifier: new PublicClassifier<EffUsernameGenerationOptions>([
+        "wordCapitalize",
+        "wordIncludeNumber",
+      ]),
+      state: GENERATOR_DISK,
+      initial: DefaultEffUsernameOptions,
+      options: {
+        deserializer: (value) => value,
+        clearOn: ["logout"],
+      },
+    } satisfies ObjectKey<EffUsernameGenerationOptions>,
   },
   policy: {
     type: PolicyType.PasswordGenerator,

--- a/libs/tools/generator/core/src/data/generators.ts
+++ b/libs/tools/generator/core/src/data/generators.ts
@@ -46,7 +46,10 @@ import { DefaultPasswordBoundaries } from "./default-password-boundaries";
 import { DefaultPasswordGenerationOptions } from "./default-password-generation-options";
 import { DefaultSubaddressOptions } from "./default-subaddress-generator-options";
 
-const PASSPHRASE = Object.freeze({
+const PASSPHRASE: CredentialGeneratorConfiguration<
+  PassphraseGenerationOptions,
+  PassphraseGeneratorPolicy
+> = Object.freeze({
   id: "passphrase",
   category: "password",
   nameKey: "passphrase",
@@ -100,12 +103,12 @@ const PASSPHRASE = Object.freeze({
     createEvaluator: (policy) => new PassphraseGeneratorOptionsEvaluator(policy),
     toConstraints: (policy) => new PassphrasePolicyConstraints(policy),
   },
-} satisfies CredentialGeneratorConfiguration<
-  PassphraseGenerationOptions,
-  PassphraseGeneratorPolicy
->);
+});
 
-const PASSWORD = Object.freeze({
+const PASSWORD: CredentialGeneratorConfiguration<
+  PasswordGenerationOptions,
+  PasswordGeneratorPolicy
+> = Object.freeze({
   id: "password",
   category: "password",
   nameKey: "password",
@@ -176,57 +179,58 @@ const PASSWORD = Object.freeze({
     createEvaluator: (policy) => new PasswordGeneratorOptionsEvaluator(policy),
     toConstraints: (policy) => new DynamicPasswordPolicyConstraints(policy),
   },
-} satisfies CredentialGeneratorConfiguration<PasswordGenerationOptions, PasswordGeneratorPolicy>);
+});
 
-const USERNAME = Object.freeze({
-  id: "username",
-  category: "username",
-  nameKey: "randomWord",
-  generateKey: "generateUsername",
-  generatedValueKey: "username",
-  copyKey: "copyUsername",
-  onlyOnRequest: false,
-  request: [],
-  engine: {
-    create(
-      dependencies: GeneratorDependencyProvider,
-    ): CredentialGenerator<EffUsernameGenerationOptions> {
-      return new UsernameRandomizer(dependencies.randomizer);
-    },
-  },
-  settings: {
-    initial: DefaultEffUsernameOptions,
-    constraints: {},
-    account: {
-      key: "effUsernameGeneratorSettings",
-      target: "object",
-      format: "plain",
-      classifier: new PublicClassifier<EffUsernameGenerationOptions>([
-        "wordCapitalize",
-        "wordIncludeNumber",
-      ]),
-      state: GENERATOR_DISK,
-      initial: DefaultEffUsernameOptions,
-      options: {
-        deserializer: (value) => value,
-        clearOn: ["logout"],
+const USERNAME: CredentialGeneratorConfiguration<EffUsernameGenerationOptions, NoPolicy> =
+  Object.freeze({
+    id: "username",
+    category: "username",
+    nameKey: "randomWord",
+    generateKey: "generateUsername",
+    generatedValueKey: "username",
+    copyKey: "copyUsername",
+    onlyOnRequest: false,
+    request: [],
+    engine: {
+      create(
+        dependencies: GeneratorDependencyProvider,
+      ): CredentialGenerator<EffUsernameGenerationOptions> {
+        return new UsernameRandomizer(dependencies.randomizer);
       },
-    } satisfies ObjectKey<EffUsernameGenerationOptions>,
-  },
-  policy: {
-    type: PolicyType.PasswordGenerator,
-    disabledValue: {},
-    combine(_acc: NoPolicy, _policy: Policy) {
-      return {};
     },
-    createEvaluator(_policy: NoPolicy) {
-      return new DefaultPolicyEvaluator<EffUsernameGenerationOptions>();
+    settings: {
+      initial: DefaultEffUsernameOptions,
+      constraints: {},
+      account: {
+        key: "effUsernameGeneratorSettings",
+        target: "object",
+        format: "plain",
+        classifier: new PublicClassifier<EffUsernameGenerationOptions>([
+          "wordCapitalize",
+          "wordIncludeNumber",
+        ]),
+        state: GENERATOR_DISK,
+        initial: DefaultEffUsernameOptions,
+        options: {
+          deserializer: (value) => value,
+          clearOn: ["logout"],
+        },
+      } satisfies ObjectKey<EffUsernameGenerationOptions>,
     },
-    toConstraints(_policy: NoPolicy) {
-      return new IdentityConstraint<EffUsernameGenerationOptions>();
+    policy: {
+      type: PolicyType.PasswordGenerator,
+      disabledValue: {},
+      combine(_acc: NoPolicy, _policy: Policy) {
+        return {};
+      },
+      createEvaluator(_policy: NoPolicy) {
+        return new DefaultPolicyEvaluator<EffUsernameGenerationOptions>();
+      },
+      toConstraints(_policy: NoPolicy) {
+        return new IdentityConstraint<EffUsernameGenerationOptions>();
+      },
     },
-  },
-} satisfies CredentialGeneratorConfiguration<EffUsernameGenerationOptions, NoPolicy>);
+  });
 
 const CATCHALL: CredentialGeneratorConfiguration<CatchallGenerationOptions, NoPolicy> =
   Object.freeze({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14838

## 📔 Objective

Apply policy when there's a `null` value in state by setting an initial value when loading `null`.

Note: This behavior is a basic feature of the `UserStateSubject` when using an `ObjectKey`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
