### PR TITLE
[CL-281] Override tailwind text-3xl style

### DIFF
--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -141,6 +141,9 @@ module.exports = {
         ...theme("width"),
         "90vw": "90vw",
       }),
+      fontSize: {
+        "3xl": ["28px", "32px"],
+      },
     },
   },
   plugins: [

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -142,7 +142,7 @@ module.exports = {
         "90vw": "90vw",
       }),
       fontSize: {
-        "3xl": ["28px", "32px"],
+        "3xl": ["1.75rem", "2rem"],
       },
     },
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-281](https://bitwarden.atlassian.net/browse/CL-281)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We are overriding the `text-3xl` tailwind style to have: `font-size: 1.75rem; line-height: 2rem;`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="242" alt="Screenshot 2025-03-06 at 8 40 40 AM" src="https://github.com/user-attachments/assets/39510f9e-c20c-4a85-90dc-7ad36a78c171" />




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-281]: https://bitwarden.atlassian.net/browse/CL-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ