### PR TITLE
[PM-15353] invert ambiguous flag

### DIFF
--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -33,7 +33,7 @@ export class GenerateCommand {
       includeNumber: normalizedOptions.includeNumber,
       minNumber: normalizedOptions.minNumber,
       minSpecial: normalizedOptions.minSpecial,
-      ambiguous: normalizedOptions.ambiguous,
+      ambiguous: !normalizedOptions.ambiguous,
     };
 
     const enforcedOptions = (await this.stateService.getIsAuthenticated())


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15353

## 📔 Objective

Fix broken ambiguous flag on CLI. 

The services use `true` to indicate ambiguous characters should be included. The CLI was passing `false`.

## 📸 Screenshots

Example output with `--ambiguous` flag:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/cc5616b3-3b9a-4201-b6b4-9cfb9194ed35">

## 🦕 System evolution

Note that when `--ambiguous` is present, ambiguous characters are _excluded_. The flag would more properly be called `--no-ambiguous`, but changing this is out of scope of this PR. 

We should consider addressing this when we migrate the CLI to the credential generator backend. An appropriate solution would issue a deprecation warning when the old flag is used. That could be updated to a failure when the deprecated flag is removed.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
