### PR TITLE
Enable Subresource Integrity on Web

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -161,7 +161,8 @@
         "webpack",
         "webpack-cli",
         "webpack-dev-server",
-        "webpack-node-externals"
+        "webpack-node-externals",
+        "webpack-subresource-integrity"
       ],
       "description": "Platform owned dependencies",
       "commitMessagePrefix": "[deps] Platform:",

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -7,6 +7,7 @@ const HtmlWebpackInjector = require("html-webpack-injector");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
 const webpack = require("webpack");
 
 const config = require("./config.js");
@@ -85,6 +86,13 @@ const moduleRules = [
 ];
 
 const plugins = [
+  new SubresourceIntegrityPlugin({
+    // Only enable SRI in production, otherwise it might break hot reloading.
+    // If for some reason you need to enable it in development, make sure to also set
+    // optimization.realContentHash to true in the webpack config.
+    enabled: NODE_ENV === "production",
+    hashFuncNames: ["sha512"],
+  }),
   new HtmlWebpackPlugin({
     template: "./src/index.html",
     filename: "index.html",
@@ -382,6 +390,7 @@ const webpackConfig = {
     filename: "[name].[contenthash].js",
     path: path.resolve(__dirname, "build"),
     clean: true,
+    crossOriginLoading: "anonymous",
   },
   module: {
     noParse: /argon2(-simd)?\.wasm$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "tabbable": "6.2.0",
         "tldts": "6.1.74",
         "utf-8-validate": "6.0.5",
+        "webpack-subresource-integrity": "^5.1.0",
         "zone.js": "0.14.10",
         "zxcvbn": "4.4.2"
       },

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "tabbable": "6.2.0",
     "tldts": "6.1.74",
     "utf-8-validate": "6.0.5",
+    "webpack-subresource-integrity": "^5.1.0",
     "zone.js": "0.14.10",
     "zxcvbn": "4.4.2"
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

I've been looking into ways to allow users to verify the authenticity of the web vault, in a very similar way to https://github.com/tasn/webext-signed-pages

The first step for that is enabling SRI so all the scripts that we load from the `index.html` are cryptographically checked against their hash. 

This is working locally for me but needs more testing, specially it would be important to make sure any CDNs that serve the web vault don't modify the files in any way, as they'd refuse to load.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
