### PR TITLE
[PM-15943] - fix extension flicker when filling in a password

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -747,7 +747,7 @@ describe("AutofillService", () => {
       jest.spyOn(autofillService as any, "generateFillScript");
       jest.spyOn(autofillService as any, "generateLoginFillScript");
       jest.spyOn(logService, "info");
-      jest.spyOn(cipherService, "updateLastUsedDate");
+      jest.spyOn(chrome.runtime, "sendMessage");
       jest.spyOn(eventCollectionService, "collect");
 
       const autofillResult = await autofillService.doAutoFill(autofillOptions);
@@ -769,7 +769,10 @@ describe("AutofillService", () => {
       );
       expect(autofillService["generateLoginFillScript"]).toHaveBeenCalled();
       expect(logService.info).not.toHaveBeenCalled();
-      expect(cipherService.updateLastUsedDate).toHaveBeenCalledWith(autofillOptions.cipher.id);
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+        cipherId: autofillOptions.cipher.id,
+        command: "updateLastUsedDate",
+      });
       expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
         autofillOptions.pageDetails[0].tab.id,
         {
@@ -890,11 +893,11 @@ describe("AutofillService", () => {
 
     it("skips updating the cipher's last used date if the passed options indicate that we should skip the last used cipher", async () => {
       autofillOptions.skipLastUsed = true;
-      jest.spyOn(cipherService, "updateLastUsedDate");
+      jest.spyOn(chrome.runtime, "sendMessage");
 
       await autofillService.doAutoFill(autofillOptions);
 
-      expect(cipherService.updateLastUsedDate).not.toHaveBeenCalled();
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
     });
 
     it("returns early if the fillScript cannot be generated", async () => {

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -463,8 +463,13 @@ export default class AutofillService implements AutofillServiceInterface {
         fillScript.properties.delay_between_operations = 20;
 
         didAutofill = true;
+
         if (!options.skipLastUsed) {
-          await this.cipherService.updateLastUsedDate(options.cipher.id);
+          // In order to prevent a UI update send message to background script to update last used date
+          await chrome.runtime.sendMessage({
+            command: "updateLastUsedDate",
+            cipherId: options.cipher.id,
+          });
         }
 
         // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1142,6 +1142,7 @@ export default class MainBackground {
       this.accountService,
       lockService,
       this.billingAccountProfileStateService,
+      this.cipherService,
     );
     this.nativeMessagingBackground = new NativeMessagingBackground(
       this.keyService,

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -16,6 +16,7 @@ import { MessageListener, isExternalMessage } from "@bitwarden/common/platform/m
 import { devFlagEnabled } from "@bitwarden/common/platform/misc/flags";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { NotificationsService } from "@bitwarden/common/platform/notifications";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { BiometricsCommands } from "@bitwarden/key-management";
 
@@ -53,6 +54,7 @@ export default class RuntimeBackground {
     private accountService: AccountService,
     private readonly lockService: LockService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private cipherService: CipherService,
   ) {
     // onInstalled listener must be wired up before anything else, so we do it in the ctor
     chrome.runtime.onInstalled.addListener((details: any) => {
@@ -199,6 +201,9 @@ export default class RuntimeBackground {
       }
       case BiometricsCommands.GetBiometricsStatusForUser: {
         return await this.main.biometricsService.getBiometricsStatusForUser(msg.userId);
+      }
+      case "updateLastUsedDate": {
+        return await this.cipherService.updateLastUsedDate(msg.cipherId);
       }
       case "getUseTreeWalkerApiForPageDetailsCollectionFeatureFlag": {
         return await this.configService.getFeatureFlag(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15943

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where, upon autofilling, the extension UI would quickly reload before closing. The cause was the call to `await this.cipherService.updateLastUsedDate(options.cipher.id);` which was causing the service to re-emit values and the consuming components to re-render. Doing the update in the background avoids the UI flicker but still ensures the last used password is still top of the autofill suggestion list.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/5bbb4b1c-3e49-40cc-98d4-19c793bd6642


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
