### PR TITLE
[BRE-560] Display rollout percentage in run name

### DIFF
--- a/.github/workflows/staged-rollout-desktop.yml
+++ b/.github/workflows/staged-rollout-desktop.yml
@@ -1,4 +1,5 @@
 name: Staged Rollout Desktop
+run-name: Staged Rollout Desktop - ${{ inputs.rollout_percentage }}%
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-560](https://bitwarden.atlassian.net/browse/BRE-560)

## 📔 Objective

Simple update to show the rollout percentage input in the run-name

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-560]: https://bitwarden.atlassian.net/browse/BRE-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ