### PR TITLE
[PM-19209] Update New device verification error response expectation

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -159,7 +159,7 @@ export class ApiService implements ApiServiceAbstraction {
    * The message (responseJson.ErrorModel.Message) that comes back from the server when a new device verification is required.
    */
   private static readonly NEW_DEVICE_VERIFICATION_REQUIRED_MESSAGE =
-    "new device verification required";
+    "New device verification required.";
 
   constructor(
     private tokenService: TokenService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19209](https://bitwarden.atlassian.net/browse/PM-19209)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

fix : updating error string for new device response from server.

We are currently using a brittle string comparison to know that we need to accomplish new device verification. The error string response was changed and that was causing an error where a user wasn't given the option to login with a new device, but were just given an error toast.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Web Vault

https://github.com/user-attachments/assets/878e39c3-7ab6-4e70-a58e-68c52f89fe87

### Desktop

https://github.com/user-attachments/assets/b0b95830-ed76-4cdc-a68b-d54de8b2c690

### CLI

https://github.com/user-attachments/assets/05938983-0eaf-43ef-a12b-ed53549803b1

### Browser

https://github.com/user-attachments/assets/5c6a255e-78a9-4f2b-8438-5177783b3247


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19209]: https://bitwarden.atlassian.net/browse/PM-19209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ