### PR TITLE
CL-276 - Update tab styles

### DIFF
--- a/libs/components/src/tabs/shared/tab-list-item.directive.ts
+++ b/libs/components/src/tabs/shared/tab-list-item.directive.ts
@@ -44,7 +44,7 @@ export class TabListItemDirective implements FocusableOption {
    */
   get textColorClassList(): string[] {
     if (this.disabled) {
-      return ["!tw-text-muted", "hover:!tw-text-muted"];
+      return ["!tw-text-secondary-300", "hover:!tw-text-secondary-300"];
     }
     if (this.active) {
       return ["!tw-text-primary-600", "hover:!tw-text-primary-700"];
@@ -60,7 +60,7 @@ export class TabListItemDirective implements FocusableOption {
       "tw-px-4",
       "tw-font-semibold",
       "tw-transition",
-      "tw-rounded-t",
+      "tw-rounded-t-lg",
       "tw-border-0",
       "tw-border-x",
       "tw-border-t-4",
@@ -71,12 +71,12 @@ export class TabListItemDirective implements FocusableOption {
       "focus-visible:tw-z-10",
       "focus-visible:tw-outline-none",
       "focus-visible:tw-ring-2",
-      "focus-visible:tw-ring-primary-700",
+      "focus-visible:tw-ring-primary-600",
     ];
   }
 
   get disabledClassList(): string[] {
-    return ["!tw-bg-secondary-100", "!tw-no-underline", "tw-cursor-not-allowed"];
+    return ["!tw-no-underline", "tw-cursor-not-allowed"];
   }
 
   get activeClassList(): string[] {
@@ -87,6 +87,7 @@ export class TabListItemDirective implements FocusableOption {
       "tw-border-b",
       "tw-border-b-background",
       "!tw-bg-background",
+      "hover:tw-no-underline",
       "hover:tw-border-t-primary-700",
       "focus-visible:tw-border-t-primary-700",
       "focus-visible:!tw-text-primary-700",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-276

## 📔 Objective

Update the tab component styles to match the new Design System styles:
- Update top border radius for active and focus states 
- Update focus ring to primary-600
- Remove active state text underline
- Update disabled styles

## 📸 Screenshots

**Before:**
<img width="600" alt="Screenshot 2025-01-24 at 10 59 15 AM" src="https://github.com/user-attachments/assets/1394dced-5888-41c6-96d4-cb00937d1f5b" />

**After:** 
<img width="550" alt="Screenshot 2025-01-24 at 10 59 24 AM" src="https://github.com/user-attachments/assets/bc9d8a8e-fe96-4fb4-8030-2fcd55e0a80e" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
