### PR TITLE
[PM-17745] Catch network errors in new device notification guard

### DIFF
--- a/libs/angular/src/vault/guards/new-device-verification-notice.guard.spec.ts
+++ b/libs/angular/src/vault/guards/new-device-verification-notice.guard.spec.ts
@@ -36,7 +36,7 @@ describe("NewDeviceVerificationNoticeGuard", () => {
 
     return Promise.resolve(false);
   });
-  const isSelfHost = jest.fn().mockResolvedValue(false);
+  const isSelfHost = jest.fn().mockReturnValue(false);
   const getProfileTwoFactorEnabled = jest.fn().mockResolvedValue(false);
   const policyAppliesToActiveUser$ = jest.fn().mockReturnValue(new BehaviorSubject<boolean>(false));
   const noticeState$ = jest.fn().mockReturnValue(new BehaviorSubject(null));

--- a/libs/angular/src/vault/guards/new-device-verification-notice.guard.spec.ts
+++ b/libs/angular/src/vault/guards/new-device-verification-notice.guard.spec.ts
@@ -139,6 +139,12 @@ describe("NewDeviceVerificationNoticeGuard", () => {
     expect(await newDeviceGuard()).toBe(true);
   });
 
+  it("returns `true` when the profile service throws an error", async () => {
+    getProfileCreationDate.mockRejectedValueOnce(new Error("test"));
+
+    expect(await newDeviceGuard()).toBe(true);
+  });
+
   describe("temp flag", () => {
     beforeEach(() => {
       getFeatureFlag.mockImplementation((key) => {

--- a/libs/angular/src/vault/guards/new-device-verification-notice.guard.ts
+++ b/libs/angular/src/vault/guards/new-device-verification-notice.guard.ts
@@ -1,6 +1,6 @@
 import { inject } from "@angular/core";
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from "@angular/router";
-import { Observable, firstValueFrom } from "rxjs";
+import { firstValueFrom, Observable } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
@@ -47,17 +47,23 @@ export const NewDeviceVerificationNoticeGuard: CanActivateFn = async (
     return router.createUrlTree(["/login"]);
   }
 
-  const has2FAEnabled = await hasATwoFactorProviderEnabled(vaultProfileService, currentAcct.id);
-  const isSelfHosted = await platformUtilsService.isSelfHost();
-  const requiresSSO = await isSSORequired(policyService);
-  const isProfileLessThanWeekOld = await profileIsLessThanWeekOld(
-    vaultProfileService,
-    currentAcct.id,
-  );
+  try {
+    const isSelfHosted = platformUtilsService.isSelfHost();
+    const requiresSSO = await isSSORequired(policyService);
+    const has2FAEnabled = await hasATwoFactorProviderEnabled(vaultProfileService, currentAcct.id);
+    const isProfileLessThanWeekOld = await profileIsLessThanWeekOld(
+      vaultProfileService,
+      currentAcct.id,
+    );
 
-  // When any of the following are true, the device verification notice is
-  // not applicable for the user.
-  if (has2FAEnabled || isSelfHosted || requiresSSO || isProfileLessThanWeekOld) {
+    // When any of the following are true, the device verification notice is
+    // not applicable for the user.
+    if (has2FAEnabled || isSelfHosted || requiresSSO || isProfileLessThanWeekOld) {
+      return true;
+    }
+  } catch {
+    // Skip showing the notice if there was a problem determining applicability
+    // The most likely problem to occur is the user not having a network connection
     return true;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17745](https://bitwarden.atlassian.net/browse/PM-17745)

## 📔 Objective

Add `try/catch` to the `NewDeviceVerificationNoticeGuard` to prevent locking users out of the client when there is a network error or is otherwise unable to retrieve the user profile to determine eligibility for showing the new device notification.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17745]: https://bitwarden.atlassian.net/browse/PM-17745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ