### PR TITLE
[PM-8634] - CLI - return updated folder when saving a folder

### DIFF
--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -14,6 +14,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { Folder } from "@bitwarden/common/vault/models/domain/folder";
 import { KeyService } from "@bitwarden/key-management";
 
 import { OrganizationCollectionRequest } from "../admin-console/models/request/organization-collection.request";
@@ -152,8 +153,8 @@ export class EditCommand {
     const userKey = await this.keyService.getUserKeyWithLegacySupport(activeUserId);
     const encFolder = await this.folderService.encrypt(folderView, userKey);
     try {
-      await this.folderApiService.save(encFolder, activeUserId);
-      const updatedFolder = await this.folderService.get(folder.id, activeUserId);
+      const folder = await this.folderApiService.save(encFolder, activeUserId);
+      const updatedFolder = new Folder(folder);
       const decFolder = await updatedFolder.decrypt();
       const res = new FolderResponse(decFolder);
       return Response.success(res);

--- a/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
+++ b/libs/common/src/vault/abstractions/folder/folder-api.service.abstraction.ts
@@ -2,11 +2,12 @@
 // @ts-strict-ignore
 
 import { UserId } from "../../../types/guid";
+import { FolderData } from "../../models/data/folder.data";
 import { Folder } from "../../models/domain/folder";
 import { FolderResponse } from "../../models/response/folder.response";
 
 export class FolderApiServiceAbstraction {
-  save: (folder: Folder, userId: UserId) => Promise<any>;
+  save: (folder: Folder, userId: UserId) => Promise<FolderData>;
   delete: (id: string, userId: UserId) => Promise<any>;
   get: (id: string) => Promise<FolderResponse>;
   deleteAll: (userId: UserId) => Promise<void>;

--- a/libs/common/src/vault/services/folder/folder-api.service.ts
+++ b/libs/common/src/vault/services/folder/folder-api.service.ts
@@ -13,7 +13,7 @@ export class FolderApiService implements FolderApiServiceAbstraction {
     private apiService: ApiService,
   ) {}
 
-  async save(folder: Folder, userId: UserId): Promise<any> {
+  async save(folder: Folder, userId: UserId): Promise<FolderData> {
     const request = new FolderRequest(folder);
 
     let response: FolderResponse;
@@ -26,6 +26,7 @@ export class FolderApiService implements FolderApiServiceAbstraction {
 
     const data = new FolderData(response);
     await this.folderService.upsert(data, userId);
+    return data;
   }
 
   async delete(id: string, userId: UserId): Promise<any> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8634

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the folder `save` function to return the updated folder to allow the `editFolder` to return the updated folder to the client.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![403936255-b150f1ca-cd48-4ce6-826a-1e5248609fe7](https://github.com/user-attachments/assets/eb3c254d-503e-439c-883e-9ac1b07fb753)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
