### PR TITLE
[PM-18463] [PM-18465] At-risk Password Page Fixes

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1397,14 +1397,14 @@
   },
   "useAnotherTwoStepMethod": {
     "message": "Use another two-step login method"
-  },  
+  },
   "selectAnotherMethod": {
     "message": "Select another method",
     "description": "Select another two-step login method"
   },
   "useYourRecoveryCode": {
     "message": "Use your recovery code"
-  }, 
+  },
   "insertYubiKey": {
     "message": "Insert your YubiKey into your computer's USB port, then touch its button."
   },
@@ -2446,8 +2446,17 @@
   "atRiskPasswords": {
     "message": "At-risk passwords"
   },
-  "atRiskPasswordsDescSingleOrg": {
-    "message": "$ORGANIZATION$ is requesting you change the $COUNT$ passwords because they are at risk.",
+  "atRiskPasswordDescSingleOrg": {
+    "message": "$ORGANIZATION$ is requesting you change one password because it is at-risk.",
+    "placeholders": {
+      "organization": {
+        "content": "$1",
+        "example": "Acme Corp"
+      }
+    }
+  },
+  "atRiskPasswordsDescSingleOrgPlural": {
+    "message": "$ORGANIZATION$ is requesting you change the $COUNT$ passwords because they are at-risk.",
     "placeholders": {
       "organization": {
         "content": "$1",
@@ -2459,8 +2468,8 @@
       }
     }
   },
-  "atRiskPasswordsDescMultiOrg": {
-    "message": "Your organizations are requesting you change the $COUNT$ passwords because they are at risk.",
+  "atRiskPasswordsDescMultiOrgPlural": {
+    "message": "Your organizations are requesting you change the $COUNT$ passwords because they are at-risk.",
     "placeholders": {
       "count": {
         "content": "$1",

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
@@ -18,6 +18,7 @@
       buttonType="primary"
       (click)="activateInlineAutofillMenuVisibility()"
       data-testid="turn-on-autofill-button"
+      class="tw-mr-2"
     >
       {{ "turnOnAutofill" | i18n }}
     </button>

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
@@ -6,7 +6,7 @@
   </popup-header>
 
   <bit-callout
-    *ngIf="!(inlineAutofillSettingEnabled$ | async) && !(calloutDismissed$ | async)"
+    *ngIf="showAutofillCallout$ | async"
     type="info"
     [title]="'changeAtRiskPasswordsFaster' | i18n"
     data-testid="autofill-callout"

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
@@ -193,8 +193,27 @@ describe("AtRiskPasswordsComponent", () => {
 
   describe("pageDescription$", () => {
     it("should use single org description when tasks belong to one org", async () => {
-      const description = await firstValueFrom(component["pageDescription$"]);
-      expect(description).toBe("atRiskPasswordsDescSingleOrg");
+      // Single task
+      let description = await firstValueFrom(component["pageDescription$"]);
+      expect(description).toBe("atRiskPasswordDescSingleOrg");
+
+      // Multiple tasks
+      mockTasks$.next([
+        {
+          id: "task",
+          organizationId: "org",
+          cipherId: "cipher",
+          type: SecurityTaskType.UpdateAtRiskCredential,
+        } as SecurityTask,
+        {
+          id: "task2",
+          organizationId: "org",
+          cipherId: "cipher2",
+          type: SecurityTaskType.UpdateAtRiskCredential,
+        } as SecurityTask,
+      ]);
+      description = await firstValueFrom(component["pageDescription$"]);
+      expect(description).toBe("atRiskPasswordsDescSingleOrgPlural");
     });
 
     it("should use multiple org description when tasks belong to multiple orgs", async () => {
@@ -213,7 +232,7 @@ describe("AtRiskPasswordsComponent", () => {
         } as SecurityTask,
       ]);
       const description = await firstValueFrom(component["pageDescription$"]);
-      expect(description).toBe("atRiskPasswordsDescMultiOrg");
+      expect(description).toBe("atRiskPasswordsDescMultiOrgPlural");
     });
   });
 

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
@@ -133,11 +133,19 @@ export class AtRiskPasswordsComponent {
         const [orgId] = orgIds;
         return this.organizationService.organizations$(userId).pipe(
           getOrganizationById(orgId),
-          map((org) => this.i18nService.t("atRiskPasswordsDescSingleOrg", org?.name, tasks.length)),
+          map((org) =>
+            this.i18nService.t(
+              tasks.length === 1
+                ? "atRiskPasswordDescSingleOrg"
+                : "atRiskPasswordsDescSingleOrgPlural",
+              org?.name,
+              tasks.length,
+            ),
+          ),
         );
       }
 
-      return of(this.i18nService.t("atRiskPasswordsDescMultiOrg", tasks.length));
+      return of(this.i18nService.t("atRiskPasswordsDescMultiOrgPlural", tasks.length));
     }),
   );
 

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
@@ -105,12 +105,21 @@ export class AtRiskPasswordsComponent {
     startWith(true),
   );
 
-  protected calloutDismissed$ = this.activeUserData$.pipe(
+  private calloutDismissed$ = this.activeUserData$.pipe(
     switchMap(({ userId }) => this.atRiskPasswordPageService.isCalloutDismissed(userId)),
   );
-
-  protected inlineAutofillSettingEnabled$ = this.autofillSettingsService.inlineMenuVisibility$.pipe(
+  private inlineAutofillSettingEnabled$ = this.autofillSettingsService.inlineMenuVisibility$.pipe(
     map((setting) => setting !== AutofillOverlayVisibility.Off),
+  );
+
+  protected showAutofillCallout$ = combineLatest([
+    this.calloutDismissed$,
+    this.inlineAutofillSettingEnabled$,
+  ]).pipe(
+    map(([calloutDismissed, inlineAutofillSettingEnabled]) => {
+      return !calloutDismissed && !inlineAutofillSettingEnabled;
+    }),
+    startWith(false),
   );
 
   protected atRiskItems$ = this.activeUserData$.pipe(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18463](https://bitwarden.atlassian.net/browse/PM-18463)
[PM-18465](https://bitwarden.atlassian.net/browse/PM-18465)

## 📔 Objective

PM-18463
- Fix missing hyphen in page description
- Fix pluralization of page description when the user only has a single task
- Fix spacing between UI buttons

PM-18465
- Prevent autofill callout from flashing briefly after previously being dismissed

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/cf36ff24-c817-465d-b9d4-4e13abe934f8)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18463]: https://bitwarden.atlassian.net/browse/PM-18463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-18465]: https://bitwarden.atlassian.net/browse/PM-18465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ