### PR TITLE
[PM-16836] Fix ssh generation and import not being available when agent featureflag is disabled

### DIFF
--- a/apps/desktop/src/platform/main/main-ssh-agent.service.ts
+++ b/apps/desktop/src/platform/main/main-ssh-agent.service.ts
@@ -24,7 +24,23 @@ export class MainSshAgentService {
   constructor(
     private logService: LogService,
     private messagingService: MessagingService,
-  ) {}
+  ) {
+    ipcMain.handle(
+      "sshagent.generatekey",
+      async (event: any, { keyAlgorithm }: { keyAlgorithm: string }): Promise<sshagent.SshKey> => {
+        return await sshagent.generateKeypair(keyAlgorithm);
+      },
+    );
+    ipcMain.handle(
+      "sshagent.importkey",
+      async (
+        event: any,
+        { privateKey, password }: { privateKey: string; password?: string },
+      ): Promise<sshagent.SshKeyImportResult> => {
+        return sshagent.importKey(privateKey, password);
+      },
+    );
+  }
 
   init() {
     // handle sign request passing to UI
@@ -92,21 +108,6 @@ export class MainSshAgentService {
       "sshagent.signrequestresponse",
       async (event: any, { requestId, accepted }: { requestId: number; accepted: boolean }) => {
         this.requestResponses.push({ requestId, accepted, timestamp: new Date() });
-      },
-    );
-    ipcMain.handle(
-      "sshagent.generatekey",
-      async (event: any, { keyAlgorithm }: { keyAlgorithm: string }): Promise<sshagent.SshKey> => {
-        return await sshagent.generateKeypair(keyAlgorithm);
-      },
-    );
-    ipcMain.handle(
-      "sshagent.importkey",
-      async (
-        event: any,
-        { privateKey, password }: { privateKey: string; password?: string },
-      ): Promise<sshagent.SshKeyImportResult> => {
-        return sshagent.importKey(privateKey, password);
       },
     );
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-16836

## 📔 Objective

Keygen and import were accidentally also in the featureflag for the ssh-agent, since it is (temporarily until moved to the sdk) within the ssh-agent module in desktop-native.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
