### PR TITLE
[PM-14289] - vault cipher form - set default owner as organization from collection when possible

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -747,16 +747,23 @@ export class VaultComponent implements OnInit, OnDestroy {
       null,
       cipherType,
     );
+    const collectionId =
+      this.activeFilter.collectionId !== "AllCollections" && this.activeFilter.collectionId != null
+        ? this.activeFilter.collectionId
+        : null;
+    let organizationId =
+      this.activeFilter.organizationId !== "MyVault" && this.activeFilter.organizationId != null
+        ? this.activeFilter.organizationId
+        : null;
+    // If the user is filtering by a collection but not by an organization, attempt get the organization ID from the collection
+    if (collectionId && !organizationId) {
+      organizationId = (await firstValueFrom(this.vaultFilterService.filteredCollections$)).find(
+        (c) => c.id === this.activeFilter.collectionId,
+      )?.organizationId;
+    }
     cipherFormConfig.initialValues = {
-      organizationId:
-        this.activeFilter.organizationId !== "MyVault" && this.activeFilter.organizationId != null
-          ? (this.activeFilter.organizationId as OrganizationId)
-          : null,
-      collectionIds:
-        this.activeFilter.collectionId !== "AllCollections" &&
-        this.activeFilter.collectionId != null
-          ? [this.activeFilter.collectionId as CollectionId]
-          : [],
+      organizationId: organizationId as OrganizationId,
+      collectionIds: [collectionId as CollectionId],
       folderId: this.activeFilter.folderId,
     };
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -755,11 +755,14 @@ export class VaultComponent implements OnInit, OnDestroy {
       this.activeFilter.organizationId !== "MyVault" && this.activeFilter.organizationId != null
         ? this.activeFilter.organizationId
         : null;
-    // If the user is filtering by a collection but not by an organization, attempt get the organization ID from the collection
-    if (collectionId && !organizationId) {
-      organizationId = (await firstValueFrom(this.vaultFilterService.filteredCollections$)).find(
-        (c) => c.id === this.activeFilter.collectionId,
-      )?.organizationId;
+    // Attempt to get the organization ID from the collection if present
+    if (collectionId) {
+      const organizationIdFromCollection = (
+        await firstValueFrom(this.vaultFilterService.filteredCollections$)
+      ).find((c) => c.id === this.activeFilter.collectionId)?.organizationId;
+      if (organizationIdFromCollection) {
+        organizationId = organizationIdFromCollection;
+      }
     }
     cipherFormConfig.initialValues = {
       organizationId: organizationId as OrganizationId,

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -178,6 +178,11 @@ export class ItemDetailsSectionComponent implements OnInit {
     return this.allowPersonalOwnership ? null : this.organizations[0].id;
   }
 
+  get defaultOrganizationId() {
+    const collectionId = this.initialValues?.collectionIds?.[0];
+    return this.collections.find((c) => c.id === collectionId)?.organizationId;
+  }
+
   async ngOnInit() {
     if (!this.allowPersonalOwnership && this.organizations.length === 0) {
       throw new Error("No organizations available for ownership.");
@@ -188,7 +193,8 @@ export class ItemDetailsSectionComponent implements OnInit {
     } else {
       this.itemDetailsForm.setValue({
         name: this.initialValues?.name || "",
-        organizationId: this.initialValues?.organizationId || this.defaultOwner,
+        organizationId:
+          this.initialValues?.organizationId || this.defaultOrganizationId || this.defaultOwner,
         folderId: this.initialValues?.folderId || null,
         collectionIds: [],
         favorite: false,

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -178,11 +178,6 @@ export class ItemDetailsSectionComponent implements OnInit {
     return this.allowPersonalOwnership ? null : this.organizations[0].id;
   }
 
-  get defaultOrganizationId() {
-    const collectionId = this.initialValues?.collectionIds?.[0];
-    return this.collections.find((c) => c.id === collectionId)?.organizationId;
-  }
-
   async ngOnInit() {
     if (!this.allowPersonalOwnership && this.organizations.length === 0) {
       throw new Error("No organizations available for ownership.");
@@ -193,8 +188,7 @@ export class ItemDetailsSectionComponent implements OnInit {
     } else {
       this.itemDetailsForm.setValue({
         name: this.initialValues?.name || "",
-        organizationId:
-          this.initialValues?.organizationId || this.defaultOrganizationId || this.defaultOwner,
+        organizationId: this.initialValues?.organizationId || this.defaultOwner,
         folderId: this.initialValues?.folderId || null,
         collectionIds: [],
         favorite: false,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14289

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where if the user goes directly to a collection and creates a new item the default owner was previously being set to the user even if the collection was part of an organization. We now attempt to get the organization from the `vaultFilterService` using the filtered `collectionId` when populating the form's initial values to be used when setting the default owner.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
