### PR TITLE
Update Bitwarden mobile repositories at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Please refer to the [Clients section](https://contributing.bitwarden.com/getting
 ## Related projects:
 
 - [bitwarden/server](https://github.com/bitwarden/server): The core infrastructure backend (API, database, Docker, etc).
-- [bitwarden/mobile](https://github.com/bitwarden/mobile): The mobile app vault (iOS and Android).
+- [bitwarden/ios](https://github.com/bitwarden/ios): Bitwarden mobile app for iOS. 
+- [bitwarden/android](https://github.com/bitwarden/android): Bitwarden mobile app for Android. 
 - [bitwarden/directory-connector](https://github.com/bitwarden/directory-connector): A tool for syncing a directory (AD, LDAP, Azure, G Suite, Okta) to an organization.
 
 # We're Hiring!


### PR DESCRIPTION
The https://github.com/bitwarden/mobile repository was retired. Update current Bitwarden mobile repositories at README.md .