### PR TITLE
[PM-15520] Fix empty organization payment status observable

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault.component.html
@@ -1,4 +1,6 @@
-<app-vault-banners [organizationsPaymentStatus]="organizationsPaymentStatus"></app-vault-banners>
+<app-vault-banners
+  [organizationsPaymentStatus]="organizationsPaymentStatus$ | async"
+></app-vault-banners>
 
 <app-vault-header
   [filter]="filter"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15520](https://bitwarden.atlassian.net/browse/PM-15520)

## 📔 Objective

Fix the `organizationsPaymentStatus$` observable so that it does not return an empty observable when the user is not the owner of any organization. This would prevent the vault from refreshing as it would show a loading spinner while it waits for the empty observable to never emit.

Also, moves the `organizationsPaymentStatus$` out of the `firstSetup` subscription to avoid depending on the payment status for rendering the vault. That way if the `organizationsPaymentStatus$` observable fails or hangs, the vault is still capable of being rendered.

## 📸 Screenshots


https://github.com/user-attachments/assets/964131f1-ecb6-4171-a46f-1a95cb35a647


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15520]: https://bitwarden.atlassian.net/browse/PM-15520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ