### PR TITLE
Auth/PM-18506 - LoginViaAuthReqComp - fix missing spaces

### DIFF
--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
@@ -32,7 +32,8 @@
     </button>
 
     <div *ngIf="clientType !== ClientType.Browser" class="tw-mt-4">
-      <span>{{ "needAnotherOptionV1" | i18n }}</span>
+      <span>{{ "needAnotherOptionV1" | i18n }}</span
+      >&nbsp;
       <a [routerLink]="backToRoute" bitLink linkType="primary">{{
         "viewAllLogInOptions" | i18n
       }}</a>
@@ -46,7 +47,8 @@
     <code class="tw-text-code">{{ fingerprintPhrase }}</code>
 
     <div class="tw-mt-4">
-      <span>{{ "troubleLoggingIn" | i18n }}</span>
+      <span>{{ "troubleLoggingIn" | i18n }}</span
+      >&nbsp;
       <a [routerLink]="backToRoute" bitLink linkType="primary">{{
         "viewAllLogInOptions" | i18n
       }}</a>


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18506

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To add missing spaces into the bottom of the `LoginViaAuthRequestComponent` for the admin auth request and normal auth request flows. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Login via Admin Auth request:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/85b534c8-1e99-4b55-a2b5-411c7e31d9bc" />

Login via Normal Auth Request:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/0434e958-a4f5-49da-82cf-486acec502fd" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
