### PR TITLE
Add hideIfEmpty to bit-nav-group

### DIFF
--- a/libs/components/src/navigation/nav-group.component.html
+++ b/libs/components/src/navigation/nav-group.component.html
@@ -1,54 +1,56 @@
 <!-- This a higher order component that composes `NavItemComponent`  -->
-<bit-nav-item
-  [text]="text"
-  [icon]="icon"
-  [route]="route"
-  [relativeTo]="relativeTo"
-  [routerLinkActiveOptions]="routerLinkActiveOptions"
-  [variant]="variant"
-  [treeDepth]="treeDepth"
-  (mainContentClicked)="handleMainContentClicked()"
-  [ariaLabel]="ariaLabel"
-  [hideActiveStyles]="parentHideActiveStyles"
->
-  <ng-template #button>
-    <button
-      type="button"
-      class="tw-ml-auto"
-      [bitIconButton]="
-        open ? 'bwi-angle-up' : variant === 'tree' ? 'bwi-angle-right' : 'bwi-angle-down'
-      "
-      [buttonType]="'light'"
-      (click)="toggle($event)"
-      size="small"
-      [title]="'toggleCollapse' | i18n"
-      aria-haspopup="true"
-      [attr.aria-expanded]="open.toString()"
-      [attr.aria-controls]="contentId"
-      [attr.aria-label]="['toggleCollapse' | i18n, text].join(' ')"
-    ></button>
-  </ng-template>
+<ng-container *ngIf="!hideIfEmpty || nestedNavComponents.length > 0">
+  <bit-nav-item
+    [text]="text"
+    [icon]="icon"
+    [route]="route"
+    [relativeTo]="relativeTo"
+    [routerLinkActiveOptions]="routerLinkActiveOptions"
+    [variant]="variant"
+    [treeDepth]="treeDepth"
+    (mainContentClicked)="handleMainContentClicked()"
+    [ariaLabel]="ariaLabel"
+    [hideActiveStyles]="parentHideActiveStyles"
+  >
+    <ng-template #button>
+      <button
+        type="button"
+        class="tw-ml-auto"
+        [bitIconButton]="
+          open ? 'bwi-angle-up' : variant === 'tree' ? 'bwi-angle-right' : 'bwi-angle-down'
+        "
+        [buttonType]="'light'"
+        (click)="toggle($event)"
+        size="small"
+        [title]="'toggleCollapse' | i18n"
+        aria-haspopup="true"
+        [attr.aria-expanded]="open.toString()"
+        [attr.aria-controls]="contentId"
+        [attr.aria-label]="['toggleCollapse' | i18n, text].join(' ')"
+      ></button>
+    </ng-template>
 
-  <!-- Show toggle to the left for trees otherwise to the right -->
-  <ng-container slot="start" *ngIf="variant === 'tree'">
-    <ng-container *ngTemplateOutlet="button"></ng-container>
-  </ng-container>
-  <ng-container slot="end">
-    <ng-content select="[slot=end]"></ng-content>
-    <ng-container *ngIf="variant !== 'tree'">
+    <!-- Show toggle to the left for trees otherwise to the right -->
+    <ng-container slot="start" *ngIf="variant === 'tree'">
       <ng-container *ngTemplateOutlet="button"></ng-container>
     </ng-container>
-  </ng-container>
-</bit-nav-item>
+    <ng-container slot="end">
+      <ng-content select="[slot=end]"></ng-content>
+      <ng-container *ngIf="variant !== 'tree'">
+        <ng-container *ngTemplateOutlet="button"></ng-container>
+      </ng-container>
+    </ng-container>
+  </bit-nav-item>
 
-<!-- [attr.aria-controls] of the above button expects a unique ID on the controlled element -->
-<ng-container *ngIf="sideNavService.open$ | async">
-  <div
-    *ngIf="open"
-    [attr.id]="contentId"
-    [attr.aria-label]="[text, 'submenu' | i18n].join(' ')"
-    role="group"
-  >
-    <ng-content></ng-content>
-  </div>
+  <!-- [attr.aria-controls] of the above button expects a unique ID on the controlled element -->
+  <ng-container *ngIf="sideNavService.open$ | async">
+    <div
+      *ngIf="open"
+      [attr.id]="contentId"
+      [attr.aria-label]="[text, 'submenu' | i18n].join(' ')"
+      role="group"
+    >
+      <ng-content></ng-content>
+    </div>
+  </ng-container>
 </ng-container>

--- a/libs/components/src/navigation/nav-group.component.ts
+++ b/libs/components/src/navigation/nav-group.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterContentInit,
+  booleanAttribute,
   Component,
   ContentChildren,
   EventEmitter,
@@ -43,7 +44,7 @@ export class NavGroupComponent extends NavBaseComponent implements AfterContentI
   /**
    * Automatically hide the nav group if there are no child buttons
    */
-  @Input()
+  @Input({ transform: booleanAttribute })
   hideIfEmpty = false;
 
   @Output()

--- a/libs/components/src/navigation/nav-group.component.ts
+++ b/libs/components/src/navigation/nav-group.component.ts
@@ -40,6 +40,12 @@ export class NavGroupComponent extends NavBaseComponent implements AfterContentI
   @Input()
   open = false;
 
+  /**
+   * Automatically hide the nav group if there are no child buttons
+   */
+  @Input()
+  hideIfEmpty = false;
+
   @Output()
   openChange = new EventEmitter<boolean>();
 

--- a/libs/components/src/navigation/nav-group.stories.ts
+++ b/libs/components/src/navigation/nav-group.stories.ts
@@ -88,6 +88,30 @@ export const Default: StoryObj<NavGroupComponent> = {
   }),
 };
 
+export const HideEmptyGroups: StoryObj<NavGroupComponent & { renderChildren: boolean }> = {
+  args: {
+    hideIfEmpty: true,
+    renderChildren: false,
+  },
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-side-nav>
+        <bit-nav-group text="Hello World (Anchor)" [route]="['a']" icon="bwi-filter" [hideIfEmpty]="hideIfEmpty">
+          <bit-nav-item text="Child A" route="a" icon="bwi-filter" *ngIf="renderChildren"></bit-nav-item>
+          <bit-nav-item text="Child B" route="b" *ngIf="renderChildren"></bit-nav-item>
+          <bit-nav-item text="Child C" route="c" icon="bwi-filter" *ngIf="renderChildren"></bit-nav-item>
+        </bit-nav-group>
+        <bit-nav-group text="Lorem Ipsum (Button)" icon="bwi-filter">
+          <bit-nav-item text="Child A" icon="bwi-filter"></bit-nav-item>
+          <bit-nav-item text="Child B"></bit-nav-item>
+          <bit-nav-item text="Child C" icon="bwi-filter"></bit-nav-item>
+        </bit-nav-group>
+      </bit-side-nav>
+    `,
+  }),
+};
+
 export const Tree: StoryObj<NavGroupComponent> = {
   render: (args) => ({
     props: args,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
TBA depending on feedback

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In our layouts, we often have a `bit-nav-group` with child `bit-nav-item`s which are conditionally rendered based on the user's permissions. If no child items are rendered, then the user can't access anything in the group, so we hide the group.

For example:

```ts
    <bit-nav-group
      icon="bwi-sliders"
      [text]="'reporting' | i18n"
      route="reporting"
      *ngIf="organization.canAccessEventLogs || organization.canAccessReports)"  // duplicate logic
    >
      <bit-nav-item
        [text]="'eventLogs' | i18n"
        route="reporting/events"
        *ngIf="organization.canAccessEventLogs"
      ></bit-nav-item>
      <bit-nav-item
        [text]="'reports' | i18n"
        route="reporting/reports"
        *ngIf="organization.canAccessReports"
      ></bit-nav-item>
    </bit-nav-group>
```

As you can see, this means we have to duplicate the conditional logic of each item in the `bit-nav-group` `ngIf`. This is cumbersome especially if you have many child items.

This PR adds a new input property to `bit-nav-group` called `hideIfEmpty`, which will not render the group at all if it has no child items. This means we can omit the `bit-nav-group` `ngIf` in the example above and let the group take care of itself.

Note that most changes in the diff are indentation changes. I recommend using the hide whitespace setting when reviewing.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
