### PR TITLE
pm-18441 add loading icon to member details

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.html
@@ -5,7 +5,13 @@
     class="tw-grow"
   ></bit-search>
 
-  <button type="button" bitButton buttonType="primary" [bitAction]="exportReportAction">
+  <button
+    type="button"
+    bitButton
+    buttonType="primary"
+    [bitAction]="exportReportAction"
+    *ngIf="!(isLoading$ | async)"
+  >
     <span>{{ "export" | i18n }}</span>
     <i class="bwi bwi-fw bwi-sign-in" aria-hidden="true"></i>
   </button>
@@ -17,7 +23,18 @@
   </p>
 </div>
 
-<bit-table [dataSource]="dataSource" class="tw-mt-2">
+<ng-container *ngIf="isLoading$ | async">
+  <div class="tw-flex-col tw-flex tw-justify-center tw-items-center tw-gap-5 tw-mt-4">
+    <i
+      class="bwi bwi-2x bwi-spinner bwi-spin tw-text-primary-600"
+      title="{{ 'loading' | i18n }}"
+      aria-hidden="true"
+    ></i>
+    <h2 bitTypography="h1">{{ "loading" | i18n }}</h2>
+  </div>
+</ng-container>
+
+<bit-table *ngIf="!(isLoading$ | async)" [dataSource]="dataSource" class="tw-mt-2">
   <ng-container header>
     <tr>
       <th bitCell bitSortable="name" default>{{ "members" | i18n }}</th>

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/member-access-report.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { debounceTime, firstValueFrom, lastValueFrom } from "rxjs";
+import { BehaviorSubject, debounceTime, firstValueFrom, lastValueFrom } from "rxjs";
 
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
 import { safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
@@ -48,6 +48,7 @@ export class MemberAccessReportComponent implements OnInit {
   protected searchControl = new FormControl("", { nonNullable: true });
   protected organizationId: OrganizationId;
   protected orgIsOnSecretsManagerStandalone: boolean;
+  protected isLoading$ = new BehaviorSubject(true);
 
   constructor(
     private route: ActivatedRoute,
@@ -64,6 +65,8 @@ export class MemberAccessReportComponent implements OnInit {
   }
 
   async ngOnInit() {
+    this.isLoading$.next(true);
+
     const params = await firstValueFrom(this.route.params);
     this.organizationId = params.organizationId;
 
@@ -74,6 +77,8 @@ export class MemberAccessReportComponent implements OnInit {
     this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
 
     await this.load();
+
+    this.isLoading$.next(false);
   }
 
   async load() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18441

## 📔 Objective

To add a loading icon to the member details report

## 📸 Screenshots

### - When loading, the search bar, export button and the grid are hidden.
![image](https://github.com/user-attachments/assets/08c157bc-1653-40e9-86c4-e6405b832704)

### - When loading is done, all elements are exposed:
![image](https://github.com/user-attachments/assets/af6505d7-9bc3-4a53-8c01-237382451cb9)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
