### PR TITLE
[PM-15572] - don't allow restore for 'edit except password' permission

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -235,7 +235,11 @@ export class ViewV2Component {
   }
 
   protected showFooter(): boolean {
-    return this.cipher && (!this.cipher.isDeleted || (this.cipher.isDeleted && this.cipher.edit));
+    return (
+      this.cipher &&
+      (!this.cipher.isDeleted ||
+        (this.cipher.isDeleted && this.cipher.edit && this.cipher.viewPassword))
+    );
   }
 
   /**

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
@@ -31,7 +31,7 @@
         ></i>
         <span slot="secondary">{{ cipher.subTitle }}</span>
       </button>
-      <ng-container slot="end" *ngIf="cipher.edit">
+      <ng-container slot="end" *ngIf="cipher.edit && cipher.viewPassword">
         <bit-item-action>
           <button
             type="button"

--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -101,8 +101,8 @@ export class CipherViewComponent implements OnChanges, OnDestroy {
       return false;
     }
 
-    const { username, password, totp } = this.cipher.login;
-    return username || password || totp;
+    const { username, password, totp, fido2Credentials } = this.cipher.login;
+    return username || password || totp || fido2Credentials;
   }
 
   get hasAutofill() {

--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -101,8 +101,8 @@ export class CipherViewComponent implements OnChanges, OnDestroy {
       return false;
     }
 
-    const { username, password, totp, fido2Credentials } = this.cipher.login;
-    return username || password || totp || fido2Credentials;
+    const { username, password, totp } = this.cipher.login;
+    return username || password || totp;
   }
 
   get hasAutofill() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15572

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the ability to restore deleted ciphers for users with the "edit, except passwords" permission.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
