### PR TITLE
[PM-16917] Remove jest-extended dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -214,6 +214,7 @@
         "jest-junit",
         "jest-mock-extended",
         "jest-preset-angular",
+        "jest-diff",
         "lint-staged",
         "ts-jest"
       ],

--- a/libs/admin-console/src/common/collections/services/default-vnext-collection.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-vnext-collection.service.spec.ts
@@ -91,7 +91,7 @@ describe("DefaultvNextCollectionService", () => {
 
       // Assert emitted values
       expect(result.length).toBe(2);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         {
           id: collection1.id,
           name: "DEC_NAME_" + collection1.id,
@@ -167,7 +167,7 @@ describe("DefaultvNextCollectionService", () => {
       const result = await firstValueFrom(collectionService.encryptedCollections$(userId));
 
       expect(result.length).toBe(2);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         {
           id: collection1.id,
           name: makeEncString("ENC_NAME_" + collection1.id),
@@ -205,7 +205,7 @@ describe("DefaultvNextCollectionService", () => {
 
       const result = await firstValueFrom(collectionService.encryptedCollections$(userId));
       expect(result.length).toBe(3);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         {
           id: collection1.id,
           name: makeEncString("UPDATED_ENC_NAME_" + collection1.id),
@@ -230,7 +230,7 @@ describe("DefaultvNextCollectionService", () => {
 
       const result = await firstValueFrom(collectionService.encryptedCollections$(userId));
       expect(result.length).toBe(1);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         {
           id: collection1.id,
           name: makeEncString("ENC_NAME_" + collection1.id),
@@ -253,7 +253,7 @@ describe("DefaultvNextCollectionService", () => {
 
       const result = await firstValueFrom(collectionService.encryptedCollections$(userId));
       expect(result.length).toBe(1);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         {
           id: newCollection3.id,
           name: makeEncString("ENC_NAME_" + newCollection3.id),

--- a/libs/admin-console/test.setup.ts
+++ b/libs/admin-console/test.setup.ts
@@ -1,5 +1,9 @@
 import { webcrypto } from "crypto";
+
+import { addCustomMatchers } from "@bitwarden/common/spec";
 import "jest-preset-angular/setup-jest";
+
+addCustomMatchers();
 
 Object.defineProperty(window, "CSS", { value: null });
 Object.defineProperty(window, "getComputedStyle", {

--- a/libs/admin-console/tsconfig.json
+++ b/libs/admin-console/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../shared/tsconfig.libs",
-  "include": ["src", "spec"],
+  "include": ["src", "spec", "../../libs/common/custom-matchers.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/libs/common/spec/matchers/index.ts
+++ b/libs/common/spec/matchers/index.ts
@@ -1,15 +1,11 @@
-import * as matchers from "jest-extended";
-
 import { toBeFulfilled, toBeResolved, toBeRejected } from "./promise-fulfilled";
 import { toAlmostEqual } from "./to-almost-equal";
+import { toContainPartialObjects } from "./to-contain-partial-objects";
 import { toEqualBuffer } from "./to-equal-buffer";
 
 export * from "./to-equal-buffer";
 export * from "./to-almost-equal";
 export * from "./promise-fulfilled";
-
-// add all jest-extended matchers
-expect.extend(matchers);
 
 export function addCustomMatchers() {
   expect.extend({
@@ -18,6 +14,7 @@ export function addCustomMatchers() {
     toBeFulfilled: toBeFulfilled,
     toBeResolved: toBeResolved,
     toBeRejected: toBeRejected,
+    toContainPartialObjects,
   });
 }
 
@@ -59,4 +56,9 @@ export interface CustomMatchers<R = unknown> {
    * @returns CustomMatcherResult indicating whether or not the test passed
    */
   toBeRejected(withinMs?: number): Promise<R>;
+  /**
+   * Matches if the received array contains all the expected objects using partial matching (expect.objectContaining).
+   * @param expected An array of partial objects that should be contained in the received array.
+   */
+  toContainPartialObjects<T>(expected: Array<T>): R;
 }

--- a/libs/common/spec/matchers/to-contain-partial-objects.spec.ts
+++ b/libs/common/spec/matchers/to-contain-partial-objects.spec.ts
@@ -1,0 +1,77 @@
+describe("toContainPartialObjects", () => {
+  describe("matches", () => {
+    it("if the array only contains the partial objects", () => {
+      const actual = [
+        {
+          id: 1,
+          name: "foo",
+        },
+        {
+          id: 2,
+          name: "bar",
+        },
+      ];
+
+      const expected = [{ id: 1 }, { id: 2 }];
+
+      expect(actual).toContainPartialObjects(expected);
+    });
+
+    it("if the array contains the partial objects and other objects", () => {
+      const actual = [
+        {
+          id: 1,
+          name: "foo",
+        },
+        {
+          id: 2,
+          name: "bar",
+        },
+        {
+          id: 3,
+          name: "baz",
+        },
+      ];
+
+      const expected = [{ id: 1 }, { id: 2 }];
+
+      expect(actual).toContainPartialObjects(expected);
+    });
+  });
+
+  describe("doesn't match", () => {
+    it("if the array does not contain any partial objects", () => {
+      const actual = [
+        {
+          id: 1,
+          name: "foo",
+        },
+        {
+          id: 2,
+          name: "bar",
+        },
+      ];
+
+      const expected = [{ id: 1, name: "Foo" }];
+
+      expect(actual).not.toContainPartialObjects(expected);
+    });
+
+    it("if the array contains some but not all partial objects", () => {
+      const actual = [
+        {
+          id: 1,
+          name: "foo",
+        },
+        {
+          id: 2,
+          name: "bar",
+        },
+      ];
+
+      const expected = [{ id: 2 }, { id: 3 }];
+
+      expect(actual).not.toContainPartialObjects(expected);
+    });
+  });
+});

--- a/libs/common/spec/matchers/to-contain-partial-objects.ts
+++ b/libs/common/spec/matchers/to-contain-partial-objects.ts
@@ -1,0 +1,16 @@
+import { diff } from "jest-diff";
+
+export const toContainPartialObjects: jest.CustomMatcher = function <T>(
+  received: Array<T>,
+  expected: Array<T>,
+) {
+  const pass = this.equals(
+    received,
+    expect.arrayContaining(expected.map((e) => expect.objectContaining(e))),
+  );
+
+  return {
+    message: () => diff(expected, received),
+    pass: pass,
+  };
+};

--- a/libs/common/src/tools/rx.spec.ts
+++ b/libs/common/src/tools/rx.spec.ts
@@ -56,7 +56,7 @@ describe("errorOnChange", () => {
 
     source$.complete();
 
-    expect(complete).toBeTrue();
+    expect(complete).toBe(true);
   });
 
   it("errors when the input changes", async () => {

--- a/libs/common/src/vault/services/folder/folder.service.spec.ts
+++ b/libs/common/src/vault/services/folder/folder.service.spec.ts
@@ -76,7 +76,7 @@ describe("Folder Service", () => {
 
       expect(result.length).toBe(2);
       expect(result).toContainPartialObjects([
-        { id: "1", name: makeEncString("ENC_STRING_2") },
+        { id: "1", name: makeEncString("ENC_STRING_1") },
         { id: "2", name: makeEncString("ENC_STRING_2") },
       ]);
     });

--- a/libs/common/src/vault/services/folder/folder.service.spec.ts
+++ b/libs/common/src/vault/services/folder/folder.service.spec.ts
@@ -75,8 +75,8 @@ describe("Folder Service", () => {
       const result = await firstValueFrom(folderService.folders$(mockUserId));
 
       expect(result.length).toBe(2);
-      expect(result).toIncludeAllPartialMembers([
-        { id: "1", name: makeEncString("ENC_STRING_1") },
+      expect(result).toContainPartialObjects([
+        { id: "1", name: makeEncString("ENC_STRING_2") },
         { id: "2", name: makeEncString("ENC_STRING_2") },
       ]);
     });
@@ -96,7 +96,7 @@ describe("Folder Service", () => {
       const result = await firstValueFrom(folderService.folderViews$(mockUserId));
 
       expect(result.length).toBe(3);
-      expect(result).toIncludeAllPartialMembers([
+      expect(result).toContainPartialObjects([
         { id: "1", name: "DEC" },
         { id: "2", name: "DEC" },
         { name: "No Folder" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,7 @@
         "html-webpack-injector": "1.1.4",
         "html-webpack-plugin": "5.6.3",
         "husky": "9.1.4",
-        "jest-extended": "4.0.2",
+        "jest-diff": "29.7.0",
         "jest-junit": "16.0.0",
         "jest-mock-extended": "3.0.7",
         "jest-preset-angular": "14.1.1",
@@ -20718,28 +20718,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-extended": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-4.0.2.tgz",
-      "integrity": "sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-diff": "^29.0.0",
-        "jest-get-type": "^29.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "jest": ">=27.2.5"
-      },
-      "peerDependenciesMeta": {
-        "jest": {
-          "optional": true
-        }
       }
     },
     "node_modules/jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "html-webpack-injector": "1.1.4",
     "html-webpack-plugin": "5.6.3",
     "husky": "9.1.4",
-    "jest-extended": "4.0.2",
+    "jest-diff": "29.7.0",
     "jest-junit": "16.0.0",
     "jest-mock-extended": "3.0.7",
     "jest-preset-angular": "14.1.1",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16917
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
@Hinton requested that we reconsider whether we need the `jest-extended` dependency.

We only use 2 matchers from it:
- `tobeTrue()` - trivially rewritten as `expect().toBe(true)`.
- `toIncludeAllPartialMembers` - this checks that all the expected objects appear in the array using a partial match (e.g. `objectContaining`). This is useful but was easy enough to implement our own version of.

I have made these changes and removed `jest-extended`.

Unfortunately I did need to add `jest-diff` to present a readable error message if the custom matcher fails. However, this is already used by jest so it's not net new. Also, it's officially maintained by jest rather than the community. So overall I still think this is an improvement.

I made SM Team the owner of `jest-diff` for renovate purposes, just to keep it grouped with the existing configuration for jest packages.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
