### PR TITLE
Adjustments to Renovate configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,16 +85,21 @@ apps/web/src/app/core @bitwarden/team-platform-dev
 apps/web/src/app/shared @bitwarden/team-platform-dev
 apps/web/src/translation-constants.ts @bitwarden/team-platform-dev
 # Workflows
-.github/workflows/brew-bump-desktop.yml @bitwarden/team-platform-dev
+# Any changes here should also be reflected in Renovate configuration
+.github/workflows/automatic-issue-responses.yml @bitwarden/team-platform-dev
+.github/workflows/automatic-pull-request-responses.yml @bitwarden/team-platform-dev
 .github/workflows/build-browser.yml @bitwarden/team-platform-dev
 .github/workflows/build-cli.yml @bitwarden/team-platform-dev
 .github/workflows/build-desktop.yml @bitwarden/team-platform-dev
 .github/workflows/build-web.yml @bitwarden/team-platform-dev
 .github/workflows/chromatic.yml @bitwarden/team-platform-dev
+.github/workflows/crowdin-pull.yml @bitwarden/team-platform-dev
+.github/workflows/enforce-labels.yml @bitwarden/team-platform-dev
 .github/workflows/lint.yml @bitwarden/team-platform-dev
 .github/workflows/locales-lint.yml @bitwarden/team-platform-dev
 .github/workflows/repository-management.yml @bitwarden/team-platform-dev
 .github/workflows/scan.yml @bitwarden/team-platform-dev
+.github/workflows/stale-bot.yml @bitwarden/team-platform-dev
 .github/workflows/test.yml @bitwarden/team-platform-dev
 .github/workflows/version-auto-bump.yml @bitwarden/team-platform-dev
 # ESLint custom rules
@@ -146,6 +151,7 @@ apps/desktop/src/locales/en/messages.json
 apps/web/src/locales/en/messages.json
 
 ## BRE team owns these workflows ##
+# Any changes here should also be reflected in Renovate configuration ##
 .github/workflows/brew-bump-desktop.yml @bitwarden/dept-bre
 .github/workflows/deploy-web.yml @bitwarden/dept-bre
 .github/workflows/publish-cli.yml @bitwarden/dept-bre
@@ -153,13 +159,11 @@ apps/web/src/locales/en/messages.json
 .github/workflows/publish-web.yml @bitwarden/dept-bre
 .github/workflows/retrieve-current-desktop-rollout.yml @bitwarden/dept-bre
 .github/workflows/staged-rollout-desktop.yml @bitwarden/dept-bre
-
-## Shared ownership workflows ##
-.github/workflows/release-browser.yml
-.github/workflows/release-cli.yml
-.github/workflows/release-desktop-beta.yml
-.github/workflows/release-desktop.yml
-.github/workflows/release-web.yml
+.github/workflows/release-browser.yml @bitwarden/dept-bre
+.github/workflows/release-cli.yml @bitwarden/dept-bre
+.github/workflows/release-desktop-beta.yml @bitwarden/dept-bre
+.github/workflows/release-desktop.yml @bitwarden/dept-bre
+.github/workflows/release-web.yml @bitwarden/dept-bre
 
 ## Docker files have shared ownership ##
 **/Dockerfile

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,18 +63,20 @@
       commitMessagePrefix: "[deps] Platform:",
     },
     {
-      groupName: "napi",
-      matchPackageNames: ["napi", "napi-build", "napi-derive"],
-    },
-    {
+      // Disable major and minor updates for TypeScript and Zone.js because they are managed by Angular
       matchPackageNames: ["typescript", "zone.js"],
       matchUpdateTypes: ["major", "minor"],
       description: "Determined by Angular",
       enabled: false,
     },
     {
+      // Enable patch updates for TypeScript and Zone.js
       matchPackageNames: ["typescript", "zone.js"],
       matchUpdateTypes: "patch",
+    },
+    {
+      groupName: "napi",
+      matchPackageNames: ["napi", "napi-build", "napi-derive"],
     },
     {
       groupName: "jest",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,22 @@
   enabledManagers: ["cargo", "github-actions", "npm"],
   packageRules: [
     {
-      // Group all minor updates for GitHub Actions together
+      // Group all build/test/lint workflows for GitHub Actions together for Platform
+      // Since they are code owners we don't need to assign a review team in Renovate
       groupName: "github-action minor",
       matchManagers: ["github-actions"],
+      matchFileNames: ["workflows/build/**", "workflows/test/**", "workflows/lint/**"],
       matchUpdateTypes: ["minor"],
+      commitMessagePrefix: "[deps] Platform:",
+    },
+    {
+      // Group all release-related workflows for GitHub Actions together for BRE
+      // Since they are code owners we don't need to assign a review team in Renovate
+      groupName: "github-action minor",
+      matchManagers: ["github-actions"],
+      matchFileNames: ["workflows/release/**"],
+      matchUpdateTypes: ["minor"],
+      commitMessagePrefix: "[deps] BRE:",
     },
     {
       // Ignore all patch updates for GitHub Actions

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,46 +1,55 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["cargo", "github-actions", "npm"],
-  "packageRules": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>bitwarden/renovate-config"], // Extends our default configuration for pinned dependencies
+  enabledManagers: ["cargo", "github-actions", "npm"],
+  packageRules: [
     {
-      "groupName": "github-action minor",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor"]
+      // Group all minor updates for GitHub Actions together
+      groupName: "github-action minor",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor"],
     },
     {
-      "matchManagers": ["cargo"],
-      "commitMessagePrefix": "[deps] Platform:"
+      // Ignore all patch updates for GitHub Actions
+      matchManagers: ["github-actions"],
+      updateTypes: ["patch"],
+      enabled: false,
     },
     {
-      "groupName": "napi",
-      "matchPackageNames": ["napi", "napi-build", "napi-derive"]
+      // The desktop_native module is code-owned by Platform, so we're applying the Platform
+      // prefix to ensure that the PR has the right prefix on it for automation
+      matchManagers: ["cargo"],
+      commitMessagePrefix: "[deps] Platform:",
     },
     {
-      "matchPackageNames": ["typescript", "zone.js"],
-      "matchUpdateTypes": ["major", "minor"],
-      "description": "Determined by Angular",
-      "enabled": false
+      groupName: "napi",
+      matchPackageNames: ["napi", "napi-build", "napi-derive"],
     },
     {
-      "matchPackageNames": ["typescript", "zone.js"],
-      "matchUpdateTypes": "patch"
+      matchPackageNames: ["typescript", "zone.js"],
+      matchUpdateTypes: ["major", "minor"],
+      description: "Determined by Angular",
+      enabled: false,
     },
     {
-      "groupName": "jest",
-      "matchPackageNames": ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
-      "matchUpdateTypes": "major"
+      matchPackageNames: ["typescript", "zone.js"],
+      matchUpdateTypes: "patch",
     },
     {
-      "groupName": "macOS/iOS bindings",
-      "matchPackageNames": ["core-foundation", "security-framework", "security-framework-sys"]
+      groupName: "jest",
+      matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
+      matchUpdateTypes: "major",
     },
     {
-      "groupName": "zbus",
-      "matchPackageNames": ["zbus", "zbus_polkit"]
+      groupName: "macOS/iOS bindings",
+      matchPackageNames: ["core-foundation", "security-framework", "security-framework-sys"],
     },
     {
-      "matchPackageNames": [
+      groupName: "zbus",
+      matchPackageNames: ["zbus", "zbus_polkit"],
+    },
+    {
+      matchPackageNames: [
         "base64-loader",
         "buffer",
         "bufferutil",
@@ -56,20 +65,20 @@
         "style-loader",
         "ts-loader",
         "url",
-        "util"
+        "util",
       ],
-      "description": "Admin Console owned dependencies",
-      "commitMessagePrefix": "[deps] AC:",
-      "reviewers": ["team:team-admin-console-dev"]
+      description: "Admin Console owned dependencies",
+      commitMessagePrefix: "[deps] AC:",
+      reviewers: ["team:team-admin-console-dev"],
     },
     {
-      "matchPackageNames": ["qrious"],
-      "description": "Auth owned dependencies",
-      "commitMessagePrefix": "[deps] Auth:",
-      "reviewers": ["team:team-auth-dev"]
+      matchPackageNames: ["qrious"],
+      description: "Auth owned dependencies",
+      commitMessagePrefix: "[deps] Auth:",
+      reviewers: ["team:team-auth-dev"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@angular-eslint/schematics",
         "angular-eslint",
         "eslint-config-prettier",
@@ -82,14 +91,14 @@
         "eslint",
         "husky",
         "lint-staged",
-        "typescript-eslint"
+        "typescript-eslint",
       ],
-      "description": "Architecture owned dependencies",
-      "commitMessagePrefix": "[deps] Architecture:",
-      "reviewers": ["team:dept-architecture"]
+      description: "Architecture owned dependencies",
+      commitMessagePrefix: "[deps] Architecture:",
+      reviewers: ["team:dept-architecture"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@angular-eslint/eslint-plugin-template",
         "@angular-eslint/eslint-plugin",
         "@angular-eslint/schematics",
@@ -105,13 +114,13 @@
         "eslint-plugin-tailwindcss",
         "eslint",
         "husky",
-        "lint-staged"
+        "lint-staged",
       ],
-      "groupName": "Linting minor-patch",
-      "matchUpdateTypes": ["minor", "patch"]
+      groupName: "Linting minor-patch",
+      matchUpdateTypes: ["minor", "patch"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@emotion/css",
         "@webcomponents/custom-elements",
         "concurrently",
@@ -126,20 +135,20 @@
         "@storybook/web-components-webpack5",
         "tabbable",
         "tldts",
-        "wait-on"
+        "wait-on",
       ],
-      "description": "Autofill owned dependencies",
-      "commitMessagePrefix": "[deps] Autofill:",
-      "reviewers": ["team:team-autofill-dev"]
+      description: "Autofill owned dependencies",
+      commitMessagePrefix: "[deps] Autofill:",
+      reviewers: ["team:team-autofill-dev"],
     },
     {
-      "matchPackageNames": ["braintree-web-drop-in"],
-      "description": "Billing owned dependencies",
-      "commitMessagePrefix": "[deps] Billing:",
-      "reviewers": ["team:team-billing-dev"]
+      matchPackageNames: ["braintree-web-drop-in"],
+      description: "Billing owned dependencies",
+      commitMessagePrefix: "[deps] Billing:",
+      reviewers: ["team:team-billing-dev"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@babel/core",
         "@babel/preset-env",
         "@bitwarden/sdk-internal",
@@ -179,14 +188,14 @@
         "webpack",
         "webpack-cli",
         "webpack-dev-server",
-        "webpack-node-externals"
+        "webpack-node-externals",
       ],
-      "description": "Platform owned dependencies",
-      "commitMessagePrefix": "[deps] Platform:",
-      "reviewers": ["team:team-platform-dev"]
+      description: "Platform owned dependencies",
+      commitMessagePrefix: "[deps] Platform:",
+      reviewers: ["team:team-platform-dev"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@angular-devkit/build-angular",
         "@angular/animations",
         "@angular/cdk",
@@ -223,27 +232,27 @@
         "remark-gfm",
         "storybook",
         "tailwindcss",
-        "zone.js"
+        "zone.js",
       ],
-      "description": "UI Foundation owned dependencies",
-      "commitMessagePrefix": "[deps] UI Foundation:",
-      "reviewers": ["team:team-ui-foundation"]
+      description: "UI Foundation owned dependencies",
+      commitMessagePrefix: "[deps] UI Foundation:",
+      reviewers: ["team:team-ui-foundation"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@types/jest",
         "jest-junit",
         "jest-mock-extended",
         "jest-preset-angular",
         "jest-diff",
-        "ts-jest"
+        "ts-jest",
       ],
-      "description": "Secrets Manager owned dependencies",
-      "commitMessagePrefix": "[deps] SM:",
-      "reviewers": ["team:team-secrets-manager-dev"]
+      description: "Secrets Manager owned dependencies",
+      commitMessagePrefix: "[deps] SM:",
+      reviewers: ["team:team-secrets-manager-dev"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@microsoft/signalr-protocol-msgpack",
         "@microsoft/signalr",
         "@types/jsdom",
@@ -254,14 +263,14 @@
         "oidc-client-ts",
         "papaparse",
         "utf-8-validate",
-        "zxcvbn"
+        "zxcvbn",
       ],
-      "description": "Tools owned dependencies",
-      "commitMessagePrefix": "[deps] Tools:",
-      "reviewers": ["team:team-tools-dev"]
+      description: "Tools owned dependencies",
+      commitMessagePrefix: "[deps] Tools:",
+      reviewers: ["team:team-tools-dev"],
     },
     {
-      "matchPackageNames": [
+      matchPackageNames: [
         "@koa/multer",
         "@koa/router",
         "@types/inquirer",
@@ -287,18 +296,18 @@
         "node-fetch",
         "open",
         "proper-lockfile",
-        "qrcode-parser"
+        "qrcode-parser",
       ],
-      "description": "Vault owned dependencies",
-      "commitMessagePrefix": "[deps] Vault:",
-      "reviewers": ["team:team-vault-dev"]
+      description: "Vault owned dependencies",
+      commitMessagePrefix: "[deps] Vault:",
+      reviewers: ["team:team-vault-dev"],
     },
     {
-      "matchPackageNames": ["@types/argon2-browser", "argon2", "argon2-browser", "big-integer"],
-      "description": "Key Management owned dependencies",
-      "commitMessagePrefix": "[deps] KM:",
-      "reviewers": ["team:team-key-management-dev"]
-    }
+      matchPackageNames: ["@types/argon2-browser", "argon2", "argon2-browser", "big-integer"],
+      description: "Key Management owned dependencies",
+      commitMessagePrefix: "[deps] KM:",
+      reviewers: ["team:team-key-management-dev"],
+    },
   ],
-  "ignoreDeps": ["@types/koa-bodyparser", "bootstrap", "node-ipc", "node", "npm"]
+  ignoreDeps: ["@types/koa-bodyparser", "bootstrap", "node-ipc", "node", "npm"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,11 +4,34 @@
   enabledManagers: ["cargo", "github-actions", "npm"],
   packageRules: [
     {
+      // Ignore all patch updates for GitHub Actions
+      matchManagers: ["github-actions"],
+      updateTypes: ["patch"],
+      enabled: false,
+    },
+    {
       // Group all build/test/lint workflows for GitHub Actions together for Platform
       // Since they are code owners we don't need to assign a review team in Renovate
       groupName: "github-action minor",
       matchManagers: ["github-actions"],
-      matchFileNames: ["workflows/build/**", "workflows/test/**", "workflows/lint/**"],
+      matchFileNames: [
+        "./github/workflows/automatic-issue-responses.yml",
+        "./github/workflows/automatic-pull-request-responses.yml",
+        "./github/workflows/build-browser.yml",
+        "./github/workflows/build-cli.yml",
+        "./github/workflows/build-desktop.yml",
+        "./github/workflows/build-web.yml",
+        "./github/workflows/chromatic.yml",
+        "./github/workflows/crowdin-pull.yml",
+        "./github/workflows/enforce-labels.yml",
+        "./github/workflows/lint.yml",
+        "./github/workflows/locales-lint.yml",
+        "./github/workflows/repository-management.yml",
+        "./github/workflows/scan.yml",
+        "./github/workflows/stale-bot.yml",
+        "./github/workflows/test.yml",
+        "./github/workflows/version-auto-bump.yml",
+      ],
       matchUpdateTypes: ["minor"],
       commitMessagePrefix: "[deps] Platform:",
     },
@@ -17,15 +40,21 @@
       // Since they are code owners we don't need to assign a review team in Renovate
       groupName: "github-action minor",
       matchManagers: ["github-actions"],
-      matchFileNames: ["workflows/release/**"],
+      matchFileNames: [
+        "./github/workflows/brew-bump-desktop.yml",
+        "./github/workflows/deploy-web.yml",
+        "./github/workflows/publish-cli.yml",
+        "./github/workflows/publish-desktop.yml",
+        "./github/workflows/publish-web.yml",
+        "./github/workflows/retrieve-current-desktop-rollout.yml",
+        "./github/workflows/staged-rollout-desktop.yml",
+        "./github/workflows/release-cli.yml",
+        "./github/workflows/release-desktop-beta.yml",
+        "./github/workflows/release-desktop.yml",
+        "./github/workflows/release-web.yml",
+      ],
       matchUpdateTypes: ["minor"],
       commitMessagePrefix: "[deps] BRE:",
-    },
-    {
-      // Ignore all patch updates for GitHub Actions
-      matchManagers: ["github-actions"],
-      updateTypes: ["patch"],
-      enabled: false,
     },
     {
       // The desktop_native module is code-owned by Platform, so we're applying the Platform

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,24 +70,27 @@
       enabled: false,
     },
     {
-      // Enable patch updates for TypeScript and Zone.js
+      // Renovate should manage patch updates for TypeScript and Zone.js, despite ignoring major and minor
       matchPackageNames: ["typescript", "zone.js"],
       matchUpdateTypes: "patch",
     },
     {
+      // We need to update all the Jest-related packages together, to reduce PR noise
+      groupName: "jest",
+      matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
+    },
+    {
+      // We want to group all napi-related packages together for all updates, to reduce PR noise
       groupName: "napi",
       matchPackageNames: ["napi", "napi-build", "napi-derive"],
     },
     {
-      groupName: "jest",
-      matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
-      matchUpdateTypes: "major",
-    },
-    {
+      // We want to group all macOS/iOS binding-related packages together for all updates, to reduce PR noise
       groupName: "macOS/iOS bindings",
       matchPackageNames: ["core-foundation", "security-framework", "security-framework-sys"],
     },
     {
+      // We want to group all zbus-related packages together for all updates, to reduce PR noise
       groupName: "zbus",
       matchPackageNames: ["zbus", "zbus_polkit"],
     },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

1. Converted `renovate.json` to `renovate.json5`. This will allow us to add comments to the configuration to document our dependency management decisions.
2. Added initial comments to the document for some of our less clear configuration options.
3. Fixed a hole in the `github-actions` logic that was introduced by https://github.com/bitwarden/clients/pull/12818. This PR removed the `patch` updates from the grouping, but didn't disable them.  This means that we're now getting individual PRs for every patch, which is not what we want.
4. Adjusted out the `github-actions` configuration to create a PR group for minor updates _for each owning team_ instead of all updates together in one PR. This required assigning code owners to each of our workflows, which I did based on current ownership designations.  The CI/CD Partnership will eventually shift the `release-*` workflows to the development teams, at which point these will need to be adjusted.
6. Removed the restriction to only group `jest` dependencies together for `major` updates. This was done when we were favoring smaller, independent PRs, but having a grouping of these related dependencies will ease the load on Platform.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
