### PR TITLE
[PM-18218] CLI: SSO improvements

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -739,7 +739,7 @@ export class LoginCommand {
         try {
           this.ssoRedirectUri = "http://localhost:" + port;
           callbackServer.listen(port, () => {
-            const uri =
+            let uri =
               webUrl +
               "/#/sso?clientId=" +
               "cli" +
@@ -749,6 +749,9 @@ export class LoginCommand {
               state +
               "&codeChallenge=" +
               codeChallenge;
+            if (this.options.sso != true) {
+              uri += "&identifier=" + this.options.sso;
+            }
             CliUtils.writeLn(uri);
             this.platformUtilsService.launchUri(uri);
           });

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -43,6 +43,7 @@ import { NodeUtils } from "@bitwarden/node/node-utils";
 
 import { Response } from "../../models/response";
 import { MessageResponse } from "../../models/response/message.response";
+import { CliUtils } from "../../utils";
 
 export class LoginCommand {
   protected canInteract: boolean;
@@ -738,17 +739,18 @@ export class LoginCommand {
         try {
           this.ssoRedirectUri = "http://localhost:" + port;
           callbackServer.listen(port, () => {
-            this.platformUtilsService.launchUri(
+            const uri =
               webUrl +
-                "/#/sso?clientId=" +
-                "cli" +
-                "&redirectUri=" +
-                encodeURIComponent(this.ssoRedirectUri) +
-                "&state=" +
-                state +
-                "&codeChallenge=" +
-                codeChallenge,
-            );
+              "/#/sso?clientId=" +
+              "cli" +
+              "&redirectUri=" +
+              encodeURIComponent(this.ssoRedirectUri) +
+              "&state=" +
+              state +
+              "&codeChallenge=" +
+              codeChallenge;
+            CliUtils.writeLn(uri);
+            this.platformUtilsService.launchUri(uri);
           });
           foundPort = true;
           break;

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -752,7 +752,9 @@ export class LoginCommand {
             if (this.options.sso != true) {
               uri += "&identifier=" + this.options.sso;
             }
-            CliUtils.writeLn(uri);
+            if (process.env.BW_RAW != "true") {
+              CliUtils.writeLn(uri);
+            }
             this.platformUtilsService.launchUri(uri);
           });
           foundPort = true;

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -118,7 +118,7 @@ export class Program extends BaseProgram {
       .description("Log into a user account.")
       .option("--method <method>", "Two-step login method.")
       .option("--code <code>", "Two-step login code.")
-      .option("--sso", "Log in with Single-Sign On.")
+      .option("--sso [sso-identifier]", "Log in with Single-Sign On.", "")
       .option("--apikey", "Log in with an Api Key.")
       .option("--passwordenv <passwordenv>", "Environment variable storing your password")
       .option(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## Summary

This PR introduces two improvements to the CLI client:
- The SSO-Prompt URL is printed as console output.
  -  This enables the usage of SSO in scenarios where opening  a browser doesn't work (such as in containers and ssh sessions, including devcontainers, port forwarding for the callback-url is usually not an issue in these cases).
- The `--sso` parameter now takes an optional `[sso-identifier]` argument, allowing the user to skip the SSO-Identifier input prompt.

## 📔 Objective

- Enable usage of the CLI in containerized applications (such as devcontainers) where 'platformUtilsService.launchUri' doesn't work.
- Reduce user interaction overhead due to SSO-Identifier input prompt, even if only one SSO-Provider is configured.

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed
- [ ] Written new unit and / or integration tests where applicable
- [x] Protected functional changes with optionality (feature flags)
~~- [ ] Used internationalization (i18n) for all UI strings~~  (Doesn't apply)
- [ ] CI builds passed
~~- [ ] Communicated to DevOps any deployment requirements~~  (Doesn't apply)
- [ ] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
