### PR TITLE
[PM-13894] updating the text area for notes to have 5 rows

### DIFF
--- a/libs/vault/src/cipher-view/additional-options/additional-options.component.html
+++ b/libs/vault/src/cipher-view/additional-options/additional-options.component.html
@@ -5,7 +5,7 @@
   <bit-card class="[&_bit-form-field:last-of-type]:tw-mb-0">
     <bit-form-field disableReadOnlyBorder>
       <bit-label>{{ "note" | i18n }}</bit-label>
-      <textarea readonly bitInput aria-readonly="true">{{ notes }}</textarea>
+      <textarea readonly bitInput rows="5" aria-readonly="true">{{ notes }}</textarea>
       <button
         bitSuffix
         bitIconButton="bwi-clone"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13894

## 📔 Objective

Update the note box size on view Note to be 5 lines.
## 📸 Screenshots

![image](https://github.com/user-attachments/assets/7b00d2b4-cd96-4378-8653-1a69630f45c2)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
