### PR TITLE
[PM-15046] Do not regenerate passwords on every overlay ciphers update

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -362,8 +362,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.inlineMenuFido2Credentials.clear();
     this.storeInlineMenuFido2Credentials$.next(currentTab.id);
 
-    await this.generatePassword();
-
     const ciphersViews = await this.getCipherViews(currentTab, updateAllCipherTypes);
     for (let cipherIndex = 0; cipherIndex < ciphersViews.length; cipherIndex++) {
       this.inlineMenuCiphers.set(`inline-menu-cipher-${cipherIndex}`, ciphersViews[cipherIndex]);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15046
https://github.com/bitwarden/clients/issues/12047

## 📔 Objective

A `generatePassword` call in `handleOverlayCiphersUpdate` of `OverlayBackground` is causing the password generation to fire as a side-effect of any user interaction with a page. This update stops that behaviour, so the generated password history is not flooded with entries the user has never seen.

Note, this behaviour is ultimately behind the `inline-menu-positioning-improvements` feature flag

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
