### PR TITLE
[PM-19081] Replace new send button with NewSendDropdown component

### DIFF
--- a/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.html
+++ b/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.html
@@ -1,0 +1,29 @@
+<button
+  bitButton
+  [bitMenuTriggerFor]="itemOptions"
+  buttonType="primary"
+  type="button"
+  class="tw-w-full"
+>
+  <i *ngIf="!hideIcon" class="bwi bwi-plus-f" aria-hidden="true"></i>
+  {{ (hideIcon ? "createSend" : "new") | i18n }}
+</button>
+<bit-menu #itemOptions class="tw-w-full">
+  <a bitMenuItem (click)="createSend(sendType.Text)">
+    <i class="bwi bwi-file-text" slot="start" aria-hidden="true"></i>
+    {{ "sendTypeText" | i18n }}
+  </a>
+  <a bitMenuItem (click)="createSend(sendType.File)">
+    <i class="bwi bwi-file" slot="start" aria-hidden="true"></i>
+    {{ "sendTypeFile" | i18n }}
+    <button
+      type="button"
+      slot="end"
+      *ngIf="!(canAccessPremium$ | async)"
+      bitBadge
+      variant="success"
+    >
+      {{ "premium" | i18n }}
+    </button>
+  </a>
+</bit-menu>

--- a/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.spec.ts
+++ b/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.spec.ts
@@ -1,0 +1,86 @@
+import { CommonModule } from "@angular/common";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { of } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
+import { ButtonModule, MenuModule, BadgeModule } from "@bitwarden/components";
+
+import { NewSendDropdownComponent } from "./new-send-dropdown.component";
+
+describe("NewSendDropdownComponent", () => {
+  let component: NewSendDropdownComponent;
+  let fixture: ComponentFixture<NewSendDropdownComponent>;
+  let accountServiceMock: any;
+  let billingAccountProfileStateServiceMock: any;
+  let messagingServiceMock: any;
+
+  beforeEach(async () => {
+    accountServiceMock = {
+      activeAccount$: of({ id: "test-account-id" }),
+    };
+
+    billingAccountProfileStateServiceMock = {
+      hasPremiumFromAnySource$: jest.fn().mockReturnValue(of(true)),
+    };
+
+    messagingServiceMock = {
+      send: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, JslibModule, ButtonModule, MenuModule, BadgeModule],
+      providers: [
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: AccountService, useValue: accountServiceMock },
+        {
+          provide: BillingAccountProfileStateService,
+          useValue: billingAccountProfileStateServiceMock,
+        },
+        { provide: MessagingService, useValue: messagingServiceMock },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewSendDropdownComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should emit onCreateSendOfType when createSend is called with a valid type", async () => {
+    const sendType = SendType.Text;
+    jest.spyOn(component.onCreateSendOfType, "emit");
+
+    await component.createSend(sendType);
+
+    expect(component.onCreateSendOfType.emit).toHaveBeenCalledWith(sendType);
+  });
+
+  it("should call messagingService.send when createSend is called with SendType.File and no premium access", async () => {
+    billingAccountProfileStateServiceMock.hasPremiumFromAnySource$.mockReturnValue(of(false));
+
+    await component.createSend(SendType.File);
+
+    expect(messagingServiceMock.send).toHaveBeenCalledWith("openPremium");
+  });
+
+  it("should not call messagingService.send when createSend is called with SendType.File and has premium access", async () => {
+    const sendType = SendType.File;
+    jest.spyOn(component.onCreateSendOfType, "emit");
+    billingAccountProfileStateServiceMock.hasPremiumFromAnySource$.mockReturnValue(of(true));
+
+    await component.createSend(sendType);
+
+    expect(messagingServiceMock.send).not.toHaveBeenCalled();
+    expect(component.onCreateSendOfType.emit).toHaveBeenCalledWith(sendType);
+  });
+});

--- a/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.ts
+++ b/apps/desktop/src/app/tools/send/new-send/new-send-dropdown.component.ts
@@ -1,0 +1,61 @@
+import { CommonModule } from "@angular/common";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { firstValueFrom, Observable, of, switchMap } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
+import { BadgeModule, ButtonModule, MenuModule } from "@bitwarden/components";
+
+@Component({
+  selector: "tools-new-send-dropdown",
+  templateUrl: "new-send-dropdown.component.html",
+  standalone: true,
+  imports: [JslibModule, CommonModule, ButtonModule, MenuModule, BadgeModule],
+})
+/**
+ * A dropdown component that allows the user to create a new Send of a specific type.
+ */
+export class NewSendDropdownComponent {
+  /** If true, the plus icon will be hidden */
+  @Input() hideIcon: boolean = false;
+
+  /** SendType provided for the markup to pass back the selected type of Send */
+  protected sendType = SendType;
+
+  /** Indicates whether the user can access premium features. */
+  protected canAccessPremium$: Observable<boolean>;
+
+  /** Emitted when an allowed SendType has been selected. */
+  @Output() onCreateSendOfType = new EventEmitter<SendType>();
+
+  constructor(
+    private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private accountService: AccountService,
+    private messagingService: MessagingService,
+  ) {
+    this.canAccessPremium$ = this.accountService.activeAccount$.pipe(
+      switchMap((account) =>
+        account
+          ? this.billingAccountProfileStateService.hasPremiumFromAnySource$(account.id)
+          : of(false),
+      ),
+    );
+  }
+
+  /**
+   * Emits an event with the user selected SendType, for the hosting control to launch the Add new Send page with the provided SendType.
+   * If has user does not have premium access and the type is File, the user will be redirected to the premium settings page.
+   * @param type The type of Send to create.
+   */
+  async createSend(type: SendType) {
+    if (!(await firstValueFrom(this.canAccessPremium$)) && type === SendType.File) {
+      this.messagingService.send("openPremium");
+      return;
+    }
+
+    this.onCreateSendOfType.emit(type);
+  }
+}

--- a/apps/desktop/src/app/tools/send/send.component.html
+++ b/apps/desktop/src/app/tools/send/send.component.html
@@ -138,7 +138,13 @@
         </ng-container>
       </div>
       <div class="footer">
+        <tools-new-send-dropdown
+          *ngIf="isDesktopSendUIRefreshEnabled$ | async"
+          (onCreateSendOfType)="addSend($event)"
+        >
+        </tools-new-send-dropdown>
         <button
+          *ngIf="!(isDesktopSendUIRefreshEnabled$ | async)"
           type="button"
           (click)="addSend()"
           class="block primary"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3439,6 +3439,12 @@
       }
     }
   },
+  "new": {
+    "message": "New"
+  },
+  "premium": {
+    "message": "Premium"
+  },
   "backTo": {
     "message": "Back to $NAME$",
     "description": "Navigate back to a previous folder or collection",

--- a/apps/desktop/src/scss/buttons.scss
+++ b/apps/desktop/src/scss/buttons.scss
@@ -1,7 +1,7 @@
 @import "variables.scss";
 
 .btn,
-.vault .footer button,
+.vault .footer button:not([bitButton]):not([bitIconButton]),
 .modal-footer button {
   border-radius: $border-radius;
   padding: 7px 15px;


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19081

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This is initial work for a larger Desktop UI refresh, starting with replacing the Add/Edit pages for Send. The old Add page had a dropdown to select a type, this is now incorporated into the NewDropdown button instead of the page.

This work replaces the current add Send button with the NewSendDropdown, when the feature flag is enabled.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/99286688-5942-4262-bc32-ff7b72e3985d) | ![image](https://github.com/user-attachments/assets/090d19f0-6aa8-4cb2-b19d-4433d72f12c5)|

## 🐞 Known issues
- The menu being displayed like this:
![image](https://github.com/user-attachments/assets/a43d5ded-592f-4b3c-bea0-a19551252781)
Is a bug within the CL component (menu/cdk) which will be addressed at a later point.
- Likely also the width of the NewSendDropdown button

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
