### PR TITLE
Fix Strict Type: Emergency View Dialog

### DIFF
--- a/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
+++ b/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
@@ -40,7 +40,7 @@ export class EmergencyViewDialogComponent {
    * The title of the dialog. Updates based on the cipher type.
    * @protected
    */
-  protected title: string;
+  protected title: string = "";
 
   constructor(
     @Inject(DIALOG_DATA) protected params: EmergencyViewDialogParams,


### PR DESCRIPTION
## 📔 Objective

https://github.com/bitwarden/clients/pull/12054 was an older PR that was raised before strict typing was enabled but merged after it was enabled. One property to add a default value to for all strict typing to pass.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
