### PR TITLE
[PM-19656] Fix zip option not being set correctly after navigating to Admin Console

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -330,12 +330,10 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       .pipe(takeUntil(this.destroy$))
       .subscribe(([value, isExportAttachmentsEnabled]) => {
         this.organizationId = value !== "myVault" ? value : undefined;
+
+        this.formatOptions = this.formatOptions.filter((option) => option.value !== "zip");
         if (value === "myVault" && isExportAttachmentsEnabled) {
-          if (!this.formatOptions.some((option) => option.value === "zip")) {
-            this.formatOptions.push({ name: ".zip (with attachments)", value: "zip" });
-          }
-        } else {
-          this.formatOptions = this.formatOptions.filter((option) => option.value !== "zip");
+          this.formatOptions.push({ name: ".zip (with attachments)", value: "zip" });
         }
       });
   }

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -225,6 +225,20 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       ),
     );
 
+    combineLatest([
+      this.exportForm.controls.vaultSelector.valueChanges,
+      this.isExportAttachmentsEnabled$,
+    ])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([value, isExportAttachmentsEnabled]) => {
+        this.organizationId = value !== "myVault" ? value : undefined;
+
+        this.formatOptions = this.formatOptions.filter((option) => option.value !== "zip");
+        if (value === "myVault" && isExportAttachmentsEnabled) {
+          this.formatOptions.push({ name: ".zip (with attachments)", value: "zip" });
+        }
+      });
+
     merge(
       this.exportForm.get("format").valueChanges,
       this.exportForm.get("fileEncryptionType").valueChanges,
@@ -322,20 +336,6 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
         takeUntil(this.destroy$),
       )
       .subscribe();
-
-    combineLatest([
-      this.exportForm.controls.vaultSelector.valueChanges,
-      this.isExportAttachmentsEnabled$,
-    ])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([value, isExportAttachmentsEnabled]) => {
-        this.organizationId = value !== "myVault" ? value : undefined;
-
-        this.formatOptions = this.formatOptions.filter((option) => option.value !== "zip");
-        if (value === "myVault" && isExportAttachmentsEnabled) {
-          this.formatOptions.push({ name: ".zip (with attachments)", value: "zip" });
-        }
-      });
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19656

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
QA defect: When the user navigates to the Admin console export and then navigates back to the password manager export, then the zip option is not displayed anymore.

The reason being that the changes to `vaultSelector` were happening before the subscription to it's changes were set up. Moving the subscription up within ngOnInit solves this.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
