### PR TITLE
[PM-18287] Bugfix - Vault autofill suggestions view hangs on load when the current tab is on the blocked domains list

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -67,6 +67,7 @@ describe("VaultPopupAutofillService", () => {
       .mockReturnValue(true);
 
     mockAutofillService.collectPageDetailsFromTab$.mockReturnValue(new BehaviorSubject([]));
+    mockDomainSettingsService.blockedInteractionsUris$ = new BehaviorSubject({});
 
     testBed = TestBed.configureTestingModule({
       providers: [

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -146,10 +146,16 @@ export class VaultPopupAutofillService {
         return of([]);
       }
 
-      return this.currentTabIsOnBlocklist$.pipe(
-        switchMap((isBlocked) => {
-          if (isBlocked) {
-            return of([]);
+      return this.domainSettingsService.blockedInteractionsUris$.pipe(
+        switchMap((blockedURIs) => {
+          // This blocked URI logic will be updated to use the common util in PM-18219
+          if (blockedURIs && tab?.url?.length) {
+            const tabURL = new URL(tab.url);
+            const tabIsBlocked = Object.keys(blockedURIs).includes(tabURL.hostname);
+
+            if (tabIsBlocked) {
+              return of([]);
+            }
           }
 
           return this.autofillService.collectPageDetailsFromTab$(tab);

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -145,7 +145,16 @@ export class VaultPopupAutofillService {
       if (!tab) {
         return of([]);
       }
-      return this.autofillService.collectPageDetailsFromTab$(tab);
+
+      return this.currentTabIsOnBlocklist$.pipe(
+        switchMap((isBlocked) => {
+          if (isBlocked) {
+            return of([]);
+          }
+
+          return this.autofillService.collectPageDetailsFromTab$(tab);
+        }),
+      );
     }),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18287](https://bitwarden.atlassian.net/browse/PM-18287)

## 📔 Objective

Vault autofill suggestions view hangs on load when the current tab is on the blocked domains list.

The issue in this case was two-fold:
- Primarily, `_currentPageDetails` in `VaultPopupAutofillService` would invoke `AutofillService.collectPageDetailsFromTab$` which was unguarded against cases where the current page was blocked. The page details state informs several presentational aspects of the autofill suggestions, including whether cards and identities should be included in the page suggestions (and is gathered via script injection).
- `AutofillService.collectPageDetailsFromTab$` in turn invokes `BrowserApi.tabSendMessage`. In Chrome, this will result in a thrown error if the targeted tab has no listener for the message. Firefox, on the other hand, does not throw an error, and so doesn't trigger the fallback handling of `pageDetailsFallback$.next([]);` (consequently leaving state constantly awaiting).

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-18287]: https://bitwarden.atlassian.net/browse/PM-18287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ