### PR TITLE
[PM-19082] Ensure the SendType is always set when building a SendFormConfig

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/services/default-send-form-config.service.ts
+++ b/libs/tools/send/send-ui/src/send-form/services/default-send-form-config.service.ts
@@ -34,7 +34,7 @@ export class DefaultSendFormConfigService implements SendFormConfigService {
 
     return {
       mode,
-      sendType: sendType,
+      sendType: send?.type ?? sendType ?? SendType.Text,
       areSendsAllowed,
       originalSend: send,
     };


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19082

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The current buildConfig method on the DefaultSendFormConfigService has an optional sendType and within in edit mode the SendId is passed in, but the SendType might no be passed in, as it’s not required.

This ensures the type is always set, either by passing in the SendType, taken from the loaded Send or falling back to SendType.Text

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
