### PR TITLE
Fix noop notification service registration

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Subject, filter, firstValueFrom, map, merge, timeout } from "rxjs";
+import { filter, firstValueFrom, map, merge, Subject, timeout } from "rxjs";
 
 import { CollectionService, DefaultCollectionService } from "@bitwarden/admin-console/common";
 import {
@@ -112,10 +112,10 @@ import { NotificationsService } from "@bitwarden/common/platform/notifications";
 // eslint-disable-next-line no-restricted-imports -- Needed for service creation
 import {
   DefaultNotificationsService,
-  WorkerWebPushConnectionService,
   SignalRConnectionService,
   UnsupportedWebPushConnectionService,
   WebPushNotificationsApiService,
+  WorkerWebPushConnectionService,
 } from "@bitwarden/common/platform/notifications/internal";
 import { ScheduledTaskNames } from "@bitwarden/common/platform/scheduling";
 import { AppIdService } from "@bitwarden/common/platform/services/app-id.service";
@@ -198,10 +198,10 @@ import { FolderService } from "@bitwarden/common/vault/services/folder/folder.se
 import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/services/vault-settings/vault-settings.service";
 import {
-  PasswordGenerationServiceAbstraction,
-  UsernameGenerationServiceAbstraction,
   legacyPasswordGenerationServiceFactory,
   legacyUsernameGenerationServiceFactory,
+  PasswordGenerationServiceAbstraction,
+  UsernameGenerationServiceAbstraction,
 } from "@bitwarden/generator-legacy";
 import {
   ImportApiService,
@@ -210,11 +210,11 @@ import {
   ImportServiceAbstraction,
 } from "@bitwarden/importer/core";
 import {
-  BiometricStateService,
   BiometricsService,
+  BiometricStateService,
   DefaultBiometricStateService,
-  DefaultKeyService,
   DefaultKdfConfigService,
+  DefaultKeyService,
   KdfConfigService,
   KeyService as KeyServiceAbstraction,
 } from "@bitwarden/key-management";
@@ -1057,6 +1057,7 @@ export default class MainBackground {
     }
 
     this.notificationsService = new DefaultNotificationsService(
+      this.logService,
       this.syncService,
       this.appIdService,
       this.environmentService,
@@ -1066,7 +1067,6 @@ export default class MainBackground {
       new SignalRConnectionService(this.apiService, this.logService),
       this.authService,
       this.webPushConnectionService,
-      this.logService,
     );
 
     this.fido2UserInterfaceService = new BrowserFido2UserInterfaceService(this.authService);

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -906,6 +906,7 @@ const safeProviders: SafeProvider[] = [
       ? NoopNotificationsService
       : DefaultNotificationsService,
     deps: [
+      LogService,
       SyncService,
       AppIdServiceAbstraction,
       EnvironmentService,
@@ -915,7 +916,6 @@ const safeProviders: SafeProvider[] = [
       SignalRConnectionService,
       AuthServiceAbstraction,
       WebPushConnectionService,
-      LogService,
     ],
   }),
   safeProvider({

--- a/libs/common/src/platform/notifications/internal/default-notifications.service.spec.ts
+++ b/libs/common/src/platform/notifications/internal/default-notifications.service.spec.ts
@@ -22,7 +22,7 @@ import {
   DefaultNotificationsService,
   DISABLED_NOTIFICATIONS_URL,
 } from "./default-notifications.service";
-import { SignalRNotification, SignalRConnectionService } from "./signalr-connection.service";
+import { SignalRConnectionService, SignalRNotification } from "./signalr-connection.service";
 import { WebPushConnectionService, WebPushConnector } from "./webpush-connection.service";
 import { WorkerWebPushConnectionService } from "./worker-webpush-connection.service";
 
@@ -92,6 +92,7 @@ describe("NotificationsService", () => {
     );
 
     sut = new DefaultNotificationsService(
+      mock<LogService>(),
       syncService,
       appIdService,
       environmentService,
@@ -101,7 +102,6 @@ describe("NotificationsService", () => {
       signalRNotificationConnectionService,
       authService,
       webPushNotificationConnectionService,
-      mock<LogService>(),
     );
   });
 

--- a/libs/common/src/platform/notifications/internal/default-notifications.service.ts
+++ b/libs/common/src/platform/notifications/internal/default-notifications.service.ts
@@ -42,6 +42,7 @@ export class DefaultNotificationsService implements NotificationsServiceAbstract
   private activitySubject = new BehaviorSubject<"active" | "inactive">("active");
 
   constructor(
+    private readonly logService: LogService,
     private syncService: SyncService,
     private appIdService: AppIdService,
     private environmentService: EnvironmentService,
@@ -51,7 +52,6 @@ export class DefaultNotificationsService implements NotificationsServiceAbstract
     private readonly signalRConnectionService: SignalRConnectionService,
     private readonly authService: AuthService,
     private readonly webPushConnectionService: WebPushConnectionService,
-    private readonly logService: LogService,
   ) {
     this.notifications$ = this.accountService.activeAccount$.pipe(
       map((account) => account?.id),


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

#11346 re-ordered the constructor parameters of the default notification service causing a mismatch with the noop notification service. This re-orders them to be the same to prevent the Web application from failing to start with the noop service.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
