### PR TITLE
[PM-19273] [opaque] LoginStrategyService - refactor makeprepasswordloginmasterkey

### DIFF
--- a/libs/auth/src/common/abstractions/login-strategy.service.ts
+++ b/libs/auth/src/common/abstractions/login-strategy.service.ts
@@ -5,8 +5,6 @@ import { Observable } from "rxjs";
 import { AuthenticationType } from "@bitwarden/common/auth/enums/authentication-type";
 import { AuthResult } from "@bitwarden/common/auth/models/domain/auth-result";
 import { TokenTwoFactorRequest } from "@bitwarden/common/auth/models/request/identity-token/token-two-factor.request";
-import { MasterKey } from "@bitwarden/common/types/key";
-import { KdfConfig } from "@bitwarden/key-management";
 
 import {
   UserApiLoginCredentials,
@@ -70,15 +68,6 @@ export abstract class LoginStrategyServiceAbstraction {
     // TODO: PM-15162 - deprecate captchaResponse
     captchaResponse: string,
   ) => Promise<AuthResult>;
-
-  /**
-   * Creates a master key from the provided master password and email, using the provided kdfConfig.
-   */
-  makePrePasswordLoginMasterKey: (
-    masterPassword: string,
-    email: string,
-    kdfConfig: KdfConfig,
-  ) => Promise<MasterKey>;
   /**
    * Emits true if the authentication session has expired.
    */

--- a/libs/auth/src/common/abstractions/login-strategy.service.ts
+++ b/libs/auth/src/common/abstractions/login-strategy.service.ts
@@ -71,18 +71,13 @@ export abstract class LoginStrategyServiceAbstraction {
     captchaResponse: string,
   ) => Promise<AuthResult>;
 
-  // TODO: PM-19273 - Refactor makePrePasswordLoginMasterKey to no longer be on the service
-  // once PM-18176 removes the Recover2faComponent dependency.
   /**
-   * Creates a master key from the provided master password and email.
-   * If a KdfConfig is provided, it will be used to generate the key.
-   * Otherwise, the PrePasswordLogin endpoint will be used to retrieve the user's
-   * KdfConfig.
+   * Creates a master key from the provided master password and email, using the provided kdfConfig.
    */
   makePrePasswordLoginMasterKey: (
     masterPassword: string,
     email: string,
-    kdfConfig?: KdfConfig,
+    kdfConfig: KdfConfig,
   ) => Promise<MasterKey>;
   /**
    * Emits true if the authentication session has expired.

--- a/libs/auth/src/common/login-strategies/base-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/base-login.strategy.spec.ts
@@ -42,11 +42,10 @@ import {
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey, MasterKey } from "@bitwarden/common/types/key";
-import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+import { KdfConfigService, KeyService, PBKDF2KdfConfig } from "@bitwarden/key-management";
 
-import { LoginStrategyServiceAbstraction } from "../abstractions";
 import { InternalUserDecryptionOptionsServiceAbstraction } from "../abstractions/user-decryption-options.service.abstraction";
-import { PasswordLoginCredentials } from "../models";
+import { PasswordHashLoginCredentials } from "../models";
 import { UserDecryptionOptions } from "../models/domain/user-decryption-options";
 
 import { PasswordLoginStrategy, PasswordLoginStrategyData } from "./password-login.strategy";
@@ -102,12 +101,11 @@ export function identityTokenResponseFactory(
 }
 
 // TODO: add tests for latest changes to base class for TDE
-describe("LoginStrategy", () => {
+describe("BaseLoginStrategy", () => {
   let cache: PasswordLoginStrategyData;
   let accountService: FakeAccountService;
   let masterPasswordService: FakeMasterPasswordService;
 
-  let loginStrategyService: MockProxy<LoginStrategyServiceAbstraction>;
   let keyService: MockProxy<KeyService>;
   let encryptService: MockProxy<EncryptService>;
   let apiService: MockProxy<ApiService>;
@@ -127,13 +125,12 @@ describe("LoginStrategy", () => {
   let environmentService: MockProxy<EnvironmentService>;
 
   let passwordLoginStrategy: PasswordLoginStrategy;
-  let credentials: PasswordLoginCredentials;
+  let credentials: PasswordHashLoginCredentials;
 
   beforeEach(async () => {
     accountService = mockAccountServiceWith(userId);
     masterPasswordService = new FakeMasterPasswordService();
 
-    loginStrategyService = mock<LoginStrategyServiceAbstraction>();
     keyService = mock<KeyService>();
     encryptService = mock<EncryptService>();
     apiService = mock<ApiService>();
@@ -161,7 +158,6 @@ describe("LoginStrategy", () => {
       cache,
       passwordStrengthService,
       policyService,
-      loginStrategyService,
       accountService as unknown as AccountService,
       masterPasswordService,
       keyService,
@@ -180,7 +176,7 @@ describe("LoginStrategy", () => {
       kdfConfigService,
       environmentService,
     );
-    credentials = new PasswordLoginCredentials(email, masterPassword);
+    credentials = new PasswordHashLoginCredentials(email, masterPassword, new PBKDF2KdfConfig());
   });
 
   describe("base class", () => {
@@ -508,7 +504,6 @@ describe("LoginStrategy", () => {
         cache,
         passwordStrengthService,
         policyService,
-        loginStrategyService,
         accountService as AccountService,
         masterPasswordService,
         keyService,
@@ -572,7 +567,6 @@ describe("LoginStrategy", () => {
         cache,
         passwordStrengthService,
         policyService,
-        loginStrategyService,
         accountService as AccountService,
         masterPasswordService,
         keyService,

--- a/libs/auth/src/common/login-strategies/opaque-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/opaque-login.strategy.ts
@@ -21,7 +21,6 @@ import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/pass
 import { UserId } from "@bitwarden/common/types/guid";
 import { MasterKey } from "@bitwarden/common/types/key";
 
-import { LoginStrategyServiceAbstraction } from "../abstractions";
 import { OpaqueLoginCredentials } from "../models/domain/login-credentials";
 import { CacheData } from "../services/login-strategies/login-strategy.state";
 
@@ -77,7 +76,6 @@ export class OpaqueLoginStrategy extends BaseLoginStrategy {
     data: OpaqueLoginStrategyData,
     private passwordStrengthService: PasswordStrengthServiceAbstraction,
     private policyService: PolicyService,
-    private loginStrategyService: LoginStrategyServiceAbstraction,
     ...sharedDeps: ConstructorParameters<typeof BaseLoginStrategy>
   ) {
     super(...sharedDeps);
@@ -97,11 +95,7 @@ export class OpaqueLoginStrategy extends BaseLoginStrategy {
 
     // Even though we are completing OPAQUE authN and not logging in with password hash,
     // we still need to hash the master password for logged in user verification scenarios.
-    data.masterKey = await this.loginStrategyService.makePrePasswordLoginMasterKey(
-      masterPassword,
-      email,
-      kdfConfig,
-    );
+    data.masterKey = await this.makePrePasswordLoginMasterKey(masterPassword, email, kdfConfig);
 
     // Hash the password early (before authentication) so we don't persist it in memory in plaintext
     data.localMasterKeyHash = await this.keyService.hashMasterKey(

--- a/libs/auth/src/common/login-strategies/password-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.ts
@@ -19,7 +19,6 @@ import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/pass
 import { UserId } from "@bitwarden/common/types/guid";
 import { MasterKey } from "@bitwarden/common/types/key";
 
-import { LoginStrategyServiceAbstraction } from "../abstractions";
 import { PasswordHashLoginCredentials } from "../models/domain/login-credentials";
 import { CacheData } from "../services/login-strategies/login-strategy.state";
 
@@ -66,7 +65,6 @@ export class PasswordLoginStrategy extends BaseLoginStrategy {
     data: PasswordLoginStrategyData,
     private passwordStrengthService: PasswordStrengthServiceAbstraction,
     private policyService: PolicyService,
-    private loginStrategyService: LoginStrategyServiceAbstraction,
     ...sharedDeps: ConstructorParameters<typeof BaseLoginStrategy>
   ) {
     super(...sharedDeps);
@@ -84,11 +82,7 @@ export class PasswordLoginStrategy extends BaseLoginStrategy {
 
     const data = new PasswordLoginStrategyData();
 
-    data.masterKey = await this.loginStrategyService.makePrePasswordLoginMasterKey(
-      masterPassword,
-      email,
-      kdfConfig,
-    );
+    data.masterKey = await this.makePrePasswordLoginMasterKey(masterPassword, email, kdfConfig);
     data.userEnteredEmail = email;
 
     // Hash the password early (before authentication) so we don't persist it in memory in plaintext

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
@@ -36,8 +36,7 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { TaskSchedulerService, ScheduledTaskNames } from "@bitwarden/common/platform/scheduling";
 import { GlobalState, GlobalStateProvider } from "@bitwarden/common/platform/state";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
-import { MasterKey } from "@bitwarden/common/types/key";
-import { KeyService, KdfConfig, KdfConfigService } from "@bitwarden/key-management";
+import { KeyService, KdfConfigService } from "@bitwarden/key-management";
 
 import { AuthRequestServiceAbstraction, LoginStrategyServiceAbstraction } from "../../abstractions";
 import { InternalUserDecryptionOptionsServiceAbstraction } from "../../abstractions/user-decryption-options.service.abstraction";
@@ -237,7 +236,7 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
       ownedCredentials = { ...credentials };
     }
 
-    await this.currentAuthnTypeState.update((_) => credentials.type);
+    await this.currentAuthnTypeState.update((_) => ownedCredentials.type);
 
     const strategy = await firstValueFrom(this.loginStrategy$);
 
@@ -324,22 +323,6 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
     }
   }
 
-  async makePrePasswordLoginMasterKey(
-    masterPassword: string,
-    email: string,
-    kdfConfig: KdfConfig,
-  ): Promise<MasterKey> {
-    email = email.trim().toLowerCase();
-
-    if (!kdfConfig) {
-      throw new Error("KDF config is required");
-    }
-
-    kdfConfig.validateKdfConfigForPreLogin();
-
-    return this.keyService.makeMasterKey(masterPassword, email, kdfConfig);
-  }
-
   private async clearCache(): Promise<void> {
     await this.currentAuthnTypeState.update((_) => null);
     await this.loginStrategyCacheState.update((_) => null);
@@ -413,7 +396,6 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
           data?.password ?? new PasswordLoginStrategyData(),
           this.passwordStrengthService,
           this.policyService,
-          this,
           ...sharedDeps,
         );
       case AuthenticationType.Sso:
@@ -447,11 +429,10 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
           data?.opaque ?? new OpaqueLoginStrategyData(),
           this.passwordStrengthService,
           this.policyService,
-          this,
           ...sharedDeps,
         );
       default:
-        return null;
+        throw new Error("No matching strategy found for AuthenticationType " + strategy);
     }
   }
 }

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
@@ -327,25 +327,12 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
   async makePrePasswordLoginMasterKey(
     masterPassword: string,
     email: string,
-    kdfConfig?: KdfConfig,
+    kdfConfig: KdfConfig,
   ): Promise<MasterKey> {
     email = email.trim().toLowerCase();
 
     if (!kdfConfig) {
-      try {
-        const preloginResponse = await this.prePasswordLoginApiService.postPrePasswordLogin(
-          new PrePasswordLoginRequest(email),
-        );
-        kdfConfig = preloginResponse?.toKdfConfig();
-      } catch (e: any) {
-        if (e == null || e.statusCode !== 404) {
-          throw e;
-        }
-      }
-
-      if (!kdfConfig) {
-        throw new Error("KDF config is required");
-      }
+      throw new Error("KDF config is required");
     }
 
     kdfConfig.validateKdfConfigForPreLogin();


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19273
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`loginStrategyService.makePrePasswordLoginMasterKey` is no longer called with a null kdfConfig. Make that parameter required and remove dead code. Also move the method onto the base login strategy, as it is now only used by subclasses of that class.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
