### PR TITLE
[PM-16910] Fix biometrics being disabled before permission is granted

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -206,6 +206,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         switchMap(async () => {
           const status = await this.biometricsService.getBiometricsStatusForUser(activeAccount.id);
           const biometricSettingAvailable =
+            !(await BrowserApi.permissionsGranted(["nativeMessaging"])) ||
             (status !== BiometricsStatus.DesktopDisconnected &&
               status !== BiometricsStatus.NotEnabledInConnectedDesktopApp) ||
             (await this.vaultTimeoutSettingsService.isBiometricLockSet());


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16910

## 📔 Objective

The refactor of biometrics made the settings dynamically enable based on the status of the biometrics service. However, this did not take into account permissions being granted. It failed to connect because no permission was granted, and thus disabled the settings button. But clicking the settings button first prompts for permission, making it impossible to enable biometrics. This makes it so the button is always enabled before permissions are granted.

## 📸 Screenshots

Note that this screen recording also includes other changes to fix biometrics, which must be tested together to exhibit this behavior.  These changes are:

https://github.com/bitwarden/clients/pull/12797
[bitwarden.atlassian.net/browse/PM-16914](https://bitwarden.atlassian.net/browse/PM-16914)

https://github.com/bitwarden/clients/pull/12799
[bitwarden.atlassian.net/browse/PM-16932](https://bitwarden.atlassian.net/browse/PM-16932)

https://github.com/bitwarden/clients/pull/12792
[bitwarden.atlassian.net/browse/PM-16910](https://bitwarden.atlassian.net/browse/PM-16910)

https://github.com/bitwarden/clients/pull/12781
[bitwarden.atlassian.net/browse/PM-16895](https://bitwarden.atlassian.net/browse/PM-16895)


https://github.com/user-attachments/assets/d5b57c9a-f591-41bb-8fdd-b0e3d74e8f61

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
