### PR TITLE
[PM-16262] Make `getEnvironment` observable and use it in SdkService

### DIFF
--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -128,5 +128,10 @@ export abstract class EnvironmentService {
   /**
    * Get the environment from state. Useful if you need to get the environment for another user.
    */
+  abstract getEnvironment$(userId?: string): Observable<Environment | undefined>;
+
+  /**
+   * @deprecated Use {@link getEnvironment$} instead.
+   */
   abstract getEnvironment(userId?: string): Promise<Environment | undefined>;
 }

--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -314,7 +314,7 @@ describe("EnvironmentService", () => {
 
       await switchUser(testUser);
 
-      const env = await sut.getEnvironment();
+      const env = await firstValueFrom(sut.getEnvironment$());
       expect(env.getHostname()).toBe(expectedHost);
     });
 
@@ -325,7 +325,7 @@ describe("EnvironmentService", () => {
       setGlobalData(region, new EnvironmentUrls());
       setUserData(Region.US, new EnvironmentUrls());
 
-      const env = await sut.getEnvironment();
+      const env = await firstValueFrom(sut.getEnvironment$());
       expect(env.getHostname()).toBe(expectedHost);
     });
 
@@ -338,7 +338,7 @@ describe("EnvironmentService", () => {
         setGlobalData(region, new EnvironmentUrls());
         setUserData(Region.US, new EnvironmentUrls());
 
-        const env = await sut.getEnvironment(testUser);
+        const env = await firstValueFrom(sut.getEnvironment$(testUser));
         expect(env.getHostname()).toBe(expectedHost);
       },
     );
@@ -355,7 +355,7 @@ describe("EnvironmentService", () => {
 
         await switchUser(testUser);
 
-        const env = await sut.getEnvironment(alternateTestUser);
+        const env = await firstValueFrom(sut.getEnvironment$(alternateTestUser));
         expect(env.getHostname()).toBe(expectedHost);
       },
     );
@@ -366,7 +366,7 @@ describe("EnvironmentService", () => {
       setGlobalData(Region.SelfHosted, globalSelfHostUrls);
       setUserData(Region.EU, new EnvironmentUrls());
 
-      const env = await sut.getEnvironment();
+      const env = await firstValueFrom(sut.getEnvironment$());
       expect(env.getHostname()).toBe("base.example.com");
     });
 
@@ -377,7 +377,7 @@ describe("EnvironmentService", () => {
       setGlobalData(Region.SelfHosted, globalSelfHostUrls);
       setUserData(Region.EU, new EnvironmentUrls());
 
-      const env = await sut.getEnvironment();
+      const env = await firstValueFrom(sut.getEnvironment$());
       expect(env.getHostname()).toBe("vault.example.com");
     });
 
@@ -391,7 +391,7 @@ describe("EnvironmentService", () => {
 
       await switchUser(testUser);
 
-      const env = await sut.getEnvironment(alternateTestUser);
+      const env = await firstValueFrom(sut.getEnvironment$(alternateTestUser));
       expect(env.getHostname()).toBe("base.example.com");
     });
   });

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -271,23 +271,27 @@ export class DefaultEnvironmentService implements EnvironmentService {
     }
   }
 
-  async getEnvironment(userId?: UserId): Promise<Environment | undefined> {
+  getEnvironment$(userId?: UserId): Observable<Environment | undefined> {
     if (userId == null) {
-      return await firstValueFrom(this.environment$);
+      return this.environment$;
     }
 
-    const state = await this.getEnvironmentState(userId);
-    return this.buildEnvironment(state.region, state.urls);
+    return this.activeAccountId$.pipe(
+      switchMap((activeUserId) => {
+        // Previous rules dictated that we only get from user scoped state if there is an active user.
+        if (activeUserId == null) {
+          return this.globalState.state$;
+        }
+        return this.stateProvider.getUser(userId ?? activeUserId, USER_ENVIRONMENT_KEY).state$;
+      }),
+      map((state) => {
+        return this.buildEnvironment(state?.region, state?.urls);
+      }),
+    );
   }
 
-  private async getEnvironmentState(userId: UserId | null) {
-    // Previous rules dictated that we only get from user scoped state if there is an active user.
-    const activeUserId = await firstValueFrom(this.activeAccountId$);
-    return activeUserId == null
-      ? await firstValueFrom(this.globalState.state$)
-      : await firstValueFrom(
-          this.stateProvider.getUser(userId ?? activeUserId, USER_ENVIRONMENT_KEY).state$,
-        );
+  async getEnvironment(userId?: UserId): Promise<Environment | undefined> {
+    return firstValueFrom(this.getEnvironment$(userId));
   }
 
   async seedUserEnvironment(userId: UserId) {

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -290,6 +290,9 @@ export class DefaultEnvironmentService implements EnvironmentService {
     );
   }
 
+  /**
+   * @deprecated Use getEnvironment$ instead.
+   */
   async getEnvironment(userId?: UserId): Promise<Environment | undefined> {
     return firstValueFrom(this.getEnvironment$(userId));
   }

--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -60,6 +60,9 @@ describe("DefaultSdkService", () => {
       const userId = "user-id" as UserId;
 
       beforeEach(() => {
+        environmentService.getEnvironment$
+          .calledWith(userId)
+          .mockReturnValue(new BehaviorSubject(mock<Environment>()));
         accountService.accounts$ = of({
           [userId]: { email: "email", emailVerified: true, name: "name" } as AccountInfo,
         });

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -107,7 +107,7 @@ export class DefaultSdkService implements SdkService {
     );
 
     const client$ = combineLatest([
-      this.environmentService.environment$,
+      this.environmentService.getEnvironment(userId),
       account$,
       kdfParams$,
       privateKey$,

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -107,7 +107,7 @@ export class DefaultSdkService implements SdkService {
     );
 
     const client$ = combineLatest([
-      this.environmentService.getEnvironment(userId),
+      this.environmentService.getEnvironment$(userId),
       account$,
       kdfParams$,
       privateKey$,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The main objective was to fix a bug where we depended on the wrong environment in `SdkService`. To do that we had to first convert `getEnvironment` to observable

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
