### PR TITLE
[PM-14473] AC - "New" item button

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -104,72 +104,97 @@
     *ngIf="filter.type !== 'trash' && filter.collectionId !== Unassigned && organization"
     class="tw-shrink-0"
   >
-    <div *ngIf="canCreateCipher && canCreateCollection" appListDropdown>
+    <!-- "New" menu is always shown for Extension Refresh unless the user cannot create a cipher -->
+    <ng-container *ngIf="extensionRefreshEnabled && canCreateCipher; else nonRefresh">
+      <div appListDropdown>
+        <button
+          bitButton
+          buttonType="primary"
+          type="button"
+          [bitMenuTriggerFor]="addOptions"
+          id="newItemDropdown"
+          appA11yTitle="{{ 'new' | i18n }}"
+        >
+          <i class="bwi bwi-plus-f" aria-hidden="true"></i>
+          {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
+        </button>
+        <bit-menu #addOptions aria-labelledby="newItemDropdown">
+          <button type="button" bitMenuItem (click)="addCipher(CipherType.Login)">
+            <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
+            {{ "typeLogin" | i18n }}
+          </button>
+          <button type="button" bitMenuItem (click)="addCipher(CipherType.Card)">
+            <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
+            {{ "typeCard" | i18n }}
+          </button>
+          <button type="button" bitMenuItem (click)="addCipher(CipherType.Identity)">
+            <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
+            {{ "typeIdentity" | i18n }}
+          </button>
+          <button type="button" bitMenuItem (click)="addCipher(CipherType.SecureNote)">
+            <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
+            {{ "note" | i18n }}
+          </button>
+          <ng-container *ngIf="canCreateCollection">
+            <bit-menu-divider></bit-menu-divider>
+            <button type="button" bitMenuItem (click)="addCollection()">
+              <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
+              {{ "collection" | i18n }}
+            </button>
+          </ng-container>
+        </bit-menu>
+      </div>
+    </ng-container>
+
+    <ng-template #nonRefresh>
+      <!-- Show a menu when the user can create a cipher and collection -->
+      <div *ngIf="canCreateCipher && canCreateCollection" appListDropdown>
+        <button
+          bitButton
+          buttonType="primary"
+          type="button"
+          [bitMenuTriggerFor]="addOptions"
+          id="newItemDropdown"
+          appA11yTitle="{{ 'new' | i18n }}"
+        >
+          <i class="bwi bwi-plus-f" aria-hidden="true"></i>
+          {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
+        </button>
+        <bit-menu #addOptions aria-labelledby="newItemDropdown">
+          <button type="button" bitMenuItem (click)="addCipher()">
+            <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>
+            {{ "item" | i18n }}
+          </button>
+          <button type="button" bitMenuItem (click)="addCollection()">
+            <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
+            {{ "collection" | i18n }}
+          </button>
+        </bit-menu>
+      </div>
+
+      <!-- Show a single button when the user can only create a cipher -->
       <button
+        *ngIf="canCreateCipher && !canCreateCollection"
+        type="button"
         bitButton
         buttonType="primary"
-        type="button"
-        [bitMenuTriggerFor]="addOptions"
-        id="newItemDropdown"
-        appA11yTitle="{{ 'new' | i18n }}"
+        (click)="addCipher()"
       >
-        <i class="bwi bwi-plus-f" aria-hidden="true"></i>
-        {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
+        <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+        {{ "newItem" | i18n }}
       </button>
-      <bit-menu #addOptions aria-labelledby="newItemDropdown">
-        <ng-container [ngSwitch]="extensionRefreshEnabled">
-          <ng-container *ngSwitchCase="true">
-            <button type="button" bitMenuItem (click)="addCipher(CipherType.Login)">
-              <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
-              {{ "typeLogin" | i18n }}
-            </button>
-            <button type="button" bitMenuItem (click)="addCipher(CipherType.Card)">
-              <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
-              {{ "typeCard" | i18n }}
-            </button>
-            <button type="button" bitMenuItem (click)="addCipher(CipherType.Identity)">
-              <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
-              {{ "typeIdentity" | i18n }}
-            </button>
-            <button type="button" bitMenuItem (click)="addCipher(CipherType.SecureNote)">
-              <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
-              {{ "note" | i18n }}
-            </button>
-            <bit-menu-divider></bit-menu-divider>
-          </ng-container>
-          <ng-container *ngSwitchCase="false">
-            <button type="button" bitMenuItem (click)="addCipher()">
-              <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>
-              {{ "item" | i18n }}
-            </button>
-          </ng-container>
-        </ng-container>
-        <button type="button" bitMenuItem (click)="addCollection()">
-          <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
-          {{ "collection" | i18n }}
-        </button>
-      </bit-menu>
-    </div>
-    <button
-      *ngIf="canCreateCipher && !canCreateCollection"
-      type="button"
-      bitButton
-      buttonType="primary"
-      (click)="addCipher()"
-    >
-      <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-      {{ "newItem" | i18n }}
-    </button>
 
-    <button
-      *ngIf="canCreateCollection && !canCreateCipher"
-      type="button"
-      bitButton
-      buttonType="primary"
-      (click)="addCollection()"
-    >
-      <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-      {{ "newCollection" | i18n }}
-    </button>
+      <!-- Show a single button when the user can only create a collection -->
+      <button
+        *ngIf="canCreateCollection && !canCreateCipher"
+        type="button"
+        bitButton
+        buttonType="primary"
+        (click)="addCollection()"
+      >
+        <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+        {{ "newCollection" | i18n }}
+      </button>
+    </ng-template>
   </div>
 </app-header>

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.ts
@@ -57,7 +57,7 @@ export class VaultHeaderComponent implements OnInit {
    */
   @Input() loading: boolean;
 
-  /** Current active fitler */
+  /** Current active filter */
   @Input() filter: RoutedVaultFilterModel;
 
   /** The organization currently being viewed */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14473](https://bitwarden.atlassian.net/browse/PM-14473)

## 📔 Objective

The ticket is geared towards custom users that _cannot_ create a collection. Those users were only seeing the "new item" button rather than the dropdown to select the cipher type.

This was caused by the hierarchy of logic favoring the user's permissions rather than the extension refresh first. To solve:
- I moved the check for extension refresh up, so the user will always see the dropdown menu unless they can _only_ create collection<sup>1</sup>. 
  - This does create a little but of duplicate markup, but it will be easy to strip out the non-refresh code once that is enabled.
- There is internal logic within the dropdown menu to properly show the available options respective of the permissions.

<sup>1</sup> I wasn't able to find permissions to test this scenario. Is there a way to get a user who can _only_ create collections?

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/701e0821-d019-4005-95bc-b308a2adfccf"/>

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14473]: https://bitwarden.atlassian.net/browse/PM-14473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ