### PR TITLE
[PM-19339] Innovation Archive - Extension cleanup

### DIFF
--- a/apps/browser/src/vault/popup/settings/archive.component.html
+++ b/apps/browser/src/vault/popup/settings/archive.component.html
@@ -14,60 +14,59 @@
           </h2>
           <span bitTypography="body1" slot="end">{{ archivedItems.length }}</span>
         </bit-section-header>
-      </bit-section>
-
-      <bit-item-group>
-        @for (cipher of archivedItems; track cipher.id) {
-          <bit-item>
-            <button
-              bit-item-content
-              type="button"
-              [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
-              (click)="view(cipher)"
-            >
-              <div slot="start" class="tw-justify-start tw-w-7 tw-flex">
-                <app-vault-icon [cipher]="cipher"></app-vault-icon>
-              </div>
-              <span data-testid="item-name">{{ cipher.name }}</span>
-              @if (cipher.hasAttachments) {
-                <i class="bwi bwi-paperclip bwi-sm" [appA11yTitle]="'attachments' | i18n"></i>
-              }
-              <span slot="secondary">{{ cipher.subTitle }}</span>
-            </button>
-            <bit-item-action slot="end">
+        <bit-item-group>
+          @for (cipher of archivedItems; track cipher.id) {
+            <bit-item>
               <button
+                bit-item-content
                 type="button"
-                bitIconButton="bwi-ellipsis-v"
-                size="small"
-                [attr.aria-label]="'moreOptionsLabel' | i18n: cipher.name"
-                [title]="'moreOptionsTitle' | i18n: cipher.name"
-                [bitMenuTriggerFor]="moreOptions"
-              ></button>
-              <bit-menu #moreOptions>
-                <button type="button" bitMenuItem (click)="edit(cipher)">
-                  {{ "edit" | i18n }}
-                </button>
-                <button type="button" bitMenuItem (click)="clone(cipher)">
-                  {{ "clone" | i18n }}
-                </button>
-                <button type="button" bitMenuItem (click)="unarchive(cipher)">
-                  {{ "unarchive" | i18n }}
-                </button>
+                [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
+                (click)="view(cipher)"
+              >
+                <div slot="start" class="tw-justify-start tw-w-7 tw-flex">
+                  <app-vault-icon [cipher]="cipher"></app-vault-icon>
+                </div>
+                <span data-testid="item-name">{{ cipher.name }}</span>
+                @if (cipher.hasAttachments) {
+                  <i class="bwi bwi-paperclip bwi-sm" [appA11yTitle]="'attachments' | i18n"></i>
+                }
+                <span slot="secondary">{{ cipher.subTitle }}</span>
+              </button>
+              <bit-item-action slot="end">
                 <button
                   type="button"
-                  bitMenuItem
-                  *appCanDeleteCipher="cipher"
-                  (click)="delete(cipher)"
-                >
-                  <span class="tw-text-danger">
-                    {{ "delete" | i18n }}
-                  </span>
-                </button>
-              </bit-menu>
-            </bit-item-action>
-          </bit-item>
-        }
-      </bit-item-group>
+                  bitIconButton="bwi-ellipsis-v"
+                  size="small"
+                  [attr.aria-label]="'moreOptionsLabel' | i18n: cipher.name"
+                  [title]="'moreOptionsTitle' | i18n: cipher.name"
+                  [bitMenuTriggerFor]="moreOptions"
+                ></button>
+                <bit-menu #moreOptions>
+                  <button type="button" bitMenuItem (click)="edit(cipher)">
+                    {{ "edit" | i18n }}
+                  </button>
+                  <button type="button" bitMenuItem (click)="clone(cipher)">
+                    {{ "clone" | i18n }}
+                  </button>
+                  <button type="button" bitMenuItem (click)="unarchive(cipher)">
+                    {{ "unarchive" | i18n }}
+                  </button>
+                  <button
+                    type="button"
+                    bitMenuItem
+                    *appCanDeleteCipher="cipher"
+                    (click)="delete(cipher)"
+                  >
+                    <span class="tw-text-danger">
+                      {{ "delete" | i18n }}
+                    </span>
+                  </button>
+                </bit-menu>
+              </bit-item-action>
+            </bit-item>
+          }
+        </bit-item-group>
+      </bit-section>
     } @else {
       <bit-no-items class="tw-flex tw-h-full tw-items-center tw-justify-center">
         <ng-container slot="title">

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -224,6 +224,7 @@ export class CipherService implements CipherServiceAbstraction {
     cipher.type = model.type;
     cipher.collectionIds = model.collectionIds;
     cipher.revisionDate = model.revisionDate;
+    cipher.archivedDate = model.archivedDate;
     cipher.reprompt = model.reprompt;
     cipher.edit = model.edit;
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19339](https://bitwarden.atlassian.net/browse/PM-19339)

## 📔 Objective

- Fix header spacing on the Archive items page
- Fix cipher archivedDate being lost on cipher modification

## 📸 Screenshots

<img width="389" alt="image" src="https://github.com/user-attachments/assets/c788763b-2ee2-48af-a8c8-4101885618d3" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19339]: https://bitwarden.atlassian.net/browse/PM-19339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ