### PR TITLE
[PM-14964] revert passphrase minimum

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2889,9 +2889,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "passwordLengthHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Explains password 'length' boundaries to the user",
+  "generatorBoundariesHint": {
+    "message": "Value must be between $MIN$ and $MAX$.",
+    "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -2900,27 +2900,25 @@
       "max": {
         "content": "$2",
         "example": "128"
-      },
+      }
+    }
+  },
+  "passwordLengthRecommendationHint": {
+    "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "placeholders": {
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "14"
       }
     }
   },
-  "passphraseNumWordsHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Explains passphrase 'number of words' boundaries to the user",
+  "passphraseNumWordsRecommendationHint": {
+    "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
-      "min": {
-        "content": "$1",
-        "example": "8"
-      },
-      "max": {
-        "content": "$2",
-        "example": "128"
-      },
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "6"
       }
     }

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2903,6 +2903,9 @@
       }
     }
   },
+  "passphraseNumWordsHint": {
+    "message": "We recommend at least 6 words for strong security."
+  },
   "usernameType": {
     "message": "Username type"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2905,7 +2905,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a length to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -2915,7 +2915,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a number of words to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2889,7 +2889,7 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
+  "spinboxBoundariesHint": {
     "message": "Value must be between $MIN$ and $MAX$.",
     "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
@@ -2905,7 +2905,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -2915,7 +2915,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2889,9 +2889,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
-    "message": "Value must be between $MIN$ and $MAX$",
-    "description": "Explains spin box minimum and maximum values to the user",
+  "passwordLengthHint": {
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Explains password 'length' boundaries to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -2900,11 +2900,30 @@
       "max": {
         "content": "$2",
         "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "14"
       }
     }
   },
   "passphraseNumWordsHint": {
-    "message": "We recommend at least 6 words for strong security."
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Explains passphrase 'number of words' boundaries to the user",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "8"
+      },
+      "max": {
+        "content": "$2",
+        "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "6"
+      }
+    }
   },
   "usernameType": {
     "message": "Username type"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2444,7 +2444,7 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
+  "spinboxBoundariesHint": {
     "message": "Value must be between $MIN$ and $MAX$.",
     "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
@@ -2460,7 +2460,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -2470,7 +2470,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2445,7 +2445,7 @@
     "message": "Generate email"
   },
   "generatorBoundariesHint": {
-    "message": "Value must be between $MIN$ and $MAX$",
+    "message": "Value must be between $MIN$ and $MAX$.",
     "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
       "min": {
@@ -2457,6 +2457,9 @@
         "example": "128"
       }
     }
+  },
+  "passphraseNumWordsHint": {
+    "message": "We recommend at least 6 words for strong security."
   },
   "usernameType": {
     "message": "Username type"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2444,9 +2444,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "passwordLengthHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Explains password 'length' boundaries to the user",
+  "generatorBoundariesHint": {
+    "message": "Value must be between $MIN$ and $MAX$.",
+    "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -2455,27 +2455,25 @@
       "max": {
         "content": "$2",
         "example": "128"
-      },
+      }
+    }
+  },
+  "passwordLengthRecommendationHint": {
+    "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "placeholders": {
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "14"
       }
     }
   },
-  "passphraseNumWordsHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Explains passphrase 'number of words' boundaries to the user",
+  "passphraseNumWordsRecommendationHint": {
+    "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
-      "min": {
-        "content": "$1",
-        "example": "8"
-      },
-      "max": {
-        "content": "$2",
-        "example": "128"
-      },
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "6"
       }
     }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2444,9 +2444,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
-    "message": "Value must be between $MIN$ and $MAX$.",
-    "description": "Explains spin box minimum and maximum values to the user",
+  "passwordLengthHint": {
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Explains password 'length' boundaries to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -2455,11 +2455,30 @@
       "max": {
         "content": "$2",
         "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "14"
       }
     }
   },
   "passphraseNumWordsHint": {
-    "message": "We recommend at least 6 words for strong security."
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Explains passphrase 'number of words' boundaries to the user",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "8"
+      },
+      "max": {
+        "content": "$2",
+        "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "6"
+      }
+    }
   },
   "usernameType": {
     "message": "Username type"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2460,7 +2460,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a length to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -2470,7 +2470,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a number of words to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/web/src/app/admin-console/organizations/policies/password-generator.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/password-generator.component.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, map } from "rxjs";
 
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DefaultPassphraseBoundaries, DefaultPasswordBoundaries } from "@bitwarden/generator-core";
+import { Generators } from "@bitwarden/generator-core";
 
 import { BasePolicy, BasePolicyComponent } from "./base-policy.component";
 
@@ -26,8 +26,8 @@ export class PasswordGeneratorPolicyComponent extends BasePolicyComponent {
     minLength: [
       null,
       [
-        Validators.min(DefaultPasswordBoundaries.length.min),
-        Validators.max(DefaultPasswordBoundaries.length.max),
+        Validators.min(Generators.password.settings.constraints.length.min),
+        Validators.max(Generators.password.settings.constraints.length.max),
       ],
     ],
     useUpper: [null],
@@ -37,22 +37,22 @@ export class PasswordGeneratorPolicyComponent extends BasePolicyComponent {
     minNumbers: [
       null,
       [
-        Validators.min(DefaultPasswordBoundaries.minDigits.min),
-        Validators.max(DefaultPasswordBoundaries.minDigits.max),
+        Validators.min(Generators.password.settings.constraints.minNumber.min),
+        Validators.max(Generators.password.settings.constraints.minNumber.max),
       ],
     ],
     minSpecial: [
       null,
       [
-        Validators.min(DefaultPasswordBoundaries.minSpecialCharacters.min),
-        Validators.max(DefaultPasswordBoundaries.minSpecialCharacters.max),
+        Validators.min(Generators.password.settings.constraints.minSpecial.min),
+        Validators.max(Generators.password.settings.constraints.minSpecial.max),
       ],
     ],
     minNumberWords: [
       null,
       [
-        Validators.min(DefaultPassphraseBoundaries.numWords.min),
-        Validators.max(DefaultPassphraseBoundaries.numWords.max),
+        Validators.min(Generators.passphrase.settings.constraints.numWords.min),
+        Validators.max(Generators.passphrase.settings.constraints.numWords.max),
       ],
     ],
     capitalize: [null],

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6484,7 +6484,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a length to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -6494,7 +6494,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
+    "description": "Appended to `spinboxBoundariesHint` to recommend a number of words to the user. This must include any language-specific 'sentence' separator characters (e.g. a space in english).",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6482,6 +6482,9 @@
       }
     }
   },
+  "passphraseNumWordsHint": {
+    "message": "We recommend at least 6 words for strong security."
+  },
   "usernameType": {
     "message": "Username type"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6468,9 +6468,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "passwordLengthHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Explains password 'length' boundaries to the user",
+  "generatorBoundariesHint": {
+    "message": "Value must be between $MIN$ and $MAX$.",
+    "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -6479,27 +6479,25 @@
       "max": {
         "content": "$2",
         "example": "128"
-      },
+      }
+    }
+  },
+  "passwordLengthRecommendationHint": {
+    "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "placeholders": {
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "14"
       }
     }
   },
-  "passphraseNumWordsHint": {
-    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Explains passphrase 'number of words' boundaries to the user",
+  "passphraseNumWordsRecommendationHint": {
+    "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
-      "min": {
-        "content": "$1",
-        "example": "8"
-      },
-      "max": {
-        "content": "$2",
-        "example": "128"
-      },
       "recommended": {
-        "content": "$3",
+        "content": "$1",
         "example": "6"
       }
     }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6468,7 +6468,7 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
+  "spinboxBoundariesHint": {
     "message": "Value must be between $MIN$ and $MAX$.",
     "description": "Explains spin box minimum and maximum values to the user",
     "placeholders": {
@@ -6484,7 +6484,7 @@
   },
   "passwordLengthRecommendationHint": {
     "message": " Use $RECOMMENDED$ characters or more to generate a strong password.",
-    "description": "Extends `generatorBoundariesHint` to recommend a length to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a length to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",
@@ -6494,7 +6494,7 @@
   },
   "passphraseNumWordsRecommendationHint": {
     "message": " Use $RECOMMENDED$ words or more to generate a strong passphrase.",
-    "description": "Extends `generatorBoundariesHint` to recommend a number of words to the user",
+    "description": "Extends `spinboxBoundariesHint` to recommend a number of words to the user",
     "placeholders": {
       "recommended": {
         "content": "$1",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6468,9 +6468,9 @@
   "generateEmail": {
     "message": "Generate email"
   },
-  "generatorBoundariesHint": {
-    "message": "Value must be between $MIN$ and $MAX$",
-    "description": "Explains spin box minimum and maximum values to the user",
+  "passwordLengthHint": {
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ characters or more to generate a strong password.",
+    "description": "Explains password 'length' boundaries to the user",
     "placeholders": {
       "min": {
         "content": "$1",
@@ -6479,11 +6479,30 @@
       "max": {
         "content": "$2",
         "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "14"
       }
     }
   },
   "passphraseNumWordsHint": {
-    "message": "We recommend at least 6 words for strong security."
+    "message": "Value must be between $MIN$ and $MAX$. Use $RECOMMENDED$ words or more to generate a strong passphrase.",
+    "description": "Explains passphrase 'number of words' boundaries to the user",
+    "placeholders": {
+      "min": {
+        "content": "$1",
+        "example": "8"
+      },
+      "max": {
+        "content": "$2",
+        "example": "128"
+      },
+      "recommended": {
+        "content": "$3",
+        "example": "6"
+      }
+    }
   },
   "usernameType": {
     "message": "Username type"

--- a/libs/common/src/tools/types.ts
+++ b/libs/common/src/tools/types.ts
@@ -28,6 +28,11 @@ type NumberConstraints = {
   /** maximum number value. When absent, min value is unbounded. */
   max?: number;
 
+  /** recommended value. This is the value bitwarden recommends
+   *  to the user as an appropriate value.
+   */
+  recommendation?: number;
+
   /** requires the number be a multiple of the step value;
    *  this field must be a positive number. +0 and Infinity are
    *  prohibited. When absent, any number is accepted.

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -100,11 +100,12 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
         this.toggleEnabled(Controls.capitalize, !constraints.capitalize?.readonly);
         this.toggleEnabled(Controls.includeNumber, !constraints.includeNumber?.readonly);
 
-        const boundariesHint = this.i18nService.t(
-          "generatorBoundariesHint",
-          constraints.numWords.min?.toString(),
-          constraints.numWords.max?.toString(),
-        );
+        const boundariesHint =
+          this.i18nService.t(
+            "generatorBoundariesHint",
+            constraints.numWords.min?.toString(),
+            constraints.numWords.max?.toString(),
+          ) + this.i18nService.t("passphraseNumWordsHint");
         this.numWordsBoundariesHint.next(boundariesHint);
       });
 

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -100,12 +100,12 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
         this.toggleEnabled(Controls.capitalize, !constraints.capitalize?.readonly);
         this.toggleEnabled(Controls.includeNumber, !constraints.includeNumber?.readonly);
 
-        const boundariesHint =
-          this.i18nService.t(
-            "generatorBoundariesHint",
-            constraints.numWords.min?.toString(),
-            constraints.numWords.max?.toString(),
-          ) + this.i18nService.t("passphraseNumWordsHint");
+        const boundariesHint = this.i18nService.t(
+          "passphraseNumWordsHint",
+          constraints.numWords.min?.toString(),
+          constraints.numWords.max?.toString(),
+          constraints.numWords.recommendation?.toString(),
+        );
         this.numWordsBoundariesHint.next(boundariesHint);
       });
 

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -88,7 +88,7 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
         this.settings.patchValue(state, { emitEvent: false });
 
         let boundariesHint = this.i18nService.t(
-          "generatorBoundariesHint",
+          "spinboxBoundariesHint",
           constraints.numWords.min?.toString(),
           constraints.numWords.max?.toString(),
         );

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -82,9 +82,24 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
     const settings = await this.generatorService.settings(Generators.passphrase, { singleUserId$ });
 
     // skips reactive event emissions to break a subscription cycle
-    settings.pipe(takeUntil(this.destroyed$)).subscribe((s) => {
-      this.settings.patchValue(s, { emitEvent: false });
-    });
+    settings.withConstraints$
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe(({ state, constraints }) => {
+        this.settings.patchValue(state, { emitEvent: false });
+
+        let boundariesHint = this.i18nService.t(
+          "generatorBoundariesHint",
+          constraints.numWords.min?.toString(),
+          constraints.numWords.max?.toString(),
+        );
+        if (state.numWords <= (constraints.numWords.recommendation ?? 0)) {
+          boundariesHint += this.i18nService.t(
+            "passphraseNumWordsRecommendationHint",
+            constraints.numWords.recommendation?.toString(),
+          );
+        }
+        this.numWordsBoundariesHint.next(boundariesHint);
+      });
 
     // the first emission is the current value; subsequent emissions are updates
     settings.pipe(skip(1), takeUntil(this.destroyed$)).subscribe(this.onUpdated);
@@ -99,14 +114,6 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
 
         this.toggleEnabled(Controls.capitalize, !constraints.capitalize?.readonly);
         this.toggleEnabled(Controls.includeNumber, !constraints.includeNumber?.readonly);
-
-        const boundariesHint = this.i18nService.t(
-          "passphraseNumWordsHint",
-          constraints.numWords.min?.toString(),
-          constraints.numWords.max?.toString(),
-          constraints.numWords.recommendation?.toString(),
-        );
-        this.numWordsBoundariesHint.next(boundariesHint);
       });
 
     // now that outputs are set up, connect inputs

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -125,7 +125,7 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
       )
       .subscribe(([state, constraints]) => {
         let boundariesHint = this.i18nService.t(
-          "generatorBoundariesHint",
+          "spinboxBoundariesHint",
           constraints.length.min?.toString(),
           constraints.length.max?.toString(),
         );

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -150,9 +150,10 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
         }
 
         const boundariesHint = this.i18nService.t(
-          "generatorBoundariesHint",
+          "passwordLengthHint",
           constraints.length.min?.toString(),
           constraints.length.max?.toString(),
+          constraints.length.recommendation?.toString(),
         );
         this.lengthBoundariesHint.next(boundariesHint);
       });

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -112,20 +112,33 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
     const settings = await this.generatorService.settings(Generators.password, { singleUserId$ });
 
     // bind settings to the UI
-    settings
+    settings.withConstraints$
       .pipe(
-        map((settings) => {
+        map(({ state, constraints }) => {
           // interface is "avoid" while storage is "include"
-          const s: any = { ...settings };
+          const s: any = { ...state };
           s.avoidAmbiguous = !s.ambiguous;
           delete s.ambiguous;
-          return s;
+          return [s, constraints] as const;
         }),
         takeUntil(this.destroyed$),
       )
-      .subscribe((s) => {
+      .subscribe(([state, constraints]) => {
+        let boundariesHint = this.i18nService.t(
+          "generatorBoundariesHint",
+          constraints.length.min?.toString(),
+          constraints.length.max?.toString(),
+        );
+        if (state.length <= (constraints.length.recommendation ?? 0)) {
+          boundariesHint += this.i18nService.t(
+            "passwordLengthRecommendationHint",
+            constraints.length.recommendation?.toString(),
+          );
+        }
+        this.lengthBoundariesHint.next(boundariesHint);
+
         // skips reactive event emissions to break a subscription cycle
-        this.settings.patchValue(s, { emitEvent: false });
+        this.settings.patchValue(state, { emitEvent: false });
       });
 
     // explain policy & disable policy-overridden fields
@@ -148,14 +161,6 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
         for (const [control, enabled] of toggles) {
           this.toggleEnabled(control, enabled);
         }
-
-        const boundariesHint = this.i18nService.t(
-          "passwordLengthHint",
-          constraints.length.min?.toString(),
-          constraints.length.max?.toString(),
-          constraints.length.recommendation?.toString(),
-        );
-        this.lengthBoundariesHint.next(boundariesHint);
       });
 
     // cascade selections between checkboxes and spinboxes

--- a/libs/tools/generator/core/src/data/default-passphrase-boundaries.ts
+++ b/libs/tools/generator/core/src/data/default-passphrase-boundaries.ts
@@ -1,6 +1,6 @@
 function initializeBoundaries() {
   const numWords = Object.freeze({
-    min: 6,
+    min: 3,
     max: 20,
   });
 

--- a/libs/tools/generator/core/src/data/generators.ts
+++ b/libs/tools/generator/core/src/data/generators.ts
@@ -71,6 +71,7 @@ const PASSPHRASE: CredentialGeneratorConfiguration<
       numWords: {
         min: DefaultPassphraseBoundaries.numWords.min,
         max: DefaultPassphraseBoundaries.numWords.max,
+        recommendation: DefaultPassphraseGenerationOptions.numWords,
       },
       wordSeparator: { maxLength: 1 },
     },
@@ -101,7 +102,8 @@ const PASSPHRASE: CredentialGeneratorConfiguration<
     }),
     combine: passphraseLeastPrivilege,
     createEvaluator: (policy) => new PassphraseGeneratorOptionsEvaluator(policy),
-    toConstraints: (policy) => new PassphrasePolicyConstraints(policy),
+    toConstraints: (policy) =>
+      new PassphrasePolicyConstraints(policy, PASSPHRASE.settings.constraints),
   },
 });
 
@@ -130,6 +132,7 @@ const PASSWORD: CredentialGeneratorConfiguration<
       length: {
         min: DefaultPasswordBoundaries.length.min,
         max: DefaultPasswordBoundaries.length.max,
+        recommendation: DefaultPasswordGenerationOptions.length,
       },
       minNumber: {
         min: DefaultPasswordBoundaries.minDigits.min,
@@ -177,7 +180,8 @@ const PASSWORD: CredentialGeneratorConfiguration<
     }),
     combine: passwordLeastPrivilege,
     createEvaluator: (policy) => new PasswordGeneratorOptionsEvaluator(policy),
-    toConstraints: (policy) => new DynamicPasswordPolicyConstraints(policy),
+    toConstraints: (policy) =>
+      new DynamicPasswordPolicyConstraints(policy, PASSWORD.settings.constraints),
   },
 });
 

--- a/libs/tools/generator/core/src/policies/passphrase-policy-constraints.spec.ts
+++ b/libs/tools/generator/core/src/policies/passphrase-policy-constraints.spec.ts
@@ -72,9 +72,9 @@ describe("PassphrasePolicyConstraints", () => {
     });
 
     it.each([
-      [1, 6],
+      [1, 3],
       [21, 20],
-    ])("fits numWords (=%p) within the default bounds (6 <= %p <= 20)", (value, expected) => {
+    ])("fits numWords (=%p) within the default bounds (3 <= %p <= 20)", (value, expected) => {
       const policy = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
 
       const { numWords } = policy.adjust({ ...SomeSettings, numWords: value });

--- a/libs/tools/generator/core/src/policies/passphrase-policy-constraints.spec.ts
+++ b/libs/tools/generator/core/src/policies/passphrase-policy-constraints.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPassphraseBoundaries, Policies } from "../data";
+import { Generators } from "../data";
 
 import { PassphrasePolicyConstraints } from "./passphrase-policy-constraints";
 
@@ -9,54 +9,66 @@ const SomeSettings = {
   wordSeparator: "-",
 };
 
+const disabledPolicy = Generators.passphrase.policy.disabledValue;
+const someConstraints = Generators.passphrase.settings.constraints;
+
 describe("PassphrasePolicyConstraints", () => {
   describe("constructor", () => {
     it("uses default boundaries when the policy is disabled", () => {
-      const { constraints } = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
+      const { constraints } = new PassphrasePolicyConstraints(disabledPolicy, someConstraints);
 
       expect(constraints.policyInEffect).toBeFalsy();
       expect(constraints.capitalize).toBeUndefined();
       expect(constraints.includeNumber).toBeUndefined();
-      expect(constraints.numWords).toEqual(DefaultPassphraseBoundaries.numWords);
+      expect(constraints.numWords).toEqual(someConstraints.numWords);
     });
 
     it("requires capitalization when the policy requires capitalization", () => {
-      const { constraints } = new PassphrasePolicyConstraints({
-        ...Policies.Passphrase.disabledValue,
-        capitalize: true,
-      });
+      const { constraints } = new PassphrasePolicyConstraints(
+        {
+          ...disabledPolicy,
+          capitalize: true,
+        },
+        someConstraints,
+      );
 
       expect(constraints.policyInEffect).toBeTruthy();
       expect(constraints.capitalize).toMatchObject({ readonly: true, requiredValue: true });
     });
 
     it("requires a number when the policy requires a number", () => {
-      const { constraints } = new PassphrasePolicyConstraints({
-        ...Policies.Passphrase.disabledValue,
-        includeNumber: true,
-      });
+      const { constraints } = new PassphrasePolicyConstraints(
+        {
+          ...disabledPolicy,
+          includeNumber: true,
+        },
+        someConstraints,
+      );
 
       expect(constraints.policyInEffect).toBeTruthy();
       expect(constraints.includeNumber).toMatchObject({ readonly: true, requiredValue: true });
     });
 
     it("minNumberWords <= numWords.min  when the policy requires numberCount", () => {
-      const { constraints } = new PassphrasePolicyConstraints({
-        ...Policies.Passphrase.disabledValue,
-        minNumberWords: 10,
-      });
+      const { constraints } = new PassphrasePolicyConstraints(
+        {
+          ...disabledPolicy,
+          minNumberWords: 10,
+        },
+        someConstraints,
+      );
 
       expect(constraints.policyInEffect).toBeTruthy();
       expect(constraints.numWords).toMatchObject({
         min: 10,
-        max: DefaultPassphraseBoundaries.numWords.max,
+        max: someConstraints.numWords.max,
       });
     });
   });
 
   describe("adjust", () => {
     it("allows an empty word separator", () => {
-      const policy = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
+      const policy = new PassphrasePolicyConstraints(disabledPolicy, someConstraints);
 
       const { wordSeparator } = policy.adjust({ ...SomeSettings, wordSeparator: "" });
 
@@ -64,7 +76,7 @@ describe("PassphrasePolicyConstraints", () => {
     });
 
     it("takes only the first character of wordSeparator", () => {
-      const policy = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
+      const policy = new PassphrasePolicyConstraints(disabledPolicy, someConstraints);
 
       const { wordSeparator } = policy.adjust({ ...SomeSettings, wordSeparator: "?." });
 
@@ -72,26 +84,32 @@ describe("PassphrasePolicyConstraints", () => {
     });
 
     it.each([
-      [1, 3],
-      [21, 20],
-    ])("fits numWords (=%p) within the default bounds (3 <= %p <= 20)", (value, expected) => {
-      const policy = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
+      [1, someConstraints.numWords.min, 3, someConstraints.numWords.max],
+      [21, someConstraints.numWords.min, 20, someConstraints.numWords.max],
+    ])(
+      `fits numWords (=%p) within the default bounds (%p <= %p <= %p)`,
+      (value, _, expected, __) => {
+        const policy = new PassphrasePolicyConstraints(disabledPolicy, someConstraints);
 
-      const { numWords } = policy.adjust({ ...SomeSettings, numWords: value });
+        const { numWords } = policy.adjust({ ...SomeSettings, numWords: value });
 
-      expect(numWords).toEqual(expected);
-    });
+        expect(numWords).toEqual(expected);
+      },
+    );
 
     it.each([
-      [1, 6, 6],
-      [21, 20, 20],
+      [1, 6, 6, someConstraints.numWords.max],
+      [21, 20, 20, someConstraints.numWords.max],
     ])(
-      "fits numWords (=%p) within the policy bounds (%p <= %p <= 20)",
-      (value, minNumberWords, expected) => {
-        const policy = new PassphrasePolicyConstraints({
-          ...Policies.Passphrase.disabledValue,
-          minNumberWords,
-        });
+      "fits numWords (=%p) within the policy bounds (%p <= %p <= %p)",
+      (value, minNumberWords, expected, _) => {
+        const policy = new PassphrasePolicyConstraints(
+          {
+            ...disabledPolicy,
+            minNumberWords,
+          },
+          someConstraints,
+        );
 
         const { numWords } = policy.adjust({ ...SomeSettings, numWords: value });
 
@@ -100,10 +118,13 @@ describe("PassphrasePolicyConstraints", () => {
     );
 
     it("sets capitalize to true when the policy requires it", () => {
-      const policy = new PassphrasePolicyConstraints({
-        ...Policies.Passphrase.disabledValue,
-        capitalize: true,
-      });
+      const policy = new PassphrasePolicyConstraints(
+        {
+          ...disabledPolicy,
+          capitalize: true,
+        },
+        someConstraints,
+      );
 
       const { capitalize } = policy.adjust({ ...SomeSettings, capitalize: false });
 
@@ -111,10 +132,13 @@ describe("PassphrasePolicyConstraints", () => {
     });
 
     it("sets includeNumber to true when the policy requires it", () => {
-      const policy = new PassphrasePolicyConstraints({
-        ...Policies.Passphrase.disabledValue,
-        includeNumber: true,
-      });
+      const policy = new PassphrasePolicyConstraints(
+        {
+          ...disabledPolicy,
+          includeNumber: true,
+        },
+        someConstraints,
+      );
 
       const { includeNumber } = policy.adjust({ ...SomeSettings, capitalize: false });
 
@@ -124,7 +148,7 @@ describe("PassphrasePolicyConstraints", () => {
 
   describe("fix", () => {
     it("returns its input", () => {
-      const policy = new PassphrasePolicyConstraints(Policies.Passphrase.disabledValue);
+      const policy = new PassphrasePolicyConstraints(disabledPolicy, someConstraints);
 
       const result = policy.fix(SomeSettings);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14964

## 📔 Objective

Revert 0254550b07277be7f0d6fedcd862b462e80947a3 and explain recommended boundaries using hint text.

## 📸 Screenshots

No policy; value exceeds recommended value:

<img width="376" alt="image" src="https://github.com/user-attachments/assets/ad9f52e3-6119-42cf-a020-d537a7b3ff9f">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/288e014c-4b82-4c2a-8313-d248fe20a170">

No policy; value less than or equal to recommended value:

<img width="376" alt="image" src="https://github.com/user-attachments/assets/c257140c-7cae-453b-a8b6-5b4aba30a836">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/21e6edc6-f266-4ec2-9eff-6d67da7fe330">

With policy; value exceeds recommended value:

<img width="376" alt="image" src="https://github.com/user-attachments/assets/6a2a174a-ec6c-48d3-9629-b47c3da77609">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/efeb745a-099d-49ae-bd69-011862ba22ce">

With policy' value less than or equal to recommended value:

<img width="376" alt="image" src="https://github.com/user-attachments/assets/b6f218da-f81c-410f-95f3-225802b356b3">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/675d01f9-c676-4d28-82b4-55db681a8d67">


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
