### PR TITLE
[PM-16696] New Device Verification Notice Learn More

### DIFF
--- a/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.html
+++ b/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.html
@@ -1,6 +1,14 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <p class="tw-text-center" bitTypography="body1">
     {{ "newDeviceVerificationNoticeContentPage1" | i18n }}
+    <a
+      bitLink
+      href="https://bitwarden.com/help/new-device-verification/"
+      rel="noreferrer"
+      target="_blank"
+    >
+      {{ "learnMore" | i18n }}.
+    </a>
   </p>
 
   <bit-card

--- a/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.ts
+++ b/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.ts
@@ -20,6 +20,7 @@ import {
   FormFieldModule,
   RadioButtonModule,
   TypographyModule,
+  LinkModule,
 } from "@bitwarden/components";
 
 import {
@@ -41,6 +42,7 @@ import {
     FormFieldModule,
     AsyncActionsModule,
     ReactiveFormsModule,
+    LinkModule,
   ],
 })
 export class NewDeviceVerificationNoticePageOneComponent implements OnInit, AfterViewInit {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16696](https://bitwarden.atlassian.net/browse/PM-16696)

## 📔 Objective

add learn more link to new device verification notification page one

## 📸 Screen Recording

https://github.com/user-attachments/assets/ad742a5c-41e8-4e7a-9ab6-480983ba6b80


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16696]: https://bitwarden.atlassian.net/browse/PM-16696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ