### PR TITLE
[PM-14562] Risk insights notification feature flag

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.html
@@ -28,7 +28,7 @@
 <div class="tw-mt-4 tw-flex tw-flex-col" *ngIf="!loading && dataSource.data.length">
   <div class="tw-flex tw-justify-between tw-mb-4">
     <h2 bitTypography="h2">{{ "criticalApplications" | i18n }}</h2>
-    <button bitButton buttonType="primary" type="button">
+    <button *ngIf="isNotificationsFeatureEnabled" bitButton buttonType="primary" type="button">
       <i class="bwi bwi-envelope tw-mr-2"></i>
       {{ "requestPasswordChange" | i18n }}
     </button>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.ts
@@ -15,6 +15,8 @@ import {
   ApplicationHealthReportDetailWithCriticalFlag,
   ApplicationHealthReportSummary,
 } from "@bitwarden/bit-common/tools/reports/risk-insights/models/password-health";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
@@ -51,8 +53,12 @@ export class CriticalApplicationsComponent implements OnInit {
   protected organizationId: string;
   protected applicationSummary = {} as ApplicationHealthReportSummary;
   noItemsIcon = Icons.Security;
+  isNotificationsFeatureEnabled: boolean = false;
 
-  ngOnInit() {
+  async ngOnInit() {
+    this.isNotificationsFeatureEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.EnableRiskInsightsNotifications,
+    );
     this.organizationId = this.activatedRoute.snapshot.paramMap.get("organizationId") ?? "";
     combineLatest([
       this.dataService.applications$,
@@ -116,6 +122,7 @@ export class CriticalApplicationsComponent implements OnInit {
     protected reportService: RiskInsightsReportService,
     protected dialogService: DialogService,
     protected i18nService: I18nService,
+    private configService: ConfigService,
   ) {
     this.searchControl.valueChanges
       .pipe(debounceTime(200), takeUntilDestroyed())

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -94,7 +94,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.SSHAgent]: FALSE,
   [FeatureFlag.CipherKeyEncryption]: FALSE,
   [FeatureFlag.PM11901_RefactorSelfHostingLicenseUploader]: FALSE,
-  [FeatureFlag.CriticalApps]: true,
+  [FeatureFlag.CriticalApps]: FALSE,
   [FeatureFlag.TrialPaymentOptional]: FALSE,
   [FeatureFlag.SecurityTasks]: FALSE,
   [FeatureFlag.NewDeviceVerificationTemporaryDismiss]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -47,6 +47,7 @@ export enum FeatureFlag {
   PrivateKeyRegeneration = "pm-12241-private-key-regeneration",
   ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs",
   NewDeviceVerification = "new-device-verification",
+  EnableRiskInsightsNotifications = "enable-risk-insights-notifications",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -93,7 +94,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.SSHAgent]: FALSE,
   [FeatureFlag.CipherKeyEncryption]: FALSE,
   [FeatureFlag.PM11901_RefactorSelfHostingLicenseUploader]: FALSE,
-  [FeatureFlag.CriticalApps]: FALSE,
+  [FeatureFlag.CriticalApps]: true,
   [FeatureFlag.TrialPaymentOptional]: FALSE,
   [FeatureFlag.SecurityTasks]: FALSE,
   [FeatureFlag.NewDeviceVerificationTemporaryDismiss]: FALSE,
@@ -104,6 +105,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PrivateKeyRegeneration]: FALSE,
   [FeatureFlag.ResellerManagedOrgAlert]: FALSE,
   [FeatureFlag.NewDeviceVerification]: FALSE,
+  [FeatureFlag.EnableRiskInsightsNotifications]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14562

## 📔 Objective

Adding the feature flag for risk insights notifications to the client and displaying the "request password change" button only when the feature is enabled. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
