### PR TITLE
PM-14914/ssh-key-item-type-filtering-web

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -68,6 +68,9 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     if (this.activeFilter.cipherType === CipherType.SecureNote) {
       return "searchSecureNote";
     }
+    if (this.activeFilter.cipherType === CipherType.SshKey) {
+      return "searchSshKey";
+    }
     if (this.activeFilter.selectedFolderNode?.node) {
       return "searchFolder";
     }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/services/vault-filter.service.ts
@@ -306,6 +306,12 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
         type: CipherType.SecureNote,
         icon: "bwi-sticky-note",
       },
+      {
+        id: "sshKey",
+        name: this.i18nService.t("typeSshKey"),
+        type: CipherType.SshKey,
+        icon: "bwi-key",
+      },
     ];
 
     return this.buildTypeTree(

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
@@ -23,6 +23,9 @@ export function createFilterFunction(filter: RoutedVaultFilterModel): FilterFunc
     if (filter.type === "note" && cipher.type !== CipherType.SecureNote) {
       return false;
     }
+    if (filter.type === "sshKey" && cipher.type !== CipherType.SshKey) {
+      return false;
+    }
     if (filter.type === "trash" && !cipher.isDeleted) {
       return false;
     }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/routed-vault-filter.model.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/routed-vault-filter.model.ts
@@ -1,7 +1,16 @@
 export const All = "all";
 
 // TODO: Remove `All` when moving to vertical navigation.
-const itemTypes = ["favorites", "login", "card", "identity", "note", "trash", All] as const;
+const itemTypes = [
+  "favorites",
+  "login",
+  "card",
+  "identity",
+  "note",
+  "sshKey",
+  "trash",
+  All,
+] as const;
 
 export type RoutedVaultFilterItemType = (typeof itemTypes)[number];
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14914

## 📔 Objective
in web, filtering by SSH Key would not set the vault filter active as expected in the UI or return SSH Key item types only

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
