### PR TITLE
[PM-16906] add close button to password history dialog

### DIFF
--- a/libs/tools/generator/components/src/credential-generator-history-dialog.component.html
+++ b/libs/tools/generator/components/src/credential-generator-history-dialog.component.html
@@ -14,5 +14,11 @@
     >
       {{ "clearHistory" | i18n }}
     </button>
+    <!-- FIXME: Remove the close button once the dialog doesn't overlap electron's
+         drag area.
+     -->
+    <button bitButton type="submit" buttonType="secondary" (click)="close()">
+      {{ "close" | i18n }}
+    </button>
   </ng-container>
 </bit-dialog>

--- a/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
@@ -1,5 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { DialogRef } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
@@ -34,6 +35,7 @@ export class CredentialGeneratorHistoryDialogComponent {
     private accountService: AccountService,
     private history: GeneratorHistoryService,
     private dialogService: DialogService,
+    private dialogRef: DialogRef,
   ) {
     this.accountService.activeAccount$
       .pipe(
@@ -52,7 +54,13 @@ export class CredentialGeneratorHistoryDialogComponent {
       .subscribe(this.hasHistory$);
   }
 
-  clear = async () => {
+  /** closes the dialog */
+  protected close() {
+    this.dialogRef.close();
+  }
+
+  /** Launches clear history flow */
+  protected async clear() {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "clearGeneratorHistoryTitle" },
       content: { key: "cleargGeneratorHistoryDescription" },
@@ -64,5 +72,5 @@ export class CredentialGeneratorHistoryDialogComponent {
     if (confirmed) {
       await this.history.clear(await firstValueFrom(this.userId$));
     }
-  };
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16906

## 📔 Objective

`bit-dialog` overlaps the electron windows' dragable “title” area. While waiting for a fix from UIF, this should be mitigated by adding a “close” button to the password history dialog box.

## 📸 Screenshots

Empty:
<img width="492" alt="image" src="https://github.com/user-attachments/assets/56f05e85-de80-4cdc-92e0-94ebbc77dbae" />

Lots of entries:
<img width="492" alt="image" src="https://github.com/user-attachments/assets/05f908e9-b04c-44cf-a40e-1216082ebba2" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
