### PR TITLE
Auth/PM-17466 - RegistrationFinishComp Bugfix - Add call to loginSuccessHandlerService after successful login

### DIFF
--- a/libs/auth/src/angular/registration/registration-finish/registration-finish.component.ts
+++ b/libs/auth/src/angular/registration/registration-finish/registration-finish.component.ts
@@ -16,7 +16,11 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { ToastService } from "@bitwarden/components";
 
-import { LoginStrategyServiceAbstraction, PasswordLoginCredentials } from "../../../common";
+import {
+  LoginStrategyServiceAbstraction,
+  LoginSuccessHandlerService,
+  PasswordLoginCredentials,
+} from "../../../common";
 import { AnonLayoutWrapperDataService } from "../../anon-layout/anon-layout-wrapper-data.service";
 import { InputPasswordComponent } from "../../input-password/input-password.component";
 import { PasswordInputResult } from "../../input-password/password-input-result";
@@ -68,6 +72,7 @@ export class RegistrationFinishComponent implements OnInit, OnDestroy {
     private loginStrategyService: LoginStrategyServiceAbstraction,
     private logService: LogService,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
+    private loginSuccessHandlerService: LoginSuccessHandlerService,
   ) {}
 
   async ngOnInit() {
@@ -188,6 +193,8 @@ export class RegistrationFinishComponent implements OnInit, OnDestroy {
         title: null,
         message: this.i18nService.t("youHaveBeenLoggedIn"),
       });
+
+      await this.loginSuccessHandlerService.run(authenticationResult.userId);
 
       await this.router.navigate(["/vault"]);
     } catch (e) {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17466

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve issues with the extension vault load where the vault expects a sync to have occurred already after account creation when email verification is disabled by the server flag, we are adding a call to the `loginSuccessHandlerService` which executes a full sync after a successful login. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Extension:

https://github.com/user-attachments/assets/d881461d-6ede-49b4-9362-be0b57260538

Desktop:

https://github.com/user-attachments/assets/c6dde222-b43c-4cea-a79a-08ae58a66510

Web:

https://github.com/user-attachments/assets/13231ebd-2591-42fb-ab90-2431525ff33f



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
