### PR TITLE
[PM-18685] Disable MyVault when the Person Ownership policy is true

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -1,17 +1,19 @@
 <bit-callout type="danger" title="{{ 'vaultExportDisabled' | i18n }}" *ngIf="disabledByPolicy">
   {{ "personalVaultExportPolicyInEffect" | i18n }}
 </bit-callout>
-<tools-export-scope-callout
-  [organizationId]="organizationId"
-  *ngIf="!disabledByPolicy"
-></tools-export-scope-callout>
+<tools-export-scope-callout [organizationId]="organizationId"></tools-export-scope-callout>
 
 <form [formGroup]="exportForm" [bitSubmit]="submit" id="export_form_exportForm">
   <ng-container *ngIf="organizations$ | async as organizations">
     <bit-form-field *ngIf="organizations.length > 0">
       <bit-label>{{ "exportFrom" | i18n }}</bit-label>
       <bit-select formControlName="vaultSelector">
-        <bit-option [label]="'myVault' | i18n" value="myVault" icon="bwi-user" />
+        <bit-option
+          [label]="'myVault' | i18n"
+          value="myVault"
+          icon="bwi-user"
+          *ngIf="!disabledByPolicy"
+        />
         <bit-option
           *ngFor="let o of organizations$ | async"
           [value]="o.id"

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -12,7 +12,7 @@
           [label]="'myVault' | i18n"
           value="myVault"
           icon="bwi-user"
-          *ngIf="!disabledByPolicy"
+          *ngIf="!disableByPolicy_RemovePersonalOwnership"
         />
         <bit-option
           *ngFor="let o of organizations$ | async"

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -201,15 +201,28 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       this.formDisabled.emit(c === "DISABLED");
     });
 
-    this.policyService
-      .policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport)
+    // Do not allow export if either the DisablePersonalVaultExport or PersonalOwnership policies are active
+    combineLatest([
+      this.policyService.policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport),
+      this.policyService.policyAppliesToActiveUser$(PolicyType.PersonalOwnership),
+    ])
       .pipe(takeUntil(this.destroy$))
-      .subscribe((policyAppliesToActiveUser) => {
-        this._disabledByPolicy = policyAppliesToActiveUser;
+      .subscribe(([disablePersonalVaultExport, personalOwnership]: [boolean, boolean]) => {
+        this._disabledByPolicy = disablePersonalVaultExport || personalOwnership;
         if (this.disabledByPolicy) {
           this.exportForm.disable();
         }
       });
+
+    // this.policyService
+    //   .policyAppliesToActiveUser$(PolicyType.DisablePersonalVaultExport)
+    //   .pipe(takeUntil(this.destroy$))
+    //   .subscribe((policyAppliesToActiveUser) => {
+    //     this._disabledByPolicy = policyAppliesToActiveUser;
+    //     if (this.disabledByPolicy) {
+    //       this.exportForm.disable();
+    //     }
+    //   });
 
     merge(
       this.exportForm.get("format").valueChanges,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18685

## 📔 Objective

When the Prevent Personal Ownership is true, then "My Vault" should not appear as an export option
When the Prevent Individual vault export is true, then the export option is disabled
All this applies only when the user is not an admin/owner and does not have the ability to set policies on the organisation.
 

## 📸 Screenshots

### Export form disabled 
![image](https://github.com/user-attachments/assets/2610a619-8456-483c-9cfc-4d90118add74)

### Export form is enabled - but no option to export "My Vault"
![image](https://github.com/user-attachments/assets/9c115195-904c-4d90-ba12-a36b4fa81be3)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
