### PR TITLE
[PM-19713][BEEEP] Improve performance of whether user can view subsc…

### DIFF
--- a/apps/web/src/app/layouts/user-layout.component.ts
+++ b/apps/web/src/app/layouts/user-layout.component.ts
@@ -31,8 +31,6 @@ import { WebLayoutModule } from "./web-layout.module";
 })
 export class UserLayoutComponent implements OnInit {
   protected readonly logo = PasswordManagerLogo;
-  protected hasFamilySponsorshipAvailable$: Observable<boolean>;
-  protected showSponsoredFamilies$: Observable<boolean>;
   protected showSubscription$: Observable<boolean>;
 
   constructor(

--- a/apps/web/src/app/layouts/user-layout.component.ts
+++ b/apps/web/src/app/layouts/user-layout.component.ts
@@ -31,6 +31,8 @@ import { WebLayoutModule } from "./web-layout.module";
 })
 export class UserLayoutComponent implements OnInit {
   protected readonly logo = PasswordManagerLogo;
+  protected hasFamilySponsorshipAvailable$: Observable<boolean>;
+  protected showSponsoredFamilies$: Observable<boolean>;
   protected showSubscription$: Observable<boolean>;
 
   constructor(

--- a/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
+++ b/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
@@ -68,6 +68,10 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
       this.hasPremiumFromAnyOrganization$(userId),
     ]).pipe(
       concatMap(async ([hasPremiumPersonally, hasPremiumFromOrg]) => {
+        if (hasPremiumPersonally === true || !hasPremiumFromOrg === true) {
+          return true;
+        }
+
         const isCloud = !this.platformUtilsService.isSelfHost();
 
         let billing = null;
@@ -76,7 +80,7 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
         }
 
         const cloudAndBillingHistory = isCloud && !billing?.hasNoHistory;
-        return hasPremiumPersonally || !hasPremiumFromOrg || cloudAndBillingHistory;
+        return cloudAndBillingHistory;
       }),
     );
   }

--- a/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
+++ b/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
@@ -74,12 +74,12 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
 
         const isCloud = !this.platformUtilsService.isSelfHost();
 
-        let billing = null;
         if (isCloud) {
-          billing = await this.apiService.getUserBillingHistory();
+          const billing = await this.apiService.getUserBillingHistory();
+          return !billing?.hasNoHistory;
         }
 
-        return isCloud && !billing?.hasNoHistory;
+        return false;
       }),
     );
   }

--- a/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
+++ b/libs/common/src/billing/services/account/billing-account-profile-state.service.ts
@@ -79,8 +79,7 @@ export class DefaultBillingAccountProfileStateService implements BillingAccountP
           billing = await this.apiService.getUserBillingHistory();
         }
 
-        const cloudAndBillingHistory = isCloud && !billing?.hasNoHistory;
-        return cloudAndBillingHistory;
+        return isCloud && !billing?.hasNoHistory;
       }),
     );
   }


### PR DESCRIPTION
…ription

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19713

## 📔 Objective

It appears we do at least 1-3 calls to Stripe unnecessarily when the condition could have already evaluated to true whether a user can view a subscription in the user's layout. This call happens every time when logging in.

In a situation where the individual is subscribed to Premium, the amount of calls happening in the back-end to Stripe can take 500ms to 2000ms. Notice the calls or lack of calls to `GET /accounts/billing/history` in the screenshots below.

## 📸 Screenshots

AFTER with FREE individual/account subscription

<img width="1093" alt="Screenshot 2025-03-31 at 15 29 36" src="https://github.com/user-attachments/assets/1c892dbf-8d3e-4d6b-8ec8-2a232f07e5be" />

AFTER with Premium subscription

<img width="1093" alt="Screenshot 2025-03-31 at 15 34 20" src="https://github.com/user-attachments/assets/1f3922c9-cb3f-49a6-bf5b-0e9688493ff8" />

BEFORE with FREE individual/account subscription

<img width="1093" alt="Screenshot 2025-03-31 at 15 30 27" src="https://github.com/user-attachments/assets/024689d1-4cb7-4962-8034-f54c7baa8dbe" />

BEFORE with Premium subscription

<img width="1093" alt="Screenshot 2025-03-31 at 15 32 55" src="https://github.com/user-attachments/assets/7ba1864f-1864-4ac8-8c0b-215510a59a62" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
