### PR TITLE
fix: only start ssh agent if it's enabled

### DIFF
--- a/apps/desktop/src/platform/services/ssh-agent.service.ts
+++ b/apps/desktop/src/platform/services/ssh-agent.service.ts
@@ -67,9 +67,10 @@ export class SshAgentService implements OnDestroy {
     this.configService
       .getFeatureFlag$(FeatureFlag.SSHAgent)
       .pipe(
-        concatMap(async (enabled) => {
-          this.isFeatureFlagEnabled = enabled;
-          if (!(await ipc.platform.sshAgent.isLoaded()) && enabled) {
+        withLatestFrom(this.desktopSettingsService.sshAgentEnabled$),
+        concatMap(async ([featureFlagEnabled, settingEnabled]) => {
+          this.isFeatureFlagEnabled = featureFlagEnabled;
+          if (!(await ipc.platform.sshAgent.isLoaded()) && featureFlagEnabled && settingEnabled) {
             await ipc.platform.sshAgent.init();
           }
         }),


### PR DESCRIPTION
closes #13150

## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/13150

## 📔 Objective

Currently, BitWarden will bind to the SSH unix socket/named pipe even if it's disabled in settings. On Linux, it doesn't appear to be a big deal (at least on my setup) but on Windows it hijacks the `openssh-ssh-agent` named pipe, which causes inconveniences for people who want to use a different SSH agent. This PR adds a check for the `sshAgentEnabled` setting before asking the native side to initialize it.

I'm not super familiar with the codebase so this might not be the best way to solve it, but it was the first solution I found. Let me know if it needs to be changed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
