### PR TITLE
Add cdk-visually-hidden to tw-theme for Angular CDK LiveAnnouncer

### DIFF
--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -244,3 +244,8 @@ summary.tw-list-none::-webkit-details-marker {
   height: 100%;
   overflow: hidden;
 }
+
+/** Used by CDK a11y services */
+.cdk-visually-hidden {
+  @apply tw-sr-only;
+}

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -194,6 +194,9 @@
   --tw-ring-offset-color: #002b36;
 }
 
+/** Used by CDK a11y services */
+@import "@angular/cdk/a11y-prebuilt.css";
+
 @import "./popover/popover.component.css";
 @import "./search/search.component.css";
 
@@ -243,9 +246,4 @@ summary.tw-list-none::-webkit-details-marker {
   position: relative;
   height: 100%;
   overflow: hidden;
-}
-
-/** Used by CDK a11y services */
-.cdk-visually-hidden {
-  @apply tw-sr-only;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17207

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Angular CKD LiveAnnouncer depends on some css logic to hide announcements from being displayed. We are currently missing this functionality as we don't import CDK styles globally.

Resolves #13260
Resolves https://github.com/bitwarden/clients/issues/13471

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
