### PR TITLE
[PM-16702] Adding break-words to imported filename

### DIFF
--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -409,7 +409,7 @@
       <div [hidden]="showLastPassOptions">
         <bit-form-field>
           <bit-label>{{ "selectImportFile" | i18n }}</bit-label>
-          <div class="file-selector tw-pt-2 tw-pb-1">
+          <div class="file-selector tw-pt-2 tw-pb-1 tw-break-words">
             <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
               {{ "chooseFile" | i18n }}
             </button>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16702

## 📔 Objective

When importing a file, if the file name is a long and without any spaces, the file name will overflow the viewport and looks less refined. This PR adds the break-words class to prevent the overflow in all clients, though the issue is much less noticeable in web in general due to the typically larger viewport.

## 📸 Screenshots

Before:

![image](https://github.com/user-attachments/assets/4b2a6604-dc5e-438b-bf85-e3e5705d61f1)

After:

![image](https://github.com/user-attachments/assets/035dc58a-f219-4d0b-88db-7d6c1243ef62)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
