### PR TITLE
[PM-15156] Copy update on Organization member Delete modals

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.html
@@ -8,7 +8,7 @@
     </bit-callout>
     <ng-container *ngIf="!done">
       <bit-callout type="warning" *ngIf="users.length > 0 && !error">
-        <p bitTypography="body1">{{ "deleteOrganizationUserWarning" | i18n }}</p>
+        <p bitTypography="body1">{{ "deleteManyOrganizationUsersWarningDesc" | i18n }}</p>
       </bit-callout>
       <bit-table>
         <ng-container header>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.html
@@ -1,4 +1,4 @@
-<bit-dialog dialogSize="large" [title]="'removeUsers' | i18n">
+<bit-dialog dialogSize="large" [title]="'removeMembers' | i18n">
   <ng-container bitDialogContent>
     <bit-callout type="danger" *ngIf="users.length <= 0">
       {{ "noSelectedUsersApplicable" | i18n }}
@@ -79,7 +79,7 @@
       [disabled]="loading"
       [bitAction]="submit"
     >
-      {{ "removeUsers" | i18n }}
+      {{ "removeMembers" | i18n }}
     </button>
     <button bitButton type="button" buttonType="secondary" bitDialogClose>
       {{ "close" | i18n }}

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -579,7 +579,10 @@ export class MemberDialogComponent implements OnDestroy {
         key: "deleteOrganizationUser",
         placeholders: [this.params.name],
       },
-      content: { key: "deleteOrganizationUserWarning" },
+      content: {
+        key: "deleteOrganizationUserWarningDesc",
+        placeholders: [this.params.name],
+      },
       type: "warning",
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -742,7 +742,10 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
         key: "deleteOrganizationUser",
         placeholders: [this.userNamePipe.transform(user)],
       },
-      content: { key: "deleteOrganizationUserWarning" },
+      content: {
+        key: "deleteOrganizationUserWarningDesc",
+        placeholders: [this.userNamePipe.transform(user)],
+      },
       type: "warning",
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9715,9 +9715,19 @@
       "description": "Title for the delete organization user dialog"
     }
   },
-  "deleteOrganizationUserWarning": {
-    "message": "When a member is deleted, their Bitwarden account and individual vault data will be permanently deleted. Collection data will remain in the organization. To reinstate them they must create an account and be onboarded again.",
-    "description": "Warning for the delete organization user dialog"
+  "deleteOrganizationUserWarningDesc": {
+    "message": "This will permanently delete all items owned by $NAME$. Collection items are not impacted.",
+    "description": "Warning description for the delete organization user dialog",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "John Doe"
+      }
+    }
+  },
+  "deleteManyOrganizationUsersWarningDesc": {
+    "message": "This will permanently delete all items owned by the following members. Collection items are not impacted.",
+    "description": "Warning description for the bulk delete organization users dialog"
   },
   "organizationUserDeleted": {
     "message": "Deleted $NAME$",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9787,5 +9787,8 @@
   },
   "descriptorCode": {
     "message": "Descriptor code"
+  },
+  "removeMembers": {
+    "message": "Remove members"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15156

## 📔 Objective

Update warning messages for bulk delete dialog and single member deletion.

[Single delete](https://www.figma.com/proto/lHZXTF0bl9fEB42FroKNOb/Account-management-and-deprovisioning?page-id=1783%3A33700&node-id=1984-18922&node-type=frame&viewport=-1190%2C-5500%2C0.39&t=7jCztb2PXpqrl9Lx-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1984%3A18857&show-proto-sidebar=1)

[Bulk delete](https://www.figma.com/proto/lHZXTF0bl9fEB42FroKNOb/Account-management-and-deprovisioning?page-id=1783%3A33700&node-id=1984-18940&node-type=frame&viewport=-1190%2C-5500%2C0.39&t=7jCztb2PXpqrl9Lx-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1984%3A18879&show-proto-sidebar=1)

## 📸 Screenshots

Rename 'Delete members' to 'Remove members' on bulk remove dialog:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/9ba1867f-4c45-4239-a483-95c47ecc0065">

Simplify warning on single delete: 
<img width="414" alt="image" src="https://github.com/user-attachments/assets/c8ec4476-8f24-4d56-b01a-ce5203bde285">

Simplify warning on bulk delete:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/ece3334a-3b4b-4c3b-87f1-7fee6c58a2e1">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
