### PR TITLE
[PM-18859] Mobile Viewports - Extension Prompt

### DIFF
--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.spec.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.spec.ts
@@ -87,6 +87,15 @@ describe("BrowserExtensionPromptComponent", () => {
       const mobileText = fixture.debugElement.query(By.css("p")).nativeElement;
       expect(mobileText.textContent.trim()).toBe("reopenLinkOnDesktop");
     });
+
+    it("sets min-width on the body", () => {
+      expect(document.body.style.minWidth).toBe("auto");
+    });
+
+    it("removes min-width on destroy", () => {
+      fixture.destroy();
+      expect(document.body.style.minWidth).toBe("");
+    });
   });
 
   describe("manual error state", () => {

--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.ts
@@ -1,5 +1,5 @@
-import { CommonModule } from "@angular/common";
-import { Component, OnInit } from "@angular/core";
+import { CommonModule, DOCUMENT } from "@angular/common";
+import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
 
 import { ButtonComponent, IconModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -16,7 +16,7 @@ import {
   standalone: true,
   imports: [CommonModule, I18nPipe, ButtonComponent, IconModule],
 })
-export class BrowserExtensionPromptComponent implements OnInit {
+export class BrowserExtensionPromptComponent implements OnInit, OnDestroy {
   /** Current state of the prompt page */
   protected pageState$ = this.browserExtensionPromptService.pageState$;
 
@@ -25,10 +25,24 @@ export class BrowserExtensionPromptComponent implements OnInit {
 
   protected BitwardenIcon = VaultIcons.BitwardenIcon;
 
-  constructor(private browserExtensionPromptService: BrowserExtensionPromptService) {}
+  constructor(
+    private browserExtensionPromptService: BrowserExtensionPromptService,
+    @Inject(DOCUMENT) private document: Document,
+  ) {}
 
   ngOnInit(): void {
     this.browserExtensionPromptService.start();
+
+    // It is not be uncommon for users to hit this page from a mobile device.
+    // There are global styles that set a min-width on the body which cause
+    // the page to render poorly. Remove them here.
+    // https://github.com/bitwarden/clients/blob/main/apps/web/src/scss/base.scss#L6
+    this.document.body.style.minWidth = "auto";
+  }
+
+  ngOnDestroy(): void {
+    // Reset the body min-width when the component is destroyed
+    this.document.body.style.minWidth = "";
   }
 
   openExtension(): void {

--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.ts
@@ -25,6 +25,9 @@ export class BrowserExtensionPromptComponent implements OnInit, OnDestroy {
 
   protected BitwardenIcon = VaultIcons.BitwardenIcon;
 
+  /** Content of the meta[name="viewport"] element */
+  private viewportContent: string | null = null;
+
   constructor(
     private browserExtensionPromptService: BrowserExtensionPromptService,
     @Inject(DOCUMENT) private document: Document,
@@ -34,15 +37,27 @@ export class BrowserExtensionPromptComponent implements OnInit, OnDestroy {
     this.browserExtensionPromptService.start();
 
     // It is not be uncommon for users to hit this page from a mobile device.
-    // There are global styles that set a min-width on the body which cause
-    // the page to render poorly. Remove them here.
+    // There are global styles and the viewport meta tag that set a min-width
+    // for the page which cause it to render poorly. Remove them here.
     // https://github.com/bitwarden/clients/blob/main/apps/web/src/scss/base.scss#L6
     this.document.body.style.minWidth = "auto";
+
+    const viewportMeta = this.document.querySelector('meta[name="viewport"]');
+
+    // Save the current viewport content to reset it when the component is destroyed
+    this.viewportContent = viewportMeta?.getAttribute("content") ?? null;
+    viewportMeta?.setAttribute("content", "width=device-width, initial-scale=1.0");
   }
 
   ngOnDestroy(): void {
     // Reset the body min-width when the component is destroyed
     this.document.body.style.minWidth = "";
+
+    if (this.viewportContent !== null) {
+      this.document
+        .querySelector('meta[name="viewport"]')
+        ?.setAttribute("content", this.viewportContent);
+    }
   }
 
   openExtension(): void {

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -17,7 +17,7 @@
     class="tw-text-center tw-mb-4 sm:tw-mb-6"
     [ngClass]="{ 'tw-max-w-md tw-mx-auto': titleAreaMaxWidth === 'md' }"
   >
-    <div class="tw-inline md:tw-block tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32">
+    <div class="tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32">
       <bit-icon [icon]="icon"></bit-icon>
     </div>
 

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -17,7 +17,7 @@
     class="tw-text-center tw-mb-4 sm:tw-mb-6"
     [ngClass]="{ 'tw-max-w-md tw-mx-auto': titleAreaMaxWidth === 'md' }"
   >
-    <div class="tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32 [&>svg]:tw-max-w-full">
+    <div class="tw-inline md:tw-block tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32">
       <bit-icon [icon]="icon"></bit-icon>
     </div>
 

--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
+++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
@@ -17,7 +17,7 @@
     class="tw-text-center tw-mb-4 sm:tw-mb-6"
     [ngClass]="{ 'tw-max-w-md tw-mx-auto': titleAreaMaxWidth === 'md' }"
   >
-    <div class="tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32">
+    <div class="tw-mx-auto tw-max-w-24 sm:tw-max-w-28 md:tw-max-w-32 [&>svg]:tw-max-w-full">
       <bit-icon [icon]="icon"></bit-icon>
     </div>
 

--- a/libs/vault/src/icons/browser-extension.ts
+++ b/libs/vault/src/icons/browser-extension.ts
@@ -1,7 +1,7 @@
 import { svgIcon } from "@bitwarden/components";
 
 export const BrowserExtensionIcon = svgIcon`
-<svg width="115" height="114" viewBox="0 0 115 114" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="tw-max-w-full" width="115" height="114" viewBox="0 0 115 114" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect class="tw-stroke-art-primary" width="107.16" height="70.68" rx="10" transform="matrix(-1 0 0 1 111.08 21.66)" stroke-width="4"/>
   <rect class="tw-stroke-art-accent" x="77.88" y="36.91" width="24.79" height="33.34" rx="5" stroke-width="2"/>
   <rect class="tw-fill-art-primary" x="97.97" y="25.65" width="5.7" height="5.7" rx="2" />


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18859](https://bitwarden.atlassian.net/browse/PM-18859)

## 📔 Objective

Present the `/browser-extension-prompt` page in a mobile friendly fashion.
- The original issue that was called out by Kyra is caused by global styles/configuration set to not let the width of the page go below `1010px`.
  - Editing this globally would be a huge undertaking across teams and be a large impact to QA to start allowing for mobile/tablet viewports.
  - [Min-width set on the body](https://github.com/bitwarden/clients/blob/f95ce4e44253d7f724cae8cb580016d24755c091/apps/web/src/scss/base.scss#L6)
  - [viewport meta](https://github.com/bitwarden/clients/blob/5e3830fb5140052aaffbf5af345f80550ae0c211/apps/web/src/index.html#L5)
- To provide a better experience for this individual page, those values out/removed and then replaced when the component is destroyed. 

## 📸 Screenshots

@sukhleenb @danielleflinn The oddity with only implementing the fix for this page is that while routing/loading occurs the page is not mobile friendly and "shifts" into view. Not a huge impact, but I thought it was worth calling out!

<video src="https://github.com/user-attachments/assets/a813c62b-ebe4-4d8c-8647-c24556c6eb43" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18859]: https://bitwarden.atlassian.net/browse/PM-18859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ