### PR TITLE
[PM-12557] - center align custom field buttons

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -87,7 +87,7 @@
           (click)="openAddEditCustomFieldDialog({ index: i, label: field.value.name })"
           [appA11yTitle]="'editFieldLabel' | i18n: field.value.name"
           bitIconButton="bwi-pencil-square"
-          class="tw-self-end"
+          class="tw-self-center tw-mt-1"
           data-testid="edit-custom-field-button"
           *ngIf="!isPartialEdit"
         ></button>
@@ -95,7 +95,7 @@
         <button
           type="button"
           bitIconButton="bwi-hamburger"
-          class="tw-self-end"
+          class="tw-self-center tw-mt-1"
           cdkDragHandle
           [appA11yTitle]="'reorderToggleButton' | i18n: field.value.name"
           (keydown)="handleKeyDown($event, field.value.name, i)"

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -87,7 +87,7 @@
           (click)="openAddEditCustomFieldDialog({ index: i, label: field.value.name })"
           [appA11yTitle]="'editFieldLabel' | i18n: field.value.name"
           bitIconButton="bwi-pencil-square"
-          class="tw-self-center tw-mt-1"
+          class="tw-self-center tw-mt-2"
           data-testid="edit-custom-field-button"
           *ngIf="!isPartialEdit"
         ></button>
@@ -95,7 +95,7 @@
         <button
           type="button"
           bitIconButton="bwi-hamburger"
-          class="tw-self-center tw-mt-1"
+          class="tw-self-center tw-mt-2"
           cdkDragHandle
           [appA11yTitle]="'reorderToggleButton' | i18n: field.value.name"
           (keydown)="handleKeyDown($event, field.value.name, i)"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12557


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR center aligns the custom field buttons with the input

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2025-03-03 at 3 31 17 PM](https://github.com/user-attachments/assets/d0a949c0-b920-4de4-a29e-05b3540eb10e)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
