### PR TITLE
[CL-522] Reduce font size for checkbox and radio labels

### DIFF
--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -22,8 +22,8 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "tw-border",
     "tw-border-solid",
     "tw-border-secondary-500",
-    "tw-h-5",
-    "tw-w-5",
+    "tw-h-[1.12rem]",
+    "tw-w-[1.12rem]",
     "tw-mr-1.5",
     "tw-flex-none", // Flexbox fix for bit-form-control
 
@@ -82,11 +82,11 @@ export class CheckboxComponent implements BitFormControlAbstraction {
 
   @HostBinding("style.--mask-image")
   protected maskImage =
-    `url('data:image/svg+xml,%3Csvg class="svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12" height="12" viewBox="0 0 10 10"%3E%3Cpath d="M0.5 6.2L2.9 8.6L9.5 1.4" fill="none" stroke="white" stroke-width="2"%3E%3C/path%3E%3C/svg%3E')`;
+    `url('data:image/svg+xml,%3Csvg class="svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="10" viewBox="0 0 10 10"%3E%3Cpath d="M0.5 6.2L2.9 8.6L9.5 1.4" fill="none" stroke="white" stroke-width="2"%3E%3C/path%3E%3C/svg%3E')`;
 
   @HostBinding("style.--indeterminate-mask-image")
   protected indeterminateImage =
-    `url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 13 13"%3E%3Cpath stroke="%23fff" stroke-width="2" d="M2.5 6.5h8"/%3E%3C/svg%3E%0A')`;
+    `url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 13 13"%3E%3Cpath stroke="%23fff" stroke-width="2" d="M2.5 6.5h8"/%3E%3C/svg%3E%0A')`;
 
   @HostBinding()
   @Input()

--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -25,7 +25,6 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "tw-h-5",
     "tw-w-5",
     "tw-mr-1.5",
-    "tw-bottom-[-1px]", // Fix checkbox looking off-center
     "tw-flex-none", // Flexbox fix for bit-form-control
 
     "before:tw-content-['']",

--- a/libs/components/src/form-control/form-control.component.html
+++ b/libs/components/src/form-control/form-control.component.html
@@ -7,7 +7,7 @@
     class="tw-inline-flex tw-flex-col"
     [ngClass]="formControl.disabled ? 'tw-text-muted' : 'tw-text-main'"
   >
-    <span bitTypography="body1">
+    <span bitTypography="body2">
       <ng-content select="bit-label"></ng-content>
       <span *ngIf="required" class="tw-text-xs tw-font-normal"> ({{ "required" | i18n }})</span>
     </span>

--- a/libs/components/src/form-control/form-control.module.ts
+++ b/libs/components/src/form-control/form-control.module.ts
@@ -1,13 +1,14 @@
 import { NgModule } from "@angular/core";
 
 import { SharedModule } from "../shared";
+import { TypographyModule } from "../typography";
 
 import { FormControlComponent } from "./form-control.component";
 import { BitHintComponent } from "./hint.component";
 import { BitLabel } from "./label.component";
 
 @NgModule({
-  imports: [SharedModule, BitLabel],
+  imports: [SharedModule, BitLabel, TypographyModule],
   declarations: [FormControlComponent, BitHintComponent],
   exports: [FormControlComponent, BitLabel, BitHintComponent],
 })

--- a/libs/components/src/form/form.stories.ts
+++ b/libs/components/src/form/form.stories.ts
@@ -51,6 +51,10 @@ export default {
               inputEmail: "Input is not an email-address.",
               inputMinValue: (min) => `Input value must be at least ${min}.`,
               inputMaxValue: (max) => `Input value must not exceed ${max}.`,
+              multiSelectPlaceholder: "-- Type to Filter --",
+              multiSelectLoading: "Retrieving options...",
+              multiSelectNotFound: "No items found",
+              multiSelectClearAll: "Clear all",
             });
           },
         },
@@ -70,6 +74,7 @@ const exampleFormObj = fb.group({
   name: ["", [Validators.required]],
   email: ["", [Validators.required, Validators.email, forbiddenNameValidator(/bit/i)]],
   country: [undefined as string | undefined, [Validators.required]],
+  groups: [],
   terms: [false, [Validators.requiredTrue]],
   updates: ["yes"],
   age: [null, [Validators.min(0), Validators.max(150)]],
@@ -115,7 +120,7 @@ export const FullExample: Story = {
           <bit-label>Groups</bit-label>
           <bit-multi-select
             class="tw-w-full"
-            formControlName="select"
+            formControlName="groups"
             [baseItems]="baseItems"
             [removeSelectedItems]="removeSelectedItems"
             [loading]="false"

--- a/libs/components/src/radio-button/radio-group.component.html
+++ b/libs/components/src/radio-button/radio-group.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="label">
   <fieldset>
-    <legend class="tw-mb-1 tw-block tw-text-base tw-font-semibold tw-text-main">
+    <legend class="tw-mb-1 tw-block tw-text-sm tw-font-semibold tw-text-main">
       <ng-content select="bit-label"></ng-content>
       <span *ngIf="required" class="tw-text-xs tw-font-normal"> ({{ "required" | i18n }})</span>
     </legend>

--- a/libs/components/src/radio-button/radio-input.component.ts
+++ b/libs/components/src/radio-button/radio-input.component.ts
@@ -25,8 +25,8 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "tw-border",
     "tw-border-solid",
     "tw-border-secondary-600",
-    "tw-w-5",
-    "tw-h-5",
+    "tw-w-[1.12rem]",
+    "tw-h-[1.12rem]",
     "tw-mr-1.5",
     "tw-flex-none", // Flexbox fix for bit-form-control
 

--- a/libs/components/src/radio-button/radio-input.component.ts
+++ b/libs/components/src/radio-button/radio-input.component.ts
@@ -28,7 +28,6 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "tw-w-5",
     "tw-h-5",
     "tw-mr-1.5",
-    "tw-bottom-[-1px]", // Fix checkbox looking off-center
     "tw-flex-none", // Flexbox fix for bit-form-control
 
     "hover:tw-border-2",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-522](https://bitwarden.atlassian.net/browse/CL-522)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR reduces the font size of checkbox and radio labels from `body1` to `body2`, which will improve the way forms and pages with these elements look by normalizing the font size hierarchy.

It also fixes a couple of errors in the form full example story.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| ![Screenshot 2024-12-04 at 10 34 46 AM](https://github.com/user-attachments/assets/44dfb1c4-d114-4950-be0d-5c718c1bd1cf) | ![Screenshot 2024-12-04 at 2 56 01 PM](https://github.com/user-attachments/assets/840fd79a-556b-4162-9818-62298851de1d) |
| ![Screenshot 2024-12-04 at 3 47 53 PM](https://github.com/user-attachments/assets/dbc21f21-3ac2-474c-9688-c0b895d9824c) | ![Screenshot 2024-12-04 at 3 15 58 PM](https://github.com/user-attachments/assets/f5d0958c-e60e-4785-9f81-7ab9e76a90a4) |
| ![Screenshot 2024-12-04 at 3 47 46 PM](https://github.com/user-attachments/assets/eda71c3e-f999-44eb-ab0c-36c6b5228a04) | ![Screenshot 2024-12-04 at 3 16 19 PM](https://github.com/user-attachments/assets/73f947f0-fc28-4550-9d9c-404eb874b60e) |
| ![Screenshot 2024-12-04 at 3 47 35 PM](https://github.com/user-attachments/assets/fb9310f4-3637-4490-94c8-a390953aaaa5) | ![Screenshot 2024-12-04 at 3 29 36 PM](https://github.com/user-attachments/assets/46cb7e61-cd58-44db-ac85-4b838edc6861) |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-522]: https://bitwarden.atlassian.net/browse/CL-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ