### PR TITLE
Handle Unix Not Found Error

### DIFF
--- a/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
+++ b/apps/desktop/src/platform/main/desktop-credential-storage-listener.ts
@@ -5,6 +5,10 @@ import { ipcMain } from "electron";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
 import { passwords } from "@bitwarden/desktop-napi";
 
+const WindowsNotFoundError = "Password not found.";
+const MacOSNotFoundError = "The specified item could not be found in the keychain.";
+const UnixNotFoundError = "no result";
+
 export class DesktopCredentialStorageListener {
   constructor(
     private serviceName: string,
@@ -36,12 +40,16 @@ export class DesktopCredentialStorageListener {
         return val;
       } catch (e) {
         if (
-          e.message === "Password not found." ||
-          e.message === "The specified item could not be found in the keychain."
+          e.message === WindowsNotFoundError ||
+          e.message === MacOSNotFoundError ||
+          e.message === UnixNotFoundError
         ) {
           return null;
         }
-        this.logService.info(e);
+        this.logService.warning(
+          `Error while event in the keytar action: ${message?.action ?? "Unknown action"}`,
+          e,
+        );
       }
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

While doing other work I noticed a fair amount of `no result` logs on unix operating systems. That is because we weren't special handling that error from secure storage operations and instead logging the error. I think this would have lead to a behavioral difference with secure storage too. It would instead be returning `undefined` vs `null`. I changed it to specially check the error like we already do for [windows](https://github.com/bitwarden/clients/blob/ab197049f54b87b9f0a25dbe00b9c84afea2d09c/apps/desktop/desktop_native/core/src/password/windows.rs#L104) and [macos](https://github.com/bitwarden/clients/blob/ab197049f54b87b9f0a25dbe00b9c84afea2d09c/apps/desktop/desktop_native/core/src/password/macos.rs#L59) and then making the unhandled errors have a bit more info.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
