### PR TITLE
[CL-524] Ignore kitchen sink virtual scroll story

### DIFF
--- a/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
@@ -12,7 +12,7 @@ import { TableDataSource, TableModule } from "../../../table";
   imports: [DialogModule, IconButtonModule, SectionComponent, TableModule, ScrollingModule],
   template: /*html*/ `<bit-section>
     <cdk-virtual-scroll-viewport scrollWindow itemSize="47">
-      <bit-table [dataSource]="dataSource" data-chromatic="ignore">
+      <bit-table [dataSource]="dataSource">
         <ng-container header>
           <tr>
             <th bitCell bitSortable="id" default>Id</th>

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -196,4 +196,10 @@ export const VirtualScrollBlockingDialog: Story = {
 
     await userEvent.click(dialogButton);
   },
+  parameters: {
+    chromatic: {
+      // TODO CL-524 fix flaky story (number of virtual scroll rows is inconsistent)
+      disableSnapshot: true,
+    },
+  },
 };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-524](https://bitwarden.atlassian.net/browse/CL-524)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The kitchen sink virtual scroll story is still causing unwanted diffs because the previous method used to ignore changes (`data-chromatic=ignore`) does not ignore height changes, which is exactly what's causing the diffs. Skipping the whole test for now until we can figure out why the row count is inconsistent.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-524]: https://bitwarden.atlassian.net/browse/CL-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ