### PR TITLE
[PM-16102] Display autofill shortcut on Fill button hover

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -55,11 +55,7 @@
               bitBadge
               variant="primary"
               (click)="doAutofill(cipher)"
-              [title]="
-                autofillShortcutTooltip()
-                  ? autofillShortcutTooltip()
-                  : ('autofillTitle' | i18n: cipher.name)
-              "
+              [title]="autofillShortcutTooltip() ?? ('autofillTitle' | i18n: cipher.name)"
               [attr.aria-label]="'autofillTitle' | i18n: cipher.name"
             >
               {{ "fill" | i18n }}

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -55,7 +55,11 @@
               bitBadge
               variant="primary"
               (click)="doAutofill(cipher)"
-              [title]="'autofillTitle' | i18n: cipher.name"
+              [title]="
+                autofillShortcutTooltip()
+                  ? autofillShortcutTooltip()
+                  : ('autofillTitle' | i18n: cipher.name)
+              "
               [attr.aria-label]="'autofillTitle' | i18n: cipher.name"
             >
               {{ "fill" | i18n }}

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -2,12 +2,22 @@
 // @ts-strict-ignore
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
-import { booleanAttribute, Component, EventEmitter, inject, Input, Output } from "@angular/core";
+import {
+  AfterViewInit,
+  booleanAttribute,
+  Component,
+  EventEmitter,
+  inject,
+  Input,
+  Output,
+  signal,
+} from "@angular/core";
 import { Router, RouterLink } from "@angular/router";
 import { map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
@@ -50,7 +60,7 @@ import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options
   templateUrl: "vault-list-items-container.component.html",
   standalone: true,
 })
-export class VaultListItemsContainerComponent {
+export class VaultListItemsContainerComponent implements AfterViewInit {
   private compactModeService = inject(CompactModeService);
 
   /**
@@ -133,13 +143,28 @@ export class VaultListItemsContainerComponent {
     return cipher.collections[0]?.name;
   }
 
+  protected autofillShortcutTooltip = signal<string | undefined>(undefined);
+
   constructor(
     private i18nService: I18nService,
     private vaultPopupAutofillService: VaultPopupAutofillService,
     private passwordRepromptService: PasswordRepromptService,
     private cipherService: CipherService,
     private router: Router,
+    private platformUtilsService: PlatformUtilsService,
   ) {}
+
+  async ngAfterViewInit() {
+    const autofillShortcut = await this.platformUtilsService.getAutofillKeyboardShortcut();
+
+    if (autofillShortcut === "") {
+      this.autofillShortcutTooltip.set(undefined);
+    } else {
+      const autofillTitle = this.i18nService.t("autoFill");
+
+      this.autofillShortcutTooltip.set(`${autofillTitle} ${autofillShortcut}`);
+    }
+  }
 
   /**
    * Launches the login cipher in a new browser tab.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-16102](https://bitwarden.atlassian.net/browse/PM-16102)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a user hovers over the "fill" button in the extension, we want the title to display the autofill keyboard shortcut that they have configured. This will serve as a reminder that they can use the keyboard shortcut. If it's not configured, the title will display what it currently displays, which is the name of the cipher. The aria label will remain as the cipher name even if a keyboard shortcut is configured.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Without configured shortcut | With configured shortcut |
|--------|--------|
| ![Screenshot 2024-12-20 at 2 13 24 PM](https://github.com/user-attachments/assets/075d3e07-0093-4fb0-8a88-08f3775b00df) |  ![Screenshot 2024-12-20 at 2 13 36 PM](https://github.com/user-attachments/assets/d55437df-527b-4394-a405-dda390faf69b) |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16102]: https://bitwarden.atlassian.net/browse/PM-16102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ