### PR TITLE
[PM-17162] Migrate shared components

### DIFF
--- a/apps/web/src/app/components/environment-selector/environment-selector.component.html
+++ b/apps/web/src/app/components/environment-selector/environment-selector.component.html
@@ -6,10 +6,9 @@
       [attr.href]="
         region == currentRegion ? 'javascript:void(0)' : region.urls.webVault + routeAndParams
       "
-      class="pr-4"
     >
       <i
-        class="bwi bwi-fw bwi-sm bwi-check pb-1"
+        class="bwi bwi-fw bwi-sm bwi-check"
         aria-hidden="true"
         [style.visibility]="region == currentRegion ? 'visible' : 'hidden'"
       ></i>

--- a/apps/web/src/app/layouts/frontend-layout.component.html
+++ b/apps/web/src/app/layouts/frontend-layout.component.html
@@ -1,6 +1,8 @@
 <router-outlet></router-outlet>
-<div class="container my-5 text-muted text-center">
+
+<footer class="tw-text-center tw-my-12">
   <environment-selector></environment-selector>
-  &copy; {{ year }} Bitwarden Inc. <br />
-  {{ "versionNumber" | i18n: version }}
-</div>
+
+  <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
+  <div bitTypography="body2">{{ version }}</div>
+</footer>

--- a/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
+++ b/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
@@ -10,7 +10,7 @@
   <i
     slot="end"
     *ngIf="!activeOrganization.enabled"
-    class="bwi bwi-exclamation-triangle tw-my-auto !text-alt-2"
+    class="bwi bwi-exclamation-triangle tw-my-auto"
     [attr.aria-label]="'organizationIsDisabled' | i18n"
     appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
   ></i>
@@ -27,7 +27,7 @@
       <i
         slot="end"
         *ngIf="org.enabled == false"
-        class="bwi bwi-exclamation-triangle !text-alt-2"
+        class="bwi bwi-exclamation-triangle"
         [attr.aria-label]="'organizationIsDisabled' | i18n"
         appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
       ></i>

--- a/apps/web/src/app/settings/domain-rules.component.html
+++ b/apps/web/src/app/settings/domain-rules.component.html
@@ -43,7 +43,7 @@
     <button type="submit" bitButton bitFormButton buttonType="primary">
       {{ "save" | i18n }}
     </button>
-    <h2 bitTypography="h2" class="spaced-header">{{ "globalEqDomains" | i18n }}</h2>
+    <h2 bitTypography="h2" class="tw-mt-16">{{ "globalEqDomains" | i18n }}</h2>
     <p bitTypography="body1" *ngIf="loading">
       <i
         class="bwi bwi-spinner bwi-spin tw-text-muted"

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="projectSecrets?.secrets && projectSecrets?.project; else spinner">
     <div
       *ngIf="projectSecrets.secrets?.length > 0 && projectSecrets.project?.write"
-      class="float-right tw-mt-3 tw-items-center"
+      class="tw-float-right tw-mt-3 tw-items-center"
     >
       <button type="button" bitButton buttonType="secondary" (click)="openNewSecretDialog()">
         <i class="bwi bwi-plus" aria-hidden="true"></i>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html
@@ -14,7 +14,6 @@
       bitInput
       type="file"
       id="file"
-      class="form-control-file"
       name="file"
       (change)="setSelectedFile($event)"
       accept="application/JSON"
@@ -23,7 +22,7 @@
     />
     <bit-hint>{{ "acceptedFormats" | i18n }} Bitwarden (json)</bit-hint>
   </bit-form-field>
-  <div class="my-4">
+  <div class="tw-my-4">
     {{ "or" | i18n }}
   </div>
   <bit-form-field>
@@ -31,7 +30,6 @@
     <textarea
       bitInput
       id="pastedContents"
-      class="form-control"
       name="FileContents"
       formControlName="pastedContents"
     ></textarea>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17162

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Migrates the following components to not use bootstrap.

- apps/web/src/app/components/environment-selector/environment-selector.component.html
- apps/web/src/app/layouts/frontend-layout.component.html
- apps/web/src/app/layouts/org-switcher/org-switcher.component.html
- apps/web/src/app/settings/domain-rules.component.html
- bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-secrets.component.html
- bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.html

Styling should be identical or only have minor differences.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Two components experienced minor visual changes. Frontend footer is more aligned with the new annon-layout, environment switcher has some weird padding removed and more compliant with the general menu components, and secrets manager import has some grey background within the text area removed.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/e0169f5c-0686-4a84-8a7c-a8867ccff876)|![image](https://github.com/user-attachments/assets/7f7db205-964f-4bb2-be47-ab25874fd9b5)|
|![image](https://github.com/user-attachments/assets/28c49fc4-4e27-4054-8166-4189a208ca74)|![image](https://github.com/user-attachments/assets/049c9d90-9ac5-4a87-be77-84827b2c2d89)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
