### PR TITLE
fix(safari): make sure to return from bespoke reload clause

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -458,7 +458,7 @@ export class BrowserApi {
     // and that prompts us to show a new tab, this apparently doesn't happen on sideloaded
     // extensions and only shows itself production scenarios. See: https://bitwarden.atlassian.net/browse/PM-12298
     if (this.isSafariApi) {
-      self.location.reload();
+      return self.location.reload();
     }
     return chrome.runtime.reload();
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16564

## 📔 Objective

On https://github.com/bitwarden/clients/pull/12326 I refactored and extended a bit of special case logic for process reloads on Safari. This appears to have caused a regression, and I think it's because I didn't return from the function when Safari reloads. This makes it still call `chrome.runtime.reload()`, which makes Safari send an "install" event, which leads to our extension opening it's Getting Started page.

This commit returns after the location reload in Safari. This is tricky to test locally as the issue does not appear with sideloaded apps. I'll test it with Testflight!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes