### PR TITLE
[PM-18639] Bugfix - Resend Admin Auth Request After Previous Denial

### DIFF
--- a/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
@@ -16,7 +16,7 @@ export class DefaultAuthRequestApiService implements AuthRequestApiService {
       const path = `/auth-requests/${requestId}`;
       const response = await this.apiService.send("GET", path, null, true, true);
 
-      return response;
+      return new AuthRequestResponse(response);
     } catch (e: unknown) {
       this.logService.error(e);
       throw e;
@@ -28,7 +28,7 @@ export class DefaultAuthRequestApiService implements AuthRequestApiService {
       const path = `/auth-requests/${requestId}/response?code=${accessCode}`;
       const response = await this.apiService.send("GET", path, null, false, true);
 
-      return response;
+      return new AuthRequestResponse(response);
     } catch (e: unknown) {
       this.logService.error(e);
       throw e;
@@ -45,7 +45,7 @@ export class DefaultAuthRequestApiService implements AuthRequestApiService {
         true,
       );
 
-      return response;
+      return new AuthRequestResponse(response);
     } catch (e: unknown) {
       this.logService.error(e);
       throw e;
@@ -56,7 +56,7 @@ export class DefaultAuthRequestApiService implements AuthRequestApiService {
     try {
       const response = await this.apiService.send("POST", "/auth-requests/", request, false, true);
 
-      return response;
+      return new AuthRequestResponse(response);
     } catch (e: unknown) {
       this.logService.error(e);
       throw e;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18639

## 📔 Objective

This PR makes sure we are specifically constructing and returning a `new AuthRequestResponse()` object from the `AuthRequestApiService` calls.

**Background**
In https://github.com/bitwarden/clients/pull/11545 we created an `AuthRequestApiService` as part of the refresh work for the `LoginViaAuthRequestComponent`. In that new `AuthRequestApiService` I missed wrapping the returned response in a `new AuthRequestResponse()` constructor.

This object construction is important in the case of this bug because it sets the `isAnswered` property [here](https://github.com/bitwarden/clients/blob/main/libs/common/src/auth/models/response/auth-request.response.ts#L58).

The bug occurred because this `isAnswered` property was getting read as `undefined` [here](https://github.com/bitwarden/clients/blob/main/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts#L309), which led to `handleExistingAdminAuthReqDeletedOrDenied()` never being run, and thus never clearing the previous Admin Auth Request from state.

## 📸 Screenshots

https://github.com/user-attachments/assets/39fe0918-737e-44cd-8174-2c8b6cc5b1d1

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
