### PR TITLE
PM-18522 Adjust Confirmation UI text to accommodate truncating

### DIFF
--- a/apps/browser/src/autofill/content/components/lit-stories/notification/footer.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/notification/footer.lit-stories.ts
@@ -9,6 +9,7 @@ type Args = {
   notificationType: NotificationType;
   theme: Theme;
   handleSaveAction: (e: Event) => void;
+  i18n: { [key: string]: string };
 };
 
 export default {
@@ -23,6 +24,11 @@ export default {
   args: {
     theme: ThemeTypes.Light,
     notificationType: "add",
+    i18n: {
+      saveAsNewLoginAction: "Save as New Login",
+      saveAction: "Save",
+    },
+    handleSaveAction: () => alert("Save action triggered"),
   },
   parameters: {
     design: {

--- a/apps/browser/src/autofill/content/components/lit-stories/rows/button-row.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/rows/button-row.lit-stories.ts
@@ -7,15 +7,18 @@ import { ButtonRow } from "../../rows/button-row";
 type Args = {
   theme: Theme;
   buttonAction: (e: Event) => void;
+  buttonText: string;
 };
 
 export default {
   title: "Components/Rows/Button Row",
   argTypes: {
     theme: { control: "select", options: [...Object.values(ThemeTypes)] },
+    buttonText: { control: "text" },
   },
   args: {
     theme: ThemeTypes.Light,
+    buttonText: "Action",
   },
 } as Meta<Args>;
 

--- a/apps/browser/src/autofill/content/components/notification/confirmation-message.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation-message.ts
@@ -35,7 +35,6 @@ const baseTextStyles = css`
   text-align: left;
   text-overflow: ellipsis;
   line-height: 24px;
-  white-space: nowrap;
   font-family: "DM Sans", sans-serif;
   font-size: 16px;
 `;

--- a/apps/browser/src/autofill/content/components/notification/confirmation.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation.ts
@@ -54,5 +54,4 @@ const notificationConfirmationBodyStyles = ({ theme }: { theme: Theme }) => css`
   justify-content: flex-start;
   background-color: ${themes[theme].background.alt};
   padding: 12px;
-  white-space: nowrap;
 `;

--- a/apps/browser/src/autofill/content/components/notification/container.ts
+++ b/apps/browser/src/autofill/content/components/notification/container.ts
@@ -58,6 +58,7 @@ export function NotificationContainer({
         handleSaveAction,
         theme,
         notificationType: type,
+        i18n,
       })}
     </div>
   `;

--- a/apps/browser/src/autofill/content/components/notification/footer.ts
+++ b/apps/browser/src/autofill/content/components/notification/footer.ts
@@ -15,14 +15,16 @@ export function NotificationFooter({
   handleSaveAction,
   notificationType,
   theme,
+  i18n,
 }: {
   handleSaveAction: (e: Event) => void;
+  i18n: { [key: string]: string };
   notificationType?: NotificationType;
   theme: Theme;
 }) {
   const isChangeNotification = notificationType === NotificationTypes.Change;
-  // @TODO localize
-  const saveNewItemText = "Save as new login";
+  const saveNewItemText = i18n.saveAsNewLoginAction;
+  const buttonText = i18n.saveAction;
 
   return html`
     <div class=${notificationFooterStyles({ theme })}>
@@ -32,7 +34,7 @@ export function NotificationFooter({
             handleAction: handleSaveAction,
             theme,
           })
-        : ButtonRow({ theme, buttonAction: handleSaveAction })}
+        : ButtonRow({ theme, buttonAction: handleSaveAction, buttonText })}
     </div>
   `;
 }

--- a/apps/browser/src/autofill/content/components/rows/button-row.ts
+++ b/apps/browser/src/autofill/content/components/rows/button-row.ts
@@ -15,7 +15,7 @@ export function ButtonRow({
 }: {
   theme: Theme;
   buttonAction: (e: Event) => void;
-  buttonText?: string;
+  buttonText: string;
 }) {
   return html`
     <div class=${buttonRowStyles}>

--- a/apps/browser/src/autofill/content/components/rows/button-row.ts
+++ b/apps/browser/src/autofill/content/components/rows/button-row.ts
@@ -11,16 +11,18 @@ import { DropdownMenu } from "../dropdown-menu";
 export function ButtonRow({
   theme,
   buttonAction,
+  buttonText,
 }: {
   theme: Theme;
   buttonAction: (e: Event) => void;
+  buttonText?: string;
 }) {
   return html`
     <div class=${buttonRowStyles}>
       ${[
         ActionButton({
           buttonAction: buttonAction,
-          buttonText: "Action Button",
+          buttonText,
           theme,
         }),
         DropdownContainer({


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18522
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adjust styling on confirmation UI to no longer truncate full string when a user name is too long, but still truncate the username 

Additional clean up: Added action button text and localized save as new login 

## 📸 Screenshots

![Screenshot 2025-02-28 at 11 34 43 AM](https://github.com/user-attachments/assets/f62e4717-6167-4c57-8d09-40971ec31862)
![Screenshot 2025-02-28 at 11 32 26 AM](https://github.com/user-attachments/assets/acfa5b76-90e5-4d6d-8a29-d84543affa2f)
![Screenshot 2025-02-28 at 11 31 46 AM](https://github.com/user-attachments/assets/300dacad-7fb3-49d6-8397-0088affb43a1)
![Screenshot 2025-02-28 at 1 34 10 PM](https://github.com/user-attachments/assets/4ae9092d-c74f-4fcc-9b93-1424d204b94c)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
