### PR TITLE
[PM-17088] Prevent lock component init when switching to unlocked account

### DIFF
--- a/libs/key-management/src/angular/lock/components/lock.component.ts
+++ b/libs/key-management/src/angular/lock/components/lock.component.ts
@@ -244,6 +244,10 @@ export class LockComponent implements OnInit, OnDestroy {
     if (activeAccount == null) {
       return;
     }
+    // this account may be unlocked, prevent any prompts so we can redirect to vault
+    if (await this.keyService.hasUserKeyInMemory(activeAccount.id)) {
+      return;
+    }
 
     this.setEmailAsPageSubtitle(activeAccount.email);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17088
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a new user is selected through account switching, the new lock component will reinitialize with that user. If that user is unlocked, the app will quickly redirect to vault, but that reinitialization was still running. This meant that things like bio prompts would show before switching to vault.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
