### PR TITLE
[PM-13829] Add organizationId to isAdmin check, refactor isAdmin to getter

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -713,19 +713,24 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   protected deleteCipher() {
-    // cipher.collectionIds may be null or an empty array. Either is a valid indication that the item is unassigned.
-    const asAdmin =
-      this.organization?.canEditAllCiphers ||
-      !this.cipher.collectionIds ||
-      this.cipher.collectionIds.length === 0;
     return this.cipher.isDeleted
-      ? this.cipherService.deleteWithServer(this.cipher.id, asAdmin)
-      : this.cipherService.softDeleteWithServer(this.cipher.id, asAdmin);
+      ? this.cipherService.deleteWithServer(this.cipher.id, this.asAdmin)
+      : this.cipherService.softDeleteWithServer(this.cipher.id, this.asAdmin);
   }
 
   protected restoreCipher() {
-    const asAdmin = this.organization?.canEditAllCiphers;
-    return this.cipherService.restoreWithServer(this.cipher.id, asAdmin);
+    return this.cipherService.restoreWithServer(this.cipher.id, this.asAdmin);
+  }
+
+  get asAdmin(): boolean {
+    // cipher.collectionIds may be null or an empty array. Either is a valid indication that the item is unassigned.
+    return (
+      this.cipher.organizationId !== null &&
+      this.cipher.organizationId.length > 0 &&
+      (this.organization?.canEditAllCiphers ||
+        !this.cipher.collectionIds ||
+        this.cipher.collectionIds.length === 0)
+    );
   }
 
   get defaultOwnerId(): string | null {

--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -722,8 +722,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
     return this.cipherService.restoreWithServer(this.cipher.id, this.asAdmin);
   }
 
+  /**
+   * Determines if a cipher must be deleted as an admin by belonging to an organization and being unassigned to a collection.
+   */
   get asAdmin(): boolean {
-    // cipher.collectionIds may be null or an empty array. Either is a valid indication that the item is unassigned.
     return (
       this.cipher.organizationId !== null &&
       this.cipher.organizationId.length > 0 &&


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13829

## 📔 Objective

This PR adds a check to see if a cipher belongs to an organization to determine which REST call to make. Personal items should not be deleted with the admin delete call. This check is refactored as a getter property and is added to the `restoreCipher()` function to resolve the same issue.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
