### PR TITLE
Auth/PM-17877 Add device on all API requests

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -674,7 +674,7 @@ export default class MainBackground {
       this.messagingService,
     );
 
-    this.appIdService = new AppIdService(this.storageService, this.logService);
+    this.appIdService = new AppIdService(this.storageService);
 
     this.userDecryptionOptionsService = new UserDecryptionOptionsService(this.stateProvider);
     this.organizationService = new DefaultOrganizationService(this.stateProvider);

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -446,7 +446,7 @@ export class ServiceContainer {
       this.kdfConfigService,
     );
 
-    this.appIdService = new AppIdService(this.storageService, this.logService);
+    this.appIdService = new AppIdService(this.storageService);
 
     const customUserAgent =
       "Bitwarden_CLI/" +

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -279,7 +279,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: AppIdService,
     useClass: DefaultAppIdService,
-    deps: [OBSERVABLE_DISK_LOCAL_STORAGE, LogService],
+    deps: [OBSERVABLE_DISK_LOCAL_STORAGE],
   }),
   safeProvider({
     provide: LoginComponentService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -410,7 +410,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: AppIdServiceAbstraction,
     useClass: AppIdService,
-    deps: [OBSERVABLE_DISK_STORAGE, LogService],
+    deps: [OBSERVABLE_DISK_STORAGE],
   }),
   safeProvider({
     provide: AuditServiceAbstraction,

--- a/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
@@ -20,10 +20,7 @@ export abstract class DevicesApiServiceAbstraction {
     deviceKeyEncryptedDevicePrivateKey: string,
   ) => Promise<DeviceResponse>;
 
-  updateTrust: (
-    updateDevicesTrustRequestModel: UpdateDevicesTrustRequest,
-    deviceIdentifier: string,
-  ) => Promise<void>;
+  updateTrust: (updateDevicesTrustRequestModel: UpdateDevicesTrustRequest) => Promise<void>;
 
   getDeviceKeys: (
     deviceIdentifier: string,
@@ -31,11 +28,10 @@ export abstract class DevicesApiServiceAbstraction {
   ) => Promise<ProtectedDeviceResponse>;
 
   /**
-   * Notifies the server that the device has a device key, but didn't receive any associated decryption keys.
+   * Notifies the server that the current device has a device key, but didn't receive any associated decryption keys.
    * Note: For debugging purposes only.
-   * @param deviceIdentifier - current device identifier
    */
-  postDeviceTrustLoss: (deviceIdentifier: string) => Promise<void>;
+  postDeviceTrustLoss: () => Promise<void>;
 
   /**
    * Deactivates a device

--- a/libs/common/src/auth/abstractions/devices/devices.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/devices/devices.service.abstraction.ts
@@ -5,7 +5,6 @@ import { DeviceView } from "./views/device.view";
 
 export abstract class DevicesServiceAbstraction {
   abstract getDevices$(): Observable<Array<DeviceView>>;
-  abstract getDeviceByIdentifier$(deviceIdentifier: string): Observable<DeviceView>;
   abstract isDeviceKnownForUser$(email: string, deviceIdentifier: string): Observable<boolean>;
   abstract updateTrustedDeviceKeys$(
     deviceIdentifier: string,

--- a/libs/common/src/auth/services/device-trust.service.implementation.ts
+++ b/libs/common/src/auth/services/device-trust.service.implementation.ts
@@ -252,7 +252,7 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
       "[Device trust rotation] Posting device trust update with current device:",
       deviceIdentifier,
     );
-    await this.devicesApiService.updateTrust(trustRequest, deviceIdentifier);
+    await this.devicesApiService.updateTrust(trustRequest);
     this.logService.info("[Device trust rotation] Device trust update posted successfully.");
   }
 
@@ -359,8 +359,7 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
   }
 
   async recordDeviceTrustLoss(): Promise<void> {
-    const deviceIdentifier = await this.appIdService.getAppId();
-    await this.devicesApiService.postDeviceTrustLoss(deviceIdentifier);
+    await this.devicesApiService.postDeviceTrustLoss();
   }
 
   private getSecureStorageOptions(userId: UserId): StorageOptions {

--- a/libs/common/src/auth/services/device-trust.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust.service.spec.ts
@@ -774,7 +774,6 @@ describe("deviceTrustService", () => {
                 updateTrustModel.currentDevice.encryptedUserKey === "4.ZW5jcnlwdGVkdXNlcg=="
               );
             }),
-            expect.stringMatching("test_device_identifier"),
           );
         });
       });

--- a/libs/common/src/auth/services/devices-api.service.implementation.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.ts
@@ -73,10 +73,7 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
     return new DeviceResponse(result);
   }
 
-  async updateTrust(
-    updateDevicesTrustRequestModel: UpdateDevicesTrustRequest,
-    deviceIdentifier: string,
-  ): Promise<void> {
+  async updateTrust(updateDevicesTrustRequestModel: UpdateDevicesTrustRequest): Promise<void> {
     await this.apiService.send(
       "POST",
       "/devices/update-trust",
@@ -84,9 +81,6 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
       true,
       false,
       null,
-      (headers) => {
-        headers.set("Device-Identifier", deviceIdentifier);
-      },
     );
   }
 
@@ -104,18 +98,8 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
     return new ProtectedDeviceResponse(result);
   }
 
-  async postDeviceTrustLoss(deviceIdentifier: string): Promise<void> {
-    await this.apiService.send(
-      "POST",
-      "/devices/lost-trust",
-      null,
-      true,
-      false,
-      null,
-      (headers) => {
-        headers.set("Device-Identifier", deviceIdentifier);
-      },
-    );
+  async postDeviceTrustLoss(): Promise<void> {
+    await this.apiService.send("POST", "/devices/lost-trust", null, true, false);
   }
 
   async deactivateDevice(deviceId: string): Promise<void> {

--- a/libs/common/src/platform/services/app-id.service.spec.ts
+++ b/libs/common/src/platform/services/app-id.service.spec.ts
@@ -1,7 +1,4 @@
-import { mock } from "jest-mock-extended";
-
 import { FakeStorageService } from "../../../spec";
-import { LogService } from "../abstractions/log.service";
 import { Utils } from "../misc/utils";
 
 import { ANONYMOUS_APP_ID_KEY, APP_ID_KEY, AppIdService } from "./app-id.service";
@@ -12,7 +9,7 @@ describe("AppIdService", () => {
 
   beforeEach(() => {
     fakeStorageService = new FakeStorageService();
-    sut = new AppIdService(fakeStorageService, mock<LogService>());
+    sut = new AppIdService(fakeStorageService);
   });
 
   afterEach(() => {

--- a/libs/common/src/platform/services/app-id.service.ts
+++ b/libs/common/src/platform/services/app-id.service.ts
@@ -13,7 +13,6 @@ export class AppIdService implements AppIdServiceAbstraction {
   ) {}
 
   async getAppId(): Promise<string> {
-    this.logService.info("Retrieving application id");
     return await this.getEnsuredValue(APP_ID_KEY);
   }
 

--- a/libs/common/src/platform/services/app-id.service.ts
+++ b/libs/common/src/platform/services/app-id.service.ts
@@ -1,5 +1,4 @@
 import { AppIdService as AppIdServiceAbstraction } from "../abstractions/app-id.service";
-import { LogService } from "../abstractions/log.service";
 import { AbstractStorageService } from "../abstractions/storage.service";
 import { Utils } from "../misc/utils";
 
@@ -7,10 +6,7 @@ export const APP_ID_KEY = "global_applicationId_appId";
 export const ANONYMOUS_APP_ID_KEY = "global_applicationId_appId";
 
 export class AppIdService implements AppIdServiceAbstraction {
-  constructor(
-    private readonly storageService: AbstractStorageService,
-    private readonly logService: LogService,
-  ) {}
+  constructor(private readonly storageService: AbstractStorageService) {}
 
   async getAppId(): Promise<string> {
     return await this.getEnsuredValue(APP_ID_KEY);

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1913,6 +1913,7 @@ export class ApiService implements ApiServiceAbstraction {
     let requestBody: any = null;
     const headers = new Headers({
       "Device-Type": this.deviceType,
+      "Device-Identifier": await this.appIdService.getAppId(),
     });
 
     if (flagEnabled("prereleaseBuild")) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17877

## 📔 Objective

In order to provide LaunchDarkly context for targeting based on device identifier, we would like to include `Device-Identifier` on all API requests. This is accomplished by adding the header at the `ApiService` level. As the `AppIdService` will generate the `appId` if it does not yet exist, there is not a check for existence before adding the header.

Since the header is now being added on all requests, this PR also removes 2 `alterHeaders` implementations that were used for `updateTrust()` and `postDeviceTrustLoss()`, since the header will already be there.

## 📸 Screenshots

### On `POST` of cipher update, as an example
![image](https://github.com/user-attachments/assets/5977341e-4574-4d33-a029-995c4950ed65)

### On `update-trust` when rotating a user's encryption key with trusted devices
![image](https://github.com/user-attachments/assets/56162962-0a18-4486-b043-5a4ce46ef710)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
