### PR TITLE
Auth/PM-8113 - Extension - AuthPopoutWindows - Add new method + refactor names

### DIFF
--- a/apps/browser/src/auth/popup/two-factor.component.ts
+++ b/apps/browser/src/auth/popup/two-factor.component.ts
@@ -33,7 +33,7 @@ import { BrowserApi } from "../../platform/browser/browser-api";
 import { ZonedMessageListenerService } from "../../platform/browser/zoned-message-listener.service";
 import BrowserPopupUtils from "../../platform/popup/browser-popup-utils";
 
-import { closeTwoFactorAuthPopout } from "./utils/auth-popout-window";
+import { closeTwoFactorAuthWebAuthnPopout } from "./utils/auth-popout-window";
 
 @Component({
   selector: "app-two-factor",
@@ -171,7 +171,7 @@ export class TwoFactorComponent extends BaseTwoFactorComponent implements OnInit
 
           // We don't need this window anymore because the intent is for the user to be left
           // on the web vault screen which tells them to continue in the browser extension (sidebar or popup)
-          await closeTwoFactorAuthPopout();
+          await closeTwoFactorAuthWebAuthnPopout();
         };
       }
     });

--- a/apps/browser/src/auth/popup/utils/auth-popout-window.spec.ts
+++ b/apps/browser/src/auth/popup/utils/auth-popout-window.spec.ts
@@ -7,8 +7,8 @@ import {
   openUnlockPopout,
   closeUnlockPopout,
   openSsoAuthResultPopout,
-  openTwoFactorAuthPopout,
-  closeTwoFactorAuthPopout,
+  openTwoFactorAuthWebAuthnPopout,
+  closeTwoFactorAuthWebAuthnPopout,
   closeSsoAuthResultPopout,
 } from "./auth-popout-window";
 
@@ -106,22 +106,22 @@ describe("AuthPopoutWindow", () => {
     });
   });
 
-  describe("openTwoFactorAuthPopout", () => {
-    it("opens a window that facilitates two factor authentication", async () => {
-      await openTwoFactorAuthPopout({ data: "data", remember: "remember" });
+  describe("openTwoFactorAuthWebAuthnPopout", () => {
+    it("opens a window that facilitates two factor authentication via WebAuthn", async () => {
+      await openTwoFactorAuthWebAuthnPopout({ data: "data", remember: "remember" });
 
       expect(openPopoutSpy).toHaveBeenCalledWith(
         "popup/index.html#/2fa;webAuthnResponse=data;remember=remember",
-        { singleActionKey: AuthPopoutType.twoFactorAuth },
+        { singleActionKey: AuthPopoutType.twoFactorAuthWebAuthn },
       );
     });
   });
 
-  describe("closeTwoFactorAuthPopout", () => {
-    it("closes the two-factor authentication window", async () => {
-      await closeTwoFactorAuthPopout();
+  describe("closeTwoFactorAuthWebAuthnPopout", () => {
+    it("closes the two-factor authentication WebAuthn window", async () => {
+      await closeTwoFactorAuthWebAuthnPopout();
 
-      expect(closeSingleActionPopoutSpy).toHaveBeenCalledWith(AuthPopoutType.twoFactorAuth);
+      expect(closeSingleActionPopoutSpy).toHaveBeenCalledWith(AuthPopoutType.twoFactorAuthWebAuthn);
     });
   });
 });

--- a/apps/browser/src/auth/popup/utils/auth-popout-window.spec.ts
+++ b/apps/browser/src/auth/popup/utils/auth-popout-window.spec.ts
@@ -9,6 +9,7 @@ import {
   openSsoAuthResultPopout,
   openTwoFactorAuthPopout,
   closeTwoFactorAuthPopout,
+  closeSsoAuthResultPopout,
 } from "./auth-popout-window";
 
 describe("AuthPopoutWindow", () => {
@@ -94,6 +95,14 @@ describe("AuthPopoutWindow", () => {
       expect(openPopoutSpy).toHaveBeenCalledWith("popup/index.html#/sso?code=code&state=state", {
         singleActionKey: AuthPopoutType.ssoAuthResult,
       });
+    });
+  });
+
+  describe("closeSsoAuthResultPopout", () => {
+    it("closes the SSO authentication result popout window", async () => {
+      await closeSsoAuthResultPopout();
+
+      expect(closeSingleActionPopoutSpy).toHaveBeenCalledWith(AuthPopoutType.ssoAuthResult);
     });
   });
 

--- a/apps/browser/src/auth/popup/utils/auth-popout-window.ts
+++ b/apps/browser/src/auth/popup/utils/auth-popout-window.ts
@@ -6,7 +6,7 @@ import BrowserPopupUtils from "../../../platform/popup/browser-popup-utils";
 const AuthPopoutType = {
   unlockExtension: "auth_unlockExtension",
   ssoAuthResult: "auth_ssoAuthResult",
-  twoFactorAuth: "auth_twoFactorAuth",
+  twoFactorAuthWebAuthn: "auth_twoFactorAuthWebAuthn",
 } as const;
 const extensionUnlockUrls = new Set([
   chrome.runtime.getURL("popup/index.html#/lock"),
@@ -60,33 +60,37 @@ async function openSsoAuthResultPopout(resultData: { code: string; state: string
 }
 
 /**
- * Closes the two-factor authentication popout window.
+ * Closes the SSO authentication result popout window.
  */
 async function closeSsoAuthResultPopout() {
   await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.ssoAuthResult);
 }
 
 /**
- * Opens a window that facilitates two-factor authentication.
+ * Opens a popout that facilitates two-factor authentication via WebAuthn.
  *
- * @param twoFactorAuthData - The data from the two-factor authentication.
+ * @param twoFactorAuthWebAuthnData - The data to send ot the popout via query param.
+ * It includes the WebAuthn response and whether to save the 2FA remember me token or not.
  */
-async function openTwoFactorAuthPopout(twoFactorAuthData: { data: string; remember: string }) {
-  const { data, remember } = twoFactorAuthData;
+async function openTwoFactorAuthWebAuthnPopout(twoFactorAuthWebAuthnData: {
+  data: string;
+  remember: string;
+}) {
+  const { data, remember } = twoFactorAuthWebAuthnData;
   const params =
     `webAuthnResponse=${encodeURIComponent(data)};` + `remember=${encodeURIComponent(remember)}`;
   const twoFactorUrl = `popup/index.html#/2fa;${params}`;
 
   await BrowserPopupUtils.openPopout(twoFactorUrl, {
-    singleActionKey: AuthPopoutType.twoFactorAuth,
+    singleActionKey: AuthPopoutType.twoFactorAuthWebAuthn,
   });
 }
 
 /**
  * Closes the two-factor authentication popout window.
  */
-async function closeTwoFactorAuthPopout() {
-  await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.twoFactorAuth);
+async function closeTwoFactorAuthWebAuthnPopout() {
+  await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.twoFactorAuthWebAuthn);
 }
 
 export {
@@ -95,6 +99,6 @@ export {
   closeUnlockPopout,
   openSsoAuthResultPopout,
   closeSsoAuthResultPopout,
-  openTwoFactorAuthPopout,
-  closeTwoFactorAuthPopout,
+  openTwoFactorAuthWebAuthnPopout,
+  closeTwoFactorAuthWebAuthnPopout,
 };

--- a/apps/browser/src/auth/popup/utils/auth-popout-window.ts
+++ b/apps/browser/src/auth/popup/utils/auth-popout-window.ts
@@ -60,6 +60,13 @@ async function openSsoAuthResultPopout(resultData: { code: string; state: string
 }
 
 /**
+ * Closes the two-factor authentication popout window.
+ */
+async function closeSsoAuthResultPopout() {
+  await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.ssoAuthResult);
+}
+
+/**
  * Opens a window that facilitates two-factor authentication.
  *
  * @param twoFactorAuthData - The data from the two-factor authentication.
@@ -87,6 +94,7 @@ export {
   openUnlockPopout,
   closeUnlockPopout,
   openSsoAuthResultPopout,
+  closeSsoAuthResultPopout,
   openTwoFactorAuthPopout,
   closeTwoFactorAuthPopout,
 };

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -22,7 +22,7 @@ import { BiometricsCommands } from "@bitwarden/key-management";
 import {
   closeUnlockPopout,
   openSsoAuthResultPopout,
-  openTwoFactorAuthPopout,
+  openTwoFactorAuthWebAuthnPopout,
 } from "../auth/popup/utils/auth-popout-window";
 import { LockedVaultPendingNotificationsData } from "../autofill/background/abstractions/notification.background";
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
@@ -333,7 +333,7 @@ export default class RuntimeBackground {
           return;
         }
 
-        await openTwoFactorAuthPopout(msg);
+        await openTwoFactorAuthWebAuthnPopout(msg);
         break;
       }
       case "reloadPopup":


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8113

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
As part of the 2FA UI refresh work, I discovered the need to update and enhance the Auth owned `AuthPopoutWindows.ts` to add additional clarity + add support for closing the SSO auth result popout. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
