### PR TITLE
[PM-17179] Remove Bootstrap style from LoginDecryptionOptionsComponent

### DIFF
--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.html
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="loading">
-  <div class="text-center">
+  <div class="tw-text-center">
     <i
       class="bwi bwi-spinner bwi-spin bwi-2x tw-text-muted"
       title="{{ 'loading' | i18n }}"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17179?atlOrigin=eyJpIjoiNWQ5OTc0OTc5MTZiNGFlOWJjNzRjODI2NTE2YzdmNjkiLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Replaces the Bootstrap styles from the LoginDecryptionOptionsComponent with the Tailwind equivalents.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![Screenshot 2025-02-11 at 4 04 55 PM](https://github.com/user-attachments/assets/323bcfef-e549-4d28-82d6-8ed423ff0029)

![Screenshot 2025-02-11 at 4 03 12 PM](https://github.com/user-attachments/assets/f0351695-af96-408a-a74a-0abf469e5a00)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
