### PR TITLE
[PM-13764] - Update Collection Settings

### DIFF
--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -231,6 +231,20 @@ export class AppComponent implements OnDestroy, OnInit {
             }
             break;
           }
+          case "syncOrganizationCollectionSettingChanged": {
+            const { organizationId, limitCollectionCreation, limitCollectionDeletion } = message;
+            const organizations = await firstValueFrom(this.organizationService.organizations$);
+            const organization = organizations.find((org) => org.id === organizationId);
+
+            if (organization) {
+              await this.organizationService.upsert({
+                ...organization,
+                limitCollectionCreation: limitCollectionCreation,
+                limitCollectionDeletion: limitCollectionDeletion,
+              });
+            }
+            break;
+          }
           default:
             break;
         }

--- a/libs/common/src/enums/notification-type.enum.ts
+++ b/libs/common/src/enums/notification-type.enum.ts
@@ -23,4 +23,5 @@ export enum NotificationType {
 
   SyncOrganizations = 17,
   SyncOrganizationStatusChanged = 18,
+  SyncOrganizationCollectionSettingChanged = 19,
 }

--- a/libs/common/src/models/response/notification.response.ts
+++ b/libs/common/src/models/response/notification.response.ts
@@ -45,6 +45,9 @@ export class NotificationResponse extends BaseResponse {
       case NotificationType.SyncOrganizationStatusChanged:
         this.payload = new OrganizationStatusPushNotification(payload);
         break;
+      case NotificationType.SyncOrganizationCollectionSettingChanged:
+        this.payload = new OrganizationCollectionSettingChangedPushNotification(payload);
+        break;
       default:
         break;
     }
@@ -124,5 +127,19 @@ export class OrganizationStatusPushNotification extends BaseResponse {
     super(response);
     this.organizationId = this.getResponseProperty("OrganizationId");
     this.enabled = this.getResponseProperty("Enabled");
+  }
+}
+
+export class OrganizationCollectionSettingChangedPushNotification extends BaseResponse {
+  organizationId: string;
+  limitCollectionCreation: boolean;
+  limitCollectionDeletion: boolean;
+
+  constructor(response: any) {
+    super(response);
+
+    this.organizationId = this.getResponseProperty("OrganizationId");
+    this.limitCollectionCreation = this.getResponseProperty("LimitCollectionCreation");
+    this.limitCollectionDeletion = this.getResponseProperty("LimitCollectionDeletion");
   }
 }

--- a/libs/common/src/services/notifications.service.ts
+++ b/libs/common/src/services/notifications.service.ts
@@ -89,7 +89,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
       .withHubProtocol(new signalRMsgPack.MessagePackHubProtocol() as signalR.IHubProtocol)
       // .configureLogging(signalR.LogLevel.Trace)
       .build();
-    ``;
+
     this.signalrConnection.on("ReceiveMessage", (data: any) =>
       this.processNotification(new NotificationResponse(data)),
     );

--- a/libs/common/src/services/notifications.service.ts
+++ b/libs/common/src/services/notifications.service.ts
@@ -89,7 +89,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
       .withHubProtocol(new signalRMsgPack.MessagePackHubProtocol() as signalR.IHubProtocol)
       // .configureLogging(signalR.LogLevel.Trace)
       .build();
-
+    ``;
     this.signalrConnection.on("ReceiveMessage", (data: any) =>
       this.processNotification(new NotificationResponse(data)),
     );
@@ -223,6 +223,11 @@ export class NotificationsService implements NotificationsServiceAbstraction {
         }
         break;
       case NotificationType.SyncOrganizationStatusChanged:
+        if (isAuthenticated) {
+          await this.syncService.fullSync(true);
+        }
+        break;
+      case NotificationType.SyncOrganizationCollectionSettingChanged:
         if (isAuthenticated) {
           await this.syncService.fullSync(true);
         }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-13764](https://bitwarden.atlassian.net/browse/PM-13764)

## 📔 Objective
When the server pushes the notification message, the cached organization can be updated locally to set the "Create Organization" and "Delete Organization".

Link to server side changes: https://github.com/bitwarden/server/pull/5230

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/6b968fd1-19b7-4cad-b508-422be02cb4e0)

![image](https://github.com/user-attachments/assets/2c4d60de-e941-44bc-896c-a5e92a2d6253)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13764]: https://bitwarden.atlassian.net/browse/PM-13764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ