### PR TITLE
[PM-15559] Fix hide passwords in AC for users that have view, except password

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -283,15 +283,16 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
       this.formConfig.mode = "edit";
     }
 
-    let cipher: Cipher;
+    let cipher = await this.cipherService.get(cipherView.id);
 
-    // When the form config is used within the Admin Console, retrieve the cipher from the admin endpoint
-    if (this.formConfig.isAdminConsole) {
+    // When the form config is used within the Admin Console, retrieve the cipher from the admin endpoint (if not found in local state)
+    if (this.formConfig.isAdminConsole && (cipher == null || this.formConfig.admin)) {
       const cipherResponse = await this.apiService.getCipherAdmin(cipherView.id);
+      cipherResponse.edit = true;
+      cipherResponse.viewPassword = true;
+
       const cipherData = new CipherData(cipherResponse);
       cipher = new Cipher(cipherData);
-    } else {
-      cipher = await this.cipherService.get(cipherView.id);
     }
 
     // Store the updated cipher so any following edits use the most up to date cipher

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -281,6 +281,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     // If the cipher was newly created (via add/clone), switch the form to edit for subsequent edits.
     if (this._originalFormMode === "add" || this._originalFormMode === "clone") {
       this.formConfig.mode = "edit";
+      this.formConfig.initialValues = null;
     }
 
     let cipher = await this.cipherService.get(cipherView.id);

--- a/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.ts
+++ b/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.ts
@@ -5,8 +5,10 @@ import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType, OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
+import { OrganizationUserStatusType, PolicyType } from "@bitwarden/common/admin-console/enums";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { CipherId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -25,6 +27,7 @@ export class AdminConsoleCipherFormConfigService implements CipherFormConfigServ
   private organizationService: OrganizationService = inject(OrganizationService);
   private routedVaultFilterService: RoutedVaultFilterService = inject(RoutedVaultFilterService);
   private collectionAdminService: CollectionAdminService = inject(CollectionAdminService);
+  private cipherService: CipherService = inject(CipherService);
   private apiService: ApiService = inject(ApiService);
 
   private allowPersonalOwnership$ = this.policyService
@@ -57,7 +60,6 @@ export class AdminConsoleCipherFormConfigService implements CipherFormConfigServ
     cipherId?: CipherId,
     cipherType?: CipherType,
   ): Promise<CipherFormConfig> {
-    const cipher = await this.getCipher(cipherId);
     const [organization, allowPersonalOwnership, allOrganizations, allCollections] =
       await firstValueFrom(
         combineLatest([
@@ -74,7 +76,7 @@ export class AdminConsoleCipherFormConfigService implements CipherFormConfigServ
     // Only allow the user to assign to their personal vault when cloning and
     // the policies are enabled for it.
     const allowPersonalOwnershipOnlyForClone = mode === "clone" ? allowPersonalOwnership : false;
-
+    const cipher = await this.getCipher(cipherId, organization);
     return {
       mode,
       cipherType: cipher?.type ?? cipherType ?? CipherType.Login,
@@ -89,14 +91,26 @@ export class AdminConsoleCipherFormConfigService implements CipherFormConfigServ
     };
   }
 
-  private async getCipher(id?: CipherId): Promise<Cipher | null> {
+  private async getCipher(id: CipherId | null, organization: Organization): Promise<Cipher | null> {
     if (id == null) {
-      return Promise.resolve(null);
+      return null;
     }
 
-    // Retrieve the cipher through the means of an admin
+    const localCipher = await this.cipherService.get(id);
+
+    // Fetch from the API because we don't need the permissions in local state OR the cipher was not found (e.g. unassigned)
+    if (organization.canEditAllCiphers || localCipher == null) {
+      return await this.getCipherFromAdminApi(id);
+    }
+
+    return localCipher;
+  }
+
+  private async getCipherFromAdminApi(id: CipherId): Promise<Cipher> {
     const cipherResponse = await this.apiService.getCipherAdmin(id);
+    // Ensure admin response includes permissions that allow editing
     cipherResponse.edit = true;
+    cipherResponse.viewPassword = true;
 
     const cipherData = new CipherData(cipherResponse);
     return new Cipher(cipherData);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15559](https://bitwarden.atlassian.net/browse/PM-15559)

## 📔 Objective

The admin console cipher form service was always fetching ciphers from the API which do not have permissions available. The PR updates the logic to only fetch from the API when the user has `CanEditAllCiphers` permission or when the cipher is `Unassigned` (and thus only available via the admin API). 

The same applies after the form is submitted, we should only fetch the updated cipher from the API.

## 📸 Screenshots


https://github.com/user-attachments/assets/4b21bbd8-ed9e-488e-82e0-6797e2cca5b8



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15559]: https://bitwarden.atlassian.net/browse/PM-15559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ