### PR TITLE
[PM-18219] Normalize blocked domain checks to a common util

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -13,6 +13,7 @@ import {
   Subject,
   switchMap,
 } from "rxjs";
+import { getHostname } from "tldts";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -84,13 +85,14 @@ export class VaultPopupAutofillService {
   showCurrentTabIsBlockedBanner$: Observable<boolean> = combineLatest([
     this.domainSettingsService.blockedInteractionsUris$,
     this.currentAutofillTab$,
-    this.currentTabIsOnBlocklist$,
   ]).pipe(
-    map(([blockedInteractionsUrls, currentTab, tabIsBlocked]) => {
+    map(([blockedInteractionsUrls, currentTab]) => {
       if (blockedInteractionsUrls && currentTab?.url?.length) {
-        const tabURL = new URL(currentTab.url);
+        const tabHostname = getHostname(currentTab.url, { allowPrivateDomains: true });
+        const tabIsBlocked = isUrlInList(currentTab.url, blockedInteractionsUrls);
+
         const showScriptInjectionIsBlockedBanner =
-          tabIsBlocked && !blockedInteractionsUrls[tabURL.hostname]?.bannerIsDismissed;
+          tabIsBlocked && !blockedInteractionsUrls[tabHostname]?.bannerIsDismissed;
 
         return showScriptInjectionIsBlockedBanner;
       }

--- a/libs/common/src/autofill/utils.ts
+++ b/libs/common/src/autofill/utils.ts
@@ -1,6 +1,5 @@
-import { getHostname } from "tldts";
-
 import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 
 import { CardView } from "../vault/models/view/card.view";
 
@@ -346,7 +345,7 @@ export function isUrlInList(url: string = "", urlList: NeverDomains = {}): boole
   if (urlListKeys.length && url?.length) {
     let tabHostname;
     try {
-      tabHostname = getHostname(url, { allowPrivateDomains: true });
+      tabHostname = Utils.getHostname(url);
     } catch {
       // If the input was invalid, exit early and return false
       return false;

--- a/libs/common/src/autofill/utils.ts
+++ b/libs/common/src/autofill/utils.ts
@@ -353,13 +353,7 @@ export function isUrlInList(url: string = "", urlList: NeverDomains = {}): boole
     }
 
     if (tabHostname) {
-      const tabIsBlocked = urlListKeys.some((blockedHostname) =>
-        tabHostname.endsWith(blockedHostname),
-      );
-
-      if (tabIsBlocked) {
-        return true;
-      }
+      return urlListKeys.some((blockedHostname) => tabHostname.endsWith(blockedHostname));
     }
   }
 

--- a/libs/common/src/autofill/utils.ts
+++ b/libs/common/src/autofill/utils.ts
@@ -1,3 +1,7 @@
+import { getHostname } from "tldts";
+
+import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
+
 import { CardView } from "../vault/models/view/card.view";
 
 import {
@@ -328,4 +332,36 @@ export function parseYearMonthExpiry(combinedExpiryValue: string): [Year | null,
   parsedMonth = normalizedParsedMonth?.length ? normalizedParsedMonth : null;
 
   return [parsedYear, parsedMonth];
+}
+
+/**
+ * Takes a URL string and a NeverDomains object and determines if the passed URL's hostname is in `urlList`
+ *
+ * @param {string} url - representation of URL to check
+ * @param {NeverDomains} urlList - object with hostname key names
+ */
+export function isUrlInList(url: string = "", urlList: NeverDomains = {}): boolean {
+  const urlListKeys = urlList && Object.keys(urlList);
+
+  if (urlListKeys.length && url?.length) {
+    let tabHostname;
+    try {
+      tabHostname = getHostname(url, { allowPrivateDomains: true });
+    } catch {
+      // If the input was invalid, exit early and return false
+      return false;
+    }
+
+    if (tabHostname) {
+      const tabIsBlocked = urlListKeys.some((blockedHostname) =>
+        tabHostname.endsWith(blockedHostname),
+      );
+
+      if (tabIsBlocked) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18219

## 📔 Objective

- In callsites where we resolve a URI (from the current/active tab) against blocked domains, we use slightly differing logic - we should unify that logic (ideally abstracted to a single resolver)

- The current resolution pattern for current URI against blocked domains is to look for an exact match. However, in cases where the user has included a subdomain `sandbox.paypal.com` the current URI hostname value will resolve to `www.sandbox.paypal.com`. Resolution checks the `currentUri` with an `endsWith` against the blocked URLs array (do not use `startsWith` as that will allow unsafe comparisons against packed subdomains; e.g. `sandbox.paypal.com.some.otherdomain.com`)

- Rename "URI" to "URL" to reflect contextual expectations and narrower case support

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
