### PR TITLE
[PM-15021] Improve in-tab experience for extension

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-width.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-width.service.ts
@@ -50,7 +50,7 @@ export class PopupWidthService {
 
   private static setStyle(width: PopupWidthOption) {
     const pxWidth = PopupWidthOptions[width] ?? PopupWidthOptions.default;
-    document.body.style.width = `${pxWidth}px`;
+    document.body.style.minWidth = `${pxWidth}px`;
   }
 
   /**

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -19,7 +19,7 @@ body {
 }
 
 body {
-  min-width: 380px !important;
+  min-width: 380px;
   height: 600px !important;
   position: relative;
   min-height: 100vh;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-15021](https://bitwarden.atlassian.net/browse/PM-15021)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When opening the browser extension in a new tab, the UI remained constrained to the width of the extension window. It should stretch to fill the tab window. This improves the experience because animations and dialogs span the full width, which caused jarring visuals and missing functionality.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/210cd1f9-e1b9-4dc9-a162-04515c459c1e

After:

https://github.com/user-attachments/assets/585b7ea7-b7a7-464c-9ab9-096d4a678d70

Confirming no regressions to popup and popout views:


https://github.com/user-attachments/assets/72fbb2e7-3de5-4aff-9801-3bb670706d1c



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15021]: https://bitwarden.atlassian.net/browse/PM-15021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ