### PR TITLE
Replace account service with Input

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.html
@@ -8,6 +8,7 @@
 
   <vault-cipher-form-generator
     [type]="params.type"
+    [account]="account"
     (valueGenerated)="onValueGenerated($event)"
   ></vault-cipher-form-generator>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
@@ -4,7 +4,9 @@ import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
 import { Overlay } from "@angular/cdk/overlay";
 import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
+import { Subject, takeUntil } from "rxjs";
 
+import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { ButtonModule, DialogService } from "@bitwarden/components";
 import { CipherFormGeneratorComponent } from "@bitwarden/vault";
@@ -60,11 +62,26 @@ export class VaultGeneratorDialogComponent {
    */
   protected generatedValue: string = "";
 
+  /**
+   * The currently active account.
+   */
+  protected account: Account | null = null;
+
+  /**
+   * Emits when the component is destroyed to clean up subscriptions.
+   */
+  private readonly destroyed$ = new Subject<void>();
+
   constructor(
     @Inject(DIALOG_DATA) protected params: GeneratorDialogParams,
     private dialogRef: DialogRef<GeneratorDialogResult>,
     private i18nService: I18nService,
-  ) {}
+    private accountService: AccountService,
+  ) {
+    this.accountService.activeAccount$.pipe(takeUntil(this.destroyed$)).subscribe((account) => {
+      this.account = account;
+    });
+  }
 
   /**
    * Close the dialog without selecting a value.

--- a/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.html
+++ b/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.html
@@ -6,6 +6,7 @@
     <vault-cipher-form-generator
       [type]="params.type"
       (valueGenerated)="onValueGenerated($event)"
+      [account]="account"
       disableMargin
     ></vault-cipher-form-generator>
   </ng-container>

--- a/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.ts
+++ b/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.ts
@@ -3,7 +3,9 @@
 import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
+import { takeUntil, Subject } from "rxjs";
 
+import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { ButtonModule, DialogModule, DialogService } from "@bitwarden/components";
 import { CipherFormGeneratorComponent } from "@bitwarden/vault";
@@ -48,11 +50,26 @@ export class WebVaultGeneratorDialogComponent {
    */
   protected generatedValue: string = "";
 
+  /**
+   * The currently active account.
+   */
+  protected account: Account | null = null;
+
+  /**
+   * Emits when the component is destroyed to clean up subscriptions.
+   */
+  private readonly destroyed$ = new Subject<void>();
+
   constructor(
     @Inject(DIALOG_DATA) protected params: WebVaultGeneratorDialogParams,
     private dialogRef: DialogRef<WebVaultGeneratorDialogResult>,
     private i18nService: I18nService,
-  ) {}
+    private accountService: AccountService,
+  ) {
+    this.accountService.activeAccount$.pipe(takeUntil(this.destroyed$)).subscribe((account) => {
+      this.account = account;
+    });
+  }
 
   /**
    * Close the dialog without selecting a value.

--- a/libs/tools/generator/components/src/catchall-settings.component.ts
+++ b/libs/tools/generator/components/src/catchall-settings.component.ts
@@ -4,15 +4,13 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angu
 import { FormBuilder } from "@angular/forms";
 import { BehaviorSubject, map, skip, Subject, takeUntil, withLatestFrom } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
   CatchallGenerationOptions,
   CredentialGeneratorService,
   Generators,
 } from "@bitwarden/generator-core";
-
-import { completeOnAccountSwitch } from "./util";
 
 /** Options group for catchall emails */
 @Component({
@@ -21,15 +19,15 @@ import { completeOnAccountSwitch } from "./util";
 })
 export class CatchallSettingsComponent implements OnInit, OnDestroy {
   /** Instantiates the component
-   *  @param accountService queries user availability
    *  @param generatorService settings and policy logic
    *  @param formBuilder reactive form controls
    */
   constructor(
     private formBuilder: FormBuilder,
     private generatorService: CredentialGeneratorService,
-    private accountService: AccountService,
   ) {}
+
+  @Input() account: Account | null = null;
 
   /** Binds the component to a specific user's settings.
    *  When this input is not provided, the form binds to the active
@@ -84,10 +82,11 @@ export class CatchallSettingsComponent implements OnInit, OnDestroy {
       return new BehaviorSubject(this.userId as UserId).asObservable();
     }
 
-    return this.accountService.activeAccount$.pipe(
-      completeOnAccountSwitch(),
-      takeUntil(this.destroyed$),
-    );
+    if (this.account) {
+      return new BehaviorSubject(this.account.id as UserId).asObservable();
+    }
+
+    return new BehaviorSubject<UserId | null>(null).asObservable();
   }
 
   private readonly destroyed$ = new Subject<void>();

--- a/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
@@ -2,12 +2,12 @@
 // @ts-strict-ignore
 import { DialogRef } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { BehaviorSubject, distinctUntilChanged, firstValueFrom, map, switchMap } from "rxjs";
+import { BehaviorSubject, firstValueFrom, map, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { ButtonModule, DialogModule, DialogService } from "@bitwarden/components";
 import { GeneratorHistoryService } from "@bitwarden/generator-history";
@@ -28,22 +28,18 @@ import { EmptyCredentialHistoryComponent } from "./empty-credential-history.comp
   ],
 })
 export class CredentialGeneratorHistoryDialogComponent {
+  @Input() account: Account | null = null;
   protected readonly hasHistory$ = new BehaviorSubject<boolean>(false);
   protected readonly userId$ = new BehaviorSubject<UserId>(null);
 
   constructor(
-    private accountService: AccountService,
     private history: GeneratorHistoryService,
     private dialogService: DialogService,
     private dialogRef: DialogRef,
   ) {
-    this.accountService.activeAccount$
-      .pipe(
-        takeUntilDestroyed(),
-        map(({ id }) => id),
-        distinctUntilChanged(),
-      )
-      .subscribe(this.userId$);
+    if (this.account) {
+      this.userId$.next(this.account.id);
+    }
 
     this.userId$
       .pipe(

--- a/libs/tools/generator/components/src/credential-generator-history.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history.component.ts
@@ -1,13 +1,13 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterLink } from "@angular/router";
-import { BehaviorSubject, distinctUntilChanged, map, switchMap } from "rxjs";
+import { BehaviorSubject, map, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
   ColorPasswordModule,
@@ -40,21 +40,17 @@ import { GeneratorModule } from "./generator.module";
   ],
 })
 export class CredentialGeneratorHistoryComponent {
+  @Input() account: Account | null = null;
   protected readonly userId$ = new BehaviorSubject<UserId>(null);
   protected readonly credentials$ = new BehaviorSubject<GeneratedCredential[]>([]);
 
   constructor(
-    private accountService: AccountService,
     private generatorService: CredentialGeneratorService,
     private history: GeneratorHistoryService,
   ) {
-    this.accountService.activeAccount$
-      .pipe(
-        takeUntilDestroyed(),
-        map(({ id }) => id),
-        distinctUntilChanged(),
-      )
-      .subscribe(this.userId$);
+    if (this.account) {
+      this.userId$.next(this.account.id);
+    }
 
     this.userId$
       .pipe(

--- a/libs/tools/generator/components/src/credential-generator.component.ts
+++ b/libs/tools/generator/components/src/credential-generator.component.ts
@@ -17,7 +17,7 @@ import {
   withLatestFrom,
 } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { IntegrationId } from "@bitwarden/common/tools/integration";
@@ -57,7 +57,6 @@ export class CredentialGeneratorComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private logService: LogService,
     private i18nService: I18nService,
-    private accountService: AccountService,
     private zone: NgZone,
     private formBuilder: FormBuilder,
   ) {}
@@ -67,6 +66,9 @@ export class CredentialGeneratorComponent implements OnInit, OnDestroy {
    */
   @Input()
   userId: UserId | null;
+
+  @Input()
+  account: Account | null = null;
 
   /** Emits credentials created from a generation request. */
   @Output()
@@ -97,13 +99,9 @@ export class CredentialGeneratorComponent implements OnInit, OnDestroy {
     if (this.userId) {
       this.userId$.next(this.userId);
     } else {
-      this.accountService.activeAccount$
-        .pipe(
-          map((acct) => acct.id),
-          distinctUntilChanged(),
-          takeUntil(this.destroyed),
-        )
-        .subscribe(this.userId$);
+      if (this.account) {
+        this.userId$.next(this.account.id);
+      }
     }
 
     this.generatorService

--- a/libs/tools/generator/components/src/passphrase-settings.component.ts
+++ b/libs/tools/generator/components/src/passphrase-settings.component.ts
@@ -13,7 +13,7 @@ import {
   ReplaySubject,
 } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
@@ -21,8 +21,6 @@ import {
   CredentialGeneratorService,
   PassphraseGenerationOptions,
 } from "@bitwarden/generator-core";
-
-import { completeOnAccountSwitch } from "./util";
 
 const Controls = Object.freeze({
   numWords: "numWords",
@@ -38,7 +36,6 @@ const Controls = Object.freeze({
 })
 export class PassphraseSettingsComponent implements OnInit, OnDestroy {
   /** Instantiates the component
-   *  @param accountService queries user availability
    *  @param generatorService settings and policy logic
    *  @param i18nService localize hints
    *  @param formBuilder reactive form controls
@@ -47,7 +44,6 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
     private formBuilder: FormBuilder,
     private generatorService: CredentialGeneratorService,
     private i18nService: I18nService,
-    private accountService: AccountService,
   ) {}
 
   /** Binds the component to a specific user's settings.
@@ -56,6 +52,9 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
    */
   @Input()
   userId: UserId | null;
+
+  @Input()
+  account: Account | null = null;
 
   /** When `true`, an options header is displayed by the component. Otherwise, the header is hidden. */
   @Input()
@@ -159,10 +158,11 @@ export class PassphraseSettingsComponent implements OnInit, OnDestroy {
       return new BehaviorSubject(this.userId as UserId).asObservable();
     }
 
-    return this.accountService.activeAccount$.pipe(
-      completeOnAccountSwitch(),
-      takeUntil(this.destroyed$),
-    );
+    if (this.account) {
+      return new BehaviorSubject(this.account.id as UserId).asObservable();
+    }
+
+    return new BehaviorSubject<UserId | null>(null).asObservable();
   }
 
   private readonly destroyed$ = new Subject<void>();

--- a/libs/tools/generator/components/src/password-generator.component.html
+++ b/libs/tools/generator/components/src/password-generator.component.html
@@ -40,6 +40,7 @@
   class="tw-mt-6"
   *ngIf="(algorithm$ | async)?.id === 'password'"
   [userId]="this.userId$ | async"
+  [account]="account"
   [disableMargin]="disableMargin"
   (onUpdated)="generate('password settings')"
 />
@@ -47,6 +48,7 @@
   class="tw-mt-6"
   *ngIf="(algorithm$ | async)?.id === 'passphrase'"
   [userId]="this.userId$ | async"
+  [account]="account"
   (onUpdated)="generate('passphrase settings')"
   [disableMargin]="disableMargin"
 />

--- a/libs/tools/generator/components/src/password-generator.component.ts
+++ b/libs/tools/generator/components/src/password-generator.component.ts
@@ -15,7 +15,7 @@ import {
   withLatestFrom,
 } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -43,9 +43,10 @@ export class PasswordGeneratorComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private logService: LogService,
     private i18nService: I18nService,
-    private accountService: AccountService,
     private zone: NgZone,
   ) {}
+
+  @Input() account: Account | null = null;
 
   /** Binds the component to a specific user's settings.
    *  When this input is not provided, the form binds to the active
@@ -101,13 +102,9 @@ export class PasswordGeneratorComponent implements OnInit, OnDestroy {
     if (this.userId) {
       this.userId$.next(this.userId);
     } else {
-      this.accountService.activeAccount$
-        .pipe(
-          map((acct) => acct.id),
-          distinctUntilChanged(),
-          takeUntil(this.destroyed),
-        )
-        .subscribe(this.userId$);
+      if (this.account) {
+        this.userId$.next(this.account.id);
+      }
     }
 
     this.generatorService

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -15,7 +15,7 @@ import {
   withLatestFrom,
 } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
@@ -23,8 +23,6 @@ import {
   CredentialGeneratorService,
   PasswordGenerationOptions,
 } from "@bitwarden/generator-core";
-
-import { completeOnAccountSwitch } from "./util";
 
 const Controls = Object.freeze({
   length: "length",
@@ -44,7 +42,6 @@ const Controls = Object.freeze({
 })
 export class PasswordSettingsComponent implements OnInit, OnDestroy {
   /** Instantiates the component
-   *  @param accountService queries user availability
    *  @param generatorService settings and policy logic
    *  @param i18nService localize hints
    *  @param formBuilder reactive form controls
@@ -53,7 +50,6 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
     private formBuilder: FormBuilder,
     private generatorService: CredentialGeneratorService,
     private i18nService: I18nService,
-    private accountService: AccountService,
   ) {}
 
   /** Binds the password component to a specific user's settings.
@@ -62,6 +58,9 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
    */
   @Input()
   userId: UserId | null;
+
+  @Input()
+  account: Account | null = null;
 
   /** When `true`, an options header is displayed by the component. Otherwise, the header is hidden. */
   @Input()
@@ -250,10 +249,11 @@ export class PasswordSettingsComponent implements OnInit, OnDestroy {
       return new BehaviorSubject(this.userId as UserId).asObservable();
     }
 
-    return this.accountService.activeAccount$.pipe(
-      completeOnAccountSwitch(),
-      takeUntil(this.destroyed$),
-    );
+    if (this.account) {
+      return new BehaviorSubject(this.account.id as UserId).asObservable();
+    }
+
+    return new BehaviorSubject<UserId | null>(null).asObservable();
   }
 
   private readonly destroyed$ = new Subject<void>();

--- a/libs/tools/generator/components/src/username-generator.component.html
+++ b/libs/tools/generator/components/src/username-generator.component.html
@@ -61,21 +61,25 @@
       <tools-catchall-settings
         *ngIf="(algorithm$ | async)?.id === 'catchall'"
         [userId]="this.userId$ | async"
+        [account]="account"
         (onUpdated)="generate('catchall settings')"
       />
       <tools-forwarder-settings
         *ngIf="!!(forwarderId$ | async)"
         [forwarder]="forwarderId$ | async"
         [userId]="this.userId$ | async"
+        [account]="account"
       />
       <tools-subaddress-settings
         *ngIf="(algorithm$ | async)?.id === 'subaddress'"
         [userId]="this.userId$ | async"
+        [account]="account"
         (onUpdated)="generate('subaddress settings')"
       />
       <tools-username-settings
         *ngIf="(algorithm$ | async)?.id === 'username'"
         [userId]="this.userId$ | async"
+        [account]="account"
         (onUpdated)="generate('username settings')"
       />
     </bit-card>

--- a/libs/tools/generator/components/src/username-generator.component.ts
+++ b/libs/tools/generator/components/src/username-generator.component.ts
@@ -18,7 +18,7 @@ import {
   withLatestFrom,
 } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { IntegrationId } from "@bitwarden/common/tools/integration";
@@ -53,7 +53,6 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
   /** Instantiates the username generator
    *  @param generatorService generates credentials; stores preferences
    *  @param i18nService localizes generator algorithm descriptions
-   *  @param accountService discovers the active user when one is not provided
    *  @param zone detects generator settings updates originating from the generator services
    *  @param formBuilder binds reactive form
    */
@@ -63,10 +62,11 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private logService: LogService,
     private i18nService: I18nService,
-    private accountService: AccountService,
     private zone: NgZone,
     private formBuilder: FormBuilder,
   ) {}
+
+  @Input() account: Account | null = null;
 
   /** Binds the component to a specific user's settings. When this input is not provided,
    * the form binds to the active user
@@ -98,13 +98,9 @@ export class UsernameGeneratorComponent implements OnInit, OnDestroy {
     if (this.userId) {
       this.userId$.next(this.userId);
     } else {
-      this.accountService.activeAccount$
-        .pipe(
-          map((acct) => acct.id),
-          distinctUntilChanged(),
-          takeUntil(this.destroyed),
-        )
-        .subscribe(this.userId$);
+      if (this.account) {
+        this.userId$.next(this.account.id);
+      }
     }
 
     this.generatorService

--- a/libs/tools/generator/components/src/username-settings.component.ts
+++ b/libs/tools/generator/components/src/username-settings.component.ts
@@ -4,15 +4,13 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angu
 import { FormBuilder } from "@angular/forms";
 import { BehaviorSubject, map, skip, Subject, takeUntil, withLatestFrom } from "rxjs";
 
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import {
   CredentialGeneratorService,
   EffUsernameGenerationOptions,
   Generators,
 } from "@bitwarden/generator-core";
-
-import { completeOnAccountSwitch } from "./util";
 
 /** Options group for usernames */
 @Component({
@@ -21,14 +19,12 @@ import { completeOnAccountSwitch } from "./util";
 })
 export class UsernameSettingsComponent implements OnInit, OnDestroy {
   /** Instantiates the component
-   *  @param accountService queries user availability
    *  @param generatorService settings and policy logic
    *  @param formBuilder reactive form controls
    */
   constructor(
     private formBuilder: FormBuilder,
     private generatorService: CredentialGeneratorService,
-    private accountService: AccountService,
   ) {}
 
   /** Binds the component to a specific user's settings.
@@ -37,6 +33,9 @@ export class UsernameSettingsComponent implements OnInit, OnDestroy {
    */
   @Input()
   userId: UserId | null;
+
+  @Input()
+  account: Account | null = null;
 
   /** Emits settings updates and completes if the settings become unavailable.
    * @remarks this does not emit the initial settings. If you would like
@@ -84,10 +83,11 @@ export class UsernameSettingsComponent implements OnInit, OnDestroy {
       return new BehaviorSubject(this.userId as UserId).asObservable();
     }
 
-    return this.accountService.activeAccount$.pipe(
-      completeOnAccountSwitch(),
-      takeUntil(this.destroyed$),
-    );
+    if (this.account) {
+      return new BehaviorSubject(this.account.id as UserId).asObservable();
+    }
+
+    return new BehaviorSubject<UserId | null>(null).asObservable();
   }
 
   private readonly destroyed$ = new Subject<void>();

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
@@ -1,12 +1,14 @@
 <tools-password-generator
   *ngIf="type === 'password'"
   [disableMargin]="disableMargin"
+  [account]="account"
   (onGenerated)="onCredentialGenerated($event)"
   (onAlgorithm)="algorithm($event)"
 ></tools-password-generator>
 <tools-username-generator
   *ngIf="type === 'username'"
   [disableMargin]="disableMargin"
+  [account]="account"
   (onGenerated)="onCredentialGenerated($event)"
   (onAlgorithm)="algorithm($event)"
 ></tools-username-generator>

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
@@ -4,6 +4,7 @@ import { coerceBooleanProperty } from "@angular/cdk/coercion";
 import { CommonModule } from "@angular/common";
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { GeneratorModule } from "@bitwarden/generator-components";
 import { AlgorithmInfo, GeneratedCredential } from "@bitwarden/generator-core";
 
@@ -20,6 +21,11 @@ import { AlgorithmInfo, GeneratedCredential } from "@bitwarden/generator-core";
 export class CipherFormGeneratorComponent {
   @Input()
   algorithm: (selected: AlgorithmInfo) => void;
+
+  /**
+   * The account object passed from the parent component.
+   */
+  @Input() account: Account | null = null;
 
   /**
    * The type of generator form to show.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16822

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
This PR replaces the direct usage of AccountService with an @Input() account in all components within @bitwarden/generator-components. The goal is to decouple components from AccountService and make them more reusable by leveraging reactive @Input() bindings for the account.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
