### PR TITLE
[PM-432] - Protect entire item when Master Password Re-prompt is selected - desktop

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault.component.html
+++ b/apps/desktop/src/vault/app/vault/vault.component.html
@@ -16,7 +16,7 @@
     [cipherId]="cipherId"
     [collectionId]="activeFilter?.selectedCollectionId"
     (onCloneCipher)="cloneCipherWithoutPasswordPrompt($event)"
-    (onEditCipher)="editCipherWithoutPasswordPrompt($event)"
+    (onEditCipher)="editCipher($event)"
     (onViewCipherPasswordHistory)="viewCipherPasswordHistory($event)"
     (onRestoredCipher)="restoredCipher($event)"
     (onDeletedCipher)="deletedCipher($event)"

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -91,6 +91,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   userHasPremiumAccess = false;
   activeFilter: VaultFilter = new VaultFilter();
   activeUserId: UserId;
+  cipherIdRepromptList: string[] = [];
 
   private modal: ModalRef = null;
   private componentIsDestroyed$ = new Subject<boolean>();
@@ -297,6 +298,8 @@ export class VaultComponent implements OnInit, OnDestroy {
 
   async viewCipher(cipher: CipherView) {
     if (!(await this.canNavigateAway("view", cipher))) {
+      return;
+    } else if (!(await this.passwordReprompt(cipher))) {
       return;
     }
 
@@ -821,9 +824,16 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   private async passwordReprompt(cipher: CipherView) {
-    return (
-      cipher.reprompt === CipherRepromptType.None ||
-      (await this.passwordRepromptService.showPasswordPrompt())
-    );
+    if (this.cipherIdRepromptList.includes(cipher.id)) {
+      return true;
+    }
+    if (cipher.reprompt === CipherRepromptType.None) {
+      return;
+    }
+    const repromptResult = await this.passwordRepromptService.showPasswordPrompt();
+    if (repromptResult) {
+      this.cipherIdRepromptList.push(cipher.id);
+    }
+    return repromptResult;
   }
 }

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -823,11 +823,12 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   private async passwordReprompt(cipher: CipherView) {
-    if (this.cipherRepromptId === cipher.id) {
+    if (cipher.reprompt === CipherRepromptType.None) {
+      this.cipherRepromptId = null;
       return true;
     }
-    if (cipher.reprompt === CipherRepromptType.None) {
-      return;
+    if (this.cipherRepromptId === cipher.id) {
+      return true;
     }
     const repromptResult = await this.passwordRepromptService.showPasswordPrompt();
     if (repromptResult) {

--- a/apps/desktop/src/vault/app/vault/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault.component.ts
@@ -91,7 +91,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   userHasPremiumAccess = false;
   activeFilter: VaultFilter = new VaultFilter();
   activeUserId: UserId;
-  cipherIdRepromptList: string[] = [];
+  cipherRepromptId: string | null = null;
 
   private modal: ModalRef = null;
   private componentIsDestroyed$ = new Subject<boolean>();
@@ -769,9 +769,8 @@ export class VaultComponent implements OnInit, OnDestroy {
   private copyValue(cipher: CipherView, value: string, labelI18nKey: string, aType: string) {
     this.functionWithChangeDetection(async () => {
       if (
-        cipher.reprompt !== CipherRepromptType.None &&
         this.passwordRepromptService.protectedFields().includes(aType) &&
-        !(await this.passwordRepromptService.showPasswordPrompt())
+        !(await this.passwordReprompt(cipher))
       ) {
         return;
       }
@@ -824,7 +823,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   private async passwordReprompt(cipher: CipherView) {
-    if (this.cipherIdRepromptList.includes(cipher.id)) {
+    if (this.cipherRepromptId === cipher.id) {
       return true;
     }
     if (cipher.reprompt === CipherRepromptType.None) {
@@ -832,7 +831,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
     const repromptResult = await this.passwordRepromptService.showPasswordPrompt();
     if (repromptResult) {
-      this.cipherIdRepromptList.push(cipher.id);
+      this.cipherRepromptId = cipher.id;
     }
     return repromptResult;
   }

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -203,12 +203,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   }
 
   async edit() {
-    if (await this.promptPassword()) {
-      this.onEditCipher.emit(this.cipher);
-      return true;
-    }
-
-    return false;
+    this.onEditCipher.emit(this.cipher);
   }
 
   async clone() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-432

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR triggers a password re-prompt when viewing a MP enabled cipher in the desktop client and retains the prompt while the cipher is being viewed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/13888a50-bb93-4b85-aa4d-28a41b4b5e92



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
