### PR TITLE
[PM-19582] Set correct filename extensions on vault-export

### DIFF
--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
@@ -81,7 +81,7 @@ export class IndividualVaultExportService
     return {
       type: "text/plain",
       data: await this.buildPasswordExport(exportVault.data, password),
-      fileName: ExportHelper.getFileName("json"),
+      fileName: ExportHelper.getFileName("", "encrypted_json"),
     } as ExportedVaultAsString;
   }
 
@@ -126,7 +126,7 @@ export class IndividualVaultExportService
     return {
       type: "application/zip",
       data: blobData,
-      fileName: ExportHelper.getFileName("json"),
+      fileName: ExportHelper.getFileName("", "json"),
     } as ExportedVaultAsBlob;
   }
 
@@ -185,14 +185,14 @@ export class IndividualVaultExportService
       return {
         type: "text/plain",
         data: this.buildCsvExport(decFolders, decCiphers),
-        fileName: ExportHelper.getFileName("csv"),
+        fileName: ExportHelper.getFileName("", "csv"),
       } as ExportedVaultAsString;
     }
 
     return {
       type: "text/plain",
       data: this.buildJsonExport(decFolders, decCiphers),
-      fileName: ExportHelper.getFileName("json"),
+      fileName: ExportHelper.getFileName("", "json"),
     } as ExportedVaultAsString;
   }
 
@@ -250,7 +250,7 @@ export class IndividualVaultExportService
     return {
       type: "text/plain",
       data: JSON.stringify(jsonDoc, null, "  "),
-      fileName: ExportHelper.getFileName("json"),
+      fileName: ExportHelper.getFileName("", "json"),
     } as ExportedVaultAsString;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19582

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While testing the changes made with https://github.com/bitwarden/clients/pull/13842, QA discovered that the filename extensions weren't set properly. They defaulted to `.csv` even if `.json` was selected. This only occurred on individual vault exports.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
