### PR TITLE
[PM-13711] invert ambiguous character flag

### DIFF
--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -117,7 +117,7 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
         map((settings) => {
           // interface is "avoid" while storage is "include"
           const s: any = { ...settings };
-          s.avoidAmbiguous = s.ambiguous;
+          s.avoidAmbiguous = !s.ambiguous;
           delete s.ambiguous;
           return s;
         }),
@@ -205,7 +205,7 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
         map(([, settings]) => {
           // interface is "avoid" while storage is "include"
           const s: any = { ...settings };
-          s.ambiguous = s.avoidAmbiguous;
+          s.ambiguous = !s.avoidAmbiguous;
           delete s.avoidAmbiguous;
           return s;
         }),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13711

## 📔 Objective

Fix a bug where the generator interpreted the "avoid ambiguous characters" flag as an "include ambiguous characters" flag.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
