### PR TITLE
[PM-19538] Add shareReplay to internal orgKeys subscription

### DIFF
--- a/libs/admin-console/src/common/collections/services/default-collection.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection.service.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { combineLatest, firstValueFrom, map, Observable, of, switchMap } from "rxjs";
+import { combineLatest, firstValueFrom, map, Observable, of, shareReplay, switchMap } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
@@ -8,10 +8,10 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
   ActiveUserState,
-  StateProvider,
   COLLECTION_DATA,
   DeriveDefinition,
   DerivedState,
+  StateProvider,
   UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
@@ -84,6 +84,7 @@ export class DefaultCollectionService implements CollectionService {
       switchMap(([userId, collectionData]) =>
         combineLatest([of(collectionData), this.keyService.orgKeys$(userId)]),
       ),
+      shareReplay({ refCount: false, bufferSize: 1 }),
     );
 
     this.decryptedCollectionDataState = this.stateProvider.getDerived(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19538](https://bitwarden.atlassian.net/browse/PM-19538)

## 📔 Objective

`encryptedCollectionsWithKeys` is re-subscribed to for every subscription to `decryptedCollectionViews$()` which in turn subscribes to `keyService.orgKeys$` repeatedly causing delays for users with many (dozens) of organizations. Adding a `shareReplay` to this internal observable ensures we're not repeatedly decrypting orgKeys for every subscription to decrypted collections.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19538]: https://bitwarden.atlassian.net/browse/PM-19538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ