### PR TITLE
[PM-14952] - show "close" button if user doesn't have edit permission in vault dialog trash

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
@@ -60,14 +60,11 @@
     >
       {{ "save" | i18n }}
     </button>
-    <button
-      bitButton
-      type="button"
-      buttonType="secondary"
-      (click)="cancel()"
-      *ngIf="!canDelete || !showRestore"
-    >
+    <button bitButton type="button" buttonType="secondary" (click)="cancel()" *ngIf="showCancel">
       {{ "cancel" | i18n }}
+    </button>
+    <button bitButton type="button" buttonType="secondary" (click)="cancel()" *ngIf="showClose">
+      {{ "close" | i18n }}
     </button>
     <div class="tw-ml-auto" *ngIf="showDelete">
       <button

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
@@ -39,7 +39,7 @@
     <button *ngIf="showRestore" [bitAction]="restore" bitButton buttonType="primary" type="button">
       {{ "restore" | i18n }}
     </button>
-    <ng-container *ngIf="showCipherView && !showRestore">
+    <ng-container *ngIf="showEdit">
       <button
         bitButton
         [bitAction]="switchToEdit"
@@ -65,7 +65,7 @@
       type="button"
       buttonType="secondary"
       (click)="cancel()"
-      *ngIf="!showCipherView && !showRestore"
+      *ngIf="!canDelete || !showRestore"
     >
       {{ "cancel" | i18n }}
     </button>
@@ -76,7 +76,7 @@
         buttonType="danger"
         [appA11yTitle]="'delete' | i18n"
         [bitAction]="delete"
-        [disabled]="!(canDeleteCipher$ | async)"
+        [disabled]="!canDelete"
         data-testid="delete-cipher-btn"
       ></button>
     </div>

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -209,11 +209,11 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   }
 
   protected get showCancel() {
-    return !this.isTrashFilter && !this.showCipherView && !this.showRestore;
+    return !this.isTrashFilter && !this.showCipherView;
   }
 
   protected get showClose() {
-    return this.isTrashFilter && !this.showCipherView && !this.showRestore;
+    return this.isTrashFilter && !this.showRestore;
   }
 
   /**
@@ -221,9 +221,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
    * A user may restore items if they have delete permissions and the item is in the trash.
    */
   protected async canUserRestore() {
-    return (
-      this.isTrashFilter && this.cipher?.isDeleted && (await firstValueFrom(this.canDeleteCipher$))
-    );
+    return this.isTrashFilter && this.cipher?.isDeleted && this.canDelete;
   }
 
   protected showRestore: boolean;
@@ -237,7 +235,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   }
 
   protected get showEdit() {
-    return this.showCipherView && this.canDelete && !this.showRestore;
+    return this.showCipherView && !this.isTrashFilter && !this.showRestore;
   }
 
   protected get showDelete() {

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -204,12 +204,26 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     ),
   );
 
+  protected get isTrashFilter() {
+    return this.filter?.type === "trash";
+  }
+
+  protected get showCancel() {
+    return !this.isTrashFilter && !this.showCipherView && !this.showRestore;
+  }
+
+  protected get showClose() {
+    return this.isTrashFilter && !this.showCipherView && !this.showRestore;
+  }
+
   /**
    * Determines if the user may restore the item.
    * A user may restore items if they have delete permissions and the item is in the trash.
    */
   protected async canUserRestore() {
-    return this.filter?.type === "trash" && this.cipher?.isDeleted && this.canDelete;
+    return (
+      this.isTrashFilter && this.cipher?.isDeleted && (await firstValueFrom(this.canDeleteCipher$))
+    );
   }
 
   protected showRestore: boolean;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14952

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR replaces the "Edit" button with a "Cancel" button while a user without edit permission is viewing an item in the trash. It also cleans up a bit of the logic in the component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|![Screenshot 2025-01-23 at 11 29 15 AM](https://github.com/user-attachments/assets/bb4412e0-7a64-4ddf-8f93-ef507bd06c7a)|![Screenshot 2025-01-23 at 11 51 35 AM](https://github.com/user-attachments/assets/0dc1cac9-62e8-4538-81e6-7e759eb50008)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
