### PR TITLE
[PM-17793] Fix Vault Loading

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -94,8 +94,12 @@ export class VaultPopupItemsService {
         runInsideAngular(this.ngZone),
         tap(() => this._ciphersLoading$.next()),
         waitUntilSync(this.syncService),
-        switchMap(() => Utils.asyncToObservable(() => this.cipherService.getAllDecrypted(userId))),
-        withLatestFrom(this.cipherService.failedToDecryptCiphers$(userId)),
+        switchMap(() =>
+          combineLatest([
+            Utils.asyncToObservable(() => this.cipherService.getAllDecrypted(userId)),
+            this.cipherService.failedToDecryptCiphers$(userId),
+          ]),
+        ),
         map(([ciphers, failedToDecryptCiphers]) => [...failedToDecryptCiphers, ...ciphers]),
       ),
     ),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17793

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes the vault page from getting stuck in an infinite loading indicator. The exact reason it was broken with the code before is still a bit of a mystery even though the implementations are _pretty_ close to the same thing. I had a `tap` after the `getAllDecrypted` call and a `tap` after `failedToDecryptCiphers` and both get an emission but we never get to the `map` right after the `withLatestFrom`. My best guess is some kind of race condition that makes the internals of `withLatestFrom` believe it hasn't received an emission from the source and the past in observable.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/c2e2059b-96f4-4566-9583-d88b76872466

After:

https://github.com/user-attachments/assets/0111ade0-207e-4d99-867b-c71a0b76b2d5

(Briefly seeing the old lock screen happens occasionally before this fix it just happened to not happen in the before recording a took and happened to happen in the after.)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
