### PR TITLE
Revert Opera to Mv2 build

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -208,7 +208,11 @@ jobs:
           - name: "opera"
             npm_command: "dist:opera"
             archive_name: "dist-opera.zip"
-            artifact_name: "dist-opera-MV3"
+            artifact_name: "dist-opera"
+          - name: "opera-mv3"
+            npm_command: "dist:opera:mv3"
+            archive_name: "dist-opera.zip"
+            artifact_name: "DO-NOT-USE-FOR-PROD-dist-opera-MV3"
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -6,7 +6,7 @@
     "build:chrome": "cross-env BROWSER=chrome MANIFEST_VERSION=3 webpack",
     "build:edge": "cross-env BROWSER=edge MANIFEST_VERSION=3 webpack",
     "build:firefox": "cross-env BROWSER=firefox webpack",
-    "build:opera": "cross-env BROWSER=opera MANIFEST_VERSION=3 webpack",
+    "build:opera": "cross-env BROWSER=opera webpack",
     "build:safari": "cross-env BROWSER=safari webpack",
     "build:watch": "npm run build:watch:chrome",
     "build:watch:chrome": "npm run build:chrome -- --watch",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8319
https://bitwarden.atlassian.net/browse/PM-17141

## 📔 Objective

Reverts part of https://github.com/bitwarden/clients/pull/12674.

We have encountered issues with the Opera Mv3 build and need to revert to Mv2 so they can be addressed.

This changes the `build-browser` workflow to produce the `dist-opera` artifact as before, along with the `DO-NOT-USE` Mv3 artifact.  It then changes the `build:opera` script to build the Mv2 version, so that version will be used in the workflow.

Note that the workflows run on this branch are those in `main` and therefore are building the Mv3 artifact still.

We will address the underlying issue and test the functionality in the Mv3 build locally before attempting the Mv3 release again.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
