### PR TITLE
[PM-15533] Fix cipher form dialog when used in admin console

### DIFF
--- a/libs/angular/src/vault/components/add-edit.component.ts
+++ b/libs/angular/src/vault/components/add-edit.component.ts
@@ -699,7 +699,6 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   protected saveCipher(cipher: Cipher) {
-    const isNotClone = this.editMode && !this.cloneMode;
     let orgAdmin = this.organization?.canEditAllCiphers;
 
     // if a cipher is unassigned we want to check if they are an admin or have permission to edit any collection
@@ -709,7 +708,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
 
     return this.cipher.id == null
       ? this.cipherService.createWithServer(cipher, orgAdmin)
-      : this.cipherService.updateWithServer(cipher, orgAdmin, isNotClone);
+      : this.cipherService.updateWithServer(cipher, orgAdmin);
   }
 
   protected deleteCipher() {

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -229,11 +229,11 @@ describe("Cipher Service", () => {
   });
 
   describe("updateWithServer()", () => {
-    it("should call apiService.putCipherAdmin when orgAdmin and isNotClone params are true", async () => {
+    it("should call apiService.putCipherAdmin when orgAdmin param is true", async () => {
       const spy = jest
         .spyOn(apiService, "putCipherAdmin")
         .mockImplementation(() => Promise.resolve<any>(cipherObj.toCipherData()));
-      await cipherService.updateWithServer(cipherObj, true, true);
+      await cipherService.updateWithServer(cipherObj, true);
       const expectedObj = new CipherRequest(cipherObj);
 
       expect(spy).toHaveBeenCalled();
@@ -252,7 +252,7 @@ describe("Cipher Service", () => {
       expect(spy).toHaveBeenCalledWith(cipherObj.id, expectedObj);
     });
 
-    it("should call apiService.putPartialCipher when orgAdmin, isNotClone, and edit are false", async () => {
+    it("should call apiService.putPartialCipher when orgAdmin, and edit are false", async () => {
       cipherObj.edit = false;
       const spy = jest
         .spyOn(apiService, "putPartialCipher")

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -709,13 +709,9 @@ export class CipherService implements CipherServiceAbstraction {
     return new Cipher(updated[cipher.id as CipherId]);
   }
 
-  async updateWithServer(
-    cipher: Cipher,
-    orgAdmin?: boolean,
-    isNotClone?: boolean,
-  ): Promise<Cipher> {
+  async updateWithServer(cipher: Cipher, orgAdmin?: boolean): Promise<Cipher> {
     let response: CipherResponse;
-    if (orgAdmin && isNotClone) {
+    if (orgAdmin) {
       const request = new CipherRequest(cipher);
       response = await this.apiService.putCipherAdmin(cipher.id, request);
       const data = new CipherData(response, cipher.collectionIds);

--- a/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
@@ -71,7 +71,6 @@ export class DefaultCipherFormService implements CipherFormService {
       await this.cipherService.updateWithServer(
         encryptedCipher,
         config.admin || originalCollectionIds.size === 0,
-        config.mode !== "clone",
       );
 
       // Then save the new collection changes separately


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15533](https://bitwarden.atlassian.net/browse/PM-15533)

## 📔 Objective

The `isNotClone` parameter in the `cipherService.updateWithServer()` method is no longer relevant to the new cipher from dialog and was improperly restricting admins from editing items.

## 📸 Screenshots


https://github.com/user-attachments/assets/30c64bc0-add6-414b-90b1-70cdc37820b2



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15533]: https://bitwarden.atlassian.net/browse/PM-15533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ