### PR TITLE
[PM-18529] Remove persist-popup-view feature flag

### DIFF
--- a/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
@@ -9,10 +9,8 @@ import {
   Router,
   UrlSerializer,
 } from "@angular/router";
-import { filter, first, firstValueFrom, map, Observable, of, switchMap, tap } from "rxjs";
+import { filter, first, firstValueFrom, map, Observable, switchMap, tap } from "rxjs";
 
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { GlobalStateProvider } from "@bitwarden/common/platform/state";
 
 import { POPUP_ROUTE_HISTORY_KEY } from "../../../platform/services/popup-view-cache-background.service";
@@ -113,29 +111,18 @@ export class PopupRouterCacheService {
 
 /**
  * Redirect to the last visited route. Should be applied to root route.
- *
- * If `FeatureFlag.PersistPopupView` is disabled, do nothing.
  **/
 export const popupRouterCacheGuard = (() => {
-  const configService = inject(ConfigService);
   const popupHistoryService = inject(PopupRouterCacheService);
   const urlSerializer = inject(UrlSerializer);
 
-  return configService.getFeatureFlag$(FeatureFlag.PersistPopupView).pipe(
-    switchMap((featureEnabled) => {
-      if (!featureEnabled) {
-        return of(true);
+  return popupHistoryService.last$().pipe(
+    map((url: string) => {
+      if (!url) {
+        return true;
       }
 
-      return popupHistoryService.last$().pipe(
-        map((url: string) => {
-          if (!url) {
-            return true;
-          }
-
-          return urlSerializer.parse(url);
-        }),
-      );
+      return urlSerializer.parse(url);
     }),
   );
 }) satisfies CanActivateFn;

--- a/apps/browser/src/platform/popup/view-cache/popup-view-cache.service.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-view-cache.service.ts
@@ -20,8 +20,6 @@ import {
   SignalCacheOptions,
   ViewCacheService,
 } from "@bitwarden/angular/platform/abstractions/view-cache.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { MessageSender } from "@bitwarden/common/platform/messaging";
 import { GlobalStateProvider } from "@bitwarden/common/platform/state";
 
@@ -40,12 +38,9 @@ import {
   providedIn: "root",
 })
 export class PopupViewCacheService implements ViewCacheService {
-  private configService = inject(ConfigService);
   private globalStateProvider = inject(GlobalStateProvider);
   private messageSender = inject(MessageSender);
   private router = inject(Router);
-
-  private featureEnabled: boolean;
 
   private _cache: Record<string, string>;
   private get cache(): Record<string, string> {
@@ -59,10 +54,9 @@ export class PopupViewCacheService implements ViewCacheService {
    * Initialize the service. This should only be called once.
    */
   async init() {
-    this.featureEnabled = await this.configService.getFeatureFlag(FeatureFlag.PersistPopupView);
-    const initialState = this.featureEnabled
-      ? await firstValueFrom(this.globalStateProvider.get(POPUP_VIEW_CACHE_KEY).state$)
-      : {};
+    const initialState = await firstValueFrom(
+      this.globalStateProvider.get(POPUP_VIEW_CACHE_KEY).state$,
+    );
     this._cache = Object.freeze(initialState ?? {});
 
     this.router.events
@@ -122,10 +116,6 @@ export class PopupViewCacheService implements ViewCacheService {
   }
 
   private updateState(key: string, value: string) {
-    if (!this.featureEnabled) {
-      return;
-    }
-
     this.messageSender.send(SAVE_VIEW_CACHE_COMMAND, {
       key,
       value,

--- a/apps/browser/src/platform/popup/view-cache/popup-view-cache.spec.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-view-cache.spec.ts
@@ -206,21 +206,4 @@ describe("popup view cache", () => {
     expect(messageSenderMock.send).toHaveBeenCalledWith(ClEAR_VIEW_CACHE_COMMAND, {});
     expect(service["_cache"]).toEqual({});
   });
-
-  it("should ignore cached values when feature flag is off", async () => {
-    jest.spyOn(configServiceMock, "getFeatureFlag").mockResolvedValue(false);
-
-    await initServiceWithState({ "foo-123": JSON.stringify("bar") });
-
-    const injector = TestBed.inject(Injector);
-
-    const signal = service.signal({
-      key: "foo-123",
-      initialValue: "foo",
-      injector,
-    });
-
-    // The cached state is ignored
-    expect(signal()).toBe("foo");
-  });
 });

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -30,7 +30,6 @@ export enum FeatureFlag {
 
   AC1795_UpdatedSubscriptionStatusSection = "AC-1795_updated-subscription-status-section",
   ExtensionRefresh = "extension-refresh",
-  PersistPopupView = "persist-popup-view",
   PM4154_BulkEncryptionService = "PM-4154-bulk-encryption-service",
   TwoFactorComponentRefactor = "two-factor-component-refactor",
   VaultBulkManagementAction = "vault-bulk-management-action",
@@ -91,7 +90,6 @@ export const DefaultFeatureFlagValue = {
 
   [FeatureFlag.AC1795_UpdatedSubscriptionStatusSection]: FALSE,
   [FeatureFlag.ExtensionRefresh]: FALSE,
-  [FeatureFlag.PersistPopupView]: FALSE,
   [FeatureFlag.PM4154_BulkEncryptionService]: FALSE,
   [FeatureFlag.TwoFactorComponentRefactor]: FALSE,
   [FeatureFlag.VaultBulkManagementAction]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18529

## 📔 Objective

Remove the `persist-popup-view` feature flag from clients.

This flag has been enabled on all 3 environments since December 17.

## 📸 Screenshots

https://github.com/user-attachments/assets/d184a904-3792-45ac-b4a8-2ba4c01342dc

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
