### PR TITLE
Slight codeowners change for ssh agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,7 +105,8 @@ apps/desktop/macos/autofill-extension @bitwarden/team-autofill-dev
 # DuckDuckGo integration
 apps/desktop/native-messaging-test-runner @bitwarden/team-autofill-dev
 apps/desktop/src/services/duckduckgo-message-handler.service.ts @bitwarden/team-autofill-dev
-
+# SSH Agent
+apps/desktop/desktop_native/core/src/ssh_agent @bitwarden/team-autofill-dev @bitwarden/wg-ssh-keys
 
 ## Component Library ##
 .storybook @bitwarden/team-design-system
@@ -137,9 +138,6 @@ apps/browser/store/locales/en
 apps/cli/src/locales/en/messages.json
 apps/desktop/src/locales/en/messages.json
 apps/web/src/locales/en/messages.json
-
-## Ssh agent temporary co-codeowner
-apps/desktop/desktop_native/core/src/ssh_agent @bitwarden/team-platform-dev @bitwarden/wg-ssh-keys @bitwarden/team-autofill-dev
 
 ## BRE team owns these workflows ##
 .github/workflows/brew-bump-desktop.yml @bitwarden/dept-bre


### PR DESCRIPTION
## 📔 Objective

I didn't realize auto merge was on for [this PR](https://github.com/bitwarden/clients/pull/12365).

Just a small thing related to my comment [here](https://github.com/bitwarden/clients/pull/12365#discussion_r1884538621): any worth in moving this under the Autofill team section? We can keep platform if desired, wasn't sure if they were retaining ownership or not. (I can definitely add them back, so no problem either way.)

I made this PR more as a proposal, so no big deal.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
