### PR TITLE
[PM-18549] Do not clear route or view persistence on tab change

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1312,7 +1312,7 @@ export default class MainBackground {
     await (this.i18nService as I18nService).init();
     (this.eventUploadService as EventUploadService).init(true);
 
-    this.popupViewCacheBackgroundService.startObservingTabChanges();
+    this.popupViewCacheBackgroundService.startObservingMessages();
 
     await this.vaultTimeoutService.init(true);
     this.fido2Background.init();

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -1,6 +1,4 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-import { switchMap, merge, delay, filter, concatMap, map, first, of } from "rxjs";
+import { switchMap, delay, filter, concatMap } from "rxjs";
 
 import { CommandDefinition, MessageListener } from "@bitwarden/common/platform/messaging";
 import {
@@ -14,7 +12,6 @@ import {
   GlobalStateProvider,
 } from "@bitwarden/common/platform/state";
 
-import { BrowserApi } from "../browser/browser-api";
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
 const popupClosedPortName = "new_popup";
@@ -78,27 +75,9 @@ export class PopupViewCacheBackgroundService {
       .pipe(concatMap(() => this.popupViewCacheState.update(() => null)))
       .subscribe();
 
-    merge(
-      // on tab changed, excluding extension tabs
-      fromChromeEvent(chrome.tabs.onActivated).pipe(
-        switchMap((tabs) => BrowserApi.getTab(tabs[0].tabId)),
-        switchMap((tab) => {
-          // FireFox sets the `url` to "about:blank" and won't populate the `url` until the `onUpdated` event
-          if (tab.url !== "about:blank") {
-            return of(tab);
-          }
-
-          return fromChromeEvent(chrome.tabs.onUpdated).pipe(
-            first(),
-            switchMap(([tabId]) => BrowserApi.getTab(tabId)),
-          );
-        }),
-        map((tab) => tab.url || tab.pendingUrl),
-        filter((url) => !url.startsWith(chrome.runtime.getURL(""))),
-      ),
-
-      // on popup closed, with 2 minute delay that is cancelled by re-opening the popup
-      fromChromeEvent(chrome.runtime.onConnect).pipe(
+    // on popup closed, with 2 minute delay that is cancelled by re-opening the popup
+    fromChromeEvent(chrome.runtime.onConnect)
+      .pipe(
         filter(([port]) => port.name === popupClosedPortName),
         switchMap(([port]) =>
           fromChromeEvent(port.onDisconnect).pipe(
@@ -108,9 +87,7 @@ export class PopupViewCacheBackgroundService {
             ),
           ),
         ),
-      ),
-    )
-      .pipe(switchMap(() => this.clearState()))
+      )
       .subscribe();
   }
 

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -57,7 +57,7 @@ export class PopupViewCacheBackgroundService {
     );
   }
 
-  startObservingTabChanges() {
+  startObservingMessages() {
     this.messageListener
       .messages$(SAVE_VIEW_CACHE_COMMAND)
       .pipe(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18549

## 📔 Objective

In order to support using extension route persistence for login flows that require the user to go to their email inbox or another tab to perform the operation, we need to remove the restriction that cleared the cache on tab change.

Examples of user flows that would require this are:
- New Device Verification OTP (the trigger for this issue)
- Email 2FA

Note that I also removed the TS strict comment from this file while I was modifying it.

## 📸 Screenshots

https://github.com/user-attachments/assets/08eeb0a6-c282-41dc-ab4e-a6c15f4af949

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
