### PR TITLE
[PM-18869][defect] - browser - vault list not updating after favorite/unfavorite

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -174,7 +174,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     this.cipherService
       .failedToDecryptCiphers$(activeUserId)
       .pipe(
-        map((ciphers) => ciphers.filter((c) => !c.isDeleted)),
+        map((ciphers) => (ciphers ? ciphers.filter((c) => !c.isDeleted) : [])),
         filter((ciphers) => ciphers.length > 0),
         take(1),
         takeUntilDestroyed(this.destroyRef),

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -107,7 +107,7 @@ export class VaultPopupItemsService {
             this.cipherService.failedToDecryptCiphers$(userId),
           ]),
         ),
-        map(([ciphers, failedToDecryptCiphers]) => [...failedToDecryptCiphers, ...ciphers]),
+        map(([ciphers, failedToDecryptCiphers]) => [...(failedToDecryptCiphers || []), ...ciphers]),
       ),
     ),
     shareReplay({ refCount: true, bufferSize: 1 }),

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -13,7 +13,6 @@ import {
   startWith,
   switchMap,
   take,
-  tap,
 } from "rxjs";
 
 import { CollectionService, CollectionView } from "@bitwarden/admin-console/common";
@@ -358,10 +357,10 @@ export class VaultPopupListFiltersService {
     switchMap((userId) => {
       // Observable of cipher views
       const cipherViews$ = this.cipherService.cipherViews$(userId).pipe(
-        tap((cipherViews) => {
-          this.cipherViews = Object.values(cipherViews);
+        map((ciphers) => {
+          this.cipherViews = ciphers ? Object.values(ciphers) : [];
+          return this.cipherViews;
         }),
-        map((ciphers) => Object.values(ciphers)),
       );
 
       return combineLatest([

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -31,7 +31,7 @@ export abstract class CipherService implements UserKeyRotationDataProvider<Ciphe
    *
    * An empty array indicates that all ciphers were successfully decrypted.
    */
-  abstract failedToDecryptCiphers$(userId: UserId): Observable<CipherView[]>;
+  abstract failedToDecryptCiphers$(userId: UserId): Observable<CipherView[] | null>;
   abstract clearCache(userId: UserId): Promise<void>;
   abstract encrypt(
     model: CipherView,

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -148,7 +148,7 @@ export class CipherService implements CipherServiceAbstraction {
    *
    * An empty array indicates that all ciphers were successfully decrypted.
    */
-  failedToDecryptCiphers$(userId: UserId): Observable<CipherView[]> {
+  failedToDecryptCiphers$(userId: UserId): Observable<CipherView[] | null> {
     return this.failedToDecryptCiphersState(userId).state$.pipe(
       filter((ciphers) => ciphers != null),
       switchMap((ciphers) => merge(this.forceCipherViews$, of(ciphers))),

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -148,7 +148,7 @@ export class CipherService implements CipherServiceAbstraction {
    *
    * An empty array indicates that all ciphers were successfully decrypted.
    */
-  failedToDecryptCiphers$(userId: UserId): Observable<CipherView[] | null> {
+  failedToDecryptCiphers$(userId: UserId): Observable<CipherView[]> {
     return this.failedToDecryptCiphersState(userId).state$.pipe(
       filter((ciphers) => ciphers != null),
       switchMap((ciphers) => merge(this.forceCipherViews$, of(ciphers))),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18869

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where the vault list wasn't updating after favoring/unfavoriting an item. This was due a few places attempting to call `cipherService.cipherViews$` when it was `null`. Accounting for this fixed the issue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## Before
https://github.com/user-attachments/assets/f3932154-7eed-49a4-8cef-ca7cfd587345


## After
https://github.com/user-attachments/assets/55a39f20-3c07-4d2b-9294-1355dce831a0



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
