### PR TITLE
Check device id and creationDate for falsey values

### DIFF
--- a/apps/web/src/app/auth/settings/security/device-management.component.ts
+++ b/apps/web/src/app/auth/settings/security/device-management.component.ts
@@ -180,7 +180,7 @@ export class DeviceManagementComponent {
   private updateDeviceTable(devices: Array<DeviceView>): void {
     this.dataSource.data = devices
       .map((device: DeviceView): DeviceTableData | null => {
-        if (device.id == undefined) {
+        if (!device.id) {
           this.validationService.showError(new Error(this.i18nService.t("deviceIdMissing")));
           return null;
         }
@@ -190,7 +190,7 @@ export class DeviceManagementComponent {
           return null;
         }
 
-        if (device.creationDate == undefined) {
+        if (!device.creationDate) {
           this.validationService.showError(
             new Error(this.i18nService.t("deviceCreationDateMissing")),
           );


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Follow up from feedback for https://bitwarden.atlassian.net/browse/PM-18757

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Checks the device `id` and `creationDate` for empty strings (or any falsey values) since they are strings (defined in `libs/common/src/auth/abstractions/devices/views/device.view.ts`).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
