### PR TITLE
[CL-508] extension width setting

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4849,5 +4849,14 @@
   },
   "beta": {
     "message": "Beta"
+  },
+  "width": {
+    "message": "Width"
+  },
+  "wide": {
+    "message": "Wide"
+  },
+  "extraWide": {
+    "message": "Extra wide"
   }
 }

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4850,8 +4850,8 @@
   "beta": {
     "message": "Beta"
   },
-  "width": {
-    "message": "Width"
+  "extensionWidth": {
+    "message": "Extension width"
   },
   "wide": {
     "message": "Wide"

--- a/apps/browser/src/platform/popup/browser-popup-utils.ts
+++ b/apps/browser/src/platform/popup/browser-popup-utils.ts
@@ -1,6 +1,7 @@
 import { BrowserApi } from "../browser/browser-api";
 
 import { ScrollOptions } from "./abstractions/browser-popup-utils.abstractions";
+import { PopupWidthOptions } from "./layout/popup-width.service";
 
 class BrowserPopupUtils {
   /**
@@ -108,7 +109,7 @@ class BrowserPopupUtils {
     const defaultPopoutWindowOptions: chrome.windows.CreateData = {
       type: "popup",
       focused: true,
-      width: 380,
+      width: Math.max(PopupWidthOptions.default, document.body.clientWidth),
       height: 630,
     };
     const offsetRight = 15;

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -510,3 +510,25 @@ export const TransparentHeader: Story = {
     `,
   }),
 };
+
+export const WidthOptions: Story = {
+  render: (args) => ({
+    props: args,
+    template: /* HTML */ `
+      <div class="tw-flex tw-flex-col tw-gap-4 tw-text-main">
+        <div>Default:</div>
+        <div class="tw-h-[640px] tw-w-[380px] tw-border tw-border-solid tw-border-secondary-300">
+          <mock-vault-page></mock-vault-page>
+        </div>
+        <div>Wide:</div>
+        <div class="tw-h-[640px] tw-w-[480px] tw-border tw-border-solid tw-border-secondary-300">
+          <mock-vault-page></mock-vault-page>
+        </div>
+        <div>Extra wide:</div>
+        <div class="tw-h-[640px] tw-w-[600px] tw-border tw-border-solid tw-border-secondary-300">
+          <mock-vault-page></mock-vault-page>
+        </div>
+      </div>
+    `,
+  }),
+};

--- a/apps/browser/src/platform/popup/layout/popup-width.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-width.service.ts
@@ -4,7 +4,7 @@ import { map, Observable } from "rxjs";
 import {
   GlobalStateProvider,
   KeyDefinition,
-  POPUP_WIDTH_DISK,
+  POPUP_STYLE_DISK,
 } from "@bitwarden/common/platform/state";
 
 /**
@@ -20,7 +20,7 @@ export const PopupWidthOptions = Object.freeze({
 type PopupWidthOptions = typeof PopupWidthOptions;
 export type PopupWidthOption = keyof PopupWidthOptions;
 
-const POPUP_WIDTH_KEY_DEF = new KeyDefinition<PopupWidthOption>(POPUP_WIDTH_DISK, "popup-width", {
+const POPUP_WIDTH_KEY_DEF = new KeyDefinition<PopupWidthOption>(POPUP_STYLE_DISK, "popup-width", {
   deserializer: (s) => s,
 });
 

--- a/apps/browser/src/platform/popup/layout/popup-width.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-width.service.ts
@@ -1,10 +1,13 @@
 import { inject, Injectable } from "@angular/core";
 import { map, Observable } from "rxjs";
 
-import { GlobalStateProvider, KeyDefinition, THEMING_DISK } from "@bitwarden/common/platform/state";
+import {
+  GlobalStateProvider,
+  KeyDefinition,
+  POPUP_WIDTH_DISK,
+} from "@bitwarden/common/platform/state";
 
 /**
- * Available widths for the extension popup.
  *
  * Value represents width in pixels
  */
@@ -17,7 +20,7 @@ export const PopupWidthOptions = Object.freeze({
 type PopupWidthOptions = typeof PopupWidthOptions;
 export type PopupWidthOption = keyof PopupWidthOptions;
 
-const POPUP_WIDTH_KEY_DEF = new KeyDefinition<PopupWidthOption>(THEMING_DISK, "popup-width", {
+const POPUP_WIDTH_KEY_DEF = new KeyDefinition<PopupWidthOption>(POPUP_WIDTH_DISK, "popup-width", {
   deserializer: (s) => s,
 });
 

--- a/apps/browser/src/platform/popup/layout/popup-width.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-width.service.ts
@@ -1,0 +1,60 @@
+import { inject, Injectable } from "@angular/core";
+import { map, Observable } from "rxjs";
+
+import { GlobalStateProvider, KeyDefinition, THEMING_DISK } from "@bitwarden/common/platform/state";
+
+/**
+ * Available widths for the extension popup.
+ *
+ * Value represents width in pixels
+ */
+export const PopupWidthOptions = Object.freeze({
+  default: 380,
+  wide: 480,
+  "extra-wide": 600,
+});
+
+type PopupWidthOptions = typeof PopupWidthOptions;
+export type PopupWidthOption = keyof PopupWidthOptions;
+
+const POPUP_WIDTH_KEY_DEF = new KeyDefinition<PopupWidthOption>(THEMING_DISK, "popup-width", {
+  deserializer: (s) => s,
+});
+
+/**
+ * Updates the extension popup width based on a user setting
+ **/
+@Injectable({ providedIn: "root" })
+export class PopupWidthService {
+  private static readonly LocalStorageKey = "bw-popup-width";
+  private readonly state = inject(GlobalStateProvider).get(POPUP_WIDTH_KEY_DEF);
+
+  readonly width$: Observable<PopupWidthOption> = this.state.state$.pipe(
+    map((state) => state ?? "default"),
+  );
+
+  async setWidth(width: PopupWidthOption) {
+    await this.state.update(() => width);
+  }
+
+  /** Begin listening for state changes */
+  init() {
+    this.width$.subscribe((width: PopupWidthOption) => {
+      PopupWidthService.setStyle(width);
+      localStorage.setItem(PopupWidthService.LocalStorageKey, width);
+    });
+  }
+
+  private static setStyle(width: PopupWidthOption) {
+    const pxWidth = PopupWidthOptions[width] ?? PopupWidthOptions.default;
+    document.body.style.width = `${pxWidth}px`;
+  }
+
+  /**
+   * To keep the popup size from flickering on bootstrap, we store the width in `localStorage` so we can quickly & synchronously reference it.
+   **/
+  static initBodyWidthFromLocalStorage() {
+    const storedValue = localStorage.getItem(PopupWidthService.LocalStorageKey);
+    this.setStyle(storedValue as any);
+  }
+}

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -25,6 +25,7 @@ import {
 
 import { flagEnabled } from "../platform/flags";
 import { PopupCompactModeService } from "../platform/popup/layout/popup-compact-mode.service";
+import { PopupWidthService } from "../platform/popup/layout/popup-width.service";
 import { PopupViewCacheService } from "../platform/popup/view-cache/popup-view-cache.service";
 import { initPopupClosedListener } from "../platform/services/popup-view-cache-background.service";
 import { BrowserSendStateService } from "../tools/popup/services/browser-send-state.service";
@@ -44,6 +45,7 @@ import { DesktopSyncVerificationDialogComponent } from "./components/desktop-syn
 export class AppComponent implements OnInit, OnDestroy {
   private viewCacheService = inject(PopupViewCacheService);
   private compactModeService = inject(PopupCompactModeService);
+  private widthService = inject(PopupWidthService);
 
   private lastActivity: Date;
   private activeUserId: UserId;
@@ -99,6 +101,7 @@ export class AppComponent implements OnInit, OnDestroy {
     await this.viewCacheService.init();
 
     this.compactModeService.init();
+    this.widthService.init();
 
     // Component states must not persist between closing and reopening the popup, otherwise they become dead objects
     // Clear them aggressively to make sure this doesn't occur

--- a/apps/browser/src/popup/main.ts
+++ b/apps/browser/src/popup/main.ts
@@ -1,6 +1,7 @@
 import { enableProdMode } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 
+import { PopupWidthService } from "../platform/popup/layout/popup-width.service";
 import { BrowserPlatformUtilsService } from "../platform/services/platform-utils/browser-platform-utils.service";
 
 require("./scss/popup.scss");
@@ -8,7 +9,8 @@ require("./scss/tailwind.css");
 
 import { AppModule } from "./app.module";
 
-// We put this first to minimize the delay in window changing.
+// We put these first to minimize the delay in window changing.
+PopupWidthService.initBodyWidthFromLocalStorage();
 // Should be removed once we deprecate support for Safari 16.0 and older. See Jira ticket [PM-1861]
 if (BrowserPlatformUtilsService.shouldApplySafariHeightFix(window)) {
   document.documentElement.classList.add("safari_height_fix");

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -19,7 +19,7 @@ body {
 }
 
 body {
-  width: 380px !important;
+  min-width: 380px !important;
   height: 600px !important;
   position: relative;
   min-height: 100vh;

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -19,7 +19,7 @@
       </bit-form-field>
 
       <bit-form-field>
-        <bit-label>{{ "width" | i18n }}</bit-label>
+        <bit-label>{{ "extensionWidth" | i18n }}</bit-label>
         <bit-select formControlName="width" [items]="widthOptions"></bit-select>
       </bit-form-field>
 

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -18,6 +18,11 @@
         </bit-select>
       </bit-form-field>
 
+      <bit-form-field>
+        <bit-label>{{ "width" | i18n }}</bit-label>
+        <bit-select formControlName="width" [items]="widthOptions"></bit-select>
+      </bit-form-field>
+
       <bit-form-control>
         <input bitCheckbox formControlName="enableCompactMode" type="checkbox" />
         <bit-label

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.spec.ts
@@ -16,6 +16,7 @@ import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-stat
 import { PopupCompactModeService } from "../../../platform/popup/layout/popup-compact-mode.service";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
+import { PopupWidthService } from "../../../platform/popup/layout/popup-width.service";
 
 import { AppearanceV2Component } from "./appearance-v2.component";
 
@@ -51,6 +52,11 @@ describe("AppearanceV2Component", () => {
   const setEnableRoutingAnimation = jest.fn().mockResolvedValue(undefined);
   const setEnableCompactMode = jest.fn().mockResolvedValue(undefined);
 
+  const mockWidthService: Partial<PopupWidthService> = {
+    width$: new BehaviorSubject("default"),
+    setWidth: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     setSelectedTheme.mockClear();
     setShowFavicons.mockClear();
@@ -78,6 +84,10 @@ describe("AppearanceV2Component", () => {
           provide: PopupCompactModeService,
           useValue: { enabled$: enableCompactMode$, setEnabled: setEnableCompactMode },
         },
+        {
+          provide: PopupWidthService,
+          useValue: mockWidthService,
+        },
       ],
     })
       .overrideComponent(AppearanceV2Component, {
@@ -102,6 +112,7 @@ describe("AppearanceV2Component", () => {
       enableBadgeCounter: true,
       theme: ThemeType.Nord,
       enableCompactMode: false,
+      width: "default",
     });
   });
 

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -121,9 +121,6 @@ export class DefaultConfigService implements ConfigService {
   }
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {
-    if (key === FeatureFlag.ExtensionRefresh || key === FeatureFlag.PersistPopupView) {
-      return of(true);
-    }
     return this.serverConfig$.pipe(
       map((serverConfig) => this.getFeatureFlagValue(serverConfig, key)),
     );

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -121,6 +121,9 @@ export class DefaultConfigService implements ConfigService {
   }
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {
+    if (key === FeatureFlag.ExtensionRefresh || key === FeatureFlag.PersistPopupView) {
+      return of(true);
+    }
     return this.serverConfig$.pipe(
       map((serverConfig) => this.getFeatureFlagValue(serverConfig, key)),
     );

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -123,7 +123,7 @@ export const TASK_SCHEDULER_DISK = new StateDefinition("taskScheduler", "disk");
 
 // Design System
 
-export const POPUP_WIDTH_DISK = new StateDefinition("popupWidth", "disk");
+export const POPUP_STYLE_DISK = new StateDefinition("popupStyle", "disk");
 
 // Secrets Manager
 

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -121,6 +121,10 @@ export const TRANSLATION_DISK = new StateDefinition("translation", "disk", { web
 export const ANIMATION_DISK = new StateDefinition("animation", "disk");
 export const TASK_SCHEDULER_DISK = new StateDefinition("taskScheduler", "disk");
 
+// Design System
+
+export const POPUP_WIDTH_DISK = new StateDefinition("popupWidth", "disk");
+
 // Secrets Manager
 
 export const SM_ONBOARDING_DISK = new StateDefinition("smOnboarding", "disk", {

--- a/libs/components/src/select/index.ts
+++ b/libs/components/src/select/index.ts
@@ -1,3 +1,4 @@
 export * from "./select.module";
 export * from "./select.component";
+export * from "./option";
 export * from "./option.component";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-508

## 📔 Objective

Adds an setting to the extension for configuring the popup's width. 🚀 

## 📸 Screenshots

https://github.com/user-attachments/assets/e6b64008-501a-4f81-94e8-fb53c0720bfd



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
