### PR TITLE
[PM-14874] Update account ownership message in account page

### DIFF
--- a/apps/web/src/app/auth/settings/account/profile.component.html
+++ b/apps/web/src/app/auth/settings/account/profile.component.html
@@ -37,7 +37,7 @@
         </button>
       </div>
       <div *ngIf="managingOrganization$ | async as managingOrganization">
-        {{ "accountIsManagedMessage" | i18n: managingOrganization?.name }}
+        {{ "accountIsOwnedMessage" | i18n: managingOrganization?.name }}
         <a href="https://bitwarden.com/help/claimed-accounts">
           <i class="bwi bwi-question-circle" aria-hidden="true"></i>
         </a>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1767,8 +1767,8 @@
   "sessionsDeauthorized": {
     "message": "All sessions deauthorized"
   },
-  "accountIsManagedMessage": {
-    "message": "This account is managed by $ORGANIZATIONNAME$",
+  "accountIsOwnedMessage": {
+    "message": "This account is owned by $ORGANIZATIONNAME$",
     "placeholders": {
       "organizationName": {
         "content": "$1",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14874

## 📔 Objective

> As a result of the copy updates we have been making (replacing Verified domains as Claimed accounts, using ownership terminology instead of managed) we would like to replace managed with owned on the members Account page
> [Figma](https://www.figma.com/proto/lHZXTF0bl9fEB42FroKNOb/Account-management-and-deprovisioning?page-id=1%3A12&node-id=530-47299&viewport=-2598%2C-1498%2C0.23&t=PScSIhiDMXqxj9fV-1&scaling=scale-down-width&content-scaling=fixed&starting-point-node-id=530%3A47299&show-proto-sidebar=1)

## 📸 Screenshots

<img width="873" alt="image" src="https://github.com/user-attachments/assets/85c8b4fd-244f-4609-88c9-484a3b067009">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
