### PR TITLE
feat(device-approval-persistence): [PM-19380] Device Approval Persistence

### DIFF
--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -90,7 +90,6 @@ export class LocalBackedSessionStorageService
           this.logService.warning(
             `Possible unnecessary write to local session storage. Key: ${key}`,
           );
-          this.logService.warning(obj as any);
         }
       } catch (err) {
         this.logService.warning(`Error while comparing values for key: ${key}`);

--- a/libs/angular/src/platform/abstractions/view-cache.service.ts
+++ b/libs/angular/src/platform/abstractions/view-cache.service.ts
@@ -9,7 +9,7 @@ type Deserializer<T> = {
    * @param jsonValue The JSON object representation of your state.
    * @returns The fully typed version of your state.
    */
-  readonly deserializer?: (jsonValue: Jsonify<T>) => T;
+  readonly deserializer?: (jsonValue: Jsonify<T>) => T | null;
 };
 
 type BaseCacheOptions<T> = {

--- a/libs/auth/src/angular/login-via-auth-request/AUTH_REQUEST_LOGIN_README.md
+++ b/libs/auth/src/angular/login-via-auth-request/AUTH_REQUEST_LOGIN_README.md
@@ -1,0 +1,203 @@
+# Authentication Flows Documentation
+
+## Standard Auth Request Flows
+
+### Flow 1: Unauthed user requests approval from device; Approving device has a masterKey in memory
+
+1. Unauthed user clicks "Login with device"
+2. Navigates to /login-with-device which creates a StandardAuthRequest
+3. Receives approval from a device with authRequestPublicKey(masterKey)
+4. Decrypts masterKey
+5. Decrypts userKey
+6. Proceeds to vault
+
+### Flow 2: Unauthed user requests approval from device; Approving device does NOT have a masterKey in memory
+
+1. Unauthed user clicks "Login with device"
+2. Navigates to /login-with-device which creates a StandardAuthRequest
+3. Receives approval from a device with authRequestPublicKey(userKey)
+4. Decrypts userKey
+5. Proceeds to vault
+
+**Note:** This flow is an uncommon scenario and relates to TDE off-boarding. The following describes how a user could
+get into this flow:
+
+1. An SSO TD user logs into a device via an Admin auth request approval, therefore this device does NOT have a masterKey
+   in memory
+2. The org admin:
+   - Changes the member decryption options from "Trusted devices" to "Master password" AND
+   - Turns off the "Require single sign-on authentication" policy
+3. On another device, the user clicks "Login with device", which they can do because the org no longer requires SSO
+4. The user approves from the device they had previously logged into with SSO TD, which does NOT have a masterKey in
+   memory
+
+### Flow 3: Authed SSO TD user requests approval from device; Approving device has a masterKey in memory
+
+1. SSO TD user authenticates via SSO
+2. Navigates to /login-initiated
+3. Clicks "Approve from your other device"
+4. Navigates to /login-with-device which creates a StandardAuthRequest
+5. Receives approval from device with authRequestPublicKey(masterKey)
+6. Decrypts masterKey
+7. Decrypts userKey
+8. Establishes trust (if required)
+9. Proceeds to vault
+
+### Flow 4: Authed SSO TD user requests approval from device; Approving device does NOT have a masterKey in memory
+
+1. SSO TD user authenticates via SSO
+2. Navigates to /login-initiated
+3. Clicks "Approve from your other device"
+4. Navigates to /login-with-device which creates a StandardAuthRequest
+5. Receives approval from device with authRequestPublicKey(userKey)
+6. Decrypts userKey
+7. Establishes trust (if required)
+8. Proceeds to vault
+
+## Admin Auth Request Flow
+
+### Flow: Authed SSO TD user requests admin approval
+
+1. SSO TD user authenticates via SSO
+2. Navigates to /login-initiated
+3. Clicks "Request admin approval"
+4. Navigates to /admin-approval-requested which creates an AdminAuthRequest
+5. Receives approval from device with authRequestPublicKey(userKey)
+6. Decrypts userKey
+7. Establishes trust (if required)
+8. Proceeds to vault
+
+**Note:** TDE users are required to be enrolled in admin password reset, which gives the admin access to the user's
+userKey. This is how admins are able to send over the authRequestPublicKey(userKey) to the user to allow them to unlock.
+
+## Summary Table
+
+| Flow            | Auth Status | Clicks Button [active route]                        | Navigates to              | Approving device has masterKey in memory\*        |
+| --------------- | ----------- | --------------------------------------------------- | ------------------------- | ------------------------------------------------- |
+| Standard Flow 1 | unauthed    | "Login with device" [/login]                        | /login-with-device        | yes                                               |
+| Standard Flow 2 | unauthed    | "Login with device" [/login]                        | /login-with-device        | no                                                |
+| Standard Flow 3 | authed      | "Approve from your other device" [/login-initiated] | /login-with-device        | yes                                               |
+| Standard Flow 4 | authed      | "Approve from your other device" [/login-initiated] | /login-with-device        | no                                                |
+| Admin Flow      | authed      | "Request admin approval" [/login-initiated]         | /admin-approval-requested | NA - admin requests always send encrypted userKey |
+
+**Note:** The phrase "in memory" here is important. It is possible for a user to have a master password for their
+account, but not have a masterKey IN MEMORY for a specific device. For example, if a user registers an account with a
+master password, then joins an SSO TD org, then logs in to a device via SSO and admin auth request, they are now logged
+into that device but that device does not have masterKey IN MEMORY.
+
+## State Management
+
+### View Cache
+
+The component uses `LoginViaAuthRequestCacheService` to manage persistent state across page refreshes. This cache
+stores:
+
+- Auth Request ID
+- Private Key
+- Access Code
+
+The cache is used to:
+
+1. Preserve authentication state during extension close
+2. Allow resumption of pending auth requests
+3. Enable processing of approved requests after navigation/refresh
+
+### Component State Variables
+
+Key state variables maintained during the authentication process:
+
+#### Authentication Keys
+
+```
+private authRequestKeyPair: {
+    publicKey: Uint8Array | undefined;
+    privateKey: Uint8Array | undefined;
+} | undefined
+```
+
+- Stores the RSA key pair used for secure communication
+- Generated during auth request initialization
+- Required for decrypting approved auth responses
+
+#### Access Code
+
+```
+private accessCode: string | undefined
+```
+
+- 25-character generated password
+- Used for retrieving auth responses when user is not authenticated
+- Required for standard auth flows
+
+#### Authentication Status
+
+```
+private authStatus: AuthenticationStatus | undefined
+```
+
+- Tracks whether user is authenticated via SSO
+- Determines available flows and API endpoints
+- Affects navigation paths (`/login` vs `/login-initiated`)
+
+#### Flow Control
+
+```
+protected flow = Flow.StandardAuthRequest
+```
+
+- Determines current authentication flow (Standard vs Admin)
+- Affects UI rendering and request handling
+- Set based on route and authentication state
+
+### State Flow Examples
+
+#### Standard Auth Request Cache Flow
+
+1. User initiates login with device
+2. Component generates auth request and keys
+3. Cache service stores:
+   ```
+   cacheLoginView(
+     authRequestResponse.id,
+     authRequestKeyPair.privateKey,
+     accessCode
+   )
+   ```
+4. On page refresh/navigation:
+   - Component retrieves cached view
+   - Reestablishes connection using cached credentials
+   - Continues monitoring for approval
+
+#### Admin Auth Request State Flow
+
+1. User requests admin approval
+2. Component stores admin request in `AuthRequestService`:
+   ```
+   setAdminAuthRequest(
+     new AdminAuthRequestStorable({
+       id: authRequestResponse.id,
+       privateKey: authRequestKeyPair.privateKey
+     }),
+     userId
+   )
+   ```
+3. On subsequent visits:
+   - Component checks for existing admin requests
+   - Either resumes monitoring or starts new request
+   - Clears state after successful approval
+
+### State Cleanup
+
+State cleanup occurs in several scenarios:
+
+- Component destruction (`ngOnDestroy`)
+- Successful authentication
+- Request denial or timeout
+- Manual navigation away
+
+Key cleanup actions:
+
+1. Hub connection termination
+2. Cache clearance
+3. Admin request state removal
+4. Key pair disposal

--- a/libs/auth/src/angular/login-via-auth-request/AUTH_REQUEST_LOGIN_README.md
+++ b/libs/auth/src/angular/login-via-auth-request/AUTH_REQUEST_LOGIN_README.md
@@ -89,8 +89,8 @@ into that device but that device does not have masterKey IN MEMORY.
 
 ### View Cache
 
-The component uses `LoginViaAuthRequestCacheService` to manage persistent state across page refreshes. This cache
-stores:
+The component uses `LoginViaAuthRequestCacheService` to manage persistent state across extension close and reopen.
+This cache stores:
 
 - Auth Request ID
 - Private Key
@@ -100,7 +100,7 @@ The cache is used to:
 
 1. Preserve authentication state during extension close
 2. Allow resumption of pending auth requests
-3. Enable processing of approved requests after navigation/refresh
+3. Enable processing of approved requests after extension close and reopen.
 
 ### Component State Variables
 
@@ -163,7 +163,7 @@ protected flow = Flow.StandardAuthRequest
      accessCode
    )
    ```
-4. On page refresh/navigation:
+4. On page refresh/revisit:
    - Component retrieves cached view
    - Reestablishes connection using cached credentials
    - Continues monitoring for approval

--- a/libs/auth/src/angular/login-via-auth-request/auth_request_login_readme.md
+++ b/libs/auth/src/angular/login-via-auth-request/auth_request_login_readme.md
@@ -67,7 +67,7 @@ get into this flow:
 7. Establishes trust (if required)
 8. Proceeds to vault
 
-**Note:** TDE users are required to be enrolled in admin password reset, which gives the admin access to the user's
+**Note:** TDE users are required to be enrolled in admin account recovery, which gives the admin access to the user's
 userKey. This is how admins are able to send over the authRequestPublicKey(userKey) to the user to allow them to unlock.
 
 ## Summary Table

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
@@ -26,7 +26,7 @@
       block
       buttonType="secondary"
       class="tw-mt-4"
-      (click)="startStandardAuthRequestLogin(true)"
+      (click)="startStandardAuthRequestLogin()"
     >
       {{ "resendNotification" | i18n }}
     </button>

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
@@ -1,57 +1,65 @@
-<div class="tw-text-center">
-  <ng-container *ngIf="flow === Flow.StandardAuthRequest">
-    <p *ngIf="clientType !== ClientType.Web">
-      {{ "notificationSentDevicePart1" | i18n }}
-      <a
-        bitLink
-        linkType="primary"
-        class="tw-cursor-pointer"
-        [href]="deviceManagementUrl"
-        target="_blank"
-        rel="noreferrer"
-        >{{ "notificationSentDeviceAnchor" | i18n }}</a
-      >. {{ "notificationSentDevicePart2" | i18n }}
-    </p>
-    <p *ngIf="clientType === ClientType.Web">
-      {{ "notificationSentDeviceComplete" | i18n }}
-    </p>
+<ng-container *ngIf="loading">
+  <div class="tw-flex tw-items-center tw-justify-center">
+    <i class="bwi bwi-spinner bwi-spin bwi-3x" aria-hidden="true"></i>
+  </div>
+</ng-container>
 
-    <div class="tw-font-semibold">{{ "fingerprintPhraseHeader" | i18n }}</div>
-    <code class="tw-text-code">{{ fingerprintPhrase }}</code>
+<ng-container *ngIf="!loading">
+  <div class="tw-text-center">
+    <ng-container *ngIf="flow === Flow.StandardAuthRequest">
+      <p *ngIf="clientType !== ClientType.Web">
+        {{ "notificationSentDevicePart1" | i18n }}
+        <a
+          bitLink
+          linkType="primary"
+          class="tw-cursor-pointer"
+          [href]="deviceManagementUrl"
+          target="_blank"
+          rel="noreferrer"
+          >{{ "notificationSentDeviceAnchor" | i18n }}</a
+        >. {{ "notificationSentDevicePart2" | i18n }}
+      </p>
+      <p *ngIf="clientType === ClientType.Web">
+        {{ "notificationSentDeviceComplete" | i18n }}
+      </p>
 
-    <button
-      *ngIf="showResendNotification"
-      type="button"
-      bitButton
-      block
-      buttonType="secondary"
-      class="tw-mt-4"
-      (click)="startStandardAuthRequestLogin()"
-    >
-      {{ "resendNotification" | i18n }}
-    </button>
+      <div class="tw-font-semibold">{{ "fingerprintPhraseHeader" | i18n }}</div>
+      <code class="tw-text-code">{{ fingerprintPhrase }}</code>
 
-    <div *ngIf="clientType !== ClientType.Browser" class="tw-mt-4">
-      <span>{{ "needAnotherOptionV1" | i18n }}</span
-      >&nbsp;
-      <a [routerLink]="backToRoute" bitLink linkType="primary">{{
-        "viewAllLogInOptions" | i18n
-      }}</a>
-    </div>
-  </ng-container>
+      <button
+        *ngIf="showResendNotification"
+        type="button"
+        bitButton
+        block
+        buttonType="secondary"
+        class="tw-mt-4"
+        (click)="startStandardAuthRequestLogin()"
+      >
+        {{ "resendNotification" | i18n }}
+      </button>
 
-  <ng-container *ngIf="flow === Flow.AdminAuthRequest">
-    <p>{{ "youWillBeNotifiedOnceTheRequestIsApproved" | i18n }}</p>
+      <div *ngIf="clientType !== ClientType.Browser" class="tw-mt-4">
+        <span>{{ "needAnotherOptionV1" | i18n }}</span
+        >&nbsp;
+        <a [routerLink]="backToRoute" bitLink linkType="primary">{{
+          "viewAllLogInOptions" | i18n
+        }}</a>
+      </div>
+    </ng-container>
 
-    <div class="tw-font-semibold">{{ "fingerprintPhraseHeader" | i18n }}</div>
-    <code class="tw-text-code">{{ fingerprintPhrase }}</code>
+    <ng-container *ngIf="flow === Flow.AdminAuthRequest">
+      <p>{{ "youWillBeNotifiedOnceTheRequestIsApproved" | i18n }}</p>
 
-    <div class="tw-mt-4">
-      <span>{{ "troubleLoggingIn" | i18n }}</span
-      >&nbsp;
-      <a [routerLink]="backToRoute" bitLink linkType="primary">{{
-        "viewAllLogInOptions" | i18n
-      }}</a>
-    </div>
-  </ng-container>
-</div>
+      <div class="tw-font-semibold">{{ "fingerprintPhraseHeader" | i18n }}</div>
+      <code class="tw-text-code">{{ fingerprintPhrase }}</code>
+
+      <div class="tw-mt-4">
+        <span>{{ "troubleLoggingIn" | i18n }}</span
+        >&nbsp;
+        <a [routerLink]="backToRoute" bitLink linkType="primary">{{
+          "viewAllLogInOptions" | i18n
+        }}</a>
+      </div>
+    </ng-container>
+  </div>
+</ng-container>

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.html
@@ -33,7 +33,7 @@
         block
         buttonType="secondary"
         class="tw-mt-4"
-        (click)="startStandardAuthRequestLogin()"
+        (click)="handleNewStandardAuthRequestLogin()"
       >
         {{ "resendNotification" | i18n }}
       </button>

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -187,9 +187,9 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
   private async initStandardAuthRequestFlow(): Promise<void> {
     this.flow = Flow.StandardAuthRequest;
 
-    this.email = (await firstValueFrom(this.loginEmailService.loginEmail$)) || undefined;
+    const email = (await firstValueFrom(this.loginEmailService.loginEmail$)) || undefined;
 
-    if (!this.email) {
+    if (!email) {
       await this.handleMissingEmail();
       return;
     }

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -567,12 +567,14 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
         await this.reloadCachedStandardAuthRequestIfOneExists();
       }
     } catch (error) {
+      if (error instanceof ErrorResponse && error.statusCode === HttpStatusCode.NotFound) {
+        return await this.clearExistingStandardAuthRequestAndStartNewRequest();
+      }
       if (error instanceof ErrorResponse) {
         await this.router.navigate([this.backToRoute]);
         this.validationService.showError(error);
         return;
       }
-
       this.logService.error(error);
     } finally {
       // Manually clean out the cache to make sure sensitive

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -68,7 +68,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
   private accessCode: string | undefined = undefined;
   private authStatus: AuthenticationStatus | undefined = undefined;
   private showResendNotificationTimeoutSeconds = 12;
-  private loading = true;
+  protected loading = true;
 
   protected backToRoute = "/login";
   protected clientType: ClientType;
@@ -617,6 +617,9 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Clear the cached auth request from state since we're using it to log in.
+    this.loginViaAuthRequestCacheService.clearCacheLoginView();
+
     // Note: keys are set by AuthRequestLoginStrategy success handling
     const authResult = await this.loginStrategyService.logIn(authRequestLoginCredentials);
 
@@ -654,6 +657,9 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
     // clear the admin auth request from state so it cannot be used again (it's a one time use)
     // TODO: this should eventually be enforced via deleting this on the server once it is used
     await this.authRequestService.clearAdminAuthRequest(userId);
+
+    // [Standard Flow Cleanup] Clear the cached auth request from state
+    this.loginViaAuthRequestCacheService.clearCacheLoginView();
 
     this.toastService.showToast({
       variant: "success",

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -112,7 +112,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       .pipe(takeUntilDestroyed())
       .subscribe((requestId) => {
         this.loading = true;
-        this.handleExistingAuthRequestLogin(requestId).catch((e: Error) => {
+        this.handleExistingStandardAuthRequestLogin(requestId).catch((e: Error) => {
           this.toastService.showToast({
             variant: "error",
             title: this.i18nService.t("error"),
@@ -199,7 +199,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       }
 
       await this.reloadCachedStandardAuthRequest(cachedAuthRequest);
-      await this.handleExistingAuthRequestLogin(cachedAuthRequest.id);
+      await this.handleExistingStandardAuthRequestLogin(cachedAuthRequest.id);
     } else {
       await this.handleNewStandardAuthRequestLogin();
     }
@@ -345,7 +345,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       );
 
       // We don't need the public key for handling the authentication request because
-      // the handleExistingAuthRequestLogin function will receive the public key back
+      // the handleExistingStandardAuthRequestLogin function will receive the public key back
       // from the looked up auth request, and all we need is to make sure that
       // we can use the cached private key that is associated with it.
       this.authRequestKeyPair = {
@@ -570,7 +570,9 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
    * @param requestId The ID of the Auth Request to process
    * @returns A boolean indicating whether the Auth Request was successfully processed
    */
-  private async handleExistingAuthRequestLogin(requestId: string): Promise<void> {
+  private async handleExistingStandardAuthRequestLogin(requestId: string): Promise<void> {
+    this.showResendNotification = false;
+
     try {
       const authRequestResponse = await this.retrieveAuthRequest(requestId);
 
@@ -605,6 +607,10 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       }
       this.logService.error(error);
     }
+
+    setTimeout(() => {
+      this.showResendNotification = true;
+    }, this.showResendNotificationTimeoutSeconds * 1000);
   }
 
   private async handleAuthenticatedFlows(authRequestResponse: AuthRequestResponse) {

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -165,6 +165,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // [Admin Request Flow State Management] Check cached auth request
     const existingAdminAuthRequest = await this.reloadCachedAdminAuthRequest(userId);
 
     if (existingAdminAuthRequest) {

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -112,7 +112,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       .pipe(takeUntilDestroyed())
       .subscribe((requestId) => {
         this.loading = true;
-        this.handleExistingStandardAuthRequestLogin(requestId).catch((e: Error) => {
+        this.handleExistingAuthRequestLogin(requestId).catch((e: Error) => {
           this.toastService.showToast({
             variant: "error",
             title: this.i18nService.t("error"),
@@ -199,7 +199,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       }
 
       await this.reloadCachedStandardAuthRequest(cachedAuthRequest);
-      await this.handleExistingStandardAuthRequestLogin(cachedAuthRequest.id);
+      await this.handleExistingAuthRequestLogin(cachedAuthRequest.id);
     } else {
       await this.handleNewStandardAuthRequestLogin();
     }
@@ -345,7 +345,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       );
 
       // We don't need the public key for handling the authentication request because
-      // the handleExistingStandardAuthRequestLogin function will receive the public key back
+      // the handleExistingAuthRequestLogin function will receive the public key back
       // from the looked up auth request, and all we need is to make sure that
       // we can use the cached private key that is associated with it.
       this.authRequestKeyPair = {
@@ -570,7 +570,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
    * @param requestId The ID of the Auth Request to process
    * @returns A boolean indicating whether the Auth Request was successfully processed
    */
-  private async handleExistingStandardAuthRequestLogin(requestId: string): Promise<void> {
+  private async handleExistingAuthRequestLogin(requestId: string): Promise<void> {
     this.showResendNotification = false;
 
     try {

--- a/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.ts
+++ b/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.ts
@@ -1,8 +1,6 @@
 import { inject, Injectable, WritableSignal } from "@angular/core";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/abstractions/view-cache.service";
-import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
-import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
 import { LoginViaAuthRequestView } from "@bitwarden/common/auth/models/view/login-via-auth-request.view";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -45,12 +43,7 @@ export class LoginViaAuthRequestCacheService {
   /**
    * Update the cache with the new LoginView.
    */
-  cacheLoginView(
-    authRequest: AuthRequest,
-    authRequestResponse: AuthRequestResponse,
-    fingerprintPhrase: string,
-    keys: { privateKey: Uint8Array | undefined; publicKey: Uint8Array | undefined },
-  ): void {
+  cacheLoginView(id: string, privateKey: Uint8Array, accessCode: string): void {
     if (!this.featureEnabled) {
       return;
     }
@@ -59,11 +52,9 @@ export class LoginViaAuthRequestCacheService {
     // data can be properly formed when json-ified. If not done, they are not stored properly and
     // will not be parsable by the cryptography library after coming out of storage.
     this.defaultLoginViaAuthRequestCache.set({
-      authRequest,
-      authRequestResponse,
-      fingerprintPhrase,
-      privateKey: keys.privateKey ? Utils.fromBufferToB64(keys.privateKey.buffer) : undefined,
-      publicKey: keys.publicKey ? Utils.fromBufferToB64(keys.publicKey.buffer) : undefined,
+      id: id,
+      privateKey: Utils.fromBufferToB64(privateKey.buffer),
+      accessCode: accessCode,
     } as LoginViaAuthRequestView);
   }
 

--- a/libs/common/src/auth/models/view/login-via-auth-request.view.ts
+++ b/libs/common/src/auth/models/view/login-via-auth-request.view.ts
@@ -1,15 +1,11 @@
 import { Jsonify } from "type-fest";
 
-import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
-import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
 import { View } from "@bitwarden/common/models/view/view";
 
 export class LoginViaAuthRequestView implements View {
-  authRequest: AuthRequest | undefined = undefined;
-  authRequestResponse: AuthRequestResponse | undefined = undefined;
-  fingerprintPhrase: string | undefined = undefined;
+  id: string | undefined = undefined;
+  accessCode: string | undefined = undefined;
   privateKey: string | undefined = undefined;
-  publicKey: string | undefined = undefined;
 
   static fromJSON(obj: Partial<Jsonify<LoginViaAuthRequestView>>): LoginViaAuthRequestView {
     return Object.assign(new LoginViaAuthRequestView(), obj);

--- a/libs/common/src/auth/models/view/login-via-auth-request.view.ts
+++ b/libs/common/src/auth/models/view/login-via-auth-request.view.ts
@@ -7,7 +7,10 @@ export class LoginViaAuthRequestView implements View {
   accessCode: string | undefined = undefined;
   privateKey: string | undefined = undefined;
 
-  static fromJSON(obj: Partial<Jsonify<LoginViaAuthRequestView>>): LoginViaAuthRequestView {
+  static fromJSON(obj: Partial<Jsonify<LoginViaAuthRequestView>>): LoginViaAuthRequestView | null {
+    if (obj == null) {
+      return null;
+    }
     return Object.assign(new LoginViaAuthRequestView(), obj);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19380

## 📔 Objective

* Fixed standard login with device auth request flow for when the extension is closed.
* Restructured code to be easier to follow.
* Added documentation for login with auth request process.

## 📸 Screenshots

Recordings of 9 Flows

Browser
* Login with device
* TDE User approve from another device
* TDE User admin approval

Web
* Login with device
* TDE User approve from another device
* TDE User admin approval

Desktop
* Login with device
* TDE User approve from another device
* TDE User admin approval

https://drive.google.com/drive/folders/17pAw4ijHzO-dxZIx2XCD0wz38vt96GgP?usp=sharing

These flows were also tested on main, but there are no recordings of those for time savings sake. They are working as far as my domain of testing is concerned.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
