### PR TITLE
[PM-15015]  Adding Request Country Name to auth requests approval dialog

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -921,6 +921,9 @@
   "no": {
     "message": "No"
   },
+  "location": {
+    "message": "Location"
+  },
   "unexpectedError": {
     "message": "An unexpected error has occurred."
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -882,7 +882,7 @@
   },
   "useYourRecoveryCode": {
     "message": "Use your recovery code"
-  }, 
+  },
   "insertYubiKey": {
     "message": "Insert your YubiKey into your computer's USB port, then touch its button."
   },
@@ -1012,6 +1012,9 @@
   },
   "no": {
     "message": "No"
+  },
+  "location": {
+    "message": "Location"
   },
   "overwritePassword": {
     "message": "Overwrite password"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1053,6 +1053,9 @@
   "no": {
     "message": "No"
   },
+  "location": {
+    "message": "Location"
+  },
   "loginOrCreateNewAccount": {
     "message": "Log in or create a new account to access your secure vault."
   },

--- a/bitwarden_license/bit-common/src/admin-console/auth-requests/pending-auth-request.view.ts
+++ b/bitwarden_license/bit-common/src/admin-console/auth-requests/pending-auth-request.view.ts
@@ -13,6 +13,7 @@ export class PendingAuthRequestView implements View {
   requestDeviceIdentifier: string;
   requestDeviceType: string;
   requestIpAddress: string;
+  requestCountryName: string;
   creationDate: Date;
 
   static fromResponse(response: PendingOrganizationAuthRequestResponse): PendingAuthRequestView {

--- a/bitwarden_license/bit-common/src/admin-console/auth-requests/pending-organization-auth-request.response.ts
+++ b/bitwarden_license/bit-common/src/admin-console/auth-requests/pending-organization-auth-request.response.ts
@@ -9,6 +9,7 @@ export class PendingOrganizationAuthRequestResponse extends BaseResponse {
   requestDeviceIdentifier: string;
   requestDeviceType: string;
   requestIpAddress: string;
+  requestCountryName: string;
   creationDate: string;
 
   constructor(response: any) {
@@ -21,6 +22,7 @@ export class PendingOrganizationAuthRequestResponse extends BaseResponse {
     this.requestDeviceIdentifier = this.getResponseProperty("RequestDeviceIdentifier");
     this.requestDeviceType = this.getResponseProperty("RequestDeviceType");
     this.requestIpAddress = this.getResponseProperty("RequestIpAddress");
+    this.requestCountryName = this.getResponseProperty("RequestCountryName");
     this.creationDate = this.getResponseProperty("CreationDate");
   }
 }

--- a/libs/auth/src/angular/login-approval/login-approval.component.html
+++ b/libs/auth/src/angular/login-approval/login-approval.component.html
@@ -18,8 +18,11 @@
         <p>{{ authRequestResponse?.requestDeviceType }}</p>
       </div>
       <div>
-        <b>{{ "ipAddress" | i18n }}</b>
-        <p>{{ authRequestResponse?.requestIpAddress }}</p>
+        <b>{{ "location" | i18n }}</b>
+        <p>
+          <span class="tw-capitalize">{{ authRequestResponse?.requestCountryName }} </span>
+          ({{ authRequestResponse?.requestIpAddress }})
+        </p>
       </div>
       <div>
         <b>{{ "time" | i18n }}</b>

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -382,7 +382,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
      * | Standard Flow 1 | unauthed    | "Login with device"              [/login]           | /login-with-device        | yes                                                   |
      * | Standard Flow 2 | unauthed    | "Login with device"              [/login]           | /login-with-device        | no                                                    |
      * | Standard Flow 3 | authed      | "Approve from your other device" [/login-initiated] | /login-with-device        | yes                                                   |
-     * | Standard Flow 4 | authed      | "Approve from your other device" [/login-initiated] | /login-with-device        | no                                                    |                                                |
+     * | Standard Flow 4 | authed      | "Approve from your other device" [/login-initiated] | /login-with-device        | no                                                    |
      * | Admin Flow      | authed      | "Request admin approval"         [/login-initiated] | /admin-approval-requested | NA - admin requests always send encrypted userKey     |
      * |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
      *    * Note 1: The phrase "in memory" here is important. It is possible for a user to have a master password for their account, but not have a masterKey IN MEMORY for

--- a/libs/common/src/auth/models/response/auth-request.response.ts
+++ b/libs/common/src/auth/models/response/auth-request.response.ts
@@ -10,6 +10,7 @@ export class AuthRequestResponse extends BaseResponse {
   requestDeviceTypeValue: DeviceType;
   requestDeviceIdentifier: string;
   requestIpAddress: string;
+  requestCountryName: string;
   key: string; // could be either an encrypted MasterKey or an encrypted UserKey
   masterPasswordHash: string; // if hash is present, the `key` above is an encrypted MasterKey (else `key` is an encrypted UserKey)
   creationDate: string;
@@ -26,6 +27,7 @@ export class AuthRequestResponse extends BaseResponse {
     this.requestDeviceTypeValue = this.getResponseProperty("RequestDeviceTypeValue");
     this.requestDeviceIdentifier = this.getResponseProperty("RequestDeviceIdentifier");
     this.requestIpAddress = this.getResponseProperty("RequestIpAddress");
+    this.requestCountryName = this.getResponseProperty("RequestCountryName");
     this.key = this.getResponseProperty("Key");
     this.masterPasswordHash = this.getResponseProperty("MasterPasswordHash");
     this.creationDate = this.getResponseProperty("CreationDate");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-15015](https://bitwarden.atlassian.net/browse/PM-15015)

[Server PR](https://github.com/bitwarden/server/pull/5471)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We are adding country name from the request header to the `AuthRequest` for better readability for users trying to decide to approve an auth request.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Screen shot from Desktop
![electron_SIvkC4eiCD](https://github.com/user-attachments/assets/3e57e655-40ed-47e6-b399-81b5e5b49cdc)

A screen shot of the desktop dialog.

### Video of Approval

https://github.com/user-attachments/assets/e65c757e-178c-4e83-a501-341b4e02a1ee

User uses web app approvals to allow desktop to login. The login flow is not impacted by the changes as the user is allowed to login to the vault on the desktop after inputting their two-factor authentication code.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15015]: https://bitwarden.atlassian.net/browse/PM-15015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ