### PR TITLE
[PM-17713] Ensure cached cipher value is used only if initialized from cache

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -178,7 +178,7 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
   getInitialCipherView(): CipherView {
     const cachedCipherView = this.cipherFormCacheService.getCachedCipherView();
 
-    if (cachedCipherView) {
+    if (cachedCipherView && this.initializedWithCachedCipher()) {
       return cachedCipherView;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17713](https://bitwarden.atlassian.net/browse/PM-17713)

## 📔 Objective

The various child forms call `cipherFormContainer.getInitialCipherView()` sequentially as they're initialized. However, once the first component is initialized, it ends saving a new value to the cache which is then read by the subsequent child form components. 

This is fine when there is a value in the cache; however, when creating a new cipher without a cache this causes subsequent child forms to skip their `initiNewCipher()` methods because they believe they're restoring from cache. Which, for example, caused the autofill section to not populate the first empty URL for new login ciphers.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17713]: https://bitwarden.atlassian.net/browse/PM-17713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ