### PR TITLE
[PM-15611] UI Bugfix - WebAuthn 2FA iFrame height adjustment

### DIFF
--- a/apps/web/src/scss/plugins.scss
+++ b/apps/web/src/scss/plugins.scss
@@ -12,7 +12,7 @@
 }
 
 #web-authn-frame {
-  height: 290px;
+  height: 315px;
   @include themify($themes) {
     background: themed("imgLoading") 0 0 no-repeat;
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15611

## 📔 Objective

Adjust height of WebAuthn 2FA iframe so it doesn't get cut off.

## 📸 Screenshots

| Before  | After |
| ------------- | ------------- |
| ![image-20241205-200706](https://github.com/user-attachments/assets/67e39d3c-d2af-4267-8501-52ade1cc1cf5) | <img width="541" alt="Screenshot 2024-12-05 at 3 30 32 PM" src="https://github.com/user-attachments/assets/f928fcd2-bbde-44e1-a6b5-90cbe8d94f1b"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
