### PR TITLE
[PM-15535] User with Edit* permission can permanently delete item from more actions menu on extension

### DIFF
--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
@@ -30,7 +30,12 @@
             <button type="button" bitMenuItem (click)="restore(cipher)">
               {{ "restore" | i18n }}
             </button>
-            <button type="button" bitMenuItem (click)="delete(cipher)">
+            <button
+              type="button"
+              bitMenuItem
+              *ngIf="canDelete$(cipher) | async"
+              (click)="delete(cipher)"
+            >
               {{ "deleteForever" | i18n }}
             </button>
           </bit-menu>

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
@@ -30,12 +30,7 @@
             <button type="button" bitMenuItem (click)="restore(cipher)">
               {{ "restore" | i18n }}
             </button>
-            <button
-              type="button"
-              bitMenuItem
-              *ngIf="canDelete$(cipher) | async"
-              (click)="delete(cipher)"
-            >
+            <button type="button" bitMenuItem *appCanDeleteCipher="cipher" (click)="delete(cipher)">
               {{ "deleteForever" | i18n }}
             </button>
           </bit-menu>

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
@@ -7,7 +7,6 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import {
   DialogService,
   IconButtonModule,
@@ -18,7 +17,7 @@ import {
   ToastService,
   TypographyModule,
 } from "@bitwarden/components";
-import { PasswordRepromptService } from "@bitwarden/vault";
+import { CanDeleteCipherDirective, PasswordRepromptService } from "@bitwarden/vault";
 
 @Component({
   selector: "app-trash-list-items-container",
@@ -30,6 +29,7 @@ import { PasswordRepromptService } from "@bitwarden/vault";
     JslibModule,
     SectionComponent,
     SectionHeaderComponent,
+    CanDeleteCipherDirective,
     MenuModule,
     IconButtonModule,
     TypographyModule,
@@ -46,13 +46,6 @@ export class TrashListItemsContainerComponent {
   @Input()
   headerText: string;
 
-  /**
-   * Determines if the user can delete the specified cipher.
-   * @param cipher The cipher item to evaluate for deletion permissions.
-   * @returns An observable that emits a boolean value indicating if the user can delete the cipher.
-   */
-  canDelete$ = (cipher: CipherView) => this.cipherAuthorizationService.canDeleteCipher$(cipher);
-
   constructor(
     private cipherService: CipherService,
     private logService: LogService,
@@ -61,7 +54,6 @@ export class TrashListItemsContainerComponent {
     private dialogService: DialogService,
     private passwordRepromptService: PasswordRepromptService,
     private router: Router,
-    private cipherAuthorizationService: CipherAuthorizationService,
   ) {}
 
   async restore(cipher: CipherView) {

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
@@ -7,6 +7,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import {
   DialogService,
   IconButtonModule,
@@ -44,6 +45,13 @@ export class TrashListItemsContainerComponent {
   @Input()
   headerText: string;
 
+  /**
+   * Determines if the user can delete the specified cipher.
+   * @param cipher The cipher item to evaluate for deletion permissions.
+   * @returns An observable that emits a boolean value indicating if the user can delete the cipher.
+   */
+  canDelete$ = (cipher: CipherView) => this.cipherAuthorizationService.canDeleteCipher$(cipher);
+
   constructor(
     private cipherService: CipherService,
     private logService: LogService,
@@ -52,6 +60,7 @@ export class TrashListItemsContainerComponent {
     private dialogService: DialogService,
     private passwordRepromptService: PasswordRepromptService,
     private router: Router,
+    private cipherAuthorizationService: CipherAuthorizationService,
   ) {}
 
   async restore(cipher: CipherView) {

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Input } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -34,6 +34,7 @@ import { PasswordRepromptService } from "@bitwarden/vault";
     IconButtonModule,
     TypographyModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TrashListItemsContainerComponent {
   /**

--- a/apps/browser/src/vault/popup/settings/trash.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CalloutModule, NoItemsModule } from "@bitwarden/components";
@@ -27,6 +27,7 @@ import { TrashListItemsContainerComponent } from "./trash-list-items-container/t
     CalloutModule,
     NoItemsModule,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TrashComponent {
   protected deletedCiphers$ = this.vaultPopupItemsService.deletedCiphers$;

--- a/libs/vault/src/components/can-delete-cipher.directive.ts
+++ b/libs/vault/src/components/can-delete-cipher.directive.ts
@@ -1,6 +1,5 @@
 import { Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { Subject } from "rxjs";
+import { Subject, takeUntil } from "rxjs";
 
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
@@ -20,7 +19,7 @@ export class CanDeleteCipherDirective implements OnDestroy {
 
     this.cipherAuthorizationService
       .canDeleteCipher$(cipher)
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntil(this.destroy$))
       .subscribe((canDelete: boolean) => {
         if (canDelete) {
           this.viewContainer.createEmbeddedView(this.templateRef);

--- a/libs/vault/src/components/can-delete-cipher.directive.ts
+++ b/libs/vault/src/components/can-delete-cipher.directive.ts
@@ -1,0 +1,43 @@
+import { Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Subject } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+
+/**
+ * Only shows the element if the user can delete the cipher.
+ */
+@Directive({
+  selector: "[appCanDeleteCipher]",
+  standalone: true,
+})
+export class CanDeleteCipherDirective implements OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  @Input("appCanDeleteCipher") set cipher(cipher: CipherView) {
+    this.viewContainer.clear();
+
+    this.cipherAuthorizationService
+      .canDeleteCipher$(cipher)
+      .pipe(takeUntilDestroyed())
+      .subscribe((canDelete: boolean) => {
+        if (canDelete) {
+          this.viewContainer.createEmbeddedView(this.templateRef);
+        } else {
+          this.viewContainer.clear();
+        }
+      });
+  }
+
+  constructor(
+    private templateRef: TemplateRef<any>,
+    private viewContainer: ViewContainerRef,
+    private cipherAuthorizationService: CipherAuthorizationService,
+  ) {}
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -2,6 +2,7 @@ export { PasswordRepromptService } from "./services/password-reprompt.service";
 export { CopyCipherFieldService, CopyAction } from "./services/copy-cipher-field.service";
 export { CopyCipherFieldDirective } from "./components/copy-cipher-field.directive";
 export { OrgIconDirective } from "./components/org-icon.directive";
+export { CanDeleteCipherDirective } from "./components/can-delete-cipher.directive";
 
 export * from "./cipher-view";
 export * from "./cipher-form";


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15535
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Added permission check to restrict delete functionality in the trash component.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots


https://github.com/user-attachments/assets/23ff3114-49bf-4032-83c0-2823fed4794a




<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
