### PR TITLE
[PM-15808]Show suspended org modals for orgs in 'unpaid' & 'canceled' status

### DIFF
--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="large" [loading]="loading">
     <span bitDialogTitle class="tw-font-semibold">
-      {{ "upgradeFreeOrganization" | i18n: currentPlanName }}
+      {{ dialogHeaderName }}
     </span>
     <div bitDialogContent>
       <p>{{ "upgradePlans" | i18n }}</p>
@@ -330,9 +330,15 @@
         <br />
       </ng-container>
       <!-- Payment info -->
-      <ng-container *ngIf="formGroup.value.productTier !== productTypes.Free">
+      <ng-container
+        *ngIf="formGroup.value.productTier !== productTypes.Free || isSubscriptionCanceled"
+      >
         <h2 bitTypography="h4">{{ "paymentMethod" | i18n }}</h2>
-        <p *ngIf="!showPayment && (paymentSource || billing?.paymentSource)">
+        <p
+          *ngIf="
+            !showPayment && (paymentSource || billing?.paymentSource) && !isSubscriptionCanceled
+          "
+        >
           <i class="bwi bwi-fw" [ngClass]="paymentSourceClasses"></i>
           {{
             deprecateStripeSourcesAPI
@@ -344,23 +350,11 @@
           </span>
           <a></a>
         </p>
-        <app-payment
-          *ngIf="
-            (upgradeRequiresPaymentMethod || showPayment || isPaymentSourceEmpty()) &&
-            !deprecateStripeSourcesAPI
-          "
-          [hideCredit]="true"
-        ></app-payment>
-        <app-payment-v2
-          *ngIf="
-            (upgradeRequiresPaymentMethod || showPayment || isPaymentSourceEmpty()) &&
-            deprecateStripeSourcesAPI
-          "
-          [showAccountCredit]="false"
-        >
+        <app-payment *ngIf="shouldShowPaymentOptions()" [hideCredit]="true"></app-payment>
+        <app-payment-v2 *ngIf="shouldShowDeprecatedPaymentOptions()" [showAccountCredit]="false">
         </app-payment-v2>
         <app-tax-info
-          *ngIf="showPayment || upgradeRequiresPaymentMethod || isPaymentSourceEmpty()"
+          *ngIf="canShowPaymentDetails()"
           (onCountryChanged)="changedCountry()"
         ></app-tax-info>
         <div id="price" class="tw-mt-4">

--- a/apps/web/src/app/billing/organizations/organization-billing.module.ts
+++ b/apps/web/src/app/billing/organizations/organization-billing.module.ts
@@ -8,7 +8,6 @@ import { BillingSharedModule } from "../shared";
 import { AdjustSubscription } from "./adjust-subscription.component";
 import { BillingSyncApiKeyComponent } from "./billing-sync-api-key.component";
 import { BillingSyncKeyComponent } from "./billing-sync-key.component";
-import { ChangePlanDialogComponent } from "./change-plan-dialog.component";
 import { ChangePlanComponent } from "./change-plan.component";
 import { DownloadLicenceDialogComponent } from "./download-license.component";
 import { OrgBillingHistoryViewComponent } from "./organization-billing-history-view.component";
@@ -44,7 +43,6 @@ import { SubscriptionStatusComponent } from "./subscription-status.component";
     SecretsManagerSubscribeStandaloneComponent,
     SubscriptionHiddenComponent,
     SubscriptionStatusComponent,
-    ChangePlanDialogComponent,
     OrganizationPaymentMethodComponent,
   ],
 })

--- a/apps/web/src/app/billing/services/trial-flow.service.ts
+++ b/apps/web/src/app/billing/services/trial-flow.service.ts
@@ -2,7 +2,9 @@
 // @ts-strict-ignore
 import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
+import { lastValueFrom } from "rxjs";
 
+import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { BillingSourceResponse } from "@bitwarden/common/billing/models/response/billing.response";
@@ -13,6 +15,10 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { DialogService } from "@bitwarden/components";
 
 import { FreeTrial } from "../../core/types/free-trial";
+import {
+  ChangePlanDialogResultType,
+  openChangePlanDialog,
+} from "../organizations/change-plan-dialog.component";
 
 @Injectable({ providedIn: "root" })
 export class TrialFlowService {
@@ -21,17 +27,18 @@ export class TrialFlowService {
     protected dialogService: DialogService,
     private router: Router,
     protected billingApiService: BillingApiServiceAbstraction,
+    private organizationApiService: OrganizationApiServiceAbstraction,
   ) {}
   checkForOrgsWithUpcomingPaymentIssues(
     organization: Organization,
     organizationSubscription: OrganizationSubscriptionResponse,
     paymentSource: BillingSourceResponse | PaymentSourceResponse,
   ): FreeTrial {
-    const trialEndDate = organizationSubscription?.subscription?.trialEndDate;
+    const trialEndDate = organizationSubscription.subscription?.trialEndDate;
     const displayBanner =
       !paymentSource &&
-      organization?.isOwner &&
-      organizationSubscription?.subscription?.status === "trialing";
+      organization.isOwner &&
+      organizationSubscription?.subscription.status === "trialing";
     const trialRemainingDays = trialEndDate ? this.calculateTrialRemainingDays(trialEndDate) : 0;
     const freeTrialMessage = this.getFreeTrialMessage(trialRemainingDays);
 
@@ -64,20 +71,28 @@ export class TrialFlowService {
 
   async handleUnpaidSubscriptionDialog(
     org: Organization,
-    organizationBillingMetadata: OrganizationBillingMetadataResponse,
+    billingMetadata: OrganizationBillingMetadataResponse,
   ): Promise<void> {
-    if (organizationBillingMetadata.isSubscriptionUnpaid) {
-      const confirmed = await this.promptForPaymentNavigation(org);
+    if (billingMetadata.isSubscriptionUnpaid || billingMetadata.isSubscriptionCanceled) {
+      const confirmed = await this.promptForPaymentNavigation(
+        org,
+        billingMetadata.isSubscriptionCanceled,
+        billingMetadata.isSubscriptionUnpaid,
+      );
       if (confirmed) {
-        await this.navigateToPaymentMethod(org?.id);
+        await this.navigateToPaymentMethod(org.id);
       }
     }
   }
 
-  private async promptForPaymentNavigation(org: Organization): Promise<boolean> {
-    if (!org?.isOwner) {
+  private async promptForPaymentNavigation(
+    org: Organization,
+    isCanceled: boolean,
+    isUnpaid: boolean,
+  ): Promise<boolean> {
+    if (!org.isOwner && !org.isProviderUser) {
       await this.dialogService.openSimpleDialog({
-        title: this.i18nService.t("suspendedOrganizationTitle", org?.name),
+        title: this.i18nService.t("suspendedOrganizationTitle", org.name),
         content: { key: "suspendedUserOrgMessage" },
         type: "danger",
         acceptButtonText: this.i18nService.t("close"),
@@ -85,18 +100,51 @@ export class TrialFlowService {
       });
       return false;
     }
-    return await this.dialogService.openSimpleDialog({
-      title: this.i18nService.t("suspendedOrganizationTitle", org?.name),
-      content: { key: "suspendedOwnerOrgMessage" },
-      type: "danger",
-      acceptButtonText: this.i18nService.t("continue"),
-      cancelButtonText: this.i18nService.t("close"),
-    });
+    if (org.hasProvider) {
+      await this.dialogService.openSimpleDialog({
+        title: this.i18nService.t("suspendedOrganizationTitle", org.name),
+        content: { key: "suspendedManagedOrgMessage", placeholders: [org.providerName] },
+        type: "danger",
+        acceptButtonText: this.i18nService.t("close"),
+        cancelButtonText: null,
+      });
+      return false;
+    }
+
+    if (org.isOwner && isUnpaid) {
+      return await this.dialogService.openSimpleDialog({
+        title: this.i18nService.t("suspendedOrganizationTitle", org.name),
+        content: { key: "suspendedOwnerOrgMessage" },
+        type: "danger",
+        acceptButtonText: this.i18nService.t("continue"),
+        cancelButtonText: this.i18nService.t("close"),
+      });
+    }
+    if (org.isOwner && isCanceled) {
+      await this.changePlan(org);
+    }
   }
 
   private async navigateToPaymentMethod(orgId: string) {
     await this.router.navigate(["organizations", `${orgId}`, "billing", "payment-method"], {
       state: { launchPaymentModalAutomatically: true },
     });
+  }
+
+  private async changePlan(org: Organization) {
+    const subscription = await this.organizationApiService.getSubscription(org.id);
+    const reference = openChangePlanDialog(this.dialogService, {
+      data: {
+        organizationId: org.id,
+        subscription: subscription,
+        productTierType: org.productTierType,
+      },
+    });
+
+    const result = await lastValueFrom(reference.closed);
+
+    if (result === ChangePlanDialogResultType.Closed) {
+      return;
+    }
   }
 }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -6,7 +6,6 @@ import { firstValueFrom, Subject } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
-import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -16,6 +15,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
 import { DialogService } from "@bitwarden/components";
 
+import { TrialFlowService } from "../../../../billing/services/trial-flow.service";
 import { VaultFilterService } from "../services/abstractions/vault-filter.service";
 import {
   VaultFilterList,
@@ -90,7 +90,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
 
     return "searchVault";
   }
-
+  private trialFlowService = inject(TrialFlowService);
   constructor(
     protected vaultFilterService: VaultFilterService,
     protected policyService: PolicyService,
@@ -126,12 +126,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         this.i18nService.t("disabledOrganizationFilterError"),
       );
       const metadata = await this.billingApiService.getOrganizationBillingMetadata(orgNode.node.id);
-      if (metadata.isSubscriptionUnpaid) {
-        const confirmed = await this.promptForPaymentNavigation(orgNode.node);
-        if (confirmed) {
-          await this.navigateToPaymentMethod(orgNode.node.id);
-        }
-      }
+      await this.trialFlowService.handleUnpaidSubscriptionDialog(orgNode.node, metadata);
       return;
     }
     const filter = this.activeFilter;
@@ -143,32 +138,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     this.vaultFilterService.setOrganizationFilter(orgNode.node);
     await this.vaultFilterService.expandOrgFilter();
   };
-
-  private async promptForPaymentNavigation(org: Organization): Promise<boolean> {
-    if (!org?.isOwner) {
-      await this.dialogService.openSimpleDialog({
-        title: this.i18nService.t("suspendedOrganizationTitle", org?.name),
-        content: { key: "suspendedUserOrgMessage" },
-        type: "danger",
-        acceptButtonText: this.i18nService.t("close"),
-        cancelButtonText: null,
-      });
-      return false;
-    }
-    return await this.dialogService.openSimpleDialog({
-      title: this.i18nService.t("suspendedOrganizationTitle", org?.name),
-      content: { key: "suspendedOwnerOrgMessage" },
-      type: "danger",
-      acceptButtonText: this.i18nService.t("continue"),
-      cancelButtonText: this.i18nService.t("close"),
-    });
-  }
-
-  private async navigateToPaymentMethod(orgId: string) {
-    await this.router.navigate(["organizations", `${orgId}`, "billing", "payment-method"], {
-      state: { launchPaymentModalAutomatically: true },
-    });
-  }
 
   applyTypeFilter = async (filterNode: TreeNode<CipherTypeFilter>): Promise<void> => {
     const filter = this.activeFilter;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3158,6 +3158,9 @@
   "organizationUpgraded": {
     "message": "Organization upgraded"
   },
+  "restartOrganizationSubscription": {
+    "message": "Organization subscription restarted"
+  },
   "leave": {
     "message": "Leave"
   },
@@ -9590,6 +9593,9 @@
       }
     }
   },
+  "restartSubscription": {
+    "message": "Restart your subscription"
+  },
   "includeSsoAuthenticationMessage": {
     "message": "SSO Authentication"
   },
@@ -9875,6 +9881,15 @@
   },
   "suspendedUserOrgMessage": {
     "message": "Contact your organization owner for assistance."
+  },
+  "suspendedManagedOrgMessage": {
+    "message": "Contact $PROVIDER$ for assistance.",
+    "placeholders": {
+      "provider": {
+        "content": "$1",
+        "example": "Acme c"
+      }
+    }
   },
   "suspendedOwnerOrgMessage": {
     "message": "To regain access to your organization, add a payment method."

--- a/libs/common/src/billing/abstractions/billing-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/billing-api.service.abstraction.ts
@@ -8,6 +8,7 @@ import { VerifyBankAccountRequest } from "@bitwarden/common/billing/models/reque
 import { InvoicesResponse } from "@bitwarden/common/billing/models/response/invoices.response";
 import { PaymentMethodResponse } from "@bitwarden/common/billing/models/response/payment-method.response";
 
+import { OrganizationCreateRequest } from "../../admin-console/models/request/organization-create.request";
 import { SubscriptionCancellationRequest } from "../../billing/models/request/subscription-cancellation.request";
 import { OrganizationBillingMetadataResponse } from "../../billing/models/response/organization-billing-metadata.response";
 import { PlanResponse } from "../../billing/models/response/plan.response";
@@ -73,5 +74,9 @@ export abstract class BillingApiServiceAbstraction {
   verifyOrganizationBankAccount: (
     organizationId: string,
     request: VerifyBankAccountRequest,
+  ) => Promise<void>;
+  restartSubscription: (
+    organizationId: string,
+    request: OrganizationCreateRequest,
   ) => Promise<void>;
 }

--- a/libs/common/src/billing/abstractions/organization-billing.service.ts
+++ b/libs/common/src/billing/abstractions/organization-billing.service.ts
@@ -57,4 +57,9 @@ export abstract class OrganizationBillingServiceAbstraction {
   ) => Promise<OrganizationResponse>;
 
   startFree: (subscription: SubscriptionInformation) => Promise<OrganizationResponse>;
+
+  restartSubscription: (
+    organizationId: string,
+    subscription: SubscriptionInformation,
+  ) => Promise<void>;
 }

--- a/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
+++ b/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
@@ -6,6 +6,7 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
   isOnSecretsManagerStandalone: boolean;
   isSubscriptionUnpaid: boolean;
   hasSubscription: boolean;
+  isSubscriptionCanceled: boolean;
 
   constructor(response: any) {
     super(response);
@@ -14,5 +15,6 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
     this.isOnSecretsManagerStandalone = this.getResponseProperty("IsOnSecretsManagerStandalone");
     this.isSubscriptionUnpaid = this.getResponseProperty("IsSubscriptionUnpaid");
     this.hasSubscription = this.getResponseProperty("HasSubscription");
+    this.isSubscriptionCanceled = this.getResponseProperty("IsSubscriptionCanceled");
   }
 }

--- a/libs/common/src/billing/services/billing-api.service.ts
+++ b/libs/common/src/billing/services/billing-api.service.ts
@@ -10,6 +10,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { ToastService } from "@bitwarden/components";
 
 import { ApiService } from "../../abstractions/api.service";
+import { OrganizationCreateRequest } from "../../admin-console/models/request/organization-create.request";
 import { BillingApiServiceAbstraction } from "../../billing/abstractions";
 import { PaymentMethodType } from "../../billing/enums";
 import { ExpandedTaxInfoUpdateRequest } from "../../billing/models/request/expanded-tax-info-update.request";
@@ -208,6 +209,19 @@ export class BillingApiService implements BillingApiServiceAbstraction {
     return await this.apiService.send(
       "POST",
       "/organizations/" + organizationId + "/billing/payment-method/verify-bank-account",
+      request,
+      true,
+      false,
+    );
+  }
+
+  async restartSubscription(
+    organizationId: string,
+    request: OrganizationCreateRequest,
+  ): Promise<void> {
+    return await this.apiService.send(
+      "POST",
+      "/organizations/" + organizationId + "/billing/restart-subscription",
       request,
       true,
       false,

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -127,6 +127,25 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
     return response;
   }
 
+  async restartSubscription(
+    organizationId: string,
+    subscription: SubscriptionInformation,
+  ): Promise<void> {
+    const request = new OrganizationCreateRequest();
+
+    const organizationKeys = await this.makeOrganizationKeys();
+
+    this.setOrganizationKeys(request, organizationKeys);
+
+    this.setOrganizationInformation(request, subscription.organization);
+
+    this.setPlanInformation(request, subscription.plan);
+
+    this.setPaymentInformation(request, subscription.payment);
+
+    await this.billingApiService.restartSubscription(organizationId, request);
+  }
+
   private async makeOrganizationKeys(): Promise<OrganizationKeys> {
     const [encryptedKey, key] = await this.keyService.makeOrgKey<OrgKey>();
     const [publicKey, encryptedPrivateKey] = await this.keyService.makeKeyPair(key);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15808
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
display a modal (see figma)

there will be different versions of the modal depending on the user role and whether the organization is independent, MSP managed, or reseller managed.

For the independent org Owner

when subscription is in unpaid, keep the existing flow where they see the notice, and then they are taken to the payment method section of the admin console.

when the subscription is in canceled, then we show them the upgrade path UI.

we show them the current equivalent to their previous subscription. So, if they were on a Family, we show them Family, if they were on Enterprise 2019, we show them CURRENT Enterprise.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Uploading Screen Recording 2024-12-20 at 16.55.32.mov…


Uploading Screen Recording 2024-12-20 at 16.56.47.mov…


Uploading Screen Recording 2024-12-20 at 17.09.00.mov…

<img width="1728" alt="Screenshot 2024-12-20 at 16 53 28" src="https://github.com/user-attachments/assets/39ef394a-540d-4798-b4da-fc296381d8e6" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
