### PR TITLE
[PM-13991] - Edit login - reorder website URIs

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1397,14 +1397,14 @@
   },
   "useAnotherTwoStepMethod": {
     "message": "Use another two-step login method"
-  },  
+  },
   "selectAnotherMethod": {
     "message": "Select another method",
     "description": "Select another two-step login method"
   },
   "useYourRecoveryCode": {
     "message": "Use your recovery code"
-  }, 
+  },
   "insertYubiKey": {
     "message": "Insert your YubiKey into your computer's USB port, then touch its button."
   },
@@ -1640,6 +1640,9 @@
   },
   "dragToSort": {
     "message": "Drag to sort"
+  },
+  "dragToReorder": {
+    "message": "Drag to reorder"
   },
   "cfTypeText": {
     "message": "Text"
@@ -4625,6 +4628,9 @@
         "example": "Custom field"
       }
     }
+  },
+  "reorderWebsiteUriButton": {
+    "message": "Reorder website URI. Use arrow key to move item up or down."
   },
   "reorderFieldUp": {
     "message": "$LABEL$ moved up, position $INDEX$ of $LENGTH$",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4542,6 +4542,40 @@
       }
     }
   },
+  "reorderFieldUp": {
+    "message": "$LABEL$ moved up, position $INDEX$ of $LENGTH$",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Custom field"
+      },
+      "index": {
+        "content": "$2",
+        "example": "1"
+      },
+      "length": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
+  "reorderFieldDown": {
+    "message": "$LABEL$ moved down, position $INDEX$ of $LENGTH$",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Custom field"
+      },
+      "index": {
+        "content": "$2",
+        "example": "1"
+      },
+      "length": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
   "keyUpdateFoldersFailed": {
     "message": "When updating your encryption key, your folders could not be decrypted. To continue with the update, your folders must be deleted. No vault items will be deleted if you proceed."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -443,6 +443,9 @@
   "dragToSort": {
     "message": "Drag to sort"
   },
+  "dragToReorder": {
+    "message": "Drag to reorder"
+  },
   "cfTypeText": {
     "message": "Text"
   },
@@ -1488,7 +1491,7 @@
   },
   "useYourRecoveryCode": {
     "message": "Use your recovery code"
-  }, 
+  },
   "insertYubiKey": {
     "message": "Insert your YubiKey into your computer's USB port, then touch its button."
   },

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -5,12 +5,14 @@
     </h2>
   </bit-section-header>
 
-  <bit-card>
+  <bit-card cdkDropList (cdkDropListDropped)="onUriItemDrop($event)">
     <ng-container formArrayName="uris">
       <vault-autofill-uri-option
         *ngFor="let uri of uriControls; let i = index"
+        cdkDrag
         [formControlName]="i"
         (remove)="removeUri(i)"
+        (onKeydown)="onUriItemKeydown($event, i)"
         [canReorder]="uriControls.length > 1"
         [canRemove]="uriControls.length > 1"
         [defaultMatchDetection]="defaultMatchDetection$ | async"

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -11,6 +11,7 @@
         *ngFor="let uri of uriControls; let i = index"
         [formControlName]="i"
         (remove)="removeUri(i)"
+        [canReorder]="uriControls.length > 1"
         [canRemove]="uriControls.length > 1"
         [defaultMatchDetection]="defaultMatchDetection$ | async"
         [index]="i"

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
@@ -1,4 +1,5 @@
 import { LiveAnnouncer } from "@angular/cdk/a11y";
+import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
@@ -15,6 +16,14 @@ import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherFormContainer } from "../../cipher-form-container";
 
 import { AutofillOptionsComponent } from "./autofill-options.component";
+
+jest.mock("@angular/cdk/drag-drop", () => {
+  const actual = jest.requireActual("@angular/cdk/drag-drop");
+  return {
+    ...actual,
+    moveItemInArray: jest.fn(actual.moveItemInArray),
+  };
+});
 
 describe("AutofillOptionsComponent", () => {
   let component: AutofillOptionsComponent;
@@ -254,5 +263,101 @@ describe("AutofillOptionsComponent", () => {
     fixture.detectChanges();
 
     expect(component.autofillOptionsForm.value.uris.length).toEqual(1);
+  });
+
+  describe("Drag & Drop Functionality", () => {
+    beforeEach(() => {
+      // Prevent auto‑adding an empty URI by setting a non‑null initial value.
+      // This overrides the call to initNewCipher.
+      cipherFormContainer.config = { initialValues: { loginUri: "https://dummy.com" } };
+
+      // Now clear any existing URIs (including the auto‑added one)
+      component.autofillOptionsForm.controls.uris.clear();
+
+      // Add exactly three URIs that we want to test reordering on.
+      component.addUri({ uri: "https://first.com", matchDetection: null });
+      component.addUri({ uri: "https://second.com", matchDetection: null });
+      component.addUri({ uri: "https://third.com", matchDetection: null });
+      fixture.detectChanges();
+    });
+
+    it("should reorder URI inputs on drop event", () => {
+      // Simulate a drop event that moves the first URI (index 0) to the last position (index 2).
+      const dropEvent: CdkDragDrop<HTMLDivElement> = {
+        previousIndex: 0,
+        currentIndex: 2,
+        container: null,
+        previousContainer: null,
+        isPointerOverContainer: true,
+        item: null,
+        distance: { x: 0, y: 0 },
+      } as any;
+
+      component.onUriItemDrop(dropEvent);
+      fixture.detectChanges();
+
+      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 0, 2);
+    });
+
+    it("should reorder URI input via keyboard ArrowUp", async () => {
+      // Clear and add exactly two URIs.
+      component.autofillOptionsForm.controls.uris.clear();
+      component.addUri({ uri: "https://first.com", matchDetection: null });
+      component.addUri({ uri: "https://second.com", matchDetection: null });
+      fixture.detectChanges();
+
+      // Simulate pressing ArrowUp on the second URI (index 1)
+      const keyEvent = {
+        key: "ArrowUp",
+        preventDefault: jest.fn(),
+        target: document.createElement("button"),
+      } as KeyboardEvent;
+
+      // Force requestAnimationFrame to run synchronously
+      jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+        cb(new Date().getTime());
+        return 0;
+      });
+      (liveAnnouncer.announce as jest.Mock).mockResolvedValue(null);
+
+      await component.onUriItemKeydown(keyEvent, 1);
+      fixture.detectChanges();
+
+      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 1, 0);
+      expect(liveAnnouncer.announce).toHaveBeenCalledWith(
+        "reorderFieldUp websiteUri 1 2",
+        "assertive",
+      );
+    });
+
+    it("should reorder URI input via keyboard ArrowDown", async () => {
+      // Clear and add exactly three URIs.
+      component.autofillOptionsForm.controls.uris.clear();
+      component.addUri({ uri: "https://first.com", matchDetection: null });
+      component.addUri({ uri: "https://second.com", matchDetection: null });
+      component.addUri({ uri: "https://third.com", matchDetection: null });
+      fixture.detectChanges();
+
+      // Simulate pressing ArrowDown on the second URI (index 1)
+      const keyEvent = {
+        key: "ArrowDown",
+        preventDefault: jest.fn(),
+        target: document.createElement("button"),
+      } as KeyboardEvent;
+
+      jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+        cb(new Date().getTime());
+        return 0;
+      });
+      (liveAnnouncer.announce as jest.Mock).mockResolvedValue(null);
+
+      await component.onUriItemKeydown(keyEvent, 1);
+
+      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 1, 2);
+      expect(liveAnnouncer.announce).toHaveBeenCalledWith(
+        "reorderFieldDown websiteUri 3 3",
+        "assertive",
+      );
+    });
   });
 });

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
@@ -269,7 +269,6 @@ describe("AutofillOptionsComponent", () => {
     beforeEach(() => {
       // Prevent auto‑adding an empty URI by setting a non‑null initial value.
       // This overrides the call to initNewCipher.
-      cipherFormContainer.config = { initialValues: { loginUri: "https://dummy.com" } };
 
       // Now clear any existing URIs (including the auto‑added one)
       component.autofillOptionsForm.controls.uris.clear();
@@ -296,7 +295,11 @@ describe("AutofillOptionsComponent", () => {
       component.onUriItemDrop(dropEvent);
       fixture.detectChanges();
 
-      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 0, 2);
+      expect(moveItemInArray).toHaveBeenCalledWith(
+        component.autofillOptionsForm.controls.uris.controls,
+        0,
+        2,
+      );
     });
 
     it("should reorder URI input via keyboard ArrowUp", async () => {
@@ -311,7 +314,7 @@ describe("AutofillOptionsComponent", () => {
         key: "ArrowUp",
         preventDefault: jest.fn(),
         target: document.createElement("button"),
-      } as KeyboardEvent;
+      } as unknown as KeyboardEvent;
 
       // Force requestAnimationFrame to run synchronously
       jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
@@ -323,7 +326,11 @@ describe("AutofillOptionsComponent", () => {
       await component.onUriItemKeydown(keyEvent, 1);
       fixture.detectChanges();
 
-      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 1, 0);
+      expect(moveItemInArray).toHaveBeenCalledWith(
+        component.autofillOptionsForm.controls.uris.controls,
+        1,
+        0,
+      );
       expect(liveAnnouncer.announce).toHaveBeenCalledWith(
         "reorderFieldUp websiteUri 1 2",
         "assertive",
@@ -343,7 +350,7 @@ describe("AutofillOptionsComponent", () => {
         key: "ArrowDown",
         preventDefault: jest.fn(),
         target: document.createElement("button"),
-      } as KeyboardEvent;
+      } as unknown as KeyboardEvent;
 
       jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
         cb(new Date().getTime());
@@ -353,7 +360,11 @@ describe("AutofillOptionsComponent", () => {
 
       await component.onUriItemKeydown(keyEvent, 1);
 
-      expect(moveItemInArray).toHaveBeenCalledWith(component.uriControls, 1, 2);
+      expect(moveItemInArray).toHaveBeenCalledWith(
+        component.autofillOptionsForm.controls.uris.controls,
+        1,
+        2,
+      );
       expect(liveAnnouncer.announce).toHaveBeenCalledWith(
         "reorderFieldDown websiteUri 3 3",
         "assertive",

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
@@ -1,43 +1,50 @@
 <ng-container [formGroup]="uriForm">
-  <bit-form-field [class.!tw-mb-1]="showMatchDetection">
-    <bit-label>{{ uriLabel }}</bit-label>
-    <input bitInput formControlName="uri" #uriInput />
-    <button
-      type="button"
-      bitIconButton="bwi-cog"
-      bitSuffix
-      [appA11yTitle]="toggleTitle"
-      (click)="toggleMatchDetection()"
-      data-testid="toggle-match-detection-button"
-    ></button>
-    <button
-      type="button"
-      bitIconButton="bwi-minus-circle"
-      buttonType="danger"
-      bitSuffix
-      [appA11yTitle]="'deleteWebsite' | i18n"
-      *ngIf="canRemove"
-      (click)="removeUri()"
-      data-testid="remove-uri-button"
-    ></button>
-  </bit-form-field>
-  <button
-    type="button"
-    bitIconButton="bwi-hamburger"
-    class="tw-self-end"
-    cdkDragHandle
-    [appA11yTitle]="'reorderWebsiteUriButton' | i18n"
-    data-testid="reorder-toggle-button"
-    *ngIf="canReorder"
-  ></button>
-  <bit-form-field *ngIf="showMatchDetection" class="!tw-mb-5">
-    <bit-label>{{ "matchDetection" | i18n }}</bit-label>
-    <bit-select formControlName="matchDetection" #matchDetectionSelect>
-      <bit-option
-        *ngFor="let o of uriMatchOptions"
-        [label]="o.label"
-        [value]="o.value"
-      ></bit-option>
-    </bit-select>
-  </bit-form-field>
+  <div class="tw-mb-4 pt-1">
+    <div class="tw-flex tw-pt-2" [class.!tw-mb-1]="showMatchDetection">
+      <bit-form-field disableMargin class="tw-flex-1 !tw-pt-0">
+        <bit-label>{{ uriLabel }}</bit-label>
+        <input bitInput formControlName="uri" #uriInput />
+        <button
+          type="button"
+          bitIconButton="bwi-cog"
+          bitSuffix
+          [appA11yTitle]="toggleTitle"
+          (click)="toggleMatchDetection()"
+          data-testid="toggle-match-detection-button"
+        ></button>
+        <button
+          type="button"
+          bitIconButton="bwi-minus-circle"
+          buttonType="danger"
+          bitSuffix
+          [appA11yTitle]="'deleteWebsite' | i18n"
+          *ngIf="canRemove"
+          (click)="removeUri()"
+          data-testid="remove-uri-button"
+        ></button>
+      </bit-form-field>
+      <div class="tw-flex tw-items-center tw-ml-1.5">
+        <button
+          type="button"
+          bitIconButton="bwi-hamburger"
+          class="!tw-py-0 !tw-px-1"
+          cdkDragHandle
+          [appA11yTitle]="'reorderToggleButton' | i18n: uriLabel"
+          (keydown)="handleKeydown($event)"
+          data-testid="reorder-toggle-button"
+          *ngIf="canReorder"
+        ></button>
+      </div>
+    </div>
+    <bit-form-field *ngIf="showMatchDetection" class="!tw-mb-5">
+      <bit-label>{{ "matchDetection" | i18n }}</bit-label>
+      <bit-select formControlName="matchDetection" #matchDetectionSelect>
+        <bit-option
+          *ngFor="let o of uriMatchOptions"
+          [label]="o.label"
+          [value]="o.value"
+        ></bit-option>
+      </bit-select>
+    </bit-form-field>
+  </div>
 </ng-container>

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
@@ -21,7 +21,15 @@
       data-testid="remove-uri-button"
     ></button>
   </bit-form-field>
-
+  <button
+    type="button"
+    bitIconButton="bwi-hamburger"
+    class="tw-self-end"
+    cdkDragHandle
+    [appA11yTitle]="'reorderWebsiteUriButton' | i18n"
+    data-testid="reorder-toggle-button"
+    *ngIf="canReorder"
+  ></button>
   <bit-form-field *ngIf="showMatchDetection" class="!tw-mb-5">
     <bit-label>{{ "matchDetection" | i18n }}</bit-label>
     <bit-select formControlName="matchDetection" #matchDetectionSelect>

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -1,5 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { DragDropModule } from "@angular/cdk/drag-drop";
 import { NgForOf, NgIf } from "@angular/common";
 import {
   Component,
@@ -43,6 +44,7 @@ import {
     },
   ],
   imports: [
+    DragDropModule,
     FormFieldModule,
     ReactiveFormsModule,
     IconButtonModule,
@@ -107,6 +109,9 @@ export class UriOptionComponent implements ControlValueAccessor {
    */
   @Input({ required: true }) index: number;
 
+  @Output()
+  onKeydown = new EventEmitter<KeyboardEvent>();
+
   /**
    * Emits when the remove button is clicked and URI should be removed from the form.
    */
@@ -137,6 +142,10 @@ export class UriOptionComponent implements ControlValueAccessor {
   // NG_VALUE_ACCESSOR implementation
   private onChange: any = () => {};
   private onTouched: any = () => {};
+
+  protected handleKeydown(event: KeyboardEvent) {
+    this.onKeydown.emit(event);
+  }
 
   constructor(
     private formBuilder: FormBuilder,

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -75,6 +75,12 @@ export class UriOptionComponent implements ControlValueAccessor {
   ];
 
   /**
+   * Whether the option can be reordered. If false, the reorder button will be hidden.
+   */
+  @Input({ required: true })
+  canReorder: boolean;
+
+  /**
    * Whether the URI can be removed from the form. If false, the remove button will be hidden.
    */
   @Input({ required: true })


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13991

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the ability to reorder the login website uri's via drag and drop or keyboard.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/a1022db9-d929-44d7-8ce6-247c82424500


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
