### PR TITLE
[PM-14990] Add password prompt for ssh key import

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -207,6 +207,21 @@
   "sshKeyGenerated": {
     "message": "A new SSH key was generated"
   },
+  "sshKeyWrongPassword": {
+    "message": "The password you entered is incorrect."
+  },
+  "importSshKey": {
+    "message": "Import"
+  },
+  "confirmSshKeyPassword": {
+    "message": "Confirm password"
+  },
+  "enterSshKeyPasswordDesc": {
+    "message": "Enter the password for the SSH key."
+  },
+  "enterSshKeyPassword": {
+    "message": "Enter password"
+  },
   "sshAgentUnlockRequired": {
     "message": "Please unlock your vault to approve the SSH key request."
   },
@@ -1734,10 +1749,10 @@
   "deleteAccountWarning": {
     "message": "Deleting your account is permanent. It cannot be undone."
   },
-  "cannotDeleteAccount":{
+  "cannotDeleteAccount": {
     "message": "Cannot delete account"
   },
-  "cannotDeleteAccountDesc":{
+  "cannotDeleteAccountDesc": {
     "message": "This action cannot be completed because your account is owned by an organization. Contact your organization administrator for additional details."
   },
   "accountDeleted": {

--- a/apps/desktop/src/vault/app/vault/add-edit.component.ts
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.ts
@@ -26,7 +26,6 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import { SshKeyPasswordPromptComponent } from "@bitwarden/importer/ui";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
-
 const BroadcasterSubscriptionId = "AddEditComponent";
 
 @Component({

--- a/libs/importer/src/components/dialog/index.ts
+++ b/libs/importer/src/components/dialog/index.ts
@@ -1,3 +1,4 @@
 export * from "./import-error-dialog.component";
 export * from "./import-success-dialog.component";
 export * from "./file-password-prompt.component";
+export * from "./sshkey-password-prompt.component";

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
@@ -1,0 +1,31 @@
+<form [formGroup]="formGroup" [bitSubmit]="submit">
+  <bit-dialog>
+    <span bitDialogTitle>
+      {{ "enterSshKeyPassword" | i18n }}
+    </span>
+
+    <div bitDialogContent>
+      {{ "enterSshKeyPasswordDesc" | i18n }}
+      <bit-form-field class="tw-mt-6">
+        <bit-label>{{ "confirmSshKeyPassword" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="password"
+          formControlName="sshKeyPassword"
+          appAutofocus
+          appInputVerbatim
+        />
+        <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+      </bit-form-field>
+    </div>
+
+    <ng-container bitDialogFooter>
+      <button bitButton buttonType="primary" type="submit">
+        <span>{{ "importSshKey" | i18n }}</span>
+      </button>
+      <button bitButton bitDialogClose buttonType="secondary" type="button">
+        <span>{{ "cancel" | i18n }}</span>
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
@@ -1,0 +1,46 @@
+import { DialogRef } from "@angular/cdk/dialog";
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  DialogModule,
+  FormFieldModule,
+  IconButtonModule,
+} from "@bitwarden/components";
+
+@Component({
+  templateUrl: "sshkey-password-prompt.component.html",
+  standalone: true,
+  imports: [
+    CommonModule,
+    JslibModule,
+    DialogModule,
+    FormFieldModule,
+    AsyncActionsModule,
+    ButtonModule,
+    IconButtonModule,
+    ReactiveFormsModule,
+  ],
+})
+export class SshKeyPasswordPromptComponent {
+  protected formGroup = this.formBuilder.group({
+    sshKeyPassword: ["", Validators.required],
+  });
+
+  constructor(
+    public dialogRef: DialogRef,
+    protected formBuilder: FormBuilder,
+  ) {}
+
+  submit = () => {
+    this.formGroup.markAsTouched();
+    if (!this.formGroup.valid) {
+      return;
+    }
+    this.dialogRef.close(this.formGroup.value.sshKeyPassword);
+  };
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14990

## 📔 Objective

Adds a password prompt UI for importing password protected ssh keys in the desktop app.

## 📸 Screenshots

https://github.com/user-attachments/assets/fa66e14d-5556-4a1b-b54f-6d4fbb9cf964



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
