### PR TITLE
[PM-15106] - add loading state to risk insights

### DIFF
--- a/apps/web/src/app/tools/access-intelligence/all-applications.component.html
+++ b/apps/web/src/app/tools/access-intelligence/all-applications.component.html
@@ -1,10 +1,5 @@
 <div *ngIf="loading">
-  <i
-    class="bwi bwi-spinner bwi-spin tw-text-muted"
-    title="{{ 'loading' | i18n }}"
-    aria-hidden="true"
-  ></i>
-  <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  <tools-applications-loading></tools-applications-loading>
 </div>
 <div class="tw-mt-4" *ngIf="!loading && !dataSource.data.length">
   <bit-no-items [icon]="noItemsIcon" class="tw-text-main">

--- a/apps/web/src/app/tools/access-intelligence/all-applications.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/all-applications.component.ts
@@ -32,11 +32,21 @@ import { HeaderModule } from "../../layouts/header/header.module";
 import { SharedModule } from "../../shared";
 import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
 
+import { ApplicationsLoadingComponent } from "./applications-loading.component";
+
 @Component({
   standalone: true,
   selector: "tools-all-applications",
   templateUrl: "./all-applications.component.html",
-  imports: [HeaderModule, CardComponent, SearchModule, PipesModule, NoItemsModule, SharedModule],
+  imports: [
+    ApplicationsLoadingComponent,
+    HeaderModule,
+    CardComponent,
+    SearchModule,
+    PipesModule,
+    NoItemsModule,
+    SharedModule,
+  ],
   providers: [MemberCipherDetailsApiService],
 })
 export class AllApplicationsComponent implements OnInit {
@@ -67,7 +77,7 @@ export class AllApplicationsComponent implements OnInit {
           this.applicationHealthReport =
             await this.passwordHealthService.generateReportDetails(organizationId);
           this.dataSource.data = this.applicationHealthReport.details;
-          this.loading = false;
+          // this.loading = false;
         }),
       )
       .subscribe();

--- a/apps/web/src/app/tools/access-intelligence/applications-loading.component.html
+++ b/apps/web/src/app/tools/access-intelligence/applications-loading.component.html
@@ -1,0 +1,8 @@
+<div class="tw-flex-col tw-flex tw-justify-center tw-items-center tw-gap-3 tw-mt-2">
+  <i
+    class="bwi bwi-lg bwi-spinner bwi-spin text-primary"
+    title="{{ 'loading' | i18n }}"
+    aria-hidden="true"
+  ></i>
+  <h2 bitTypography="h4">{{ "generatingRiskInsights" | i18n }}</h2>
+</div>

--- a/apps/web/src/app/tools/access-intelligence/applications-loading.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/applications-loading.component.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+
+import { SharedModule } from "../../shared";
+
+@Component({
+  selector: "tools-applications-loading",
+  standalone: true,
+  imports: [CommonModule, JslibModule, SharedModule],
+  templateUrl: "./applications-loading.component.html",
+})
+export class ApplicationsLoadingComponent {
+  constructor() {}
+}

--- a/apps/web/src/app/tools/access-intelligence/critical-applications.component.html
+++ b/apps/web/src/app/tools/access-intelligence/critical-applications.component.html
@@ -1,10 +1,5 @@
 <div *ngIf="loading">
-  <i
-    class="bwi bwi-spinner bwi-spin tw-text-muted"
-    title="{{ 'loading' | i18n }}"
-    aria-hidden="true"
-  ></i>
-  <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  <tools-applications-loading></tools-applications-loading>
 </div>
 <div class="tw-mt-4" *ngIf="!dataSource.data.length">
   <bit-no-items [icon]="noItemsIcon" class="tw-text-main">

--- a/apps/web/src/app/tools/access-intelligence/critical-applications.component.ts
+++ b/apps/web/src/app/tools/access-intelligence/critical-applications.component.ts
@@ -13,13 +13,22 @@ import { SharedModule } from "../../shared";
 import { PipesModule } from "../../vault/individual-vault/pipes/pipes.module";
 
 import { applicationTableMockData } from "./application-table.mock";
+import { ApplicationsLoadingComponent } from "./applications-loading.component";
 import { RiskInsightsTabType } from "./risk-insights.component";
 
 @Component({
   standalone: true,
   selector: "tools-critical-applications",
   templateUrl: "./critical-applications.component.html",
-  imports: [CardComponent, HeaderModule, SearchModule, NoItemsModule, PipesModule, SharedModule],
+  imports: [
+    ApplicationsLoadingComponent,
+    CardComponent,
+    HeaderModule,
+    SearchModule,
+    NoItemsModule,
+    PipesModule,
+    SharedModule,
+  ],
 })
 export class CriticalApplicationsComponent implements OnInit {
   protected dataSource = new TableDataSource<any>();

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17,6 +17,9 @@
   "reviewAtRiskPasswords": {
     "message": "Review at-risk passwords (weak, exposed, or reused) across applications. Select your most critical applications to prioritize security actions for your users to address at-risk passwords."
   },
+  "generatingRiskInsights": {
+    "message": "Generating your risk insights..."
+  },
   "dataLastUpdated": {
     "message": "Data last updated: $DATE$",
     "placeholders": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15106

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a loading state to the "All applications" and "Critical Applications" tabs in the risk insights page.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2024-11-20 at 4 39 42 PM](https://github.com/user-attachments/assets/2198b465-08c5-4ecd-a194-d1c0e7c9be92)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
