### PR TITLE
[PM-16610] - Desktop  - collapse nested collection initially

### DIFF
--- a/libs/angular/src/vault/vault-filter/components/collection-filter.component.ts
+++ b/libs/angular/src/vault/vault-filter/components/collection-filter.component.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, EventEmitter, Input, Output } from "@angular/core";
+import { Directive, EventEmitter, Input, OnInit, Output } from "@angular/core";
 
 import { CollectionView } from "@bitwarden/admin-console/common";
 import { ITreeNodeObject } from "@bitwarden/common/vault/models/domain/tree-node";
@@ -10,7 +10,7 @@ import { TopLevelTreeNode } from "../models/top-level-tree-node.model";
 import { VaultFilter } from "../models/vault-filter.model";
 
 @Directive()
-export class CollectionFilterComponent {
+export class CollectionFilterComponent implements OnInit {
   @Input() hide = false;
   @Input() collapsedFilterNodes: Set<string>;
   @Input() collectionNodes: DynamicTreeNode<CollectionView>;
@@ -50,5 +50,14 @@ export class CollectionFilterComponent {
 
   async toggleCollapse(node: ITreeNodeObject) {
     this.onNodeCollapseStateChange.emit(node);
+  }
+
+  ngOnInit() {
+    // Populate the set with all node IDs so all nodes are collapsed initially.
+    if (this.collectionNodes?.fullList) {
+      this.collectionNodes.fullList.forEach((node) => {
+        this.collapsedFilterNodes.add(node.id);
+      });
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[All Collections opening on vault timeout - MacOS](https://bitwarden.atlassian.net/browse/PM-16610)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR sets all the collections in the collections filter as collapsed on initialization.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/6e74b620-2c74-49d1-bc55-c977b3908a83




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
