### PR TITLE
[PM-15945] Add logout option to TDE approval screen

### DIFF
--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.html
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.html
@@ -56,5 +56,9 @@
     >
       {{ "requestAdminApproval" | i18n }}
     </button>
+
+    <button type="button" bitButton bitFormButton block (click)="logOut()">
+      {{ "logOut" | i18n }}
+    </button>
   </div>
 </ng-container>

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
@@ -30,6 +30,7 @@ import {
   AsyncActionsModule,
   ButtonModule,
   CheckboxModule,
+  DialogService,
   FormFieldModule,
   ToastService,
   TypographyModule,
@@ -90,6 +91,7 @@ export class LoginDecryptionOptionsComponent implements OnInit {
     private apiService: ApiService,
     private destroyRef: DestroyRef,
     private deviceTrustService: DeviceTrustServiceAbstraction,
+    private dialogService: DialogService,
     private formBuilder: FormBuilder,
     private i18nService: I18nService,
     private keyService: KeyService,
@@ -297,5 +299,19 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   protected async requestAdminApproval() {
     this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["/admin-approval-requested"]);
+  }
+
+  async logOut() {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "logOut" },
+      content: { key: "logOutConfirmation" },
+      acceptButtonText: { key: "logOut" },
+      type: "warning",
+    });
+
+    const userId = (await firstValueFrom(this.accountService.activeAccount$))?.id;
+    if (confirmed) {
+      this.messagingService.send("logout", { userId: userId });
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15945

## 📔 Objective

This PR adds a logout option to the TDE approval screen. A TDE user on this page cannot use the "Back" button or click the Bitwarden logo to navigate back to `/` because the user is currently authenticated, which means that navigating to the `/` route would activate the [redirectGuard](https://github.com/bitwarden/clients/blob/main/libs/angular/src/auth/guards/redirect.guard.ts#L60) and simply route the user back to `/login-initiated`. So we must log the user out first before routing.

## 📸 Screenshots

https://github.com/user-attachments/assets/18b4487b-f0fe-41ad-b5b6-daff95796c6b

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
