### PR TITLE
[PM-4783] Special case browser error

### DIFF
--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.spec.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.spec.ts
@@ -243,6 +243,7 @@ describe("Browser Utils Service", () => {
     });
 
     it("copies the passed text using the offscreen document if the extension is using manifest v3", async () => {
+      BrowserApi.sendMessageWithResponse = jest.fn();
       const text = "test";
       offscreenDocumentService.offscreenApiSupported.mockReturnValue(true);
       getManifestVersionSpy.mockReturnValue(3);
@@ -317,6 +318,7 @@ describe("Browser Utils Service", () => {
     });
 
     it("reads the clipboard text using the offscreen document", async () => {
+      BrowserApi.sendMessageWithResponse = jest.fn();
       offscreenDocumentService.offscreenApiSupported.mockReturnValue(true);
       getManifestVersionSpy.mockReturnValue(3);
       offscreenDocumentService.withDocument.mockImplementationOnce((_, __, callback) =>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-7548

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Right now during use of the browser extension we get a lot of `Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.` errors in the console. After investigation it seems that most of them are coming from the `checkVaultPopupHeartbeat` which adds up since that is called quite often. The solution for this is to no longer not check the `chrome.runtime.lastError` and then special case the message that essentially means that the popup doesn't exist. Resolving `false` makes sense in that case. This cleans up the console a lot making it easier to focus on real logs. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
