### PR TITLE
Focus input after toggling visibility. (#12554)

### DIFF
--- a/libs/components/src/form-field/password-input-toggle.directive.ts
+++ b/libs/components/src/form-field/password-input-toggle.directive.ts
@@ -66,6 +66,7 @@ export class BitPasswordInputToggleDirective implements AfterContentInit, OnChan
     if (this.formField.input?.type != null) {
       this.formField.input.type = this.toggled ? "text" : "password";
       this.formField.input.spellcheck = this.toggled ? false : undefined;
+      this.formField.input.focus();
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/12554

## 📔 Objective

Eliminate a very annoying papercut by focusing the form input after toggling the input's visibility.

## 📸 Screenshots

n/a but I will record a video if desired

I understand that #12554 has been closed for internal reasons, however, those reasons were not sufficiently described such that I could address whatever "trade-offs with other side-effects of shifting the focus automatically" as [described in this comment](https://github.com/bitwarden/clients/issues/12554#issuecomment-2704911917).

I am happy to make modifications or write tests if someone could explain the trade-offs!

This is an annoyance I feel every time I need to toggle the visibility of the master password field in bitwarden, and I'd really like to see it fixed. Please let me know how I can help move this fix to regressed behavior forward.