### PR TITLE
[CL-530] Exclude CL inputs from global css

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -66,9 +66,9 @@ a {
   }
 }
 
-input,
+input:not(bit-form-field input),
 select,
-textarea {
+textarea:not(bit-form-field textarea) {
   @include themify($themes) {
     color: themed("textColor");
     background-color: themed("inputBackgroundColor");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-530](https://bitwarden.atlassian.net/browse/CL-530)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a css override that excludes the component library form field components from receiving background colors set in global css.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="1055" alt="Screenshot 2025-02-04 at 3 43 55 PM" src="https://github.com/user-attachments/assets/dd2032c0-d7f4-4f42-9d35-23375a133a50" /> | <img width="1055" alt="Screenshot 2025-02-04 at 3 43 45 PM" src="https://github.com/user-attachments/assets/f6fb5783-db14-4319-878b-ac38dc32edc3" /> |
| <img width="1055" alt="Screenshot 2025-02-04 at 3 44 09 PM" src="https://github.com/user-attachments/assets/9ed6cd60-4534-4f3f-99ec-4bd8f618a5fe" /> | <img width="1055" alt="Screenshot 2025-02-04 at 3 43 27 PM" src="https://github.com/user-attachments/assets/af6019d4-9686-4b0a-b891-be6ca4cb4b7d" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-530]: https://bitwarden.atlassian.net/browse/CL-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ