### PR TITLE
[PM-16133] - [Vault] Implement persistence on filters in Vault view

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-header/vault-header-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-header/vault-header-v2.component.spec.ts
@@ -75,7 +75,7 @@ describe("VaultHeaderV2Component", () => {
         { provide: LogService, useValue: mock<LogService>() },
         {
           provide: VaultPopupItemsService,
-          useValue: mock<VaultPopupItemsService>({ latestSearchText$: new BehaviorSubject("") }),
+          useValue: mock<VaultPopupItemsService>({ searchText$: new BehaviorSubject("") }),
         },
         {
           provide: SyncService,

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
@@ -28,9 +28,6 @@ export class VaultV2SearchComponent {
   }
 
   onSearchTextChanged() {
-    if (!this.searchText) {
-      return;
-    }
     this.vaultPopupItemsService.applyFilter(this.searchText);
   }
 

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
@@ -20,7 +18,7 @@ const SearchTextDebounceInterval = 200;
   templateUrl: "vault-v2-search.component.html",
 })
 export class VaultV2SearchComponent {
-  searchText: string;
+  searchText: string | null = null;
 
   private searchText$ = new Subject<string>();
 
@@ -30,11 +28,14 @@ export class VaultV2SearchComponent {
   }
 
   onSearchTextChanged() {
-    this.searchText$.next(this.searchText);
+    if (!this.searchText) {
+      return;
+    }
+    this.vaultPopupItemsService.applyFilter(this.searchText);
   }
 
   subscribeToLatestSearchText(): Subscription {
-    return this.vaultPopupItemsService.latestSearchText$
+    return this.vaultPopupItemsService.searchText$
       .pipe(
         takeUntilDestroyed(),
         filter((data) => !!data),

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed } from "@angular/core/testing";
+import { WritableSignal, signal } from "@angular/core";
+import { TestBed, discardPeriodicTasks, fakeAsync, tick } from "@angular/core/testing";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, timeout } from "rxjs";
 
@@ -21,6 +22,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 // eslint-disable-next-line no-restricted-imports
 import { InlineMenuFieldQualificationService } from "../../../../../browser/src/autofill/services/inline-menu-field-qualification.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
+import { PopupViewCacheService } from "../../../platform/popup/view-cache/popup-view-cache.service";
 
 import { VaultPopupAutofillService } from "./vault-popup-autofill.service";
 import { VaultPopupItemsService } from "./vault-popup-items.service";
@@ -35,6 +37,10 @@ describe("VaultPopupItemsService", () => {
   let mockOrg: Organization;
   let mockCollections: CollectionView[];
   let activeUserLastSync$: BehaviorSubject<Date>;
+  let viewCacheService: {
+    signal: jest.Mock;
+    mockSignal: WritableSignal<string | null>;
+  };
 
   const cipherServiceMock = mock<CipherService>();
   const vaultSettingsServiceMock = mock<VaultSettingsService>();
@@ -109,6 +115,12 @@ describe("VaultPopupItemsService", () => {
     activeUserLastSync$ = new BehaviorSubject(new Date());
     syncServiceMock.activeUserLastSync$.mockReturnValue(activeUserLastSync$);
 
+    const testSearchSignal = createMockSignal<string | null>("");
+    viewCacheService = {
+      mockSignal: testSearchSignal,
+      signal: jest.fn((options) => testSearchSignal),
+    };
+
     testBed = TestBed.configureTestingModule({
       providers: [
         { provide: CipherService, useValue: cipherServiceMock },
@@ -124,6 +136,7 @@ describe("VaultPopupItemsService", () => {
           provide: InlineMenuFieldQualificationService,
           useValue: inlineMenuFieldQualificationServiceMock,
         },
+        { provide: PopupViewCacheService, useValue: viewCacheService },
       ],
     });
 
@@ -447,6 +460,23 @@ describe("VaultPopupItemsService", () => {
       });
     });
   });
+
+  it("should update searchText$ when applyFilter is called", fakeAsync(() => {
+    let latestValue: string | null;
+    service.searchText$.subscribe((val) => {
+      latestValue = val;
+    });
+    tick();
+    expect(latestValue!).toEqual("");
+
+    service.applyFilter("test search");
+    tick();
+    expect(latestValue!).toEqual("test search");
+
+    expect(viewCacheService.mockSignal()).toEqual("test search");
+
+    discardPeriodicTasks();
+  }));
 });
 
 // A function to generate a list of ciphers of different types
@@ -500,4 +530,10 @@ function cipherFactory(count: number): Record<CipherId, CipherView> {
     }
   }
   return Object.fromEntries(ciphers.map((c) => [c.id, c]));
+}
+
+function createMockSignal<T>(initialValue: T): WritableSignal<T> {
+  const s = signal(initialValue);
+  s.set = (value: T) => s.update(() => value);
+  return s;
 }

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -286,7 +286,7 @@ export class VaultPopupItemsService {
     private accountService: AccountService,
   ) {}
 
-  applyFilter(newSearchText: string) {
+  applyFilter(newSearchText: string | null) {
     this.cachedSearchText.set(newSearchText);
   }
 

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -48,13 +48,11 @@ import { MY_VAULT_ID, VaultPopupListFiltersService } from "./vault-popup-list-fi
   providedIn: "root",
 })
 export class VaultPopupItemsService {
-  // Replace: private _searchText$ = new BehaviorSubject<string>("");
   private cachedSearchText = inject(PopupViewCacheService).signal({
     key: "vault-search-text",
     initialValue: "",
   });
 
-  // New observable for search text
   readonly searchText$ = toObservable(this.cachedSearchText);
 
   /**
@@ -288,7 +286,6 @@ export class VaultPopupItemsService {
     private accountService: AccountService,
   ) {}
 
-  // Update existing methods
   applyFilter(newSearchText: string) {
     this.cachedSearchText.set(newSearchText);
   }

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
@@ -85,11 +85,11 @@ describe("VaultPopupListFiltersService", () => {
     policyService.policyAppliesToActiveUser$.mockClear();
 
     const accountService = mockAccountServiceWith("userId" as UserId);
-    const testCachedSignal = createMockSignal<CachedFilterState>({});
+    const mockCachedSignal = createMockSignal<CachedFilterState>({});
 
     viewCacheService = {
-      mockSignal: testCachedSignal,
-      signal: jest.fn(() => testCachedSignal),
+      mockSignal: mockCachedSignal,
+      signal: jest.fn(() => mockCachedSignal),
     };
 
     collectionService.getAllNested = () => Promise.resolve([]);

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
@@ -71,12 +71,6 @@ describe("VaultPopupListFiltersService", () => {
   const state$ = new BehaviorSubject<boolean>(false);
   const update = jest.fn().mockResolvedValue(undefined);
 
-  function createMockSignal<T>(initialValue: T): WritableSignal<T> {
-    const s = signal(initialValue);
-    s.set = (value: T) => s.update(() => value);
-    return s;
-  }
-
   beforeEach(() => {
     _memberOrganizations$ = new BehaviorSubject<Organization[]>([]); // Fresh instance per test
     folderViews$ = new BehaviorSubject([]); // Fresh instance per test
@@ -616,3 +610,9 @@ describe("VaultPopupListFiltersService", () => {
     }));
   });
 });
+
+function createMockSignal<T>(initialValue: T): WritableSignal<T> {
+  const s = signal(initialValue);
+  s.set = (value: T) => s.update(() => value);
+  return s;
+}

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -47,7 +47,7 @@ const FILTER_VISIBILITY_KEY = new KeyDefinition<boolean>(VAULT_SETTINGS_DISK, "f
   deserializer: (obj) => obj,
 });
 
-interface CachedFilterState {
+export interface CachedFilterState {
   organizationId?: string;
   collectionId?: string;
   folderId?: string;
@@ -138,7 +138,6 @@ export class VaultPopupListFiltersService {
           cipherType: null,
         };
 
-        // Handle organization
         if (state.organizationId) {
           if (state.organizationId === MY_VAULT_ID) {
             patchValue.organization = { id: MY_VAULT_ID } as Organization;
@@ -148,7 +147,6 @@ export class VaultPopupListFiltersService {
           }
         }
 
-        // Handle collection
         if (state.collectionId) {
           const collection = collectionOptions
             .flatMap((c) => this.flattenOptions(c))
@@ -156,7 +154,6 @@ export class VaultPopupListFiltersService {
           patchValue.collection = collection || null;
         }
 
-        // Handle folder
         if (state.folderId) {
           const folder = folderOptions
             .flatMap((f) => this.flattenOptions(f))
@@ -164,16 +161,14 @@ export class VaultPopupListFiltersService {
           patchValue.folder = folder || null;
         }
 
-        // Handle cipher type
         if (state.cipherType) {
           patchValue.cipherType = state.cipherType;
         }
 
-        this.filterForm.patchValue(patchValue, { emitEvent: false });
+        this.filterForm.patchValue(patchValue);
       });
   }
 
-  // Add this helper method to flatten nested options
   private flattenOptions<T>(option: ChipSelectOption<T>): ChipSelectOption<T>[] {
     return [option, ...(option.children?.flatMap((c) => this.flattenOptions(c)) || [])];
   }
@@ -386,7 +381,7 @@ export class VaultPopupListFiltersService {
         map(([filters, folders, cipherViews]): [PopupListFilter, FolderView[], CipherView[]] => {
           if (folders.length === 1 && folders[0].id === null) {
             // Do not display folder selections when only the "no folder" option is available.
-            return [filters, [], cipherViews];
+            return [filters as PopupListFilter, [], cipherViews];
           }
 
           // Sort folders by alphabetic name
@@ -405,7 +400,7 @@ export class VaultPopupListFiltersService {
             // Move the "no folder" option to the end of the list
             arrangedFolders = [...folders.filter((f) => f.id !== null), updatedNoFolder];
           }
-          return [filters, arrangedFolders, cipherViews];
+          return [filters as PopupListFilter, arrangedFolders, cipherViews];
         }),
         map(([filters, folders, cipherViews]) => {
           const organizationId = filters.organization?.id ?? null;

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -189,7 +189,6 @@ export class VaultPopupListFiltersService {
       .pipe(takeUntilDestroyed())
       .subscribe(this.validateOrganizationChange.bind(this));
 
-    // Get the cached filter state
     const cachedFilters = this.viewCacheService.signal<CachedFilterState>({
       key: "vault-filters",
       initialValue: {},
@@ -198,10 +197,7 @@ export class VaultPopupListFiltersService {
 
     // Load initial state from cache
     toObservable(cachedFilters)
-      .pipe(
-        take(1),
-        filter((state) => Object.keys(state).length > 0),
-      )
+      .pipe(filter((state) => Object.keys(state).length > 0))
       .subscribe((state) => this.deserializeFilters(state));
 
     // Save changes to cache


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16133

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR introduces persistence of the vault filters and search function. It leverages the `PopupViewCacheService` as the caching mechanism.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/540e0d2a-6861-4555-9fc1-5233b559c3af



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
