### PR TITLE
[PM-16859] Fix item creation resetting to login item type on browser

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -50,7 +50,7 @@ export class NewItemDropdownV2Component implements OnInit {
     this.tab = await BrowserApi.getTabFromCurrentWindow();
   }
 
-  async buildQueryParams(type: CipherType): Promise<AddEditQueryParams> {
+  buildQueryParams(type: CipherType): AddEditQueryParams {
     const poppedOut = BrowserPopupUtils.inPopout(window);
 
     const loginDetails: { uri?: string; name?: string } = {};

--- a/apps/web/src/app/vault/individual-vault/add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/add-edit.component.ts
@@ -107,7 +107,11 @@ export class AddEditComponent extends BaseAddEditComponent implements OnInit, On
 
     // https://bitwarden.atlassian.net/browse/PM-10413
     // cannot generate ssh keys so block creation
-    if (this.type === CipherType.SshKey && this.cipherId == null) {
+    if (
+      this.type === CipherType.SshKey &&
+      this.cipherId == null &&
+      !(await this.configService.getFeatureFlag(FeatureFlag.SSHKeyVaultItem))
+    ) {
       this.type = CipherType.Login;
       this.cipher.type = CipherType.Login;
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16859

## 📔 Objective

https://github.com/bitwarden/clients/pull/12176 updated buildQueryParams in new-item-dropdown-v2 to be async, which (somehow) broke item creation on browsers, resetting to login always.

Also makes code blocking ssh-key creation on web dependent on the featureflag.

## 📸 Screenshots

https://github.com/user-attachments/assets/032d3cf0-4098-4b72-a6c9-db8cb4a4e26e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
