### PR TITLE
[PM-18663] Fix calls to bit-button loading states

### DIFF
--- a/apps/browser/src/billing/popup/settings/premium-v2.component.html
+++ b/apps/browser/src/billing/popup/settings/premium-v2.component.html
@@ -45,14 +45,14 @@
       #refreshBtn
       type="button"
       (click)="refresh()"
-      [disabled]="$any(refreshBtn).loading"
+      [disabled]="$any(refreshBtn).loading()"
       [appApiAction]="refreshPromise"
       bitButton
     >
-      <span [hidden]="$any(refreshBtn).loading">{{ "premiumRefresh" | i18n }}</span>
+      <span [hidden]="$any(refreshBtn).loading()">{{ "premiumRefresh" | i18n }}</span>
       <i
         class="bwi bwi-spinner bwi-spin bwi-lg bwi-fw"
-        [hidden]="!$any(refreshBtn).loading"
+        [hidden]="!$any(refreshBtn).loading()"
         aria-hidden="true"
       ></i>
     </button>

--- a/apps/web/src/app/billing/individual/user-subscription.component.html
+++ b/apps/web/src/app/billing/individual/user-subscription.component.html
@@ -27,7 +27,7 @@
       #reinstateBtn
       (click)="reinstate()"
       [appApiAction]="reinstatePromise"
-      [disabled]="$any(reinstateBtn).loading"
+      [disabled]="$any(reinstateBtn).loading()"
     >
       {{ "reinstateSubscription" | i18n }}
     </button>
@@ -109,7 +109,7 @@
         class="tw-ml-auto"
         (click)="cancelSubscription()"
         [appApiAction]="cancelPromise"
-        [disabled]="$any(cancelBtn).loading"
+        [disabled]="$any(cancelBtn).loading()"
         *ngIf="subscription && !subscription.cancelled && !subscriptionMarkedForCancel"
       >
         {{ "cancelSubscription" | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-18663](https://bitwarden.atlassian.net/browse/PM-18663)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In #12835, we changed the way the button component's loading and disabled properties are implemented, from inputs to signals. I went through and updated consumer files because signals are accessed by calling them, but missed a few instances that were referencing those properties in the template file. This PR fixes those so that the buttons aren't displayed as infinitely loading.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Example with the browser extension file

| Before | After |
|--------|--------|
| ![Screenshot 2025-02-27 at 10 41 26 AM](https://github.com/user-attachments/assets/413794c1-a3cb-461f-be4d-00f819cd9428) |![Screenshot 2025-02-27 at 10 40 41 AM](https://github.com/user-attachments/assets/5ef96397-9545-4d84-a35b-24ce85fdf744) |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18663]: https://bitwarden.atlassian.net/browse/PM-18663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ