### PR TITLE
[PM-17443] Navigation After Deletion

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Observable } from "rxjs";
 
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { EventType } from "@bitwarden/common/enums";
@@ -42,7 +42,7 @@ describe("AddEditV2Component", () => {
 
   const buildConfigResponse = { originalCipher: {} } as CipherFormConfig;
   const buildConfig = jest.fn((mode: CipherFormMode) =>
-    Promise.resolve({ mode, ...buildConfigResponse }),
+    Promise.resolve({ ...buildConfigResponse, mode }),
   );
   const queryParams$ = new BehaviorSubject({});
   const disable = jest.fn();
@@ -57,9 +57,10 @@ describe("AddEditV2Component", () => {
     back.mockClear();
     collect.mockClear();
 
-    addEditCipherInfo$ = new BehaviorSubject(null);
+    addEditCipherInfo$ = new BehaviorSubject<AddEditCipherInfo | null>(null);
     cipherServiceMock = mock<CipherService>();
-    cipherServiceMock.addEditCipherInfo$ = addEditCipherInfo$.asObservable();
+    cipherServiceMock.addEditCipherInfo$ =
+      addEditCipherInfo$.asObservable() as Observable<AddEditCipherInfo>;
 
     await TestBed.configureTestingModule({
       imports: [AddEditV2Component],
@@ -101,7 +102,7 @@ describe("AddEditV2Component", () => {
 
         tick();
 
-        expect(buildConfig.mock.lastCall[0]).toBe("add");
+        expect(buildConfig.mock.lastCall![0]).toBe("add");
         expect(component.config.mode).toBe("add");
       }));
 
@@ -110,7 +111,7 @@ describe("AddEditV2Component", () => {
 
         tick();
 
-        expect(buildConfig.mock.lastCall[0]).toBe("clone");
+        expect(buildConfig.mock.lastCall![0]).toBe("clone");
         expect(component.config.mode).toBe("clone");
       }));
 
@@ -120,7 +121,7 @@ describe("AddEditV2Component", () => {
 
         tick();
 
-        expect(buildConfig.mock.lastCall[0]).toBe("edit");
+        expect(buildConfig.mock.lastCall![0]).toBe("edit");
         expect(component.config.mode).toBe("edit");
       }));
 
@@ -130,7 +131,7 @@ describe("AddEditV2Component", () => {
 
         tick();
 
-        expect(buildConfig.mock.lastCall[0]).toBe("edit");
+        expect(buildConfig.mock.lastCall![0]).toBe("edit");
         expect(component.config.mode).toBe("partial-edit");
       }));
     });
@@ -227,7 +228,7 @@ describe("AddEditV2Component", () => {
 
       tick();
 
-      expect(component.config.initialValues.username).toBe("identity-username");
+      expect(component.config.initialValues!.username).toBe("identity-username");
     }));
 
     it("overrides query params with `addEditCipherInfo` values", fakeAsync(() => {
@@ -240,7 +241,7 @@ describe("AddEditV2Component", () => {
 
       tick();
 
-      expect(component.config.initialValues.name).toBe("AddEditCipherName");
+      expect(component.config.initialValues!.name).toBe("AddEditCipherName");
     }));
 
     it("clears `addEditCipherInfo` after initialization", fakeAsync(() => {

--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.spec.ts
@@ -353,5 +353,12 @@ describe("AddEditV2Component", () => {
       await component.delete();
       expect(deleteCipherSpy).toHaveBeenCalled();
     });
+
+    it("navigates to vault tab after deletion", async () => {
+      jest.spyOn(component["dialogService"], "openSimpleDialog").mockResolvedValue(true);
+      await component.delete();
+
+      expect(navigate).toHaveBeenCalledWith(["/tabs/vault"]);
+    });
   });
 });

--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -377,7 +377,7 @@ export class AddEditV2Component implements OnInit {
       return false;
     }
 
-    await this.router.navigate([""]);
+    await this.router.navigate(["/tabs/vault"]);
 
     this.toastService.showToast({
       variant: "success",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17443](https://bitwarden.atlassian.net/browse/PM-17443)

## 📔 Objective

When the `PersistPopupView` flag is active the root route has a [popupRouterCacheGuard](https://github.com/bitwarden/clients/blob/5d014fb7d3fad156c61bfa5c6c859b6633b011d4/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts#L130-L136) that will navigate to the last route.

This causes the edit view to stay in view when deleting a cipher. Navigating to `/tabs/vault` directly fixes the issue as the guard is avoided.

I also fixed strict-typings in the test file while I was here.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/dfe7f464-3308-4cb3-9841-02668d95beda" />|<video src="https://github.com/user-attachments/assets/737cfb6d-fc87-45e5-8f42-2755e2cdff6c" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17443]: https://bitwarden.atlassian.net/browse/PM-17443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ