### PR TITLE
fix: use newly-minted policy methods in metadata provider

### DIFF
--- a/libs/tools/generator/core/src/services/generator-metadata-provider.spec.ts
+++ b/libs/tools/generator/core/src/services/generator-metadata-provider.spec.ts
@@ -295,7 +295,7 @@ describe("GeneratorMetadataProvider", () => {
       [Algorithm.username, effWordList],
       [Algorithm.password, password],
     ])("gets a specific algorithm", async (algorithm, metadata) => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, [
         metadata,
       ]);
@@ -311,7 +311,7 @@ describe("GeneratorMetadataProvider", () => {
       [Type.username, [effWordList]],
       [Type.password, [password, passphrase]],
     ])("gets a category of algorithms", async (category, metadata) => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, metadata);
       const result = new ReplaySubject<CredentialAlgorithm[]>(1);
 
@@ -329,7 +329,7 @@ describe("GeneratorMetadataProvider", () => {
           overridePasswordType: Algorithm.password,
         },
       } as any);
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([policy]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([policy]));
       const metadata = [password, passphrase];
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, metadata);
       const algorithmResult = new ReplaySubject<CredentialAlgorithm[]>(1);
@@ -347,7 +347,7 @@ describe("GeneratorMetadataProvider", () => {
     });
 
     it("omits algorithms whose metadata is unavailable", async () => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, [
         password,
       ]);
@@ -389,7 +389,7 @@ describe("GeneratorMetadataProvider", () => {
       [Type.username, effWordList],
       [Type.password, password],
     ])("emits the user's %s preference", async (type, metadata) => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, [
         metadata,
       ]);
@@ -401,7 +401,7 @@ describe("GeneratorMetadataProvider", () => {
     });
 
     it("emits a default when the user's preference is unavailable", async () => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, [
         plusAddress,
       ]);
@@ -416,7 +416,7 @@ describe("GeneratorMetadataProvider", () => {
     });
 
     it("emits undefined when the user's preference is unavailable and there is no metadata", async () => {
-      SomePolicyService.getAll$.mockReturnValue(new BehaviorSubject([]));
+      SomePolicyService.policiesByType$.mockReturnValue(new BehaviorSubject([]));
       const provider = new GeneratorMetadataProvider(SystemProvider, ApplicationProvider, []);
       const result = new ReplaySubject<CredentialAlgorithm | undefined>(1);
 

--- a/libs/tools/generator/core/src/services/generator-metadata-provider.ts
+++ b/libs/tools/generator/core/src/services/generator-metadata-provider.ts
@@ -145,12 +145,14 @@ export class GeneratorMetadataProvider {
 
     const available$ = id$.pipe(
       switchMap((id) => {
-        const policies$ = this.application.policy.getAll$(PolicyType.PasswordGenerator, id).pipe(
-          map((p) => availableAlgorithms_vNext(p).filter((a) => this._metadata.has(a))),
-          map((p) => new Set(p)),
-          // complete policy emissions otherwise `switchMap` holds `available$` open indefinitely
-          takeUntil(anyComplete(id$)),
-        );
+        const policies$ = this.application.policy
+          .policiesByType$(PolicyType.PasswordGenerator, id)
+          .pipe(
+            map((p) => availableAlgorithms_vNext(p).filter((a) => this._metadata.has(a))),
+            map((p) => new Set(p)),
+            // complete policy emissions otherwise `switchMap` holds `available$` open indefinitely
+            takeUntil(anyComplete(id$)),
+          );
         return policies$;
       }),
       map(


### PR DESCRIPTION

## 🎟️ Tracking

Who's asking

## 📔 Objective

Recently the policy service was [refactored](https://github.com/bitwarden/clients/pull/13678) and some method signatures were changed. One of these changes involved renaming the `getAll` observable to `policiesByType`.

This was not merged into the [metadata provider work](https://github.com/bitwarden/clients/pull/13744) before it was merged, so those changes were committed using removed method signatures.

This commit updates these references.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
