### PR TITLE
[PM-17715] Remove feature flag check from New Device Verification opt-out

### DIFF
--- a/apps/web/src/app/auth/settings/account/account.component.html
+++ b/apps/web/src/app/auth/settings/account/account.component.html
@@ -9,7 +9,7 @@
   </div>
 
   <app-danger-zone>
-    <ng-container *ngIf="showSetNewDeviceLoginProtection$ | async">
+    <ng-container>
       <button
         *ngIf="verifyNewDeviceLogin"
         type="button"

--- a/apps/web/src/app/auth/settings/account/account.component.ts
+++ b/apps/web/src/app/auth/settings/account/account.component.ts
@@ -34,7 +34,6 @@ export class AccountComponent implements OnInit, OnDestroy {
   showChangeEmail$: Observable<boolean> = new Observable();
   showPurgeVault$: Observable<boolean> = new Observable();
   showDeleteAccount$: Observable<boolean> = new Observable();
-  showSetNewDeviceLoginProtection$: Observable<boolean> = new Observable();
   verifyNewDeviceLogin: boolean = true;
 
   constructor(
@@ -48,9 +47,6 @@ export class AccountComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
 
-    this.showSetNewDeviceLoginProtection$ = this.configService.getFeatureFlag$(
-      FeatureFlag.NewDeviceVerification,
-    );
     const isAccountDeprovisioningEnabled$ = this.configService.getFeatureFlag$(
       FeatureFlag.AccountDeprovisioning,
     );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17715

## 📔 Objective

In https://github.com/bitwarden/clients/pull/12880 we added the ability for users to opt out of New Device Verification.

In the original PR, the functionality was gated behind the `new-device-verification` feature flag.

This PR removes this feature from the larger feature flag scope, so that we can allow users to opt out prior to the feature being introduced.

See https://github.com/bitwarden/server/pull/5342 for corresponding server PR.

## 📸 Screenshots

https://github.com/user-attachments/assets/33ca29d1-7fb9-4ee0-8735-7606197eaf41

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
