### PR TITLE
Replace `Rc.take` with `Rc.use`

### DIFF
--- a/libs/common/src/platform/misc/reference-counting/rc.spec.ts
+++ b/libs/common/src/platform/misc/reference-counting/rc.spec.ts
@@ -25,6 +25,150 @@ describe("Rc", () => {
     rc = new Rc(value);
   });
 
+  describe("use", () => {
+    describe("given Rc has not been marked for disposal", () => {
+      describe("given callback is synchronous", () => {
+        it("calls the callback", () => {
+          const spy = jest.fn();
+
+          rc.use(() => {
+            spy();
+          });
+
+          expect(spy).toHaveBeenCalled();
+        });
+
+        it("provides value in callback", () => {
+          rc.use((v) => {
+            expect(v).toBe(value);
+          });
+        });
+
+        it("increases refCount while value is in use", () => {
+          rc.use(() => {
+            expect(rc["refCount"]).toBe(1);
+          });
+
+          expect(rc["refCount"]).toBe(0);
+        });
+
+        it("does not free value when refCount reaches 0 when not marked for disposal", () => {
+          rc.use(() => {});
+
+          expect(value.isFreed).toBe(false);
+        });
+
+        it("frees value directly when marked for disposal if refCount is 0", () => {
+          rc.use(() => {});
+
+          rc.markForDisposal();
+
+          expect(value.isFreed).toBe(true);
+        });
+
+        it("frees value after refCount reaches 0 when rc is marked for disposal while in use", () => {
+          rc.use(() => {
+            rc.markForDisposal();
+            expect(value.isFreed).toBe(false);
+          });
+
+          expect(value.isFreed).toBe(true);
+        });
+
+        it("throws error when trying to take a disposed reference", () => {
+          rc.markForDisposal();
+
+          expect(() => rc.use(() => {})).toThrow();
+        });
+      });
+
+      describe("given callback is asynchronous", () => {
+        it("awaits the callback", async () => {
+          const spy = jest.fn();
+
+          await rc.use(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            spy();
+          });
+
+          expect(spy).toHaveBeenCalled();
+        });
+
+        it("provides value in callback", async () => {
+          await rc.use(async (v) => {
+            expect(v).toBe(value);
+          });
+        });
+
+        it("increases refCount while value is in use", async () => {
+          let resolveCallback: () => void;
+          const promise = new Promise<void>((resolve) => {
+            resolveCallback = resolve;
+          });
+
+          const usePromise = rc.use(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            await promise;
+          });
+
+          // should be 1 because the callback has not resolved yet
+          expect(rc["refCount"]).toBe(1);
+
+          resolveCallback();
+          await usePromise;
+
+          // should be 0 because the callback has resolved
+          expect(rc["refCount"]).toBe(0);
+        });
+
+        it("does not free value when refCount reaches 0 when not marked for disposal", async () => {
+          await rc.use(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          });
+
+          expect(value.isFreed).toBe(false);
+        });
+
+        it("frees value directly when marked for disposal if refCount is 0", async () => {
+          await rc.use(async () => {});
+
+          rc.markForDisposal();
+
+          expect(value.isFreed).toBe(true);
+        });
+
+        it("frees value after refCount reaches 0 when rc is marked for disposal while in use", async () => {
+          let resolveCallback: () => void;
+          const promise = new Promise<void>((resolve) => {
+            resolveCallback = resolve;
+          });
+
+          const usePromise = rc.use(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            await promise;
+          });
+
+          rc.markForDisposal();
+
+          // should not be freed yet because the callback has not resolved
+          expect(value.isFreed).toBe(false);
+
+          resolveCallback();
+          await usePromise;
+
+          // should be freed because the callback has resolved
+          expect(value.isFreed).toBe(true);
+        });
+
+        it("throws error when trying to take a disposed reference", async () => {
+          rc.markForDisposal();
+
+          await expect(async () => await rc.use(async () => {})).rejects.toThrow();
+        });
+      });
+    });
+  });
+
   it("should increase refCount when taken", () => {
     rc.take();
 

--- a/libs/common/src/platform/misc/reference-counting/rc.spec.ts
+++ b/libs/common/src/platform/misc/reference-counting/rc.spec.ts
@@ -1,11 +1,3 @@
-// Temporary workaround for Symbol.dispose
-// remove when https://github.com/jestjs/jest/issues/14874 is resolved and *released*
-const disposeSymbol: unique symbol = Symbol("Symbol.dispose");
-const asyncDisposeSymbol: unique symbol = Symbol("Symbol.asyncDispose");
-(Symbol as any).asyncDispose ??= asyncDisposeSymbol as unknown as SymbolConstructor["asyncDispose"];
-(Symbol as any).dispose ??= disposeSymbol as unknown as SymbolConstructor["dispose"];
-
-// Import needs to be after the workaround
 import { Rc } from "./rc";
 
 export class FreeableTestValue {
@@ -167,71 +159,5 @@ describe("Rc", () => {
         });
       });
     });
-  });
-
-  it("should increase refCount when taken", () => {
-    rc.take();
-
-    expect(rc["refCount"]).toBe(1);
-  });
-
-  it("should return value on take", () => {
-    // eslint-disable-next-line @bitwarden/platform/required-using
-    const reference = rc.take();
-
-    expect(reference.value).toBe(value);
-  });
-
-  it("should decrease refCount when disposing reference", () => {
-    // eslint-disable-next-line @bitwarden/platform/required-using
-    const reference = rc.take();
-
-    reference[Symbol.dispose]();
-
-    expect(rc["refCount"]).toBe(0);
-  });
-
-  it("should automatically decrease refCount when reference goes out of scope", () => {
-    {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      using reference = rc.take();
-    }
-
-    expect(rc["refCount"]).toBe(0);
-  });
-
-  it("should not free value when refCount reaches 0 if not marked for disposal", () => {
-    // eslint-disable-next-line @bitwarden/platform/required-using
-    const reference = rc.take();
-
-    reference[Symbol.dispose]();
-
-    expect(value.isFreed).toBe(false);
-  });
-
-  it("should free value when refCount reaches 0 and rc is marked for disposal", () => {
-    // eslint-disable-next-line @bitwarden/platform/required-using
-    const reference = rc.take();
-    rc.markForDisposal();
-
-    reference[Symbol.dispose]();
-
-    expect(value.isFreed).toBe(true);
-  });
-
-  it("should free value when marked for disposal if refCount is 0", () => {
-    // eslint-disable-next-line @bitwarden/platform/required-using
-    const reference = rc.take();
-    reference[Symbol.dispose]();
-
-    rc.markForDisposal();
-
-    expect(value.isFreed).toBe(true);
-  });
-
-  it("should throw error when trying to take a disposed reference", () => {
-    rc.markForDisposal();
-
-    expect(() => rc.take()).toThrow();
   });
 });

--- a/libs/common/src/platform/misc/reference-counting/rc.ts
+++ b/libs/common/src/platform/misc/reference-counting/rc.ts
@@ -2,6 +2,8 @@ import { UsingRequired } from "../using-required";
 
 export type Freeable = { free: () => void };
 
+type UseReturnValue<T> = T extends (value: any) => Promise<unknown> ? Promise<void> : void;
+
 /**
  * Reference counted disposable value.
  * This class is used to manage the lifetime of a value that needs to be
@@ -14,6 +16,39 @@ export class Rc<T extends Freeable> {
 
   constructor(value: T) {
     this.value = value;
+  }
+
+  /**
+   * Use the value in a callback.
+   * The callback will be called immediately if the value is not marked for disposal.
+   * If the callback returns a promise, the promise will be awaited.
+   *
+   * @example
+   * ```typescript
+   * function someFunction(rc: Rc<SomeValue>) {
+   *   using reference = rc.use((value) => {
+   *     value.doSomething();
+   *   });
+   * }
+   * ```
+   *
+   * @param fn The callback to call with the value.
+   */
+  use<Callback extends (value: T) => unknown>(fn: Callback): UseReturnValue<Callback> {
+    if (this.markedForDisposal) {
+      throw new Error("Cannot use a value marked for disposal");
+    }
+
+    this.refCount++;
+    const maybePromise = fn(this.value);
+
+    if (maybePromise instanceof Promise) {
+      return maybePromise.then(() => {
+        this.release();
+      }) as UseReturnValue<Callback>;
+    } else {
+      this.release();
+    }
   }
 
   /**

--- a/libs/common/src/platform/misc/reference-counting/rc.ts
+++ b/libs/common/src/platform/misc/reference-counting/rc.ts
@@ -1,5 +1,3 @@
-import { UsingRequired } from "../using-required";
-
 export type Freeable = { free: () => void };
 
 type UseReturnValue<T> = T extends (value: any) => Promise<unknown> ? Promise<void> : void;
@@ -52,33 +50,6 @@ export class Rc<T extends Freeable> {
   }
 
   /**
-   * Use this function when you want to use the underlying object.
-   * This will guarantee that you have a reference to the object
-   * and that it won't be freed until your reference goes out of scope.
-   *
-   * This function must be used with the `using` keyword.
-   *
-   * @example
-   * ```typescript
-   * function someFunction(rc: Rc<SomeValue>) {
-   *   using reference = rc.take();
-   *   reference.value.doSomething();
-   *   // reference is automatically disposed here
-   * }
-   * ```
-   *
-   * @returns The value.
-   */
-  take(): Ref<T> {
-    if (this.markedForDisposal) {
-      throw new Error("Cannot take a reference to a value marked for disposal");
-    }
-
-    this.refCount++;
-    return new Ref(() => this.release(), this.value);
-  }
-
-  /**
    * Mark this Rc for disposal. When the refCount reaches 0, the value
    * will be freed.
    */
@@ -96,16 +67,5 @@ export class Rc<T extends Freeable> {
     if (this.refCount === 0 && this.markedForDisposal) {
       this.value.free();
     }
-  }
-}
-
-export class Ref<T extends Freeable> implements UsingRequired {
-  constructor(
-    private readonly release: () => void,
-    readonly value: T,
-  ) {}
-
-  [Symbol.dispose]() {
-    this.release();
   }
 }

--- a/libs/common/src/platform/misc/using-required.ts
+++ b/libs/common/src/platform/misc/using-required.ts
@@ -1,9 +1,24 @@
 export type Disposable = { [Symbol.dispose]: () => void };
 
 /**
- * Types implementing this type must be used together with the `using` keyword
+ * Types implementing this type must be used together with the `using` keyword,
+ * a rule which is enforced by the linter.
  *
- * @example using ref = rc.take();
+ * @deprecated At this time only Chrome supports the `using` keyword.
+ *             Wait for other browsers to catch up before using this type.
+ * @example
+ * ```
+ * class Resource implements UsingRequired {
+ *   [Symbol.dispose]() {
+ *   // free the resource
+ *   }
+ * }
+ *
+ * function useResource() {
+ *   using resource = new Resource();
+ *   // resource is disposed when the block ends
+ * }
+ * ```
  */
 // We want to use `interface` here because it creates a separate type.
 // Type aliasing would not expose `UsingRequired` to the linter.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Apparently `using` is only supported in Chrome 🫠 https://caniuse.com/mdn-javascript_statements_using

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
