### PR TITLE
[PM-19435] Update extension short name to no longer be localized

### DIFF
--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extName__",
-  "short_name": "__MSG_appName__",
+  "short_name": "Bitwarden",
   "version": "2025.3.2",
   "description": "__MSG_extDesc__",
   "default_locale": "en",

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "minimum_chrome_version": "102.0",
   "name": "__MSG_extName__",
-  "short_name": "__MSG_appName__",
+  "short_name": "Bitwarden",
   "version": "2025.3.2",
   "description": "__MSG_extDesc__",
   "default_locale": "en",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19435

## 📔 Objective

In order to address an issue that prevents Opera extensions from being uploaded, we must ensure that the `short_name` placeholder (not the localized value) is less than 12 characters.  Rather than shorten the placeholder, we have opted to not localize this value until Opera has address the underlying problem.

We are tracking internally the work to add it back in https://bitwarden.atlassian.net/browse/PM-19610.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
