### PR TITLE
[PR-13659] revert adding executor function and logging

### DIFF
--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -17,7 +17,6 @@ import {
   PinService,
   PinServiceAbstraction,
   UserDecryptionOptionsService,
-  Executor,
 } from "@bitwarden/auth/common";
 import { EventCollectionService as EventCollectionServiceAbstraction } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { EventUploadService as EventUploadServiceAbstraction } from "@bitwarden/common/abstractions/event/event-upload.service";
@@ -615,11 +614,6 @@ export class ServiceContainer {
       this.configService,
     );
 
-    // Execute any authn session timeout logic without any wrapping logic.
-    // An executor is required to ensure the logic is executed in an Angular context when it
-    // it is available.
-    const authnSessionTimeoutExecutor: Executor = (fn) => fn();
-
     this.loginStrategyService = new LoginStrategyService(
       this.accountService,
       this.masterPasswordService,
@@ -646,7 +640,6 @@ export class ServiceContainer {
       this.vaultTimeoutSettingsService,
       this.kdfConfigService,
       this.taskSchedulerService,
-      authnSessionTimeoutExecutor,
     );
 
     // FIXME: CLI does not support autofill

--- a/libs/angular/src/auth/components/two-factor.component.ts
+++ b/libs/angular/src/auth/components/two-factor.component.ts
@@ -102,20 +102,10 @@ export class TwoFactorComponent extends CaptchaProtectedComponent implements OnI
     super(environmentService, i18nService, platformUtilsService, toastService);
     this.webAuthnSupported = this.platformUtilsService.supportsWebAuthn(win);
 
-    this.logService.info(
-      "Subscribing to timeout on LoginStrategyService with service id: " +
-        this.loginStrategyService.id,
-    );
-
     // Add subscription to twoFactorTimeout$ and navigate to twoFactorTimeoutRoute if expired
     this.loginStrategyService.twoFactorTimeout$
       .pipe(takeUntilDestroyed())
       .subscribe(async (expired) => {
-        this.logService.info(
-          "Received emission from  LoginStrategyService.twoFactorTimeout$ with service id: " +
-            this.loginStrategyService.id,
-        );
-
         if (!expired) {
           return;
         }

--- a/libs/angular/src/services/injection-tokens.ts
+++ b/libs/angular/src/services/injection-tokens.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 
-import { Executor, LogoutReason } from "@bitwarden/auth/common";
+import { LogoutReason } from "@bitwarden/auth/common";
 import { ClientType } from "@bitwarden/common/enums";
 import { RegionConfig } from "@bitwarden/common/platform/abstractions/environment.service";
 import {
@@ -67,8 +67,4 @@ export const REFRESH_ACCESS_TOKEN_ERROR_CALLBACK = new SafeInjectionToken<() => 
  */
 export const ENV_ADDITIONAL_REGIONS = new SafeInjectionToken<RegionConfig[]>(
   "ENV_ADDITIONAL_REGIONS",
-);
-
-export const AUTHN_SESSION_TIMEOUT_EXECUTOR = new SafeInjectionToken<Executor>(
-  "AuthnSessionTimeoutExecutor",
 );

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler, LOCALE_ID, NgModule, NgZone } from "@angular/core";
+import { ErrorHandler, LOCALE_ID, NgModule } from "@angular/core";
 import { Subject } from "rxjs";
 
 import {
@@ -319,7 +319,6 @@ import {
   CLIENT_TYPE,
   REFRESH_ACCESS_TOKEN_ERROR_CALLBACK,
   ENV_ADDITIONAL_REGIONS,
-  AUTHN_SESSION_TIMEOUT_EXECUTOR,
 } from "./injection-tokens";
 import { ModalService } from "./modal.service";
 
@@ -413,11 +412,6 @@ const safeProviders: SafeProvider[] = [
     ],
   }),
   safeProvider({
-    provide: AUTHN_SESSION_TIMEOUT_EXECUTOR,
-    useFactory: (ngZone: NgZone) => (fn: () => void) => ngZone.run(fn),
-    deps: [NgZone],
-  }),
-  safeProvider({
     provide: LoginStrategyServiceAbstraction,
     useClass: LoginStrategyService,
     deps: [
@@ -446,7 +440,6 @@ const safeProviders: SafeProvider[] = [
       VaultTimeoutSettingsServiceAbstraction,
       KdfConfigService,
       TaskSchedulerService,
-      AUTHN_SESSION_TIMEOUT_EXECUTOR,
     ],
   }),
   safeProvider({

--- a/libs/auth/src/common/abstractions/login-strategy.service.ts
+++ b/libs/auth/src/common/abstractions/login-strategy.service.ts
@@ -14,8 +14,6 @@ import {
 } from "../models/domain/login-credentials";
 
 export abstract class LoginStrategyServiceAbstraction {
-  id: string;
-
   /**
    * The current strategy being used to authenticate.
    * Emits null if the session has timed out.

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
@@ -71,8 +71,6 @@ import {
 
 const sessionTimeoutLength = 5 * 60 * 1000; // 5 minutes
 
-export type Executor = (fn: () => void) => void;
-
 export class LoginStrategyService implements LoginStrategyServiceAbstraction {
   private sessionTimeoutSubscription: Subscription;
   private currentAuthnTypeState: GlobalState<AuthenticationType | null>;
@@ -120,7 +118,6 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
     protected vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     protected kdfConfigService: KdfConfigService,
     protected taskSchedulerService: TaskSchedulerService,
-    private authnSessionTimeoutExecutor: Executor = (fn) => fn(), // Default to no-op
   ) {
     this.currentAuthnTypeState = this.stateProvider.get(CURRENT_LOGIN_STRATEGY_KEY);
     this.loginStrategyCacheState = this.stateProvider.get(CACHE_KEY);
@@ -131,14 +128,12 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
     this.taskSchedulerService.registerTaskHandler(
       ScheduledTaskNames.loginStrategySessionTimeout,
       async () => {
-        this.authnSessionTimeoutExecutor(async () => {
-          this.twoFactorTimeoutSubject.next(true);
-          try {
-            await this.clearCache();
-          } catch (e) {
-            this.logService.error("Failed to clear cache during session timeout", e);
-          }
-        });
+        this.twoFactorTimeoutSubject.next(true);
+        try {
+          await this.clearCache();
+        } catch (e) {
+          this.logService.error("Failed to clear cache during session timeout", e);
+        }
       },
     );
 

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
@@ -7,7 +7,6 @@ import {
   shareReplay,
   Subscription,
   BehaviorSubject,
-  tap,
 } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -32,7 +31,6 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { TaskSchedulerService, ScheduledTaskNames } from "@bitwarden/common/platform/scheduling";
 import { GlobalState, GlobalStateProvider } from "@bitwarden/common/platform/state";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/src/auth/abstractions/device-trust.service.abstraction";
@@ -83,36 +81,7 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
   private authRequestPushNotificationState: GlobalState<string>;
   private twoFactorTimeoutSubject = new BehaviorSubject<boolean>(false);
 
-  twoFactorTimeout$: Observable<boolean> = this.twoFactorTimeoutSubject.asObservable().pipe(
-    // line 87 is the tap?
-    tap({
-      next: (value) => {
-        this.logService.info(
-          `LoginStrategyService.twoFactorTimeout$ with service id: ${this.id} emmitted value: ${value}`,
-        );
-      },
-      error: (error: unknown) => {
-        this.logService.error(
-          `LoginStrategyService.twoFactorTimeout$ with service id: ${this.id} errored with error: ${JSON.stringify(error)}`,
-        );
-      },
-      finalize: () => {
-        this.logService.info(
-          `LoginStrategyService.twoFactorTimeout$ with service id: ${this.id} finalized`,
-        );
-      },
-      complete: () => {
-        this.logService.info(
-          `LoginStrategyService.twoFactorTimeout$ with service id: ${this.id} completed`,
-        );
-      },
-      subscribe: () => {
-        this.logService.info(
-          `LoginStrategyService.twoFactorTimeout$ with service id: ${this.id} subscribed`,
-        );
-      },
-    }),
-  );
+  twoFactorTimeout$: Observable<boolean> = this.twoFactorTimeoutSubject.asObservable();
 
   private loginStrategy$: Observable<
     | UserApiLoginStrategy
@@ -124,8 +93,6 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
   >;
 
   currentAuthType$: Observable<AuthenticationType | null>;
-
-  id: string = Utils.newGuid();
 
   constructor(
     protected accountService: AccountService,
@@ -164,7 +131,6 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
     this.taskSchedulerService.registerTaskHandler(
       ScheduledTaskNames.loginStrategySessionTimeout,
       async () => {
-        this.logService.info("Timeout executing for LoginStrategyService with id: " + this.id);
         this.authnSessionTimeoutExecutor(async () => {
           this.twoFactorTimeoutSubject.next(true);
           try {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-13659?atlOrigin=eyJpIjoiMGZkZTFkMjZhNzdiNDZmYzljODI0MjYzMWJkZWZlYTQiLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Reverts adding an `authnSessionTimeoutExecutor` and logging used for debugging the original PM-13659 work. It turned out the `two-factor-component-refactor` feature flag needs to be disabled in dev so these changes were unnecessary.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
