### PR TITLE
[PM-15418] Remove bitItem and use plain bitLink button for opening generator history

### DIFF
--- a/apps/desktop/src/app/tools/generator/credential-generator.component.html
+++ b/apps/desktop/src/app/tools/generator/credential-generator.component.html
@@ -2,18 +2,15 @@
   <span bitDialogTitle>{{ "generator" | i18n }}</span>
   <ng-container bitDialogContent>
     <tools-credential-generator />
-    <bit-item>
-      <button
-        type="button"
-        bitLink
-        bit-item-content
-        aria-haspopup="true"
-        (click)="openHistoryDialog()"
-      >
-        {{ "generatorHistory" | i18n }}
-        <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
-      </button>
-    </bit-item>
+    <button
+      type="button"
+      bitLink
+      linkType="primary"
+      aria-haspopup="true"
+      (click)="openHistoryDialog()"
+    >
+      {{ "generatorHistory" | i18n }}
+    </button>
   </ng-container>
   <ng-container bitDialogFooter>
     <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>

--- a/apps/desktop/src/app/tools/generator/credential-generator.component.ts
+++ b/apps/desktop/src/app/tools/generator/credential-generator.component.ts
@@ -1,13 +1,7 @@
 import { Component } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import {
-  ButtonModule,
-  DialogModule,
-  DialogService,
-  ItemModule,
-  LinkModule,
-} from "@bitwarden/components";
+import { ButtonModule, DialogModule, DialogService, LinkModule } from "@bitwarden/components";
 import {
   CredentialGeneratorHistoryDialogComponent,
   GeneratorModule,
@@ -17,15 +11,7 @@ import {
   standalone: true,
   selector: "credential-generator",
   templateUrl: "credential-generator.component.html",
-  imports: [
-    DialogModule,
-    ButtonModule,
-    JslibModule,
-    GeneratorModule,
-    ItemModule,
-    ButtonModule,
-    LinkModule,
-  ],
+  imports: [DialogModule, ButtonModule, JslibModule, GeneratorModule, ButtonModule, LinkModule],
 })
 export class CredentialGeneratorComponent {
   constructor(private dialogService: DialogService) {}

--- a/apps/web/src/app/tools/credential-generator/credential-generator.component.html
+++ b/apps/web/src/app/tools/credential-generator/credential-generator.component.html
@@ -2,16 +2,13 @@
 
 <bit-container>
   <tools-credential-generator />
-  <bit-item>
-    <button
-      type="button"
-      bitLink
-      bit-item-content
-      aria-haspopup="true"
-      (click)="openHistoryDialog()"
-    >
-      {{ "generatorHistory" | i18n }}
-      <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
-    </button>
-  </bit-item>
+  <button
+    bitLink
+    type="button"
+    linkType="primary"
+    aria-haspopup="true"
+    (click)="openHistoryDialog()"
+  >
+    {{ "generatorHistory" | i18n }}
+  </button>
 </bit-container>

--- a/apps/web/src/app/tools/credential-generator/credential-generator.component.ts
+++ b/apps/web/src/app/tools/credential-generator/credential-generator.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 
-import { ButtonModule, DialogService, ItemModule, LinkModule } from "@bitwarden/components";
+import { ButtonModule, DialogService, LinkModule } from "@bitwarden/components";
 import {
   CredentialGeneratorHistoryDialogComponent,
   GeneratorModule,
@@ -13,7 +13,7 @@ import { SharedModule } from "../../shared";
   standalone: true,
   selector: "credential-generator",
   templateUrl: "credential-generator.component.html",
-  imports: [SharedModule, HeaderModule, GeneratorModule, ItemModule, ButtonModule, LinkModule],
+  imports: [SharedModule, HeaderModule, GeneratorModule, ButtonModule, LinkModule],
 })
 export class CredentialGeneratorComponent {
   constructor(private dialogService: DialogService) {}


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15418
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Feedback from design: Use plain bitLink button instead of a bitLink wrapped by a bitItem
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Web (before/after)
![image](https://github.com/user-attachments/assets/34b67598-aef9-43f8-8683-0537aea5dc51)
![image](https://github.com/user-attachments/assets/94891661-14bc-4760-a718-145acb60aceb)

### Desktop (before/after)
![image](https://github.com/user-attachments/assets/102c87df-27e9-4aa2-923d-a49616d4184f)
![image](https://github.com/user-attachments/assets/b4e4f7ab-516f-478f-8bc8-24ef431cfdb4)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
