### PR TITLE
[PM-16505] new device verification browser scroll remove

### DIFF
--- a/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
+++ b/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
@@ -20,6 +20,7 @@
     [showReadonlyHostname]="showReadonlyHostname"
     [hideLogo]="true"
     [maxWidth]="maxWidth"
+    [hideFooter]="hideFooter"
   >
     <router-outlet></router-outlet>
     <router-outlet slot="secondary" name="secondary"></router-outlet>

--- a/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
+++ b/apps/browser/src/auth/popup/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
@@ -25,6 +25,7 @@ export interface ExtensionAnonLayoutWrapperData extends AnonLayoutWrapperData {
   showAcctSwitcher?: boolean;
   showBackButton?: boolean;
   showLogo?: boolean;
+  hideFooter?: boolean;
 }
 
 @Component({
@@ -54,6 +55,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
   protected showReadonlyHostname: boolean;
   protected maxWidth: "md" | "3xl";
   protected hasLoggedInAccount: boolean = false;
+  protected hideFooter: boolean;
 
   protected theme: string;
   protected logo = ExtensionBitwardenLogo;
@@ -112,6 +114,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
       this.pageIcon = firstChildRouteData["pageIcon"];
     }
 
+    this.hideFooter = Boolean(firstChildRouteData["hideFooter"]);
     this.showReadonlyHostname = Boolean(firstChildRouteData["showReadonlyHostname"]);
     this.maxWidth = firstChildRouteData["maxWidth"];
 
@@ -158,6 +161,10 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
       this.pageIcon = data.pageIcon !== null ? data.pageIcon : null;
     }
 
+    if (data.hideFooter !== undefined) {
+      this.hideFooter = data.hideFooter !== null ? data.hideFooter : null;
+    }
+
     if (data.showReadonlyHostname !== undefined) {
       this.showReadonlyHostname = data.showReadonlyHostname;
     }
@@ -194,6 +201,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.showBackButton = null;
     this.showLogo = null;
     this.maxWidth = null;
+    this.hideFooter = null;
   }
 
   ngOnDestroy() {

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -714,6 +714,7 @@ const routes: Routes = [
           pageTitle: {
             key: "importantNotice",
           },
+          hideFooter: true,
         },
       },
       {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16505](https://bitwarden.atlassian.net/browse/PM-16505)

## 📔 Objective

Added a `hideFooter` value to the extension anon wrapper for the browser call. This will remove the excess footer element and the scroll bar that appears on page 1 of the new device verification notification in the browser. 

## 📸 Screenshots

![Screenshot 2024-12-30 at 6 42 17 AM](https://github.com/user-attachments/assets/7e4f81ac-15b0-4faa-8757-32952d606d37)
![Screenshot 2024-12-30 at 6 42 24 AM](https://github.com/user-attachments/assets/c6633dba-c294-4f10-bfb1-f11d689ec58c)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16505]: https://bitwarden.atlassian.net/browse/PM-16505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ