### PR TITLE
[PM-16682] Return a localized error message for entering tax information

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
@@ -23,8 +23,7 @@ import { KeyService } from "@bitwarden/key-management";
   templateUrl: "setup.component.html",
 })
 export class SetupComponent implements OnInit, OnDestroy {
-  @ViewChild(ManageTaxInformationComponent)
-  manageTaxInformationComponent: ManageTaxInformationComponent;
+  @ViewChild(ManageTaxInformationComponent) taxInformationComponent: ManageTaxInformationComponent;
 
   loading = true;
   providerId: string;
@@ -111,7 +110,7 @@ export class SetupComponent implements OnInit, OnDestroy {
     try {
       this.formGroup.markAllAsTouched();
 
-      if (!this.manageTaxInformationComponent.validate() || !this.formGroup.valid) {
+      if (!this.taxInformationComponent.validate() || !this.formGroup.valid) {
         return;
       }
 
@@ -125,7 +124,7 @@ export class SetupComponent implements OnInit, OnDestroy {
       request.key = key;
 
       request.taxInfo = new ExpandedTaxInfoUpdateRequest();
-      const taxInformation = this.manageTaxInformationComponent.getTaxInformation();
+      const taxInformation = this.taxInformationComponent.getTaxInformation();
 
       request.taxInfo.country = taxInformation.country;
       request.taxInfo.postalCode = taxInformation.postalCode;
@@ -147,6 +146,7 @@ export class SetupComponent implements OnInit, OnDestroy {
 
       await this.router.navigate(["/providers", provider.id]);
     } catch (e) {
+      e.message = this.i18nService.translate(e.message) || e.message;
       this.validationService.showError(e);
     }
   };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16682

## 📔 Objective

When setting up a new provider, the tax information is not being saved, neither is the error message shown as would be expected if the tax id is invalid.

This pull request allows returning localized error messages when entering tax information for setting up providers,

Not blocking, but is combined with: https://github.com/bitwarden/server/pull/5211

## 📸 Screenshots

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/9f1abc7b-522b-4a1e-af73-5686a735fbfb" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
