### PR TITLE
[PM-14901] Fix ssh keys being empty when creating while filter is active

### DIFF
--- a/libs/common/src/vault/models/view/ssh-key.view.ts
+++ b/libs/common/src/vault/models/view/ssh-key.view.ts
@@ -17,6 +17,10 @@ export class SshKeyView extends ItemView {
   }
 
   get maskedPrivateKey(): string {
+    if (!this.privateKey || this.privateKey.length === 0) {
+      return "";
+    }
+
     let lines = this.privateKey.split("\n").filter((l) => l.trim() !== "");
     lines = lines.map((l, i) => {
       if (i === 0 || i === lines.length - 1) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14901
## 📔 Objective

Creation while filtering to the ssh key category was broken since generate was only invoked when switching item type. Now it also generates when creating the component - if the active item type is ssh keys. Additionally an issue causing error logs is fixed when the private key was not yet set.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
