### PR TITLE
[PM-617] - Menu component does not open to top of triggering elements at the bottom of a viewport 

### DIFF
--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -48,11 +48,12 @@ export class MenuTriggerForDirective implements OnDestroy {
           overlayX: "start",
           overlayY: "top",
         },
+        // Fallback position: show above the trigger
         {
-          originX: "end",
-          originY: "bottom",
-          overlayX: "end",
-          overlayY: "top",
+          originX: "start",
+          originY: "top",
+          overlayX: "start",
+          overlayY: "bottom",
         },
       ])
       .withLockedPosition(true)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/CL-617

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the fallback position config to ensure that the menu renders above the trigger.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|![Screenshot 2025-03-27 at 5 00 03 PM](https://github.com/user-attachments/assets/4731ef1a-c20c-43da-adc1-bcd8f77a9f51)|![Screenshot 2025-03-27 at 4 59 23 PM](https://github.com/user-attachments/assets/9718fdfd-4e77-4214-ab58-7fc7f760459b)|

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
