### PR TITLE
[PM-15520] Move organizationPaymentStatus$ out of page setup flow and…

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault.component.html
@@ -1,4 +1,6 @@
-<app-vault-banners [organizationsPaymentStatus]="organizationsPaymentStatus"></app-vault-banners>
+<app-vault-banners
+  [organizationsPaymentStatus]="organizationsPaymentStatus$ | async"
+></app-vault-banners>
 
 <app-vault-header
   [filter]="filter"

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -180,7 +180,6 @@ export class VaultComponent implements OnInit, OnDestroy {
   protected canCreateCollections = false;
   protected currentSearchText$: Observable<string>;
   private activeUserId: UserId;
-  protected organizationsPaymentStatus: FreeTrial[] = [];
   private searchText$ = new Subject<string>();
   private refresh$ = new BehaviorSubject<void>(null);
   private destroy$ = new Subject<void>();
@@ -206,6 +205,37 @@ export class VaultComponent implements OnInit, OnDestroy {
         ),
       ),
     ),
+  );
+
+  protected organizationsPaymentStatus$: Observable<FreeTrial[]> = combineLatest([
+    this.organizationService.organizations$.pipe(
+      map((organizations) => organizations?.filter((org) => org.isOwner) ?? []),
+    ),
+    this.hasSubscription$,
+  ]).pipe(
+    switchMap(([ownerOrgs, hasSubscription]) => {
+      if (!ownerOrgs || ownerOrgs.length === 0 || !hasSubscription) {
+        return of([]);
+      }
+      return combineLatest(
+        ownerOrgs.map((org) =>
+          combineLatest([
+            this.organizationApiService.getSubscription(org.id),
+            this.organizationApiService.getBilling(org.id),
+          ]).pipe(
+            map(([subscription, billing]) => {
+              return this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
+                org,
+                subscription,
+                billing?.paymentSource,
+              );
+            }),
+          ),
+        ),
+      );
+    }),
+    map((results) => results.filter((result) => result.shownBanner)),
+    shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
   constructor(
@@ -423,36 +453,6 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     this.unpaidSubscriptionDialog$.pipe(takeUntil(this.destroy$)).subscribe();
 
-    const organizationsPaymentStatus$ = combineLatest([
-      this.organizationService.organizations$,
-      this.hasSubscription$,
-    ]).pipe(
-      switchMap(([allOrganizations, hasSubscription]) => {
-        if (!allOrganizations || allOrganizations.length === 0 || !hasSubscription) {
-          return of([]);
-        }
-        return combineLatest(
-          allOrganizations
-            .filter((org) => org.isOwner && hasSubscription)
-            .map((org) =>
-              combineLatest([
-                this.organizationApiService.getSubscription(org.id),
-                this.organizationApiService.getBilling(org.id),
-              ]).pipe(
-                map(([subscription, billing]) => {
-                  return this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
-                    org,
-                    subscription,
-                    billing?.paymentSource,
-                  );
-                }),
-              ),
-            ),
-        );
-      }),
-      map((results) => results.filter((result) => result.shownBanner)),
-    );
-
     firstSetup$
       .pipe(
         switchMap(() => this.refresh$),
@@ -466,7 +466,6 @@ export class VaultComponent implements OnInit, OnDestroy {
             ciphers$,
             collections$,
             selectedCollection$,
-            organizationsPaymentStatus$,
           ]),
         ),
         takeUntil(this.destroy$),
@@ -480,7 +479,6 @@ export class VaultComponent implements OnInit, OnDestroy {
           ciphers,
           collections,
           selectedCollection,
-          organizationsPaymentStatus,
         ]) => {
           this.filter = filter;
           this.canAccessPremium = canAccessPremium;
@@ -496,7 +494,6 @@ export class VaultComponent implements OnInit, OnDestroy {
 
           this.showBulkMove = filter.type !== "trash";
           this.isEmpty = collections?.length === 0 && ciphers?.length === 0;
-          this.organizationsPaymentStatus = organizationsPaymentStatus;
           this.performingInitialLoad = false;
           this.refreshing = false;
         },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15520](https://bitwarden.atlassian.net/browse/PM-15520)

## 📔 Objective

(cherry picked from commit 2e53a645c90aabc7cc74026bf2a238a07df5b123)

There were conflicts when attempting to cherry-pick 2e53a645c90aabc7cc74026bf2a238a07df5b123 into `rc` has it had additional changes that did not make the cut (https://github.com/bitwarden/clients/pull/12146). This PR resolves those conflicts, undoing the specific changes made by #12146.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15520]: https://bitwarden.atlassian.net/browse/PM-15520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ