### PR TITLE
[PM-18175] Remove two factor recovery feature flag and old recovery flow

### DIFF
--- a/apps/web/src/app/auth/recover-two-factor.component.spec.ts
+++ b/apps/web/src/app/auth/recover-two-factor.component.spec.ts
@@ -9,7 +9,6 @@ import {
 } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AuthResult } from "@bitwarden/common/auth/models/domain/auth-result";
-import { TwoFactorRecoveryRequest } from "@bitwarden/common/auth/models/request/two-factor-recovery.request";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -85,15 +84,14 @@ describe("RecoverTwoFactorComponent", () => {
   describe("handleRecoveryLogin", () => {
     it("should log in successfully and navigate to the two-factor settings page", async () => {
       // Arrange
-      const request = new TwoFactorRecoveryRequest();
-      request.recoveryCode = "testRecoveryCode";
-      request.email = "test@example.com";
+      const email = "test@example.com";
+      const recoveryCode = "testRecoveryCode";
 
       const authResult = new AuthResult();
       mockLoginStrategyService.logIn.mockResolvedValue(authResult);
 
       // Act
-      await component["handleRecoveryLogin"](request);
+      await component["loginWithRecoveryCode"](email, recoveryCode);
 
       // Assert
       expect(mockLoginStrategyService.logIn).toHaveBeenCalledWith(
@@ -112,15 +110,14 @@ describe("RecoverTwoFactorComponent", () => {
 
     it("should handle login errors and redirect to login page", async () => {
       // Arrange
-      const request = new TwoFactorRecoveryRequest();
-      request.recoveryCode = "testRecoveryCode";
-      request.email = "test@example.com";
+      const email = "test@example.com";
+      const recoveryCode = "testRecoveryCode";
 
       const error = new Error("Login failed");
       mockLoginStrategyService.logIn.mockRejectedValue(error);
 
       // Act
-      await component["handleRecoveryLogin"](request);
+      await component["loginWithRecoveryCode"](email, recoveryCode);
 
       // Assert
       expect(mockLogService.error).toHaveBeenCalledWith(
@@ -128,7 +125,7 @@ describe("RecoverTwoFactorComponent", () => {
         error.message,
       );
       expect(mockRouter.navigate).toHaveBeenCalledWith(["/login"], {
-        queryParams: { email: request.email },
+        queryParams: { email: email },
       });
     });
   });

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup.component.ts
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup.component.ts
@@ -29,7 +29,6 @@ import { TwoFactorProviders } from "@bitwarden/common/auth/services/two-factor.s
 import { AuthResponse } from "@bitwarden/common/auth/types/auth-response";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -85,12 +84,7 @@ export class TwoFactorSetupComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
-    const recoveryCodeLoginFeatureFlagEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.RecoveryCodeLogin,
-    );
-    this.recoveryCodeWarningMessage = recoveryCodeLoginFeatureFlagEnabled
-      ? this.i18nService.t("yourSingleUseRecoveryCode")
-      : this.i18nService.t("twoStepLoginRecoveryWarning");
+    this.recoveryCodeWarningMessage = this.i18nService.t("yourSingleUseRecoveryCode");
 
     for (const key in TwoFactorProviders) {
       // eslint-disable-next-line

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -51,7 +51,6 @@ import { PasswordlessAuthRequest } from "../auth/models/request/passwordless-aut
 import { SecretVerificationRequest } from "../auth/models/request/secret-verification.request";
 import { TwoFactorEmailRequest } from "../auth/models/request/two-factor-email.request";
 import { TwoFactorProviderRequest } from "../auth/models/request/two-factor-provider.request";
-import { TwoFactorRecoveryRequest } from "../auth/models/request/two-factor-recovery.request";
 import { UpdateProfileRequest } from "../auth/models/request/update-profile.request";
 import { UpdateTwoFactorAuthenticatorRequest } from "../auth/models/request/update-two-factor-authenticator.request";
 import { UpdateTwoFactorDuoRequest } from "../auth/models/request/update-two-factor-duo.request";
@@ -344,7 +343,6 @@ export abstract class ApiService {
     organizationId: string,
     request: TwoFactorProviderRequest,
   ) => Promise<TwoFactorProviderResponse>;
-  postTwoFactorRecover: (request: TwoFactorRecoveryRequest) => Promise<any>;
   postTwoFactorEmailSetup: (request: TwoFactorEmailRequest) => Promise<any>;
   postTwoFactorEmail: (request: TwoFactorEmailRequest) => Promise<any>;
   getDeviceVerificationSettings: () => Promise<DeviceVerificationResponse>;

--- a/libs/common/src/auth/models/request/two-factor-recovery.request.ts
+++ b/libs/common/src/auth/models/request/two-factor-recovery.request.ts
@@ -1,8 +1,0 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-import { SecretVerificationRequest } from "./secret-verification.request";
-
-export class TwoFactorRecoveryRequest extends SecretVerificationRequest {
-  recoveryCode: string;
-  email: string;
-}

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -44,7 +44,6 @@ export enum FeatureFlag {
   ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs",
   AccountDeprovisioningBanner = "pm-17120-account-deprovisioning-admin-console-banner",
   PM15179_AddExistingOrgsFromProviderPortal = "pm-15179-add-existing-orgs-from-provider-portal",
-  RecoveryCodeLogin = "pm-17128-recovery-code-login",
   PM12276_BreadcrumbEventLogs = "pm-12276-breadcrumbing-for-business-features",
   PM18794_ProviderPaymentMethod = "pm-18794-provider-payment-method",
 }
@@ -101,7 +100,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ResellerManagedOrgAlert]: FALSE,
   [FeatureFlag.AccountDeprovisioningBanner]: FALSE,
   [FeatureFlag.PM15179_AddExistingOrgsFromProviderPortal]: FALSE,
-  [FeatureFlag.RecoveryCodeLogin]: FALSE,
   [FeatureFlag.PM12276_BreadcrumbEventLogs]: FALSE,
   [FeatureFlag.PM18794_ProviderPaymentMethod]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -59,7 +59,6 @@ import { PasswordlessAuthRequest } from "../auth/models/request/passwordless-aut
 import { SecretVerificationRequest } from "../auth/models/request/secret-verification.request";
 import { TwoFactorEmailRequest } from "../auth/models/request/two-factor-email.request";
 import { TwoFactorProviderRequest } from "../auth/models/request/two-factor-provider.request";
-import { TwoFactorRecoveryRequest } from "../auth/models/request/two-factor-recovery.request";
 import { UpdateProfileRequest } from "../auth/models/request/update-profile.request";
 import { UpdateTwoFactorAuthenticatorRequest } from "../auth/models/request/update-two-factor-authenticator.request";
 import { UpdateTwoFactorDuoRequest } from "../auth/models/request/update-two-factor-duo.request";
@@ -1062,10 +1061,6 @@ export class ApiService implements ApiServiceAbstraction {
       true,
     );
     return new TwoFactorProviderResponse(r);
-  }
-
-  postTwoFactorRecover(request: TwoFactorRecoveryRequest): Promise<any> {
-    return this.send("POST", "/two-factor/recover", request, false, false);
   }
 
   postTwoFactorEmailSetup(request: TwoFactorEmailRequest): Promise<any> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18175

## 📔 Objective

Removed the `RecoveryCodeLogin` feature flag.

This also allowed removal of the entire obsolete flow that `POST`ed a separate request to the server to initiate the recovery process, since we are now leveraging our normal authentication flows.

See corresponding server PR: https://github.com/bitwarden/server/pull/5513.

## 📸 Screenshots

https://github.com/user-attachments/assets/3359353c-e282-424d-9e5b-53447a605d03

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
