### PR TITLE
[PM-18812] Avoid unnecessary I/O for frequently updated state `accountProfile`

### DIFF
--- a/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
+++ b/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
@@ -54,12 +54,19 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
     hasPremiumFromAnyOrganization: boolean,
     userId: UserId,
   ): Promise<void> {
-    await this.stateProvider.getUser(userId, BILLING_ACCOUNT_PROFILE_KEY_DEFINITION).update((_) => {
-      return {
-        hasPremiumPersonally: hasPremiumPersonally,
-        hasPremiumFromAnyOrganization: hasPremiumFromAnyOrganization,
-      };
-    });
+    await this.stateProvider.getUser(userId, BILLING_ACCOUNT_PROFILE_KEY_DEFINITION).update(
+      (_) => {
+        return {
+          hasPremiumPersonally: hasPremiumPersonally,
+          hasPremiumFromAnyOrganization: hasPremiumFromAnyOrganization,
+        };
+      },
+      {
+        shouldUpdate: (state) =>
+          state.hasPremiumFromAnyOrganization !== hasPremiumFromAnyOrganization ||
+          state.hasPremiumPersonally !== hasPremiumPersonally,
+      },
+    );
   }
 
   canViewSubscription$(userId: UserId): Observable<boolean> {

--- a/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
+++ b/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
@@ -63,6 +63,7 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
       },
       {
         shouldUpdate: (state) =>
+          state == null ||
           state.hasPremiumFromAnyOrganization !== hasPremiumFromAnyOrganization ||
           state.hasPremiumPersonally !== hasPremiumPersonally,
       },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18812

## 📔 Objective

In https://bitwarden.atlassian.net/browse/PM-13086, we discovered that the root cause of (at least some of) the issues is the electron-store implementation that we use on the desktop, and how it performs reads and writes.  This is exacerbated by the large size of the data.json file in which we store all local state on the desktop.

You can see here: https://github.com/sindresorhus/conf/blob/05f1b87cc1475922ba7e9c5455cf361f07174ae7/source/index.ts#L329-L331 that every get store() does a fs.readFileSync and this getter is called every time we request a key from the store. Currently we seem to be regularly requesting the following keys:

- State Provider Framework documentation: https://contributing.bitwarden.com/architecture/deep-dives/state/#update

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
