### PR TITLE
[PM-18661] Remove early return on SSO component initialization

### DIFF
--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -155,13 +155,6 @@ export class SsoComponent implements OnInit {
       return;
     }
 
-    // Detect if we are on the first portion of the SSO flow
-    // and have been sent here from another client with the info in query params
-    if (this.hasParametersFromOtherClientRedirect(qParams)) {
-      this.initializeFromRedirectFromOtherClient(qParams);
-      return;
-    }
-
     // Detect if we have landed here but only have an SSO identifier in the URL.
     // This is used by integrations that want to "short-circuit" the login to send users
     // directly to their IdP to simulate IdP-initiated SSO, so we submit automatically.
@@ -172,8 +165,15 @@ export class SsoComponent implements OnInit {
       return;
     }
 
-    // If we're routed here with no additional parameters, we'll try to determine the
-    // identifier using claimed domain or local state saved from their last attempt.
+    // Detect if we are on the first portion of the SSO flow
+    // and have been sent here from another client with the info in query params.
+    // If so, we want to initialize the SSO flow with those values.
+    if (this.hasParametersFromOtherClientRedirect(qParams)) {
+      this.initializeFromRedirectFromOtherClient(qParams);
+    }
+
+    // Try to determine the identifier using claimed domain or local state
+    // persisted from the user's last login attempt.
     await this.initializeIdentifierFromEmailOrStorage();
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18661

## 📔 Objective

Addresses a bug in which redirect-based SSO clients (desktop, extension) were not checking claimed domains.

This is because we were early-returning from our initialization routine, when we should have been allowing the code to progress to checking for any claimed domains.

The existing logic in the `v1` `SsoComponent` can be seen [here](https://github.com/bitwarden/clients/blob/e448afb064a7a530553dcf55696253fe46f47d88/apps/web/src/app/auth/sso-v1.component.ts#L101).

## 📸 Screenshots

## Extension
https://github.com/user-attachments/assets/901cf713-bd46-4933-accb-0f354e42caed

## Desktop
https://github.com/user-attachments/assets/376abc75-2d64-4833-aa3f-c697c052e835

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
