### PR TITLE
fix: account for different build output on arm

### DIFF
--- a/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
+++ b/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
@@ -33,7 +33,11 @@ modules:
       - install bitwarden.sh /app/bin/bitwarden.sh
     sources:
       - type: dir
+        only-arches: [x86_64]
         path: ../dist/linux-unpacked
+      - type: dir
+        only-arches: [aarch64]
+        path: ../dist/linux-arm64-unpacked
       - type: script
         dest-filename: bitwarden.sh
         commands:


### PR DESCRIPTION
## 📔 Objective

While testing #12760, I needed to build the Flatpak on my arm64 VM and noticed the build path was different. This just adds the correct build dir for arm64.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
