### PR TITLE
[PM-15903] Fix icon alignment in members component options

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -148,7 +148,7 @@
                   *ngIf="showBulkRemoveUsers"
                 >
                   <span class="tw-text-danger">
-                    <i aria-hidden="true" class="bwi bwi-close"></i>
+                    <i aria-hidden="true" class="bwi bwi-fw bwi-close"></i>
                     {{ "remove" | i18n }}
                   </span>
                 </button>
@@ -159,7 +159,7 @@
                   *ngIf="showBulkDeleteUsers"
                 >
                   <span class="tw-text-danger">
-                    <i aria-hidden="true" class="bwi bwi-trash"></i>
+                    <i aria-hidden="true" class="bwi bwi-fw bwi-trash"></i>
                     {{ "delete" | i18n }}
                   </span>
                 </button>
@@ -358,7 +358,7 @@
                   (click)="deleteUser(u)"
                 >
                   <span class="tw-text-danger">
-                    <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
+                    <i class="bwi bwi-trash" aria-hidden="true"></i>
                     {{ "delete" | i18n }}
                   </span>
                 </button>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15903

## 📔 Objective

The icons for bulk remove, bulk delete, and individual delete buttons are misaligned due to missing css classes.

## 📸 Screenshots

Bulk remove and delete:
<img width="205" alt="image" src="https://github.com/user-attachments/assets/d2e58a4e-f6fb-4cac-8b0d-9175489d6347" />

Individual delete: 
<img width="165" alt="image" src="https://github.com/user-attachments/assets/88157ddb-55f4-4962-a393-a31f6def86d9" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
