### PR TITLE
[PM-17978] fix: add otp field name for Amazon

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -32,6 +32,7 @@ export class AutoFillConstants {
     "totpcode",
     "2facode",
     "approvals_code",
+    "auth-mfa-otpcode",
     "mfacode",
     "otc-code",
     "onetimecode",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17978](https://bitwarden.atlassian.net/browse/PM-17978)

## 📔 Objective

### Add otp field name for Amazon

Amazon's "two-step verification" input element has an ID of `auth-mfa-otpcode`.

From https://www.amazon.com/ap/mfa:
```html
<input type="tel" maxlength="20" id="auth-mfa-otpcode" autocomplete="off" name="otpCode" class="a-input-text a-span12 auth-autofocus auth-required-field">
```

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [ ] All formatters and local linters executed and passed
- [ ] Written new unit and / or integration tests where applicable
- ~Protected functional changes with optionality (feature flags)~
- ~Used internationalization (i18n) for all UI strings~
- [ ] CI builds passed
- [ ] Communicated to DevOps any deployment requirements
- [ ] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17978]: https://bitwarden.atlassian.net/browse/PM-17978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ