### PR TITLE
[PM-13133] Prompt user to popout the extension when creating a file send with Chrome on MacOS

### DIFF
--- a/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
+++ b/apps/browser/src/tools/popup/services/file-popout-utils.service.ts
@@ -49,7 +49,7 @@ export class FilePopoutUtilsService {
   }
 
   /**
-   * Determines whether to show a file popout callout message for Chromium-based browsers in Linux and Mac OS X Big Sur
+   * Determines whether to show a file popout callout message for Chromium-based browsers in Linux and Mac OS X
    * @param win - The window context in which the check should be performed.
    * @returns True if the extension is not in a sidebar or popout; otherwise, false.
    */
@@ -66,8 +66,6 @@ export class FilePopoutUtilsService {
   }
 
   private isUnsupportedMac(win: Window): boolean {
-    return (
-      this.platformUtilsService.isChrome() && win?.navigator?.appVersion.includes("Mac OS X 11")
-    );
+    return this.platformUtilsService.isChrome() && win?.navigator?.appVersion.includes("Mac OS X");
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13113
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
During tests adding attachments to Sends or Vault items, it was discovered there's an issue with the usage of Chrome on MacOS when selecting files. The extension would close under some circumstances, loosing all previous data.

This also occurs on Firefox and Safari and previously with Chrome on MacOS Big Sur. When this usage combination is found the user gets prompted to popout the extension before selecting any attachments. With this PR the check and the following prompt is expanded to always be shown on Chrome and any MacOS version.

Changes will be 🍒 ⛏️ 'ed to `rc` once reviewed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
