### PR TITLE
[PM-17053] Change suggested items section header copy on the basis of the URI blocked status

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4007,6 +4007,9 @@
   "passkeyRemoved": {
     "message": "Passkey removed"
   },
+  "autofillSuggestions": {
+    "message": "Autofill suggestions"
+  },
   "itemSuggestions": {
     "message": "Suggested items"
   },

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -1,7 +1,7 @@
 <app-vault-list-items-container
   *ngIf="autofillCiphers$ | async as ciphers"
   [ciphers]="ciphers"
-  [title]="'itemSuggestions' | i18n"
+  [title]="((currentURIIsBlocked$ | async) ? 'itemSuggestions' : 'autofillSuggestions') | i18n"
   [showRefresh]="showRefresh"
   (onRefresh)="refreshCurrentTab()"
   [description]="(showEmptyAutofillTip$ | async) ? ('autofillSuggestionsTip' | i18n) : null"

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.ts
@@ -65,6 +65,12 @@ export class AutofillVaultListItemsComponent implements OnInit {
     ),
   );
 
+  /**
+   * Flag indicating that the current tab location is blocked
+   */
+  currentURIIsBlocked$: Observable<boolean> =
+    this.vaultPopupAutofillService.currentTabIsOnBlocklist$;
+
   constructor(
     private vaultPopupItemsService: VaultPopupItemsService,
     private vaultPopupAutofillService: VaultPopupAutofillService,


### PR DESCRIPTION
## 🎟️ Tracking

PM-17053

## 📔 Objective

Change suggested items section header copy on the basis of the URI blocked status

## 📸 Screenshots

| blocked Tab | unblocked tab |
| --- | --- |
| ![Screenshot 2025-01-14 at 10 57 32 AM](https://github.com/user-attachments/assets/b1a6c7ad-ede3-44fb-b1b2-b36bbdbd6ec6) | ![Screenshot 2025-01-14 at 10 57 49 AM](https://github.com/user-attachments/assets/4e50ee10-af7a-4f61-b573-dd9413042e1e) |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
