### PR TITLE
Parse web push payload JSON

### DIFF
--- a/libs/common/src/models/response/notification.response.ts
+++ b/libs/common/src/models/response/notification.response.ts
@@ -12,7 +12,16 @@ export class NotificationResponse extends BaseResponse {
     this.contextId = this.getResponseProperty("ContextId");
     this.type = this.getResponseProperty("Type");
 
-    const payload = this.getResponseProperty("Payload");
+    let payload = this.getResponseProperty("Payload");
+
+    if (typeof payload === "string") {
+      try {
+        payload = JSON.parse(payload);
+      } catch {
+        // guess it was a string
+      }
+    }
+
     switch (this.type) {
       case NotificationType.SyncCipherCreate:
       case NotificationType.SyncCipherDelete:

--- a/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
+++ b/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
@@ -124,7 +124,9 @@ class MyWebPushConnector implements WebPushConnector {
           return this.webPushApiService.putSubscription(subscription.toJSON());
         }).pipe(
           switchMap(() => this.pushEvent$),
-          map((e) => new NotificationResponse(JSON.parse(e.data.json().data))),
+          map((e) => {
+            return new NotificationResponse(e.data.json().data);
+          }),
         );
       }),
     );

--- a/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
+++ b/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
@@ -124,7 +124,7 @@ class MyWebPushConnector implements WebPushConnector {
           return this.webPushApiService.putSubscription(subscription.toJSON());
         }).pipe(
           switchMap(() => this.pushEvent$),
-          map((e) => new NotificationResponse(e.data.json().data)),
+          map((e) => new NotificationResponse(JSON.parse(e.data.json().data))),
         );
       }),
     );


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-16787

## 📔 Objective

Fixes a small issue with #11346 where the payload of a push notification was not being parsed prior to sending into the `NotificationResponse` class, which expects a parsed JSON object.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
