### PR TITLE
Tools/pm 18616/disable notify button

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5,6 +5,9 @@
   "criticalApplications": {
     "message": "Critical applications"
   },
+  "noCriticalAppsAtRisk":{
+    "message": "No critical applications at risk"
+  },
   "accessIntelligence": {
     "message": "Access Intelligence"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Critical applications"
   },
   "noCriticalAppsAtRisk":{
-    "message": "No critical applications at risk"
+    "message": "No critical applications at risk."
   },
   "accessIntelligence": {
     "message": "Access Intelligence"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Critical applications"
   },
   "noCriticalAppsAtRisk":{
-    "message": "No critical applications at risk."
+    "message": "No critical applications at risk"
   },
   "accessIntelligence": {
     "message": "Access Intelligence"

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.html
@@ -37,7 +37,11 @@
       (click)="requestPasswordChange()"
     >
       <i class="bwi bwi-envelope tw-mr-2"></i>
-      {{ "requestPasswordChange" | i18n }}
+      {{
+        enableRequestPasswordChange
+          ? ("requestPasswordChange" | i18n)
+          : ("noCriticalAppsAtRisk" | i18n)
+      }}
     </button>
   </div>
   <div class="tw-flex tw-gap-6">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18616

## 📔 Objective

Disable the notifications button when there are no at-risk passwords in the critical apps list.


## 📸 Screenshots

![image](https://github.com/user-attachments/assets/5b5b323f-cec2-4d9d-8743-0bf954e699ed)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
