### PR TITLE
[PM-17852] ensure query param is removed when component is destroyed

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
@@ -1,8 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { DIALOG_DATA, DialogConfig } from "@angular/cdk/dialog";
-import { Component, Inject, OnInit } from "@angular/core";
+import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
 import { FormBuilder } from "@angular/forms";
+import { ActivatedRoute, Router } from "@angular/router";
+import { firstValueFrom, switchMap } from "rxjs";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -12,7 +14,6 @@ import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { EventView } from "@bitwarden/common/models/view/event.view";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { DialogService, TableDataSource, ToastService } from "@bitwarden/components";
 
@@ -34,7 +35,7 @@ export interface EntityEventsDialogParams {
   templateUrl: "entity-events.component.html",
   standalone: true,
 })
-export class EntityEventsComponent implements OnInit {
+export class EntityEventsComponent implements OnInit, OnDestroy {
   loading = true;
   continuationToken: string;
   protected dataSource = new TableDataSource<EventView>();
@@ -59,13 +60,14 @@ export class EntityEventsComponent implements OnInit {
     private apiService: ApiService,
     private i18nService: I18nService,
     private eventService: EventService,
-    private platformUtilsService: PlatformUtilsService,
     private userNamePipe: UserNamePipe,
     private logService: LogService,
     private organizationUserApiService: OrganizationUserApiService,
     private formBuilder: FormBuilder,
     private validationService: ValidationService,
     private toastService: ToastService,
+    private router: Router,
+    private activeRoute: ActivatedRoute,
   ) {}
 
   async ngOnInit() {
@@ -75,6 +77,25 @@ export class EntityEventsComponent implements OnInit {
       end: defaultDates[1],
     });
     await this.load();
+  }
+
+  async ngOnDestroy() {
+    await this.close();
+  }
+
+  async close() {
+    await firstValueFrom(
+      this.activeRoute.queryParams.pipe(
+        switchMap(async (params) => {
+          await this.router.navigate([], {
+            queryParams: {
+              ...params,
+              viewEvents: null,
+            },
+          });
+        }),
+      ),
+    );
   }
 
   async load() {

--- a/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
@@ -80,10 +80,6 @@ export class EntityEventsComponent implements OnInit, OnDestroy {
   }
 
   async ngOnDestroy() {
-    await this.close();
-  }
-
-  async close() {
     await firstValueFrom(
       this.activeRoute.queryParams.pipe(
         switchMap(async (params) => {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17852
## 📔 Objective
This PR fixes an issue where the veiwEvents query param is not being removed after closing the event dialog. The result is that router events will trigger an emission with the query param in the vault component that is supposed to open the entity event dialog. Removing the query param after closing the dialog resolves this issue.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots


https://github.com/user-attachments/assets/667bdff7-5430-4154-9418-51dcde64944c


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
