### PR TITLE
[PM-16219] Added permission check for organizational unsecure website report

### DIFF
--- a/apps/web/src/app/tools/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -13,6 +13,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
@@ -41,6 +42,9 @@ export class UnsecuredWebsitesReportComponent
   extends BaseUnsecuredWebsitesReportComponent
   implements OnInit
 {
+  // Contains a list of ciphers, the user running the report, can manage
+  private manageableCiphers: Cipher[];
+
   constructor(
     cipherService: CipherService,
     dialogService: DialogService,
@@ -80,11 +84,16 @@ export class UnsecuredWebsitesReportComponent
           .organizations$(userId)
           .pipe(getOrganizationById(params.organizationId)),
       );
+      this.manageableCiphers = await this.cipherService.getAll(userId);
       await super.ngOnInit();
     });
   }
 
   getAllCiphers(): Promise<CipherView[]> {
     return this.cipherService.getAllFromApiForOrganization(this.organization.id);
+  }
+
+  protected canManageCipher(c: CipherView): boolean {
+    return this.manageableCiphers.some((x) => x.id === c.id);
   }
 }

--- a/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.html
+++ b/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.html
@@ -47,15 +47,19 @@
               <app-vault-icon [cipher]="r"></app-vault-icon>
             </td>
             <td bitCell>
-              <a
-                bitLink
-                href="#"
-                appStopClick
-                (click)="selectCipher(r)"
-                title="{{ 'editItemWithName' | i18n: r.name }}"
-              >
-                {{ r.name }}
-              </a>
+              <ng-container *ngIf="!organization || canManageCipher(r); else cantManage">
+                <a
+                  bitLink
+                  href="#"
+                  appStopClick
+                  (click)="selectCipher(r)"
+                  title="{{ 'editItemWithName' | i18n: r.name }}"
+                  >{{ r.name }}</a
+                >
+              </ng-container>
+              <ng-template #cantManage>
+                <span>{{ r.name }}</span>
+              </ng-template>
               <ng-container *ngIf="!organization && r.organizationId">
                 <i
                   class="bwi bwi-collection"


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16219

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The unsecure website report when run from Admin Console did not properly check the CanManage permissions and would offer to open the View Dialog, instead of just displaying the item name.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
