### PR TITLE
[PM-18620] Skip listening to flag changes during login

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -73,7 +73,7 @@ export enum LoginUiState {
 export class LoginComponent implements OnInit, OnDestroy {
   @ViewChild("masterPasswordInputRef") masterPasswordInputRef: ElementRef | undefined;
 
-  // HACK: Once we are done listening to unauth ui refresh flag we can get rid of this.
+  // HACK: Once we are done listening to unauth ui refresh flag we can get rid of this https://bitwarden.atlassian.net/browse/PM-9678
   private isLoggingIn = false;
   private destroy$ = new Subject<void>();
   readonly Icons = { WaveIcon, VaultIcon };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18620

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We are briefly showing the old login component right after a user logs in. This is because of some weird emissions from `ConfigService` emanating from transitioning user state during login. This makes the change to ignore those flag values while the user is actively logging in. I think this makes sense as we wouldn't want to just yoink you from one process while another one is going on. 

For what it's worth I did try doing this with a `skipWhile` but it is false apparently when the emission happens and changes sometime later. 

An alternative fix here is to place a `debounceTime(50)` above the `tap` and essentially just ignore many quick emissions and only navigate them on a "stable" new flag value.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before

https://github.com/user-attachments/assets/8bd19e7a-64e2-4c62-a736-24ba5818e84f

After


https://github.com/user-attachments/assets/1e0402f4-cbf2-4222-bca7-86e30b83efec

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
