### PR TITLE
[PM-13455] [PM-15498] Risk insights milestone one merge

### DIFF
--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
@@ -59,7 +59,6 @@ export class OrganizationLayoutComponent implements OnInit {
   showPaymentAndHistory$: Observable<boolean>;
   hideNewOrgButton$: Observable<boolean>;
   organizationIsUnmanaged$: Observable<boolean>;
-  isAccessIntelligenceFeatureEnabled = false;
   enterpriseOrganization$: Observable<boolean>;
 
   constructor(

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3900,6 +3900,9 @@
   "updateBrowser": {
     "message": "Update browser"
   },
+  "generatingRiskInsights": {
+    "message": "Generating your risk insights..."
+  },
   "updateBrowserDesc": {
     "message": "You are using an unsupported web browser. The web vault may not function properly."
   },

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/models/password-health.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/models/password-health.ts
@@ -25,7 +25,7 @@ export type ApplicationHealthReportDetail = {
   passwordCount: number;
   atRiskPasswordCount: number;
   memberCount: number;
-
+  atRiskMemberCount: number;
   memberDetails: MemberDetailsFlat[];
   atRiskMemberDetails: MemberDetailsFlat[];
 };

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/index.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./member-cipher-details-api.service";
 export * from "./password-health.service";
 export * from "./risk-insights-report.service";
+export * from "./risk-insights-data.service";

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-data.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-data.service.ts
@@ -1,53 +1,62 @@
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
-import { shareReplay } from "rxjs/operators";
+import { BehaviorSubject } from "rxjs";
+import { finalize } from "rxjs/operators";
 
 import { ApplicationHealthReportDetail } from "../models/password-health";
 
 import { RiskInsightsReportService } from "./risk-insights-report.service";
 
-/**
- * Singleton service to manage the report details for the Risk Insights reports.
- */
-@Injectable({
-  providedIn: "root",
-})
+@Injectable()
 export class RiskInsightsDataService {
-  // Map to store observables per organizationId
-  private applicationsReportMap = new Map<string, Observable<ApplicationHealthReportDetail[]>>();
+  private applicationsSubject = new BehaviorSubject<ApplicationHealthReportDetail[] | null>(null);
+
+  applications$ = this.applicationsSubject.asObservable();
+
+  private isLoadingSubject = new BehaviorSubject<boolean>(false);
+  isLoading$ = this.isLoadingSubject.asObservable();
+
+  private isRefreshingSubject = new BehaviorSubject<boolean>(false);
+  isRefreshing$ = this.isRefreshingSubject.asObservable();
+
+  private errorSubject = new BehaviorSubject<string | null>(null);
+  error$ = this.errorSubject.asObservable();
+
+  private dataLastUpdatedSubject = new BehaviorSubject<Date | null>(null);
+  dataLastUpdated$ = this.dataLastUpdatedSubject.asObservable();
 
   constructor(private reportService: RiskInsightsReportService) {}
 
   /**
-   * Returns an observable for the applications report of a given organizationId.
-   * Utilizes shareReplay to ensure that the data is fetched only once
-   * and shared among multiple subscribers.
+   * Fetches the applications report and updates the applicationsSubject.
    * @param organizationId The ID of the organization.
-   * @returns Observable of ApplicationHealthReportDetail[].
    */
-  getApplicationsReport$(organizationId: string): Observable<ApplicationHealthReportDetail[]> {
-    // If the observable for this organizationId already exists, return it
-    if (this.applicationsReportMap.has(organizationId)) {
-      return this.applicationsReportMap.get(organizationId)!;
+  fetchApplicationsReport(organizationId: string, isRefresh?: boolean): void {
+    if (isRefresh) {
+      this.isRefreshingSubject.next(true);
+    } else {
+      this.isLoadingSubject.next(true);
     }
-
-    const applicationsReport$ = this.reportService
+    this.reportService
       .generateApplicationsReport$(organizationId)
-      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
-
-    // Store the observable in the map for future subscribers
-    this.applicationsReportMap.set(organizationId, applicationsReport$);
-
-    return applicationsReport$;
+      .pipe(
+        finalize(() => {
+          this.isLoadingSubject.next(false);
+          this.isRefreshingSubject.next(false);
+          this.dataLastUpdatedSubject.next(new Date());
+        }),
+      )
+      .subscribe({
+        next: (reports: ApplicationHealthReportDetail[]) => {
+          this.applicationsSubject.next(reports);
+          this.errorSubject.next(null);
+        },
+        error: () => {
+          this.applicationsSubject.next([]);
+        },
+      });
   }
 
-  /**
-   * Clears the cached observable for a specific organizationId.
-   * @param organizationId The ID of the organization.
-   */
-  clearApplicationsReportCache(organizationId: string): void {
-    if (this.applicationsReportMap.has(organizationId)) {
-      this.applicationsReportMap.delete(organizationId);
-    }
+  refreshApplicationsReport(organizationId: string): void {
+    this.fetchApplicationsReport(organizationId, true);
   }
 }

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-data.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-data.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { shareReplay } from "rxjs/operators";
+
+import { ApplicationHealthReportDetail } from "../models/password-health";
+
+import { RiskInsightsReportService } from "./risk-insights-report.service";
+
+/**
+ * Singleton service to manage the report details for the Risk Insights reports.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class RiskInsightsDataService {
+  // Map to store observables per organizationId
+  private applicationsReportMap = new Map<string, Observable<ApplicationHealthReportDetail[]>>();
+
+  constructor(private reportService: RiskInsightsReportService) {}
+
+  /**
+   * Returns an observable for the applications report of a given organizationId.
+   * Utilizes shareReplay to ensure that the data is fetched only once
+   * and shared among multiple subscribers.
+   * @param organizationId The ID of the organization.
+   * @returns Observable of ApplicationHealthReportDetail[].
+   */
+  getApplicationsReport$(organizationId: string): Observable<ApplicationHealthReportDetail[]> {
+    // If the observable for this organizationId already exists, return it
+    if (this.applicationsReportMap.has(organizationId)) {
+      return this.applicationsReportMap.get(organizationId)!;
+    }
+
+    const applicationsReport$ = this.reportService
+      .generateApplicationsReport$(organizationId)
+      .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+    // Store the observable in the map for future subscribers
+    this.applicationsReportMap.set(organizationId, applicationsReport$);
+
+    return applicationsReport$;
+  }
+
+  /**
+   * Clears the cached observable for a specific organizationId.
+   * @param organizationId The ID of the organization.
+   */
+  clearApplicationsReportCache(organizationId: string): void {
+    if (this.applicationsReportMap.has(organizationId)) {
+      this.applicationsReportMap.delete(organizationId);
+    }
+  }
+}

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
@@ -290,6 +290,7 @@ export class RiskInsightsReportService {
         : newUriDetail.cipherMembers,
       atRiskMemberDetails: existingUriDetail ? existingUriDetail.atRiskMemberDetails : [],
       atRiskPasswordCount: existingUriDetail ? existingUriDetail.atRiskPasswordCount : 0,
+      atRiskMemberCount: existingUriDetail ? existingUriDetail.atRiskMemberDetails.length : 0,
     } as ApplicationHealthReportDetail;
 
     if (isAtRisk) {

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
@@ -24,6 +24,8 @@ import {
 
 import { MemberCipherDetailsApiService } from "./member-cipher-details-api.service";
 
+// FIXME: Update this file to be type safe
+// @ts-strict-ignore
 @Injectable()
 export class RiskInsightsReportService {
   constructor(

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
@@ -24,8 +24,6 @@ import {
 
 import { MemberCipherDetailsApiService } from "./member-cipher-details-api.service";
 
-// FIXME: Update this file to be type safe
-// @ts-strict-ignore
 @Injectable()
 export class RiskInsightsReportService {
   constructor(

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
@@ -1,11 +1,11 @@
-<div *ngIf="loading">
+<div *ngIf="isLoading$ | async">
   <tools-risk-insights-loading></tools-risk-insights-loading>
 </div>
-<div class="tw-mt-4" *ngIf="!loading && !dataSource.data.length">
+<div class="tw-mt-4" *ngIf="!(isLoading$ | async) && !dataSource.data.length">
   <bit-no-items [icon]="noItemsIcon" class="tw-text-main">
     <ng-container slot="title">
       <h2 class="tw-font-semibold mt-4">
-        {{ "noAppsInOrgTitle" | i18n: organization.name }}
+        {{ "noAppsInOrgTitle" | i18n: organization?.name }}
       </h2>
     </ng-container>
     <ng-container slot="description">
@@ -23,7 +23,7 @@
     </ng-container>
   </bit-no-items>
 </div>
-<div class="tw-mt-4 tw-flex tw-flex-col" *ngIf="!loading && dataSource.data.length">
+<div class="tw-mt-4 tw-flex tw-flex-col" *ngIf="!(isLoading$ | async) && dataSource.data.length">
   <h2 class="tw-mb-6" bitTypography="h2">{{ "allApplications" | i18n }}</h2>
   <div class="tw-flex tw-gap-6">
     <tools-card

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
@@ -1,12 +1,7 @@
 <div *ngIf="loading">
-  <i
-    class="bwi bwi-spinner bwi-spin tw-text-muted"
-    title="{{ 'loading' | i18n }}"
-    aria-hidden="true"
-  ></i>
-  <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  <tools-risk-insights-loading></tools-risk-insights-loading>
 </div>
-<div class="tw-mt-4" *ngIf="!dataSource.data.length">
+<div class="tw-mt-4" *ngIf="!loading && !dataSource.data.length">
   <bit-no-items [icon]="noItemsIcon" class="tw-text-main">
     <ng-container slot="title">
       <h2 class="tw-font-semibold mt-4">
@@ -34,15 +29,15 @@
     <tools-card
       class="tw-flex-1"
       [title]="'atRiskMembers' | i18n"
-      [value]="mockAtRiskMembersCount"
-      [maxValue]="mockTotalMembersCount"
+      [value]="applicationSummary.totalAtRiskMemberCount"
+      [maxValue]="applicationSummary.totalMemberCount"
     >
     </tools-card>
     <tools-card
       class="tw-flex-1"
       [title]="'atRiskApplications' | i18n"
-      [value]="mockAtRiskAppsCount"
-      [maxValue]="mockTotalAppsCount"
+      [value]="applicationSummary.totalAtRiskApplicationCount"
+      [maxValue]="applicationSummary.totalApplicationCount"
     >
     </tools-card>
   </div>
@@ -57,7 +52,7 @@
       type="button"
       buttonType="secondary"
       bitButton
-      *ngIf="isCritialAppsFeatureEnabled"
+      *ngIf="isCriticalAppsFeatureEnabled"
       [disabled]="!selectedIds.size"
       [loading]="markingAsCritical"
       (click)="markAppsAsCritical()"
@@ -69,7 +64,7 @@
   <bit-table [dataSource]="dataSource">
     <ng-container header>
       <tr>
-        <th *ngIf="isCritialAppsFeatureEnabled"></th>
+        <th *ngIf="isCriticalAppsFeatureEnabled"></th>
         <th bitSortable="name" bitCell>{{ "application" | i18n }}</th>
         <th bitSortable="atRiskPasswords" bitCell>{{ "atRiskPasswords" | i18n }}</th>
         <th bitSortable="totalPasswords" bitCell>{{ "totalPasswords" | i18n }}</th>
@@ -79,7 +74,7 @@
     </ng-container>
     <ng-template body let-rows$>
       <tr bitRow *ngFor="let r of rows$ | async; trackBy: trackByFunction">
-        <td *ngIf="isCritialAppsFeatureEnabled">
+        <td *ngIf="isCriticalAppsFeatureEnabled">
           <input
             bitCheckbox
             type="checkbox"
@@ -88,25 +83,26 @@
           />
         </td>
         <td bitCell>
-          <span>{{ r.name }}</span>
+          <span>{{ r.applicationName }}</span>
         </td>
         <td bitCell>
           <span>
-            {{ r.atRiskPasswords }}
+            {{ r.atRiskPasswordCount }}
           </span>
         </td>
         <td bitCell>
           <span>
-            {{ r.totalPasswords }}
+            {{ r.passwordCount }}
           </span>
         </td>
         <td bitCell>
           <span>
-            {{ r.atRiskMembers }}
+            {{ r.atRiskMemberCount }}
           </span>
         </td>
+        w
         <td bitCell data-testid="total-membership">
-          {{ r.totalMembers }}
+          {{ r.memberCount }}
         </td>
       </tr>
     </ng-template>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.html
@@ -65,11 +65,11 @@
     <ng-container header>
       <tr>
         <th *ngIf="isCriticalAppsFeatureEnabled"></th>
-        <th bitSortable="name" bitCell>{{ "application" | i18n }}</th>
-        <th bitSortable="atRiskPasswords" bitCell>{{ "atRiskPasswords" | i18n }}</th>
-        <th bitSortable="totalPasswords" bitCell>{{ "totalPasswords" | i18n }}</th>
-        <th bitSortable="atRiskMembers" bitCell>{{ "atRiskMembers" | i18n }}</th>
-        <th bitSortable="totalMembers" bitCell>{{ "totalMembers" | i18n }}</th>
+        <th bitSortable="applicationName" bitCell>{{ "application" | i18n }}</th>
+        <th bitSortable="atRiskPasswordCount" bitCell>{{ "atRiskPasswords" | i18n }}</th>
+        <th bitSortable="passwordCount" bitCell>{{ "totalPasswords" | i18n }}</th>
+        <th bitSortable="atRiskMemberCount" bitCell>{{ "atRiskMembers" | i18n }}</th>
+        <th bitSortable="memberCount" bitCell>{{ "totalMembers" | i18n }}</th>
       </tr>
     </ng-container>
     <ng-template body let-rows$>
@@ -100,7 +100,6 @@
             {{ r.atRiskMemberCount }}
           </span>
         </td>
-        w
         <td bitCell data-testid="total-membership">
           {{ r.memberCount }}
         </td>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.ts
@@ -2,7 +2,7 @@ import { Component, DestroyRef, OnDestroy, OnInit, inject } from "@angular/core"
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { debounceTime, map, Observable, Subscription } from "rxjs";
+import { debounceTime, map, Observable, of, Subscription } from "rxjs";
 
 import {
   RiskInsightsDataService,
@@ -52,14 +52,14 @@ export class AllApplicationsComponent implements OnInit, OnDestroy {
   protected selectedIds: Set<number> = new Set<number>();
   protected searchControl = new FormControl("", { nonNullable: true });
   protected loading = true;
-  protected organization: Organization;
+  protected organization = {} as Organization;
   noItemsIcon = Icons.Security;
   protected markingAsCritical = false;
-  protected applicationSummary: ApplicationHealthReportSummary;
-  private subscription: Subscription;
+  protected applicationSummary = {} as ApplicationHealthReportSummary;
+  private subscription = new Subscription();
 
   destroyRef = inject(DestroyRef);
-  isLoading$: Observable<boolean>;
+  isLoading$: Observable<boolean> = of(false);
   isCriticalAppsFeatureEnabled = false;
 
   async ngOnInit() {
@@ -110,7 +110,7 @@ export class AllApplicationsComponent implements OnInit, OnDestroy {
     // TODO: implement
     this.toastService.showToast({
       variant: "warning",
-      title: null,
+      title: "",
       message: "Not yet implemented",
     });
   };
@@ -123,7 +123,7 @@ export class AllApplicationsComponent implements OnInit, OnDestroy {
         this.selectedIds.clear();
         this.toastService.showToast({
           variant: "success",
-          title: null,
+          title: "",
           message: this.i18nService.t("appsMarkedAsCritical"),
         });
         resolve(true);

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/all-applications.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Component, DestroyRef, inject, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
@@ -15,14 +13,11 @@ import {
   ApplicationHealthReportDetail,
   ApplicationHealthReportSummary,
 } from "@bitwarden/bit-common/tools/reports/risk-insights/models/password-health";
-import { AuditService } from "@bitwarden/common/abstractions/audit.service";
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   Icons,
   NoItemsModule,
@@ -82,6 +77,8 @@ export class AllApplicationsComponent implements OnInit {
         next: (applications: ApplicationHealthReportDetail[]) => {
           if (applications) {
             this.dataSource.data = applications;
+            const summary = this.reportService.generateApplicationsSummary(applications);
+            this.applicationSummary = summary;
             this.loading = false;
           }
         },
@@ -90,14 +87,12 @@ export class AllApplicationsComponent implements OnInit {
 
   constructor(
     protected cipherService: CipherService,
-    protected riskInsightsReportService: RiskInsightsReportService,
-    protected auditService: AuditService,
     protected i18nService: I18nService,
     protected activatedRoute: ActivatedRoute,
     protected toastService: ToastService,
-    protected organizationService: OrganizationService,
     protected configService: ConfigService,
     protected dataService: RiskInsightsDataService,
+    protected reportService: RiskInsightsReportService,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(200), takeUntilDestroyed())
@@ -130,8 +125,8 @@ export class AllApplicationsComponent implements OnInit {
     });
   };
 
-  trackByFunction(_: number, item: CipherView) {
-    return item.id;
+  trackByFunction(_: number, item: ApplicationHealthReportDetail) {
+    return item.applicationName;
   }
 
   onCheckboxChange(id: number, event: Event) {

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.html
@@ -1,0 +1,8 @@
+<div class="tw-flex-col tw-flex tw-justify-center tw-items-center tw-gap-5 tw-mt-4">
+  <i
+    class="bwi bwi-2x bwi-spinner bwi-spin text-primary"
+    title="{{ 'loading' | i18n }}"
+    aria-hidden="true"
+  ></i>
+  <h2 bitTypography="h1">{{ "generatingRiskInsights" | i18n }}</h2>
+</div>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+
+@Component({
+  selector: "tools-risk-insights-loading",
+  standalone: true,
+  imports: [CommonModule, JslibModule],
+  templateUrl: "./risk-insights-loading.component.html",
+})
+export class ApplicationsLoadingComponent {
+  constructor() {}
+}

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="loading">
+<div *ngIf="isLoading$ | async">
   <i
     class="bwi bwi-spinner bwi-spin tw-text-muted"
     title="{{ 'loading' | i18n }}"
@@ -6,7 +6,7 @@
   ></i>
   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
 </div>
-<ng-container *ngIf="!loading">
+<ng-container *ngIf="!(isLoading$ | async)">
   <div class="tw-mb-1 text-primary" bitTypography="body1">{{ "accessIntelligence" | i18n }}</div>
   <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
   <div class="tw-text-muted tw-max-w-4xl tw-mb-2">
@@ -21,11 +21,11 @@
       aria-hidden="true"
     ></i>
     <span class="tw-mx-4">{{
-      "dataLastUpdated" | i18n: (dataLastUpdated | date: "MMMM d, y 'at' h:mm a")
+      "dataLastUpdated" | i18n: (dataLastUpdated$ | async | date: "MMMM d, y 'at' h:mm a")
     }}</span>
     <span class="tw-flex tw-justify-center tw-w-16">
       <a
-        *ngIf="!refetching"
+        *ngIf="!(isRefreshing$ | async)"
         bitButton
         buttonType="unstyled"
         class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
@@ -35,7 +35,7 @@
       </a>
       <span>
         <i
-          *ngIf="refetching"
+          *ngIf="isRefreshing$ | async"
           class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
           aria-hidden="true"
         ></i>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
@@ -1,12 +1,4 @@
-<div *ngIf="isLoading$ | async">
-  <i
-    class="bwi bwi-spinner bwi-spin tw-text-muted"
-    title="{{ 'loading' | i18n }}"
-    aria-hidden="true"
-  ></i>
-  <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-</div>
-<ng-container *ngIf="!(isLoading$ | async)">
+<ng-container>
   <div class="tw-mb-1 text-primary" bitTypography="body1">{{ "accessIntelligence" | i18n }}</div>
   <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
   <div class="tw-text-muted tw-max-w-4xl tw-mb-2">

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
@@ -1,49 +1,66 @@
-<div class="tw-mb-1 text-primary" bitTypography="body1">{{ "accessIntelligence" | i18n }}</div>
-<h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
-<div class="tw-text-muted tw-max-w-4xl tw-mb-2">
-  {{ "reviewAtRiskPasswords" | i18n }}
-  &nbsp;<a class="text-primary" routerLink="/login">{{ "learnMore" | i18n }}</a>
+<div *ngIf="loading">
+  <i
+    class="bwi bwi-spinner bwi-spin tw-text-muted"
+    title="{{ 'loading' | i18n }}"
+    aria-hidden="true"
+  ></i>
+  <span class="tw-sr-only">{{ "loading" | i18n }}</span>
 </div>
-<div class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-2 tw-my-4">
-  <i class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] text-muted" aria-hidden="true"></i>
-  <span class="tw-mx-4">{{
-    "dataLastUpdated" | i18n: (dataLastUpdated | date: "MMMM d, y 'at' h:mm a")
-  }}</span>
-  <a
-    bitButton
-    buttonType="unstyled"
-    class="tw-border-none !tw-font-normal tw-cursor-pointer"
-    [bitAction]="refreshData.bind(this)"
+<ng-container *ngIf="!loading">
+  <div class="tw-mb-1 text-primary" bitTypography="body1">{{ "accessIntelligence" | i18n }}</div>
+  <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
+  <div class="tw-text-muted tw-max-w-4xl tw-mb-2">
+    {{ "reviewAtRiskPasswords" | i18n }}
+    &nbsp;<a class="text-primary" routerLink="/login">{{ "learnMore" | i18n }}</a>
+  </div>
+  <div
+    class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
   >
-    {{ "refresh" | i18n }}
-  </a>
-</div>
-<bit-tab-group [(selectedIndex)]="tabIndex" (selectedIndexChange)="onTabChange($event)">
-  <bit-tab label="{{ 'allApplicationsWithCount' | i18n: apps.length }}">
-    <tools-all-applications></tools-all-applications>
-  </bit-tab>
-  <bit-tab *ngIf="isCritialAppsFeatureEnabled">
-    <ng-template bitTabLabel>
-      <i class="bwi bwi-star"></i>
-      {{ "criticalApplicationsWithCount" | i18n: criticalApps.length }}
-    </ng-template>
-    <tools-critical-applications></tools-critical-applications>
-  </bit-tab>
-  <bit-tab label="Raw Data">
-    <tools-password-health></tools-password-health>
-  </bit-tab>
-  <bit-tab label="Raw Data + members">
-    <tools-password-health-members></tools-password-health-members>
-  </bit-tab>
-  <bit-tab label="Raw Data + uri">
-    <tools-password-health-members-uri></tools-password-health-members-uri>
-  </bit-tab>
-  <!-- <bit-tab>
-    <ng-template bitTabLabel>
-      <i class="bwi bwi-envelope"></i>
-      {{ "notifiedMembersWithCount" | i18n: priorityApps.length }}
-    </ng-template>
-    <h2 bitTypography="h2">{{ "notifiedMembers" | i18n }}</h2>
-    <tools-notified-members-table></tools-notified-members-table>
-  </bit-tab> -->
-</bit-tab-group>
+    <i
+      class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] text-muted"
+      aria-hidden="true"
+    ></i>
+    <span class="tw-mx-4">{{
+      "dataLastUpdated" | i18n: (dataLastUpdated | date: "MMMM d, y 'at' h:mm a")
+    }}</span>
+    <span class="tw-flex tw-justify-center tw-w-16">
+      <a
+        *ngIf="!refetching"
+        bitButton
+        buttonType="unstyled"
+        class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
+        [bitAction]="refreshData.bind(this)"
+      >
+        {{ "refresh" | i18n }}
+      </a>
+      <span>
+        <i
+          *ngIf="refetching"
+          class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
+          aria-hidden="true"
+        ></i>
+      </span>
+    </span>
+  </div>
+  <bit-tab-group [(selectedIndex)]="tabIndex" (selectedIndexChange)="onTabChange($event)">
+    <bit-tab label="{{ 'allApplicationsWithCount' | i18n: appsCount }}">
+      <tools-all-applications></tools-all-applications>
+    </bit-tab>
+    <bit-tab *ngIf="isCriticalAppsFeatureEnabled">
+      <ng-template bitTabLabel>
+        <i class="bwi bwi-star"></i>
+        {{ "criticalApplicationsWithCount" | i18n: criticalAppsCount }}
+      </ng-template>
+      <tools-critical-applications></tools-critical-applications>
+    </bit-tab>
+    <bit-tab label="Raw Data">
+      <tools-password-health></tools-password-health>
+    </bit-tab>
+    <bit-tab label="Raw Data + members">
+      <tools-password-health-members></tools-password-health-members>
+    </bit-tab>
+    <bit-tab label="Raw Data + uri">
+      <tools-password-health-members-uri></tools-password-health-members-uri>
+    </bit-tab>
+  </bit-tab-group>
+</ng-container>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.ts
@@ -47,7 +47,7 @@ export enum RiskInsightsTabType {
     NotifiedMembersTableComponent,
     TabsModule,
   ],
-  providers: [RiskInsightsReportService, MemberCipherDetailsApiService],
+  providers: [RiskInsightsReportService, MemberCipherDetailsApiService, RiskInsightsDataService],
 })
 export class RiskInsightsComponent implements OnInit {
   tabIndex: RiskInsightsTabType = RiskInsightsTabType.AllApps;
@@ -96,7 +96,7 @@ export class RiskInsightsComponent implements OnInit {
             this.dataLastUpdated$ = this.dataService.dataLastUpdated$;
             return this.dataService.applications$;
           } else {
-            return EMPTY; // Ensures switchMap always returns an Observable
+            return EMPTY;
           }
         }),
       )
@@ -104,7 +104,6 @@ export class RiskInsightsComponent implements OnInit {
         next: (applications: ApplicationHealthReportDetail[] | null) => {
           if (applications) {
             this.appsCount = applications.length;
-            // Optionally, you can calculate other counts here or in child components
           }
         },
       });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13455
https://bitwarden.atlassian.net/browse/PM-15498


## 📔 Objective

Bringing this in here to combine multiple PRs that need to be merged on top of each other. This will serve as a final PR. Combines the following PRs. 

https://github.com/bitwarden/clients/pull/12361 Creates a singleton to manage the observables for the report calls so the risk insights component and the all applications component don't make multiple calls: 

https://github.com/bitwarden/clients/pull/12254 handles the access intelligence module and initializing the risk insights report

https://github.com/bitwarden/clients/pull/12254 wiring up the UI to use the risk insights report model types. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
