### PR TITLE
Fix deep import for `CipherFormComponent`

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -36,6 +36,7 @@ import {
 } from "@bitwarden/components";
 import {
   CipherAttachmentsComponent,
+  CipherFormComponent,
   CipherFormConfig,
   CipherFormGenerationService,
   CipherFormModule,
@@ -43,7 +44,6 @@ import {
   DecryptionFailureDialogComponent,
 } from "@bitwarden/vault";
 
-import { CipherFormComponent } from "../../../../../../../libs/vault/src/cipher-form/components/cipher-form.component";
 import { SharedModule } from "../../../shared/shared.module";
 import {
   AttachmentDialogCloseResult,

--- a/libs/vault/src/cipher-form/index.ts
+++ b/libs/vault/src/cipher-form/index.ts
@@ -10,3 +10,4 @@ export { CipherFormGenerationService } from "./abstractions/cipher-form-generati
 export { DefaultCipherFormConfigService } from "./services/default-cipher-form-config.service";
 export { CipherFormGeneratorComponent } from "./components/cipher-generator/cipher-form-generator.component";
 export { CipherFormContainer } from "../cipher-form/cipher-form-container";
+export { CipherFormComponent } from "./components/cipher-form.component";


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

https://github.com/bitwarden/clients/pull/11758 had a deep import into the vault library which breaks linting. I added the `CipherFormComponent` to the barrel file and fixed the import here

## 📸 Screenshots

N/A

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
