### PR TITLE
Update Password history button label to Generator history

### DIFF
--- a/apps/desktop/src/main/menu/menu.view.ts
+++ b/apps/desktop/src/main/menu/menu.view.ts
@@ -76,7 +76,7 @@ export class ViewMenu implements IMenubarMenu {
   private get passwordHistory(): MenuItemConstructorOptions {
     return {
       id: "passwordHistory",
-      label: this.localize("passwordHistory"),
+      label: this.localize("generatorHistory"),
       click: () => this.sendMessage("openPasswordHistory"),
       enabled: !this._isLocked,
     };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16046

## 📔 Objective

This PR updates the label of the "Password history" button in the desktop app menu to "Generator history". This change ensures consistency with the rest of the app's terminology.

## 📸 Screenshots

<img width="1205" alt="Screenshot 2024-12-13 at 13 39 23" src="https://github.com/user-attachments/assets/8a036b42-4444-43ce-9da1-a5976b426c8c" />
<img width="1205" alt="Screenshot_52" src="https://github.com/user-attachments/assets/421d1980-6fd8-44d9-aa30-98117822bf6e" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
