### PR TITLE
Updated short name in MV3 manifest

### DIFF
--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "minimum_chrome_version": "102.0",
   "name": "__MSG_extName__",
-  "short_name": "__MSG_appName__",
+  "short_name": "Bitwarden",
   "version": "2025.3.1",
   "description": "__MSG_extDesc__",
   "default_locale": "en",


### PR DESCRIPTION
🎟️ Tracking
[bitwarden.atlassian.net/browse/PM-19435](https://bitwarden.atlassian.net/browse/PM-19435)

📔 Objective

We are unable to upload the Opera extension due to it not liking the fact that our placeholder `__MSG_appName__` is over 12 characters.

This was adjusted to `Bitwarden` in the Mv2 manifest in https://github.com/bitwarden/clients/pull/13989.  This does the same for the (correct) Mv3 manifest.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
