### PR TITLE
[PM-15938] - don't allow 'except password' permissions to view or copy hidden fields

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -167,6 +167,10 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
       );
     });
 
+    if (!this.cipherFormContainer.originalCipherView?.viewPassword) {
+      this.customFieldsForm.disable();
+    }
+
     // Disable the form if in partial-edit mode
     // Must happen after the initial fields are populated
     if (this.cipherFormContainer.config.mode === "partial-edit") {

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -38,6 +38,7 @@
           type="button"
           bitIconButton
           bitPasswordInputToggle
+          *ngIf="canViewPassword"
           (toggledChange)="logHiddenEvent($event)"
         ></button>
         <button
@@ -47,6 +48,7 @@
           [appCopyClick]="field.value"
           showToast
           [valueLabel]="field.name"
+          *ngIf="canViewPassword"
           [appA11yTitle]="'copyCustomField' | i18n: field.name"
           (click)="logCopyEvent()"
         ></button>

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
@@ -59,6 +59,10 @@ export class CustomFieldV2Component implements OnInit {
     return this.i18nService.t(linkedType.i18nKey);
   }
 
+  get canViewPassword() {
+    return this.cipher.viewPassword;
+  }
+
   async logHiddenEvent(hiddenFieldVisible: boolean) {
     if (hiddenFieldVisible) {
       await this.eventCollectionService.collect(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15938

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the visibility toggle and copy buttons from hidden fields in the view modal as well as disables the input in the edit modal for `except passwords` permissions.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
