### PR TITLE
[PM-15065] Extension not loading when accessed via URL

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -245,8 +245,6 @@ describe("AutofillService", () => {
     ["moz-extension://", "chrome-extension://", "safari-web-extension://"].forEach(
       (extensionPrefix) => {
         it(`returns an empty array when the tab.url starts with ${extensionPrefix}`, async () => {
-          (BrowserApi.tabSendMessage as jest.Mock).mockRejectedValueOnce(undefined);
-
           const tracker = subscribeTo(
             autofillService.collectPageDetailsFromTab$({
               ...tab,

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -241,6 +241,25 @@ describe("AutofillService", () => {
 
       expect(tracker.emissions[0]).toEqual([]);
     });
+
+    ["moz-extension://", "chrome-extension://", "safari-web-extension://"].forEach(
+      (extensionPrefix) => {
+        it(`returns an empty array when the tab.url starts with ${extensionPrefix}`, async () => {
+          (BrowserApi.tabSendMessage as jest.Mock).mockRejectedValueOnce(undefined);
+
+          const tracker = subscribeTo(
+            autofillService.collectPageDetailsFromTab$({
+              ...tab,
+              url: `${extensionPrefix}/3e42342/popup/index.html`,
+            }),
+          );
+
+          await tracker.pauseUntilReceived(1);
+
+          expect(tracker.emissions[0]).toEqual([]);
+        });
+      },
+    );
   });
 
   describe("loadAutofillScriptsOnInstall", () => {

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -134,12 +134,9 @@ export default class AutofillService implements AutofillServiceInterface {
     // - In Safari, `tabSendMessage` doesn't throw an error for this case.
     // - When opening the extension directly via the URL, `tabSendMessage` doesn't always respond nor throw an error in FireFox.
     //   Adding checks for the major 3 browsers here to be safe.
-    if (
-      !tab.url ||
-      ["moz-extension://", "chrome-extension://", "safari-web-extension://"].some((prefix) =>
-        tab.url.startsWith(prefix),
-      )
-    ) {
+    const browserPrefixes = ["moz-extension://", "chrome-extension://", "safari-web-extension://"];
+
+    if (!tab.url || browserPrefixes.some((prefix) => tab.url.startsWith(prefix))) {
       pageDetailsFallback$.next([]);
     }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -130,9 +130,16 @@ export default class AutofillService implements AutofillServiceInterface {
       pageDetailsFallback$.next([]);
     });
 
-    // Empty/New tabs do not have a URL.
-    // In Safari, `tabSendMessage` doesn't throw an error for this case. Fallback to the empty array to handle.
-    if (!tab.url) {
+    // Fallback to empty array when:
+    // - In Safari, `tabSendMessage` doesn't throw an error for this case.
+    // - When opening the extension directly via the URL, `tabSendMessage` doesn't always respond nor throw an error in FireFox.
+    //   Adding checks for the major 3 browsers here to be safe.
+    if (
+      !tab.url ||
+      ["moz-extension://", "chrome-extension://", "safari-web-extension://"].some((prefix) =>
+        tab.url.startsWith(prefix),
+      )
+    ) {
       pageDetailsFallback$.next([]);
     }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -134,9 +134,12 @@ export default class AutofillService implements AutofillServiceInterface {
     // - In Safari, `tabSendMessage` doesn't throw an error for this case.
     // - When opening the extension directly via the URL, `tabSendMessage` doesn't always respond nor throw an error in FireFox.
     //   Adding checks for the major 3 browsers here to be safe.
-    const browserPrefixes = ["moz-extension://", "chrome-extension://", "safari-web-extension://"];
-
-    if (!tab.url || browserPrefixes.some((prefix) => tab.url.startsWith(prefix))) {
+    const urlHasBrowserProtocol = [
+      "moz-extension://",
+      "chrome-extension://",
+      "safari-web-extension://",
+    ].some((protocol) => tab.url.startsWith(protocol));
+    if (!tab.url || urlHasBrowserProtocol) {
       pageDetailsFallback$.next([]);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15065](https://bitwarden.atlassian.net/browse/PM-15065)

## 📔 Objective

When loading the extension directly via URL, i.e. `moz-extension://...` the vault was failing to load in Firefox. This was occurring because `tabSendMessage` is not throwing an error and the message is not being received to provide autofill suggestions.  
- Chrome and Safari were functioning correctly but with this undocumented behavior it felt safer to add checks for those as well.   

## 📸 Screenshots

|Chrome|FireFox|Safar|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/f99cca52-1f4e-4ec7-84ea-388e8edaca21"/>|<video src="https://github.com/user-attachments/assets/fb9a48a4-f016-42e2-a916-1fd78ffd8c8d"/>|<video src="https://github.com/user-attachments/assets/e6b73033-b3d2-44cc-8740-4c849700317e"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15065]: https://bitwarden.atlassian.net/browse/PM-15065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ