### PR TITLE
[PM-17688] - generator dialog - add missing button label i18n keys. fix logic for disabling button

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2061,6 +2061,9 @@
   "usernameGenerator": {
     "message": "Username generator"
   },
+  "useThisEmail": {
+    "message": "Use this email"
+  },
   "useThisPassword": {
     "message": "Use this password"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2550,6 +2550,9 @@
   "catchallEmailDesc": {
     "message": "Use your domain's configured catch-all inbox."
   },
+  "useThisEmail": {
+    "message": "Use this email"
+  },
   "random": {
     "message": "Random"
   },

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.html
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.html
@@ -4,7 +4,7 @@
     <vault-cipher-form-generator
       [type]="data.type"
       (valueGenerated)="onCredentialGenerated($event)"
-      [algorithm]="algorithm"
+      [onAlgorithmSelected]="onAlgorithmSelected"
     />
     <bit-item>
       <button
@@ -28,6 +28,7 @@
       appA11yTitle="{{ buttonLabel }}"
       bitButton
       bitDialogClose
+      [disabled]="!(buttonLabel && credentialValue)"
     >
       {{ buttonLabel }}
     </button>

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
@@ -50,7 +50,8 @@ export class CredentialGeneratorDialogComponent {
     if (selected) {
       this.buttonLabel = selected.useGeneratedValue;
     } else {
-      // clear the credential value if we don't currently have an algorithm
+      // clear the credential value when the user is
+      // selecting the credential generation algorithm
       this.credentialValue = undefined;
     }
   };

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
@@ -46,8 +46,13 @@ export class CredentialGeneratorDialogComponent {
     private dialogService: DialogService,
   ) {}
 
-  algorithm = (selected: AlgorithmInfo) => {
-    this.buttonLabel = selected.useGeneratedValue;
+  onAlgorithmSelected = (selected?: AlgorithmInfo) => {
+    if (selected) {
+      this.buttonLabel = selected.useGeneratedValue;
+    } else {
+      // clear the credential value if we don't currently have an algorithm
+      this.credentialValue = undefined;
+    }
   };
 
   applyCredentials = () => {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6767,6 +6767,9 @@
   "catchallEmailDesc": {
     "message": "Use your domain's configured catch-all inbox."
   },
+  "useThisEmail": {
+    "message": "Use this email"
+  },
   "random": {
     "message": "Random",
     "description": "Generates domain-based username using random letters"

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.html
@@ -2,11 +2,11 @@
   *ngIf="type === 'password'"
   [disableMargin]="disableMargin"
   (onGenerated)="onCredentialGenerated($event)"
-  (onAlgorithm)="algorithm($event)"
+  (onAlgorithm)="onAlgorithmSelected($event)"
 ></tools-password-generator>
 <tools-username-generator
   *ngIf="type === 'username'"
   [disableMargin]="disableMargin"
   (onGenerated)="onCredentialGenerated($event)"
-  (onAlgorithm)="algorithm($event)"
+  (onAlgorithm)="onAlgorithmSelected($event)"
 ></tools-username-generator>

--- a/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-generator/cipher-form-generator.component.ts
@@ -19,7 +19,7 @@ import { AlgorithmInfo, GeneratedCredential } from "@bitwarden/generator-core";
 })
 export class CipherFormGeneratorComponent {
   @Input()
-  algorithm: (selected: AlgorithmInfo) => void;
+  onAlgorithmSelected: (selected: AlgorithmInfo) => void;
 
   /**
    * The type of generator form to show.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17688

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue with missing i18n keys for the username generator dialog. It also adds some logic for disabling the action button if the user hasn't selected an algorithm and/or generated a value.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/a79a8e6a-aba5-4bf1-82f1-9c47274571e9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
