### PR TITLE
[PM-14020] Compact Mode setting

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4776,5 +4776,11 @@
   },
   "generatedPassword": {
     "message": "Generated password"
+  },
+  "compactMode": {
+    "message": "Compact mode"
+  },
+  "beta": {
+    "message": "Beta"
   }
 }

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -19,6 +19,16 @@
       </bit-form-field>
 
       <bit-form-control>
+        <input bitCheckbox formControlName="compactMode" type="checkbox" />
+        <bit-label>
+          {{ "compactMode" | i18n }}
+          <span bitBadge variant="warning">
+            {{ "beta" | i18n }}
+          </span>
+        </bit-label>
+      </bit-form-control>
+
+      <bit-form-control>
         <input bitCheckbox formControlName="enableBadgeCounter" type="checkbox" />
         <bit-label>{{ "showNumberOfAutofillSuggestions" | i18n }}</bit-label>
       </bit-form-control>

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, signal } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
@@ -12,6 +12,7 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ThemeType } from "@bitwarden/common/platform/enums";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
+import { DesignSystemService } from "@bitwarden/components";
 
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
@@ -47,6 +48,7 @@ describe("AppearanceV2Component", () => {
   const setShowFavicons = jest.fn().mockResolvedValue(undefined);
   const setEnableBadgeCounter = jest.fn().mockResolvedValue(undefined);
   const setEnableRoutingAnimation = jest.fn().mockResolvedValue(undefined);
+  const compactModeSignal = signal(false);
 
   beforeEach(async () => {
     setSelectedTheme.mockClear();
@@ -71,6 +73,10 @@ describe("AppearanceV2Component", () => {
           provide: BadgeSettingsServiceAbstraction,
           useValue: { enableBadgeCounter$, setEnableBadgeCounter },
         },
+        {
+          provide: DesignSystemService,
+          useValue: { compactMode: compactModeSignal },
+        },
       ],
     })
       .overrideComponent(AppearanceV2Component, {
@@ -94,6 +100,7 @@ describe("AppearanceV2Component", () => {
       enableFavicon: true,
       enableBadgeCounter: true,
       theme: ThemeType.Nord,
+      compactMode: false,
     });
   });
 
@@ -120,6 +127,12 @@ describe("AppearanceV2Component", () => {
       component.appearanceForm.controls.enableAnimations.setValue(false);
 
       expect(setEnableRoutingAnimation).toHaveBeenCalledWith(false);
+    });
+
+    it("updates the animation setting", () => {
+      component.appearanceForm.controls.compactMode.setValue(true);
+
+      expect(compactModeSignal()).toBeTrue();
     });
   });
 });

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.ts
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.ts
@@ -12,7 +12,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { ThemeType } from "@bitwarden/common/platform/enums";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
-import { CheckboxModule } from "@bitwarden/components";
+import { BadgeModule, CheckboxModule, DesignSystemService } from "@bitwarden/components";
 
 import { CardComponent } from "../../../../../../libs/components/src/card/card.component";
 import { FormFieldModule } from "../../../../../../libs/components/src/form-field/form-field.module";
@@ -35,6 +35,7 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
     SelectModule,
     ReactiveFormsModule,
     CheckboxModule,
+    BadgeModule,
   ],
 })
 export class AppearanceV2Component implements OnInit {
@@ -43,6 +44,7 @@ export class AppearanceV2Component implements OnInit {
     enableBadgeCounter: true,
     theme: ThemeType.System,
     enableAnimations: true,
+    compactMode: false,
   });
 
   /** To avoid flashes of inaccurate values, only show the form after the entire form is populated. */
@@ -59,6 +61,7 @@ export class AppearanceV2Component implements OnInit {
     private formBuilder: FormBuilder,
     private destroyRef: DestroyRef,
     private animationControlService: AnimationControlService,
+    private designSystemService: DesignSystemService,
     i18nService: I18nService,
   ) {
     this.themeOptions = [
@@ -75,6 +78,7 @@ export class AppearanceV2Component implements OnInit {
     const enableAnimations = await firstValueFrom(
       this.animationControlService.enableRoutingAnimation$,
     );
+    const compactMode = this.designSystemService.compactMode;
 
     // Set initial values for the form
     this.appearanceForm.setValue({
@@ -82,6 +86,7 @@ export class AppearanceV2Component implements OnInit {
       enableBadgeCounter,
       theme,
       enableAnimations,
+      compactMode: compactMode(),
     });
 
     this.formLoading = false;
@@ -108,6 +113,12 @@ export class AppearanceV2Component implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((enableBadgeCounter) => {
         void this.updateAnimations(enableBadgeCounter);
+      });
+
+    this.appearanceForm.controls.compactMode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((compactModeEnabled) => {
+        this.designSystemService.compactMode.set(compactModeEnabled);
       });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14020](https://bitwarden.atlassian.net/browse/PM-14020)
Stacked on top of #11796
## 📔 Objective

Adds setting for Compact Mode which integrates in to the `DesignSystemService`

@willmartian One thing I noticed is the setting isn't persisted when the extension is closed and re-opened. I can update the service to save the setting to disk here if you'd like.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/fcec5b6e-9c3f-401a-8266-08a722abb4ba"/>

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14020]: https://bitwarden.atlassian.net/browse/PM-14020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ