### PR TITLE
Fix vault search for port on URI

### DIFF
--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -377,10 +377,6 @@ export class SearchService implements SearchServiceAbstraction {
       if (u.uri == null || u.uri === "") {
         return;
       }
-      if (u.hostname != null) {
-        uris.push(u.hostname);
-        return;
-      }
       let uri = u.uri;
       if (u.match !== UriMatchStrategy.RegularExpression) {
         const protocolIndex = uri.indexOf("://");


### PR DESCRIPTION
## 🎟️ Tracking

Solves issue [#13134](https://github.com/bitwarden/clients/issues/13134)

## 📔 Objective

The search indexer strips out port numbers from the login item URIs, thus not allowing the user to search the vault for an item with a URI that contains a port number. e.g. the user wants to find item with uri `192.168.1.2:8000`. the user searches for ":8000" but finds no results, because the uri has been stripped to `192.168.1.2` by `uriExtractor`.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/bffe38f3-62cb-421b-add5-3c84fa0fa5a3)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
