### PR TITLE
[PM-14923] Fix import dialog ssh key i18n

### DIFF
--- a/libs/importer/src/components/dialog/import-success-dialog.component.ts
+++ b/libs/importer/src/components/dialog/import-success-dialog.component.ts
@@ -75,7 +75,7 @@ export class ImportSuccessDialogComponent implements OnInit {
       list.push({ icon: "sticky-note", type: "typeSecureNote", count: secureNotes });
     }
     if (sshKeys > 0) {
-      list.push({ icon: "key", type: "typeSSHKey", count: sshKeys });
+      list.push({ icon: "key", type: "typeSshKey", count: sshKeys });
     }
     if (this.data.folders.length > 0) {
       list.push({ icon: "folder", type: "folders", count: this.data.folders.length });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14923

## 📔 Objective

The i18n key for ssh items had incorrect capitalization in the import success dialog, leading to no text being shown. This fixes the key.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/0ee97d1f-b4e2-403a-8c66-a1e3909e1bc5)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
