### PR TITLE
Auth/PM-18901 - UI Refresh - Extension Duo 2FA - fix determineDuoLaunchAction to consider if already in popout

### DIFF
--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.spec.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.spec.ts
@@ -15,6 +15,7 @@ jest.mock("../popup/utils/auth-popout-window", () => {
 
 jest.mock("../../platform/popup/browser-popup-utils", () => ({
   inSingleActionPopout: jest.fn(),
+  inPopout: jest.fn(),
 }));
 
 import { DuoLaunchAction } from "@bitwarden/auth/angular";
@@ -173,6 +174,8 @@ describe("ExtensionTwoFactorAuthComponentService", () => {
         return key === AuthPopoutType.twoFactorAuthDuo;
       });
 
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockImplementation(() => false);
+
       expect(extensionTwoFactorAuthComponentService.determineDuoLaunchAction()).toBe(
         DuoLaunchAction.DIRECT_LAUNCH,
       );
@@ -180,9 +183,19 @@ describe("ExtensionTwoFactorAuthComponentService", () => {
 
     it("should return SINGLE_ACTION_POPOUT if not in two factor auth duo popout", () => {
       jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockImplementation(() => false);
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockImplementation(() => false);
 
       expect(extensionTwoFactorAuthComponentService.determineDuoLaunchAction()).toBe(
         DuoLaunchAction.SINGLE_ACTION_POPOUT,
+      );
+    });
+
+    it("should return DIRECT_LAUNCH if in popout", () => {
+      jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockImplementation(() => false);
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockImplementation(() => true);
+
+      expect(extensionTwoFactorAuthComponentService.determineDuoLaunchAction()).toBe(
+        DuoLaunchAction.DIRECT_LAUNCH,
       );
     });
   });

--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
@@ -106,7 +106,9 @@ export class ExtensionTwoFactorAuthComponentService
       AuthPopoutType.twoFactorAuthDuo,
     );
 
-    if (inTwoFactorAuthDuoPopout) {
+    const inPopout = BrowserPopupUtils.inPopout(this.window);
+
+    if (inTwoFactorAuthDuoPopout || inPopout) {
       return DuoLaunchAction.DIRECT_LAUNCH;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18901

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
For the new extension 2FA duo flow, update `determineDuoLaunchAction` to consider if the extension is already in the popout mode.

## 📸 Screenshots

https://github.com/user-attachments/assets/e3bd9d83-0d1a-45b0-b501-e6dc93a13a3d


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
