### PR TITLE
[PM-17132] Fix rate limiter error message when upgrading organization

### DIFF
--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -1045,10 +1045,12 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
         this.estimatedTax = invoice.taxAmount;
       })
       .catch((error) => {
+        const translatedMessage = this.i18nService.t(error.message);
         this.toastService.showToast({
           title: "",
           variant: "error",
-          message: this.i18nService.t(error.message),
+          message:
+            !translatedMessage || translatedMessage === "" ? error.message : translatedMessage,
         });
       });
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17132

## 📔 Objective

When rate limiter is triggered when previewing an organization, an empty error message is being shown. This is due to the fact no translation exists for the rate limiter error message.

## 📸 Screenshots

https://github.com/user-attachments/assets/88a35a41-a7c9-4e09-8fee-deb36ee4b5f0

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
