### PR TITLE
[PM-16507] update new device verification notice state definition

### DIFF
--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -180,5 +180,8 @@ export const VAULT_BROWSER_UI_ONBOARDING = new StateDefinition("vaultBrowserUiOn
 export const NEW_DEVICE_VERIFICATION_NOTICE = new StateDefinition(
   "newDeviceVerificationNotice",
   "disk",
+  {
+    web: "disk-local",
+  },
 );
 export const VAULT_APPEARANCE = new StateDefinition("vaultAppearance", "disk");


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16507](https://bitwarden.atlassian.net/browse/PM-16507)

## 📔 Objective

When a user dismissed the new device verification notice on web, that dismissal only lasted on the one tab. Opening a new tab and logging in would should the user the notification again.

Updated the state definition to the `NEW_DEVICE_VERIFICATION_NOTICE` so the dismissal value can persist throughout new tabs. 

## 📸 Screen Recording

https://github.com/user-attachments/assets/77add635-bc8f-421c-9317-72e865956400

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16507]: https://bitwarden.atlassian.net/browse/PM-16507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ