### PR TITLE
[PM-19106] View Item Bug, folders not displaying

### DIFF
--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -171,6 +171,10 @@ export class CipherViewComponent implements OnChanges, OnDestroy {
   }
 
   async checkPendingChangePasswordTasks(userId: UserId): Promise<void> {
+    if (!(await firstValueFrom(this.isSecurityTasksEnabled$))) {
+      return;
+    }
+
     const tasks = await firstValueFrom(this.defaultTaskService.pendingTasks$(userId));
 
     this.hadPendingChangePasswordTask = tasks?.some((task) => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19106](https://bitwarden.atlassian.net/browse/PM-19106)

## 📔 Objective

Inside the `cipher-view` the task api endpoint was being called when `security-task` flag was false. 
The returning api error occurs before the folder logic in the `loadCipherData` method, which is why the folders were not showing. 
added a check to the `checkPendingChangePasswordTasks` method to look at the `security-task` flag.

## 📸 Screen Recording

https://github.com/user-attachments/assets/b473612c-a1b9-441e-afd6-489465979aca

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19106]: https://bitwarden.atlassian.net/browse/PM-19106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ