### PR TITLE
Fix desktop version to be 2025.1.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitwarden/desktop",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2025.1.8",
+  "version": "2025.1.4",
   "keywords": [
     "bitwarden",
     "password",

--- a/apps/desktop/src/package-lock.json
+++ b/apps/desktop/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/desktop",
-  "version": "2025.1.8",
+  "version": "2025.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/desktop",
-      "version": "2025.1.8",
+      "version": "2025.1.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@bitwarden/desktop-napi": "file:../desktop_native/napi"

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -2,7 +2,7 @@
   "name": "@bitwarden/desktop",
   "productName": "Bitwarden",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2025.1.8",
+  "version": "2025.1.4",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,7 +232,7 @@
     },
     "apps/desktop": {
       "name": "@bitwarden/desktop",
-      "version": "2025.1.8",
+      "version": "2025.1.4",
       "hasInstallScript": true,
       "license": "GPL-3.0"
     },


### PR DESCRIPTION
## 📔 Objective

We currently have the desktop version in `main` as `2025.1.8`, which is incorrect.  The latest desktop [release](https://github.com/bitwarden/clients/releases/tag/desktop-v2025.1.3) was `2025.1.3`, which means `main` should be `2025.1.4` after bumping the version in preparation for the next release.

What has happened is that:
1. We have an Automated Desktop Version Bump workflow [here](https://github.com/bitwarden/clients/actions/workflows/version-auto-bump.yml) that bumps the version, and it incorrectly bumped the version last week.
2. We attempted to correct this with https://github.com/bitwarden/clients/commit/01803eb29cca9283f3ba967dfca960c74fd1db6d, but it didn't update all the places the version is kept, and so the subsequent updates kept incrementing it incorrectly.

To compare these changes with what the automated workflow does, you can use [this](https://github.com/bitwarden/clients/commit/a04dd7a324af52190f61aabd87c547c641564adc) commit for comparison.  This PR changes the same 4 files to capture everywhere we change the desktop version.

Once this is in `main` it will be picked to `rc` as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
