### PR TITLE
[PM-7382] Add support for non-UUID credential

### DIFF
--- a/libs/common/src/platform/abstractions/fido2/fido2-authenticator.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/fido2/fido2-authenticator.service.abstraction.ts
@@ -64,7 +64,7 @@ export class Fido2AuthenticatorError extends Error {
 }
 
 export interface PublicKeyCredentialDescriptor {
-  id: BufferSource;
+  id: Uint8Array;
   transports?: ("ble" | "hybrid" | "internal" | "nfc" | "usb")[];
   type: "public-key";
 }

--- a/libs/common/src/platform/services/fido2/credential-id-utils.spec.ts
+++ b/libs/common/src/platform/services/fido2/credential-id-utils.spec.ts
@@ -1,4 +1,4 @@
-import { parseCredentialId } from "./credential-id-utils";
+import { compareCredentialIds, parseCredentialId } from "./credential-id-utils";
 
 describe("credential-id-utils", () => {
   describe("parseCredentialId", () => {
@@ -34,6 +34,35 @@ describe("credential-id-utils", () => {
       const result = parseCredentialId("invalid");
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("compareCredentialIds", () => {
+    it("returns true when the two credential IDs are equal", () => {
+      const a = new Uint8Array([0x01, 0x02, 0x03]);
+      const b = new Uint8Array([0x01, 0x02, 0x03]);
+
+      const result = compareCredentialIds(a, b);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when the two credential IDs are not equal", () => {
+      const a = new Uint8Array([0x01, 0x02, 0x03]);
+      const b = new Uint8Array([0x01, 0x02, 0x04]);
+
+      const result = compareCredentialIds(a, b);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the two credential IDs have different lengths", () => {
+      const a = new Uint8Array([0x01, 0x02, 0x03]);
+      const b = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+
+      const result = compareCredentialIds(a, b);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/libs/common/src/platform/services/fido2/credential-id-utils.spec.ts
+++ b/libs/common/src/platform/services/fido2/credential-id-utils.spec.ts
@@ -1,0 +1,39 @@
+import { parseCredentialId } from "./credential-id-utils";
+
+describe("credential-id-utils", () => {
+  describe("parseCredentialId", () => {
+    it("returns credentialId in binary format when given a valid UUID string", () => {
+      const result = parseCredentialId("08d70b74-e9f5-4522-a425-e5dcd40107e7");
+
+      expect(result).toEqual(
+        new Uint8Array([
+          0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
+          0xe7,
+        ]),
+      );
+    });
+
+    it("returns credentialId in binary format when given a valid Base64Url string", () => {
+      const result = parseCredentialId("b64.CNcLdOn1RSKkJeXc1AEH5w");
+
+      expect(result).toEqual(
+        new Uint8Array([
+          0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
+          0xe7,
+        ]),
+      );
+    });
+
+    it("returns undefined when given an invalid Base64 string", () => {
+      const result = parseCredentialId("b64.#$%&");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when given an invalid UUID string", () => {
+      const result = parseCredentialId("invalid");
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/libs/common/src/platform/services/fido2/credential-id-utils.ts
+++ b/libs/common/src/platform/services/fido2/credential-id-utils.ts
@@ -1,0 +1,14 @@
+import { Fido2Utils } from "./fido2-utils";
+import { guidToRawFormat } from "./guid-utils";
+
+export function parseCredentialId(encodedCredentialId: string): Uint8Array {
+  try {
+    if (encodedCredentialId.startsWith("b64.")) {
+      return Fido2Utils.stringToBuffer(encodedCredentialId.slice(4));
+    }
+
+    return guidToRawFormat(encodedCredentialId);
+  } catch {
+    return undefined;
+  }
+}

--- a/libs/common/src/platform/services/fido2/credential-id-utils.ts
+++ b/libs/common/src/platform/services/fido2/credential-id-utils.ts
@@ -12,3 +12,20 @@ export function parseCredentialId(encodedCredentialId: string): Uint8Array {
     return undefined;
   }
 }
+
+/**
+ * Compares two credential IDs for equality.
+ */
+export function compareCredentialIds(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/libs/common/src/platform/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-authenticator.service.spec.ts
@@ -26,9 +26,9 @@ import {
 import { Utils } from "../../misc/utils";
 
 import { CBOR } from "./cbor";
+import { parseCredentialId } from "./credential-id-utils";
 import { AAGUID, Fido2AuthenticatorService } from "./fido2-authenticator.service";
 import { Fido2Utils } from "./fido2-utils";
-import { guidToRawFormat } from "./guid-utils";
 
 const RpId = "bitwarden.com";
 
@@ -139,7 +139,7 @@ describe("FidoAuthenticatorService", () => {
         params = await createParams({
           excludeCredentialDescriptorList: [
             {
-              id: guidToRawFormat(excludedCipher.login.fido2Credentials[0].credentialId),
+              id: parseCredentialId(excludedCipher.login.fido2Credentials[0].credentialId),
               type: "public-key",
             },
           ],
@@ -482,7 +482,7 @@ describe("FidoAuthenticatorService", () => {
         credentialId = Utils.newGuid();
         params = await createParams({
           allowCredentialDescriptorList: [
-            { id: guidToRawFormat(credentialId), type: "public-key" },
+            { id: parseCredentialId(credentialId), type: "public-key" },
           ],
           rpId: RpId,
         });
@@ -546,7 +546,7 @@ describe("FidoAuthenticatorService", () => {
       let params: Fido2AuthenticatorGetAssertionParams;
 
       beforeEach(async () => {
-        credentialIds = [Utils.newGuid(), Utils.newGuid()];
+        credentialIds = [Utils.newGuid(), "b64.Lb5SVTumSV6gYJpeWh3laA"];
         ciphers = [
           await createCipherView(
             { type: CipherType.Login },
@@ -559,7 +559,7 @@ describe("FidoAuthenticatorService", () => {
         ];
         params = await createParams({
           allowCredentialDescriptorList: credentialIds.map((credentialId) => ({
-            id: guidToRawFormat(credentialId),
+            id: parseCredentialId(credentialId),
             type: "public-key",
           })),
           rpId: RpId,
@@ -667,7 +667,7 @@ describe("FidoAuthenticatorService", () => {
         selectedCredentialId = credentialIds[0];
         params = await createParams({
           allowCredentialDescriptorList: credentialIds.map((credentialId) => ({
-            id: guidToRawFormat(credentialId),
+            id: parseCredentialId(credentialId),
             type: "public-key",
           })),
           rpId: RpId,
@@ -723,7 +723,7 @@ describe("FidoAuthenticatorService", () => {
         const flags = encAuthData.slice(32, 33);
         const counter = encAuthData.slice(33, 37);
 
-        expect(result.selectedCredential.id).toEqual(guidToRawFormat(selectedCredentialId));
+        expect(result.selectedCredential.id).toEqual(parseCredentialId(selectedCredentialId));
         expect(result.selectedCredential.userHandle).toEqual(
           Fido2Utils.stringToBuffer(fido2Credentials[0].userHandle),
         );

--- a/libs/common/src/platform/services/fido2/guid-utils.spec.ts
+++ b/libs/common/src/platform/services/fido2/guid-utils.spec.ts
@@ -1,0 +1,28 @@
+import { guidToRawFormat } from "./guid-utils";
+
+describe("guid-utils", () => {
+  describe("guidToRawFormat", () => {
+    it.each([
+      [
+        "00000000-0000-0000-0000-000000000000",
+        [
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00,
+        ],
+        "08d70b74-e9f5-4522-a425-e5dcd40107e7",
+        [
+          0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
+          0xe7,
+        ],
+      ],
+    ])("returns UUID in binary format when given a valid UUID string", (input, expected) => {
+      const result = guidToRawFormat(input);
+
+      expect(result).toEqual(new Uint8Array(expected));
+    });
+
+    it("throws an error when given an invalid UUID string", () => {
+      expect(() => guidToRawFormat("invalid")).toThrow(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Implement support for `credentialIds` encoded as Base64. This does not change how new `credentialIds` are created, this is on purpose so that we don't break older clients

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
