### PR TITLE
[PM-18656] Remove MyVault from export options

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -201,15 +201,28 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       this.formDisabled.emit(c === "DISABLED");
     });
 
-    this.policyService
-      .policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport)
+    // Do not allow export if either the DisablePersonalVaultExport or PersonalOwnership policies are active
+    combineLatest([
+      this.policyService.policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport),
+      this.policyService.policyAppliesToActiveUser$(PolicyType.PersonalOwnership),
+    ])
       .pipe(takeUntil(this.destroy$))
-      .subscribe((policyAppliesToActiveUser) => {
-        this._disabledByPolicy = policyAppliesToActiveUser;
+      .subscribe(([disablePersonalVaultExport, personalOwnership]: [boolean, boolean]) => {
+        this._disabledByPolicy = disablePersonalVaultExport || personalOwnership;
         if (this.disabledByPolicy) {
           this.exportForm.disable();
         }
       });
+
+    // this.policyService
+    //   .policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport)
+    //   .pipe(takeUntil(this.destroy$))
+    //   .subscribe((policyAppliesToActiveUser) => {
+    //     this._disabledByPolicy = policyAppliesToActiveUser;
+    //     if (this.disabledByPolicy) {
+    //       this.exportForm.disable();
+    //     }
+    //   });
 
     merge(
       this.exportForm.get("format").valueChanges,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18685

## 📔 Objective

When either of the policy "Remove individual vault" (PolicyType.PersonalOwnership) or "Remove individual vault export" (Policy.DisablePersonalVaultExport is on, then "MyVault" is not listed on the export options.

However, organization vaults are listed.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/775d3bdb-d8d6-4961-a10f-f66508412676)
![image](https://github.com/user-attachments/assets/c5b30e89-afd3-4758-9d88-e11ac747374f)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
