### PR TITLE
fix: save indication of browser installation to storage

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -267,6 +267,7 @@ import { OffscreenDocumentService } from "../platform/offscreen-document/abstrac
 import { DefaultOffscreenDocumentService } from "../platform/offscreen-document/offscreen-document.service";
 import { BrowserTaskSchedulerService } from "../platform/services/abstractions/browser-task-scheduler.service";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
+import BrowserInitialInstallService from "../platform/services/browser-initial-install.service";
 import BrowserLocalStorageService from "../platform/services/browser-local-storage.service";
 import BrowserMemoryStorageService from "../platform/services/browser-memory-storage.service";
 import { BrowserScriptInjectorService } from "../platform/services/browser-script-injector.service";
@@ -390,6 +391,7 @@ export default class MainBackground {
   kdfConfigService: KdfConfigService;
   offscreenDocumentService: OffscreenDocumentService;
   syncServiceListener: SyncServiceListener;
+  browserInitialInstallService: BrowserInitialInstallService;
 
   webPushConnectionService: WorkerWebPushConnectionService | UnsupportedWebPushConnectionService;
   themeStateService: DefaultThemeStateService;
@@ -1043,6 +1045,8 @@ export default class MainBackground {
       this.organizationVaultExportService,
     );
 
+    this.browserInitialInstallService = new BrowserInitialInstallService(this.stateProvider);
+
     if (BrowserApi.isManifestVersion(3)) {
       const registration = (self as unknown as { registration: ServiceWorkerRegistration })
         ?.registration;
@@ -1146,6 +1150,7 @@ export default class MainBackground {
       this.accountService,
       lockService,
       this.billingAccountProfileStateService,
+      this.browserInitialInstallService,
     );
     this.nativeMessagingBackground = new NativeMessagingBackground(
       this.keyService,

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -28,6 +28,7 @@ import { LockedVaultPendingNotificationsData } from "../autofill/background/abst
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
 import { BrowserApi } from "../platform/browser/browser-api";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
+import BrowserInitialInstallService from "../platform/services/browser-initial-install.service";
 import { BrowserPlatformUtilsService } from "../platform/services/platform-utils/browser-platform-utils.service";
 
 import MainBackground from "./main.background";
@@ -53,6 +54,7 @@ export default class RuntimeBackground {
     private accountService: AccountService,
     private readonly lockService: LockService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private browserInitialInstallService: BrowserInitialInstallService,
   ) {
     // onInstalled listener must be wired up before anything else, so we do it in the ctor
     chrome.runtime.onInstalled.addListener((details: any) => {
@@ -382,7 +384,10 @@ export default class RuntimeBackground {
       void this.autofillService.loadAutofillScriptsOnInstall();
 
       if (this.onInstalledReason != null) {
-        if (this.onInstalledReason === "install") {
+        if (
+          this.onInstalledReason === "install" &&
+          !(await firstValueFrom(this.browserInitialInstallService.extensionInstalled$))
+        ) {
           if (!devFlagEnabled("skipWelcomeOnInstall")) {
             void BrowserApi.createNewTab("https://bitwarden.com/browser-start/");
           }
@@ -394,6 +399,7 @@ export default class RuntimeBackground {
           if (await this.environmentService.hasManagedEnvironment()) {
             await this.environmentService.setUrlsToManagedEnvironment();
           }
+          await this.browserInitialInstallService.setExtensionInstalled(true);
         }
 
         this.onInstalledReason = null;

--- a/apps/browser/src/platform/services/browser-initial-install.service.ts
+++ b/apps/browser/src/platform/services/browser-initial-install.service.ts
@@ -1,0 +1,31 @@
+import { Observable, map } from "rxjs";
+
+import {
+  GlobalState,
+  EXTENSION_INITIAL_INSTALL_DISK,
+  KeyDefinition,
+  StateProvider,
+} from "@bitwarden/common/platform/state";
+
+const EXTENSION_INSTALLED = new KeyDefinition<boolean>(
+  EXTENSION_INITIAL_INSTALL_DISK,
+  "extensionInstalled",
+  {
+    deserializer: (obj) => obj,
+  },
+);
+
+export default class BrowserInitialInstallService {
+  private extensionInstalled: GlobalState<boolean> =
+    this.stateProvider.getGlobal(EXTENSION_INSTALLED);
+
+  readonly extensionInstalled$: Observable<boolean> = this.extensionInstalled.state$.pipe(
+    map((x) => x ?? false),
+  );
+
+  constructor(private stateProvider: StateProvider) {}
+
+  async setExtensionInstalled(value: boolean) {
+    await this.extensionInstalled.update(() => value);
+  }
+}

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -131,6 +131,10 @@ export const THEMING_DISK = new StateDefinition("theming", "disk", { web: "disk-
 export const TRANSLATION_DISK = new StateDefinition("translation", "disk", { web: "disk-local" });
 export const ANIMATION_DISK = new StateDefinition("animation", "disk");
 export const TASK_SCHEDULER_DISK = new StateDefinition("taskScheduler", "disk");
+export const EXTENSION_INITIAL_INSTALL_DISK = new StateDefinition(
+  "extensionInitialInstall",
+  "disk",
+);
 
 // Design System
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14012
https://github.com/bitwarden/clients/issues/11694

## 📔 Objective

We're still seeing a bunch of unexpected "Getting start" screens for the extension in safari. Currently the reports seem to be scoped to just happening when the application is updated.

It seems like Safari sends an unexpected "install" browser event in update. We hook into the install event for detecting first time installs to show the "Getting started" screen.

To my knowledge there isn't a great way to fix this. What I've done on this PR is implement a simple boolean value in state that is set when the screen is shown the first time. That bit is checked _before_ showing the screen and so when it is true the screen never shows.

There is one limitation, which you can observe in the demos attached: safari profiles. Each profile maintains its own storage, so each profile will inevitably show the "Getting started" screen once. We probably don't want this, but I'm not sure what to do about it right now.

## 📸 Screenshots

**Before change**: every time I rebuild the extension I see the screen

https://github.com/user-attachments/assets/77575454-0009-4be3-b626-5a0bdd1fa5c7

**After change**: the "getting started" screen doesn't show if it has already shown once on a given safari profile (without clearing storage). 

https://github.com/user-attachments/assets/5f41f017-2d54-4b75-9add-91949dd58e7d

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
