### PR TITLE
[PM-16667] Followup clarifying work

### DIFF
--- a/libs/common/src/autofill/utils.spec.ts
+++ b/libs/common/src/autofill/utils.spec.ts
@@ -93,7 +93,7 @@ function getCardExpiryDateValues() {
     [undefined, undefined, false], // no month, no year, invalid values
     ["", "", false], // no month, no year, invalid values
     ["12", "agdredg42grg35grrr. ea3534@#^145345ag$%^  -_#$rdg ", false], // invalid values
-    ["0", `${currentYear}`, true], // invalid month
+    ["0", `${currentYear}`, false], // invalid month
     ["0", `${currentYear - 1}`, true], // invalid 0 month
     ["00", `${currentYear + 1}`, false], // invalid 0 month
     [`${currentMonth}`, "0000", true], // current month, in the year 2000

--- a/libs/common/src/autofill/utils.ts
+++ b/libs/common/src/autofill/utils.ts
@@ -51,7 +51,7 @@ export function normalizeExpiryYearFormat(yearInput: string | number): Year | nu
 
 /**
  * Takes a cipher card view and returns "true" if the month and year affirmativey indicate
- * the card is expired. Uncertain cases return "false"
+ * the card is expired. Uncertain cases return "false".
  *
  * @param {CardView} cipherCard
  * @return {*}  {boolean}
@@ -85,9 +85,9 @@ export function isCardExpired(cipherCard: CardView): boolean {
       const parsedMonthInteger = parseInt(expMonth, 10);
       const parsedMonthIsValid = parsedMonthInteger && !isNaN(parsedMonthInteger);
 
-      // If the parsed month value is 0, we don't know when the expiry passes this year, so treat it as expired
+      // If the parsed month value is 0, we don't know when the expiry passes this year, so do not treat it as expired
       if (!parsedMonthIsValid) {
-        return true;
+        return false;
       }
 
       // `Date` months are zero-indexed

--- a/libs/common/src/autofill/utils.ts
+++ b/libs/common/src/autofill/utils.ts
@@ -64,27 +64,27 @@ export function isCardExpired(cipherCard: CardView): boolean {
 
     const now = new Date();
     const normalizedYear = normalizeExpiryYearFormat(expYear);
-    const parsedYear = parseInt(normalizedYear, 10);
+    const parsedYear = normalizedYear ? parseInt(normalizedYear, 10) : NaN;
 
-    const expiryYearIsBeforeThisYear = parsedYear < now.getFullYear();
-    const expiryYearIsAfterThisYear = parsedYear > now.getFullYear();
+    const expiryYearIsBeforeCurrentYear = parsedYear < now.getFullYear();
+    const expiryYearIsAfterCurrentYear = parsedYear > now.getFullYear();
 
     // If the expiry year is before the current year, skip checking the month, since it must be expired
-    if (normalizedYear && expiryYearIsBeforeThisYear) {
+    if (normalizedYear && expiryYearIsBeforeCurrentYear) {
       return true;
     }
 
     // If the expiry year is after the current year, skip checking the month, since it cannot be expired
-    if (normalizedYear && expiryYearIsAfterThisYear) {
+    if (normalizedYear && expiryYearIsAfterCurrentYear) {
       return false;
     }
 
     if (normalizedYear && expMonth) {
       const parsedMonthInteger = parseInt(expMonth, 10);
-      const parsedMonthIsInvalid = !parsedMonthInteger || isNaN(parsedMonthInteger);
+      const parsedMonthIsValid = parsedMonthInteger && !isNaN(parsedMonthInteger);
 
       // If the parsed month value is 0, we don't know when the expiry passes this year, so treat it as expired
-      if (parsedMonthIsInvalid) {
+      if (!parsedMonthIsValid) {
         return true;
       }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-16667

## 📔 Objective

- Followup work/cleanup from https://github.com/bitwarden/clients/pull/12659
- remove `ts-strict-ignore` and make necessary changes
- In https://github.com/bitwarden/clients/pull/12659 we introduced a new codepath where we return `true` if the month is not provided/invalid, and the year is the current year. However, `isCardExpired` is meant to return `false` in uncertain cases (put another way, we're asking "is the card _definitely_ expired?"). The outcome of this change is that the expiration banner would have appeared if the user specified the current year in their card expiry but no month. After these changes, the banner will not appear in this case.


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
