### PR TITLE
[PM-12771] Password History Styles

### DIFF
--- a/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
+++ b/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
@@ -25,13 +25,14 @@
       <span class="tw-font-bold">{{ "datePasswordUpdated" | i18n }}:</span>
       {{ cipher.passwordRevisionDisplayDate | date: "medium" }}
     </p>
-    <a
+    <button
       *ngIf="cipher.hasPasswordHistory && isLogin"
-      class="tw-font-bold tw-no-underline tw-cursor-pointer tw-text-primary-600"
       (click)="viewPasswordHistory()"
       bitTypography="body2"
+      bitLink
+      type="button"
     >
       {{ "passwordHistory" | i18n }}
-    </a>
+    </button>
   </bit-card>
 </bit-section>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12771](https://bitwarden.atlassian.net/browse/PM-12771)

## 📔 Objective

- Visually the password history looked accurate to the designs, unlike the screenshot in the ticket. 
- Refactoring the password history to be a `button` and use `bitLink` does improve the consistency for future changes and make the dialog keyboard accessible. 
  - Previously the link did not have an `href` and thus was excluded from the tab order. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/5b06f009-a3d1-435d-bf47-de31494b3094" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12771]: https://bitwarden.atlassian.net/browse/PM-12771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ