### PR TITLE
[PM-17465] refactor PolicyService.getAll$ to make userId not optional

### DIFF
--- a/apps/browser/src/services/families-policy.service.ts
+++ b/apps/browser/src/services/families-policy.service.ts
@@ -47,7 +47,7 @@ export class FamiliesPolicyService {
               map((organizations) => organizations.find((org) => org.canManageSponsorships)?.id),
               switchMap((enterpriseOrgId) =>
                 this.policyService
-                  .getAll$(PolicyType.FreeFamiliesSponsorshipPolicy)
+                  .getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId)
                   .pipe(
                     map(
                       (policies) =>

--- a/apps/web/src/app/billing/services/free-families-policy.service.ts
+++ b/apps/web/src/app/billing/services/free-families-policy.service.ts
@@ -111,18 +111,18 @@ export class FreeFamiliesPolicyService {
       });
     }
 
-    return getUserId(this.accountService.activeAccount$).pipe(
+    return this.accountService.activeAccount$.pipe(
+      getUserId,
       switchMap((userId) =>
-        this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId).pipe(
-          map((policies) => ({
-            isFreeFamilyPolicyEnabled: policies.some(
-              (policy) => policy.organizationId === organizationId && policy.enabled,
-            ),
-            belongToOneEnterpriseOrgs,
-            belongToMultipleEnterpriseOrgs,
-          })),
-        ),
+        this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId),
       ),
+      map((policies) => ({
+        isFreeFamilyPolicyEnabled: policies.some(
+          (policy) => policy.organizationId === organizationId && policy.enabled,
+        ),
+        belongToOneEnterpriseOrgs,
+        belongToMultipleEnterpriseOrgs,
+      })),
     );
   }
 

--- a/apps/web/src/app/billing/services/free-families-policy.service.ts
+++ b/apps/web/src/app/billing/services/free-families-policy.service.ts
@@ -6,6 +6,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 
@@ -110,14 +111,18 @@ export class FreeFamiliesPolicyService {
       });
     }
 
-    return this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy).pipe(
-      map((policies) => ({
-        isFreeFamilyPolicyEnabled: policies.some(
-          (policy) => policy.organizationId === organizationId && policy.enabled,
+    return getUserId(this.accountService.activeAccount$).pipe(
+      switchMap((userId) =>
+        this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId).pipe(
+          map((policies) => ({
+            isFreeFamilyPolicyEnabled: policies.some(
+              (policy) => policy.organizationId === organizationId && policy.enabled,
+            ),
+            belongToOneEnterpriseOrgs,
+            belongToMultipleEnterpriseOrgs,
+          })),
         ),
-        belongToOneEnterpriseOrgs,
-        belongToMultipleEnterpriseOrgs,
-      })),
+      ),
     );
   }
 

--- a/apps/web/src/app/billing/settings/sponsored-families.component.ts
+++ b/apps/web/src/app/billing/settings/sponsored-families.component.ts
@@ -98,7 +98,7 @@ export class SponsoredFamiliesComponent implements OnInit, OnDestroy {
 
       this.availableSponsorshipOrgs$ = combineLatest([
         this.organizationService.organizations$(userId),
-        this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy),
+        this.policyService.getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId),
       ]).pipe(
         map(([organizations, policies]) =>
           organizations

--- a/apps/web/src/app/billing/settings/sponsoring-org-row.component.ts
+++ b/apps/web/src/app/billing/settings/sponsoring-org-row.component.ts
@@ -8,6 +8,8 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -38,6 +40,7 @@ export class SponsoringOrgRowComponent implements OnInit {
     private toastService: ToastService,
     private configService: ConfigService,
     private policyService: PolicyService,
+    private accountService: AccountService,
   ) {}
 
   async ngOnInit() {
@@ -53,9 +56,11 @@ export class SponsoringOrgRowComponent implements OnInit {
       FeatureFlag.DisableFreeFamiliesSponsorship,
     );
 
+    const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+
     if (this.isFreeFamilyFlagEnabled) {
       this.isFreeFamilyPolicyEnabled$ = this.policyService
-        .getAll$(PolicyType.FreeFamiliesSponsorshipPolicy)
+        .getAll$(PolicyType.FreeFamiliesSponsorshipPolicy, userId)
         .pipe(
           map(
             (policies) =>

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -165,11 +165,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
         }
       });
 
-    const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
-
-    this.policyService
-      .getAll$(PolicyType.SendOptions, userId)
+    this.accountService.activeAccount$
       .pipe(
+        getUserId,
+        switchMap((userId) => this.policyService.getAll$(PolicyType.SendOptions, userId)),
         map((policies) => policies?.some((p) => p.data.disableHideEmail)),
         takeUntil(this.destroy$),
       )

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -16,6 +16,7 @@ import {
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -164,8 +165,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
         }
       });
 
+    const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+
     this.policyService
-      .getAll$(PolicyType.SendOptions)
+      .getAll$(PolicyType.SendOptions, userId)
       .pipe(
         map((policies) => policies?.some((p) => p.data.disableHideEmail)),
         takeUntil(this.destroy$),

--- a/libs/common/src/admin-console/abstractions/policy/policy.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/policy/policy.service.abstraction.ts
@@ -30,7 +30,7 @@ export abstract class PolicyService {
    * A policy "applies" if it is enabled and the user is not exempt (e.g. because they are an Owner).
    * @param policyType the {@link PolicyType} to search for
    */
-  getAll$: (policyType: PolicyType, userId?: UserId) => Observable<Policy[]>;
+  getAll$: (policyType: PolicyType, userId: UserId) => Observable<Policy[]>;
 
   /**
    * All {@link Policy} objects for the specified user (from sync data).

--- a/libs/common/src/admin-console/services/policy/policy.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy.service.ts
@@ -51,7 +51,7 @@ export class PolicyService implements InternalPolicyServiceAbstraction {
     );
   }
 
-  getAll$(policyType: PolicyType, userId?: UserId) {
+  getAll$(policyType: PolicyType, userId: UserId) {
     const filteredPolicies$ = this.stateProvider.getUserState$(POLICIES, userId).pipe(
       map((policyData) => policyRecordToArray(policyData)),
       map((policies) => policies.filter((p) => p.type === policyType)),

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -4,11 +4,13 @@ import { CommonModule } from "@angular/common";
 import { Component, Input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
-import { firstValueFrom, map } from "rxjs";
+import { firstValueFrom, map, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
@@ -89,13 +91,18 @@ export class SendOptionsComponent implements OnInit {
     private i18nService: I18nService,
     private toastService: ToastService,
     private generatorService: CredentialGeneratorService,
+    private accountService: AccountService,
   ) {
     this.sendFormContainer.registerChildForm("sendOptionsForm", this.sendOptionsForm);
-    this.policyService
-      .getAll$(PolicyType.SendOptions)
+
+    getUserId(this.accountService.activeAccount$)
       .pipe(
-        map((policies) => policies?.some((p) => p.data.disableHideEmail)),
         takeUntilDestroyed(),
+        switchMap((userId) =>
+          this.policyService
+            .getAll$(PolicyType.SendOptions, userId)
+            .pipe(map((policies) => policies?.some((p) => p.data.disableHideEmail))),
+        ),
       )
       .subscribe((disableHideEmail) => {
         this.disableHideEmail = disableHideEmail;

--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.ts
@@ -95,14 +95,12 @@ export class SendOptionsComponent implements OnInit {
   ) {
     this.sendFormContainer.registerChildForm("sendOptionsForm", this.sendOptionsForm);
 
-    getUserId(this.accountService.activeAccount$)
+    this.accountService.activeAccount$
       .pipe(
+        getUserId,
+        switchMap((userId) => this.policyService.getAll$(PolicyType.SendOptions, userId)),
+        map((policies) => policies?.some((p) => p.data.disableHideEmail)),
         takeUntilDestroyed(),
-        switchMap((userId) =>
-          this.policyService
-            .getAll$(PolicyType.SendOptions, userId)
-            .pipe(map((policies) => policies?.some((p) => p.data.disableHideEmail))),
-        ),
       )
       .subscribe((disableHideEmail) => {
         this.disableHideEmail = disableHideEmail;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17465
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes an issue where the PolicyService.getAll$ accepts an optional userId param that is passed to the OrganizationService call that requires a userId, resulting in cases where we pass undefined to the OrganizationService call.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
