### PR TITLE
[PM-15937] ssh agent: fix first start when no .bitwarden-ssh-agent.sock exists

### DIFF
--- a/apps/desktop/desktop_native/core/src/ssh_agent/unix.rs
+++ b/apps/desktop/desktop_native/core/src/ssh_agent/unix.rs
@@ -65,7 +65,9 @@ impl BitwardenDesktopAgent {
                     "[SSH Agent Native Module] Could not remove existing socket file: {}",
                     e
                 );
-                return;
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    return;
+                }
             }
 
             match UnixListener::bind(sockname) {


### PR DESCRIPTION
## 🎟️ Tracking

#10825

## 📔 Objective

When starting the ssh-agent the first time on unix, the rust code tries to remove the previous ssh-agent socket. On first time setup, there is no file, so it fails. This change makes it fail gracefully when no file is found.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
