### PR TITLE
[PM-15571] Help link on import vault

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -3,7 +3,7 @@
   "version": "2024.12.2",
   "scripts": {
     "build": "npm run build:chrome",
-    "build:chrome": "cross-env BROWSER=chrome MANIFEST_VERSION=3 webpack",
+    "build:chrome": "cross-env BROWSER=chrome NODE_OPTIONS=\"--max-old-space-size=8192\" MANIFEST_VERSION=3 webpack",
     "build:edge": "cross-env BROWSER=edge webpack",
     "build:firefox": "cross-env BROWSER=firefox webpack",
     "build:opera": "cross-env BROWSER=opera webpack",

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -3,7 +3,7 @@
   "version": "2024.12.2",
   "scripts": {
     "build": "npm run build:chrome",
-    "build:chrome": "cross-env BROWSER=chrome NODE_OPTIONS=\"--max-old-space-size=8192\" MANIFEST_VERSION=3 webpack",
+    "build:chrome": "cross-env BROWSER=chrome MANIFEST_VERSION=3 webpack",
     "build:edge": "cross-env BROWSER=edge webpack",
     "build:firefox": "cross-env BROWSER=firefox webpack",
     "build:opera": "cross-env BROWSER=opera webpack",

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -80,7 +80,13 @@
       <bit-callout type="info" title="{{ getFormatInstructionTitle() }}" *ngIf="format">
         <ng-container *ngIf="format === 'bitwardencsv' || format === 'bitwardenjson'">
           See detailed instructions on our help site at
-          <a target="_blank" rel="noreferrer" href="https://bitwarden.com/help/export-your-data/">
+          <a
+            bitLink
+            linkType="primary"
+            target="_blank"
+            rel="noreferrer"
+            href="https://bitwarden.com/help/export-your-data/"
+          >
             https://bitwarden.com/help/export-your-data/</a
           >
         </ng-container>

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -53,6 +53,7 @@ import {
   SectionHeaderComponent,
   SelectModule,
   ToastService,
+  LinkModule,
 } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
 
@@ -115,6 +116,7 @@ const safeProviders: SafeProvider[] = [
     ContainerComponent,
     SectionHeaderComponent,
     SectionComponent,
+    LinkModule,
   ],
   providers: safeProviders,
 })


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15571
## 📔 Objective

This PR fixes a styling issue where the Bitwarden help link on the Import Vault page was not readable in Dark Mode due to poor color contrast on Extension. 
The bit-link directive with the appropriate linkType has been applied to resolve this issue.

## 📸 Screenshots

<img width="400" alt="Screenshot_53" src="https://github.com/user-attachments/assets/077a7867-844e-4ebe-ad90-f7435e9712ab" />
<img width="400" alt="Screenshot_54" src="https://github.com/user-attachments/assets/71a6f12b-0c84-4860-8b27-81254f808001" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
