### PR TITLE
[CL-510] Create slot for banners in popup-page component

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.mdx
+++ b/apps/browser/src/platform/popup/layout/popup-layout.mdx
@@ -44,6 +44,9 @@ page looks nice when the extension is popped out.
 - `above-scroll-area`
   - When the page content overflows, this content will be "stuck" to the top of the page upon
     scrolling.
+- `full-width-notice`
+  - Similar to `above-scroll-area`, this content will display before `above-scroll-area` without
+    container margin or padding.
 - default
   - Whatever content you want in `main`.
 
@@ -107,6 +110,30 @@ Common interactive elements to insert into the `end` slot are:
 - `app-pop-out`: shows popout button when the extension is not already popped out
 - "Add" button: this can be accomplished with the Button component and any custom functionality for
   that particular page
+
+### Notice
+
+<Canvas>
+  <Story of={stories.Notice} />
+</Canvas>
+
+Common interactive elements to insert into the `full-width-notice` slot are:
+
+- `bit-banner`: shows a full-width notice
+
+Usage example:
+
+```html
+<popup-page>
+  <popup-header slot="header" [pageTitle]="'vault' | i18n"> </popup-header>
+  <bit-banner slot="full-width-notice" bannerType="info" [showClose]="false">
+    This is an important note about these ciphers
+  </bit-banner>
+  <ng-container slot="above-scroll-area">
+    <app-vault-header-v2></app-vault-header-v2>
+  </ng-container>
+</popup-page>
+```
 
 ## Popup footer
 

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -11,6 +11,7 @@ import { SendService } from "@bitwarden/common/tools/send/services/send.service.
 import {
   AvatarModule,
   BadgeModule,
+  BannerModule,
   ButtonModule,
   I18nMockService,
   IconButtonModule,
@@ -124,6 +125,18 @@ class MockCurrentAccountComponent {}
   imports: [SearchModule],
 })
 class MockSearchComponent {}
+
+@Component({
+  selector: "mock-banner",
+  template: `
+    <bit-banner bannerType="info" [showClose]="false">
+      This is an important note about these ciphers
+    </bit-banner>
+  `,
+  standalone: true,
+  imports: [BannerModule],
+})
+class MockBannerComponent {}
 
 @Component({
   selector: "mock-vault-page",
@@ -298,6 +311,8 @@ export default {
         CommonModule,
         RouterModule,
         ExtensionContainerComponent,
+        MockBannerComponent,
+        MockSearchComponent,
         MockVaultSubpageComponent,
         MockVaultPageComponent,
         MockSendPageComponent,
@@ -510,6 +525,22 @@ export const TransparentHeader: Story = {
             ><span class="tw-italic tw-text-main">🤠 Custom Content</span></popup-header
           >
 
+          <vault-placeholder></vault-placeholder>
+        </popup-page>
+      </extension-container>
+    `,
+  }),
+};
+
+export const Notice: Story = {
+  render: (args) => ({
+    props: args,
+    template: /* HTML */ `
+      <extension-container>
+        <popup-page>
+          <popup-header slot="header" pageTitle="Page Header"></popup-header>
+          <mock-banner slot="full-width-notice"></mock-banner>
+          <mock-search slot="above-scroll-area"></mock-search>
           <vault-placeholder></vault-placeholder>
         </popup-page>
       </extension-container>

--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -1,5 +1,8 @@
 <ng-content select="[slot=header]"></ng-content>
 <main class="tw-flex-1 tw-overflow-hidden tw-flex tw-flex-col tw-relative tw-bg-background-alt">
+  <div class="tw-transition-colors tw-duration-200 tw-border-0 tw-border-solid">
+    <ng-content select="[slot=full-width-notice]"></ng-content>
+  </div>
   <div
     #nonScrollable
     class="tw-transition-colors tw-duration-200 tw-border-0 tw-border-b tw-border-solid tw-p-3 bit-compact:tw-p-2"

--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -1,8 +1,6 @@
 <ng-content select="[slot=header]"></ng-content>
 <main class="tw-flex-1 tw-overflow-hidden tw-flex tw-flex-col tw-relative tw-bg-background-alt">
-  <div class="tw-transition-colors tw-duration-200 tw-border-0 tw-border-solid">
-    <ng-content select="[slot=full-width-notice]"></ng-content>
-  </div>
+  <ng-content select="[slot=full-width-notice]"></ng-content>
   <div
     #nonScrollable
     class="tw-transition-colors tw-duration-200 tw-border-0 tw-border-b tw-border-solid tw-p-3 bit-compact:tw-p-2"


### PR DESCRIPTION
## 🎟️ Tracking

CL-510

## 📔 Objective

The popup-page component should have a banner content projection slot for banners. This slot will have zero margin, unlike slot="above-scroll-area".

## 📸 Screenshots

![Screenshot 2024-12-06 at 5 23 25 PM](https://github.com/user-attachments/assets/020d0c37-9480-4b8a-a25b-d0089d8044ae)
![Screenshot 2024-12-06 at 5 23 06 PM](https://github.com/user-attachments/assets/163bbfb2-f9d9-4a1e-adf4-5410bedda744)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
