### PR TITLE
fix(ci): Adjust variable name missed during lint update

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -70,7 +70,7 @@ jobs:
       retrive_secrets_keyvault: ${{ steps.config.outputs.retrive_secrets_keyvault }}
       sync_utility: ${{ steps.config.outputs.sync_utility }}
       sync_delete_destination_files: ${{ steps.config.outputs.sync_delete_destination_files }}
-      slack_channel_name: ${{ steps.config.outputs.slack-channel-name }}
+      slack_channel_name: ${{ steps.config.outputs.slack_channel_name }}
     steps:
       - name: Configure
         id: config


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/pull/12755

## 📔 Objective

On the linked PR I attempted to resolve all warnings and errors raised by the
new workflow linter. I missed one instance for Slack, which is causing
errors. This one line commit updates this variable name.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes