### PR TITLE
Add learnMoreAboutBlockedDomains translation key and append to desc.

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2345,6 +2345,9 @@
   "blockedDomains": {
     "message": "Blocked domains"
   },
+  "learnMoreAboutBlockedDomains": {
+    "message": "Learn more about blocked domains"
+  },
   "excludedDomains": {
     "message": "Excluded domains"
   },

--- a/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
@@ -6,7 +6,12 @@
   </popup-header>
 
   <div class="tw-bg-background-alt">
-    <p>{{ "blockedDomainsDesc" | i18n }}</p>
+    <bit-section>
+      <p class="tw-m-0">{{ "blockedDomainsDesc" | i18n }}</p>
+      <a bitLink linkType="primary" href="https://bitwarden.com/help/blocking-uris/">{{
+        "learnMoreAboutBlockedDomains" | i18n
+      }}</a>
+    </bit-section>
     <bit-section *ngIf="!isLoading">
       <bit-section-header>
         <h2 bitTypography="h6">{{ "domainsTitle" | i18n }}</h2>

--- a/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
@@ -8,7 +8,7 @@
   <div class="tw-bg-background-alt">
     <bit-section>
       <p class="tw-m-0">{{ "blockedDomainsDesc" | i18n }}</p>
-      <a bitLink linkType="primary" href="https://bitwarden.com/help/blocking-uris/">{{
+      <a bitLink linkType="primary" rel="noreferrer" target="_blank" href="https://bitwarden.com/help/blocking-uris/">{{
         "learnMoreAboutBlockedDomains" | i18n
       }}</a>
     </bit-section>

--- a/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/blocked-domains.component.html
@@ -8,9 +8,14 @@
   <div class="tw-bg-background-alt">
     <bit-section>
       <p class="tw-m-0">{{ "blockedDomainsDesc" | i18n }}</p>
-      <a bitLink linkType="primary" rel="noreferrer" target="_blank" href="https://bitwarden.com/help/blocking-uris/">{{
-        "learnMoreAboutBlockedDomains" | i18n
-      }}</a>
+      <a
+        bitLink
+        linkType="primary"
+        rel="noreferrer"
+        target="_blank"
+        href="https://bitwarden.com/help/blocking-uris/"
+        >{{ "learnMoreAboutBlockedDomains" | i18n }}</a
+      >
     </bit-section>
     <bit-section *ngIf="!isLoading">
       <bit-section-header>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15997](https://bitwarden.atlassian.net/browse/PM-15997)

## 📔 Objective

Adds learn more link to blocked domains description.

## 📸 Screenshots

<img width="240" alt="Screenshot 2025-02-11 at 11 17 23 AM" src="https://github.com/user-attachments/assets/6fa95c74-a50b-42bf-b77b-7506b9a6346e" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15997]: https://bitwarden.atlassian.net/browse/PM-15997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ