### PR TITLE
increase memory limit for web watch builds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "build:oss": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack",
     "build:bit": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-web/webpack.config.js",
-    "build:oss:watch": "webpack serve",
-    "build:bit:watch": "webpack serve -c ../../bitwarden_license/bit-web/webpack.config.js",
+    "build:oss:watch": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack serve",
+    "build:bit:watch": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack serve -c ../../bitwarden_license/bit-web/webpack.config.js",
     "build:bit:dev": "cross-env ENV=development npm run build:bit",
     "build:bit:dev:analyze": "cross-env LOGGING=false webpack -c ../../bitwarden_license/bit-web/webpack.config.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json build/",
     "build:bit:dev:watch": "cross-env ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" npm run build:bit:watch",


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Our client builds are presently monolithic and require a substantial amount of memory. Most builds were updated, but the web watch builds [listed in the contrib docs](https://contributing.bitwarden.com/getting-started/clients/web-vault/#build-instructions) were missed.

This ticket increases their memory limit to 8 GB.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
