### PR TITLE
[PM-18192] Fix assign to org flow for cipher edit form

### DIFF
--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -275,9 +275,9 @@ export class ItemDetailsSectionComponent implements OnInit {
         // Disable Collections Options if Owner/Admin does not have Edit/Manage permissions on item
         // Disable Collections Options if Custom user does not have Edit/Manage permissions on item
         if (
-          (organization.allowAdminAccessToAllCollectionItems &&
+          (organization?.allowAdminAccessToAllCollectionItems &&
             (!this.originalCipherView.viewPassword || !this.originalCipherView.edit)) ||
-          (organization.type === OrganizationUserType.Custom &&
+          (organization?.type === OrganizationUserType.Custom &&
             !this.originalCipherView.viewPassword)
         ) {
           this.itemDetailsForm.controls.collectionIds.disable();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18192](https://bitwarden.atlassian.net/browse/PM-18192)

## 📔 Objective

Add a null check that was preventing assigning personal items to an organization from the cipher form.

## 📸 Screenshots

https://github.com/user-attachments/assets/ace938d9-73b9-4430-aff0-91f031d1a446


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18192]: https://bitwarden.atlassian.net/browse/PM-18192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ