### PR TITLE
[PM-8220] Show toasts for other 400 responses

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -228,11 +228,14 @@ export class LoginComponent implements OnInit, OnDestroy {
                 message: this.i18nService.t("invalidMasterPassword"),
               },
             });
+          } else {
+            // Allow other 400 responses to be handled by toast
+            this.validationService.showError(error);
           }
           break;
         }
         default: {
-          // Allow all other errors to be handled by toast
+          // Allow all other error codes to be handled by toast
           this.validationService.showError(error);
         }
       }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-8220](https://bitwarden.atlassian.net/browse/PM-8220)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When a 400-error comes back from the server the password login flow assumes it's a bad password. We are now sending 400s when a user is required to use SSO to login. This allows that toast to display.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Show toast when SSO required; Show master password error under input box

https://github.com/user-attachments/assets/b2cbee73-2e7e-466d-8832-440cd7bedc66

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8220]: https://bitwarden.atlassian.net/browse/PM-8220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ