### PR TITLE
[CL-550] Update cipher form story

### DIFF
--- a/libs/vault/src/cipher-form/cipher-form.mdx
+++ b/libs/vault/src/cipher-form/cipher-form.mdx
@@ -12,6 +12,9 @@ It is configured via a `CipherFormConfig` object that is passed to the component
 create it. A default implementation of the `CipherFormConfigService` exists in the
 `@bitwarden/vault` library.
 
+The cipher form has a slot for `attachment-button`, which should be included when the form is in
+`edit` mode.
+
 <Primary />
 
 <Controls include={["config", "submitBtn"]} />

--- a/libs/vault/src/cipher-form/cipher-form.stories.ts
+++ b/libs/vault/src/cipher-form/cipher-form.stories.ts
@@ -29,7 +29,7 @@ import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
-import { AsyncActionsModule, ButtonModule, ToastService } from "@bitwarden/components";
+import { AsyncActionsModule, ButtonModule, ItemModule, ToastService } from "@bitwarden/components";
 import {
   CipherFormConfig,
   CipherFormGenerationService,
@@ -131,7 +131,7 @@ export default {
   component: CipherFormComponent,
   decorators: [
     moduleMetadata({
-      imports: [CipherFormModule, AsyncActionsModule, ButtonModule],
+      imports: [CipherFormModule, AsyncActionsModule, ButtonModule, ItemModule],
       providers: [
         {
           provide: CipherFormService,
@@ -246,7 +246,7 @@ export default {
 
 type Story = StoryObj<CipherFormComponent>;
 
-export const Default: Story = {
+export const Add: Story = {
   render: (args) => {
     return {
       props: {
@@ -254,15 +254,28 @@ export const Default: Story = {
         ...args,
       },
       template: /*html*/ `
-        <vault-cipher-form [config]="config" (cipherSaved)="onSave($event)" formId="test-form" [submitBtn]="submitBtn"></vault-cipher-form>
-        <button type="submit" form="test-form" bitButton buttonType="primary" #submitBtn>Submit</button>
+        <vault-cipher-form [config]="config" (cipherSaved)="onSave($event)" formId="test-form"></vault-cipher-form>
       `,
     };
   },
 };
 
 export const Edit: Story = {
-  ...Default,
+  render: (args) => {
+    return {
+      props: {
+        onSave: actionsData.onSave,
+        ...args,
+      },
+      template: /*html*/ `
+        <vault-cipher-form [config]="config" (cipherSaved)="onSave($event)" formId="test-form" [submitBtn]="submitBtn">
+          <bit-item slot="attachment-button">
+            <button bit-item-content type="button">Attachments</button>
+          </bit-item>
+        </vault-cipher-form>
+      `,
+    };
+  },
   args: {
     config: {
       ...defaultConfig,
@@ -273,7 +286,7 @@ export const Edit: Story = {
 };
 
 export const PartialEdit: Story = {
-  ...Default,
+  ...Add,
   args: {
     config: {
       ...defaultConfig,
@@ -284,7 +297,7 @@ export const PartialEdit: Story = {
 };
 
 export const Clone: Story = {
-  ...Default,
+  ...Add,
   args: {
     config: {
       ...defaultConfig,
@@ -294,8 +307,27 @@ export const Clone: Story = {
   },
 };
 
+export const WithSubmitButton: Story = {
+  render: (args) => {
+    return {
+      props: {
+        onSave: actionsData.onSave,
+        ...args,
+      },
+      template: /*html*/ `
+      <div class="tw-p-4">
+        <vault-cipher-form [config]="config" (cipherSaved)="onSave($event)" formId="test-form" [submitBtn]="submitBtn"></vault-cipher-form>
+      </div>
+      <div class="tw-p-4">
+        <button type="submit" form="test-form" bitButton buttonType="primary" #submitBtn>Submit</button>
+      </div>
+      `,
+    };
+  },
+};
+
 export const NoPersonalOwnership: Story = {
-  ...Default,
+  ...Add,
   args: {
     config: {
       ...defaultConfig,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-550](https://bitwarden.atlassian.net/browse/CL-550)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the story for the cipher form to more closely reflect the scope of the component. As I made spacing updates in a previous PR, I noticed the stories each included an optional submit button that is not actually part of the component, which led to some visual spacing discrepancies that looked like bugs. This PR removes the submit buttons from all stories except for a dedicated story for showcasing the form with the optional submit button and some additional bespoke spacing. The intent is that the primary stories reflect only the component, but that we still have one story for showing the composed-with-button version. I also renamed the default story to match the "mode" names of the other stories for clarity.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-27 at 11 11 11 AM](https://github.com/user-attachments/assets/2f30f774-7fde-4e31-b944-ebf8cfd3f9d5) | ![Screenshot 2025-03-27 at 11 11 18 AM](https://github.com/user-attachments/assets/a855aba7-b39e-4099-ba00-b8fb47e55dcd) |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-550]: https://bitwarden.atlassian.net/browse/CL-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ