### PR TITLE
replace toBeTrue() with toBe(true)

### DIFF
--- a/libs/common/src/tools/extension/runtime-extension-registry.spec.ts
+++ b/libs/common/src/tools/extension/runtime-extension-registry.spec.ts
@@ -143,8 +143,8 @@ describe("RuntimeExtensionRegistry", () => {
 
       const result = registry.registerSite(SomeSite).registerSite(barSite).sites();
 
-      expect(result.some(({ site }) => site.id === SomeSiteId)).toBeTrue();
-      expect(result.some(({ site }) => site.id === barSite.id)).toBeTrue();
+      expect(result.some(({ site }) => site.id === SomeSiteId)).toBe(true);
+      expect(result.some(({ site }) => site.id === barSite.id)).toBe(true);
     });
 
     it("includes permissions for a site", () => {
@@ -230,8 +230,8 @@ describe("RuntimeExtensionRegistry", () => {
 
       const result = registry.vendors();
 
-      expect(result.some(({ vendor }) => vendor.id === SomeVendorId)).toBeTrue();
-      expect(result.some(({ vendor }) => vendor.id === JustTrustUs.id)).toBeTrue();
+      expect(result.some(({ vendor }) => vendor.id === SomeVendorId)).toBe(true);
+      expect(result.some(({ vendor }) => vendor.id === JustTrustUs.id)).toBe(true);
     });
 
     it("includes permissions for a vendor", () => {
@@ -411,10 +411,10 @@ describe("RuntimeExtensionRegistry", () => {
 
       expect(
         result.some((p: any) => p.set.site === SomeSiteId && p.permission === Permission.allow),
-      ).toBeTrue();
+      ).toBe(true);
       expect(
         result.some((p: any) => p.set.site === "bar" && p.permission === Permission.deny),
-      ).toBeTrue();
+      ).toBe(true);
     });
 
     it("includes vendor permissions", () => {
@@ -428,12 +428,12 @@ describe("RuntimeExtensionRegistry", () => {
 
       expect(
         result.some((p: any) => p.set.vendor === SomeVendorId && p.permission === Permission.allow),
-      ).toBeTrue();
+      ).toBe(true);
       expect(
         result.some(
           (p: any) => p.set.vendor === JustTrustUs.id && p.permission === Permission.deny,
         ),
-      ).toBeTrue();
+      ).toBe(true);
     });
   });
 
@@ -561,13 +561,13 @@ describe("RuntimeExtensionRegistry", () => {
             ({ extension }) =>
               extension.site.id === SomeSiteId && extension.product.vendor.id === SomeVendorId,
           ),
-        ).toBeTrue();
+        ).toBe(true);
         expect(
           result.some(
             ({ extension }) =>
               extension.site.id === SomeSiteId && extension.product.vendor.id === JustTrustUs.id,
           ),
-        ).toBeTrue();
+        ).toBe(true);
       });
 
       it("includes permissions for extensions", () => {
@@ -587,7 +587,7 @@ describe("RuntimeExtensionRegistry", () => {
               extension.product.vendor.id === SomeVendorId &&
               permissions.includes(Permission.allow),
           ),
-        ).toBeTrue();
+        ).toBe(true);
       });
     });
 


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Fix broken unit tests merged in e79dab868956a21e1886f38ae8d1dbc05246ead9. The tests are broken because the `toBeTrue()` checker was removed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
