### PR TITLE
[PM-18895] Message handlers hoisting

### DIFF
--- a/apps/browser/src/autofill/content/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.ts
@@ -6,20 +6,8 @@ import {
 } from "./abstractions/content-message-handler";
 
 /**
- * IMPORTANT: Safari seems to have a bug where it doesn't properly handle
- * window message events from content scripts when the listener these events
- * is registered within a class. This is why these listeners are registered
- * at the top level of this file.
- */
-window.addEventListener("message", handleWindowMessageEvent, false);
-chrome.runtime.onMessage.addListener(handleExtensionMessage);
-setupExtensionDisconnectAction(() => {
-  window.removeEventListener("message", handleWindowMessageEvent);
-  chrome.runtime.onMessage.removeListener(handleExtensionMessage);
-});
-
-/**
  * Handlers for window messages from the content script.
+ * NOTE: These handlers should be above the event listener to ensure they are defined before being used.
  */
 const windowMessageHandlers: ContentMessageWindowEventHandlers = {
   authResult: ({ data, referrer }: { data: any; referrer: string }) =>
@@ -31,6 +19,19 @@ const windowMessageHandlers: ContentMessageWindowEventHandlers = {
     handleDuoResultMessage(data, referrer),
   [VaultMessages.OpenPopup]: () => handleOpenPopupMessage(),
 };
+
+/**
+ * IMPORTANT: Safari seems to have a bug where it doesn't properly handle
+ * window message events from content scripts when the listener these events
+ * is registered within a class. This is why these listeners are registered
+ * at the top level of this file.
+ */
+window.addEventListener("message", handleWindowMessageEvent, false);
+chrome.runtime.onMessage.addListener(handleExtensionMessage);
+setupExtensionDisconnectAction(() => {
+  window.removeEventListener("message", handleWindowMessageEvent);
+  chrome.runtime.onMessage.removeListener(handleExtensionMessage);
+});
 
 /**
  * Handles the post to the web vault showing the extension has been installed


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18895](https://bitwarden.atlassian.net/browse/PM-18895)

## 📔 Objective

When the extension is first installed or enabled it can occur that events occur before the `windowMessageHandlers` is defined. The variable is hoisted but falls into the temporal dead zone as it is accessed before initialized.
- Moving the `windowMessageHandlers` variable above event listeners solves the issue.

## 📸 Screenshots

Uninitialized error:
<img width="600" alt="Screenshot 2025-03-10 at 2 22 10 PM" src="https://github.com/user-attachments/assets/cb8fa5e4-8eb9-4a5f-8bf0-518323403434" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18895]: https://bitwarden.atlassian.net/browse/PM-18895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ