### PR TITLE
[PM-13757] Add policy component form validation to policy edit component

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.html
@@ -15,7 +15,13 @@
       </div>
     </ng-container>
     <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" [disabled]="saveDisabled" bitFormButton type="submit">
+      <button
+        bitButton
+        buttonType="primary"
+        [disabled]="saveDisabled$ | async"
+        bitFormButton
+        type="submit"
+      >
         {{ "save" | i18n }}
       </button>
       <button bitButton buttonType="secondary" bitDialogClose type="button">

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit.component.ts
@@ -8,6 +8,7 @@ import {
   ViewContainerRef,
 } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
+import { Observable, map } from "rxjs";
 
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
@@ -42,7 +43,7 @@ export class PolicyEditComponent implements AfterViewInit {
   policyType = PolicyType;
   loading = true;
   enabled = false;
-  saveDisabled = false;
+  saveDisabled$: Observable<boolean>;
   defaultTypes: any[];
   policyComponent: BasePolicyComponent;
 
@@ -73,7 +74,9 @@ export class PolicyEditComponent implements AfterViewInit {
     this.policyComponent.policy = this.data.policy;
     this.policyComponent.policyResponse = this.policyResponse;
 
-    this.saveDisabled = !this.policyResponse.canToggleState;
+    this.saveDisabled$ = this.policyComponent.data.statusChanges.pipe(
+      map((status) => status !== "VALID" || !this.policyResponse.canToggleState),
+    );
 
     this.cdr.detectChanges();
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13757

## 📔 Objective

This PR resolves an issue where the Policy Edit component's form validation on the save button is not synced with the validation status of the Policy Component's form group.

## 📸 Screenshots

![Screenshot 2024-11-25 at 1 36 01 PM](https://github.com/user-attachments/assets/25d5ccd8-a26b-44c7-84ae-daa054fd604e)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
