### PR TITLE
Fix safari autoprompt behavior

### DIFF
--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -197,10 +197,10 @@ export class AppComponent implements OnInit, OnDestroy {
         ) {
           await this.clearComponentStates();
         }
+        (window as any).previousPopupUrl = url;
         if (url.startsWith("/tabs/")) {
           await this.cipherService.setAddEditCipherInfo(null);
         }
-        (window as any).previousPopupUrl = url;
 
         // Clear route direction after animation (400ms)
         if ((window as any).routeDirection != null) {

--- a/libs/auth/src/angular/lock/lock.component.ts
+++ b/libs/auth/src/angular/lock/lock.component.ts
@@ -117,6 +117,8 @@ export class LockV2Component implements OnInit, OnDestroy {
 
   unlockingViaBiometrics = false;
 
+  private hadActiveAccount = false;
+
   constructor(
     private accountService: AccountService,
     private pinService: PinServiceAbstraction,
@@ -156,6 +158,22 @@ export class LockV2Component implements OnInit, OnDestroy {
 
     if (this.clientType === "desktop") {
       await this.desktopOnInit();
+    }
+
+    this.isInitialLockScreen = (window as any).previousPopupUrl == null;
+
+    if (this.clientType === "browser") {
+      if ((window as any).previousPopupUrl != null) {
+        /// add param
+        const url = new URL((window as any).location.href);
+        url.searchParams.set("previousPopupUrl", (window as any).previousPopupUrl);
+        (window as any).location.href = url.toString();
+      }
+      const url = new URL((window as any).location.href);
+      if (url.searchParams.has("previousPopupUrl")) {
+        this.isInitialLockScreen = false;
+        (window as any).previousPopupUrl = url.searchParams.get("previousPopupUrl");
+      }
     }
   }
 
@@ -228,7 +246,7 @@ export class LockV2Component implements OnInit, OnDestroy {
     this.unlockOptions = null;
     this.activeUnlockOption = null;
     this.formGroup = null; // new form group will be created based on new active unlock option
-    this.isInitialLockScreen = true;
+    this.isInitialLockScreen = (window as any).previousPopupUrl == null;
 
     // Desktop properties:
     this.biometricAsked = false;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15584

## 📔 Objective

Safari does not close the popup on lock due to process reload, unlike the other browsers. However, the window object is reset and the previous url is not persisted through this reload, making the extension always think  it is an initial load. Further, the account switching observable always set the components initial load state to true.

This PR fixes these behaviors.

## 📸 Screenshots


https://github.com/user-attachments/assets/55167ca7-04b0-4004-b6cb-7de42d12db78



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
