### PR TITLE
[PM-16824] update new device verification notice page for desktop learn more link

### DIFF
--- a/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.html
+++ b/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.html
@@ -1,12 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <p class="tw-text-center" bitTypography="body1">
     {{ "newDeviceVerificationNoticeContentPage1" | i18n }}
-    <a
-      bitLink
-      href="https://bitwarden.com/help/new-device-verification/"
-      rel="noreferrer"
-      target="_blank"
-    >
+    <a bitLink (click)="navigateToNewDeviceVerificationHelp($event)" href="#">
       {{ "learnMore" | i18n }}.
     </a>
   </p>

--- a/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.ts
+++ b/libs/vault/src/components/new-device-verification-notice/new-device-verification-notice-page-one.component.ts
@@ -121,4 +121,10 @@ export class NewDeviceVerificationNoticePageOneComponent implements OnInit, Afte
 
     await this.router.navigate(["/vault"]);
   };
+
+  navigateToNewDeviceVerificationHelp(event: Event) {
+    event.preventDefault();
+
+    this.platformUtilsService.launchUri("https://bitwarden.com/help/new-device-verification/");
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16824](https://bitwarden.atlassian.net/browse/PM-16824)

## 📔 Objective

using the `<a href="link">` was opening the learn more in a pop up from desktop. 

updating the learn more navigate in new device verification page one component  to use the platformso web, browser, and desktop all open the help page on a new page in the clients browser window. 

## 📸 Screen Recording


https://github.com/user-attachments/assets/ee2dc0e8-1882-4655-9f8d-52a8b333085f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16824]: https://bitwarden.atlassian.net/browse/PM-16824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ