### PR TITLE
[PM-17736] Remove conditional code around extensionRefreshFlag for Stripe/billing pages

### DIFF
--- a/apps/web/src/app/billing/services/stripe.service.ts
+++ b/apps/web/src/app/billing/services/stripe.service.ts
@@ -3,8 +3,6 @@
 import { Injectable } from "@angular/core";
 
 import { BankAccount } from "@bitwarden/common/billing/models/domain";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
 import { BillingServicesModule } from "./billing-services.module";
@@ -19,10 +17,7 @@ export class StripeService {
     cardCvc: string;
   };
 
-  constructor(
-    private logService: LogService,
-    private configService: ConfigService,
-  ) {}
+  constructor(private logService: LogService) {}
 
   /**
    * Loads [Stripe JS]{@link https://docs.stripe.com/js} in the <head> element of the current page and mounts
@@ -43,19 +38,10 @@ export class StripeService {
       const window$ = window as any;
       this.stripe = window$.Stripe(process.env.STRIPE_KEY);
       this.elements = this.stripe.elements();
-      const isExtensionRefresh = await this.configService.getFeatureFlag(
-        FeatureFlag.ExtensionRefresh,
-      );
       setTimeout(() => {
-        this.elements.create(
-          "cardNumber",
-          this.getElementOptions("cardNumber", isExtensionRefresh),
-        );
-        this.elements.create(
-          "cardExpiry",
-          this.getElementOptions("cardExpiry", isExtensionRefresh),
-        );
-        this.elements.create("cardCvc", this.getElementOptions("cardCvc", isExtensionRefresh));
+        this.elements.create("cardNumber", this.getElementOptions("cardNumber"));
+        this.elements.create("cardExpiry", this.getElementOptions("cardExpiry"));
+        this.elements.create("cardCvc", this.getElementOptions("cardCvc"));
         if (autoMount) {
           this.mountElements();
         }
@@ -150,10 +136,7 @@ export class StripeService {
     }, 500);
   }
 
-  private getElementOptions(
-    element: "cardNumber" | "cardExpiry" | "cardCvc",
-    isExtensionRefresh: boolean,
-  ): any {
+  private getElementOptions(element: "cardNumber" | "cardExpiry" | "cardCvc"): any {
     const options: any = {
       style: {
         base: {
@@ -178,15 +161,12 @@ export class StripeService {
       },
     };
 
-    // Unique settings that should only be applied when the extension refresh flag is active
-    if (isExtensionRefresh) {
-      options.style.base.fontWeight = "500";
-      options.classes.base = "v2";
+    options.style.base.fontWeight = "500";
+    options.classes.base = "v2";
 
-      // Remove the placeholder for number and CVC fields
-      if (["cardNumber", "cardCvc"].includes(element)) {
-        options.placeholder = "";
-      }
+    // Remove the placeholder for number and CVC fields
+    if (["cardNumber", "cardCvc"].includes(element)) {
+      options.placeholder = "";
     }
 
     const style = getComputedStyle(document.documentElement);

--- a/apps/web/src/app/billing/shared/payment/payment-label.component.html
+++ b/apps/web/src/app/billing/shared/payment/payment-label.component.html
@@ -2,21 +2,12 @@
   <ng-content></ng-content>
 </ng-template>
 
-<ng-container *ngIf="extensionRefreshFlag; else defaultLabel">
-  <div class="tw-relative tw-mt-2">
-    <bit-label
-      [attr.for]="for"
-      class="tw-absolute tw-bg-background tw-px-1 tw-text-sm tw-text-muted -tw-top-2.5 tw-left-3 tw-mb-0 tw-max-w-full tw-pointer-events-auto"
-    >
-      <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
-      <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-    </bit-label>
-  </div>
-</ng-container>
-
-<ng-template #defaultLabel>
-  <label [attr.for]="for">
+<div class="tw-relative tw-mt-2">
+  <bit-label
+    [attr.for]="for"
+    class="tw-absolute tw-bg-background tw-px-1 tw-text-sm tw-text-muted -tw-top-2.5 tw-left-3 tw-mb-0 tw-max-w-full tw-pointer-events-auto"
+  >
     <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
     <span class="tw-text-xs tw-font-normal">({{ "required" | i18n }})</span>
-  </label>
-</ng-template>
+  </bit-label>
+</div>

--- a/apps/web/src/app/billing/shared/payment/payment-label.component.ts
+++ b/apps/web/src/app/billing/shared/payment/payment-label.component.ts
@@ -1,9 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { booleanAttribute, Component, Input, OnInit } from "@angular/core";
+import { booleanAttribute, Component, Input } from "@angular/core";
 
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { FormFieldModule } from "@bitwarden/components";
 
 import { SharedModule } from "../../../shared";
@@ -11,8 +9,7 @@ import { SharedModule } from "../../../shared";
 /**
  * Label that should be used for elements loaded via Stripe API.
  *
- * Applies the same label styles from CL form-field component when
- * the `ExtensionRefresh` flag is set.
+ * Applies the same label styles from CL form-field component
  */
 @Component({
   selector: "app-payment-label",
@@ -20,19 +17,11 @@ import { SharedModule } from "../../../shared";
   standalone: true,
   imports: [FormFieldModule, SharedModule],
 })
-export class PaymentLabelComponent implements OnInit {
+export class PaymentLabelComponent {
   /** `id` of the associated input */
   @Input({ required: true }) for: string;
   /** Displays required text on the label */
   @Input({ transform: booleanAttribute }) required = false;
 
-  protected extensionRefreshFlag = false;
-
-  constructor(private configService: ConfigService) {}
-
-  async ngOnInit(): Promise<void> {
-    this.extensionRefreshFlag = await this.configService.getFeatureFlag(
-      FeatureFlag.ExtensionRefresh,
-    );
-  }
+  constructor() {}
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17736

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With the extension refresh released, the conditional code around the ExtensionRefresh-feature-flag within the web-vault should also be removed.

Relates to https://github.com/bitwarden/clients/pull/10978

- **Remove conditional code around extensionRefreshFlag] -** https://github.com/bitwarden/clients/commit/bb627fad8b84034c01f167c3e4eeb2a58fc4168a
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
