### PR TITLE
[PM-17658] Fix persist route to clear if service worker dies

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -607,6 +607,7 @@ export default class MainBackground {
     this.popupViewCacheBackgroundService = new PopupViewCacheBackgroundService(
       messageListener,
       this.globalStateProvider,
+      this.taskSchedulerService,
     );
 
     const migrationRunner = new MigrationRunner(

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -1,8 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { switchMap, merge, delay, filter, concatMap, map, first, of } from "rxjs";
+import { switchMap, merge, delay, filter, concatMap, map, first, of, Subscription } from "rxjs";
 
 import { CommandDefinition, MessageListener } from "@bitwarden/common/platform/messaging";
+import { ScheduledTaskNames, TaskSchedulerService } from "@bitwarden/common/platform/scheduling";
+import { toScheduler } from "@bitwarden/common/platform/scheduling/task-scheduler.service";
 import {
   POPUP_VIEW_MEMORY,
   KeyDefinition,
@@ -45,53 +47,71 @@ export class PopupViewCacheBackgroundService {
   constructor(
     private messageListener: MessageListener,
     private globalStateProvider: GlobalStateProvider,
+    private readonly taskSchedulerService: TaskSchedulerService,
   ) {}
 
   startObservingTabChanges() {
-    this.messageListener
-      .messages$(SAVE_VIEW_CACHE_COMMAND)
-      .pipe(
-        concatMap(async ({ key, value }) =>
-          this.popupViewCacheState.update((state) => ({
-            ...state,
-            [key]: value,
-          })),
+    const combinedSubscription = new Subscription();
+
+    combinedSubscription.add(
+      this.messageListener
+        .messages$(SAVE_VIEW_CACHE_COMMAND)
+        .pipe(
+          concatMap(async ({ key, value }) =>
+            this.popupViewCacheState.update((state) => ({
+              ...state,
+              [key]: value,
+            })),
+          ),
+        )
+        .subscribe(),
+    );
+
+    combinedSubscription.add(
+      this.messageListener
+        .messages$(ClEAR_VIEW_CACHE_COMMAND)
+        .pipe(concatMap(() => this.popupViewCacheState.update(() => null)))
+        .subscribe(),
+    );
+
+    combinedSubscription.add(
+      merge(
+        // on tab changed, excluding extension tabs
+        fromChromeEvent(chrome.tabs.onActivated).pipe(
+          switchMap((tabs) => BrowserApi.getTab(tabs[0].tabId)),
+          switchMap((tab) => {
+            // FireFox sets the `url` to "about:blank" and won't populate the `url` until the `onUpdated` event
+            if (tab.url !== "about:blank") {
+              return of(tab);
+            }
+
+            return fromChromeEvent(chrome.tabs.onUpdated).pipe(
+              first(),
+              switchMap(([tabId]) => BrowserApi.getTab(tabId)),
+            );
+          }),
+          map((tab) => tab.url || tab.pendingUrl),
+          filter((url) => !url.startsWith(chrome.runtime.getURL(""))),
+        ),
+
+        // on popup closed, with 2 minute delay that is cancelled by re-opening the popup
+        fromChromeEvent(chrome.runtime.onConnect).pipe(
+          filter(([port]) => port.name === popupClosedPortName),
+          switchMap(([port]) =>
+            fromChromeEvent(port.onDisconnect).pipe(
+              delay(
+                1000 * 60 * 2,
+                toScheduler(this.taskSchedulerService, ScheduledTaskNames.clearPopupViewCache),
+              ),
+            ),
+          ),
         ),
       )
-      .subscribe();
+        .pipe(switchMap(() => this.clearState()))
+        .subscribe(),
+    );
 
-    this.messageListener
-      .messages$(ClEAR_VIEW_CACHE_COMMAND)
-      .pipe(concatMap(() => this.popupViewCacheState.update(() => null)))
-      .subscribe();
-
-    merge(
-      // on tab changed, excluding extension tabs
-      fromChromeEvent(chrome.tabs.onActivated).pipe(
-        switchMap((tabs) => BrowserApi.getTab(tabs[0].tabId)),
-        switchMap((tab) => {
-          // FireFox sets the `url` to "about:blank" and won't populate the `url` until the `onUpdated` event
-          if (tab.url !== "about:blank") {
-            return of(tab);
-          }
-
-          return fromChromeEvent(chrome.tabs.onUpdated).pipe(
-            first(),
-            switchMap(([tabId]) => BrowserApi.getTab(tabId)),
-          );
-        }),
-        map((tab) => tab.url || tab.pendingUrl),
-        filter((url) => !url.startsWith(chrome.runtime.getURL(""))),
-      ),
-
-      // on popup closed, with 2 minute delay that is cancelled by re-opening the popup
-      fromChromeEvent(chrome.runtime.onConnect).pipe(
-        filter(([port]) => port.name === popupClosedPortName),
-        switchMap(([port]) => fromChromeEvent(port.onDisconnect).pipe(delay(1000 * 60 * 2))),
-      ),
-    )
-      .pipe(switchMap(() => this.clearState()))
-      .subscribe();
+    return combinedSubscription;
   }
 
   async clearState() {

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -51,7 +51,14 @@ export class PopupViewCacheBackgroundService {
     private messageListener: MessageListener,
     private globalStateProvider: GlobalStateProvider,
     private readonly taskSchedulerService: TaskSchedulerService,
-  ) {}
+  ) {
+    this.taskSchedulerService.registerTaskHandler(
+      ScheduledTaskNames.clearPopupViewCache,
+      async () => {
+        await this.clearState();
+      },
+    );
+  }
 
   startObservingTabChanges() {
     this.messageListener

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -3,8 +3,11 @@
 import { switchMap, merge, delay, filter, concatMap, map, first, of } from "rxjs";
 
 import { CommandDefinition, MessageListener } from "@bitwarden/common/platform/messaging";
-import { ScheduledTaskNames, TaskSchedulerService } from "@bitwarden/common/platform/scheduling";
-import { toScheduler } from "@bitwarden/common/platform/scheduling/task-scheduler.service";
+import {
+  ScheduledTaskNames,
+  TaskSchedulerService,
+  toScheduler,
+} from "@bitwarden/common/platform/scheduling";
 import {
   POPUP_VIEW_MEMORY,
   KeyDefinition,

--- a/libs/common/src/platform/scheduling/index.ts
+++ b/libs/common/src/platform/scheduling/index.ts
@@ -1,3 +1,3 @@
-export { TaskSchedulerService } from "./task-scheduler.service";
+export { TaskSchedulerService, toScheduler } from "./task-scheduler.service";
 export { DefaultTaskSchedulerService } from "./default-task-scheduler.service";
 export { ScheduledTaskNames, ScheduledTaskName } from "./scheduled-task-name.enum";

--- a/libs/common/src/platform/scheduling/scheduled-task-name.enum.ts
+++ b/libs/common/src/platform/scheduling/scheduled-task-name.enum.ts
@@ -7,6 +7,7 @@ export const ScheduledTaskNames = {
   scheduleNextSyncInterval: "scheduleNextSyncInterval",
   eventUploadsInterval: "eventUploadsInterval",
   vaultTimeoutCheckInterval: "vaultTimeoutCheckInterval",
+  clearPopupViewCache: "clearPopupViewCache",
 } as const;
 
 export type ScheduledTaskName = (typeof ScheduledTaskNames)[keyof typeof ScheduledTaskNames];

--- a/libs/common/src/platform/scheduling/task-scheduler.service.ts
+++ b/libs/common/src/platform/scheduling/task-scheduler.service.ts
@@ -23,7 +23,7 @@ import { ScheduledTaskName } from "./scheduled-task-name.enum";
  *     messageListener.messages$(MY_MESSAGE).pipe(
  *        debounceTime(
  *          10 * 1000,
- *          toScheduler(taskScheduler),
+ *          toScheduler(taskScheduler, ShedulerTaskNames.myTaskName),
  *        ),
  *     )
  *       .subscribe((msg) => this.doThing(msg));

--- a/libs/common/src/platform/scheduling/task-scheduler.service.ts
+++ b/libs/common/src/platform/scheduling/task-scheduler.service.ts
@@ -10,7 +10,26 @@ import { ScheduledTaskName } from "./scheduled-task-name.enum";
  * @description On MV3 browser extensions this uses the `chrome.alarms` API. As such you need
  * to be careful that you observable is subscribed to during startup of the service worker.
  * This ensures that if the service worker dies and awakens for a chrome alarm event, then
- * your code will be guaranteed to be added.
+ * your code will be guaranteed to be added. The scheduler returned here should behave
+ * similarly to the built in {@link https://rxjs.dev/api/index/const/asyncScheduler asyncScheduler}
+ * that is the default to many rxjs operators.
+ *
+ * @link https://rxjs.dev/guide/scheduler#using-schedulers
+ *
+ * @example
+ * ```ts
+ * class MyService {
+ *   constructor(messageListener: MessageListener, taskScheduler: TaskSchedulerService) {
+ *     messageListener.messages$(MY_MESSAGE).pipe(
+ *        debounceTime(
+ *          10 * 1000,
+ *          toScheduler(taskScheduler),
+ *        ),
+ *     )
+ *       .subscribe((msg) => this.doThing(msg));
+ *   }
+ * }
+ * ```
  *
  * @param taskScheduler The task scheduler service to use to shedule RXJS work.
  * @param taskName The name of the task that the handler should be registered and scheduled based on.

--- a/libs/common/src/platform/scheduling/task-scheduler.service.ts
+++ b/libs/common/src/platform/scheduling/task-scheduler.service.ts
@@ -1,8 +1,37 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Subscription } from "rxjs";
+import { asyncScheduler, SchedulerLike, Subscription } from "rxjs";
 
 import { ScheduledTaskName } from "./scheduled-task-name.enum";
+
+/**
+ *
+ * @param taskScheduler
+ * @param taskName
+ * @returns
+ */
+export function toScheduler(
+  taskScheduler: TaskSchedulerService,
+  taskName: ScheduledTaskName,
+): SchedulerLike {
+  return new TaskSchedulerSheduler(taskScheduler, taskName);
+}
+
+class TaskSchedulerSheduler implements SchedulerLike {
+  constructor(
+    private readonly taskSchedulerService: TaskSchedulerService,
+    private readonly taskName: ScheduledTaskName,
+  ) {}
+
+  schedule<T>(work: (state?: T) => void, delay?: number, state?: T): Subscription {
+    this.taskSchedulerService.registerTaskHandler(this.taskName, () => work(state));
+    return this.taskSchedulerService.setTimeout(this.taskName, delay ?? 0);
+  }
+
+  now(): number {
+    return asyncScheduler.now();
+  }
+}
 
 export abstract class TaskSchedulerService {
   protected taskHandlers: Map<string, () => void>;

--- a/libs/common/src/platform/scheduling/task-scheduler.service.ts
+++ b/libs/common/src/platform/scheduling/task-scheduler.service.ts
@@ -5,10 +5,16 @@ import { asyncScheduler, SchedulerLike, Subscription } from "rxjs";
 import { ScheduledTaskName } from "./scheduled-task-name.enum";
 
 /**
+ * Creates a RXJS scheduler based on a {@link TaskSchedulerService}.
  *
- * @param taskScheduler
- * @param taskName
- * @returns
+ * @description On MV3 browser extensions this uses the `chrome.alarms` API. As such you need
+ * to be careful that you observable is subscribed to during startup of the service worker.
+ * This ensures that if the service worker dies and awakens for a chrome alarm event, then
+ * your code will be guaranteed to be added.
+ *
+ * @param taskScheduler The task scheduler service to use to shedule RXJS work.
+ * @param taskName The name of the task that the handler should be registered and scheduled based on.
+ * @returns A SchedulerLike object that can be passed in to RXJS operators like `delay` and `timeout`.
  */
 export function toScheduler(
   taskScheduler: TaskSchedulerService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17658

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fix `delay` to still trigger a cleanup even in the event that the service worker dies. By using a `SchedulerLike` based on our own `TaskSchedulerService` it will utilize a more long lived scheduling infrastructure when needed. When it's not needed it will still use `setTimeout` under the hood, just like the default scheduler in rxjs. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
