### PR TITLE
[PM-15386] Refactor DomainVerificationComponent to warn about enabling SingleOrg policy only when it is not already enabled

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
@@ -14,6 +14,8 @@ import {
 import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { OrgDomainServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain.service.abstraction";
 import { OrganizationDomainResponse } from "@bitwarden/common/admin-console/abstractions/organization-domain/responses/organization-domain.response";
+import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { HttpStatusCode } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
@@ -33,6 +35,7 @@ import {
 })
 export class DomainVerificationComponent implements OnInit, OnDestroy {
   private componentDestroyed$ = new Subject<void>();
+  private singleOrgPolicyEnabled = false;
 
   loading = true;
 
@@ -48,6 +51,7 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
     private validationService: ValidationService,
     private toastService: ToastService,
     private configService: ConfigService,
+    private policyApiService: PolicyApiServiceAbstraction,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -71,6 +75,14 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
   async load() {
     await this.orgDomainApiService.getAllByOrgId(this.organizationId);
 
+    if (await this.configService.getFeatureFlag(FeatureFlag.AccountDeprovisioning)) {
+      const singleOrgPolicy = await this.policyApiService.getPolicy(
+        this.organizationId,
+        PolicyType.SingleOrg,
+      );
+      this.singleOrgPolicyEnabled = singleOrgPolicy?.enabled ?? false;
+    }
+
     this.loading = false;
   }
 
@@ -87,6 +99,7 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
         map(async ([accountDeprovisioningEnabled, organizationDomains]) => {
           if (
             accountDeprovisioningEnabled &&
+            !this.singleOrgPolicyEnabled &&
             organizationDomains.every((domain) => domain.verifiedDate === null)
           ) {
             await this.dialogService.openSimpleDialog({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15386

## 📔 Objective

The pop up for the warning message “Verifying a domain will turn on the single organization policy“ will show up even if the single org policy is enabled. This PR addresses this by checking the policy state to decide if it shows the warning or not.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
