### PR TITLE
Auth/PM-14588 - Extension Account Security Component + Account Fingerprint Dialog styling fixes

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -5,7 +5,7 @@
     </ng-container>
   </popup-header>
 
-  <div class="tw-bg-background-alt tw-p-2" [formGroup]="form">
+  <div [formGroup]="form">
     <bit-section>
       <bit-section-header>
         <h2 bitTypography="h6">{{ "unlockMethods" | i18n }}</h2>
@@ -59,6 +59,7 @@
         </bit-form-control>
       </bit-card>
     </bit-section>
+
     <bit-section>
       <bit-section-header>
         <h2 bitTypography="h6">{{ "vaultTimeoutHeader" | i18n }}</h2>
@@ -71,6 +72,7 @@
           ngDefaultControl
         >
         </auth-vault-timeout-input>
+
         <bit-form-field disableMargin>
           <bit-label for="vaultTimeoutAction">{{ "vaultTimeoutAction1" | i18n }}</bit-label>
           <bit-select id="vaultTimeoutAction" formControlName="vaultTimeoutAction">
@@ -81,24 +83,24 @@
             >
             </bit-option>
           </bit-select>
-          <bit-hint class="tw-text-sm" id="vaultTimeoutActionHelp">
-            {{ "vaultTimeoutActionDesc" | i18n }}
-          </bit-hint>
+
           <bit-hint *ngIf="!availableVaultTimeoutActions.includes(VaultTimeoutAction.Lock)">
             {{ "unlockMethodNeededToChangeTimeoutActionDesc" | i18n }}<br />
           </bit-hint>
         </bit-form-field>
-        <bit-hint *ngIf="hasVaultTimeoutPolicy">
+
+        <bit-hint *ngIf="hasVaultTimeoutPolicy" class="tw-mt-4">
           {{ "vaultTimeoutPolicyAffectingOptions" | i18n }}
         </bit-hint>
       </bit-card>
     </bit-section>
+
     <bit-section>
       <bit-section-header>
         <h2 bitTypography="h6">{{ "otherOptions" | i18n }}</h2>
       </bit-section-header>
       <bit-item>
-        <button bit-item-content type="button" appStopClick (click)="fingerprint()">
+        <button bit-item-content type="button" appStopClick (click)="openAcctFingerprintDialog()">
           {{ "fingerprintPhrase" | i18n }}
         </button>
       </bit-item>

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -622,7 +622,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     }
   }
 
-  async fingerprint() {
+  async openAcctFingerprintDialog() {
     const activeUserId = await firstValueFrom(
       this.accountService.activeAccount$.pipe(map((a) => a?.id)),
     );

--- a/libs/auth/src/angular/fingerprint-dialog/fingerprint-dialog.component.html
+++ b/libs/auth/src/angular/fingerprint-dialog/fingerprint-dialog.component.html
@@ -1,5 +1,5 @@
 <bit-simple-dialog>
-  <i bitDialogIcon class="bwi bwi-info-circle tw-text-3xl" aria-hidden="true"></i>
+  <i bitDialogIcon class="bwi bwi-info-circle tw-text-info tw-text-3xl" aria-hidden="true"></i>
   <span bitDialogTitle
     ><strong>{{ "yourAccountsFingerprint" | i18n }}:</strong></span
   >


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14588

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve some minor styling issues on the Extension `AccountSecurityComponent` and the global `FingerprintDialogComponent`

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:
![image](https://github.com/user-attachments/assets/521928ff-9cda-44d7-b995-19fe6ba24267)


After (normal scenario w/ no org policy requirements):
<img width="388" alt="image" src="https://github.com/user-attachments/assets/8a164934-c519-433e-baae-f2841ea38384" />

After (demo of org policy requirements having proper spacing between timeout action select):
<img width="391" alt="image" src="https://github.com/user-attachments/assets/12e99ee6-e0f3-4e54-a03d-957a2c096203" />



Fingerprint dialog now has correct info icon styling:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/0d1b260f-c15f-440a-9e0a-2339dfe4c20b" />





## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
