### PR TITLE
[PM-16094] Remove lowercasing of vault page headers titles

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -326,15 +326,15 @@ export class AddEditV2Component implements OnInit {
 
     switch (type) {
       case CipherType.Login:
-        return this.i18nService.t(partOne, this.i18nService.t("typeLogin").toLocaleLowerCase());
+        return this.i18nService.t(partOne, this.i18nService.t("typeLogin"));
       case CipherType.Card:
-        return this.i18nService.t(partOne, this.i18nService.t("typeCard").toLocaleLowerCase());
+        return this.i18nService.t(partOne, this.i18nService.t("typeCard"));
       case CipherType.Identity:
-        return this.i18nService.t(partOne, this.i18nService.t("typeIdentity").toLocaleLowerCase());
+        return this.i18nService.t(partOne, this.i18nService.t("typeIdentity"));
       case CipherType.SecureNote:
-        return this.i18nService.t(partOne, this.i18nService.t("note").toLocaleLowerCase());
+        return this.i18nService.t(partOne, this.i18nService.t("note"));
       case CipherType.SshKey:
-        return this.i18nService.t(partOne, this.i18nService.t("typeSshKey").toLocaleLowerCase());
+        return this.i18nService.t(partOne, this.i18nService.t("typeSshKey"));
     }
   }
 }

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -137,21 +137,21 @@ describe("ViewV2Component", () => {
       params$.next({ cipherId: mockCipher.id });
       flush(); // Resolve all promises
 
-      expect(component.headerText).toEqual("viewItemHeader typelogin");
+      expect(component.headerText).toEqual("viewItemHeader typeLogin");
 
       // Set header text for a card
       mockCipher.type = CipherType.Card;
       params$.next({ cipherId: mockCipher.id });
       flush(); // Resolve all promises
 
-      expect(component.headerText).toEqual("viewItemHeader typecard");
+      expect(component.headerText).toEqual("viewItemHeader typeCard");
 
       // Set header text for an identity
       mockCipher.type = CipherType.Identity;
       params$.next({ cipherId: mockCipher.id });
       flush(); // Resolve all promises
 
-      expect(component.headerText).toEqual("viewItemHeader typeidentity");
+      expect(component.headerText).toEqual("viewItemHeader typeIdentity");
 
       // Set header text for a secure note
       mockCipher.type = CipherType.SecureNote;

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -146,18 +146,15 @@ export class ViewV2Component {
   setHeader(type: CipherType) {
     switch (type) {
       case CipherType.Login:
-        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeLogin").toLowerCase());
+        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeLogin"));
       case CipherType.Card:
-        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeCard").toLowerCase());
+        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeCard"));
       case CipherType.Identity:
-        return this.i18nService.t(
-          "viewItemHeader",
-          this.i18nService.t("typeIdentity").toLowerCase(),
-        );
+        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeIdentity"));
       case CipherType.SecureNote:
-        return this.i18nService.t("viewItemHeader", this.i18nService.t("note").toLowerCase());
+        return this.i18nService.t("viewItemHeader", this.i18nService.t("note"));
       case CipherType.SshKey:
-        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeSshkey").toLowerCase());
+        return this.i18nService.t("viewItemHeader", this.i18nService.t("typeSshkey"));
     }
   }
 

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -419,19 +419,19 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
 
     switch (type) {
       case CipherType.Login:
-        this.title = this.i18nService.t(partOne, this.i18nService.t("typeLogin").toLowerCase());
+        this.title = this.i18nService.t(partOne, this.i18nService.t("typeLogin"));
         break;
       case CipherType.Card:
-        this.title = this.i18nService.t(partOne, this.i18nService.t("typeCard").toLowerCase());
+        this.title = this.i18nService.t(partOne, this.i18nService.t("typeCard"));
         break;
       case CipherType.Identity:
-        this.title = this.i18nService.t(partOne, this.i18nService.t("typeIdentity").toLowerCase());
+        this.title = this.i18nService.t(partOne, this.i18nService.t("typeIdentity"));
         break;
       case CipherType.SecureNote:
-        this.title = this.i18nService.t(partOne, this.i18nService.t("note").toLowerCase());
+        this.title = this.i18nService.t(partOne, this.i18nService.t("note"));
         break;
       case CipherType.SshKey:
-        this.title = this.i18nService.t(partOne, this.i18nService.t("typeSshKey").toLowerCase());
+        this.title = this.i18nService.t(partOne, this.i18nService.t("typeSshKey"));
         break;
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16094

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Nouns in different languages are capitalized. The `.toLowerCase()` used within the header overrides the translation which takes care of language-specific capitalization.

This was initially observed when using the German extension/web-vault

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before
![image](https://github.com/user-attachments/assets/1f6ff831-b4eb-4fd3-9957-31665ef4b886)
![image](https://github.com/user-attachments/assets/7c24ddd1-3da7-4152-9121-ca6159a0eaa6)

![image](https://github.com/user-attachments/assets/2b683645-5d82-4dd7-b612-6167f0427ff2)
![image](https://github.com/user-attachments/assets/882c4534-8871-4d3f-a047-4d41a387ef3c)

### After
![image](https://github.com/user-attachments/assets/ce68cca3-d443-4e73-b2ee-69dee5aeb6a8)
![image](https://github.com/user-attachments/assets/f9c62231-17a9-4836-9b09-495f65f7f2ff)

![image](https://github.com/user-attachments/assets/faf39ae5-33d7-44fd-99ba-e8a2dd751c1e)
![image](https://github.com/user-attachments/assets/4d960d74-a908-48c3-a70a-a4c3d50e1cf4)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
