### PR TITLE
[BRE-563] Reverting out electron_publish option.  Needs to always happen

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -22,11 +22,6 @@ on:
         required: true
         default: '10'
         type: string
-      electron_publish:
-        description: 'Publish Electron blob to AWS'
-        required: true
-        default: true
-        type: boolean
       snap_publish:
         description: 'Publish to Snap store'
         required: true
@@ -111,7 +106,6 @@ jobs:
     name: Electron blob publish
     runs-on: ubuntu-22.04
     needs: setup
-    if: inputs.electron_publish
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
       _RELEASE_TAG: ${{ needs.setup.outputs.tag_name }}


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-563](https://bitwarden.atlassian.net/browse/BRE-563)

## 📔 Objective

Reverting out ability to turn off electron publishing, which publishes all artifacts and is needed for other installers to function properly.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-563]: https://bitwarden.atlassian.net/browse/BRE-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ