### PR TITLE
[PM-18946] Improve Vault loading experience

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -967,7 +967,7 @@ describe("OverlayBackground", () => {
             icon: {
               fallbackImage: "",
               icon: "bwi-credit-card",
-              image: undefined,
+              image: null,
               imageEnabled: true,
             },
             id: "inline-menu-cipher-0",
@@ -1005,7 +1005,7 @@ describe("OverlayBackground", () => {
               icon: {
                 fallbackImage: "",
                 icon: "bwi-id-card",
-                image: undefined,
+                image: null,
                 imageEnabled: true,
               },
               id: "inline-menu-cipher-1",
@@ -1046,7 +1046,7 @@ describe("OverlayBackground", () => {
               icon: {
                 fallbackImage: "",
                 icon: "bwi-id-card",
-                image: undefined,
+                image: null,
                 imageEnabled: true,
               },
               id: "inline-menu-cipher-0",
@@ -1118,7 +1118,7 @@ describe("OverlayBackground", () => {
               icon: {
                 fallbackImage: "",
                 icon: "bwi-id-card",
-                image: undefined,
+                image: null,
                 imageEnabled: true,
               },
               id: "inline-menu-cipher-1",

--- a/apps/browser/src/autofill/deprecated/background/overlay.background.deprecated.spec.ts
+++ b/apps/browser/src/autofill/deprecated/background/overlay.background.deprecated.spec.ts
@@ -355,7 +355,7 @@ describe("OverlayBackground", () => {
           icon: {
             fallbackImage: "",
             icon: "bwi-credit-card",
-            image: undefined,
+            image: null,
             imageEnabled: true,
           },
           id: "overlay-cipher-2",
@@ -370,7 +370,7 @@ describe("OverlayBackground", () => {
           icon: {
             fallbackImage: "",
             icon: "bwi-credit-card",
-            image: undefined,
+            image: null,
             imageEnabled: true,
           },
           id: "overlay-cipher-3",

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -28,10 +28,7 @@
   ></blocked-injection-banner>
 
   <!-- Show search & filters outside of the scroll area of the page -->
-  <ng-container
-    slot="above-scroll-area"
-    *ngIf="vaultState !== VaultStateEnum.Empty && !(loading$ | async)"
-  >
+  <ng-container slot="above-scroll-area" *ngIf="vaultState !== VaultStateEnum.Empty">
     <vault-at-risk-password-callout
       *appIfFeature="FeatureFlag.SecurityTasks"
     ></vault-at-risk-password-callout>

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -2,7 +2,6 @@ import { CdkVirtualScrollableElement, ScrollingModule } from "@angular/cdk/scrol
 import { CommonModule } from "@angular/common";
 import { AfterViewInit, Component, DestroyRef, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { RouterLink } from "@angular/router";
 import {
   combineLatest,
   filter,
@@ -12,6 +11,7 @@ import {
   shareReplay,
   switchMap,
   take,
+  startWith,
 } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -22,13 +22,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
-import {
-  BannerComponent,
-  ButtonModule,
-  DialogService,
-  Icons,
-  NoItemsModule,
-} from "@bitwarden/components";
+import { ButtonModule, DialogService, Icons, NoItemsModule } from "@bitwarden/components";
 import { DecryptionFailureDialogComponent, VaultIcons } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../../auth/popup/account-switching/current-account.component";
@@ -73,12 +67,9 @@ enum VaultState {
     AutofillVaultListItemsComponent,
     VaultListItemsContainerComponent,
     ButtonModule,
-    RouterLink,
     NewItemDropdownV2Component,
     ScrollingModule,
     VaultHeaderV2Component,
-    DecryptionFailureDialogComponent,
-    BannerComponent,
     AtRiskPasswordCalloutComponent,
     NewSettingsCalloutComponent,
   ],
@@ -96,6 +87,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   protected loading$ = combineLatest([this.vaultPopupItemsService.loading$, this.allFilters$]).pipe(
     map(([itemsLoading, filters]) => itemsLoading || !filters),
     shareReplay({ bufferSize: 1, refCount: true }),
+    startWith(true),
   );
 
   protected newItemItemValues$: Observable<NewItemInitialValues> =

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -15,7 +15,6 @@ import {
 } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -29,6 +28,7 @@ import { CurrentAccountComponent } from "../../../../auth/popup/account-switchin
 import { PopOutComponent } from "../../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
+import { VaultPopupCopyButtonsService } from "../../services/vault-popup-copy-buttons.service";
 import { VaultPopupItemsService } from "../../services/vault-popup-items.service";
 import { VaultPopupListFiltersService } from "../../services/vault-popup-list-filters.service";
 import { VaultPopupScrollPositionService } from "../../services/vault-popup-scroll-position.service";
@@ -84,7 +84,12 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   protected remainingCiphers$ = this.vaultPopupItemsService.remainingCiphers$;
   protected allFilters$ = this.vaultPopupListFiltersService.allFilters$;
 
-  protected loading$ = combineLatest([this.vaultPopupItemsService.loading$, this.allFilters$]).pipe(
+  protected loading$ = combineLatest([
+    this.vaultPopupItemsService.loading$,
+    this.allFilters$,
+    // Added as a dependency to avoid flashing the copyActions on slower devices
+    this.vaultCopyButtonsService.showQuickCopyActions$,
+  ]).pipe(
     map(([itemsLoading, filters]) => itemsLoading || !filters),
     shareReplay({ bufferSize: 1, refCount: true }),
     startWith(true),
@@ -122,8 +127,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     private destroyRef: DestroyRef,
     private cipherService: CipherService,
     private dialogService: DialogService,
-    private vaultProfileService: VaultProfileService,
-    private vaultPageService: VaultPageService,
+    private vaultCopyButtonsService: VaultPopupCopyButtonsService,
   ) {
     combineLatest([
       this.vaultPopupItemsService.emptyVault$,

--- a/apps/browser/src/vault/popup/services/vault-popup-copy-buttons.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-copy-buttons.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from "@angular/core";
-import { map, Observable } from "rxjs";
+import { map, Observable, shareReplay } from "rxjs";
 
 import {
   GlobalStateProvider,
@@ -31,6 +31,7 @@ export class VaultPopupCopyButtonsService {
 
   showQuickCopyActions$: Observable<boolean> = this.displayMode$.pipe(
     map((displayMode) => displayMode === "quick"),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
   async setShowQuickCopyActions(value: boolean) {

--- a/apps/web/src/app/vault/components/vault-items/vault-items.stories.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.stories.ts
@@ -17,7 +17,10 @@ import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.servic
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import {
+  Environment,
+  EnvironmentService,
+} from "@bitwarden/common/platform/abstractions/environment.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -53,6 +56,11 @@ export default {
             getIconsUrl() {
               return "";
             },
+            environment$: new BehaviorSubject({
+              getIconsUrl() {
+                return "";
+              },
+            } as Environment).asObservable(),
           } as Partial<EnvironmentService>,
         },
         {

--- a/libs/angular/src/vault/components/icon.component.html
+++ b/libs/angular/src/vault/components/icon.component.html
@@ -2,16 +2,18 @@
   <ng-container *ngIf="data$ | async as data">
     <img
       [src]="data.image"
-      [appFallbackSrc]="data.fallbackImage"
       *ngIf="data.imageEnabled && data.image"
       class="tw-size-6 tw-rounded-md"
       alt=""
       decoding="async"
       loading="lazy"
+      [ngClass]="{ 'tw-invisible tw-absolute': !imageLoaded() }"
+      (load)="imageLoaded.set(true)"
+      (error)="imageLoaded.set(false)"
     />
     <i
       class="tw-w-6 tw-text-muted bwi bwi-lg {{ data.icon }}"
-      *ngIf="!data.imageEnabled || !data.image"
+      *ngIf="!data.imageEnabled || !data.image || !imageLoaded()"
     ></i>
   </ng-container>
 </div>

--- a/libs/common/src/vault/icon/build-cipher-icon.spec.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.spec.ts
@@ -89,7 +89,7 @@ describe("buildCipherIcon", () => {
 
       expect(iconDetails).toEqual({
         icon: "bwi-globe",
-        image: undefined,
+        image: null,
         fallbackImage: "",
         imageEnabled: false,
       });
@@ -102,7 +102,7 @@ describe("buildCipherIcon", () => {
 
       expect(iconDetails).toEqual({
         icon: "bwi-globe",
-        image: undefined,
+        image: null,
         fallbackImage: "",
         imageEnabled: true,
       });

--- a/libs/common/src/vault/icon/build-cipher-icon.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.ts
@@ -2,9 +2,20 @@ import { Utils } from "../../platform/misc/utils";
 import { CipherType } from "../enums/cipher-type";
 import { CipherView } from "../models/view/cipher.view";
 
-export function buildCipherIcon(iconsServerUrl: string, cipher: CipherView, showFavicon: boolean) {
-  let icon;
-  let image;
+export interface CipherIconDetails {
+  imageEnabled: boolean;
+  image: string | null;
+  fallbackImage: string;
+  icon: string;
+}
+
+export function buildCipherIcon(
+  iconsServerUrl: string | null,
+  cipher: CipherView,
+  showFavicon: boolean,
+): CipherIconDetails {
+  let icon: string = "bwi-globe";
+  let image: string | null = null;
   let fallbackImage = "";
   const cardIcons: Record<string, string> = {
     Visa: "card-visa",
@@ -17,6 +28,10 @@ export function buildCipherIcon(iconsServerUrl: string, cipher: CipherView, show
     UnionPay: "card-union-pay",
     RuPay: "card-ru-pay",
   };
+
+  if (iconsServerUrl == null) {
+    showFavicon = false;
+  }
 
   switch (cipher.type) {
     case CipherType.Login:
@@ -53,9 +68,7 @@ export function buildCipherIcon(iconsServerUrl: string, cipher: CipherView, show
           try {
             image = `${iconsServerUrl}/${Utils.getHostname(hostnameUri)}/icon.png`;
             fallbackImage = "images/bwi-globe.png";
-            // FIXME: Remove when updating file. Eslint update
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          } catch (e) {
+          } catch {
             // Ignore error since the fallback icon will be shown if image is null.
           }
         }

--- a/libs/common/src/vault/icon/build-cipher-icon.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.ts
@@ -5,6 +5,9 @@ import { CipherView } from "../models/view/cipher.view";
 export interface CipherIconDetails {
   imageEnabled: boolean;
   image: string | null;
+  /**
+   * @deprecated Fallback to `icon` instead which will default to "bwi-globe" if no other icon is applicable.
+   */
   fallbackImage: string;
   icon: string;
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18946](https://bitwarden.atlassian.net/browse/PM-18946)

## 📔 Objective

Improve the vault loading experience in the Browser extension for slower devices that have shown the vault rendering in chunks causing the UI to jump around. See commit messages for each change / reason.

## 📸 Screenshots

> Using Chrome Performance tab to add artificial 20x CPU slowdown.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/25ebd447-98cc-42b1-9e24-f95bc7303c50" /> | <video src="https://github.com/user-attachments/assets/72473b61-f150-402c-a8d9-a7b390c1d126" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18946]: https://bitwarden.atlassian.net/browse/PM-18946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ