### PR TITLE
[PM-19746] Add new permission check to browser

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -5,10 +5,7 @@
 
   <app-cipher-view *ngIf="cipher" [cipher]="cipher"></app-cipher-view>
 
-  <popup-footer
-    slot="footer"
-    *ngIf="(limitItemDeletion$ | async) ? (showFooter$ | async) : showFooter()"
-  >
+  <popup-footer slot="footer" *ngIf="showFooter$ | async">
     <button
       *ngIf="!cipher.isDeleted"
       buttonType="primary"
@@ -22,7 +19,7 @@
     <button
       *ngIf="
         (limitItemDeletion$ | async)
-          ? cipher.isDeleted && cipher.permissions.delete
+          ? cipher.isDeleted && cipher.permissions.restore
           : cipher.isDeleted && cipher.edit
       "
       buttonType="primary"

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.html
@@ -5,7 +5,10 @@
 
   <app-cipher-view *ngIf="cipher" [cipher]="cipher"></app-cipher-view>
 
-  <popup-footer slot="footer" *ngIf="showFooter()">
+  <popup-footer
+    slot="footer"
+    *ngIf="(limitItemDeletion$ | async) ? (showFooter$ | async) : showFooter()"
+  >
     <button
       *ngIf="!cipher.isDeleted"
       buttonType="primary"
@@ -17,7 +20,11 @@
     </button>
 
     <button
-      *ngIf="cipher.isDeleted && cipher.edit"
+      *ngIf="
+        (limitItemDeletion$ | async)
+          ? cipher.isDeleted && cipher.permissions.delete
+          : cipher.isDeleted && cipher.edit
+      "
       buttonType="primary"
       type="button"
       bitButton

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -51,6 +51,7 @@ describe("ViewV2Component", () => {
   const openSimpleDialog = jest.fn().mockResolvedValue(true);
   const stop = jest.fn();
   const showToast = jest.fn();
+  const getFeatureFlag$ = jest.fn().mockReturnValue(of(true));
 
   const mockCipher = {
     id: "122-333-444",
@@ -105,7 +106,7 @@ describe("ViewV2Component", () => {
         { provide: VaultPopupScrollPositionService, useValue: { stop } },
         { provide: VaultPopupAutofillService, useValue: mockVaultPopupAutofillService },
         { provide: ToastService, useValue: { showToast } },
-        { provide: ConfigService, useValue: { getFeatureFlag$: () => of(false) } },
+        { provide: ConfigService, useValue: { getFeatureFlag$ } },
         {
           provide: I18nService,
           useValue: {

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, flush, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { mock } from "jest-mock-extended";
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -105,6 +105,7 @@ describe("ViewV2Component", () => {
         { provide: VaultPopupScrollPositionService, useValue: { stop } },
         { provide: VaultPopupAutofillService, useValue: mockVaultPopupAutofillService },
         { provide: ToastService, useValue: { showToast } },
+        { provide: ConfigService, useValue: { getFeatureFlag$: () => of(false) } },
         {
           provide: I18nService,
           useValue: {

--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -168,7 +168,7 @@ export class ViewV2Component {
                     (cipher.isDeleted && (cipher.permissions.restore || cipher.permissions.delete)))
                 );
               }
-              return false;
+              return this.showFooterLegacy();
             }),
           );
 
@@ -269,7 +269,8 @@ export class ViewV2Component {
       : this.cipherService.softDeleteWithServer(this.cipher.id, this.activeUserId);
   }
 
-  protected showFooter(): boolean {
+  //@TODO: remove this when the LimitItemDeletion feature flag is removed
+  protected showFooterLegacy(): boolean {
     return (
       this.cipher &&
       (!this.cipher.isDeleted ||

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.html
@@ -31,7 +31,14 @@
         ></i>
         <span slot="secondary">{{ cipher.subTitle }}</span>
       </button>
-      <ng-container slot="end" *ngIf="cipher.edit && cipher.viewPassword">
+      <ng-container
+        slot="end"
+        *ngIf="
+          (limitItemDeletion$ | async)
+            ? cipher.permissions.restore
+            : cipher.edit && cipher.viewPassword
+        "
+      >
         <bit-item-action>
           <button
             type="button"

--- a/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/settings/trash-list-items-container/trash-list-items-container.component.ts
@@ -8,6 +8,8 @@ import { firstValueFrom } from "rxjs";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherId } from "@bitwarden/common/types/guid";
@@ -70,7 +72,10 @@ export class TrashListItemsContainerComponent {
     private passwordRepromptService: PasswordRepromptService,
     private accountService: AccountService,
     private router: Router,
+    private configService: ConfigService,
   ) {}
+
+  protected limitItemDeletion$ = this.configService.getFeatureFlag$(FeatureFlag.LimitItemDeletion);
 
   /**
    * The tooltip text for the organization icon for ciphers that belong to an organization.

--- a/apps/cli/src/commands/restore.command.ts
+++ b/apps/cli/src/commands/restore.command.ts
@@ -1,8 +1,11 @@
-import { firstValueFrom } from "rxjs";
+import { combineLatest, firstValueFrom, map } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 
 import { Response } from "../models/response";
 
@@ -10,6 +13,8 @@ export class RestoreCommand {
   constructor(
     private cipherService: CipherService,
     private accountService: AccountService,
+    private configService: ConfigService,
+    private cipherAuthorizationService: CipherAuthorizationService,
   ) {}
 
   async run(object: string, id: string): Promise<Response> {
@@ -27,13 +32,31 @@ export class RestoreCommand {
 
   private async restoreCipher(id: string) {
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-
     const cipher = await this.cipherService.get(id, activeUserId);
+
     if (cipher == null) {
       return Response.notFound();
     }
     if (cipher.deletedDate == null) {
       return Response.badRequest("Cipher is not in trash.");
+    }
+
+    const canRestore = await firstValueFrom(
+      combineLatest([
+        this.configService.getFeatureFlag$(FeatureFlag.LimitItemDeletion),
+        this.cipherAuthorizationService.canRestoreCipher$(cipher),
+      ]).pipe(
+        map(([enabled, canRestore]) => {
+          if (enabled && !canRestore) {
+            return false;
+          }
+          return true;
+        }),
+      ),
+    );
+
+    if (!canRestore) {
+      return Response.error("You do not have permission to restore this item");
     }
 
     try {

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -127,6 +127,8 @@ export class OssServeConfigurator {
     this.restoreCommand = new RestoreCommand(
       this.serviceContainer.cipherService,
       this.serviceContainer.accountService,
+      this.serviceContainer.configService,
+      this.serviceContainer.cipherAuthorizationService,
     );
     this.shareCommand = new ShareCommand(
       this.serviceContainer.cipherService,

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -350,6 +350,8 @@ export class VaultProgram extends BaseProgram {
         const command = new RestoreCommand(
           this.serviceContainer.cipherService,
           this.serviceContainer.accountService,
+          this.serviceContainer.configService,
+          this.serviceContainer.cipherAuthorizationService,
         );
         const response = await command.run(object, id);
         this.processResponse(response);

--- a/apps/desktop/src/vault/app/vault/view.component.html
+++ b/apps/desktop/src/vault/app/vault/view.component.html
@@ -656,7 +656,7 @@
       class="primary"
       (click)="restore()"
       appA11yTitle="{{ 'restore' | i18n }}"
-      *ngIf="cipher.isDeleted"
+      *ngIf="(limitItemDeletion$ | async) ? (canRestoreCipher$ | async) : cipher.isDeleted"
     >
       <i class="bwi bwi-undo bwi-fw bwi-lg" aria-hidden="true"></i>
     </button>

--- a/apps/desktop/src/vault/app/vault/view.component.ts
+++ b/apps/desktop/src/vault/app/vault/view.component.ts
@@ -17,8 +17,10 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -70,6 +72,7 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
     accountService: AccountService,
     toastService: ToastService,
     cipherAuthorizationService: CipherAuthorizationService,
+    private configService: ConfigService,
   ) {
     super(
       cipherService,
@@ -99,6 +102,9 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
       cipherAuthorizationService,
     );
   }
+
+  protected limitItemDeletion$ = this.configService.getFeatureFlag$(FeatureFlag.LimitItemDeletion);
+
   ngOnInit() {
     super.ngOnInit();
 

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -59,6 +59,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   @Output() onRestoredCipher = new EventEmitter<CipherView>();
 
   canDeleteCipher$: Observable<boolean>;
+  canRestoreCipher$: Observable<boolean>;
   cipher: CipherView;
   showPassword: boolean;
   showPasswordCount: boolean;
@@ -159,6 +160,7 @@ export class ViewComponent implements OnDestroy, OnInit {
     this.canDeleteCipher$ = this.cipherAuthorizationService.canDeleteCipher$(this.cipher, [
       this.collectionId as CollectionId,
     ]);
+    this.canRestoreCipher$ = this.cipherAuthorizationService.canRestoreCipher$(this.cipher);
 
     if (this.cipher.folderId) {
       this.folder = await (


### PR DESCRIPTION
## 🎟️ Tracking
http://bitwarden.atlassian.net/browse/PM-19746
https://bitwarden.atlassian.net/browse/PM-19748
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds new permission logic to vault item trash container in the extension. Fixes permission model for CLI and Desktop
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/62201706-15a5-4b01-b735-7f889bb0baf1

https://github.com/user-attachments/assets/a93c469a-ec30-4dcb-b973-6843d4ce422d

![Screenshot 2025-04-01 at 1 52 08 PM](https://github.com/user-attachments/assets/c886a8bd-875c-4dac-9895-6171a6356f66)


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
