### PR TITLE
Clean up CSS classes that aren't tailwind-compatible

### DIFF
--- a/libs/tools/generator/components/src/catchall-settings.component.html
+++ b/libs/tools/generator/components/src/catchall-settings.component.html
@@ -1,4 +1,4 @@
-<form class="box" [formGroup]="settings" class="tw-container">
+<form [formGroup]="settings" class="tw-container">
   <bit-form-field>
     <bit-label>{{ "domainName" | i18n }}</bit-label>
     <input

--- a/libs/tools/generator/components/src/credential-generator.component.html
+++ b/libs/tools/generator/components/src/credential-generator.component.html
@@ -56,7 +56,7 @@
   </bit-section-header>
   <div class="tw-mb-4">
     <bit-card>
-      <form [formGroup]="username" class="box tw-container">
+      <form [formGroup]="username" class="tw-container">
         <bit-form-field>
           <bit-label>{{ "type" | i18n }}</bit-label>
           <bit-select
@@ -70,7 +70,7 @@
           }}</bit-hint>
         </bit-form-field>
       </form>
-      <form *ngIf="showForwarder$ | async" [formGroup]="forwarder" class="box tw-container">
+      <form *ngIf="showForwarder$ | async" [formGroup]="forwarder" class="tw-container">
         <bit-form-field>
           <bit-label>{{ "service" | i18n }}</bit-label>
           <bit-select

--- a/libs/tools/generator/components/src/forwarder-settings.component.html
+++ b/libs/tools/generator/components/src/forwarder-settings.component.html
@@ -1,4 +1,4 @@
-<form class="box" [formGroup]="settings" class="tw-container">
+<form [formGroup]="settings" class="tw-container">
   <bit-form-field *ngIf="displayDomain">
     <bit-label>{{ "forwarderDomainName" | i18n }}</bit-label>
     <input

--- a/libs/tools/generator/components/src/passphrase-settings.component.html
+++ b/libs/tools/generator/components/src/passphrase-settings.component.html
@@ -2,7 +2,7 @@
   <bit-section-header *ngIf="showHeader">
     <h6 bitTypography="h6">{{ "options" | i18n }}</h6>
   </bit-section-header>
-  <form class="box" [formGroup]="settings" class="tw-container">
+  <form [formGroup]="settings" class="tw-container">
     <div class="tw-mb-4">
       <bit-card>
         <bit-form-field disableMargin>

--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -2,7 +2,7 @@
   <bit-section-header *ngIf="showHeader">
     <h2 bitTypography="h6">{{ "options" | i18n }}</h2>
   </bit-section-header>
-  <form class="box" [formGroup]="settings" class="tw-container">
+  <form [formGroup]="settings" class="tw-container">
     <div class="tw-mb-4">
       <bit-card>
         <bit-form-field disableMargin>

--- a/libs/tools/generator/components/src/subaddress-settings.component.html
+++ b/libs/tools/generator/components/src/subaddress-settings.component.html
@@ -1,4 +1,4 @@
-<form class="box" [formGroup]="settings" class="tw-container">
+<form [formGroup]="settings" class="tw-container">
   <bit-form-field>
     <bit-label>{{ "email" | i18n }}</bit-label>
     <input

--- a/libs/tools/generator/components/src/username-generator.component.html
+++ b/libs/tools/generator/components/src/username-generator.component.html
@@ -33,7 +33,7 @@
   </bit-section-header>
   <div [ngClass]="{ 'tw-mb-4': !disableMargin }">
     <bit-card>
-      <form class="box" [formGroup]="username" class="tw-container">
+      <form [formGroup]="username" class="tw-container">
         <bit-form-field>
           <bit-label>{{ "type" | i18n }}</bit-label>
           <bit-select
@@ -47,7 +47,7 @@
           }}</bit-hint>
         </bit-form-field>
       </form>
-      <form *ngIf="showForwarder$ | async" [formGroup]="forwarder" class="box tw-container">
+      <form *ngIf="showForwarder$ | async" [formGroup]="forwarder" class="tw-container">
         <bit-form-field>
           <bit-label>{{ "service" | i18n }}</bit-label>
           <bit-select

--- a/libs/tools/generator/components/src/username-settings.component.html
+++ b/libs/tools/generator/components/src/username-settings.component.html
@@ -1,4 +1,4 @@
-<form class="box" [formGroup]="settings" class="tw-container">
+<form [formGroup]="settings" class="tw-container">
   <bit-form-control>
     <input
       bitCheckbox

--- a/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
+++ b/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
@@ -18,12 +18,12 @@
         <i
           slot="start"
           *ngIf="send.type === sendType.Text"
-          class="bwi bwi-file-text tw-text-2xl text-muted"
+          class="bwi bwi-file-text tw-text-2xl tw-text-muted"
         ></i>
         <i
           slot="start"
           *ngIf="send.type === sendType.File"
-          class="bwi bwi-file tw-text-2xl text-muted"
+          class="bwi bwi-file tw-text-2xl tw-text-muted"
         ></i>
         {{ send.name }}
         <span slot="secondary">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17089

## 📔 Objective

Clean up CSS classes that aren't tailwind-compatible so that tailwind lints can be enabled.

These classes have no effect on the UI; there aren't updated screenshots.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
