### PR TITLE
Switch Notifications to only connect on unlocked

### DIFF
--- a/libs/common/src/platform/notifications/internal/default-notifications.service.spec.ts
+++ b/libs/common/src/platform/notifications/internal/default-notifications.service.spec.ts
@@ -225,9 +225,10 @@ describe("NotificationsService", () => {
   });
 
   it.each([
-    { initialStatus: AuthenticationStatus.Locked, updatedStatus: AuthenticationStatus.Unlocked },
-    { initialStatus: AuthenticationStatus.Unlocked, updatedStatus: AuthenticationStatus.Locked },
-    { initialStatus: AuthenticationStatus.Locked, updatedStatus: AuthenticationStatus.Locked },
+    // Temporarily rolling back notifications being connected while locked
+    // { initialStatus: AuthenticationStatus.Locked, updatedStatus: AuthenticationStatus.Unlocked },
+    // { initialStatus: AuthenticationStatus.Unlocked, updatedStatus: AuthenticationStatus.Locked },
+    // { initialStatus: AuthenticationStatus.Locked, updatedStatus: AuthenticationStatus.Locked },
     { initialStatus: AuthenticationStatus.Unlocked, updatedStatus: AuthenticationStatus.Unlocked },
   ])(
     "does not re-connect when the user transitions from $initialStatus to $updatedStatus",
@@ -252,7 +253,11 @@ describe("NotificationsService", () => {
     },
   );
 
-  it.each([AuthenticationStatus.Locked, AuthenticationStatus.Unlocked])(
+  it.each([
+    // Temporarily disabling notifications connecting while in a locked state
+    // AuthenticationStatus.Locked,
+    AuthenticationStatus.Unlocked,
+  ])(
     "connects when a user transitions from logged out to %s",
     async (newStatus: AuthenticationStatus) => {
       emitActiveUser(mockUser1);

--- a/libs/common/src/platform/notifications/internal/default-notifications.service.ts
+++ b/libs/common/src/platform/notifications/internal/default-notifications.service.ts
@@ -123,13 +123,13 @@ export class DefaultNotificationsService implements NotificationsServiceAbstract
     );
   }
 
+  // This method name is a lie currently as we also have an access token
+  // when locked, this is eventually where we want to be but it increases load
+  // on signalR so we are rolling back until we can move the load of browser to
+  // web push.
   private hasAccessToken$(userId: UserId) {
     return this.authService.authStatusFor$(userId).pipe(
-      map(
-        (authStatus) =>
-          authStatus === AuthenticationStatus.Locked ||
-          authStatus === AuthenticationStatus.Unlocked,
-      ),
+      map((authStatus) => authStatus === AuthenticationStatus.Unlocked),
       distinctUntilChanged(),
     );
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-19377

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Lowers notifications to only connect when the user is unlocked. We do eventually want users to connect to notifications while locked as well but right now this causes an increased load on us which degrades the experience for everyone. This is particularly bad because while the code here is designed to NOT reconnect (the most costly thing) during a `Unlocked` -> `Locked` state it still does because we do a process reload during the lock process. Which means this code gets completely destroyed. Small win, it did do the reconnect from pure reactive means and not needing to be called manually so I guess that is nice. Connecting to notifications through web push will be coming to the browser extension very soon and that should help us a lot here. The browser extension, chrome specifically is a large amount of the connections, web push also doesn't need to do any sort of costly reconnect during restart of the application, it just needs to validate that it still has a subscription with the OS. 

We have captured the follow-up to re-enable this in https://bitwarden.atlassian.net/browse/PM-19388.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
