### PR TITLE
Portable Desktop Fix

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -589,7 +589,7 @@ export default class MainBackground {
     this.tokenService = new TokenService(
       this.singleUserStateProvider,
       this.globalStateProvider,
-      this.platformUtilsService.supportsSecureStorage(),
+      this.platformUtilsService,
       this.secureStorageService,
       this.keyGenerationService,
       this.encryptService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -374,7 +374,7 @@ export class ServiceContainer {
     this.tokenService = new TokenService(
       this.singleUserStateProvider,
       this.globalStateProvider,
-      this.platformUtilsService.supportsSecureStorage(),
+      this.platformUtilsService,
       this.secureStorageService,
       this.keyGenerationService,
       this.encryptService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -13,7 +13,6 @@ import {
   OBSERVABLE_MEMORY_STORAGE,
   OBSERVABLE_DISK_STORAGE,
   WINDOW,
-  SUPPORTS_SECURE_STORAGE,
   SYSTEM_THEME_OBSERVABLE,
   SafeInjectionToken,
   DEFAULT_VAULT_TIMEOUT,
@@ -107,10 +106,7 @@ import { flagEnabled } from "../../platform/flags";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 import { ElectronKeyService } from "../../platform/services/electron-key.service";
 import { ElectronLogRendererService } from "../../platform/services/electron-log.renderer.service";
-import {
-  ELECTRON_SUPPORTS_SECURE_STORAGE,
-  ElectronPlatformUtilsService,
-} from "../../platform/services/electron-platform-utils.service";
+import { ElectronPlatformUtilsService } from "../../platform/services/electron-platform-utils.service";
 import { ElectronRendererMessageSender } from "../../platform/services/electron-renderer-message.sender";
 import { ElectronRendererSecureStorageService } from "../../platform/services/electron-renderer-secure-storage.service";
 import { ElectronRendererStorageService } from "../../platform/services/electron-renderer-storage.service";
@@ -168,13 +164,6 @@ const safeProviders: SafeProvider[] = [
     provide: PlatformUtilsServiceAbstraction,
     useClass: ElectronPlatformUtilsService,
     deps: [I18nServiceAbstraction, MessagingServiceAbstraction],
-  }),
-  safeProvider({
-    // We manually override the value of SUPPORTS_SECURE_STORAGE here to avoid
-    // the TokenService having to inject the PlatformUtilsService which introduces a
-    // circular dependency on Desktop only.
-    provide: SUPPORTS_SECURE_STORAGE,
-    useValue: ELECTRON_SUPPORTS_SECURE_STORAGE,
   }),
   safeProvider({
     provide: DEFAULT_VAULT_TIMEOUT,

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -18,6 +18,7 @@ import {
   isFlatpak,
   isMacAppStore,
   isSnapStore,
+  isWindowsPortable,
   isWindowsStore,
 } from "../utils";
 
@@ -145,6 +146,7 @@ export default {
   isDev: isDev(),
   isMacAppStore: isMacAppStore(),
   isWindowsStore: isWindowsStore(),
+  isWindowsPortable: isWindowsPortable(),
   isFlatpak: isFlatpak(),
   isSnapStore: isSnapStore(),
   isAppImage: isAppImage(),

--- a/apps/desktop/src/platform/services/electron-platform-utils.service.ts
+++ b/apps/desktop/src/platform/services/electron-platform-utils.service.ts
@@ -132,7 +132,10 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
   }
 
   supportsSecureStorage(): boolean {
-    return true;
+    // When using windows portable it's expected that all data is stored in the local `data.json` file
+    // if things instead get saved into Windows Credential Manager and then the user tries to move
+    // their Bitwarden executable to another computer they would be unable to unlock.
+    return !ipc.platform.isWindowsPortable;
   }
 
   getAutofillKeyboardShortcut(): Promise<string> {

--- a/apps/desktop/src/platform/services/electron-platform-utils.service.ts
+++ b/apps/desktop/src/platform/services/electron-platform-utils.service.ts
@@ -10,8 +10,6 @@ import {
 
 import { ClipboardWriteMessage } from "../types/clipboard";
 
-export const ELECTRON_SUPPORTS_SECURE_STORAGE = true;
-
 export class ElectronPlatformUtilsService implements PlatformUtilsService {
   constructor(
     protected i18nService: I18nService,
@@ -134,7 +132,7 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
   }
 
   supportsSecureStorage(): boolean {
-    return ELECTRON_SUPPORTS_SECURE_STORAGE;
+    return true;
   }
 
   getAutofillKeyboardShortcut(): Promise<string> {

--- a/libs/angular/src/services/injection-tokens.ts
+++ b/libs/angular/src/services/injection-tokens.ts
@@ -45,7 +45,6 @@ export const LOGOUT_CALLBACK = new SafeInjectionToken<
 export const LOCKED_CALLBACK = new SafeInjectionToken<(userId?: string) => Promise<void>>(
   "LOCKED_CALLBACK",
 );
-export const SUPPORTS_SECURE_STORAGE = new SafeInjectionToken<boolean>("SUPPORTS_SECURE_STORAGE");
 export const LOCALES_DIRECTORY = new SafeInjectionToken<string>("LOCALES_DIRECTORY");
 export const SYSTEM_LANGUAGE = new SafeInjectionToken<string>("SYSTEM_LANGUAGE");
 export const LOG_MAC_FAILURES = new SafeInjectionToken<boolean>("LOG_MAC_FAILURES");

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -319,7 +319,6 @@ import {
   SafeInjectionToken,
   SECURE_STORAGE,
   STATE_FACTORY,
-  SUPPORTS_SECURE_STORAGE,
   SYSTEM_LANGUAGE,
   SYSTEM_THEME_OBSERVABLE,
   WINDOW,
@@ -344,12 +343,6 @@ const safeProviders: SafeProvider[] = [
     provide: LOCALE_ID as SafeInjectionToken<string>,
     useFactory: (i18nService: I18nServiceAbstraction) => i18nService.translationLocale,
     deps: [I18nServiceAbstraction],
-  }),
-  safeProvider({
-    provide: SUPPORTS_SECURE_STORAGE,
-    useFactory: (platformUtilsService: PlatformUtilsServiceAbstraction) =>
-      platformUtilsService.supportsSecureStorage(),
-    deps: [PlatformUtilsServiceAbstraction],
   }),
   safeProvider({
     provide: LOCALES_DIRECTORY,
@@ -589,7 +582,7 @@ const safeProviders: SafeProvider[] = [
     deps: [
       SingleUserStateProvider,
       GlobalStateProvider,
-      SUPPORTS_SECURE_STORAGE,
+      PlatformUtilsServiceAbstraction,
       SECURE_STORAGE,
       KeyGenerationServiceAbstraction,
       EncryptService,

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -8,6 +8,7 @@ import { VaultTimeoutAction } from "../../enums/vault-timeout-action.enum";
 import { EncryptService } from "../../platform/abstractions/encrypt.service";
 import { KeyGenerationService } from "../../platform/abstractions/key-generation.service";
 import { LogService } from "../../platform/abstractions/log.service";
+import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { AbstractStorageService } from "../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../platform/enums";
 import { StorageOptions } from "../../platform/models/domain/storage-options";
@@ -3011,10 +3012,13 @@ describe("TokenService", () => {
 
   // Helpers
   function createTokenService(supportsSecureStorage: boolean) {
+    const platformUtilsService = mock<PlatformUtilsService>();
+    platformUtilsService.supportsSecureStorage.mockReturnValue(supportsSecureStorage);
+
     return new TokenService(
       singleUserStateProvider,
       globalStateProvider,
-      supportsSecureStorage,
+      platformUtilsService,
       secureStorageService,
       keyGenerationService,
       encryptService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-15333

Fixes #12141

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We need to support someone using the portable Bitwarden app using and signing in on one account then transporting the executable and data files to another computer and unlocking there. Right now we can't do that because we store the access token and refresh token in `Credential Manager` which is not portable to the new computer. 

The one problem with this fix is that people who are using the portable app right now on a single computer have their access token in `Credential Manager` and after this change the app will be told secure store isn't supported and won't even look there thinking they don't have an access token and they will need to fully login again. @JaredSnider-Bitwarden and I will need to discuss this and maybe we want TokenService to still look there when it's not supported, but I don't _love_ that. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
