### PR TITLE
[PM-15410][PM-15410] add nullish check when referencing `document` in `BrowserPopupUtils`

### DIFF
--- a/apps/browser/src/platform/popup/browser-popup-utils.ts
+++ b/apps/browser/src/platform/popup/browser-popup-utils.ts
@@ -111,7 +111,7 @@ class BrowserPopupUtils {
       focused: true,
       width: Math.max(
         PopupWidthOptions.default,
-        document?.body.clientWidth ?? PopupWidthOptions.default,
+        globalThis?.document.body.clientWidth ?? PopupWidthOptions.default,
       ),
       height: 630,
     };

--- a/apps/browser/src/platform/popup/browser-popup-utils.ts
+++ b/apps/browser/src/platform/popup/browser-popup-utils.ts
@@ -111,7 +111,7 @@ class BrowserPopupUtils {
       focused: true,
       width: Math.max(
         PopupWidthOptions.default,
-        globalThis?.document.body.clientWidth ?? PopupWidthOptions.default,
+        typeof document === "undefined" ? PopupWidthOptions.default : document.body.clientWidth,
       ),
       height: 630,
     };

--- a/apps/browser/src/platform/popup/browser-popup-utils.ts
+++ b/apps/browser/src/platform/popup/browser-popup-utils.ts
@@ -109,7 +109,10 @@ class BrowserPopupUtils {
     const defaultPopoutWindowOptions: chrome.windows.CreateData = {
       type: "popup",
       focused: true,
-      width: Math.max(PopupWidthOptions.default, document.body.clientWidth),
+      width: Math.max(
+        PopupWidthOptions.default,
+        document?.body.clientWidth ?? PopupWidthOptions.default,
+      ),
       height: 630,
     };
     const offsetRight = 15;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15410
https://bitwarden.atlassian.net/browse/PM-15428

## 📔 Objective

https://github.com/bitwarden/clients/pull/12040 adds a reference to `document.body.clientWidth` in the `BrowserPopupUtils.openPopout`. This is causing an error because this function is imported in the background script, where `document` is undefined (see screenshot #1). 

I assumed this was safe because `BrowserPopupUtils` is located in `apps/browser/src/platform/popup`, which contains other non-background-safe code. This is a quick fix; we probably want to make additional changes to better guard against this in the future (lint for forbidden APIs, moving this class/function somewhere else).

## 📸 Screenshots

1. 

![image](https://github.com/user-attachments/assets/249bc7f1-36e2-498f-8859-093eed78a809)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
