### PR TITLE
[CL-317] Use storybook theme addon for theme switching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -208,6 +208,7 @@
         "@storybook/addon-essentials",
         "@storybook/addon-interactions",
         "@storybook/addon-links",
+        "@storybook/addon-themes",
         "@storybook/angular",
         "@storybook/manager-api",
         "@storybook/theming",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -29,6 +29,7 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-a11y"),
     getAbsolutePath("@storybook/addon-designs"),
     getAbsolutePath("@storybook/addon-interactions"),
+    getAbsolutePath("@storybook/addon-themes"),
     {
       // @storybook/addon-docs is part of @storybook/addon-essentials
       // eslint-disable-next-line storybook/no-uninstalled-addons

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,60 +1,30 @@
 import { setCompodocJson } from "@storybook/addon-docs/angular";
+import { withThemeByClassName } from "@storybook/addon-themes";
 import { componentWrapperDecorator } from "@storybook/angular";
 import type { Preview } from "@storybook/angular";
 
 import docJson from "../documentation.json";
 setCompodocJson(docJson);
 
-const decorator = componentWrapperDecorator(
-  (story) => {
-    return /*html*/ `
-      <div
-        class="tw-border-2 tw-border-solid tw-px-5 tw-py-10"
-        [ngClass]="{
-          'tw-bg-[#ffffff] tw-border-secondary-300': theme === 'light',
-          'tw-bg-[#1f242e]': theme === 'dark',
-        }"
-      >
+const wrapperDecorator = componentWrapperDecorator((story) => {
+  return /*html*/ `
+      <div class="tw-border-2 tw-border-solid tw-border-secondary-300 tw-px-5 tw-py-10 story-wrapper">
         ${story}
       </div>
   `;
-  },
-  ({ globals }) => {
-    // We need to add the theme class to the body to support body-appended content like popovers and menus
-    document.body.classList.remove("theme_light");
-    document.body.classList.remove("theme_dark");
-
-    document.body.classList.add(`theme_${globals["theme"]}`);
-
-    return { theme: `${globals["theme"]}` };
-  },
-);
+});
 
 const preview: Preview = {
-  decorators: [decorator],
-  globalTypes: {
-    theme: {
-      description: "Global theme for components",
-      defaultValue: "light",
-      toolbar: {
-        title: "Theme",
-        icon: "circlehollow",
-        items: [
-          {
-            title: "Light",
-            value: "light",
-            icon: "sun",
-          },
-          {
-            title: "Dark",
-            value: "dark",
-            icon: "moon",
-          },
-        ],
-        dynamicTitle: true,
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: "theme_light [&_.story-wrapper]:tw-bg-[#ffffff]",
+        dark: "theme_dark [&_.story-wrapper]:tw-bg-[#1f242e]",
       },
-    },
-  },
+      defaultTheme: "light",
+    }),
+    wrapperDecorator,
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,9 +8,9 @@ setCompodocJson(docJson);
 
 const wrapperDecorator = componentWrapperDecorator((story) => {
   return /*html*/ `
-      <div class="tw-border-2 tw-border-solid tw-border-secondary-300 tw-px-5 tw-py-10 story-wrapper">
-        ${story}
-      </div>
+    <div class="tw-bg-background tw-px-5 tw-py-10">
+      ${story}
+    </div>
   `;
 });
 
@@ -18,8 +18,8 @@ const preview: Preview = {
   decorators: [
     withThemeByClassName({
       themes: {
-        light: "theme_light [&_.story-wrapper]:tw-bg-[#ffffff]",
-        dark: "theme_dark [&_.story-wrapper]:tw-bg-[#1f242e]",
+        light: "theme_light",
+        dark: "theme_dark",
       },
       defaultTheme: "light",
     }),
@@ -39,6 +39,9 @@ const preview: Preview = {
       },
     },
     docs: { source: { type: "dynamic", excludeDecorators: true } },
+    backgrounds: {
+      disable: true,
+    },
   },
   tags: ["autodocs"],
 };

--- a/libs/components/src/drawer/drawer.stories.ts
+++ b/libs/components/src/drawer/drawer.stories.ts
@@ -9,10 +9,7 @@ import { ButtonModule } from "../button";
 import { CalloutModule } from "../callout";
 import { LayoutComponent } from "../layout";
 import { mockLayoutI18n } from "../layout/mocks";
-import {
-  disableBothThemeDecorator,
-  positionFixedWrapperDecorator,
-} from "../stories/storybook-decorators";
+import { positionFixedWrapperDecorator } from "../stories/storybook-decorators";
 import { TypographyModule } from "../typography";
 import { I18nMockService } from "../utils";
 
@@ -30,7 +27,6 @@ export default {
   },
   decorators: [
     positionFixedWrapperDecorator(),
-    disableBothThemeDecorator,
     moduleMetadata({
       imports: [
         RouterTestingModule,

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -17,7 +17,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { DialogService } from "../../dialog";
 import { LayoutComponent } from "../../layout";
 import { I18nMockService } from "../../utils/i18n-mock.service";
-import { disableBothThemeDecorator, positionFixedWrapperDecorator } from "../storybook-decorators";
+import { positionFixedWrapperDecorator } from "../storybook-decorators";
 
 import { DialogVirtualScrollBlockComponent } from "./components/dialog-virtual-scroll-block.component";
 import { KitchenSinkForm } from "./components/kitchen-sink-form.component";
@@ -31,7 +31,6 @@ export default {
   component: LayoutComponent,
   decorators: [
     positionFixedWrapperDecorator(),
-    disableBothThemeDecorator,
     moduleMetadata({
       imports: [
         KitchenSinkSharedModule,

--- a/libs/components/src/stories/storybook-decorators.ts
+++ b/libs/components/src/stories/storybook-decorators.ts
@@ -17,15 +17,3 @@ export const positionFixedWrapperDecorator = (wrapper?: (story: string) => strin
         ${wrapper ? wrapper(story) : story}
       </div>`,
   );
-
-export const disableBothThemeDecorator = componentWrapperDecorator(
-  (story) => story,
-  ({ globals }) => {
-    /**
-     * avoid a bug with the way that we render the same component twice in the same iframe and how
-     * that interacts with the router-outlet
-     */
-    const themeOverride = globals["theme"] === "both" ? "light" : globals["theme"];
-    return { theme: themeOverride };
-  },
-);

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "@storybook/addon-essentials": "8.5.2",
         "@storybook/addon-interactions": "8.5.2",
         "@storybook/addon-links": "8.5.2",
+        "@storybook/addon-themes": "^8.5.2",
         "@storybook/angular": "8.5.2",
         "@storybook/manager-api": "8.5.2",
         "@storybook/theming": "8.5.2",
@@ -8702,6 +8703,22 @@
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.5.2"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-8.5.2.tgz",
+      "integrity": "sha512-MTJkPwXqLK2Co186EUw2wr+1CpVRMbuWsOmQvhMHeU704kQtSYKkhu/xmaExuDYMupn5xiKG0p8Pt5Ck3fEObQ==",
+      "dev": true,
+      "dependencies": {
         "ts-dedent": "^2.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/addon-essentials": "8.5.2",
     "@storybook/addon-interactions": "8.5.2",
     "@storybook/addon-links": "8.5.2",
+    "@storybook/addon-themes": "8.5.2",
     "@storybook/angular": "8.5.2",
     "@storybook/manager-api": "8.5.2",
     "@storybook/theming": "8.5.2",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-317](https://bitwarden.atlassian.net/browse/CL-317)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We removed light and dark theme combined mode from Storybook in a previous PR. To switch between light and dark themes, we can now use Storybook's built-in `theme` addon.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Should visually look the same as before, except for the theme switcher in the toolbar.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-317]: https://bitwarden.atlassian.net/browse/CL-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ