### PR TITLE
[CL-608] Allow custom icons in toasts

### DIFF
--- a/libs/components/src/toast/toast.component.html
+++ b/libs/components/src/toast/toast.component.html
@@ -5,7 +5,11 @@
   [attr.role]="variant === 'error' ? 'alert' : null"
 >
   <div class="tw-flex tw-items-center tw-gap-4 tw-px-2 tw-pb-1 tw-pt-2">
-    <i aria-hidden="true" class="bwi tw-text-xl tw-py-1.5 tw-px-2.5 {{ iconClass }}"></i>
+    @if (isIcon(icon)) {
+      <bit-icon class="tw-text-xl tw-py-1.5 tw-px-2.5" [icon]="icon"></bit-icon>
+    } @else {
+      <i aria-hidden="true" class="bwi tw-text-xl tw-py-1.5 tw-px-2.5 {{ iconClass }}"></i>
+    }
     <div>
       <span class="tw-sr-only">{{ variant | i18n }}</span>
       @if (title) {

--- a/libs/components/src/toast/toast.component.ts
+++ b/libs/components/src/toast/toast.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 
+import { Icon, isIcon } from "../icon";
+import { IconModule } from "../icon/icon.module";
 import { IconButtonModule } from "../icon-button";
 import { SharedModule } from "../shared";
 import { TypographyModule } from "../typography";
@@ -29,9 +31,10 @@ const variants: Record<ToastVariant, { icon: string; bgColor: string }> = {
   selector: "bit-toast",
   templateUrl: "toast.component.html",
   standalone: true,
-  imports: [SharedModule, IconButtonModule, TypographyModule],
+  imports: [SharedModule, IconButtonModule, TypographyModule, IconModule],
 })
 export class ToastComponent {
+  /** The variant of the toast */
   @Input() variant: ToastVariant = "info";
 
   /**
@@ -50,10 +53,25 @@ export class ToastComponent {
    **/
   @Input() progressWidth = 0;
 
+  /** An optional icon that overrides the existing variant definition
+   * string if you want to a use a font icon, or an Icon object if you want to use an SVG icon.
+   */
+  @Input() icon?: string | Icon;
+
   /** Emits when the user presses the close button */
   @Output() onClose = new EventEmitter<void>();
 
+  /**
+   * Checks if the provided icon is type of Icon and when that is true returns an Icon
+   */
+  protected isIcon(icon: unknown): icon is Icon {
+    return isIcon(icon);
+  }
+
   protected get iconClass(): string {
+    if (typeof this.icon === "string" && this.icon !== "") {
+      return this.icon;
+    }
     return variants[this.variant].icon;
   }
 

--- a/libs/components/src/toast/toast.service.ts
+++ b/libs/components/src/toast/toast.service.ts
@@ -11,7 +11,7 @@ export type ToastOptions = {
    * The duration the toast will persist in milliseconds
    **/
   timeout?: number;
-} & Pick<ToastComponent, "message" | "variant" | "title">;
+} & Pick<ToastComponent, "message" | "variant" | "title" | "icon">;
 
 /**
  * Presents toast notifications
@@ -26,6 +26,7 @@ export class ToastService {
         message: options.message,
         variant: options.variant,
         title: options.title,
+        icon: options?.icon,
       },
       timeOut:
         options.timeout != null && options.timeout > 0

--- a/libs/components/src/toast/toast.stories.ts
+++ b/libs/components/src/toast/toast.stories.ts
@@ -7,6 +7,7 @@ import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/an
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { ButtonModule } from "../button";
+import { Icons } from "../icon";
 import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { ToastComponent } from "./toast.component";
@@ -76,10 +77,10 @@ export const Default: Story = {
     props: args,
     template: `
       <div class="tw-flex tw-flex-col tw-min-w tw-max-w-[--bit-toast-width]">
-        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" (onClose)="onClose()" variant="success"></bit-toast>
-        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" (onClose)="onClose()" variant="info"></bit-toast>
-        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" (onClose)="onClose()" variant="warning"></bit-toast>
-        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" (onClose)="onClose()" variant="error"></bit-toast>
+        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" [icon]="icon" (onClose)="onClose()" variant="success"></bit-toast>
+        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" [icon]="icon" (onClose)="onClose()" variant="info"></bit-toast>
+        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" [icon]="icon" (onClose)="onClose()" variant="warning"></bit-toast>
+        <bit-toast [title]="title" [message]="message" [progressWidth]="progressWidth" [icon]="icon" (onClose)="onClose()" variant="error"></bit-toast>
       </div>
     `,
   }),
@@ -96,6 +97,24 @@ export const LongContent: Story = {
       "Lorem ipsum dolor sit amet, consectetur adipisci",
       "Lorem ipsum dolor sit amet, consectetur adipisci",
     ],
+  },
+};
+
+export const WithCustomIconFromFont: Story = {
+  ...Default,
+  args: {
+    title: "Foo",
+    message: ["With custom icon from font"],
+    icon: "bwi-send-f",
+  },
+};
+
+export const WithCustomIconUsingSvg: Story = {
+  ...Default,
+  args: {
+    title: "Foo",
+    message: ["With custom svg icon"],
+    icon: Icons.Search,
   },
 };
 

--- a/libs/components/src/toast/toastr.component.ts
+++ b/libs/components/src/toast/toastr.component.ts
@@ -10,6 +10,7 @@ import { ToastComponent } from "./toast.component";
       [title]="options?.payload?.title"
       [variant]="options?.payload?.variant"
       [message]="options?.payload?.message"
+      [icon]="options?.payload?.icon"
       [progressWidth]="width()"
       (onClose)="remove()"
     ></bit-toast>


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/CL-608

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Toasts already display an icon based on the configured variant. This extend the toast to have an optional icon property which can either be a `string` or an `Icon`.

For a string provided icon, it will lookup the name and display one of the icons shown in https://components.bitwarden.com/?path=/docs/documentation-icons--docs based on our font icons

If an Icon (svg) is provided, it will render it.

If none is provided it will fallback to the current behaviour and show the icon based on the variant

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### With font icon (`bwi-send-f`)
![image](https://github.com/user-attachments/assets/958b7e88-5c06-4464-9016-0bb085f77c18)

### With svg Icon (`Icons.Search`)
![image](https://github.com/user-attachments/assets/87419ff9-d14b-4c25-b1e6-e5550fe54ab3)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
