### PR TITLE
fix(general-improvement): [PM-19617] Add Shortcut to Configure Local Server

### DIFF
--- a/libs/auth/src/angular/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
+++ b/libs/auth/src/angular/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { DialogRef } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit, HostListener } from "@angular/core";
 import {
   AbstractControl,
   FormBuilder,
@@ -159,6 +159,21 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
           });
         },
       });
+  }
+
+  @HostListener("document:keydown.control.b", ["$event"])
+  onCtrlB(event: KeyboardEvent) {
+    if (process.env.ENV === "development") {
+      event.preventDefault();
+      this.formGroup.patchValue({
+        baseUrl: "",
+        webVaultUrl: "https://localhost:8080",
+        apiUrl: "http://localhost:4000",
+        identityUrl: "http://localhost:33656",
+        iconsUrl: "http://localhost:50024",
+        notificationsUrl: "http://localhost:61840",
+      });
+    }
   }
 
   submit = async () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19617

## 📔 Objective

I got tired of manually typing in the localhost config. Now a dev can input ctrl + b (for Bitwarden, maybe we can leverage the ctrl + b shortcut for other helpful shortcuts) Added secret keybind to speed up config of localhost service.

## 📸 Screenshots

https://github.com/user-attachments/assets/e445bafb-f599-495d-bd71-09593ed4c922

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
