### PR TITLE
[PM-15827] add `popupBackAction` to send item and export vault pages

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-back.directive.ts
+++ b/apps/browser/src/platform/popup/layout/popup-back.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, Optional } from "@angular/core";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { BitActionDirective, ButtonLikeAbstraction } from "@bitwarden/components";
+
+import { PopupRouterCacheService } from "../view-cache/popup-router-cache.service";
+
+/** Navigate the browser popup to the previous page when the component is clicked. */
+@Directive({
+  selector: "[popupBackAction]",
+  standalone: true,
+})
+export class PopupBackBrowserDirective extends BitActionDirective {
+  constructor(
+    buttonComponent: ButtonLikeAbstraction,
+    private router: PopupRouterCacheService,
+    @Optional() validationService?: ValidationService,
+    @Optional() logService?: LogService,
+  ) {
+    super(buttonComponent, validationService, logService);
+
+    // override `bitAction` input; the parent handles the rest
+    this.handler = () => this.router.back();
+  }
+}

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
@@ -16,6 +16,9 @@
     <button bitButton type="submit" form="sendForm" buttonType="primary" #submitBtn>
       {{ "save" | i18n }}
     </button>
+    <button bitButton type="button" buttonType="secondary" popupBackAction>
+      {{ "cancel" | i18n }}
+    </button>
     <button
       *ngIf="config?.mode !== 'add'"
       type="button"

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -29,6 +29,7 @@ import {
   SendFormModule,
 } from "@bitwarden/send-ui";
 
+import { PopupBackBrowserDirective } from "../../../../platform/popup/layout/popup-back.directive";
 import { PopupFooterComponent } from "../../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
@@ -77,6 +78,7 @@ export type AddEditQueryParams = Partial<Record<keyof QueryParams, string>>;
     SendFilePopoutDialogContainerComponent,
     SendFormModule,
     AsyncActionsModule,
+    PopupBackBrowserDirective,
   ],
 })
 export class SendAddEditComponent {

--- a/apps/browser/src/tools/popup/settings/export/export-browser-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/export/export-browser-v2.component.html
@@ -23,5 +23,8 @@
     >
       {{ "exportVault" | i18n }}
     </button>
+    <button bitButton type="button" buttonType="secondary" popupBackAction>
+      {{ "cancel" | i18n }}
+    </button>
   </popup-footer>
 </popup-page>

--- a/apps/browser/src/tools/popup/settings/export/export-browser-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/export/export-browser-v2.component.ts
@@ -7,6 +7,7 @@ import { AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/compo
 import { ExportComponent } from "@bitwarden/vault-export-ui";
 
 import { PopOutComponent } from "../../../../platform/popup/components/pop-out.component";
+import { PopupBackBrowserDirective } from "../../../../platform/popup/layout/popup-back.directive";
 import { PopupFooterComponent } from "../../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
@@ -25,6 +26,7 @@ import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page
     PopupFooterComponent,
     PopupHeaderComponent,
     PopOutComponent,
+    PopupBackBrowserDirective,
   ],
 })
 export class ExportBrowserV2Component {

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -1,4 +1,4 @@
-export { ButtonType } from "./shared/button-like.abstraction";
+export { ButtonType, ButtonLikeAbstraction } from "./shared/button-like.abstraction";
 export * from "./a11y";
 export * from "./async-actions";
 export * from "./avatar";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15827

## 📔 Objective

Add close button to sends and vault export pages.

## 📸 Screenshots

Send screen video:

https://github.com/user-attachments/assets/e1786e6b-47f9-43e7-810a-ae620f87e617

Export screen video: 

https://github.com/user-attachments/assets/e98ca4f4-80c6-4eac-a400-5037fcd4e3b2


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
