### PR TITLE
Change tsconfig to be owned by platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -161,3 +161,7 @@ apps/web/src/locales/en/messages.json
 **/*.Dockerfile
 **/.dockerignore
 **/entrypoint.sh
+
+## Overrides
+# tsconfig files are potentially dangerous and will be reviewed by platform to prevent misconfigurations
+**/tsconfig.json @bitwarden/team-platform-dev


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We regularly have to modify all tsconfig files together and having platform own them will make those PRs easier. This also adds another safe guard against teams making accidentally mistakes like cyclic dependencies.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
