### PR TITLE
Use a newly mocked autofill field for password data in AutofillOverlayContentService spec

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -459,15 +459,20 @@ describe("AutofillOverlayContentService", () => {
           const passwordFieldElement = document.getElementById(
             "password-field",
           ) as ElementWithOpId<FormFieldElement>;
-          autofillFieldData.type = "password";
+
+          const passwordFieldData = createAutofillFieldMock({
+            opid: "password-field",
+            form: "validFormId",
+            elementNumber: 2,
+            type: "password",
+          });
 
           await autofillOverlayContentService.setupOverlayListeners(
             passwordFieldElement,
-            autofillFieldData,
+            passwordFieldData,
             pageDetailsMock,
           );
           passwordFieldElement.dispatchEvent(new Event("input"));
-
           expect(autofillOverlayContentService["userFilledFields"].password).toEqual(
             passwordFieldElement,
           );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18051](https://bitwarden.atlassian.net/browse/PM-18051)

## 📔 Objective

[Removing](https://bitwarden.atlassian.net/browse/PM-16635) the `inline-menu-field-qualification` feature flag revealed a weakened assumption in a test for the `AutofillOverlayContentService`.

Namely, the spec previously reused a global mock for this spec entitled `autofillFieldData` which resembled the data for a username field, and then simply overrode its type to "password" while leaving its other attributes identical. 

I surmise with the new feature flag available, the qualification for what was a login form and what was a password field both became stricter. In other words, the overlay relies on field qualification which both identifies this field as a password, which disqualifies the form as a login form (since two passwords then are included in the form), while also still storing it in the `AutofillOverlayContentService` in a class member `userFilledFields` under the key `username` (instead of the expected `password` key), likely due to its other attributes.

This PR, instead of using the global mock with mismatched attributes (which we don't expect in the wild), creates a new `passwordFieldData`, satisfying the conditions of the test.

We may want to address some of the aforementioned conditions separately as tech debt issues.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18051]: https://bitwarden.atlassian.net/browse/PM-18051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ