### PR TITLE
Auth/PM-17693 - Web - Existing users accepting an org invite are required to update password to meet org policy requirements

### DIFF
--- a/apps/web/src/app/auth/core/services/login/web-login-component.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/login/web-login-component.service.spec.ts
@@ -74,10 +74,10 @@ describe("WebLoginComponentService", () => {
     expect(service).toBeTruthy();
   });
 
-  describe("getOrgPolicies", () => {
+  describe("getOrgPoliciesFromOrgInvite", () => {
     it("returns undefined if organization invite is null", async () => {
       acceptOrganizationInviteService.getOrganizationInvite.mockResolvedValue(null);
-      const result = await service.getOrgPolicies();
+      const result = await service.getOrgPoliciesFromOrgInvite();
       expect(result).toBeUndefined();
     });
 
@@ -94,7 +94,7 @@ describe("WebLoginComponentService", () => {
         organizationName: "org-name",
       });
       policyApiService.getPoliciesByToken.mockRejectedValue(error);
-      await service.getOrgPolicies();
+      await service.getOrgPoliciesFromOrgInvite();
       expect(logService.error).toHaveBeenCalledWith(error);
     });
 
@@ -130,7 +130,7 @@ describe("WebLoginComponentService", () => {
           of(masterPasswordPolicyOptions),
         );
 
-        const result = await service.getOrgPolicies();
+        const result = await service.getOrgPoliciesFromOrgInvite();
 
         expect(result).toEqual({
           policies: policies,

--- a/apps/web/src/app/auth/core/services/login/web-login-component.service.ts
+++ b/apps/web/src/app/auth/core/services/login/web-login-component.service.ts
@@ -48,7 +48,7 @@ export class WebLoginComponentService
     this.clientType = this.platformUtilsService.getClientType();
   }
 
-  async getOrgPolicies(): Promise<PasswordPolicies | null> {
+  async getOrgPoliciesFromOrgInvite(): Promise<PasswordPolicies | null> {
     const orgInvite = await this.acceptOrganizationInviteService.getOrganizationInvite();
 
     if (orgInvite != null) {

--- a/libs/auth/src/angular/login/default-login-component.service.spec.ts
+++ b/libs/auth/src/angular/login/default-login-component.service.spec.ts
@@ -56,13 +56,6 @@ describe("DefaultLoginComponentService", () => {
     expect(service).toBeTruthy();
   });
 
-  describe("getOrgPolicies", () => {
-    it("returns null", async () => {
-      const result = await service.getOrgPolicies();
-      expect(result).toBeNull();
-    });
-  });
-
   describe("isLoginWithPasskeySupported", () => {
     it("returns true when clientType is Web", () => {
       service["clientType"] = ClientType.Web;

--- a/libs/auth/src/angular/login/default-login-component.service.ts
+++ b/libs/auth/src/angular/login/default-login-component.service.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { firstValueFrom } from "rxjs";
 
-import { LoginComponentService, PasswordPolicies } from "@bitwarden/auth/angular";
+import { LoginComponentService } from "@bitwarden/auth/angular";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { ClientType } from "@bitwarden/common/enums";
 import { CryptoFunctionService } from "@bitwarden/common/platform/abstractions/crypto-function.service";
@@ -22,10 +22,6 @@ export class DefaultLoginComponentService implements LoginComponentService {
     protected platformUtilsService: PlatformUtilsService,
     protected ssoLoginService: SsoLoginServiceAbstraction,
   ) {}
-
-  async getOrgPolicies(): Promise<PasswordPolicies | null> {
-    return null;
-  }
 
   isLoginWithPasskeySupported(): boolean {
     return this.clientType === ClientType.Web;

--- a/libs/auth/src/angular/login/login-component.service.ts
+++ b/libs/auth/src/angular/login/login-component.service.ts
@@ -23,7 +23,7 @@ export abstract class LoginComponentService {
    * Gets the organization policies if there is an organization invite.
    * - Used by: Web
    */
-  getOrgPolicies: () => Promise<PasswordPolicies | null>;
+  getOrgPoliciesFromOrgInvite?: () => Promise<PasswordPolicies | null>;
 
   /**
    * Indicates whether login with passkey is supported on the given client

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -287,6 +287,8 @@ export class LoginComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // TODO: PM-18269 - evaluate if we can combine this with the
+    // password evaluation done in the password login strategy.
     // If there's an existing org invite, use it to get the org's password policies
     // so we can evaluate the MP against the org policies
     if (this.loginComponentService.getOrgPoliciesFromOrgInvite) {
@@ -333,12 +335,14 @@ export class LoginComponent implements OnInit, OnDestroy {
     enforcedPasswordPolicyOptions: MasterPasswordPolicyOptions,
   ): Promise<boolean> {
     try {
-      if (
-        enforcedPasswordPolicyOptions == undefined ||
-        !enforcedPasswordPolicyOptions.enforceOnLogin
-      ) {
+      if (enforcedPasswordPolicyOptions == undefined) {
         return false;
       }
+
+      // Note: we deliberately do not check enforcedPasswordPolicyOptions.enforceOnLogin
+      // as existing users who are logging in after getting an org invite should
+      // always be forced to set a password that meets the org's policy.
+      // Org Invite -> Registration also works this way for new BW users as well.
 
       const masterPassword = this.formGroup.controls.masterPassword.value;
 

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -12,6 +12,7 @@ import {
   PasswordLoginCredentials,
 } from "@bitwarden/auth/common";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyData } from "@bitwarden/common/admin-console/models/data/policy.data";
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
@@ -30,6 +31,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { UserId } from "@bitwarden/common/types/guid";
 import {
   AsyncActionsModule,
   ButtonModule,
@@ -43,7 +45,7 @@ import {
 import { AnonLayoutWrapperDataService } from "../anon-layout/anon-layout-wrapper-data.service";
 import { VaultIcon, WaveIcon } from "../icons";
 
-import { LoginComponentService } from "./login-component.service";
+import { LoginComponentService, PasswordPolicies } from "./login-component.service";
 
 const BroadcasterSubscriptionId = "LoginComponent";
 
@@ -72,7 +74,6 @@ export class LoginComponent implements OnInit, OnDestroy {
   @ViewChild("masterPasswordInputRef") masterPasswordInputRef: ElementRef | undefined;
 
   private destroy$ = new Subject<void>();
-  private enforcedMasterPasswordOptions: MasterPasswordPolicyOptions | undefined = undefined;
   readonly Icons = { WaveIcon, VaultIcon };
 
   clientType: ClientType;
@@ -96,11 +97,6 @@ export class LoginComponent implements OnInit, OnDestroy {
   get emailFormControl(): FormControl<string | null> {
     return this.formGroup.controls.email;
   }
-
-  // Web properties
-  enforcedPasswordPolicyOptions: MasterPasswordPolicyOptions | undefined;
-  policies: Policy[] | undefined;
-  showResetPasswordAutoEnrollWarning = false;
 
   // Desktop properties
   deferFocus: boolean | null = null;
@@ -281,18 +277,37 @@ export class LoginComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // User logged in successfully so execute side effects
     await this.loginSuccessHandlerService.run(authResult.userId);
+    this.loginEmailService.clearValues();
 
+    // Determine where to send the user next
     if (authResult.forcePasswordReset != ForceSetPasswordReason.None) {
-      this.loginEmailService.clearValues();
       await this.router.navigate(["update-temp-password"]);
       return;
     }
 
-    // If none of the above cases are true, proceed with login...
-    await this.evaluatePassword();
+    // If there's an existing org invite, use it to get the org's password policies
+    // so we can evaluate the MP against the org policies
+    if (this.loginComponentService.getOrgPoliciesFromOrgInvite) {
+      const orgPolicies: PasswordPolicies | null =
+        await this.loginComponentService.getOrgPoliciesFromOrgInvite();
 
-    this.loginEmailService.clearValues();
+      if (orgPolicies) {
+        // Since we have retrieved the policies, we can go ahead and set them into state for future use
+        // e.g., the update-password page currently only references state for policy data and
+        // doesn't fallback to pulling them from the server like it should if they are null.
+        await this.setPoliciesIntoState(authResult.userId, orgPolicies.policies);
+
+        const isPasswordChangeRequired = await this.isPasswordChangeRequiredByOrgPolicy(
+          orgPolicies.enforcedPasswordPolicyOptions,
+        );
+        if (isPasswordChangeRequired) {
+          await this.router.navigate(["update-password"]);
+          return;
+        }
+      }
+    }
 
     if (this.clientType === ClientType.Browser) {
       await this.router.navigate(["/tabs/vault"]);
@@ -310,54 +325,49 @@ export class LoginComponent implements OnInit, OnDestroy {
     await this.loginComponentService.launchSsoBrowserWindow(email, clientId);
   }
 
-  protected async evaluatePassword(): Promise<void> {
+  /**
+   * Checks if the master password meets the enforced policy requirements
+   * and if the user is required to change their password.
+   */
+  private async isPasswordChangeRequiredByOrgPolicy(
+    enforcedPasswordPolicyOptions: MasterPasswordPolicyOptions,
+  ): Promise<boolean> {
     try {
-      // If we do not have any saved policies, attempt to load them from the service
-      if (this.enforcedMasterPasswordOptions == undefined) {
-        this.enforcedMasterPasswordOptions = await firstValueFrom(
-          this.policyService.masterPasswordPolicyOptions$(),
-        );
+      if (
+        enforcedPasswordPolicyOptions == undefined ||
+        !enforcedPasswordPolicyOptions.enforceOnLogin
+      ) {
+        return false;
       }
 
-      if (this.requirePasswordChange()) {
-        await this.router.navigate(["update-password"]);
-        return;
+      const masterPassword = this.formGroup.controls.masterPassword.value;
+
+      // Return false if masterPassword is null/undefined since this is only evaluated after successful login
+      if (!masterPassword) {
+        return false;
       }
+
+      const passwordStrength = this.passwordStrengthService.getPasswordStrength(
+        masterPassword,
+        this.formGroup.value.email ?? undefined,
+      )?.score;
+
+      return !this.policyService.evaluateMasterPassword(
+        passwordStrength,
+        masterPassword,
+        enforcedPasswordPolicyOptions,
+      );
     } catch (e) {
       // Do not prevent unlock if there is an error evaluating policies
       this.logService.error(e);
+      return false;
     }
   }
 
-  /**
-   * Checks if the master password meets the enforced policy requirements
-   * If not, returns false
-   */
-  private requirePasswordChange(): boolean {
-    if (
-      this.enforcedMasterPasswordOptions == undefined ||
-      !this.enforcedMasterPasswordOptions.enforceOnLogin
-    ) {
-      return false;
-    }
-
-    const masterPassword = this.formGroup.controls.masterPassword.value;
-
-    // Return false if masterPassword is null/undefined since this is only evaluated after successful login
-    if (!masterPassword) {
-      return false;
-    }
-
-    const passwordStrength = this.passwordStrengthService.getPasswordStrength(
-      masterPassword,
-      this.formGroup.value.email ?? undefined,
-    )?.score;
-
-    return !this.policyService.evaluateMasterPassword(
-      passwordStrength,
-      masterPassword,
-      this.enforcedMasterPasswordOptions,
-    );
+  private async setPoliciesIntoState(userId: UserId, policies: Policy[]): Promise<void> {
+    const policiesData: { [id: string]: PolicyData } = {};
+    policies.map((p) => (policiesData[p.id] = PolicyData.fromPolicy(p)));
+    await this.policyService.replace(policiesData, userId);
   }
 
   protected async startAuthRequestLogin(): Promise<void> {
@@ -528,12 +538,6 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   private async defaultOnInit(): Promise<void> {
-    // If there's an existing org invite, use it to get the password policies
-    const orgPolicies = await this.loginComponentService.getOrgPolicies();
-
-    this.policies = orgPolicies?.policies;
-    this.showResetPasswordAutoEnrollWarning = orgPolicies?.isPolicyAndAutoEnrollEnabled ?? false;
-
     let paramEmailIsSet = false;
 
     const params = await firstValueFrom(this.activatedRoute.queryParams);


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17693

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To restore the functionality that we broke during the UI refresh where existing BW users that are invited to an organization should be forced to update their password to meet org master password policy requirements (regardless of the `enforceOnLogin` setting).

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
As info, org invites are only accepted on the web. 

https://github.com/user-attachments/assets/31dd44ac-d13a-4f07-b082-2660d025ed33

https://github.com/user-attachments/assets/547f9d4c-7270-4ed6-91db-ca6924537f29


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
