### PR TITLE
Add support for fido2 2fa on mac

### DIFF
--- a/apps/desktop/src/platform/services/electron-platform-utils.service.ts
+++ b/apps/desktop/src/platform/services/electron-platform-utils.service.ts
@@ -80,7 +80,9 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
   // Temporarily restricted to only Windows until https://github.com/electron/electron/pull/28349
   // has been merged and an updated electron build is available.
   supportsWebAuthn(win: Window): boolean {
-    return this.getDevice() === DeviceType.WindowsDesktop;
+    return (
+      this.getDevice() === DeviceType.WindowsDesktop || this.getDevice() === DeviceType.MacOsDesktop
+    );
   }
 
   supportsDuo(): boolean {


### PR DESCRIPTION
## 🎟️ Tracking

todo

## 📔 Objective

Fido2 on electron desktop on mac works, when no pin is required, only the pin is unimplemented. Therefore, we can just enable it for 2fa.

## 📸 Screenshots

todo

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
