### PR TITLE
[PM-15065] Vault Loading on empty tabs

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -143,7 +143,7 @@ describe("AutofillService", () => {
   });
 
   describe("collectPageDetailsFromTab$", () => {
-    const tab = mock<chrome.tabs.Tab>({ id: 1 });
+    const tab = mock<chrome.tabs.Tab>({ id: 1, url: "https://www.example.com" });
     const messages = new Subject<CollectPageDetailsResponseMessage>();
 
     function mockCollectPageDetailsResponseMessage(
@@ -217,6 +217,24 @@ describe("AutofillService", () => {
       await pausePromise;
 
       expect(tracker.emissions[1]).toBeUndefined();
+    });
+
+    it("returns an empty array when the tab.url is empty", async () => {
+      const tracker = subscribeTo(autofillService.collectPageDetailsFromTab$({ ...tab, url: "" }));
+
+      await tracker.pauseUntilReceived(1);
+
+      expect(tracker.emissions[0]).toEqual([]);
+    });
+
+    it("returns an empty array when the `BrowserApi.tabSendMessage` throws an error", async () => {
+      (BrowserApi.tabSendMessage as jest.Mock).mockRejectedValueOnce(undefined);
+
+      const tracker = subscribeTo(autofillService.collectPageDetailsFromTab$(tab));
+
+      await tracker.pauseUntilReceived(1);
+
+      expect(tracker.emissions[0]).toEqual([]);
     });
   });
 

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -205,10 +205,11 @@ export class BrowserApi {
       return;
     }
 
-    return new Promise<TResponse>((resolve) => {
+    return new Promise<TResponse>((resolve, reject) => {
       chrome.tabs.sendMessage(tab.id, obj, options, (response) => {
         if (chrome.runtime.lastError) {
           // Some error happened
+          reject();
         }
         resolve(response);
       });

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -10,7 +10,6 @@ import {
   startWith,
   Subject,
   switchMap,
-  timeout,
 } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -75,9 +74,7 @@ export class VaultPopupAutofillService {
       if (!tab) {
         return of([]);
       }
-      return this.autofillService
-        .collectPageDetailsFromTab$(tab)
-        .pipe(timeout({ first: 1500, with: () => of([]) }));
+      return this.autofillService.collectPageDetailsFromTab$(tab);
     }),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15065](https://bitwarden.atlassian.net/browse/PM-15065)

## 📔 Objective

When on a non-standard page or empty tab is focused when opening the extension, the vault was taking longer than expected to load. This was caused from a message never being received in the `collectPageDetailsFromTab$` observable.
- The underlying `sendMessage` fails in Chrome and Firefox. That error was ignored in the `tabSendMessage`, I now rejected the promise to surface the error.
- Safari does not throw an error but a new tab does not have a `url`, I added a check for that as there wouldn't be autofill information (to my knowledge) 

#### Rejecting the promise

This approach falls in line with what is happening but it is also introducing a new set of logic where `tabSendMessage` is called. Scanning the codebase there are places that have error handling and some that do not. If there is a more idiomatic approach, let me know!

## 📸 Screenshots

|Chrome|FireFox|Safari|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/39491e05-7188-4b76-84e8-4d2ff2056a5b" />|<video src="https://github.com/user-attachments/assets/eb169b6a-47a0-4893-88d6-08e6342971fb" />|<video src="https://github.com/user-attachments/assets/ded838f4-d17a-445a-ae27-60280d75c90d" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
