### PR TITLE
Auth/PM-18654 - Desktop Login V1 Component - use correct destroy hook to avoid subscription overstaying welcome

### DIFF
--- a/apps/desktop/src/auth/login/login-v1.component.ts
+++ b/apps/desktop/src/auth/login/login-v1.component.ts
@@ -156,7 +156,7 @@ export class LoginComponentV1 extends BaseLoginComponent implements OnInit, OnDe
             });
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntil(this.componentDestroyed$),
       )
       .subscribe();
   }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18654

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve the issue where the desktop `LoginV1Component` `listenForUnauthUiRefreshFlagChanges()` method used the base component destroy hook which was overridden and not called so the subscription stayed active. During initial login, this would emit (even on other components) and force navigation to the root and interrupt the SSO process while JIT provisioning users - often before the Org SSO identifier could be set into state. The user would be redirected by the redirect guard to the login initiated screen but without the appropriate state set. 

The reason this only applies during the initial install scenario is because the app doesn't have the new UI flags cached as the selected environment.  The reason this bug occurs is because of (1) Loading the desktop w/ the default prod env results in the old UI (`LoginV1`) being shown (2) User changes to the QA / local env where the UI refresh flags are on (3) The stream in the `LoginV1` component isn't cleaned up on the switch appropriately. Thus, setting the stage for the bug to occur. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
