### PR TITLE
[PM-15979] restore min max attributes

### DIFF
--- a/libs/tools/generator/components/src/passphrase-settings.component.html
+++ b/libs/tools/generator/components/src/passphrase-settings.component.html
@@ -12,6 +12,8 @@
             formControlName="numWords"
             id="num-words"
             type="number"
+            [min]="numWordsMin"
+            [max]="numWordsMax"
             (change)="save('numWords')"
           />
           <bit-hint>{{ numWordsBoundariesHint$ | async }}</bit-hint>

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -114,6 +114,9 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
         this.wordSeparatorMaxLength = constraints.wordSeparator.maxLength;
         this.policyInEffect = constraints.policyInEffect;
 
+        this.numWordsMin = constraints.numWords.min;
+        this.numWordsMax = constraints.numWords.max;
+
         this.toggleEnabled(Controls.capitalize, !constraints.capitalize?.readonly);
         this.toggleEnabled(Controls.includeNumber, !constraints.includeNumber?.readonly);
       });
@@ -127,6 +130,12 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
       )
       .subscribe(settings);
   }
+
+  /** attribute binding for numWords[min] */
+  protected numWordsMin: number;
+
+  /** attribute binding for numWords[max] */
+  protected numWordsMax: number;
 
   /** attribute binding for wordSeparator[maxlength] */
   protected wordSeparatorMaxLength: number;

--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -7,7 +7,14 @@
       <bit-card>
         <bit-form-field disableMargin>
           <bit-label>{{ "length" | i18n }}</bit-label>
-          <input bitInput formControlName="length" type="number" (change)="save('length')" />
+          <input
+            bitInput
+            formControlName="length"
+            type="number"
+            [min]="lengthMin"
+            [max]="lengthMax"
+            (change)="save('length')"
+          />
           <bit-hint>{{ lengthBoundariesHint$ | async }}</bit-hint>
         </bit-form-field>
       </bit-card>
@@ -71,7 +78,9 @@
               bitInput
               type="number"
               formControlName="minNumber"
-              (change)="save('minNumbers')"
+              [min]="minNumberMin"
+              [max]="minNumberMax"
+              (change)="save('minNumber')"
             />
           </bit-form-field>
           <bit-form-field class="tw-w-full tw-basis-1/2">
@@ -80,6 +89,8 @@
               bitInput
               type="number"
               formControlName="minSpecial"
+              [min]="minSpecialMin"
+              [max]="minSpecialMax"
               (change)="save('minSpecial')"
             />
           </bit-form-field>

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -150,6 +150,13 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
       .subscribe(({ constraints }) => {
         this.policyInEffect = constraints.policyInEffect;
 
+        this.lengthMin = constraints.length.min;
+        this.lengthMax = constraints.length.max;
+        this.minNumberMin = constraints.minNumber.min;
+        this.minNumberMax = constraints.minNumber.max;
+        this.minSpecialMin = constraints.minSpecial.min;
+        this.minSpecialMax - constraints.minSpecial.max;
+
         const toggles = [
           [Controls.length, constraints.length.min < constraints.length.max],
           [Controls.uppercase, !constraints.uppercase?.readonly],
@@ -226,6 +233,24 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
   save(site: string = "component api call") {
     this.saveSettings.next(site);
   }
+
+  /** attribute binding for length[min] */
+  protected lengthMin: number;
+
+  /** attribute binding for length[max] */
+  protected lengthMax: number;
+
+  /** attribute binding for minNumber[min] */
+  protected minNumberMin: number;
+
+  /** attribute binding for minNumber[max] */
+  protected minNumberMax: number;
+
+  /** attribute binding for minSpecial[min] */
+  protected minSpecialMin: number;
+
+  /** attribute binding for minSpecial[max] */
+  protected minSpecialMax: number;
 
   /** display binding for enterprise policy notice */
   protected policyInEffect: boolean;

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -155,7 +155,7 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
         this.minNumberMin = constraints.minNumber.min;
         this.minNumberMax = constraints.minNumber.max;
         this.minSpecialMin = constraints.minSpecial.min;
-        this.minSpecialMax - constraints.minSpecial.max;
+        this.minSpecialMax = constraints.minSpecial.max;
 
         const toggles = [
           [Controls.length, constraints.length.min < constraints.length.max],


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15979

## 📔 Objective

Restoring the min/max attributes prevents a UI desync when the generator's autocorrection logic completes within the same change detection cycle that signals the change.

It introduces an error message flicker in Chromium browsers. This happens because the invalid value is detected and the UI updated before autocorrection occurs. Then the autocorrected value is written into the form, validation re-runs, and updates the UI to hide the error message.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
