### PR TITLE
[PM-18707] Fix desktop live sync

### DIFF
--- a/libs/angular/src/vault/components/vault-items.component.ts
+++ b/libs/angular/src/vault/components/vault-items.component.ts
@@ -1,8 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Directive, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { BehaviorSubject, Subject, firstValueFrom, from, map, switchMap, takeUntil } from "rxjs";
+import { BehaviorSubject, Subject, firstValueFrom, from, switchMap, takeUntil } from "rxjs";
 
 import { SearchService } from "@bitwarden/common/abstractions/search.service";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -22,11 +21,9 @@ export class VaultItemsComponent implements OnInit, OnDestroy {
 
   loaded = false;
   ciphers: CipherView[] = [];
-  searchPlaceholder: string = null;
   filter: (cipher: CipherView) => boolean = null;
   deleted = false;
   organization: Organization;
-  accessEvents = false;
 
   protected searchPending = false;
 
@@ -45,20 +42,7 @@ export class VaultItemsComponent implements OnInit, OnDestroy {
     protected searchService: SearchService,
     protected cipherService: CipherService,
     protected accountService: AccountService,
-  ) {
-    this.accountService.activeAccount$
-      .pipe(
-        getUserId,
-        switchMap((userId) =>
-          this.cipherService.cipherViews$(userId).pipe(map((ciphers) => ({ userId, ciphers }))),
-        ),
-        takeUntilDestroyed(),
-      )
-      .subscribe(({ userId, ciphers }) => {
-        void this.doSearch(ciphers, userId);
-        this.loaded = true;
-      });
-  }
+  ) {}
 
   ngOnInit(): void {
     this._searchText$


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18707](https://bitwarden.atlassian.net/browse/PM-18707)

## 📔 Objective

Fix the live sync feature on Desktop by waiting for ElectronStore storage service to stabilize in the CipherService before continuing on with an `upsert` operation.

The `ElectronStorageService` save method does not "wait" for the Electron store to finish saving (`store.set()` is not awaitable) so our upsert methods in the `CipherService` notify subscribers to the store that the value has been updated. This appears to race, and our subscribers fetch the value from the ElectronStore (`store.get()`) before the prior `store.set()` call finalized. This results in cipherService subscribers (`ciphers$` and `cipherViews$`) receiving and caching the old cipher data; causing the UI to become stale.

Adding an artificial delay of one tick (`await new Promise((r) => setTimeout(r, 0))`) after saving state in the `CipherService` allows the ElectronStore to stabilize and the next emission from `ciphers$` and `cipherViews$` will have the most up to date data. 

## 📸 Screenshots

https://github.com/user-attachments/assets/2077cabb-e903-4535-afee-bc5c79d701ab


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18707]: https://bitwarden.atlassian.net/browse/PM-18707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ