### PR TITLE
[PM-17042] Biometrics auto prompt popup does not show up on safari

### DIFF
--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -97,7 +97,7 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
           if (await this.keyService.validateUserKey(userKey, userId)) {
             await this.biometricStateService.setBiometricUnlockEnabled(true);
             await this.biometricStateService.setFingerprintValidated(true);
-            this.keyService.setUserKey(userKey, userId);
+            await this.keyService.setUserKey(userKey, userId);
             return userKey;
           }
         } else {
@@ -115,7 +115,7 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
           if (await this.keyService.validateUserKey(userKey, userId)) {
             await this.biometricStateService.setBiometricUnlockEnabled(true);
             await this.biometricStateService.setFingerprintValidated(true);
-            this.keyService.setUserKey(userKey, userId);
+            await this.keyService.setUserKey(userKey, userId);
             return userKey;
           }
         } else {

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -137,8 +137,8 @@ export class AppComponent implements OnInit, OnDestroy {
             this.toastService._showToast(msg);
           } else if (msg.command === "reloadProcess") {
             if (this.platformUtilsService.isSafari()) {
-              window.setTimeout(() => {
-                this.biometricStateService.updateLastProcessReload();
+              window.setTimeout(async () => {
+                await this.biometricStateService.updateLastProcessReload();
                 window.location.reload();
               }, 2000);
             }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -36,6 +36,8 @@
       "@bitwarden/platform": ["./libs/platform/src"],
       "@bitwarden/node/*": ["./libs/node/src/*"],
       "@bitwarden/vault": ["./libs/vault/src"],
+      "@bitwarden/key-management": ["./libs/key-management/src"],
+      "@bitwarden/key-management/angular": ["./libs/key-management/src/angular"],
       "@bitwarden/bit-common/*": ["./bitwarden_license/bit-common/src/*"]
     },
     "plugins": [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17042

## 📔 Objective

This is due to missing await before process reload, triggered by lock, effectively disabling the biometrics auto prompt on safari.
This should be detected by eslint, but due to misconfiguration, nothing was reported. Also fixed two other missing awaits on biometrics unlock.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
