### PR TITLE
[PM-17541] Fix folder service key definition

### DIFF
--- a/libs/common/src/state-migrations/migrate.ts
+++ b/libs/common/src/state-migrations/migrate.ts
@@ -66,13 +66,14 @@ import { ForwarderOptionsMigrator } from "./migrations/65-migrate-forwarder-sett
 import { MoveFinalDesktopSettingsMigrator } from "./migrations/66-move-final-desktop-settings";
 import { RemoveUnassignedItemsBannerDismissed } from "./migrations/67-remove-unassigned-items-banner-dismissed";
 import { MoveLastSyncDate } from "./migrations/68-move-last-sync-date";
+import { MigrateIncorrectFolderKey } from "./migrations/69-migrate-incorrect-folder-key";
 import { MoveBiometricAutoPromptToAccount } from "./migrations/7-move-biometric-auto-prompt-to-account";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 68;
+export const CURRENT_VERSION = 69;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -142,7 +143,8 @@ export function createMigrationBuilder() {
     .with(ForwarderOptionsMigrator, 64, 65)
     .with(MoveFinalDesktopSettingsMigrator, 65, 66)
     .with(RemoveUnassignedItemsBannerDismissed, 66, 67)
-    .with(MoveLastSyncDate, 67, CURRENT_VERSION);
+    .with(MoveLastSyncDate, 67, 68)
+    .with(MigrateIncorrectFolderKey, 68, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
+++ b/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
@@ -5,8 +5,8 @@ import { MigrateIncorrectFolderKey } from "./69-migrate-incorrect-folder-key";
 function exampleJSON() {
   return {
     global_account_accounts: {
-      user1: null,
-      user2: null,
+      user1: null as any,
+      user2: null as any,
     },
     user_user1_folder_folder: {
       // Incorrect "folder" key

--- a/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
+++ b/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
@@ -1,4 +1,4 @@
-import { runMigrator } from "@bitwarden/common/state-migrations/migration-helper.spec";
+import { runMigrator } from "../migration-helper.spec";
 
 import { MigrateIncorrectFolderKey } from "./69-migrate-incorrect-folder-key";
 

--- a/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
+++ b/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.spec.ts
@@ -1,0 +1,98 @@
+import { runMigrator } from "@bitwarden/common/state-migrations/migration-helper.spec";
+
+import { MigrateIncorrectFolderKey } from "./69-migrate-incorrect-folder-key";
+
+function exampleJSON() {
+  return {
+    global_account_accounts: {
+      user1: null,
+      user2: null,
+    },
+    user_user1_folder_folder: {
+      // Incorrect "folder" key
+      folderId1: {
+        id: "folderId1",
+        name: "folder-name-1",
+        revisionDate: "folder-revision-date-1",
+      },
+      folderId2: {
+        id: "folderId2",
+        name: "folder-name-2",
+        revisionDate: "folder-revision-date-2",
+      },
+    },
+    user_user2_folder_folder: null as any,
+  };
+}
+
+describe("MigrateIncorrectFolderKey", () => {
+  const sut = new MigrateIncorrectFolderKey(68, 69);
+  it("migrates data", async () => {
+    const output = await runMigrator(sut, exampleJSON());
+
+    expect(output).toEqual({
+      global_account_accounts: {
+        user1: null,
+        user2: null,
+      },
+      user_user1_folder_folders: {
+        // Correct "folders" key
+        folderId1: {
+          id: "folderId1",
+          name: "folder-name-1",
+          revisionDate: "folder-revision-date-1",
+        },
+        folderId2: {
+          id: "folderId2",
+          name: "folder-name-2",
+          revisionDate: "folder-revision-date-2",
+        },
+      },
+    });
+  });
+
+  it("rolls back data", async () => {
+    const output = await runMigrator(
+      sut,
+      {
+        global_account_accounts: {
+          user1: null,
+          user2: null,
+        },
+        user_user1_folder_folders: {
+          folderId1: {
+            id: "folderId1",
+            name: "folder-name-1",
+            revisionDate: "folder-revision-date-1",
+          },
+          folderId2: {
+            id: "folderId2",
+            name: "folder-name-2",
+            revisionDate: "folder-revision-date-2",
+          },
+        },
+      },
+      "rollback",
+    );
+
+    expect(output).toEqual({
+      global_account_accounts: {
+        user1: null,
+        user2: null,
+      },
+      user_user1_folder_folder: {
+        // Incorrect "folder" key
+        folderId1: {
+          id: "folderId1",
+          name: "folder-name-1",
+          revisionDate: "folder-revision-date-1",
+        },
+        folderId2: {
+          id: "folderId2",
+          name: "folder-name-2",
+          revisionDate: "folder-revision-date-2",
+        },
+      },
+    });
+  });
+});

--- a/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.ts
+++ b/libs/common/src/state-migrations/migrations/69-migrate-incorrect-folder-key.ts
@@ -1,0 +1,45 @@
+import {
+  KeyDefinitionLike,
+  MigrationHelper,
+} from "@bitwarden/common/state-migrations/migration-helper";
+import { Migrator } from "@bitwarden/common/state-migrations/migrator";
+
+const BAD_FOLDER_KEY: KeyDefinitionLike = {
+  key: "folder", // We inadvertently changed the key from "folders" to "folder"
+  stateDefinition: {
+    name: "folder",
+  },
+};
+
+const GOOD_FOLDER_KEY: KeyDefinitionLike = {
+  key: "folders", // We should keep the key as "folders"
+  stateDefinition: {
+    name: "folder",
+  },
+};
+
+export class MigrateIncorrectFolderKey extends Migrator<68, 69> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    async function migrateUser(userId: string) {
+      const value = await helper.getFromUser(userId, BAD_FOLDER_KEY);
+      if (value != null) {
+        await helper.setToUser(userId, GOOD_FOLDER_KEY, value);
+      }
+      await helper.removeFromUser(userId, BAD_FOLDER_KEY);
+    }
+    const users = await helper.getKnownUserIds();
+    await Promise.all(users.map((userId) => migrateUser(userId)));
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    async function rollbackUser(userId: string) {
+      const value = await helper.getFromUser(userId, GOOD_FOLDER_KEY);
+      if (value != null) {
+        await helper.setToUser(userId, BAD_FOLDER_KEY, value);
+      }
+      await helper.removeFromUser(userId, GOOD_FOLDER_KEY);
+    }
+    const users = await helper.getKnownUserIds();
+    await Promise.all(users.map((userId) => rollbackUser(userId)));
+  }
+}

--- a/libs/common/src/vault/services/key-state/folder.state.ts
+++ b/libs/common/src/vault/services/key-state/folder.state.ts
@@ -6,7 +6,7 @@ import { FolderView } from "../../models/view/folder.view";
 
 export const FOLDER_ENCRYPTED_FOLDERS = UserKeyDefinition.record<FolderData>(
   FOLDER_DISK,
-  "folder",
+  "folders",
   {
     deserializer: (obj: Jsonify<FolderData>) => FolderData.fromJSON(obj),
     clearOn: ["logout"],


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17541](https://bitwarden.atlassian.net/browse/PM-17541)

## 📔 Objective

Update the `FOLDER_ENCRYPTED_FOLDERS` key definition key back to `folders` and write a migration script to revert any users that may have updated to the `folder` key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17541]: https://bitwarden.atlassian.net/browse/PM-17541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ