### PR TITLE
[CL-569] Optionally allow item content to wrap

### DIFF
--- a/libs/components/src/item/item-content.component.html
+++ b/libs/components/src/item/item-content.component.html
@@ -6,14 +6,26 @@
       bitTypography="body2"
       class="tw-text-main tw-truncate tw-inline-flex tw-items-center tw-gap-1.5 tw-w-full"
     >
-      <div class="tw-truncate">
+      <div
+        [ngClass]="{
+          'tw-truncate': truncate,
+          'tw-text-wrap tw-overflow-auto tw-break-words': !truncate,
+        }"
+      >
         <ng-content></ng-content>
       </div>
       <div class="tw-flex-grow">
         <ng-content select="[slot=default-trailing]"></ng-content>
       </div>
     </div>
-    <div bitTypography="helper" class="tw-text-muted tw-w-full tw-truncate">
+    <div
+      bitTypography="helper"
+      class="tw-text-muted tw-w-full"
+      [ngClass]="{
+        'tw-truncate': truncate,
+        'tw-text-wrap tw-overflow-auto tw-break-words': !truncate,
+      }"
+    >
       <ng-content select="[slot=secondary]"></ng-content>
     </div>
   </div>

--- a/libs/components/src/item/item-content.component.ts
+++ b/libs/components/src/item/item-content.component.ts
@@ -6,6 +6,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  Input,
   signal,
   ViewChild,
 } from "@angular/core";
@@ -31,6 +32,13 @@ export class ItemContentComponent implements AfterContentChecked {
   @ViewChild("endSlot") endSlot: ElementRef<HTMLDivElement>;
 
   protected endSlotHasChildren = signal(false);
+
+  /**
+   * Determines whether text will truncate or wrap.
+   *
+   * Default behavior is truncation.
+   */
+  @Input() truncate = true;
 
   ngAfterContentChecked(): void {
     this.endSlotHasChildren.set(this.endSlot?.nativeElement.childElementCount > 0);

--- a/libs/components/src/item/item.mdx
+++ b/libs/components/src/item/item.mdx
@@ -111,6 +111,30 @@ Actions are commonly icon buttons or badge buttons.
 </bit-item>
 ```
 
+## Text Overflow Behavior
+
+The default behavior for long text is to truncate it. However, you have the option of changing it to
+wrap instead if that is what the design calls for.
+
+This can be changed by passing `[truncate]="false"` to the `bit-item-content`.
+
+```html
+<bit-item>
+  <bit-item-content [truncate]="false">
+    Long text goes here!
+    <ng-container slot="secondary">This could also be very long text</ng-container>
+  </bit-item-content>
+</bit-item>
+```
+
+### Truncation (Default)
+
+<Story of={stories.TextOverflowTruncate} />
+
+### Wrap
+
+<Story of={stories.TextOverflowWrap} />
+
 ## Item Groups
 
 Groups of items can be associated by wrapping them in the `<bit-item-group>`.

--- a/libs/components/src/item/item.stories.ts
+++ b/libs/components/src/item/item.stories.ts
@@ -135,12 +135,35 @@ export const ContentTypes: Story = {
   }),
 };
 
-export const TextOverflow: Story = {
+export const TextOverflowTruncate: Story = {
   render: (args) => ({
     props: args,
     template: /*html*/ `
       <bit-item>
         <bit-item-content>
+          <i slot="start" class="bwi bwi-globe tw-text-2xl tw-text-muted" aria-hidden="true"></i>
+          Helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo!
+          <ng-container slot="secondary">Worlddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd!</ng-container>
+        </bit-item-content>
+        <ng-container slot="end">
+          <bit-item-action>
+            <button type="button" bitIconButton="bwi-clone" size="small"></button>
+          </bit-item-action>
+          <bit-item-action>
+            <button type="button" bitIconButton="bwi-ellipsis-v" size="small"></button>
+          </bit-item-action>
+        </ng-container>
+      </bit-item>
+    `,
+  }),
+};
+
+export const TextOverflowWrap: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-item>
+        <bit-item-content [truncate]="false">
           <i slot="start" class="bwi bwi-globe tw-text-2xl tw-text-muted" aria-hidden="true"></i>
           Helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo!
           <ng-container slot="secondary">Worlddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd!</ng-container>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[CL-569](https://bitwarden.atlassian.net/browse/CL-569)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR adds the option to allow bit item content to wrap instead of truncate.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Check Storybook action for new text overflow wrap story. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-569]: https://bitwarden.atlassian.net/browse/CL-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ