### PR TITLE
[PM-12726] - [Defect] [Web] "Secure Note" shows in item filters instead of "Note"

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -243,7 +243,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
       },
       {
         id: "note",
-        name: this.i18nService.t("typeSecureNote"),
+        name: this.i18nService.t("note"),
         type: CipherType.SecureNote,
         icon: "bwi-sticky-note",
       },

--- a/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
+++ b/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
@@ -3,12 +3,12 @@
     <h2 bitTypography="h6">{{ "itemHistory" | i18n }}</h2>
   </bit-section-header>
   <bit-card>
-    <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-none">
+    <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-all">
       <span class="tw-font-bold">{{ "lastEdited" | i18n }}:</span>
       {{ cipher.revisionDate | date: "medium" }}
     </p>
     <p
-      class="tw-text-xs tw-text-muted tw-select-none"
+      class="tw-text-xs tw-text-muted tw-select-all"
       [ngClass]="{
         'tw-mb-1 ': cipher.hasPasswordHistory,
         'tw-mb-0': !cipher.hasPasswordHistory,
@@ -19,7 +19,7 @@
     </p>
     <p
       *ngIf="cipher.passwordRevisionDisplayDate"
-      class="tw-text-xs tw-text-muted tw-select-none"
+      class="tw-text-xs tw-text-muted tw-select-all"
       [ngClass]="{ 'tw-mb-3': cipher.hasPasswordHistory }"
     >
       <span class="tw-font-bold">{{ "datePasswordUpdated" | i18n }}:</span>

--- a/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
+++ b/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
@@ -3,12 +3,12 @@
     <h2 bitTypography="h6">{{ "itemHistory" | i18n }}</h2>
   </bit-section-header>
   <bit-card>
-    <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-all">
+    <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-none">
       <span class="tw-font-bold">{{ "lastEdited" | i18n }}:</span>
       {{ cipher.revisionDate | date: "medium" }}
     </p>
     <p
-      class="tw-text-xs tw-text-muted tw-select-all"
+      class="tw-text-xs tw-text-muted tw-select-none"
       [ngClass]="{
         'tw-mb-1 ': cipher.hasPasswordHistory,
         'tw-mb-0': !cipher.hasPasswordHistory,
@@ -19,7 +19,7 @@
     </p>
     <p
       *ngIf="cipher.passwordRevisionDisplayDate"
-      class="tw-text-xs tw-text-muted tw-select-all"
+      class="tw-text-xs tw-text-muted tw-select-none"
       [ngClass]="{ 'tw-mb-3': cipher.hasPasswordHistory }"
     >
       <span class="tw-font-bold">{{ "datePasswordUpdated" | i18n }}:</span>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-12726

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2025-03-05 at 1 05 13 PM](https://github.com/user-attachments/assets/9389e8ed-b06a-43f7-a86a-7c01ba9ad694)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
