### PR TITLE
[PM-14653] PM/AC Delete Cipher

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -466,12 +466,15 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
    * Helper method to delete cipher.
    */
   private async deleteCipher(): Promise<void> {
+    const { isAdminConsole } = this.formConfig;
+
     const cipherIsUnassigned =
-      !this.cipher.collectionIds || this.cipher.collectionIds?.length === 0;
+      isAdminConsole && (!this.cipher.collectionIds || this.cipher.collectionIds?.length === 0);
 
     // Delete the cipher as an admin when:
-    // - the organization allows for owners/admins to manage all collections/items
-    // - the cipher is unassigned
+    // - The organization allows for owners/admins to manage all collections/items
+    // - The cipher is unassigned and the cipher is being deleted from the admin console.
+    //   The AC check is needed because logic is used for personal vault items which do not have collections
     const asAdmin = this.organization?.canEditAllCiphers || cipherIsUnassigned;
 
     if (this.cipher.isDeleted) {

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -470,8 +470,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
 
     // Delete the cipher as an admin when:
     // - The organization allows for owners/admins to manage all collections/items
-    // - The cipher is unassigned and the cipher is being deleted from the admin console.
-    //   The AC check is needed because logic is used for personal vault items which do not have collections
+    // - The cipher is unassigned
     const asAdmin = this.organization?.canEditAllCiphers || cipherIsUnassigned;
 
     if (this.cipher.isDeleted) {

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -466,10 +466,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
    * Helper method to delete cipher.
    */
   private async deleteCipher(): Promise<void> {
-    const { isAdminConsole } = this.formConfig;
-
-    const cipherIsUnassigned =
-      isAdminConsole && (!this.cipher.collectionIds || this.cipher.collectionIds?.length === 0);
+    const cipherIsUnassigned = this.cipher.isUnassigned;
 
     // Delete the cipher as an admin when:
     // - The organization allows for owners/admins to manage all collections/items


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14653](https://bitwarden.atlassian.net/browse/PM-14653)

## 📔 Objective

The `VaultItemDialogComponent` is shared between Password Manager and Admin Console.
- Personal Items do not have assigned collections, the collection check to use the admin endpoint should only be applicable when the dialog is rendered within the Admin Console.

## 📸 Screenshots

| AC - Unassigned Cipher | AC - Assigned Cipher | PM - Personal Cipher|
|-|-|-|
| <video src="https://github.com/user-attachments/assets/47a82007-2348-4809-92fc-d02acbb7f8cb" />| <video src="https://github.com/user-attachments/assets/49f45dd0-e523-4e3e-a4fe-5f2f4dd69a06" />| <video src="https://github.com/user-attachments/assets/6fa2811f-52b7-42c6-a6c2-dad7f6579c9e" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14653]: https://bitwarden.atlassian.net/browse/PM-14653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ