### PR TITLE
fix(safari): add a bespoke implementation for `reloadExtension`

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1051,14 +1051,6 @@ export default class MainBackground {
 
     const systemUtilsServiceReloadCallback = async () => {
       await this.taskSchedulerService.clearAllScheduledTasks();
-      if (this.platformUtilsService.isSafari()) {
-        // If we do `chrome.runtime.reload` on safari they will send an onInstalled reason of install
-        // and that prompts us to show a new tab, this apparently doesn't happen on sideloaded
-        // extensions and only shows itself production scenarios. See: https://bitwarden.atlassian.net/browse/PM-12298
-        self.location.reload();
-        return;
-      }
-
       BrowserApi.reloadExtension();
     };
 

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -437,6 +437,12 @@ export class BrowserApi {
    * Handles reloading the extension using the underlying functionality exposed by the browser API.
    */
   static reloadExtension() {
+    // If we do `chrome.runtime.reload` on safari they will send an onInstalled reason of install
+    // and that prompts us to show a new tab, this apparently doesn't happen on sideloaded
+    // extensions and only shows itself production scenarios. See: https://bitwarden.atlassian.net/browse/PM-12298
+    if (this.isSafariApi) {
+      self.location.reload();
+    }
     return chrome.runtime.reload();
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-14012
https://github.com/bitwarden/clients/issues/11694
https://github.com/bitwarden/clients/issues/3840

## 📔 Objective

Safari handles `chrome.runtime.reload` weird. It triggers an `install` event, which we use to show the "Getting started with the Bitwarden extension" tab. This results in that tab being opened whenever we reload the extension for any reason.

This was fixed for one case on https://github.com/bitwarden/clients/pull/11115, but this left out the case for native messaging [here](https://github.com/bitwarden/clients/blob/17cd251732bf61737ffe5b937f8e1cdc5379073a/apps/browser/src/background/nativeMessaging.background.ts#L91).

To fix this forever for any calls to refresh the extension via `BrowserApi` I've moved the condition into that method instead of its references.

Unfortunately, this isn't testable via sideloaded extensions and is a bit of a shot in the dark. The original implementation seemed to fix some use cases, so there is evidence supporting the claim. The only concerning area is if there is a marked difference between checking for safari with `PlatformUtilsService` or `BrowserApi`, but there isn't. They both check if the user agent is Safari.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes