### PR TITLE
fix: use `WeakMap` in `DerivedStateProvider` to separate user state caches

### DIFF
--- a/libs/common/src/platform/state/implementations/default-derived-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-derived-state.provider.ts
@@ -8,7 +8,14 @@ import { DerivedStateProvider } from "../derived-state.provider";
 import { DefaultDerivedState } from "./default-derived-state";
 
 export class DefaultDerivedStateProvider implements DerivedStateProvider {
-  private cache: Record<string, DerivedState<unknown>> = {};
+  /**
+   * The cache uses a WeakMap to maintain separate derived states per user.
+   * Each user's state Observable acts as a unique key, without needing to
+   * pass around `userId`. Also, when a user's state Observable is cleaned up
+   * (like during an account swap) their cache is automatically garbage
+   * collected.
+   */
+  private cache = new WeakMap<Observable<unknown>, Record<string, DerivedState<unknown>>>();
 
   constructor() {}
 
@@ -17,8 +24,14 @@ export class DefaultDerivedStateProvider implements DerivedStateProvider {
     deriveDefinition: DeriveDefinition<TFrom, TTo, TDeps>,
     dependencies: TDeps,
   ): DerivedState<TTo> {
+    let stateCache = this.cache.get(parentState$);
+    if (!stateCache) {
+      stateCache = {};
+      this.cache.set(parentState$, stateCache);
+    }
+
     const cacheKey = deriveDefinition.buildCacheKey();
-    const existingDerivedState = this.cache[cacheKey];
+    const existingDerivedState = stateCache[cacheKey];
     if (existingDerivedState != null) {
       // I have to cast out of the unknown generic but this should be safe if rules
       // around domain token are made
@@ -26,7 +39,7 @@ export class DefaultDerivedStateProvider implements DerivedStateProvider {
     }
 
     const newDerivedState = this.buildDerivedState(parentState$, deriveDefinition, dependencies);
-    this.cache[cacheKey] = newDerivedState;
+    stateCache[cacheKey] = newDerivedState;
     return newDerivedState;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15914

## 📔 Objective

When switching accounts derived state was still fetching from a cache for the
previous account, leading to UI elements being displayed with data from an
inactive account's cache. The DerivedStateProvider now uses a WeakMap to
maintain separate caches for each user's state Observable.

- Modifies DefaultDerivedStateProvider to use WeakMap for caching
- Each user's state Observable gets its own definition cache
- Added test to verify correct behavior during account switching
- Automatically cleans up inactive user caches on parentState change

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes