### PR TITLE
[CL-527] Add truncate class to new organization button

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
@@ -121,7 +121,7 @@
     ></ng-container>
     <li class="filter-option" *ngIf="showAddLink">
       <span class="filter-buttons">
-        <a href="#" routerLink="{{ addInfo.route }}" class="filter-button">
+        <a href="#" routerLink="{{ addInfo.route }}" class="filter-button tw-truncate">
           <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
           &nbsp;{{ addInfo.text | i18n }}
         </a>


### PR DESCRIPTION
## 🎟️ Tracking

[CL-527](https://bitwarden.atlassian.net/browse/CL-527)

## 📔 Objective

This PR adds the `tw-truncate` class to the `+ New Organization` button in the individual vault, so that it truncates like the rest of the filter items and does not overflow its div

## 📸 Screenshots

Before:
![image](https://github.com/user-attachments/assets/9365010f-6410-49b2-ac9b-3a9b81d7b86c)

After:
![image](https://github.com/user-attachments/assets/49ed811a-a497-45c3-af28-601d1b9cf8b3)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-527]: https://bitwarden.atlassian.net/browse/CL-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ