### PR TITLE
[PM-17974] Fix Browser vault not rendering after initial unlock 

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -69,13 +69,13 @@
       <app-autofill-vault-list-items></app-autofill-vault-list-items>
       <app-vault-list-items-container
         [title]="'favorites' | i18n"
-        [ciphers]="favoriteCiphers$ | async"
+        [ciphers]="(favoriteCiphers$ | async) || []"
         id="favorites"
         collapsibleKey="favorites"
       ></app-vault-list-items-container>
       <app-vault-list-items-container
         [title]="'allItems' | i18n"
-        [ciphers]="remainingCiphers$ | async"
+        [ciphers]="(remainingCiphers$ | async) || []"
         id="allItems"
         disableSectionMargin
         collapsibleKey="allItems"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17974](https://bitwarden.atlassian.net/browse/PM-17974)

## 📔 Objective

https://github.com/bitwarden/clients/pull/13068 introduced a change that didn't expect a `null` list of ciphers during first load and would throw an exception. This PR prevents passing a null value while the `async` pipe resolves.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17974]: https://bitwarden.atlassian.net/browse/PM-17974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ