### PR TITLE
[PM-258] Add text-muted to custom avatar picker

### DIFF
--- a/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.html
+++ b/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.html
@@ -33,7 +33,7 @@
         >
           <i
             [style.color]="customTextColor$ | async"
-            class="bwi bwi-pencil text-muted tw-m-auto tw-text-3xl"
+            class="bwi bwi-pencil !tw-text-muted tw-m-auto tw-text-3xl"
           ></i>
           <input
             tabindex="-1"

--- a/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.html
+++ b/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.html
@@ -33,7 +33,7 @@
         >
           <i
             [style.color]="customTextColor$ | async"
-            class="bwi bwi-pencil tw-m-auto tw-text-3xl"
+            class="bwi bwi-pencil text-muted tw-m-auto tw-text-3xl"
           ></i>
           <input
             tabindex="-1"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-258](https://bitwarden.atlassian.net/browse/PM-258)

## 📔 Objective

This PR adds the `text-muted` class to the custom avatar color picker, so that the contrast is better when viewing in dark mode. Effects both light and dark mode.

## 📸 Screenshots

Before:

![image](https://github.com/user-attachments/assets/950df0fe-0a68-4de8-a54a-aa69959c4b9d)
![image](https://github.com/user-attachments/assets/bb7c9e38-7045-47f4-a5e9-f7265ad0042a)

After:

![image](https://github.com/user-attachments/assets/976d1f12-306c-4068-a559-00b5213510fc)
![image](https://github.com/user-attachments/assets/ec288215-6550-437a-9d6c-911ce4f65346)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-258]: https://bitwarden.atlassian.net/browse/PM-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ