### PR TITLE
[PM-15557] Log missing Cipher_ClientViewed event in Web

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -9,9 +9,11 @@ import { map } from "rxjs/operators";
 
 import { CollectionView } from "@bitwarden/admin-console/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { EventType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -237,6 +239,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     private premiumUpgradeService: PremiumUpgradePromptService,
     private cipherAuthorizationService: CipherAuthorizationService,
     private apiService: ApiService,
+    private eventCollectionService: EventCollectionService,
   ) {
     this.updateTitle();
   }
@@ -256,6 +259,13 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         this.cipher,
         [this.params.activeCollectionId],
         this.params.isAdminConsoleAction,
+      );
+
+      await this.eventCollectionService.collect(
+        EventType.Cipher_ClientViewed,
+        this.cipher.id,
+        false,
+        this.cipher.organizationId,
       );
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15557](https://bitwarden.atlassian.net/browse/PM-15557)

## 📔 Objective

Log the `Ciphever_ClientViewed` event when the `VaultItemDialog` in Web opens.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
