### PR TITLE
[PM-17912] Sync vault when saving an item

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -500,6 +500,9 @@ export class VaultComponent implements OnInit, OnDestroy {
     this.action = "view";
     this.go();
     await this.vaultItemsComponent.refresh();
+
+    // FIXME: workaround for https://github.com/bitwarden/clients/issues/12022
+    await this.syncService.fullSync(true, true);
   }
 
   async deletedCipher(cipher: CipherView) {


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/12022

## 📔 Objective

This syncs the vault after an item is saved, as a workaround for the bug where saved items do not show the changes that were made until some action is taken to "refresh" the view of the item.

This is almost certainly the wrong way to fix the bug, but I wanted to demonstrate a workaround to get more visibility on this issue and prompt further discussion on what the real solution might be.

I copied the `await this.syncService.fullSync(true, true)` line from [`apps/desktop/src/app/app.component.ts#L355`](https://github.com/bitwarden/clients/blob/e73cb3e3ff4490d5410198241cce754242099296/apps/desktop/src/app/app.component.ts#L355), and did not preserve the try/catch behavior. Also note that if you [scroll up](https://github.com/bitwarden/clients/blob/e73cb3e3ff4490d5410198241cce754242099296/apps/desktop/src/app/app.component.ts#L177-L182) in that file you'll see a `DEPRECATED` comment that warns `Please do not use the AppComponent to send events between services`, so even if syncing on item save *is* the correct solution for this bug, I'm probably doing it the wrong way.

Also note that with this workaround, there is still a delay after saving the item in which the old state is displayed before the vault finishes syncing, at which point the item changes to show the new state.