### PR TITLE
[PM-12699] - increase size of password history dialog

### DIFF
--- a/apps/web/src/app/vault/individual-vault/password-history.component.html
+++ b/apps/web/src/app/vault/individual-vault/password-history.component.html
@@ -1,4 +1,4 @@
-<bit-dialog dialogSize="small" background="alt">
+<bit-dialog background="alt">
   <span bitDialogTitle>
     {{ "passwordHistory" | i18n }}
   </span>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12699

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR increases the size of the password history dialog to the default size as per design.

## 📸 Screenshots


![Screenshot 2025-03-04 at 4 51 36 PM](https://github.com/user-attachments/assets/6a964409-c797-4ae8-a369-fff21b78e136)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
