### PR TITLE
Refactor symmetric encrypt interface

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["Csprng", "decryptable", "Popout", "Reprompt", "takeuntil"],
+  "cSpell.words": ["Csprng", "Decapsulation", "decryptable", "Popout", "Reprompt", "takeuntil"],
   "search.exclude": {
     "**/locales/[^e]*/messages.json": true,
     "**/locales/*[^n]/messages.json": true,

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -350,7 +350,7 @@ export class NativeMessagingBackground {
       await this.secureCommunication();
     }
 
-    return await this.encryptService.encrypt(
+    return await this.encryptService.encryptString(
       JSON.stringify(message),
       this.secureChannel!.sharedSecret!,
     );

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.spec.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.spec.ts
@@ -127,7 +127,7 @@ describe("LocalBackedSessionStorage", () => {
   describe("save", () => {
     const encString = makeEncString("encrypted");
     beforeEach(() => {
-      encryptService.encrypt.mockResolvedValue(encString);
+      encryptService.encryptString.mockResolvedValue(encString);
     });
 
     it("logs a warning when saving the same value twice and in a dev environment", async () => {
@@ -157,7 +157,10 @@ describe("LocalBackedSessionStorage", () => {
 
     it("encrypts and saves the value to local storage", async () => {
       await sut.save("test", "value");
-      expect(encryptService.encrypt).toHaveBeenCalledWith(JSON.stringify("value"), sessionKey);
+      expect(encryptService.encryptString).toHaveBeenCalledWith(
+        JSON.stringify("value"),
+        sessionKey,
+      );
       expect(localStorage.internalStore["session_test"]).toEqual(encString.encryptedString);
     });
 

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -140,7 +140,10 @@ export class LocalBackedSessionStorageService
     }
 
     const valueJson = JSON.stringify(value);
-    const encValue = await this.encryptService.encrypt(valueJson, await this.sessionKey.get());
+    const encValue = await this.encryptService.encryptString(
+      valueJson,
+      await this.sessionKey.get(),
+    );
     await this.localStorage.save(this.sessionStorageKey(key), encValue.encryptedString);
   }
 

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -204,7 +204,7 @@ export class EditCommand {
               (u) => new SelectionReadOnlyRequest(u.id, u.readOnly, u.hidePasswords, u.manage),
             );
       const request = new CollectionRequest();
-      request.name = (await this.encryptService.encrypt(req.name, orgKey)).encryptedString;
+      request.name = (await this.encryptService.encryptString(req.name, orgKey)).encryptedString;
       request.externalId = req.externalId;
       request.groups = groups;
       request.users = users;

--- a/apps/cli/src/platform/services/node-env-secure-storage.service.ts
+++ b/apps/cli/src/platform/services/node-env-secure-storage.service.ts
@@ -61,7 +61,7 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
     if (sessionKey == null) {
       throw new Error("No session key available.");
     }
-    const encValue = await this.encryptService.encryptToBytes(
+    const encValue = await this.encryptService.encryptFileData(
       Utils.fromB64ToArray(plainValue),
       sessionKey,
     );

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -227,7 +227,7 @@ export class CreateCommand {
               (u) => new SelectionReadOnlyRequest(u.id, u.readOnly, u.hidePasswords, u.manage),
             );
       const request = new CollectionRequest();
-      request.name = (await this.encryptService.encrypt(req.name, orgKey)).encryptedString;
+      request.name = (await this.encryptService.encryptString(req.name, orgKey)).encryptedString;
       request.externalId = req.externalId;
       request.groups = groups;
       request.users = users;

--- a/apps/desktop/src/platform/services/electron-key.service.ts
+++ b/apps/desktop/src/platform/services/electron-key.service.ts
@@ -110,7 +110,7 @@ export class ElectronKeyService extends DefaultKeyService {
       // Set a key half if it doesn't exist
       const keyBytes = await this.cryptoFunctionService.randomBytes(32);
       clientKeyHalf = Utils.fromBufferToUtf8(keyBytes) as CsprngString;
-      const encKey = await this.encryptService.encrypt(clientKeyHalf, userKey);
+      const encKey = await this.encryptService.encryptString(clientKeyHalf, userKey);
       await this.biometricStateService.setEncryptedClientKeyHalf(encKey, userId);
     }
 

--- a/apps/desktop/src/services/biometric-message-handler.service.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.ts
@@ -350,7 +350,7 @@ export class BiometricMessageHandlerService {
       throw new Error("Session secret is missing");
     }
 
-    const encrypted = await this.encryptService.encrypt(
+    const encrypted = await this.encryptService.encryptString(
       JSON.stringify(message),
       SymmetricCryptoKey.fromString(sessionSecret),
     );

--- a/apps/desktop/src/services/duckduckgo-message-handler.service.ts
+++ b/apps/desktop/src/services/duckduckgo-message-handler.service.ts
@@ -168,7 +168,7 @@ export class DuckDuckGoMessageHandlerService {
     payload: DecryptedCommandData,
     key: SymmetricCryptoKey,
   ): Promise<EncString> {
-    return await this.encryptService.encrypt(JSON.stringify(payload), key);
+    return await this.encryptService.encryptString(JSON.stringify(payload), key);
   }
 
   private async decryptPayload(message: EncryptedMessage): Promise<DecryptedCommandData> {

--- a/apps/web/src/app/auth/core/services/rotateable-key-set.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/rotateable-key-set.service.spec.ts
@@ -36,7 +36,7 @@ describe("RotateableKeySetService", () => {
       keyService.makeKeyPair.mockResolvedValue(["publicKey", encryptedPrivateKey as any]);
       keyService.getUserKey.mockResolvedValue({ key: userKey.key } as any);
       encryptService.rsaEncrypt.mockResolvedValue(encryptedUserKey as any);
-      encryptService.encrypt.mockResolvedValue(encryptedPublicKey as any);
+      encryptService.wrapEncapsulationKey.mockResolvedValue(encryptedPublicKey as any);
 
       const result = await service.createKeySet(externalKey as any);
 

--- a/apps/web/src/app/auth/core/services/rotateable-key-set.service.ts
+++ b/apps/web/src/app/auth/core/services/rotateable-key-set.service.ts
@@ -26,7 +26,10 @@ export class RotateableKeySetService {
     const userKey = await this.keyService.getUserKey();
     const rawPublicKey = Utils.fromB64ToArray(publicKey);
     const encryptedUserKey = await this.encryptService.rsaEncrypt(userKey.key, rawPublicKey);
-    const encryptedPublicKey = await this.encryptService.encrypt(rawPublicKey, userKey);
+    const encryptedPublicKey = await this.encryptService.wrapEncapsulationKey(
+      rawPublicKey,
+      userKey,
+    );
     return new RotateableKeySet(encryptedUserKey, encryptedPublicKey, encryptedPrivateKey);
   }
 
@@ -59,7 +62,10 @@ export class RotateableKeySetService {
     if (publicKey == null) {
       throw new Error("failed to rotate key set: could not decrypt public key");
     }
-    const newEncryptedPublicKey = await this.encryptService.encrypt(publicKey, newUserKey);
+    const newEncryptedPublicKey = await this.encryptService.wrapEncapsulationKey(
+      publicKey,
+      newUserKey,
+    );
     const newEncryptedUserKey = await this.encryptService.rsaEncrypt(newUserKey.key, publicKey);
 
     const newRotateableKeySet = new RotateableKeySet<ExternalKey>(

--- a/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.service.spec.ts
@@ -81,7 +81,10 @@ describe("AcceptOrganizationInviteService", () => {
         "orgPublicKey",
         { encryptedString: "string" } as EncString,
       ]);
-      encryptService.encrypt.mockResolvedValue({ encryptedString: "string" } as EncString);
+      encryptService.wrapDecapsulationKey.mockResolvedValue({
+        encryptedString: "string",
+      } as EncString);
+      encryptService.encryptString.mockResolvedValue({ encryptedString: "string" } as EncString);
       const invite = createOrgInvite({ initOrganization: true });
 
       const result = await sut.validateAndAcceptInvite(invite);

--- a/apps/web/src/app/auth/organization-invite/accept-organization.service.ts
+++ b/apps/web/src/app/auth/organization-invite/accept-organization.service.ts
@@ -141,7 +141,7 @@ export class AcceptOrganizationInviteService {
 
     const [encryptedOrgKey, orgKey] = await this.keyService.makeOrgKey<OrgKey>();
     const [orgPublicKey, encryptedOrgPrivateKey] = await this.keyService.makeKeyPair(orgKey);
-    const collection = await this.encryptService.encrypt(
+    const collection = await this.encryptService.encryptString(
       this.i18nService.t("defaultCollection"),
       orgKey,
     );

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -614,7 +614,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       if (this.createOrganization) {
         const orgKey = await this.keyService.makeOrgKey<OrgKey>();
         const key = orgKey[0].encryptedString;
-        const collection = await this.encryptService.encrypt(
+        const collection = await this.encryptService.encryptString(
           this.i18nService.t("defaultCollection"),
           orgKey[1],
         );
@@ -804,7 +804,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       );
       const providerKey = await this.keyService.getProviderKey(this.providerId);
       providerRequest.organizationCreateRequest.key = (
-        await this.encryptService.encrypt(orgKey.key, providerKey)
+        await this.encryptService.wrapSymmetricKey(orgKey, providerKey)
       ).encryptedString;
       const orgId = (
         await this.apiService.postProviderCreateOrganization(this.providerId, providerRequest)

--- a/apps/web/src/app/billing/shared/self-hosting-license-uploader/organization-self-hosting-license-uploader.component.ts
+++ b/apps/web/src/app/billing/shared/self-hosting-license-uploader/organization-self-hosting-license-uploader.component.ts
@@ -51,7 +51,7 @@ export class OrganizationSelfHostingLicenseUploaderComponent extends AbstractSel
 
     const orgKey = await this.keyService.makeOrgKey<OrgKey>();
     const key = orgKey[0].encryptedString;
-    const collection = await this.encryptService.encrypt(
+    const collection = await this.encryptService.encryptString(
       this.i18nService.t("defaultCollection"),
       orgKey[1],
     );

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
@@ -119,7 +119,10 @@ describe("KeyRotationService", () => {
       mockKeyService.hashMasterKey.mockResolvedValue("mockMasterPasswordHash");
       mockConfigService.getFeatureFlag.mockResolvedValue(true);
 
-      mockEncryptService.encrypt.mockResolvedValue({
+      mockEncryptService.wrapSymmetricKey.mockResolvedValue({
+        encryptedString: "mockEncryptedData",
+      } as any);
+      mockEncryptService.wrapDecapsulationKey.mockResolvedValue({
         encryptedString: "mockEncryptedData",
       } as any);
 

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
@@ -125,7 +125,9 @@ export class UserKeyRotationService {
     const { privateKey, publicKey } = keyPair;
 
     const accountKeysRequest = new AccountKeysRequest(
-      (await this.encryptService.encrypt(privateKey, newUnencryptedUserKey)).encryptedString!,
+      (
+        await this.encryptService.wrapDecapsulationKey(privateKey, newUnencryptedUserKey)
+      ).encryptedString!,
       Utils.fromBufferToB64(publicKey),
     );
 
@@ -357,6 +359,6 @@ export class UserKeyRotationService {
     if (privateKey == null) {
       throw new Error("No private key found for user key rotation");
     }
-    return (await this.encryptService.encrypt(privateKey, newUserKey)).encryptedString;
+    return (await this.encryptService.wrapDecapsulationKey(privateKey, newUserKey)).encryptedString;
   }
 }

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/critical-apps.service.spec.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/critical-apps.service.spec.ts
@@ -59,7 +59,7 @@ describe("CriticalAppsService", () => {
       { id: "id2", organizationId: "org1", uri: "https://example.org" },
     ] as PasswordHealthReportApplicationsResponse[];
 
-    encryptService.encrypt.mockResolvedValue(new EncString("encryptedUrlName"));
+    encryptService.encryptString.mockResolvedValue(new EncString("encryptedUrlName"));
     criticalAppsApiService.saveCriticalApps.mockReturnValue(of(response));
 
     // act
@@ -67,7 +67,7 @@ describe("CriticalAppsService", () => {
 
     // expectations
     expect(keyService.getOrgKey).toHaveBeenCalledWith("org1");
-    expect(encryptService.encrypt).toHaveBeenCalledTimes(2);
+    expect(encryptService.encryptString).toHaveBeenCalledTimes(2);
     expect(criticalAppsApiService.saveCriticalApps).toHaveBeenCalledWith(request);
   });
 
@@ -95,7 +95,7 @@ describe("CriticalAppsService", () => {
       { id: "id1", organizationId: "org1", uri: "test" },
     ] as PasswordHealthReportApplicationsResponse[];
 
-    encryptService.encrypt.mockResolvedValue(new EncString("encryptedUrlName"));
+    encryptService.encryptString.mockResolvedValue(new EncString("encryptedUrlName"));
     criticalAppsApiService.saveCriticalApps.mockReturnValue(of(response));
 
     // act
@@ -103,7 +103,7 @@ describe("CriticalAppsService", () => {
 
     // expectations
     expect(keyService.getOrgKey).toHaveBeenCalledWith("org1");
-    expect(encryptService.encrypt).toHaveBeenCalledTimes(1);
+    expect(encryptService.encryptString).toHaveBeenCalledTimes(1);
     expect(criticalAppsApiService.saveCriticalApps).toHaveBeenCalledWith(request);
   });
 

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/critical-apps.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/critical-apps.service.ts
@@ -164,7 +164,7 @@ export class CriticalAppsService {
     newEntries: string[],
   ): Promise<PasswordHealthReportApplicationsRequest[]> {
     const criticalAppsPromises = newEntries.map(async (url) => {
-      const encryptedUrlName = await this.encryptService.encrypt(url, key);
+      const encryptedUrlName = await this.encryptService.encryptString(url, key);
       return {
         organizationId: orgId,
         url: encryptedUrlName?.encryptedString?.toString() ?? "",

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
@@ -36,7 +36,7 @@ export class WebProviderService {
     const orgKey = await this.keyService.getOrgKey(organizationId);
     const providerKey = await this.keyService.getProviderKey(providerId);
 
-    const encryptedOrgKey = await this.encryptService.encrypt(orgKey.key, providerKey);
+    const encryptedOrgKey = await this.encryptService.wrapSymmetricKey(orgKey, providerKey);
 
     const request = new ProviderAddOrganizationRequest();
     request.organizationId = organizationId;
@@ -55,7 +55,7 @@ export class WebProviderService {
       ),
     );
     const providerKey = await this.keyService.getProviderKey(providerId);
-    const encryptedOrgKey = await this.encryptService.encrypt(orgKey.key, providerKey);
+    const encryptedOrgKey = await this.encryptService.wrapSymmetricKey(orgKey, providerKey);
     await this.providerApiService.addOrganizationToProvider(providerId, {
       key: encryptedOrgKey.encryptedString,
       organizationId,
@@ -74,15 +74,15 @@ export class WebProviderService {
 
     const [publicKey, encryptedPrivateKey] = await this.keyService.makeKeyPair(organizationKey);
 
-    const encryptedCollectionName = await this.encryptService.encrypt(
+    const encryptedCollectionName = await this.encryptService.encryptString(
       this.i18nService.t("defaultCollection"),
       organizationKey,
     );
 
     const providerKey = await this.keyService.getProviderKey(providerId);
 
-    const encryptedProviderKey = await this.encryptService.encrypt(
-      organizationKey.key,
+    const encryptedProviderKey = await this.encryptService.wrapSymmetricKey(
+      organizationKey,
       providerKey,
     );
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project.service.ts
@@ -93,7 +93,7 @@ export class ProjectService {
   ): Promise<ProjectRequest> {
     const orgKey = await this.getOrganizationKey(organizationId);
     const request = new ProjectRequest();
-    request.name = await this.encryptService.encrypt(projectView.name, orgKey);
+    request.name = await this.encryptService.encryptString(projectView.name, orgKey);
 
     return request;
   }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secret.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secret.service.spec.ts
@@ -24,7 +24,7 @@ describe("SecretService", () => {
 
     sut = new SecretService(keyService, apiService, encryptService, accessPolicyService);
 
-    encryptService.encrypt.mockResolvedValue({
+    encryptService.encryptString.mockResolvedValue({
       encryptedString: "mockEncryptedString",
     } as EncString);
     encryptService.decryptToUtf8.mockResolvedValue(mockUnencryptedData);

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secret.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/secret.service.ts
@@ -166,9 +166,9 @@ export class SecretService {
     const orgKey = await this.getOrganizationKey(organizationId);
     const request = new SecretRequest();
     const [key, value, note] = await Promise.all([
-      this.encryptService.encrypt(secretView.name, orgKey),
-      this.encryptService.encrypt(secretView.value, orgKey),
-      this.encryptService.encrypt(secretView.note, orgKey),
+      this.encryptService.encryptString(secretView.name, orgKey),
+      this.encryptService.encryptString(secretView.value, orgKey),
+      this.encryptService.encryptString(secretView.note, orgKey),
     ]);
     request.key = key.encryptedString;
     request.value = value.encryptedString;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access.service.ts
@@ -102,12 +102,12 @@ export class AccessService {
     const organizationKey = await this.getOrganizationKey(organizationId);
     const accessTokenRequest = new AccessTokenRequest();
     const [name, encryptedPayload, key] = await Promise.all([
-      await this.encryptService.encrypt(accessTokenView.name, organizationKey),
-      await this.encryptService.encrypt(
+      await this.encryptService.encryptString(accessTokenView.name, organizationKey),
+      await this.encryptService.encryptString(
         JSON.stringify({ encryptionKey: organizationKey.keyB64 }),
         encryptionKey,
       ),
-      await this.encryptService.encrypt(encryptionKey.keyB64, organizationKey),
+      await this.encryptService.encryptString(encryptionKey.keyB64, organizationKey),
     ]);
 
     accessTokenRequest.name = name;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.service.ts
@@ -130,7 +130,10 @@ export class ServiceAccountService {
     serviceAccountView: ServiceAccountView,
   ) {
     const request = new ServiceAccountRequest();
-    request.name = await this.encryptService.encrypt(serviceAccountView.name, organizationKey);
+    request.name = await this.encryptService.encryptString(
+      serviceAccountView.name,
+      organizationKey,
+    );
     return request;
   }
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/services/sm-porting-api.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/services/sm-porting-api.service.spec.ts
@@ -28,7 +28,7 @@ describe("SecretsManagerPortingApiService", () => {
 
     sut = new SecretsManagerPortingApiService(apiService, encryptService, keyService);
 
-    encryptService.encrypt.mockResolvedValue(mockEncryptedString);
+    encryptService.encryptString.mockResolvedValue(mockEncryptedString);
     encryptService.decryptToUtf8.mockResolvedValue(mockUnencryptedString);
 
     const mockRandomBytes = new Uint8Array(64) as CsprngArray;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/services/sm-porting-api.service.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/services/sm-porting-api.service.ts
@@ -86,7 +86,7 @@ export class SecretsManagerPortingApiService {
         importData.projects.map(async (p: any) => {
           const project = new SecretsManagerImportedProjectRequest();
           project.id = p.id;
-          project.name = await this.encryptService.encrypt(p.name, orgKey);
+          project.name = await this.encryptService.encryptString(p.name, orgKey);
           return project;
         }),
       );
@@ -96,9 +96,9 @@ export class SecretsManagerPortingApiService {
           const secret = new SecretsManagerImportedSecretRequest();
 
           [secret.key, secret.value, secret.note] = await Promise.all([
-            this.encryptService.encrypt(s.key, orgKey),
-            this.encryptService.encrypt(s.value, orgKey),
-            this.encryptService.encrypt(s.note, orgKey),
+            this.encryptService.encryptString(s.key, orgKey),
+            this.encryptService.encryptString(s.value, orgKey),
+            this.encryptService.encryptString(s.note, orgKey),
           ]);
 
           secret.id = s.id;

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -146,7 +146,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     }
     const collection = new CollectionRequest();
     collection.externalId = model.externalId;
-    collection.name = (await this.encryptService.encrypt(model.name, key)).encryptedString;
+    collection.name = (await this.encryptService.encryptString(model.name, key)).encryptedString;
     collection.groups = model.groups.map(
       (group) =>
         new SelectionReadOnlyRequest(group.id, group.readOnly, group.hidePasswords, group.manage),

--- a/libs/admin-console/src/common/collections/services/default-collection.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection.service.ts
@@ -112,7 +112,7 @@ export class DefaultCollectionService implements CollectionService {
     collection.organizationId = model.organizationId;
     collection.readOnly = model.readOnly;
     collection.externalId = model.externalId;
-    collection.name = await this.encryptService.encrypt(model.name, key);
+    collection.name = await this.encryptService.encryptString(model.name, key);
     return collection;
   }
 

--- a/libs/admin-console/src/common/collections/services/default-vnext-collection.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-vnext-collection.service.ts
@@ -113,7 +113,7 @@ export class DefaultvNextCollectionService implements vNextCollectionService {
     collection.organizationId = model.organizationId;
     collection.readOnly = model.readOnly;
     collection.externalId = model.externalId;
-    collection.name = await this.encryptService.encrypt(model.name, key);
+    collection.name = await this.encryptService.encryptString(model.name, key);
     return collection;
   }
 

--- a/libs/angular/src/auth/components/set-password.component.ts
+++ b/libs/angular/src/auth/components/set-password.component.ts
@@ -178,7 +178,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent implements
         const existingUserPublicKeyB64 = Utils.fromBufferToB64(existingUserPublicKey);
         newKeyPair = [
           existingUserPublicKeyB64,
-          await this.encryptService.encrypt(existingUserPrivateKey, userKey[0]),
+          await this.encryptService.wrapDecapsulationKey(existingUserPrivateKey, userKey[0]),
         ];
       } else {
         newKeyPair = await this.keyService.makeKeyPair(userKey[0]);

--- a/libs/auth/src/common/services/pin/pin.service.implementation.ts
+++ b/libs/auth/src/common/services/pin/pin.service.implementation.ts
@@ -193,7 +193,7 @@ export class PinService implements PinServiceAbstraction {
 
     const pinKey = await this.makePinKey(pin, email, kdfConfig);
 
-    return await this.encryptService.encrypt(userKey.key, pinKey);
+    return await this.encryptService.wrapSymmetricKey(userKey, pinKey);
   }
 
   async storePinKeyEncryptedUserKey(
@@ -239,7 +239,7 @@ export class PinService implements PinServiceAbstraction {
       throw new Error("No UserKey provided. Cannot create userKeyEncryptedPin.");
     }
 
-    return await this.encryptService.encrypt(pin, userKey);
+    return await this.encryptService.encryptString(pin, userKey);
   }
 
   async getOldPinKeyEncryptedMasterKey(userId: UserId): Promise<EncryptedString | null> {

--- a/libs/auth/src/common/services/pin/pin.service.spec.ts
+++ b/libs/auth/src/common/services/pin/pin.service.spec.ts
@@ -189,7 +189,7 @@ describe("PinService", () => {
         await sut.createPinKeyEncryptedUserKey(mockPin, mockUserKey, mockUserId);
 
         // Assert
-        expect(encryptService.encrypt).toHaveBeenCalledWith(mockUserKey.key, mockPinKey);
+        expect(encryptService.wrapSymmetricKey).toHaveBeenCalledWith(mockUserKey, mockPinKey);
       });
     });
 
@@ -278,11 +278,11 @@ describe("PinService", () => {
       });
 
       it("should create a userKeyEncryptedPin from the provided PIN and userKey", async () => {
-        encryptService.encrypt.mockResolvedValue(mockUserKeyEncryptedPin);
+        encryptService.encryptString.mockResolvedValue(mockUserKeyEncryptedPin);
 
         const result = await sut.createUserKeyEncryptedPin(mockPin, mockUserKey);
 
-        expect(encryptService.encrypt).toHaveBeenCalledWith(mockPin, mockUserKey);
+        expect(encryptService.encryptString).toHaveBeenCalledWith(mockPin, mockUserKey);
         expect(result).toEqual(mockUserKeyEncryptedPin);
       });
     });

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -293,7 +293,7 @@ describe("TokenService", () => {
 
           const mockEncryptedAccessToken = "encryptedAccessToken";
 
-          encryptService.encrypt.mockResolvedValue({
+          encryptService.encryptString.mockResolvedValue({
             encryptedString: mockEncryptedAccessToken,
           } as any);
 

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -289,7 +289,7 @@ export class TokenService implements TokenServiceAbstraction {
   private async encryptAccessToken(accessToken: string, userId: UserId): Promise<EncString> {
     const accessTokenKey = await this.getOrCreateAccessTokenKey(userId);
 
-    return await this.encryptService.encrypt(accessToken, accessTokenKey);
+    return await this.encryptService.encryptString(accessToken, accessTokenKey);
   }
 
   private async decryptAccessToken(

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -114,7 +114,7 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
   private async makeOrganizationKeys(): Promise<OrganizationKeys> {
     const [encryptedKey, key] = await this.keyService.makeOrgKey<OrgKey>();
     const [publicKey, encryptedPrivateKey] = await this.keyService.makeKeyPair(key);
-    const encryptedCollectionName = await this.encryptService.encrypt(
+    const encryptedCollectionName = await this.encryptService.encryptString(
       this.i18nService.t("defaultCollection"),
       key,
     );

--- a/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
+++ b/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
@@ -6,8 +6,24 @@ import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 
 export abstract class EncryptService {
-  abstract encrypt(plainValue: string | Uint8Array, key: SymmetricCryptoKey): Promise<EncString>;
-  abstract encryptToBytes(plainValue: Uint8Array, key: SymmetricCryptoKey): Promise<EncArrayBuffer>;
+  abstract encryptString(plainValue: string, key: SymmetricCryptoKey): Promise<EncString>;
+  abstract encryptFileData(
+    plainValue: Uint8Array,
+    key: SymmetricCryptoKey,
+  ): Promise<EncArrayBuffer>;
+  abstract wrapDecapsulationKey(
+    decapsulationKeyPcks8: Uint8Array,
+    key: SymmetricCryptoKey,
+  ): Promise<EncString>;
+  abstract wrapEncapsulationKey(
+    encapsulationKeySpki: Uint8Array,
+    key: SymmetricCryptoKey,
+  ): Promise<EncString>;
+  abstract wrapSymmetricKey(
+    encapsulatedKey: SymmetricCryptoKey,
+    key: SymmetricCryptoKey,
+  ): Promise<EncString>;
+
   /**
    * Decrypts an EncString to a string
    * @param encString - The EncString to decrypt

--- a/libs/common/src/key-management/crypto/services/encrypt.service.spec.ts
+++ b/libs/common/src/key-management/crypto/services/encrypt.service.spec.ts
@@ -28,13 +28,13 @@ describe("EncryptService", () => {
 
   describe("encrypt", () => {
     it("throws if no key is provided", () => {
-      return expect(encryptService.encrypt(null, null)).rejects.toThrow(
+      return expect(encryptService.encryptString(null, null)).rejects.toThrow(
         "No encryption key provided.",
       );
     });
     it("returns null if no data is provided", async () => {
       const key = mock<SymmetricCryptoKey>();
-      const actual = await encryptService.encrypt(null, key);
+      const actual = await encryptService.encryptString(null, key);
       expect(actual).toBeNull();
     });
     it("creates an EncString for Aes256Cbc", async () => {
@@ -42,7 +42,7 @@ describe("EncryptService", () => {
       const plainValue = "data";
       cryptoFunctionService.aesEncrypt.mockResolvedValue(makeStaticByteArray(4, 100));
       cryptoFunctionService.randomBytes.mockResolvedValue(makeStaticByteArray(16) as CsprngArray);
-      const result = await encryptService.encrypt(plainValue, key);
+      const result = await encryptService.encryptString(plainValue, key);
       expect(cryptoFunctionService.aesEncrypt).toHaveBeenCalledWith(
         Utils.fromByteStringToArray(plainValue),
         makeStaticByteArray(16),
@@ -59,7 +59,7 @@ describe("EncryptService", () => {
       cryptoFunctionService.hmac.mockResolvedValue(makeStaticByteArray(32));
       cryptoFunctionService.aesEncrypt.mockResolvedValue(makeStaticByteArray(4, 100));
       cryptoFunctionService.randomBytes.mockResolvedValue(makeStaticByteArray(16) as CsprngArray);
-      const result = await encryptService.encrypt(plainValue, key);
+      const result = await encryptService.encryptString(plainValue, key);
       expect(cryptoFunctionService.aesEncrypt).toHaveBeenCalledWith(
         Utils.fromByteStringToArray(plainValue),
         makeStaticByteArray(16),
@@ -85,7 +85,7 @@ describe("EncryptService", () => {
     const plainValue = makeStaticByteArray(16, 1);
 
     it("throws if no key is provided", () => {
-      return expect(encryptService.encryptToBytes(plainValue, null)).rejects.toThrow(
+      return expect(encryptService.encryptFileData(plainValue, null)).rejects.toThrow(
         "No encryption key",
       );
     });
@@ -97,7 +97,7 @@ describe("EncryptService", () => {
       cryptoFunctionService.randomBytes.mockResolvedValue(iv as CsprngArray);
       cryptoFunctionService.aesEncrypt.mockResolvedValue(cipherText);
 
-      const actual = await encryptService.encryptToBytes(plainValue, key);
+      const actual = await encryptService.encryptFileData(plainValue, key);
       const expectedBytes = new Uint8Array(1 + iv.byteLength + cipherText.byteLength);
       expectedBytes.set([EncryptionType.AesCbc256_B64]);
       expectedBytes.set(iv, 1);
@@ -115,7 +115,7 @@ describe("EncryptService", () => {
       cryptoFunctionService.aesEncrypt.mockResolvedValue(cipherText);
       cryptoFunctionService.hmac.mockResolvedValue(mac);
 
-      const actual = await encryptService.encryptToBytes(plainValue, key);
+      const actual = await encryptService.encryptFileData(plainValue, key);
       const expectedBytes = new Uint8Array(
         1 + iv.byteLength + mac.byteLength + cipherText.byteLength,
       );

--- a/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
+++ b/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
@@ -163,10 +163,10 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
       this.encryptService.rsaEncrypt(userKey.key, devicePublicKey),
 
       // Encrypt devicePublicKey with user key
-      this.encryptService.encrypt(devicePublicKey, userKey),
+      this.encryptService.wrapEncapsulationKey(devicePublicKey, userKey),
 
       // Encrypt devicePrivateKey with deviceKey
-      this.encryptService.encrypt(devicePrivateKey, deviceKey),
+      this.encryptService.wrapDecapsulationKey(devicePrivateKey, deviceKey),
     ]);
 
     // Send encrypted keys to server
@@ -234,7 +234,7 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
     );
 
     // Re-encrypt the device public key with the new user key
-    const encryptedDevicePublicKey = await this.encryptService.encrypt(
+    const encryptedDevicePublicKey = await this.encryptService.wrapEncapsulationKey(
       decryptedDevicePublicKey,
       newUserKey,
     );

--- a/libs/common/src/platform/models/domain/domain-base.spec.ts
+++ b/libs/common/src/platform/models/domain/domain-base.spec.ts
@@ -22,7 +22,7 @@ describe("DomainBase", () => {
   });
 
   function setUpCryptography() {
-    encryptService.encrypt.mockImplementation((value) => {
+    encryptService.encryptString.mockImplementation((value) => {
       let data: string;
       if (typeof value === "string") {
         data = value;
@@ -82,7 +82,7 @@ describe("DomainBase", () => {
 
       const domain = new TestDomain();
 
-      domain.encToString = await encryptService.encrypt("string", key);
+      domain.encToString = await encryptService.encryptString("string", key);
 
       const decrypted = await domain["decryptObjWithKey"](["encToString"], key, encryptService);
 
@@ -96,8 +96,8 @@ describe("DomainBase", () => {
 
       const domain = new TestDomain();
 
-      domain.encToString = await encryptService.encrypt("string", key);
-      domain.encString2 = await encryptService.encrypt("string2", key);
+      domain.encToString = await encryptService.encryptString("string", key);
+      domain.encString2 = await encryptService.encryptString("string2", key);
 
       const decrypted = await domain["decryptObjWithKey"](
         ["encToString", "encString2"],

--- a/libs/common/src/platform/models/domain/enc-string.spec.ts
+++ b/libs/common/src/platform/models/domain/enc-string.spec.ts
@@ -123,7 +123,7 @@ describe("EncString", () => {
       .mockResolvedValue("decrypted");
 
     function setupEncryption() {
-      encryptService.encrypt.mockImplementation(async (data, key) => {
+      encryptService.encryptString.mockImplementation(async (data, key) => {
         if (typeof data === "string") {
           return makeEncString(data);
         } else {

--- a/libs/common/src/tools/cryptography/organization-key-encryptor.spec.ts
+++ b/libs/common/src/tools/cryptography/organization-key-encryptor.spec.ts
@@ -22,7 +22,9 @@ describe("OrgKeyEncryptor", () => {
     // on this property--that the facade treats its data like a opaque objects--to trace
     // the data through several function calls. Should the encryptor interact with the
     // objects themselves, these mocks will break.
-    encryptService.encrypt.mockImplementation((p) => Promise.resolve(p as unknown as EncString));
+    encryptService.encryptString.mockImplementation((p) =>
+      Promise.resolve(p as unknown as EncString),
+    );
     encryptService.decryptToUtf8.mockImplementation((c) => Promise.resolve(c as unknown as string));
     dataPacker.pack.mockImplementation((v) => v as string);
     dataPacker.unpack.mockImplementation(<T>(v: string) => v as T);
@@ -95,7 +97,7 @@ describe("OrgKeyEncryptor", () => {
 
       // these are data flow expectations; the operations all all pass-through mocks
       expect(dataPacker.pack).toHaveBeenCalledWith(value);
-      expect(encryptService.encrypt).toHaveBeenCalledWith(value, orgKey);
+      expect(encryptService.encryptString).toHaveBeenCalledWith(value, orgKey);
       expect(result).toBe(value);
     });
   });

--- a/libs/common/src/tools/cryptography/organization-key-encryptor.ts
+++ b/libs/common/src/tools/cryptography/organization-key-encryptor.ts
@@ -37,7 +37,7 @@ export class OrganizationKeyEncryptor extends OrganizationEncryptor {
     this.assertHasValue("secret", secret);
 
     let packed = this.dataPacker.pack(secret);
-    const encrypted = await this.encryptService.encrypt(packed, this.key);
+    const encrypted = await this.encryptService.encryptString(packed, this.key);
     packed = null;
 
     return encrypted;

--- a/libs/common/src/tools/cryptography/user-key-encryptor.spec.ts
+++ b/libs/common/src/tools/cryptography/user-key-encryptor.spec.ts
@@ -22,7 +22,9 @@ describe("UserKeyEncryptor", () => {
     // on this property--that the facade treats its data like a opaque objects--to trace
     // the data through several function calls. Should the encryptor interact with the
     // objects themselves, these mocks will break.
-    encryptService.encrypt.mockImplementation((p) => Promise.resolve(p as unknown as EncString));
+    encryptService.encryptString.mockImplementation((p) =>
+      Promise.resolve(p as unknown as EncString),
+    );
     encryptService.decryptToUtf8.mockImplementation((c) => Promise.resolve(c as unknown as string));
     dataPacker.pack.mockImplementation((v) => v as string);
     dataPacker.unpack.mockImplementation(<T>(v: string) => v as T);
@@ -95,7 +97,7 @@ describe("UserKeyEncryptor", () => {
 
       // these are data flow expectations; the operations all all pass-through mocks
       expect(dataPacker.pack).toHaveBeenCalledWith(value);
-      expect(encryptService.encrypt).toHaveBeenCalledWith(value, userKey);
+      expect(encryptService.encryptString).toHaveBeenCalledWith(value, userKey);
       expect(result).toBe(value);
     });
   });

--- a/libs/common/src/tools/cryptography/user-key-encryptor.ts
+++ b/libs/common/src/tools/cryptography/user-key-encryptor.ts
@@ -37,7 +37,7 @@ export class UserKeyEncryptor extends UserEncryptor {
     this.assertHasValue("secret", secret);
 
     let packed = this.dataPacker.pack(secret);
-    const encrypted = await this.encryptService.encrypt(packed, this.key);
+    const encrypted = await this.encryptService.encryptString(packed, this.key);
     packed = null;
 
     return encrypted;

--- a/libs/common/src/tools/send/services/send.service.spec.ts
+++ b/libs/common/src/tools/send/services/send.service.spec.ts
@@ -479,7 +479,7 @@ describe("SendService", () => {
     beforeEach(() => {
       encryptService.decryptToBytes.mockResolvedValue(new Uint8Array(32));
       encryptedKey = new EncString("Re-encrypted Send Key");
-      encryptService.encrypt.mockResolvedValue(encryptedKey);
+      encryptService.wrapSymmetricKey.mockResolvedValue(encryptedKey);
     });
 
     it("returns re-encrypted user sends", async () => {

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -81,12 +81,12 @@ export class SendService implements InternalSendServiceAbstraction {
     if (key == null) {
       key = await this.keyService.getUserKey();
     }
-    send.key = await this.encryptService.encrypt(model.key, key);
-    send.name = await this.encryptService.encrypt(model.name, model.cryptoKey);
-    send.notes = await this.encryptService.encrypt(model.notes, model.cryptoKey);
+    send.key = await this.encryptService.wrapSymmetricKey(new SymmetricCryptoKey(model.key), key);
+    send.name = await this.encryptService.encryptString(model.name, model.cryptoKey);
+    send.notes = await this.encryptService.encryptString(model.notes, model.cryptoKey);
     if (send.type === SendType.Text) {
       send.text = new SendText();
-      send.text.text = await this.encryptService.encrypt(model.text.text, model.cryptoKey);
+      send.text.text = await this.encryptService.encryptString(model.text.text, model.cryptoKey);
       send.text.hidden = model.text.hidden;
     } else if (send.type === SendType.File) {
       send.file = new SendFile();
@@ -287,8 +287,10 @@ export class SendService implements InternalSendServiceAbstraction {
   ) {
     const requests = await Promise.all(
       sends.map(async (send) => {
-        const sendKey = await this.encryptService.decryptToBytes(send.key, originalUserKey);
-        send.key = await this.encryptService.encrypt(sendKey, rotateUserKey);
+        const sendKey = new SymmetricCryptoKey(
+          await this.encryptService.decryptToBytes(send.key, originalUserKey),
+        );
+        send.key = await this.encryptService.wrapSymmetricKey(sendKey, rotateUserKey);
         return new SendWithIdRequest(send);
       }),
     );
@@ -326,8 +328,8 @@ export class SendService implements InternalSendServiceAbstraction {
     if (key == null) {
       key = await this.keyService.getUserKey();
     }
-    const encFileName = await this.encryptService.encrypt(fileName, key);
-    const encFileData = await this.encryptService.encryptToBytes(new Uint8Array(data), key);
+    const encFileName = await this.encryptService.encryptString(fileName, key);
+    const encFileData = await this.encryptService.encryptFileData(new Uint8Array(data), key);
     return [encFileName, encFileData];
   }
 

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -129,8 +129,8 @@ describe("Cipher Service", () => {
   let cipherObj: Cipher;
 
   beforeEach(() => {
-    encryptService.encryptToBytes.mockReturnValue(Promise.resolve(ENCRYPTED_BYTES));
-    encryptService.encrypt.mockReturnValue(Promise.resolve(new EncString(ENCRYPTED_TEXT)));
+    encryptService.encryptFileData.mockReturnValue(Promise.resolve(ENCRYPTED_BYTES));
+    encryptService.encryptString.mockReturnValue(Promise.resolve(new EncString(ENCRYPTED_TEXT)));
 
     (window as any).bitwardenContainerService = new ContainerService(keyService, encryptService);
 
@@ -276,7 +276,8 @@ describe("Cipher Service", () => {
       keyService.makeCipherKey.mockReturnValue(
         Promise.resolve(new SymmetricCryptoKey(makeStaticByteArray(64)) as CipherKey),
       );
-      encryptService.encrypt.mockImplementation(encryptText);
+      encryptService.encryptString.mockImplementation(encryptText);
+      encryptService.wrapSymmetricKey.mockResolvedValue(new EncString("Re-encrypted Cipher Key"));
 
       jest.spyOn(cipherService as any, "getAutofillOnPageLoadDefault").mockResolvedValue(true);
     });
@@ -398,7 +399,7 @@ describe("Cipher Service", () => {
 
       encryptService.decryptToBytes.mockResolvedValue(new Uint8Array(32));
       encryptedKey = new EncString("Re-encrypted Cipher Key");
-      encryptService.encrypt.mockResolvedValue(encryptedKey);
+      encryptService.wrapSymmetricKey.mockResolvedValue(encryptedKey);
 
       keyService.makeCipherKey.mockResolvedValue(
         new SymmetricCryptoKey(new Uint8Array(32)) as CipherKey,

--- a/libs/common/src/vault/services/folder/folder.service.spec.ts
+++ b/libs/common/src/vault/services/folder/folder.service.spec.ts
@@ -110,7 +110,7 @@ describe("Folder Service", () => {
     model.id = "2";
     model.name = "Test Folder";
 
-    encryptService.encrypt.mockResolvedValue(new EncString("ENC"));
+    encryptService.encryptString.mockResolvedValue(new EncString("ENC"));
 
     const result = await folderService.encrypt(model, null);
 
@@ -211,7 +211,7 @@ describe("Folder Service", () => {
 
     beforeEach(() => {
       encryptedKey = new EncString("Re-encrypted Folder");
-      encryptService.encrypt.mockResolvedValue(encryptedKey);
+      encryptService.encryptString.mockResolvedValue(encryptedKey);
     });
 
     it("returns re-encrypted user folders", async () => {

--- a/libs/common/src/vault/services/folder/folder.service.ts
+++ b/libs/common/src/vault/services/folder/folder.service.ts
@@ -84,7 +84,7 @@ export class FolderService implements InternalFolderServiceAbstraction {
   async encrypt(model: FolderView, key: SymmetricCryptoKey): Promise<Folder> {
     const folder = new Folder();
     folder.id = model.id;
-    folder.name = await this.encryptService.encrypt(model.name, key);
+    folder.name = await this.encryptService.encryptString(model.name, key);
     return folder;
   }
 

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -232,7 +232,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     }
 
     const newUserKey = await this.keyGenerationService.createKey(512);
-    return this.buildProtectedSymmetricKey(masterKey, newUserKey.key);
+    return this.buildProtectedSymmetricKey(masterKey, newUserKey);
   }
 
   /**
@@ -319,7 +319,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     userKey?: UserKey,
   ): Promise<[UserKey, EncString]> {
     userKey ||= await this.getUserKey();
-    return await this.buildProtectedSymmetricKey(masterKey, userKey.key);
+    return await this.buildProtectedSymmetricKey(masterKey, userKey);
   }
 
   // TODO: move to MasterPasswordService
@@ -429,7 +429,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     }
 
     const newSymKey = await this.keyGenerationService.createKey(512);
-    return this.buildProtectedSymmetricKey(key, newSymKey.key);
+    return this.buildProtectedSymmetricKey(key, newSymKey);
   }
 
   private async clearOrgKeys(userId: UserId): Promise<void> {
@@ -543,7 +543,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
 
     const keyPair = await this.cryptoFunctionService.rsaGenerateKeyPair(2048);
     const publicB64 = Utils.fromBufferToB64(keyPair[0]);
-    const privateEnc = await this.encryptService.encrypt(keyPair[1], key);
+    const privateEnc = await this.encryptService.wrapDecapsulationKey(keyPair[1], key);
     return [publicB64, privateEnc];
   }
 
@@ -821,18 +821,21 @@ export class DefaultKeyService implements KeyServiceAbstraction {
 
   private async buildProtectedSymmetricKey<T extends SymmetricCryptoKey>(
     encryptionKey: SymmetricCryptoKey,
-    newSymKey: Uint8Array,
+    newSymKey: SymmetricCryptoKey,
   ): Promise<[T, EncString]> {
     let protectedSymKey: EncString;
     if (encryptionKey.key.byteLength === 32) {
       const stretchedEncryptionKey = await this.keyGenerationService.stretchKey(encryptionKey);
-      protectedSymKey = await this.encryptService.encrypt(newSymKey, stretchedEncryptionKey);
+      protectedSymKey = await this.encryptService.wrapSymmetricKey(
+        newSymKey,
+        stretchedEncryptionKey,
+      );
     } else if (encryptionKey.key.byteLength === 64) {
-      protectedSymKey = await this.encryptService.encrypt(newSymKey, encryptionKey);
+      protectedSymKey = await this.encryptService.wrapSymmetricKey(newSymKey, encryptionKey);
     } else {
       throw new Error("Invalid key size.");
     }
-    return [new SymmetricCryptoKey(newSymKey) as T, protectedSymKey];
+    return [newSymKey as T, protectedSymKey];
   }
 
   // --LEGACY METHODS--

--- a/libs/tools/export/vault-export/vault-export-core/src/services/base-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/base-vault-export.service.ts
@@ -23,8 +23,8 @@ export class BaseVaultExportService {
     const salt = Utils.fromBufferToB64(await this.cryptoFunctionService.randomBytes(16));
     const key = await this.pinService.makePinKey(password, salt, kdfConfig);
 
-    const encKeyValidation = await this.encryptService.encrypt(Utils.newGuid(), key);
-    const encText = await this.encryptService.encrypt(clearText, key);
+    const encKeyValidation = await this.encryptService.encryptString(Utils.newGuid(), key);
+    const encText = await this.encryptService.encryptString(clearText, key);
 
     const jsonDoc: BitwardenPasswordProtectedFileFormat = {
       encrypted: true,

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
@@ -181,7 +181,7 @@ describe("VaultExportService", () => {
     folderService.folderViews$.mockReturnValue(of(UserFolderViews));
     folderService.folders$.mockReturnValue(of(UserFolders));
     kdfConfigService.getKdfConfig.mockResolvedValue(DEFAULT_KDF_CONFIG);
-    encryptService.encrypt.mockResolvedValue(new EncString("encrypted"));
+    encryptService.encryptString.mockResolvedValue(new EncString("encrypted"));
 
     exportService = new IndividualVaultExportService(
       folderService,
@@ -271,7 +271,7 @@ describe("VaultExportService", () => {
       });
 
       it("has a mac property", async () => {
-        encryptService.encrypt.mockResolvedValue(mac);
+        encryptService.encryptString.mockResolvedValue(mac);
         exportString = await exportService.getPasswordProtectedExport(password);
         exportObject = JSON.parse(exportString);
 
@@ -279,7 +279,7 @@ describe("VaultExportService", () => {
       });
 
       it("has data property", async () => {
-        encryptService.encrypt.mockResolvedValue(data);
+        encryptService.encryptString.mockResolvedValue(data);
         exportString = await exportService.getPasswordProtectedExport(password);
         exportObject = JSON.parse(exportString);
 

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
@@ -108,7 +108,7 @@ export class IndividualVaultExportService
     const userKey = await this.keyService.getUserKeyWithLegacySupport(
       await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId)),
     );
-    const encKeyValidation = await this.encryptService.encrypt(Utils.newGuid(), userKey);
+    const encKeyValidation = await this.encryptService.encryptString(Utils.newGuid(), userKey);
 
     const jsonDoc: BitwardenEncryptedIndividualJsonExport = {
       encrypted: true,

--- a/libs/tools/export/vault-export/vault-export-core/src/services/org-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/org-vault-export.service.ts
@@ -248,7 +248,7 @@ export class OrganizationVaultExportService
     ciphers: Cipher[],
   ): Promise<string> {
     const orgKey = await this.keyService.getOrgKey(organizationId);
-    const encKeyValidation = await this.encryptService.encrypt(Utils.newGuid(), orgKey);
+    const encKeyValidation = await this.encryptService.encryptString(Utils.newGuid(), orgKey);
 
     const jsonDoc: BitwardenEncryptedOrgJsonExport = {
       encrypted: true,

--- a/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.spec.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.spec.ts
@@ -171,7 +171,7 @@ describe("VaultExportService", () => {
     folderService.folderViews$.mockReturnValue(of(UserFolderViews));
     folderService.folders$.mockReturnValue(of(UserFolders));
     kdfConfigService.getKdfConfig.mockResolvedValue(DEFAULT_KDF_CONFIG);
-    encryptService.encrypt.mockResolvedValue(new EncString("encrypted"));
+    encryptService.encryptString.mockResolvedValue(new EncString("encrypted"));
     keyService.userKey$.mockReturnValue(new BehaviorSubject("mockOriginalUserKey" as any));
     const userId = "" as UserId;
     const accountInfo: AccountInfo = {
@@ -270,7 +270,7 @@ describe("VaultExportService", () => {
       });
 
       it("has a mac property", async () => {
-        encryptService.encrypt.mockResolvedValue(mac);
+        encryptService.encryptString.mockResolvedValue(mac);
         exportString = await exportService.getPasswordProtectedExport(password);
         exportObject = JSON.parse(exportString);
 
@@ -278,7 +278,7 @@ describe("VaultExportService", () => {
       });
 
       it("has data property", async () => {
-        encryptService.encrypt.mockResolvedValue(data);
+        encryptService.encryptString.mockResolvedValue(data);
         exportString = await exportService.getPasswordProtectedExport(password);
         exportObject = JSON.parse(exportString);
 

--- a/libs/tools/generator/extensions/history/src/local-generator-history.service.spec.ts
+++ b/libs/tools/generator/extensions/history/src/local-generator-history.service.spec.ts
@@ -22,7 +22,9 @@ describe("LocalGeneratorHistoryService", () => {
   const userKey = new SymmetricCryptoKey(new Uint8Array(64) as CsprngArray) as UserKey;
 
   beforeEach(() => {
-    encryptService.encrypt.mockImplementation((p) => Promise.resolve(p as unknown as EncString));
+    encryptService.encryptString.mockImplementation((p) =>
+      Promise.resolve(p as unknown as EncString),
+    );
     encryptService.decryptToUtf8.mockImplementation((c) => Promise.resolve(c.encryptedString));
     keyService.getUserKey.mockImplementation(() => Promise.resolve(userKey));
     keyService.userKey$.mockImplementation(() => of(true as unknown as UserKey));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19731

## 📔 Objective

Cose (https://bitwarden.atlassian.net/browse/PM-15097) needs a mime-type passed through to the encryption. In order to not have each domain pass in mime-types for common operations (keywrap, etc), this separates the encrypt operations in `encrypt.service` by what is being encrypted, which will be later mapped to mimetypes when moving the encrypt service to use the SDK.

Specifically, we define `wrapDecapsulationKey`for encrypting private keys, `wrapEncapsulationKey` for encrypting public keys, `wrapSymmetricKeys` for encrypting symmetric keys with other symmetric keys, `encryptFileData`, `encryptString`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
