### PR TITLE
[PM-18945] Add CLI as valid SSO client

### DIFF
--- a/libs/auth/src/angular/sso/sso-component.service.ts
+++ b/libs/auth/src/angular/sso/sso-component.service.ts
@@ -1,6 +1,10 @@
 import { ClientType } from "@bitwarden/common/enums";
 
-export type SsoClientType = ClientType.Web | ClientType.Browser | ClientType.Desktop;
+export type SsoClientType =
+  | ClientType.Web
+  | ClientType.Browser
+  | ClientType.Desktop
+  | ClientType.Cli;
 
 /**
  * Abstract class for SSO component services.

--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -199,7 +199,9 @@ export class SsoComponent implements OnInit {
    * @returns True if the value is a valid SSO client type, otherwise false
    */
   private isValidSsoClientType(value: string): value is SsoClientType {
-    return [ClientType.Web, ClientType.Browser, ClientType.Desktop].includes(value as ClientType);
+    return [ClientType.Web, ClientType.Browser, ClientType.Desktop, ClientType.Cli].includes(
+      value as ClientType,
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18945

## 📔 Objective

We were not allowing CLI as a valid `ClientType` for SSO.  This was causing `clientId=web` to be passed to the server in the request to `/connect/authorize`, which was rejected for an invalid `redirect_uri`.  The CLI's `localhost` `redirect_uri` is not valid for the web client.

## 📸 Screenshots

https://github.com/user-attachments/assets/218f70a9-c7ce-4fd3-a766-8d1f21a2da5e

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
