### PR TITLE
[CL-524] Ignore flaky elements in Chromatic tests

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -304,7 +304,7 @@ export default {
   parameters: {
     // Chromatic has been reporting diffs on these stories where the item rows are not all fully loaded.
     // Trying this out to test the theory that it's taking a screenshot too quickly.
-    chromatic: { delay: 1000 },
+    chromatic: { delay: 3000 },
   },
   decorators: [
     moduleMetadata({

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -4,6 +4,7 @@ import { CommonModule } from "@angular/common";
 import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+import { expect, waitFor, within } from "@storybook/test";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -41,7 +42,7 @@ class ExtensionContainerComponent {}
 
 @Component({
   selector: "vault-placeholder",
-  template: `
+  template: /*html*/ `
     <bit-section>
       <bit-item-group aria-label="Mock Vault Items">
         <bit-item *ngFor="let item of data; index as i">
@@ -464,6 +465,20 @@ export const CompactMode: Story = {
     };
     updateLabel("compact-example");
     updateLabel("regular-example");
+
+    await waitFor(async () => {
+      const canvas = within(canvasEl);
+      const allBadges = canvas.getAllByTitle("Auto-fill");
+
+      // Chromatic has been reporting diffs on this story where the item rows are not all fully loaded.
+      // Trying this out to test the theory that it's taking a screenshot too quickly.
+
+      // Ensure that all bit-items have rendered before chromatic screenshot by awaiting
+      // all the "auto-fill" badges rendering. There are 20 rows in each vault "view" and 2 "views"
+      // rendered per story (relaxed and compact). There may be double the amount if light & dark
+      // mode are rendered together.
+      await expect(allBadges.length).toBeGreaterThanOrEqual(40);
+    });
   },
 };
 

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -4,7 +4,6 @@ import { CommonModule } from "@angular/common";
 import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
-import { expect, waitFor, within } from "@storybook/test";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -302,6 +301,11 @@ class MockVaultSubpageComponent {}
 export default {
   title: "Browser/Popup Layout",
   component: PopupPageComponent,
+  parameters: {
+    // Chromatic has been reporting diffs on these stories where the item rows are not all fully loaded.
+    // Trying this out to test the theory that it's taking a screenshot too quickly.
+    chromatic: { delay: 1000 },
+  },
   decorators: [
     moduleMetadata({
       imports: [
@@ -465,20 +469,6 @@ export const CompactMode: Story = {
     };
     updateLabel("compact-example");
     updateLabel("regular-example");
-
-    await waitFor(async () => {
-      const canvas = within(canvasEl);
-      const allBadges = canvas.getAllByTitle("Fill");
-
-      // Chromatic has been reporting diffs on this story where the item rows are not all fully loaded.
-      // Trying this out to test the theory that it's taking a screenshot too quickly.
-
-      // Ensure that all bit-items have rendered before chromatic screenshot by awaiting
-      // all the "Fill" badges rendering. There are 20 rows in each vault "view" and 2 "views"
-      // rendered per story (relaxed and compact). There may be double the amount if light & dark
-      // mode are rendered together.
-      await expect(allBadges.length).toBeGreaterThanOrEqual(40);
-    });
   },
 };
 
@@ -583,21 +573,4 @@ export const WidthOptions: Story = {
       </div>
     `,
   }),
-  play: async (context) => {
-    const canvasEl = context.canvasElement;
-
-    await waitFor(async () => {
-      const canvas = within(canvasEl);
-      const allBadges = canvas.getAllByTitle("Fill");
-
-      // Chromatic has been reporting diffs on this story where the item rows are not all fully loaded.
-      // Trying this out to test the theory that it's taking a screenshot too quickly.
-
-      // Ensure that all bit-items have rendered before chromatic screenshot by awaiting
-      // all the "Fill" badges rendering. There are 20 rows in each vault "view" and 3 "views"
-      // rendered per story (default, wide, exra wide). There may be double the amount if light & dark
-      // mode are rendered together.
-      await expect(allBadges.length).toBeGreaterThanOrEqual(60);
-    });
-  },
 };

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -304,7 +304,7 @@ export default {
   parameters: {
     // Chromatic has been reporting diffs on these stories where the item rows are not all fully loaded.
     // Trying this out to test the theory that it's taking a screenshot too quickly.
-    chromatic: { delay: 3000 },
+    chromatic: { delay: 6000 },
   },
   decorators: [
     moduleMetadata({

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -54,7 +54,7 @@ class ExtensionContainerComponent {}
 
           <ng-container slot="end">
             <bit-item-action>
-              <button type="button" bitBadge variant="primary">Auto-fill</button>
+              <button type="button" bitBadge variant="primary">Fill</button>
             </bit-item-action>
             <bit-item-action>
               <button type="button" bitIconButton="bwi-clone" aria-label="Copy item"></button>
@@ -468,13 +468,13 @@ export const CompactMode: Story = {
 
     await waitFor(async () => {
       const canvas = within(canvasEl);
-      const allBadges = canvas.getAllByTitle("Auto-fill");
+      const allBadges = canvas.getAllByTitle("Fill");
 
       // Chromatic has been reporting diffs on this story where the item rows are not all fully loaded.
       // Trying this out to test the theory that it's taking a screenshot too quickly.
 
       // Ensure that all bit-items have rendered before chromatic screenshot by awaiting
-      // all the "auto-fill" badges rendering. There are 20 rows in each vault "view" and 2 "views"
+      // all the "Fill" badges rendering. There are 20 rows in each vault "view" and 2 "views"
       // rendered per story (relaxed and compact). There may be double the amount if light & dark
       // mode are rendered together.
       await expect(allBadges.length).toBeGreaterThanOrEqual(40);
@@ -583,4 +583,21 @@ export const WidthOptions: Story = {
       </div>
     `,
   }),
+  play: async (context) => {
+    const canvasEl = context.canvasElement;
+
+    await waitFor(async () => {
+      const canvas = within(canvasEl);
+      const allBadges = canvas.getAllByTitle("Fill");
+
+      // Chromatic has been reporting diffs on this story where the item rows are not all fully loaded.
+      // Trying this out to test the theory that it's taking a screenshot too quickly.
+
+      // Ensure that all bit-items have rendered before chromatic screenshot by awaiting
+      // all the "Fill" badges rendering. There are 20 rows in each vault "view" and 3 "views"
+      // rendered per story (default, wide, exra wide). There may be double the amount if light & dark
+      // mode are rendered together.
+      await expect(allBadges.length).toBeGreaterThanOrEqual(60);
+    });
+  },
 };

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -304,7 +304,7 @@ export default {
   parameters: {
     // Chromatic has been reporting diffs on these stories where the item rows are not all fully loaded.
     // Trying this out to test the theory that it's taking a screenshot too quickly.
-    chromatic: { delay: 6000 },
+    // chromatic: { delay: 6000 },
   },
   decorators: [
     moduleMetadata({

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -301,11 +301,6 @@ class MockVaultSubpageComponent {}
 export default {
   title: "Browser/Popup Layout",
   component: PopupPageComponent,
-  parameters: {
-    // Chromatic has been reporting diffs on these stories where the item rows are not all fully loaded.
-    // Trying this out to test the theory that it's taking a screenshot too quickly.
-    // chromatic: { delay: 6000 },
-  },
   decorators: [
     moduleMetadata({
       imports: [

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -301,6 +301,12 @@ class MockVaultSubpageComponent {}
 export default {
   title: "Browser/Popup Layout",
   component: PopupPageComponent,
+  parameters: {
+    chromatic: {
+      // Disable tests while we troubleshoot their flaky-ness
+      disableSnapshot: true,
+    },
+  },
   decorators: [
     moduleMetadata({
       imports: [

--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -36,7 +36,7 @@ export class MenuTriggerForDirective implements OnDestroy {
   private defaultMenuConfig: OverlayConfig = {
     panelClass: "bit-menu-panel",
     hasBackdrop: true,
-    backdropClass: "cdk-overlay-transparent-backdrop",
+    backdropClass: ["cdk-overlay-transparent-backdrop", "bit-menu-panel-backdrop"],
     scrollStrategy: this.overlay.scrollStrategies.reposition(),
     positionStrategy: this.overlay
       .position()

--- a/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
@@ -10,9 +10,9 @@ import { TableDataSource, TableModule } from "../../../table";
   selector: "dialog-virtual-scroll-block",
   standalone: true,
   imports: [DialogModule, IconButtonModule, SectionComponent, TableModule, ScrollingModule],
-  template: ` <bit-section>
+  template: /*html*/ `<bit-section>
     <cdk-virtual-scroll-viewport scrollWindow itemSize="47">
-      <bit-table [dataSource]="dataSource">
+      <bit-table [dataSource]="dataSource" data-chromatic="ignore">
         <ng-container header>
           <tr>
             <th bitCell bitSortable="id" default>Id</th>

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -130,6 +130,9 @@ export const MenuOpen: Story = {
     const menuButton = getAllByRole(table, "button")[0];
     await userEvent.click(menuButton);
   },
+  parameters: {
+    chromatic: { ignoreSelectors: [".bit-menu-panel-backdrop"] },
+  },
 };
 
 export const DefaultDialogOpen: Story = {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-524](https://bitwarden.atlassian.net/browse/CL-524)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We're seeing some frequent and noisy Chromatic diffs for stories that have no changes. 

For the kitchen sink stories, it is usually the menu component being positioned ~1px lower or higher than the previous build, or the virtual scroll story showing more or less rows of data in the screenshot. These are not actual useful diffs, so this PR is going to try to ignore the elements that are causing the diffs while keeping the stories around.

For the popup layout stories, we are still working on debugging why sometimes the snapshots include all the item info, and sometimes they don't. The Storybook live instance consistently shows all the item info as expected, so it is an issue with how the snapshots are getting taken. While we work to figure this out, we are disabling the tests entirely so that developers are not constantly seeing diffs to these stories.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-524]: https://bitwarden.atlassian.net/browse/CL-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ