### PR TITLE
[PM-18583] Login with new device verification in CLI

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -311,6 +311,26 @@ export class LoginCommand {
         );
       }
 
+      // Opting for not checking feature flag since the server will not respond with
+      // requiresDeviceVerification if the feature flag is not enabled.
+      if (response.requiresDeviceVerification) {
+        let newDeviceToken: string = null;
+        if (this.canInteract) {
+          const answer: inquirer.Answers = await inquirer.createPromptModule({
+            output: process.stderr,
+          })({
+            type: "input",
+            name: "token",
+            message: "New device login code:",
+          });
+          newDeviceToken = answer.token;
+        }
+        if (newDeviceToken == null || newDeviceToken === "") {
+          return Response.badRequest("Code is required.");
+        }
+        response = await this.loginStrategyService.logInNewDeviceVerification(newDeviceToken);
+      }
+
       if (response.captchaSiteKey) {
         const twoFactorRequest = new TokenTwoFactorRequest(selectedProvider.type, twoFactorToken);
         const handledResponse = await this.handleCaptchaRequired(twoFactorRequest);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18583](https://bitwarden.atlassian.net/browse/PM-18583)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

User's were unable to login to the CLI with New Device Verification. This allows users to login using the device code sent via email.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before testing was completed for each round, I deleted the `data.json` for the CLI client to ensure a new generated app id to force the New Device Verification Feature to apply.

I don't have SSO set up locally so I opted to leave that test out but the API and two-factor flows being unaffected builds enough confidence in the other flows being stable with this addition.

### Logging in with password: New device code required

https://github.com/user-attachments/assets/f7cd2b22-8a7c-4d6e-958b-de3a1c1da959

1. User tries to login with mp but doesn't supply code: error
1. User tries to login with mp but supplies wrong code: error
1. (I goof and accidently hit `crtl+c` instead of `ctrl+v`.)
1. User tries to login with mp and supplies correct code: success
 
### Logging in with API-key: New device code **not** required

https://github.com/user-attachments/assets/10c44ab8-c4d4-49d0-95b6-617b23b6c010

User is able to login with API-key successfully

### logging in with two factor: New device code **not** required

https://github.com/user-attachments/assets/24ac6d2d-db78-4c38-8204-ce8d56925e2b

User is able to login with two-factor successfully

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18583]: https://bitwarden.atlassian.net/browse/PM-18583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ