### PR TITLE
[PM-15824] Prevent privileged admins from seeing read only collections in Password Manager item dialog

### DIFF
--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
@@ -91,7 +91,8 @@ describe("ItemDetailsSectionComponent", () => {
           id: "col1",
           name: "Collection 1",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
       ];
       component.originalCipherView = {
@@ -125,13 +126,15 @@ describe("ItemDetailsSectionComponent", () => {
           id: "col1",
           name: "Collection 1",
           organizationId: "org1",
-          canEditItems: (_org) => false,
+          assigned: true,
+          readOnly: true,
         } as CollectionView,
         {
           id: "col2",
           name: "Collection 2",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
       ];
       component.originalCipherView = {
@@ -386,19 +389,22 @@ describe("ItemDetailsSectionComponent", () => {
           id: "col1",
           name: "Collection 1",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
         {
           id: "col2",
           name: "Collection 2",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
         {
           id: "col3",
           name: "Collection 3",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
       ];
 
@@ -421,7 +427,8 @@ describe("ItemDetailsSectionComponent", () => {
           id: "col1",
           name: "Collection 1",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
       ];
 
@@ -453,20 +460,22 @@ describe("ItemDetailsSectionComponent", () => {
           id: "col1",
           name: "Collection 1",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
         {
           id: "col2",
           name: "Collection 2",
           organizationId: "org1",
-          canEditItems: (_org) => true,
+          assigned: true,
+          readOnly: false,
         } as CollectionView,
         {
           id: "col3",
           name: "Collection 3",
           organizationId: "org1",
           readOnly: true,
-          canEditItems: (_org) => true,
+          assigned: true,
         } as CollectionView,
       ];
 
@@ -490,21 +499,21 @@ describe("ItemDetailsSectionComponent", () => {
           name: "Collection 1",
           organizationId: "org1",
           readOnly: true,
-          canEditItems: (_org) => false,
+          assigned: false,
         } as CollectionView,
         {
           id: "col2",
           name: "Collection 2",
           organizationId: "org1",
           readOnly: true,
-          canEditItems: (_org) => false,
+          assigned: false,
         } as CollectionView,
         {
           id: "col3",
           name: "Collection 3",
           organizationId: "org1",
           readOnly: false,
-          canEditItems: (_org) => false,
+          assigned: true,
         } as CollectionView,
       ];
 
@@ -527,20 +536,20 @@ describe("ItemDetailsSectionComponent", () => {
           name: "Collection 1",
           organizationId: "org1",
           readOnly: true,
-          canEditItems: (_org) => false,
+          assigned: false,
         } as CollectionView,
         {
           id: "col2",
           name: "Collection 2",
           organizationId: "org1",
-          canEditItems: (_org) => false,
+          assigned: false,
         } as CollectionView,
         {
           id: "col3",
           name: "Collection 3",
           organizationId: "org1",
           readOnly: true,
-          canEditItems: (_org) => false,
+          assigned: false,
         } as CollectionView,
       ];
       component.originalCipherView = {

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -271,19 +271,25 @@ export class ItemDetailsSectionComponent implements OnInit {
       this.showCollectionsControl = true;
     }
 
-    const organization = this.organizations.find((o) => o.id === orgId);
-
     this.collectionOptions = this.collections
       .filter((c) => {
-        // Filter criteria:
-        // - The collection belongs to the organization
-        // - When in partial edit mode, show all org collections because the control is disabled.
-        // - The user can edit items within the collection
-        // - When viewing as an admin, all collections should be shown, even readonly. When non-admin, filter out readonly collections
-        return (
-          c.organizationId === orgId &&
-          (this.partialEdit || c.canEditItems(organization) || this.config.admin)
-        );
+        // The collection belongs to the organization
+        if (c.organizationId !== orgId) {
+          return false;
+        }
+
+        // When in partial edit mode, show all org collections because the control is disabled.
+        if (this.partialEdit) {
+          return true;
+        }
+
+        // When viewing as an admin, all collections should be shown, even readonly. (AC Only)
+        if (this.config.admin) {
+          return true;
+        }
+
+        // Non-admins can only select assigned collections that are not read only. (Non-AC)
+        return c.assigned && !c.readOnly;
       })
       .map((c) => ({
         id: c.id,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15824](https://bitwarden.atlassian.net/browse/PM-15824)

## 📔 Objective

Stop showing read only collections to admins with access to all ciphers/collections in the Password Manager. The setting to allow admins to edit all ciphers/collections only applies within the Admin Console (e.g. only when the `config.admin` is true).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15824]: https://bitwarden.atlassian.net/browse/PM-15824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ