### PR TITLE
Auth/PM-18693 - New UI - LoginComp - fix SSO click email required validation

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -629,16 +629,17 @@ export class LoginComponent implements OnInit, OnDestroy {
    * Handle the SSO button click.
    */
   async handleSsoClick() {
-    // Make sure the email is not empty, for type safety
     const email = this.formGroup.value.email;
-    if (!email) {
-      this.logService.error("Email is required for SSO");
-      return;
-    }
 
     // Make sure the email is valid
     const isEmailValid = await this.validateEmail();
     if (!isEmailValid) {
+      return;
+    }
+
+    // Make sure the email is not empty, for type safety
+    if (!email) {
+      this.logService.error("Email is required for SSO");
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18693

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To restore form validation behavior where the user is told email is required when clicking the SSO button without an email entered. 

Diagnosis:
The newly added early return logic for type safety in the `handleSsoClick()` method was preventing the `validateEmail()` method from executing which is responsible for showing the form validation errors. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before: 


https://github.com/user-attachments/assets/15a954ea-1c6d-475e-93d0-73dfa0e0b219

After:

https://github.com/user-attachments/assets/140280b2-dbc9-43c1-bd01-6cca4a7ae5be



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
