### PR TITLE
Auth/PM-17197 - UnauthGuard Trusted Devices Lock State Refactor

### DIFF
--- a/libs/angular/src/auth/guards/unauth.guard.spec.ts
+++ b/libs/angular/src/auth/guards/unauth.guard.spec.ts
@@ -5,17 +5,48 @@ import { MockProxy, mock } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
 import { EmptyComponent } from "@bitwarden/angular/platform/guard/feature-flag.guard.spec";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { DeviceTrustServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust.service.abstraction";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
 
 import { unauthGuardFn } from "./unauth.guard";
 
 describe("UnauthGuard", () => {
-  const setup = (authStatus: AuthenticationStatus) => {
+  const activeUser: Account = {
+    id: "fake_user_id" as UserId,
+    email: "test@email.com",
+    emailVerified: true,
+    name: "Test User",
+  };
+
+  const setup = (
+    activeUser: Account | null,
+    authStatus: AuthenticationStatus | null = null,
+    tdeEnabled: boolean = false,
+    everHadUserKey: boolean = false,
+  ) => {
+    const accountService: MockProxy<AccountService> = mock<AccountService>();
     const authService: MockProxy<AuthService> = mock<AuthService>();
-    authService.getAuthStatus.mockResolvedValue(authStatus);
-    const activeAccountStatusObservable = new BehaviorSubject<AuthenticationStatus>(authStatus);
-    authService.activeAccountStatus$ = activeAccountStatusObservable;
+    const keyService: MockProxy<KeyService> = mock<KeyService>();
+    const deviceTrustService: MockProxy<DeviceTrustServiceAbstraction> =
+      mock<DeviceTrustServiceAbstraction>();
+    const logService: MockProxy<LogService> = mock<LogService>();
+
+    accountService.activeAccount$ = new BehaviorSubject<Account | null>(activeUser);
+
+    if (authStatus !== null) {
+      const activeAccountStatusObservable = new BehaviorSubject<AuthenticationStatus>(authStatus);
+      authService.authStatusFor$.mockReturnValue(activeAccountStatusObservable);
+    }
+
+    keyService.everHadUserKey$ = new BehaviorSubject<boolean>(everHadUserKey);
+    deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(
+      new BehaviorSubject<boolean>(tdeEnabled),
+    );
 
     const testBed = TestBed.configureTestingModule({
       imports: [
@@ -30,6 +61,7 @@ describe("UnauthGuard", () => {
           { path: "lock", component: EmptyComponent },
           { path: "testhomepage", component: EmptyComponent },
           { path: "testlocked", component: EmptyComponent },
+          { path: "login-initiated", component: EmptyComponent },
           {
             path: "testOverrides",
             component: EmptyComponent,
@@ -39,7 +71,13 @@ describe("UnauthGuard", () => {
           },
         ]),
       ],
-      providers: [{ provide: AuthService, useValue: authService }],
+      providers: [
+        { provide: AccountService, useValue: accountService },
+        { provide: AuthService, useValue: authService },
+        { provide: KeyService, useValue: keyService },
+        { provide: DeviceTrustServiceAbstraction, useValue: deviceTrustService },
+        { provide: LogService, useValue: logService },
+      ],
     });
 
     return {
@@ -48,40 +86,54 @@ describe("UnauthGuard", () => {
   };
 
   it("should be created", () => {
-    const { router } = setup(AuthenticationStatus.LoggedOut);
+    const { router } = setup(null, AuthenticationStatus.LoggedOut);
     expect(router).toBeTruthy();
   });
 
   it("should redirect to /vault for guarded routes when logged in and unlocked", async () => {
-    const { router } = setup(AuthenticationStatus.Unlocked);
+    const { router } = setup(activeUser, AuthenticationStatus.Unlocked);
 
     await router.navigateByUrl("unauth-guarded-route");
     expect(router.url).toBe("/vault");
   });
 
-  it("should allow access to guarded routes when logged out", async () => {
-    const { router } = setup(AuthenticationStatus.LoggedOut);
+  it("should allow access to guarded routes when account is null", async () => {
+    const { router } = setup(null);
 
     await router.navigateByUrl("unauth-guarded-route");
     expect(router.url).toBe("/unauth-guarded-route");
   });
 
+  it("should allow access to guarded routes when logged out", async () => {
+    const { router } = setup(null, AuthenticationStatus.LoggedOut);
+
+    await router.navigateByUrl("unauth-guarded-route");
+    expect(router.url).toBe("/unauth-guarded-route");
+  });
+
+  it("should redirect to /login-initiated when locked, TDE is enabled, and the user hasn't decrypted yet", async () => {
+    const { router } = setup(activeUser, AuthenticationStatus.Locked, true, false);
+
+    await router.navigateByUrl("unauth-guarded-route");
+    expect(router.url).toBe("/login-initiated");
+  });
+
   it("should redirect to /lock for guarded routes when locked", async () => {
-    const { router } = setup(AuthenticationStatus.Locked);
+    const { router } = setup(activeUser, AuthenticationStatus.Locked);
 
     await router.navigateByUrl("unauth-guarded-route");
     expect(router.url).toBe("/lock");
   });
 
   it("should redirect to /testhomepage for guarded routes when testOverrides are provided and the account is unlocked", async () => {
-    const { router } = setup(AuthenticationStatus.Unlocked);
+    const { router } = setup(activeUser, AuthenticationStatus.Unlocked);
 
     await router.navigateByUrl("testOverrides");
     expect(router.url).toBe("/testhomepage");
   });
 
   it("should redirect to /testlocked for guarded routes when testOverrides are provided and the account is locked", async () => {
-    const { router } = setup(AuthenticationStatus.Locked);
+    const { router } = setup(activeUser, AuthenticationStatus.Locked);
 
     await router.navigateByUrl("testOverrides");
     expect(router.url).toBe("/testlocked");

--- a/libs/angular/src/auth/guards/unauth.guard.ts
+++ b/libs/angular/src/auth/guards/unauth.guard.ts
@@ -1,9 +1,13 @@
 import { inject } from "@angular/core";
-import { CanActivateFn, Router, UrlTree } from "@angular/router";
-import { Observable, map } from "rxjs";
+import { ActivatedRouteSnapshot, CanActivateFn, Router, UrlTree } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { DeviceTrustServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-trust.service.abstraction";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { KeyService } from "@bitwarden/key-management";
 
 type UnauthRoutes = {
   homepage: () => string;
@@ -15,23 +19,54 @@ const defaultRoutes: UnauthRoutes = {
   locked: "/lock",
 };
 
-function unauthGuard(routes: UnauthRoutes): Observable<boolean | UrlTree> {
+// TODO: PM-17195 - Investigate consolidating unauthGuard and redirectGuard into AuthStatusGuard
+async function unauthGuard(
+  route: ActivatedRouteSnapshot,
+  routes: UnauthRoutes,
+): Promise<boolean | UrlTree> {
+  const accountService = inject(AccountService);
   const authService = inject(AuthService);
   const router = inject(Router);
+  const keyService = inject(KeyService);
+  const deviceTrustService = inject(DeviceTrustServiceAbstraction);
+  const logService = inject(LogService);
 
-  return authService.activeAccountStatus$.pipe(
-    map((status) => {
-      if (status == null || status === AuthenticationStatus.LoggedOut) {
-        return true;
-      } else if (status === AuthenticationStatus.Locked) {
-        return router.createUrlTree([routes.locked]);
-      } else {
-        return router.createUrlTree([routes.homepage()]);
-      }
-    }),
+  const activeUser = await firstValueFrom(accountService.activeAccount$);
+
+  if (!activeUser) {
+    return true;
+  }
+
+  const authStatus = await firstValueFrom(authService.authStatusFor$(activeUser.id));
+
+  if (authStatus == null || authStatus === AuthenticationStatus.LoggedOut) {
+    return true;
+  }
+
+  if (authStatus === AuthenticationStatus.Unlocked) {
+    return router.createUrlTree([routes.homepage()]);
+  }
+
+  const tdeEnabled = await firstValueFrom(
+    deviceTrustService.supportsDeviceTrustByUserId$(activeUser.id),
   );
+  const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$);
+
+  // If locked, TDE is enabled, and the user hasn't decrypted yet, then redirect to the
+  // login decryption options component.
+  if (authStatus === AuthenticationStatus.Locked && tdeEnabled && !everHadUserKey) {
+    logService.info(
+      "Sending user to TDE decryption options. AuthStatus is %s. TDE support is %s. Ever had user key is %s.",
+      AuthenticationStatus[authStatus],
+      tdeEnabled,
+      everHadUserKey,
+    );
+    return router.createUrlTree(["/login-initiated"]);
+  }
+
+  return router.createUrlTree([routes.locked]);
 }
 
 export function unauthGuardFn(overrides: Partial<UnauthRoutes> = {}): CanActivateFn {
-  return () => unauthGuard({ ...defaultRoutes, ...overrides });
+  return async (route) => unauthGuard(route, { ...defaultRoutes, ...overrides });
 }

--- a/libs/common/src/auth/abstractions/device-trust.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/device-trust.service.abstraction.ts
@@ -9,7 +9,18 @@ import { DeviceKey, UserKey } from "../../types/key";
 import { DeviceResponse } from "./devices/responses/device.response";
 
 export abstract class DeviceTrustServiceAbstraction {
+  /**
+   * @deprecated - use supportsDeviceTrustByUserId instead as active user state is being deprecated
+   * by Platform
+   * @description Checks if the device trust feature is supported for the active user.
+   */
   supportsDeviceTrust$: Observable<boolean>;
+
+  /**
+   * @description Checks if the device trust feature is supported for the given user.
+   */
+  supportsDeviceTrustByUserId$: (userId: UserId) => Observable<boolean>;
+
   /**
    * @description Retrieves the users choice to trust the device which can only happen after decryption
    * Note: this value should only be used once and then reset

--- a/libs/common/src/auth/services/device-trust.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust.service.implementation.ts
@@ -81,7 +81,17 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     private configService: ConfigService,
   ) {
     this.supportsDeviceTrust$ = this.userDecryptionOptionsService.userDecryptionOptions$.pipe(
-      map((options) => options?.trustedDeviceOption != null ?? false),
+      map((options) => {
+        return options?.trustedDeviceOption != null ?? false;
+      }),
+    );
+  }
+
+  supportsDeviceTrustByUserId$(userId: UserId): Observable<boolean> {
+    return this.userDecryptionOptionsService.userDecryptionOptionsById$(userId).pipe(
+      map((options) => {
+        return options?.trustedDeviceOption != null ?? false;
+      }),
     );
   }
 

--- a/libs/common/src/auth/services/device-trust.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust.service.spec.ts
@@ -1,5 +1,7 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
 import { matches, mock } from "jest-mock-extended";
-import { BehaviorSubject, of } from "rxjs";
+import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 
 import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 
@@ -74,15 +76,54 @@ describe("deviceTrustService", () => {
     userId: mockUserId,
   };
 
+  let userDecryptionOptions: UserDecryptionOptions;
+
   beforeEach(() => {
     jest.clearAllMocks();
     const supportsSecureStorage = false; // default to false; tests will override as needed
     // By default all the tests will have a mocked active user in state provider.
     deviceTrustService = createDeviceTrustService(mockUserId, supportsSecureStorage);
+
+    userDecryptionOptions = new UserDecryptionOptions();
   });
 
   it("instantiates", () => {
     expect(deviceTrustService).not.toBeFalsy();
+  });
+
+  describe("supportsDeviceTrustByUserId$", () => {
+    it("returns true when the user has a non-null trusted device decryption option", async () => {
+      // Arrange
+      userDecryptionOptions.trustedDeviceOption = {
+        hasAdminApproval: false,
+        hasLoginApprovingDevice: false,
+        hasManageResetPasswordPermission: false,
+        isTdeOffboarding: false,
+      };
+
+      userDecryptionOptionsService.userDecryptionOptionsById$.mockReturnValue(
+        new BehaviorSubject<UserDecryptionOptions>(userDecryptionOptions),
+      );
+
+      const result = await firstValueFrom(
+        deviceTrustService.supportsDeviceTrustByUserId$(mockUserId),
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when the user has a null trusted device decryption option", async () => {
+      // Arrange
+      userDecryptionOptions.trustedDeviceOption = null;
+
+      userDecryptionOptionsService.userDecryptionOptionsById$.mockReturnValue(
+        new BehaviorSubject<UserDecryptionOptions>(userDecryptionOptions),
+      );
+
+      const result = await firstValueFrom(
+        deviceTrustService.supportsDeviceTrustByUserId$(mockUserId),
+      );
+      expect(result).toBe(false);
+    });
   });
 
   describe("User Trust Device Choice For Decryption", () => {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17197

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To make the `unauthGuard` aware of the Trusted Device Encryption lock state so that, in specific situations where you refresh on an unauthenticated screen in the sidebar of Firefox or other browsers with sidebars after completing authentication in the extension popout, the sidebar can refresh and take you to the login initiated screen appropriately. Previously, the `unauthGuard` would send the user to the lock screen and the `lockGuard` would deny navigation so the user would be left on a blank screen in the sidebar. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
https://github.com/user-attachments/assets/aa4c0511-cb1e-482f-8fec-56bd7d89d348

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
