### PR TITLE
Fix unit conversion bug

### DIFF
--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -36,6 +36,8 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AvatarService as AvatarServiceAbstraction } from "@bitwarden/common/auth/abstractions/avatar.service";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { MasterPasswordApiService as MasterPasswordApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
+import { DefaultOpaqueKeyExchangeService } from "@bitwarden/common/auth/opaque/default-opaque-key-exchange.service";
+import { OpaqueKeyExchangeApiService } from "@bitwarden/common/auth/opaque/opaque-key-exchange-api.service";
 import {
   AccountServiceImplementation,
   getUserId,
@@ -44,6 +46,7 @@ import { AuthService } from "@bitwarden/common/auth/services/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/services/avatar.service";
 import { DevicesApiServiceImplementation } from "@bitwarden/common/auth/services/devices-api.service.implementation";
 import { MasterPasswordApiService } from "@bitwarden/common/auth/services/master-password/master-password-api.service.implementation";
+import { PrePasswordLoginApiService } from "@bitwarden/common/auth/services/pre-password-login-api.service";
 import { TokenService } from "@bitwarden/common/auth/services/token.service";
 import { TwoFactorService } from "@bitwarden/common/auth/services/two-factor.service";
 import { UserVerificationApiService } from "@bitwarden/common/auth/services/user-verification/user-verification-api.service";
@@ -640,6 +643,19 @@ export class ServiceContainer {
       this.configService,
     );
 
+    const opaqueKeyExchangeApiService = new OpaqueKeyExchangeApiService(
+      this.apiService,
+      this.environmentService,
+    );
+    const opaqueKeyExchangeService = new DefaultOpaqueKeyExchangeService(
+      opaqueKeyExchangeApiService,
+      this.sdkService,
+    );
+    const prePasswordLoginApiService = new PrePasswordLoginApiService(
+      this.apiService,
+      this.environmentService,
+    );
+
     this.loginStrategyService = new LoginStrategyService(
       this.accountService,
       this.masterPasswordService,
@@ -666,6 +682,9 @@ export class ServiceContainer {
       this.vaultTimeoutSettingsService,
       this.kdfConfigService,
       this.taskSchedulerService,
+      prePasswordLoginApiService,
+      this.configService,
+      opaqueKeyExchangeService,
     );
 
     // FIXME: CLI does not support autofill

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
@@ -11,6 +11,7 @@ import { TokenTwoFactorRequest } from "@bitwarden/common/auth/models/request/ide
 import { IdentityTokenResponse } from "@bitwarden/common/auth/models/response/identity-token.response";
 import { IdentityTwoFactorResponse } from "@bitwarden/common/auth/models/response/identity-two-factor.response";
 import { PrePasswordLoginResponse } from "@bitwarden/common/auth/models/response/pre-password-login.response";
+import { OpaqueKeyExchangeService } from "@bitwarden/common/auth/opaque/opaque-key-exchange.service";
 import { PrePasswordLoginApiService } from "@bitwarden/common/auth/services/pre-password-login-api.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
@@ -22,6 +23,7 @@ import {
   VaultTimeoutSettingsService,
 } from "@bitwarden/common/key-management/vault-timeout";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -48,8 +50,6 @@ import { UserDecryptionOptionsService } from "../user-decryption-options/user-de
 
 import { LoginStrategyService } from "./login-strategy.service";
 import { CACHE_EXPIRATION_KEY } from "./login-strategy.state";
-import { OpaqueKeyExchangeService } from "@bitwarden/common/auth/opaque/opaque-key-exchange.service";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 
 // TODO: update tests to pass
 // TODO: test makePrePasswordLoginMasterKey

--- a/libs/common/src/auth/opaque/default-opaque-key-exchange.service.ts
+++ b/libs/common/src/auth/opaque/default-opaque-key-exchange.service.ts
@@ -8,7 +8,7 @@ import { OpaqueSessionId } from "@bitwarden/common/types/guid";
 
 import { UserKey } from "../../types/key";
 
-import { Argon2IdParameters, CipherConfiguration } from "./models/cipher-configuration";
+import { CipherConfiguration } from "./models/cipher-configuration";
 import { LoginFinishRequest } from "./models/login-finish.request";
 import { LoginStartRequest } from "./models/login-start.request";
 import { RegistrationFinishRequest } from "./models/registration-finish.request";
@@ -25,15 +25,14 @@ export class DefaultOpaqueKeyExchangeService implements OpaqueKeyExchangeService
   async register(
     masterPassword: string,
     userKey: UserKey,
-    keyStretchingFuncArgon2Params: Argon2IdParameters, // TODO: eval if we can use KdfConfig existing type
+    cipherConfig: CipherConfiguration,
   ): Promise<OpaqueSessionId> {
-    if (!masterPassword || !userKey || !keyStretchingFuncArgon2Params) {
+    if (!masterPassword || !userKey || !cipherConfig) {
       throw new Error(
-        `Unable to register user with missing parameters. masterPassword exists: ${!!masterPassword}, userKey exists: ${!!userKey}, keyStretchingFuncArgon2Params exists: ${!!keyStretchingFuncArgon2Params}`,
+        `Unable to register user with missing parameters. masterPassword exists: ${!!masterPassword}, userKey exists: ${!!userKey}, cipherConfig exists: ${!!cipherConfig}`,
       );
     }
 
-    const cipherConfig = new CipherConfiguration(keyStretchingFuncArgon2Params);
     const cryptoClient = (await firstValueFrom(this.sdkService.client$)).crypto();
 
     const registrationStart = cryptoClient.opaque_register_start(
@@ -81,15 +80,14 @@ export class DefaultOpaqueKeyExchangeService implements OpaqueKeyExchangeService
   async login(
     email: string,
     masterPassword: string,
-    keyStretchingFuncArgon2Params: Argon2IdParameters,
+    cipherConfig: CipherConfiguration,
   ): Promise<Uint8Array> {
-    if (!email || !masterPassword || !keyStretchingFuncArgon2Params) {
+    if (!email || !masterPassword || !cipherConfig) {
       throw new Error(
-        `Unable to log in user with missing parameters. email exists: ${!!email}; masterPassword exists: ${!!masterPassword}; keyStretchingFuncArgon2Params exists: ${!!keyStretchingFuncArgon2Params}`,
+        `Unable to log in user with missing parameters. email exists: ${!!email}; masterPassword exists: ${!!masterPassword}; cipherConfig exists: ${!!cipherConfig}`,
       );
     }
 
-    const cipherConfig = new CipherConfiguration(keyStretchingFuncArgon2Params);
     const cryptoClient = (await firstValueFrom(this.sdkService.client$)).crypto();
 
     const loginStart = cryptoClient.opaque_login_start(masterPassword, cipherConfig.toSdkConfig());

--- a/libs/common/src/auth/opaque/models/cipher-configuration.ts
+++ b/libs/common/src/auth/opaque/models/cipher-configuration.ts
@@ -1,3 +1,4 @@
+import { Argon2KdfConfig } from "@bitwarden/key-management";
 import { CipherConfiguration as CipherConfigurationSdk } from "@bitwarden/sdk-internal";
 
 // TODO: add js docs to all types / classes here.
@@ -14,6 +15,21 @@ export class CipherConfiguration {
   constructor(ksf: Argon2IdParameters) {
     this.cipherSuite = "OPAQUE_3_RISTRETTO255_OPRF_RISTRETTO255_KEGROUP_3DH_KEX_ARGON2ID13_KSF";
     this.argon2Parameters = ksf;
+  }
+
+  /**
+   * Converts from Bitwarden KDF configs to OPAQUE KSF configs.
+   *
+   * @param kdfConfig - Bitwarden KDF config
+   * @returns OPAQUE KSF config
+   */
+  static fromKdfConfig(kdfConfig: Argon2KdfConfig): CipherConfiguration {
+    return new CipherConfiguration({
+      // convert MiB to KiB
+      memory: kdfConfig.memory * 1024,
+      iterations: kdfConfig.iterations,
+      parallelism: kdfConfig.parallelism,
+    });
   }
 
   toSdkConfig(): CipherConfigurationSdk {

--- a/libs/common/src/auth/opaque/opaque-key-exchange.service.ts
+++ b/libs/common/src/auth/opaque/opaque-key-exchange.service.ts
@@ -2,7 +2,7 @@ import { OpaqueSessionId } from "@bitwarden/common/types/guid";
 
 import { UserKey } from "../../types/key";
 
-import { Argon2IdParameters } from "./models/cipher-configuration";
+import { CipherConfiguration } from "./models/cipher-configuration";
 
 export abstract class OpaqueKeyExchangeService {
   /**
@@ -11,7 +11,7 @@ export abstract class OpaqueKeyExchangeService {
   abstract register(
     masterPassword: string,
     userKey: UserKey,
-    ksfParameters: Argon2IdParameters,
+    cipherConfiguration: CipherConfiguration,
   ): Promise<OpaqueSessionId>;
 
   /**
@@ -22,6 +22,6 @@ export abstract class OpaqueKeyExchangeService {
   abstract login(
     email: string,
     masterPassword: string,
-    ksfParameters: Argon2IdParameters,
+    cipherConfiguration: CipherConfiguration,
   ): Promise<Uint8Array>;
 }

--- a/libs/key-management/src/index.ts
+++ b/libs/key-management/src/index.ts
@@ -16,6 +16,7 @@ export {
   KdfConfig,
   createKdfConfig,
   DEFAULT_KDF_CONFIG,
+  DEFAULT_OPAQUE_KDF_CONFIG,
 } from "./models/kdf-config";
 export { KdfConfigService } from "./abstractions/kdf-config.service";
 export { DefaultKdfConfigService } from "./kdf-config.service";

--- a/libs/key-management/src/models/kdf-config.ts
+++ b/libs/key-management/src/models/kdf-config.ts
@@ -141,3 +141,4 @@ export class Argon2KdfConfig {
 }
 
 export const DEFAULT_KDF_CONFIG = new PBKDF2KdfConfig(PBKDF2KdfConfig.ITERATIONS.defaultValue);
+export const DEFAULT_OPAQUE_KDF_CONFIG = new Argon2KdfConfig(1, 256, 1);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

KDF config is in MiB while the KSF config is directly referencing argon2's parameters (KiB). This also changes the opaque service api to take an entire cipher configuration instead of the argon config.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
