### PR TITLE
[PM-15391] - Autofill suggestions margin when no items appear is too large

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -6,6 +6,7 @@
   (onRefresh)="refreshCurrentTab()"
   [description]="(showEmptyAutofillTip$ | async) ? ('autofillSuggestionsTip' | i18n) : null"
   showAutofillButton
+  [disableDescriptionMargin]="showEmptyAutofillTip$ | async"
   [primaryActionAutofill]="clickItemsToAutofillVaultView"
   [groupByType]="groupByType()"
 ></app-vault-list-items-container>

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -70,7 +70,12 @@
 </ng-template>
 
 <ng-template #descriptionText>
-  <div *ngIf="description" class="tw-text-muted tw-px-1 tw-mb-2" bitTypography="body2">
+  <div
+    *ngIf="description"
+    class="tw-text-muted tw-px-1 tw-mb-2"
+    [ngClass]="{ '!tw-mb-0': disableDescriptionMargin }"
+    bitTypography="body2"
+  >
     {{ description }}
   </div>
 </ng-template>

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -246,6 +246,12 @@ export class VaultListItemsContainerComponent implements OnInit, AfterViewInit {
   disableSectionMargin: boolean = false;
 
   /**
+   * Remove the description margin
+   */
+  @Input({ transform: booleanAttribute })
+  disableDescriptionMargin: boolean = false;
+
+  /**
    * The tooltip text for the organization icon for ciphers that belong to an organization.
    * @param cipher
    */


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15391

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes some extra bottom margin from the vault list items description when it's displaying an empty autofill list. This ensures consistent spacing between the sections.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|![Screenshot 2025-03-04 at 3 16 45 PM](https://github.com/user-attachments/assets/ddaded91-cae9-45d9-9611-5a6e6efbdbf8)|![Screenshot 2025-03-04 at 3 16 28 PM](https://github.com/user-attachments/assets/09c2a4de-eb2a-45f2-92e0-ca1e8ef80a7c)|

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
