### PR TITLE
PM-19361 Notification bar dropdown folder component displays "No Folder" twice

### DIFF
--- a/apps/browser/src/autofill/content/components/notification/button-row.ts
+++ b/apps/browser/src/autofill/content/components/notification/button-row.ts
@@ -80,7 +80,7 @@ export function NotificationButtonRow({
       theme,
       primaryButton,
       selectButtons: [
-        ...(organizationOptions.length
+        ...(organizationOptions.length > 1
           ? [
               {
                 id: "organization",

--- a/apps/browser/src/autofill/content/components/notification/button-row.ts
+++ b/apps/browser/src/autofill/content/components/notification/button-row.ts
@@ -60,23 +60,18 @@ export function NotificationButtonRow({
       )
     : ([] as Option[]);
 
-  const noFolderOption: Option = {
-    default: true,
-    icon: Folder,
-    text: "No folder", // @TODO localize
-    value: "0",
-  };
   const folderOptions: Option[] = folders?.length
-    ? folders.reduce(
+    ? folders.reduce<Option[]>(
         (options, { id, name }: FolderView) => [
           ...options,
           {
             icon: Folder,
             text: name,
-            value: id,
+            value: id === null ? "0" : id,
+            default: id === null,
           },
         ],
-        [noFolderOption],
+        [],
       )
     : [];
 
@@ -85,7 +80,7 @@ export function NotificationButtonRow({
       theme,
       primaryButton,
       selectButtons: [
-        ...(organizationOptions.length > 1
+        ...(organizationOptions.length
           ? [
               {
                 id: "organization",

--- a/apps/browser/src/autofill/content/notification-bar.ts
+++ b/apps/browser/src/autofill/content/notification-bar.ts
@@ -880,7 +880,7 @@ async function loadNotificationBar() {
 
       const baseStyle = useComponentBar
         ? isNotificationFresh
-          ? "height: calc(276px + 25px); width: 450px; right: 0; transform:translateX(100%); opacity:0;"
+          ? "height: calc(276px + 50px); width: 450px; right: 0; transform:translateX(100%); opacity:0;"
           : "height: calc(276px + 25px); width: 450px; right: 0; transform:translateX(0%); opacity:1;"
         : "height: 42px; width: 100%;";
 
@@ -910,7 +910,7 @@ async function loadNotificationBar() {
     function getFrameStyle(useComponentBar: boolean): string {
       return (
         (useComponentBar
-          ? "height: calc(276px + 25px); width: 450px; right: 0;"
+          ? "height: calc(276px + 50px); width: 450px; right: 0;"
           : "height: 42px; width: 100%; left: 0;") +
         " top: 0; padding: 0; position: fixed;" +
         " z-index: 2147483647; visibility: visible;"


### PR DESCRIPTION

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19361
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

All accounts have a default `No folder` which has a null id. This folder is shown within the folders section of the vault and even if deleted, the `No folder` option will persist which gives me confidence to remove the default No folder insertion. 

- Remove default folder option
- Edit iFrame height

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2025-03-20 at 2 45 52 PM](https://github.com/user-attachments/assets/b17a181e-1461-41e4-b329-3ad317014ef8)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
