### PR TITLE
Add icon to popup

### DIFF
--- a/apps/browser/src/popup/index.ejs
+++ b/apps/browser/src/popup/index.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bitwarden</title>
     <base href="" />
+    <link rel="icon" type="image/png" href="../images/icon128.png">
   </head>
   <body>
     <app-root>


### PR DESCRIPTION
## 🎟️ Tracking

#12377 

## 📔 Objective

When installing extension as app, show the bitwarden icon

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/cd494073-99cd-4e70-a751-09998ce0720b)
Left (B) is original, right (BW icon) is with this edit applied to the unpacked extension

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
