### PR TITLE
[PM-18278] fix conditional in template

### DIFF
--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -105,7 +105,7 @@
     class="tw-shrink-0"
   >
     <!-- "New" menu is always shown unless the user cannot create a cipher -->
-    <ng-container *ngIf="canCreateCipher">
+    <ng-container *ngIf="canCreateCipher || canCreateCollection">
       <div appListDropdown>
         <button
           bitButton
@@ -119,24 +119,26 @@
           {{ "new" | i18n }}<i class="bwi tw-ml-2" aria-hidden="true"></i>
         </button>
         <bit-menu #addOptions aria-labelledby="newItemDropdown">
-          <button type="button" bitMenuItem (click)="addCipher(CipherType.Login)">
-            <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
-            {{ "typeLogin" | i18n }}
-          </button>
-          <button type="button" bitMenuItem (click)="addCipher(CipherType.Card)">
-            <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
-            {{ "typeCard" | i18n }}
-          </button>
-          <button type="button" bitMenuItem (click)="addCipher(CipherType.Identity)">
-            <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
-            {{ "typeIdentity" | i18n }}
-          </button>
-          <button type="button" bitMenuItem (click)="addCipher(CipherType.SecureNote)">
-            <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
-            {{ "note" | i18n }}
-          </button>
+          <ng-container *ngIf="canCreateCipher">
+            <button type="button" bitMenuItem (click)="addCipher(CipherType.Login)">
+              <i class="bwi bwi-globe" slot="start" aria-hidden="true"></i>
+              {{ "typeLogin" | i18n }}
+            </button>
+            <button type="button" bitMenuItem (click)="addCipher(CipherType.Card)">
+              <i class="bwi bwi-credit-card" slot="start" aria-hidden="true"></i>
+              {{ "typeCard" | i18n }}
+            </button>
+            <button type="button" bitMenuItem (click)="addCipher(CipherType.Identity)">
+              <i class="bwi bwi-id-card" slot="start" aria-hidden="true"></i>
+              {{ "typeIdentity" | i18n }}
+            </button>
+            <button type="button" bitMenuItem (click)="addCipher(CipherType.SecureNote)">
+              <i class="bwi bwi-sticky-note" slot="start" aria-hidden="true"></i>
+              {{ "note" | i18n }}
+            </button>
+          </ng-container>
           <ng-container *ngIf="canCreateCollection">
-            <bit-menu-divider></bit-menu-divider>
+            <bit-menu-divider *ngIf="canCreateCipher"></bit-menu-divider>
             <button type="button" bitMenuItem (click)="addCollection()">
               <i class="bwi bwi-fw bwi-collection" aria-hidden="true"></i>
               {{ "collection" | i18n }}

--- a/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/org-vault/vault-header/vault-header.component.html
@@ -104,7 +104,7 @@
     *ngIf="filter.type !== 'trash' && filter.collectionId !== Unassigned && organization"
     class="tw-shrink-0"
   >
-    <!-- "New" menu is always shown unless the user cannot create a cipher -->
+    <!-- "New" menu is always shown unless the user cannot create a cipher and cannot create a collection-->
     <ng-container *ngIf="canCreateCipher || canCreateCollection">
       <div appListDropdown>
         <button


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-18278
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fixes an issue where canCreateCiphers conditional overrides the canCreateCollections permission due to the structure of the template
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
![Screenshot 2025-02-13 at 2 24 21 PM](https://github.com/user-attachments/assets/ac440769-6b8c-4286-a219-9a4055b52817)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
