### PR TITLE
[PM-13737] Fix installation ID missing in events by returning an object with the 'name' property instead of a string

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/events.component.ts
@@ -131,7 +131,9 @@ export class EventsComponent extends BaseEventsComponent implements OnInit, OnDe
 
   protected getUserName(r: EventResponse, userId: string) {
     if (r.installationId != null) {
-      return `Installation: ${r.installationId}`;
+      return {
+        name: `Installation: ${r.installationId}`,
+      };
     }
 
     if (userId != null) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13737

## 📔 Objective

> When a F4E sponsorship sync happens, an event is logged in the corresponding Cloud organization, but the installation ID is not included in that event log

The issue occurred because the `getUserName` method was expected to return an object, but it returned a string when handling the installation ID.

## 📸 Screenshots

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/39f739f2-7e22-437d-90d0-d2dcf3d63eff" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
