### PR TITLE
[PM-14426] At-risk password carousel fixes

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2534,15 +2534,15 @@
     "message": "Your organization passwords are at-risk because they are weak, reused, and/or exposed.",
     "description": "Description of the review at-risk login slide on the at-risk password page carousel"
   },
-  "reviewAtRiskLoginSlideImgAlt": {
-    "message": "Illustration of a list of logins that are at-risk"
+  "reviewAtRiskLoginSlideImgAltPeriod": {
+    "message": "Illustration of a list of logins that are at-risk."
   },
   "generatePasswordSlideDesc": {
     "message": "Quickly generate a strong, unique password with the Bitwarden autofill menu on the at-risk site.",
     "description": "Description of the generate password slide on the at-risk password page carousel"
   },
-  "generatePasswordSlideImgAlt": {
-    "message": "Illustration of the Bitwarden autofill menu displaying a generated password"
+  "generatePasswordSlideImgAltPeriod": {
+    "message": "Illustration of the Bitwarden autofill menu displaying a generated password."
   },
   "updateInBitwarden": {
     "message": "Update in Bitwarden"
@@ -2551,8 +2551,8 @@
     "message": "Bitwarden will then prompt you to update the password in the password manager.",
     "description": "Description of the update in Bitwarden slide on the at-risk password page carousel"
   },
-  "updateInBitwardenSlideImgAlt": {
-    "message": "Illustration of a Bitwarden’s notification prompting the user to update the login"
+  "updateInBitwardenSlideImgAltPeriod": {
+    "message": "Illustration of a Bitwarden’s notification prompting the user to update the login."
   },
   "turnOnAutofill": {
     "message": "Turn on autofill"

--- a/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.html
@@ -47,6 +47,7 @@
       block
       [disabled]="!dismissBtnEnabled()"
       (click)="dismiss()"
+      data-testid="confirm-carousel-button"
     >
       {{ "reviewAtRiskPasswords" | i18n }}
     </button>

--- a/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.html
@@ -6,7 +6,7 @@
           class="tw-max-w-full tw-max-h-40"
           src="../../../../images/at-risk-password-carousel/review_at-risk_logins.light.png"
           appDarkImgSrc="../../../../images/at-risk-password-carousel/review_at-risk_logins.dark.png"
-          [alt]="'reviewAtRiskLoginSlideImgAlt' | i18n"
+          [alt]="'reviewAtRiskLoginSlideImgAltPeriod' | i18n"
         />
         <h2 bitTypography="h2" class="tw-mt-8">{{ "reviewAtRiskLogins" | i18n }}</h2>
         <p bitTypography="body1">
@@ -18,7 +18,7 @@
           class="tw-max-w-full tw-max-h-40"
           src="../../../../images/at-risk-password-carousel/generate_password.light.png"
           appDarkImgSrc="../../../../images/at-risk-password-carousel/generate_password.dark.png"
-          [alt]="'generatePasswordSlideImgAlt' | i18n"
+          [alt]="'generatePasswordSlideImgAltPeriod' | i18n"
         />
         <h2 bitTypography="h2" class="tw-mt-8">{{ "generatePassword" | i18n }}</h2>
         <p bitTypography="body1">
@@ -30,7 +30,7 @@
           class="tw-max-w-full tw-max-h-40"
           src="../../../../images/at-risk-password-carousel/update_login.light.png"
           appDarkImgSrc="../../../../images/at-risk-password-carousel/update_login.dark.png"
-          [alt]="'updateInBitwardenSlideImgAlt' | i18n"
+          [alt]="'updateInBitwardenSlideImgAltPeriod' | i18n"
         />
         <h2 bitTypography="h2" class="tw-mt-8">{{ "updateInBitwarden" | i18n }}</h2>
         <p bitTypography="body1">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14426](https://bitwarden.atlassian.net/browse/PM-14426) parent ticket

## 📔 Objective

- [PM-19004](https://bitwarden.atlassian.net/browse/PM-19004) - Pause after image alt text for screen readers
- [PM-19298](https://bitwarden.atlassian.net/browse/PM-19298) - Add `data-testid` to carousel button

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14426]: https://bitwarden.atlassian.net/browse/PM-14426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-19004]: https://bitwarden.atlassian.net/browse/PM-19004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-19298]: https://bitwarden.atlassian.net/browse/PM-19298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ