### PR TITLE
[PM-17041] Remove firefox autoprompt

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -20,7 +20,7 @@
             {{ biometricUnavailabilityReason }}
           </bit-hint>
         </bit-form-control>
-        <bit-form-control class="tw-pl-5" *ngIf="this.form.value.biometric">
+        <bit-form-control class="tw-pl-5" *ngIf="this.form.value.biometric && showAutoPrompt">
           <input
             bitCheckbox
             id="autoBiometricsPrompt"

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -29,6 +29,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { DeviceType } from "@bitwarden/common/enums";
 import { VaultTimeoutAction } from "@bitwarden/common/enums/vault-timeout-action.enum";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -106,6 +107,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   hasVaultTimeoutPolicy = false;
   biometricUnavailabilityReason: string;
   showChangeMasterPass = true;
+  showAutoPrompt = true;
 
   form = this.formBuilder.group({
     vaultTimeout: [null as VaultTimeout | null],
@@ -141,6 +143,11 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
+    // Firefox popup closes when unfocused by biometrics, blocking all unlock methods
+    if (this.platformUtilsService.getDevice() === DeviceType.FirefoxExtension) {
+      this.showAutoPrompt = false;
+    }
+
     const hasMasterPassword = await this.userVerificationService.hasMasterPassword();
     this.showMasterPasswordOnClientRestartOption = hasMasterPassword;
     const maximumVaultTimeoutPolicy = this.policyService.get$(PolicyType.MaximumVaultTimeout);

--- a/libs/key-management/src/angular/lock/components/lock.component.ts
+++ b/libs/key-management/src/angular/lock/components/lock.component.ts
@@ -30,7 +30,7 @@ import {
   MasterPasswordVerification,
   MasterPasswordVerificationResponse,
 } from "@bitwarden/common/auth/types/verification";
-import { ClientType } from "@bitwarden/common/enums";
+import { ClientType, DeviceType } from "@bitwarden/common/enums";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -301,6 +301,11 @@ export class LockComponent implements OnInit, OnDestroy {
     }
 
     if (this.clientType === "browser") {
+      // Firefox closes the popup when unfocused, so this would block all unlock methods
+      if (this.platformUtilsService.getDevice() === DeviceType.FirefoxExtension) {
+        return;
+      }
+
       if (
         this.unlockOptions.biometrics.enabled &&
         autoPromptBiometrics &&


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17041

## 📔 Objective

Removes biometrics autoprompt on firefox, since it is not a good user experience and blocks unlock methods from being used.

## 📸 Screenshots


https://github.com/user-attachments/assets/6ba6f13e-b6f9-41c5-ba31-79f92a0b6508


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
