### PR TITLE
[PM-18772] Rename AesCbc256 to Aes256Cbc

### DIFF
--- a/apps/desktop/desktop_native/core/src/biometric/mod.rs
+++ b/apps/desktop/desktop_native/core/src/biometric/mod.rs
@@ -60,7 +60,7 @@ fn encrypt(secret: &str, key_material: &KeyMaterial, iv_b64: &str) -> Result<Str
 
 #[allow(unused)]
 fn decrypt(secret: &CipherString, key_material: &KeyMaterial) -> Result<String> {
-    if let CipherString::AesCbc256_B64 { iv, data } = secret {
+    if let CipherString::Aes256Cbc_B64 { iv, data } = secret {
         let decrypted = crypto::decrypt_aes256(iv, data, key_material.derive_key()?)?;
 
         Ok(String::from_utf8(decrypted)?)

--- a/apps/desktop/desktop_native/core/src/biometric/windows.rs
+++ b/apps/desktop/desktop_native/core/src/biometric/windows.rs
@@ -234,7 +234,7 @@ mod tests {
             .unwrap();
 
         match secret {
-            CipherString::AesCbc256_B64 { iv, data: _ } => {
+            CipherString::Aes256Cbc_B64 { iv, data: _ } => {
                 assert_eq!(iv_b64, base64_engine.encode(iv));
             }
             _ => panic!("Invalid cipher string"),

--- a/apps/desktop/desktop_native/core/src/crypto/cipher_string.rs
+++ b/apps/desktop/desktop_native/core/src/crypto/cipher_string.rs
@@ -7,18 +7,18 @@ use crate::error::{CSParseError, Error};
 #[allow(unused, non_camel_case_types)]
 pub enum CipherString {
     // 0
-    AesCbc256_B64 {
+    Aes256Cbc_B64 {
         iv: [u8; 16],
         data: Vec<u8>,
     },
     // 1
-    AesCbc128_HmacSha256_B64 {
+    Aes128Cbc_HmacSha256_B64 {
         iv: [u8; 16],
         mac: [u8; 32],
         data: Vec<u8>,
     },
     // 2
-    AesCbc256_HmacSha256_B64 {
+    Aes256Cbc_HmacSha256_B64 {
         iv: [u8; 16],
         mac: [u8; 32],
         data: Vec<u8>,
@@ -81,7 +81,7 @@ impl FromStr for CipherString {
                     .decode(data_str)
                     .map_err(CSParseError::InvalidBase64)?;
 
-                Ok(CipherString::AesCbc256_B64 { iv, data })
+                Ok(CipherString::Aes256Cbc_B64 { iv, data })
             }
 
             ("1" | "2", 3) => {
@@ -106,9 +106,9 @@ impl FromStr for CipherString {
                     .map_err(CSParseError::InvalidBase64)?;
 
                 if enc_type == "1" {
-                    Ok(CipherString::AesCbc128_HmacSha256_B64 { iv, mac, data })
+                    Ok(CipherString::Aes128Cbc_HmacSha256_B64 { iv, mac, data })
                 } else {
-                    Ok(CipherString::AesCbc256_HmacSha256_B64 { iv, mac, data })
+                    Ok(CipherString::Aes256Cbc_HmacSha256_B64 { iv, mac, data })
                 }
             }
 
@@ -142,16 +142,16 @@ impl Display for CipherString {
         let mut parts = Vec::<&[u8]>::new();
 
         match self {
-            CipherString::AesCbc256_B64 { iv, data } => {
+            CipherString::Aes256Cbc_B64 { iv, data } => {
                 parts.push(iv);
                 parts.push(data);
             }
-            CipherString::AesCbc128_HmacSha256_B64 { iv, mac, data } => {
+            CipherString::Aes128Cbc_HmacSha256_B64 { iv, mac, data } => {
                 parts.push(iv);
                 parts.push(data);
                 parts.push(mac);
             }
-            CipherString::AesCbc256_HmacSha256_B64 { iv, mac, data } => {
+            CipherString::Aes256Cbc_HmacSha256_B64 { iv, mac, data } => {
                 parts.push(iv);
                 parts.push(data);
                 parts.push(mac);
@@ -187,9 +187,9 @@ impl Display for CipherString {
 impl CipherString {
     fn enc_type(&self) -> u8 {
         match self {
-            CipherString::AesCbc256_B64 { .. } => 0,
-            CipherString::AesCbc128_HmacSha256_B64 { .. } => 1,
-            CipherString::AesCbc256_HmacSha256_B64 { .. } => 2,
+            CipherString::Aes256Cbc_B64 { .. } => 0,
+            CipherString::Aes128Cbc_HmacSha256_B64 { .. } => 1,
+            CipherString::Aes256Cbc_HmacSha256_B64 { .. } => 2,
             CipherString::Rsa2048_OaepSha256_B64 { .. } => 3,
             CipherString::Rsa2048_OaepSha1_B64 { .. } => 4,
             CipherString::Rsa2048_OaepSha256_HmacSha256_B64 { .. } => 5,
@@ -199,9 +199,9 @@ impl CipherString {
 
     fn enc_type_name(&self) -> &str {
         match self.enc_type() {
-            0 => "AesCbc256_B64",
-            1 => "AesCbc128_HmacSha256_B64",
-            2 => "AesCbc256_HmacSha256_B64",
+            0 => "Aes256Cbc_B64",
+            1 => "Aes128Cbc_HmacSha256_B64",
+            2 => "Aes256Cbc_HmacSha256_B64",
             3 => "Rsa2048_OaepSha256_B64",
             4 => "Rsa2048_OaepSha1_B64",
             5 => "Rsa2048_OaepSha256_HmacSha256_B64",

--- a/apps/desktop/desktop_native/core/src/crypto/crypto.rs
+++ b/apps/desktop/desktop_native/core/src/crypto/crypto.rs
@@ -31,7 +31,7 @@ pub fn encrypt_aes256(
     let data = cbc::Encryptor::<aes::Aes256>::new(&key, &iv.into())
         .encrypt_padded_vec_mut::<Pkcs7>(data_dec);
 
-    Ok(CipherString::AesCbc256_B64 { iv, data })
+    Ok(CipherString::Aes256Cbc_B64 { iv, data })
 }
 
 pub fn argon2(

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.spec.ts
@@ -300,7 +300,7 @@ describe("MainBiometricsService", function () {
 
       expect(userKey).not.toBeNull();
       expect(userKey!.keyB64).toBe(biometricKey);
-      expect(userKey!.encType).toBe(EncryptionType.AesCbc256_HmacSha256_B64);
+      expect(userKey!.encType).toBe(EncryptionType.Aes256Cbc_HmacSha256_B64);
       expect(osBiometricsService.getBiometricKey).toHaveBeenCalledWith(
         "Bitwarden_biometric",
         `${userId}_user_biometric`,

--- a/apps/desktop/src/key-management/biometrics/os-biometrics-windows.service.ts
+++ b/apps/desktop/src/key-management/biometrics/os-biometrics-windows.service.ts
@@ -222,7 +222,7 @@ export default class OsBiometricsServiceWindows implements OsBiometricService {
   ): biometrics.KeyMaterial {
     let key = null;
     const innerKey = symmetricKey.inner();
-    if (innerKey.type === EncryptionType.AesCbc256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_B64) {
       key = Utils.fromBufferToB64(innerKey.encryptionKey);
     } else {
       key = Utils.fromBufferToB64(innerKey.authenticationKey);

--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.spec.ts
@@ -139,7 +139,7 @@ describe("OrganizationUserResetPasswordService", () => {
       const mockUserKey = new SymmetricCryptoKey(mockRandomBytes) as UserKey;
       keyService.encryptUserKeyWithMasterKey.mockResolvedValue([
         mockUserKey,
-        new EncString(EncryptionType.AesCbc256_HmacSha256_B64, "test-encrypted-user-key"),
+        new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, "test-encrypted-user-key"),
       ]);
     });
 

--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.spec.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.spec.ts
@@ -120,7 +120,7 @@ describe("EmergencyAccessService", () => {
         const publicKey = new Uint8Array(64);
 
         const mockUserPublicKeyEncryptedUserKey = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
+          EncryptionType.Aes256Cbc_HmacSha256_B64,
           "mockUserPublicKeyEncryptedUserKey",
         );
 
@@ -168,7 +168,7 @@ describe("EmergencyAccessService", () => {
       // must mock [UserKey, EncString] return from keyService.encryptUserKeyWithMasterKey
       // where UserKey is the decrypted grantor user key
       const mockMasterKeyEncryptedUserKey = new EncString(
-        EncryptionType.AesCbc256_HmacSha256_B64,
+        EncryptionType.Aes256Cbc_HmacSha256_B64,
         "mockMasterKeyEncryptedUserKey",
       );
 

--- a/libs/auth/src/common/services/pin/pin.service.spec.ts
+++ b/libs/auth/src/common/services/pin/pin.service.spec.ts
@@ -49,7 +49,7 @@ describe("PinService", () => {
   const mockPin = "1234";
   const mockUserKeyEncryptedPin = new EncString("userKeyEncryptedPin");
 
-  // Note: both pinKeyEncryptedUserKeys use encryptionType: 2 (AesCbc256_HmacSha256_B64)
+  // Note: both pinKeyEncryptedUserKeys use encryptionType: 2 (Aes256Cbc_HmacSha256_B64)
   const pinKeyEncryptedUserKeyEphemeral = new EncString(
     "2.gbauOANURUHqvhLTDnva1A==|nSW+fPumiuTaDB/s12+JO88uemV6rhwRSR+YR1ZzGr5j6Ei3/h+XEli2Unpz652NlZ9NTuRpHxeOqkYYJtp7J+lPMoclgteXuAzUu9kqlRc=|DeUFkhIwgkGdZA08bDnDqMMNmZk21D+H5g8IostPKAY=",
   );

--- a/libs/common/spec/utils.ts
+++ b/libs/common/spec/utils.ts
@@ -37,7 +37,7 @@ export function mockEnc(s: string): MockProxy<EncString> {
 
 export function makeEncString(data?: string) {
   data ??= Utils.newGuid();
-  return new EncString(EncryptionType.AesCbc256_HmacSha256_B64, data, "test", "test");
+  return new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, data, "test", "test");
 }
 
 export function makeStaticByteArray(length: number, start = 0) {

--- a/libs/common/src/auth/abstractions/master-password.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/master-password.service.abstraction.ts
@@ -36,7 +36,7 @@ export abstract class MasterPasswordServiceAbstraction {
    *    * @param userId The desired user
    * @param userKey The user's encrypted symmetric key
    * @throws If either the MasterKey or UserKey are not resolved, or if the UserKey encryption type
-   *         is neither AesCbc256_B64 nor AesCbc256_HmacSha256_B64
+   *         is neither Aes256Cbc_B64 nor Aes256Cbc_HmacSha256_B64
    * @returns The user key
    */
   abstract decryptUserKeyWithMasterKey: (

--- a/libs/common/src/auth/services/device-trust.service.spec.ts
+++ b/libs/common/src/auth/services/device-trust.service.spec.ts
@@ -392,12 +392,12 @@ describe("deviceTrustService", () => {
         );
 
         mockUserKeyEncryptedDevicePublicKey = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
+          EncryptionType.Aes256Cbc_HmacSha256_B64,
           "mockUserKeyEncryptedDevicePublicKey",
         );
 
         mockDeviceKeyEncryptedDevicePrivateKey = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
+          EncryptionType.Aes256Cbc_HmacSha256_B64,
           "mockDeviceKeyEncryptedDevicePrivateKey",
         );
 
@@ -555,12 +555,12 @@ describe("deviceTrustService", () => {
         mockUserKey = new SymmetricCryptoKey(mockUserKeyRandomBytes) as UserKey;
 
         mockEncryptedDevicePrivateKey = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
+          EncryptionType.Aes256Cbc_HmacSha256_B64,
           "mockEncryptedDevicePrivateKey",
         );
 
         mockEncryptedUserKey = new EncString(
-          EncryptionType.AesCbc256_HmacSha256_B64,
+          EncryptionType.Aes256Cbc_HmacSha256_B64,
           "mockEncryptedUserKey",
         );
 
@@ -731,7 +731,7 @@ describe("deviceTrustService", () => {
 
           // Mock the decryption of the public key with the old user key
           encryptService.decryptToBytes.mockImplementationOnce((_encValue, privateKeyValue) => {
-            expect(privateKeyValue.inner().type).toBe(EncryptionType.AesCbc256_HmacSha256_B64);
+            expect(privateKeyValue.inner().type).toBe(EncryptionType.Aes256Cbc_HmacSha256_B64);
             expect(new Uint8Array(privateKeyValue.toEncoded())[0]).toBe(FakeOldUserKeyMarker);
             const data = new Uint8Array(250);
             data.fill(FakeDecryptedPublicKeyMarker, 0, 1);

--- a/libs/common/src/auth/services/master-password/master-password.service.ts
+++ b/libs/common/src/auth/services/master-password/master-password.service.ts
@@ -181,13 +181,13 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
 
     let decUserKey: Uint8Array;
 
-    if (userKey.encryptionType === EncryptionType.AesCbc256_B64) {
+    if (userKey.encryptionType === EncryptionType.Aes256Cbc_B64) {
       decUserKey = await this.encryptService.decryptToBytes(
         userKey,
         masterKey,
         "Content: User Key; Encrypting Key: Master Key",
       );
-    } else if (userKey.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
+    } else if (userKey.encryptionType === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const newKey = await this.keyGenerationService.stretchKey(masterKey.inner() as Aes256CbcKey);
       decUserKey = await this.encryptService.decryptToBytes(
         userKey,

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login-prf-key.service.spec.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login-prf-key.service.spec.ts
@@ -23,7 +23,7 @@ describe("WebAuthnLoginPrfKeyService", () => {
 
       const result = await service.createSymmetricKeyFromPrf(randomBytes(32));
 
-      expect(result.inner().type).toBe(EncryptionType.AesCbc256_HmacSha256_B64);
+      expect(result.inner().type).toBe(EncryptionType.Aes256Cbc_HmacSha256_B64);
     });
   });
 });

--- a/libs/common/src/key-management/crypto/services/encrypt.service.implementation.ts
+++ b/libs/common/src/key-management/crypto/services/encrypt.service.implementation.ts
@@ -45,7 +45,7 @@ export class EncryptServiceImplementation implements EncryptService {
     }
 
     const innerKey = key.inner();
-    if (innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const encObj = await this.aesEncrypt(plainBuf, innerKey);
       const iv = Utils.fromBufferToB64(encObj.iv);
       const data = Utils.fromBufferToB64(encObj.data);
@@ -62,7 +62,7 @@ export class EncryptServiceImplementation implements EncryptService {
     }
 
     const innerKey = key.inner();
-    if (innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const encValue = await this.aesEncrypt(plainValue, innerKey);
       const macLen = encValue.mac.length;
       const encBytes = new Uint8Array(
@@ -73,7 +73,7 @@ export class EncryptServiceImplementation implements EncryptService {
       encBytes.set(new Uint8Array(encValue.mac), 1 + encValue.iv.byteLength);
       encBytes.set(new Uint8Array(encValue.data), 1 + encValue.iv.byteLength + macLen);
       return new EncArrayBuffer(encBytes);
-    } else if (innerKey.type === EncryptionType.AesCbc256_B64) {
+    } else if (innerKey.type === EncryptionType.Aes256Cbc_B64) {
       const encValue = await this.aesEncryptLegacy(plainValue, innerKey);
       const encBytes = new Uint8Array(1 + encValue.iv.byteLength + encValue.data.byteLength);
       encBytes.set([innerKey.type]);
@@ -93,8 +93,8 @@ export class EncryptServiceImplementation implements EncryptService {
     }
 
     const innerKey = key.inner();
-    if (innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
-      if (encString.encryptionType !== EncryptionType.AesCbc256_HmacSha256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
+      if (encString.encryptionType !== EncryptionType.Aes256Cbc_HmacSha256_B64) {
         this.logDecryptError(
           "Key encryption type does not match payload encryption type",
           key.inner().type,
@@ -130,8 +130,8 @@ export class EncryptServiceImplementation implements EncryptService {
         mode: "cbc",
         parameters: fastParams,
       });
-    } else if (innerKey.type === EncryptionType.AesCbc256_B64) {
-      if (encString.encryptionType !== EncryptionType.AesCbc256_B64) {
+    } else if (innerKey.type === EncryptionType.Aes256Cbc_B64) {
+      if (encString.encryptionType !== EncryptionType.Aes256Cbc_B64) {
         this.logDecryptError(
           "Key encryption type does not match payload encryption type",
           key.inner().type,
@@ -170,9 +170,9 @@ export class EncryptServiceImplementation implements EncryptService {
     }
 
     const inner = key.inner();
-    if (inner.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    if (inner.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       if (
-        encThing.encryptionType !== EncryptionType.AesCbc256_HmacSha256_B64 ||
+        encThing.encryptionType !== EncryptionType.Aes256Cbc_HmacSha256_B64 ||
         encThing.macBytes === null
       ) {
         this.logDecryptError(
@@ -209,8 +209,8 @@ export class EncryptServiceImplementation implements EncryptService {
         inner.encryptionKey,
         "cbc",
       );
-    } else if (inner.type === EncryptionType.AesCbc256_B64) {
-      if (encThing.encryptionType !== EncryptionType.AesCbc256_B64) {
+    } else if (inner.type === EncryptionType.Aes256Cbc_B64) {
+      if (encThing.encryptionType !== EncryptionType.Aes256Cbc_B64) {
         this.logDecryptError(
           "Encryption key type mismatch",
           inner.type,
@@ -305,7 +305,7 @@ export class EncryptServiceImplementation implements EncryptService {
   }
 
   /**
-   * @deprecated Removed once AesCbc256_B64 support is removed
+   * @deprecated Removed once Aes256Cbc_B64 support is removed
    */
   private async aesEncryptLegacy(data: Uint8Array, key: Aes256CbcKey): Promise<EncryptedObject> {
     const obj = new EncryptedObject();

--- a/libs/common/src/key-management/crypto/services/encrypt.service.spec.ts
+++ b/libs/common/src/key-management/crypto/services/encrypt.service.spec.ts
@@ -73,7 +73,7 @@ describe("EncryptService", () => {
 
       const actual = await encryptService.encryptToBytes(plainValue, key);
       const expectedBytes = new Uint8Array(1 + iv.byteLength + cipherText.byteLength);
-      expectedBytes.set([EncryptionType.AesCbc256_B64]);
+      expectedBytes.set([EncryptionType.Aes256Cbc_B64]);
       expectedBytes.set(iv, 1);
       expectedBytes.set(cipherText, 1 + iv.byteLength);
 
@@ -93,7 +93,7 @@ describe("EncryptService", () => {
       const expectedBytes = new Uint8Array(
         1 + iv.byteLength + mac.byteLength + cipherText.byteLength,
       );
-      expectedBytes.set([EncryptionType.AesCbc256_HmacSha256_B64]);
+      expectedBytes.set([EncryptionType.Aes256Cbc_HmacSha256_B64]);
       expectedBytes.set(iv, 1);
       expectedBytes.set(mac, 1 + iv.byteLength);
       expectedBytes.set(cipherText, 1 + iv.byteLength + mac.byteLength);
@@ -103,7 +103,7 @@ describe("EncryptService", () => {
   });
 
   describe("decryptToBytes", () => {
-    const encType = EncryptionType.AesCbc256_HmacSha256_B64;
+    const encType = EncryptionType.Aes256Cbc_HmacSha256_B64;
     const key = new SymmetricCryptoKey(makeStaticByteArray(64, 100));
     const computedMac = new Uint8Array(1);
     const encBuffer = new EncArrayBuffer(makeStaticByteArray(60, encType));
@@ -145,7 +145,7 @@ describe("EncryptService", () => {
 
     it("decrypts data with provided key for Aes256Cbc", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(32, 0));
-      const encBuffer = new EncArrayBuffer(makeStaticByteArray(60, EncryptionType.AesCbc256_B64));
+      const encBuffer = new EncArrayBuffer(makeStaticByteArray(60, EncryptionType.Aes256Cbc_B64));
       const decryptedBytes = makeStaticByteArray(10, 200);
 
       cryptoFunctionService.hmac.mockResolvedValue(makeStaticByteArray(1));
@@ -216,7 +216,7 @@ describe("EncryptService", () => {
     it("returns null if key is Aes256Cbc_HmacSha256 but encbuffer is Aes256Cbc", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(64, 0));
       cryptoFunctionService.compare.mockResolvedValue(true);
-      const buffer = new EncArrayBuffer(makeStaticByteArray(200, EncryptionType.AesCbc256_B64));
+      const buffer = new EncArrayBuffer(makeStaticByteArray(200, EncryptionType.Aes256Cbc_B64));
       const actual = await encryptService.decryptToBytes(buffer, key);
 
       expect(actual).toBeNull();
@@ -231,9 +231,9 @@ describe("EncryptService", () => {
       );
     });
 
-    it("decrypts data with provided key for AesCbc256_HmacSha256", async () => {
+    it("decrypts data with provided key for Aes256Cbc_HmacSha256", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(64, 0));
-      const encString = new EncString(EncryptionType.AesCbc256_HmacSha256_B64, "data");
+      const encString = new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, "data");
       cryptoFunctionService.aesDecryptFastParameters.mockReturnValue({
         macData: makeStaticByteArray(32, 0),
         macKey: makeStaticByteArray(32, 0),
@@ -248,9 +248,9 @@ describe("EncryptService", () => {
       expect(cryptoFunctionService.compareFast).toHaveBeenCalled();
     });
 
-    it("decrypts data with provided key for AesCbc256", async () => {
+    it("decrypts data with provided key for Aes256Cbc", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(32, 0));
-      const encString = new EncString(EncryptionType.AesCbc256_B64, "data");
+      const encString = new EncString(EncryptionType.Aes256Cbc_B64, "data");
       cryptoFunctionService.aesDecryptFastParameters.mockReturnValue({
         macData: makeStaticByteArray(32, 0),
         macKey: makeStaticByteArray(32, 0),
@@ -265,18 +265,18 @@ describe("EncryptService", () => {
       expect(cryptoFunctionService.compareFast).not.toHaveBeenCalled();
     });
 
-    it("returns null if key is AesCbc256_HMAC but encstring is AesCbc256", async () => {
+    it("returns null if key is Aes256Cbc_HMAC but encstring is Aes256Cbc", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(64, 0));
-      const encString = new EncString(EncryptionType.AesCbc256_B64, "data");
+      const encString = new EncString(EncryptionType.Aes256Cbc_B64, "data");
 
       const actual = await encryptService.decryptToUtf8(encString, key);
       expect(actual).toBeNull();
       expect(logService.error).toHaveBeenCalled();
     });
 
-    it("returns null if key is AesCbc256 but encstring is AesCbc256_HMAC", async () => {
+    it("returns null if key is Aes256Cbc but encstring is Aes256Cbc_HMAC", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(32, 0));
-      const encString = new EncString(EncryptionType.AesCbc256_HmacSha256_B64, "data");
+      const encString = new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, "data");
 
       const actual = await encryptService.decryptToUtf8(encString, key);
       expect(actual).toBeNull();
@@ -285,7 +285,7 @@ describe("EncryptService", () => {
 
     it("returns null if macs don't match", async () => {
       const key = new SymmetricCryptoKey(makeStaticByteArray(64, 0));
-      const encString = new EncString(EncryptionType.AesCbc256_HmacSha256_B64, "data");
+      const encString = new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, "data");
       cryptoFunctionService.aesDecryptFastParameters.mockReturnValue({
         macData: makeStaticByteArray(32, 0),
         macKey: makeStaticByteArray(32, 0),
@@ -345,7 +345,7 @@ describe("EncryptService", () => {
         return expect(encryptService.rsaDecrypt(encString, null)).rejects.toThrow("No private key");
       });
 
-      it.each([EncryptionType.AesCbc256_B64, EncryptionType.AesCbc256_HmacSha256_B64])(
+      it.each([EncryptionType.Aes256Cbc_B64, EncryptionType.Aes256Cbc_HmacSha256_B64])(
         "throws if encryption type is %s",
         async (encType) => {
           encString.encryptionType = encType;

--- a/libs/common/src/platform/enums/encryption-type.enum.ts
+++ b/libs/common/src/platform/enums/encryption-type.enum.ts
@@ -1,7 +1,7 @@
 export enum EncryptionType {
-  AesCbc256_B64 = 0,
-  // Type 1 was the unused and removed AesCbc128_HmacSha256_B64
-  AesCbc256_HmacSha256_B64 = 2,
+  Aes256Cbc_B64 = 0,
+  // Type 1 was the unused and removed Aes128Cbc_HmacSha256_B64
+  Aes256Cbc_HmacSha256_B64 = 2,
   Rsa2048_OaepSha256_B64 = 3,
   Rsa2048_OaepSha1_B64 = 4,
   Rsa2048_OaepSha256_HmacSha256_B64 = 5,
@@ -17,7 +17,7 @@ export function encryptionTypeToString(encryptionType: EncryptionType): string {
 }
 
 /** The expected number of parts to a serialized EncString of the given encryption type.
- * For example, an EncString of type AesCbc256_B64 will have 2 parts
+ * For example, an EncString of type Aes256Cbc_B64 will have 2 parts
  *
  * Example of annotated serialized EncStrings:
  * 0.iv|data
@@ -30,8 +30,8 @@ export function encryptionTypeToString(encryptionType: EncryptionType): string {
  * @see EncString.parseEncryptedString
  */
 export const EXPECTED_NUM_PARTS_BY_ENCRYPTION_TYPE = {
-  [EncryptionType.AesCbc256_B64]: 2,
-  [EncryptionType.AesCbc256_HmacSha256_B64]: 3,
+  [EncryptionType.Aes256Cbc_B64]: 2,
+  [EncryptionType.Aes256Cbc_HmacSha256_B64]: 3,
   [EncryptionType.Rsa2048_OaepSha256_B64]: 1,
   [EncryptionType.Rsa2048_OaepSha1_B64]: 1,
   [EncryptionType.Rsa2048_OaepSha256_HmacSha256_B64]: 2,

--- a/libs/common/src/platform/models/domain/enc-array-buffer.spec.ts
+++ b/libs/common/src/platform/models/domain/enc-array-buffer.spec.ts
@@ -5,7 +5,7 @@ import { EncArrayBuffer } from "./enc-array-buffer";
 
 describe("encArrayBuffer", () => {
   describe("parses the buffer", () => {
-    test.each([[EncryptionType.AesCbc256_HmacSha256_B64, "AesCbc256_HmacSha256_B64"]])(
+    test.each([[EncryptionType.Aes256Cbc_HmacSha256_B64, "Aes256Cbc_HmacSha256_B64"]])(
       "with %c%s",
       (encType: EncryptionType) => {
         const iv = makeStaticByteArray(16, 10);
@@ -28,8 +28,8 @@ describe("encArrayBuffer", () => {
       },
     );
 
-    it("with AesCbc256_B64", () => {
-      const encType = EncryptionType.AesCbc256_B64;
+    it("with Aes256Cbc_B64", () => {
+      const encType = EncryptionType.Aes256Cbc_B64;
       const iv = makeStaticByteArray(16, 10);
       // We use the minimum data length of 1 to test the boundary of valid lengths
       const data = makeStaticByteArray(1, 100);
@@ -50,8 +50,8 @@ describe("encArrayBuffer", () => {
 
   describe("throws if the buffer has an invalid length", () => {
     test.each([
-      [EncryptionType.AesCbc256_HmacSha256_B64, 50, "AesCbc256_HmacSha256_B64"],
-      [EncryptionType.AesCbc256_B64, 18, "AesCbc256_B64"],
+      [EncryptionType.Aes256Cbc_HmacSha256_B64, 50, "Aes256Cbc_HmacSha256_B64"],
+      [EncryptionType.Aes256Cbc_B64, 18, "Aes256Cbc_B64"],
     ])("with %c%c%s", (encType: EncryptionType, minLength: number) => {
       // Generate invalid byte array
       // Minus 1 to leave room for the encType, minus 1 to make it invalid

--- a/libs/common/src/platform/models/domain/enc-array-buffer.ts
+++ b/libs/common/src/platform/models/domain/enc-array-buffer.ts
@@ -20,7 +20,7 @@ export class EncArrayBuffer implements Encrypted {
     const encType = encBytes[0];
 
     switch (encType) {
-      case EncryptionType.AesCbc256_HmacSha256_B64: {
+      case EncryptionType.Aes256Cbc_HmacSha256_B64: {
         const minimumLength = ENC_TYPE_LENGTH + IV_LENGTH + MAC_LENGTH + MIN_DATA_LENGTH;
         if (encBytes.length < minimumLength) {
           this.throwDecryptionError();
@@ -34,7 +34,7 @@ export class EncArrayBuffer implements Encrypted {
         this.dataBytes = encBytes.slice(ENC_TYPE_LENGTH + IV_LENGTH + MAC_LENGTH);
         break;
       }
-      case EncryptionType.AesCbc256_B64: {
+      case EncryptionType.Aes256Cbc_B64: {
         const minimumLength = ENC_TYPE_LENGTH + IV_LENGTH + MIN_DATA_LENGTH;
         if (encBytes.length < minimumLength) {
           this.throwDecryptionError();

--- a/libs/common/src/platform/models/domain/enc-string.spec.ts
+++ b/libs/common/src/platform/models/domain/enc-string.spec.ts
@@ -59,9 +59,9 @@ describe("EncString", () => {
       });
 
       const cases = [
-        "aXY=|Y3Q=", // AesCbc256_B64 w/out header
-        "0.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // AesCbc256_B64 with header
-        "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // AesCbc256_HmacSha256_B64
+        "aXY=|Y3Q=", // Aes256Cbc_B64 w/out header
+        "0.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // Aes256Cbc_B64 with header
+        "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // Aes256Cbc_HmacSha256_B64
         "3.QmFzZTY0UGFydA==", // Rsa2048_OaepSha256_B64
         "4.QmFzZTY0UGFydA==", // Rsa2048_OaepSha1_B64
         "5.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==", // Rsa2048_OaepSha256_HmacSha256_B64
@@ -181,9 +181,9 @@ describe("EncString", () => {
     });
   });
 
-  describe("AesCbc256_B64", () => {
+  describe("Aes256Cbc_B64", () => {
     it("constructor", () => {
-      const encString = new EncString(EncryptionType.AesCbc256_B64, "data", "iv");
+      const encString = new EncString(EncryptionType.Aes256Cbc_B64, "data", "iv");
 
       expect(encString).toEqual({
         data: "data",
@@ -226,9 +226,9 @@ describe("EncString", () => {
     });
   });
 
-  describe("AesCbc256_HmacSha256_B64", () => {
+  describe("Aes256Cbc_HmacSha256_B64", () => {
     it("constructor", () => {
-      const encString = new EncString(EncryptionType.AesCbc256_HmacSha256_B64, "data", "iv", "mac");
+      const encString = new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, "data", "iv", "mac");
 
       expect(encString).toEqual({
         data: "data",
@@ -386,7 +386,7 @@ describe("EncString", () => {
 
   describe("toJSON", () => {
     it("Should be represented by the encrypted string", () => {
-      const encString = new EncString(EncryptionType.AesCbc256_B64, "data", "iv");
+      const encString = new EncString(EncryptionType.Aes256Cbc_B64, "data", "iv");
 
       expect(encString.toJSON()).toBe(encString.encryptedString);
     });

--- a/libs/common/src/platform/models/domain/enc-string.ts
+++ b/libs/common/src/platform/models/domain/enc-string.ts
@@ -89,12 +89,12 @@ export class EncString implements Encrypted {
     }
 
     switch (encType) {
-      case EncryptionType.AesCbc256_HmacSha256_B64:
+      case EncryptionType.Aes256Cbc_HmacSha256_B64:
         this.iv = encPieces[0];
         this.data = encPieces[1];
         this.mac = encPieces[2];
         break;
-      case EncryptionType.AesCbc256_B64:
+      case EncryptionType.Aes256Cbc_B64:
         this.iv = encPieces[0];
         this.data = encPieces[1];
         break;
@@ -131,7 +131,7 @@ export class EncString implements Encrypted {
       }
     } else {
       encPieces = encryptedString.split("|");
-      encType = EncryptionType.AesCbc256_B64;
+      encType = EncryptionType.Aes256Cbc_B64;
     }
 
     return {

--- a/libs/common/src/platform/models/domain/symmetric-crypto-key.spec.ts
+++ b/libs/common/src/platform/models/domain/symmetric-crypto-key.spec.ts
@@ -14,20 +14,20 @@ describe("SymmetricCryptoKey", () => {
   });
 
   describe("guesses encKey from key length", () => {
-    it("AesCbc256_B64", () => {
+    it("Aes256Cbc_B64", () => {
       const key = makeStaticByteArray(32);
       const cryptoKey = new SymmetricCryptoKey(key);
 
       expect(cryptoKey).toEqual({
         keyB64: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
         innerKey: {
-          type: EncryptionType.AesCbc256_B64,
+          type: EncryptionType.Aes256Cbc_B64,
           encryptionKey: key,
         },
       });
     });
 
-    it("AesCbc256_HmacSha256_B64", () => {
+    it("Aes256Cbc_HmacSha256_B64", () => {
       const key = makeStaticByteArray(64);
       const cryptoKey = new SymmetricCryptoKey(key);
 
@@ -35,7 +35,7 @@ describe("SymmetricCryptoKey", () => {
         keyB64:
           "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==",
         innerKey: {
-          type: EncryptionType.AesCbc256_HmacSha256_B64,
+          type: EncryptionType.Aes256Cbc_HmacSha256_B64,
           encryptionKey: key.slice(0, 32),
           authenticationKey: key.slice(32),
         },
@@ -73,20 +73,20 @@ describe("SymmetricCryptoKey", () => {
     const actual = key.inner();
 
     expect(actual).toEqual({
-      type: EncryptionType.AesCbc256_HmacSha256_B64,
+      type: EncryptionType.Aes256Cbc_HmacSha256_B64,
       encryptionKey: key.inner().encryptionKey,
       authenticationKey: (key.inner() as Aes256CbcHmacKey).authenticationKey,
     });
   });
 
-  it("toEncoded returns encoded key for AesCbc256_B64", () => {
+  it("toEncoded returns encoded key for Aes256Cbc_B64", () => {
     const key = new SymmetricCryptoKey(makeStaticByteArray(32));
     const actual = key.toEncoded();
 
     expect(actual).toEqual(key.inner().encryptionKey);
   });
 
-  it("toEncoded returns encoded key for AesCbc256_HmacSha256_B64", () => {
+  it("toEncoded returns encoded key for Aes256Cbc_HmacSha256_B64", () => {
     const keyBytes = makeStaticByteArray(64);
     const key = new SymmetricCryptoKey(keyBytes);
     const actual = key.toEncoded();

--- a/libs/common/src/platform/models/domain/symmetric-crypto-key.ts
+++ b/libs/common/src/platform/models/domain/symmetric-crypto-key.ts
@@ -6,13 +6,13 @@ import { Utils } from "../../../platform/misc/utils";
 import { EncryptionType } from "../../enums";
 
 export type Aes256CbcHmacKey = {
-  type: EncryptionType.AesCbc256_HmacSha256_B64;
+  type: EncryptionType.Aes256Cbc_HmacSha256_B64;
   encryptionKey: Uint8Array;
   authenticationKey: Uint8Array;
 };
 
 export type Aes256CbcKey = {
-  type: EncryptionType.AesCbc256_B64;
+  type: EncryptionType.Aes256Cbc_B64;
   encryptionKey: Uint8Array;
 };
 
@@ -36,13 +36,13 @@ export class SymmetricCryptoKey {
 
     if (key.byteLength === 32) {
       this.innerKey = {
-        type: EncryptionType.AesCbc256_B64,
+        type: EncryptionType.Aes256Cbc_B64,
         encryptionKey: key,
       };
       this.keyB64 = this.toBase64();
     } else if (key.byteLength === 64) {
       this.innerKey = {
-        type: EncryptionType.AesCbc256_HmacSha256_B64,
+        type: EncryptionType.Aes256Cbc_HmacSha256_B64,
         encryptionKey: key.slice(0, 32),
         authenticationKey: key.slice(32),
       };
@@ -74,15 +74,15 @@ export class SymmetricCryptoKey {
   /**
    * Serializes the key to a format that can be written to state or shared
    * The currently permitted format is:
-   * - AesCbc256_B64: 32 bytes (the raw key)
-   * - AesCbc256_HmacSha256_B64: 64 bytes (32 bytes encryption key, 32 bytes authentication key, concatenated)
+   * - Aes256Cbc_B64: 32 bytes (the raw key)
+   * - Aes256Cbc_HmacSha256_B64: 64 bytes (32 bytes encryption key, 32 bytes authentication key, concatenated)
    *
    * @returns The serialized key that can be written to state or encrypted and then written to state / shared
    */
   toEncoded(): Uint8Array {
-    if (this.innerKey.type === EncryptionType.AesCbc256_B64) {
+    if (this.innerKey.type === EncryptionType.Aes256Cbc_B64) {
       return this.innerKey.encryptionKey;
-    } else if (this.innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    } else if (this.innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const encodedKey = new Uint8Array(64);
       encodedKey.set(this.innerKey.encryptionKey, 0);
       encodedKey.set(this.innerKey.authenticationKey, 32);

--- a/libs/common/src/platform/services/key-generation.service.spec.ts
+++ b/libs/common/src/platform/services/key-generation.service.spec.ts
@@ -53,7 +53,7 @@ describe("KeyGenerationService", () => {
 
         expect(salt).toEqual(inputSalt);
         expect(material).toEqual(inputMaterial);
-        expect(derivedKey.inner().type).toEqual(EncryptionType.AesCbc256_HmacSha256_B64);
+        expect(derivedKey.inner().type).toEqual(EncryptionType.Aes256Cbc_HmacSha256_B64);
       },
     );
   });
@@ -68,7 +68,7 @@ describe("KeyGenerationService", () => {
 
       const key = await sut.deriveKeyFromMaterial(material, salt, purpose);
 
-      expect(key.inner().type).toEqual(EncryptionType.AesCbc256_HmacSha256_B64);
+      expect(key.inner().type).toEqual(EncryptionType.Aes256Cbc_HmacSha256_B64);
     });
   });
 
@@ -82,7 +82,7 @@ describe("KeyGenerationService", () => {
 
       const key = await sut.deriveKeyFromPassword(password, salt, kdfConfig);
 
-      expect(key.inner().type).toEqual(EncryptionType.AesCbc256_B64);
+      expect(key.inner().type).toEqual(EncryptionType.Aes256Cbc_B64);
     });
 
     it("should derive a 32 byte key from a password using argon2id", async () => {
@@ -95,7 +95,7 @@ describe("KeyGenerationService", () => {
 
       const key = await sut.deriveKeyFromPassword(password, salt, kdfConfig);
 
-      expect(key.inner().type).toEqual(EncryptionType.AesCbc256_B64);
+      expect(key.inner().type).toEqual(EncryptionType.Aes256Cbc_B64);
     });
   });
 });

--- a/libs/common/src/platform/services/key-state/user-key.state.spec.ts
+++ b/libs/common/src/platform/services/key-state/user-key.state.spec.ts
@@ -6,7 +6,7 @@ import { USER_ENCRYPTED_PRIVATE_KEY, USER_EVER_HAD_USER_KEY } from "./user-key.s
 
 function makeEncString(data?: string) {
   data ??= Utils.newGuid();
-  return new EncString(EncryptionType.AesCbc256_HmacSha256_B64, data, "test", "test");
+  return new EncString(EncryptionType.Aes256Cbc_HmacSha256_B64, data, "test", "test");
 }
 
 describe("Ever had user key", () => {

--- a/libs/common/src/platform/services/web-crypto-function.service.ts
+++ b/libs/common/src/platform/services/web-crypto-function.service.ts
@@ -246,13 +246,13 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
     key: SymmetricCryptoKey,
   ): CbcDecryptParameters<string> {
     const innerKey = key.inner();
-    if (innerKey.type === EncryptionType.AesCbc256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_B64) {
       return {
         iv: forge.util.decode64(iv),
         data: forge.util.decode64(data),
         encKey: forge.util.createBuffer(innerKey.encryptionKey).getBytes(),
       } as CbcDecryptParameters<string>;
-    } else if (innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    } else if (innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const macData = forge.util.decode64(iv) + forge.util.decode64(data);
       return {
         iv: forge.util.decode64(iv),

--- a/libs/common/src/vault/models/domain/fido2-credential.spec.ts
+++ b/libs/common/src/vault/models/domain/fido2-credential.spec.ts
@@ -170,5 +170,5 @@ describe("Fido2Credential", () => {
 });
 
 function createEncryptedEncString(s: string): EncString {
-  return new EncString(`${EncryptionType.AesCbc256_HmacSha256_B64}.${s}`);
+  return new EncString(`${EncryptionType.Aes256Cbc_HmacSha256_B64}.${s}`);
 }

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -831,13 +831,13 @@ export class DefaultKeyService implements KeyServiceAbstraction {
   ): Promise<[T, EncString]> {
     let protectedSymKey: EncString;
     const protectingKeyInner = protectingKey.inner();
-    if (protectingKeyInner.type === EncryptionType.AesCbc256_B64) {
+    if (protectingKeyInner.type === EncryptionType.Aes256Cbc_B64) {
       const stretchedEncryptionKey = await this.keyGenerationService.stretchKey(protectingKeyInner);
       protectedSymKey = await this.encryptService.encrypt(
         protectedKey.toEncoded(),
         stretchedEncryptionKey,
       );
-    } else if (protectingKeyInner.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    } else if (protectingKeyInner.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       protectedSymKey = await this.encryptService.encrypt(protectedKey.toEncoded(), protectingKey);
     } else {
       throw new Error("Unsupported key type");

--- a/libs/node/src/services/node-crypto-function.service.ts
+++ b/libs/node/src/services/node-crypto-function.service.ts
@@ -179,13 +179,13 @@ export class NodeCryptoFunctionService implements CryptoFunctionService {
 
     const innerKey = key.inner();
 
-    if (innerKey.type === EncryptionType.AesCbc256_B64) {
+    if (innerKey.type === EncryptionType.Aes256Cbc_B64) {
       return {
         iv: ivBytes,
         data: dataBytes,
         encKey: innerKey.encryptionKey,
       } as CbcDecryptParameters<Uint8Array>;
-    } else if (innerKey.type === EncryptionType.AesCbc256_HmacSha256_B64) {
+    } else if (innerKey.type === EncryptionType.Aes256Cbc_HmacSha256_B64) {
       const macData = new Uint8Array(ivBytes.length + dataBytes.length);
       macData.set(ivBytes, 0);
       macData.set(dataBytes, ivBytes.length);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18697
https://bitwarden.atlassian.net/browse/PM-18772

This is a follow-up PR to:
https://github.com/bitwarden/clients/pull/13578
https://github.com/bitwarden/clients/pull/13598
https://github.com/bitwarden/clients/pull/13599

Corresponding SDK pr: https://github.com/bitwarden/sdk-internal/pull/172

## 📔 Objective

> Currently we use: `Aes256Cbc`, but also `AesCbc256` in the SDK. In the web clients we use `AesCbc256`. In general the former order is more common.
 For instance, TLS defines: `TLS_DHE_RSA_WITH_AES_256_CBC_SHA384`. JWK defines: `AES_128_CBC_HMAC_SHA_256`, SSH defines `aes256-cbc`, COSE defines: `A256CBC`.
This is because the block cipher is: AES-128-Bit / AES-256-Bit, and the mode of operation is `CBC`. Semantically, we are currently splitting up the block cipher used and interjecting the mode of operation in the middle.
This PR renames the instances used in the SDK of `AesCbc256` to be consistent with other standards, and to be consistent within our codebase. There will be a corresponding PR for the web clients (this is in draft until then).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
