### PR TITLE
[PM-16868] Add csv export instructions for Nordpass

### DIFF
--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -395,6 +395,11 @@
           Open the FullClient, go to the Main Menu and select Export. Start the export passwords
           wizard and follow the instructions to export a CSV file.
         </ng-container>
+        <ng-container *ngIf="format === 'nordpasscsv'">
+          Log in to NordPass and open Settings &rarr; Scroll down to the Import and Export section
+          and select Export items &rarr; Enter your Master Password and select Continue. &rarr; Save
+          the CSV file on your device.
+        </ng-container>
       </bit-callout>
       <import-lastpass
         *ngIf="showLastPassOptions"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16868

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When the Nordpass was selected on the import page, no instructions for th csv export were shown. This PR adds instructions when the Nordpass csv format is selected. I must have missed this, when I implemented the importer with https://github.com/bitwarden/jslib/pull/360

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before
![image](https://github.com/user-attachments/assets/b6209d2a-2860-48fc-b1ec-d2dfc670cf35)

### After
![image](https://github.com/user-attachments/assets/0473d033-0379-4d65-89b0-7d89f20f53ae)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
