### PR TITLE
[pm-17763] Add the limitItemDeletion property to the UI checkbox

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -68,6 +68,10 @@
       <bit-label>{{ "limitCollectionDeletionDesc" | i18n }}</bit-label>
       <input type="checkbox" bitCheckbox formControlName="limitCollectionDeletion" />
     </bit-form-control>
+    <bit-form-control *ngIf="limitItemDeletionFeatureFlagIsEnabled">
+      <bit-label>{{ "limitItemDeletionDesc" | i18n }}</bit-label>
+      <input type="checkbox" bitCheckbox formControlName="limitItemDeletion" />
+    </bit-form-control>
     <button
       type="submit"
       bitButton

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -8646,6 +8646,9 @@
   "limitCollectionDeletionDesc": {
     "message": "Limit collection deletion to owners and admins"
   },
+  "limitItemDeletionDesc": {
+    "message": "Limit item deletion to members with the Can manage permission"
+  },
   "allowAdminAccessToAllCollectionItemsDesc": {
     "message": "Owners and admins can manage all collections and items"
   },

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -48,6 +48,7 @@ export enum FeatureFlag {
   ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs",
   NewDeviceVerification = "new-device-verification",
   EnableRiskInsightsNotifications = "enable-risk-insights-notifications",
+  limitItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -106,6 +107,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ResellerManagedOrgAlert]: FALSE,
   [FeatureFlag.NewDeviceVerification]: FALSE,
   [FeatureFlag.EnableRiskInsightsNotifications]: FALSE,
+  [FeatureFlag.limitItemDeletion]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17763

## 📔 Objective

1. Add the limitItemDeletion property to the UI checkbox.
2. Only display the new checkbox if the feature flag pm-15493-restrict-item-deletion-to-can-manage-permission` is on.


## 📸 Screenshots


https://github.com/user-attachments/assets/8477972a-4838-473e-ae10-b024115622bb


when the feature is off, it just sends back the original data it got from the server

![image](https://github.com/user-attachments/assets/a31cf5b7-5f7e-461b-817c-773b43afc335)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
