### PR TITLE
[PM-15943] - When filling a password, the extension flickers

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -280,10 +280,10 @@ describe("VaultPopupAutofillService", () => {
 
         it("should close popup after a timeout for chromium browsers", async () => {
           mockPlatformUtilsService.isFirefox.mockReturnValue(false);
-          jest.spyOn(global, "setTimeout");
+          jest.spyOn(global, "requestAnimationFrame");
           await service.doAutofill(mockCipher);
           jest.advanceTimersByTime(50);
-          expect(setTimeout).toHaveBeenCalledTimes(1);
+          expect(requestAnimationFrame).toHaveBeenCalled();
           expect(BrowserApi.closePopup).toHaveBeenCalled();
         });
 

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -280,7 +280,7 @@ export class VaultPopupAutofillService {
     }
 
     // Slight delay to fix bug in Chromium browsers where popup closes without copying totp to clipboard
-    setTimeout(() => BrowserApi.closePopup(window), 50);
+    requestAnimationFrame(() => BrowserApi.closePopup(window));
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15943

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR uses `requestAnimationFrame` instead of an arbitrary time value when closing the popout. This has the benefit of ensuring the copy operation completes and avoids the animation flicker noted in the ticket.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
