### PR TITLE
[PM-16895] Fix biometric prompt showing up in browser while disabled

### DIFF
--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
@@ -9,7 +9,12 @@ import {
 import { VaultTimeoutSettingsService } from "@bitwarden/common/abstractions/vault-timeout/vault-timeout-settings.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { UserId } from "@bitwarden/common/types/guid";
-import { KeyService, BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+import {
+  KeyService,
+  BiometricsService,
+  BiometricsStatus,
+  BiometricStateService,
+} from "@bitwarden/key-management";
 import { UnlockOptions } from "@bitwarden/key-management/angular";
 
 import { BrowserRouterService } from "../../../platform/popup/services/browser-router.service";
@@ -26,6 +31,7 @@ describe("ExtensionLockComponentService", () => {
   let vaultTimeoutSettingsService: MockProxy<VaultTimeoutSettingsService>;
   let keyService: MockProxy<KeyService>;
   let routerService: MockProxy<BrowserRouterService>;
+  let biometricStateService: MockProxy<BiometricStateService>;
 
   beforeEach(() => {
     userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
@@ -35,6 +41,7 @@ describe("ExtensionLockComponentService", () => {
     vaultTimeoutSettingsService = mock<VaultTimeoutSettingsService>();
     keyService = mock<KeyService>();
     routerService = mock<BrowserRouterService>();
+    biometricStateService = mock<BiometricStateService>();
 
     TestBed.configureTestingModule({
       providers: [
@@ -66,6 +73,10 @@ describe("ExtensionLockComponentService", () => {
         {
           provide: BrowserRouterService,
           useValue: routerService,
+        },
+        {
+          provide: BiometricStateService,
+          useValue: biometricStateService,
         },
       ],
     });
@@ -306,6 +317,7 @@ describe("ExtensionLockComponentService", () => {
       platformUtilsService.supportsSecureStorage.mockReturnValue(
         mockInputs.platformSupportsSecureStorage,
       );
+      biometricStateService.biometricUnlockEnabled$ = of(true);
 
       //  PIN
       pinService.isPinDecryptionAvailable.mockResolvedValue(mockInputs.pinDecryptionAvailable);

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
@@ -1,14 +1,18 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { inject } from "@angular/core";
-import { combineLatest, defer, map, Observable } from "rxjs";
+import { combineLatest, defer, firstValueFrom, map, Observable } from "rxjs";
 
 import {
   PinServiceAbstraction,
   UserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
 import { UserId } from "@bitwarden/common/types/guid";
-import { BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+import {
+  BiometricsService,
+  BiometricsStatus,
+  BiometricStateService,
+} from "@bitwarden/key-management";
 import { LockComponentService, UnlockOptions } from "@bitwarden/key-management/angular";
 
 import { BiometricErrors, BiometricErrorTypes } from "../../../models/biometricErrors";
@@ -19,6 +23,7 @@ export class ExtensionLockComponentService implements LockComponentService {
   private readonly biometricsService = inject(BiometricsService);
   private readonly pinService = inject(PinServiceAbstraction);
   private readonly routerService = inject(BrowserRouterService);
+  private readonly biometricStateService = inject(BiometricStateService);
 
   getPreviousUrl(): string | null {
     return this.routerService.getPreviousUrl();
@@ -45,7 +50,13 @@ export class ExtensionLockComponentService implements LockComponentService {
   getAvailableUnlockOptions$(userId: UserId): Observable<UnlockOptions> {
     return combineLatest([
       // Note: defer is preferable b/c it delays the execution of the function until the observable is subscribed to
-      defer(async () => await this.biometricsService.getBiometricsStatusForUser(userId)),
+      defer(async () => {
+        if (!(await firstValueFrom(this.biometricStateService.biometricUnlockEnabled$))) {
+          return BiometricsStatus.NotEnabledLocally;
+        } else {
+          return await this.biometricsService.getBiometricsStatusForUser(userId);
+        }
+      }),
       this.userDecryptionOptionsService.userDecryptionOptionsById$(userId),
       defer(() => this.pinService.isPinDecryptionAvailable(userId)),
     ]).pipe(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16895

## 📔 Objective

The biometrics service did not take into account the local settings from the biometricsstateservice to return the "NotEnabledLocally" status, and returned "desktopDisconnected" instead. The former should take priority so that the UI for biometrics gets hidden when the setting is disabled.

## 📸 Screenshots


https://github.com/user-attachments/assets/0d3eb994-24f7-4b32-9c1d-a5be91a77cc9



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
