### PR TITLE
Hide blue header for passkey popouts

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -86,7 +86,7 @@ const SyncInterval = 6 * 60 * 60 * 1000; // 6 hours
     <ng-template #exportVault></ng-template>
     <ng-template #appGenerator></ng-template>
     <ng-template #loginApproval></ng-template>
-    <app-header></app-header>
+    <app-header *ngIf="showHeader$ | async"></app-header>
 
     <div id="container">
       <div class="loading" *ngIf="loading">
@@ -112,6 +112,7 @@ export class AppComponent implements OnInit, OnDestroy {
   @ViewChild("loginApproval", { read: ViewContainerRef, static: true })
   loginApprovalModalRef: ViewContainerRef;
 
+  showHeader$ = this.accountService.showHeader$;
   loading = false;
 
   private lastActivity: Date = null;

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.html
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.html
@@ -3,7 +3,7 @@
     disableMargin
     class="tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
-    <bit-section-header class="tw-bg-background">
+    <bit-section-header class="passkey-header tw-bg-background">
       <div class="tw-flex tw-items-center">
         <bit-icon [icon]="Icons.BitwardenShield" class="tw-w-10 tw-mt-2 tw-ml-2"></bit-icon>
 
@@ -16,7 +16,7 @@
         type="button"
         bitIconButton="bwi-close"
         slot="end"
-        class="tw-mb-4 tw-mr-2"
+        class="passkey-header-close tw-mb-4 tw-mr-2"
         (click)="closeModal()"
       >
         Close

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -67,6 +67,7 @@ export class Fido2CreateComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
+    await this.accountService.setShowHeader(false);
     this.session = this.fido2UserInterfaceService.getCurrentSession();
     const rpid = await this.session.getRpId();
     const equivalentDomains = await firstValueFrom(
@@ -92,6 +93,10 @@ export class Fido2CreateComponent implements OnInit {
         this.ciphersSubject.next(relevantCiphers);
       })
       .catch((error) => this.logService.error(error));
+  }
+
+  async ngOnDestroy() {
+    await this.accountService.setShowHeader(true);
   }
 
   async addPasskeyToCipher(cipher: CipherView) {

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
 import { BehaviorSubject, firstValueFrom, map, Observable } from "rxjs";
 

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -48,7 +48,7 @@ import { DesktopSettingsService } from "../../../platform/services/desktop-setti
   ],
   templateUrl: "fido2-create.component.html",
 })
-export class Fido2CreateComponent implements OnInit {
+export class Fido2CreateComponent implements OnInit, OnDestroy {
   session?: DesktopFido2UserInterfaceSession = null;
   private ciphersSubject = new BehaviorSubject<CipherView[]>([]);
   ciphers$: Observable<CipherView[]> = this.ciphersSubject.asObservable();

--- a/apps/desktop/src/modal/passkeys/fido2-vault.component.html
+++ b/apps/desktop/src/modal/passkeys/fido2-vault.component.html
@@ -3,7 +3,7 @@
     disableMargin
     class="tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
-    <bit-section-header class="tw-bg-background">
+    <bit-section-header class="passkey-header tw-bg-background">
       <div class="tw-flex tw-items-center">
         <bit-icon [icon]="Icons.BitwardenShield" class="tw-w-10 tw-mt-2 tw-ml-2"></bit-icon>
 
@@ -13,7 +13,7 @@
         type="button"
         bitIconButton="bwi-close"
         slot="end"
-        class="tw-mb-4 tw-mr-2"
+        class="passkey-header-close tw-mb-4 tw-mr-2"
         (click)="closeModal()"
       >
         Close

--- a/apps/desktop/src/scss/header.scss
+++ b/apps/desktop/src/scss/header.scss
@@ -232,3 +232,11 @@
     font-size: $font-size-small;
   }
 }
+
+.passkey-header {
+  -webkit-app-region: drag;
+}
+
+.passkey-header-close {
+  -webkit-app-region: no-drag;
+}

--- a/libs/common/spec/fake-account-service.ts
+++ b/libs/common/spec/fake-account-service.ts
@@ -37,6 +37,8 @@ export class FakeAccountService implements AccountService {
   accountActivitySubject = new ReplaySubject<Record<UserId, Date>>(1);
   // eslint-disable-next-line rxjs/no-exposed-subjects -- test class
   accountVerifyDevicesSubject = new ReplaySubject<boolean>(1);
+  // eslint-disable-next-line rxjs/no-exposed-subjects -- test class
+  showHeaderSubject = new ReplaySubject<boolean>(1);
   private _activeUserId: UserId;
   get activeUserId() {
     return this._activeUserId;
@@ -55,6 +57,7 @@ export class FakeAccountService implements AccountService {
       }),
     );
   }
+  showHeader$ = this.showHeaderSubject.asObservable();
   get nextUpAccount$(): Observable<Account> {
     return combineLatest([this.accounts$, this.activeAccount$, this.sortedUserIds$]).pipe(
       map(([accounts, activeAccount, sortedUserIds]) => {
@@ -113,6 +116,10 @@ export class FakeAccountService implements AccountService {
     const updated = { ...current, [userId]: loggedOutInfo };
     this.accountsSubject.next(updated);
     await this.mock.clean(userId);
+  }
+
+  async setShowHeader(value: boolean): Promise<void> {
+    this.showHeaderSubject.next(value);
   }
 }
 

--- a/libs/common/src/auth/abstractions/account.service.ts
+++ b/libs/common/src/auth/abstractions/account.service.ts
@@ -49,6 +49,7 @@ export abstract class AccountService {
   sortedUserIds$: Observable<UserId[]>;
   /** Next account that is not the current active account */
   nextUpAccount$: Observable<Account>;
+  showHeader$: Observable<boolean>;
   /**
    * Updates the `accounts$` observable with the new account data.
    *
@@ -102,6 +103,11 @@ export abstract class AccountService {
    * @param lastActivity
    */
   abstract setAccountActivity(userId: UserId, lastActivity: Date): Promise<void>;
+  /**
+   * Show the account switcher.
+   * @param value
+   */
+  abstract setShowHeader(visible: boolean): Promise<void>;
 }
 
 export abstract class InternalAccountService extends AccountService {

--- a/libs/common/src/auth/services/account.service.spec.ts
+++ b/libs/common/src/auth/services/account.service.spec.ts
@@ -429,6 +429,24 @@ describe("accountService", () => {
         },
       );
     });
+
+    describe("setShowHeader", () => {
+      it("should update _showHeader$ when setShowHeader is called", async () => {
+        expect(sut["_showHeader$"].value).toBe(true);
+
+        await sut.setShowHeader(false);
+        expect(sut["_showHeader$"].value).toBe(false);
+      });
+
+      it("should emit values correctly", (done) => {
+        sut.showHeader$.subscribe((value) => {
+          expect(value).toBe(false);
+          done();
+        });
+
+        await sut.setShowHeader(false);
+      });
+    });
   });
 });
 

--- a/libs/common/src/auth/services/account.service.spec.ts
+++ b/libs/common/src/auth/services/account.service.spec.ts
@@ -435,16 +435,8 @@ describe("accountService", () => {
         expect(sut["_showHeader$"].value).toBe(true);
 
         await sut.setShowHeader(false);
+
         expect(sut["_showHeader$"].value).toBe(false);
-      });
-
-      it("should emit values correctly", (done) => {
-        sut.showHeader$.subscribe((value) => {
-          expect(value).toBe(false);
-          done();
-        });
-
-        await sut.setShowHeader(false);
       });
     });
   });

--- a/libs/common/src/auth/services/account.service.ts
+++ b/libs/common/src/auth/services/account.service.ts
@@ -6,6 +6,7 @@ import {
   distinctUntilChanged,
   shareReplay,
   combineLatest,
+  BehaviorSubject,
   Observable,
   switchMap,
   filter,
@@ -84,6 +85,7 @@ export const getOptionalUserId = map<Account | null, UserId | null>(
 export class AccountServiceImplementation implements InternalAccountService {
   private accountsState: GlobalState<Record<UserId, AccountInfo>>;
   private activeAccountIdState: GlobalState<UserId | undefined>;
+  private _showHeader$ = new BehaviorSubject<boolean>(true);
 
   accounts$: Observable<Record<UserId, AccountInfo>>;
   activeAccount$: Observable<Account | null>;
@@ -91,6 +93,7 @@ export class AccountServiceImplementation implements InternalAccountService {
   accountVerifyNewDeviceLogin$: Observable<boolean>;
   sortedUserIds$: Observable<UserId[]>;
   nextUpAccount$: Observable<Account>;
+  showHeader$ = this._showHeader$.asObservable();
 
   constructor(
     private messagingService: MessagingService,
@@ -258,6 +261,10 @@ export class AccountServiceImplementation implements InternalAccountService {
       this.logService.error(e);
       throw e;
     }
+  }
+
+  async setShowHeader(visible: boolean): Promise<void> {
+    this._showHeader$.next(visible);
   }
 
   private async setAccountInfo(userId: UserId, update: Partial<AccountInfo>): Promise<void> {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19607](https://bitwarden.atlassian.net/browse/PM-19607)

## 📔 Objective

Remove the account switcher and blue heading from the pop up windows for the create and select passkey user flow.  

To test: 
* Visit https://webauthn.io

To view available keys:
* In the input field click the key and choose Bitwarden
* You will see the updated popout without the blue header and account switcher.
* Make sure you can move the window around your screen.

To create a new key:
* Fill in the input and click `Register`
* You will see the updated popout without the blue header and account switcher.
* Make sure you can move the window around your screen.

## 📸 Screenshots

https://github.com/user-attachments/assets/394d980f-8a54-4391-b41f-be3316ff7764

<img width="687" alt="Screenshot 2025-04-02 at 3 55 18 PM" src="https://github.com/user-attachments/assets/65c3ba93-5c6a-46fc-833c-ac86f8a6be87" />
<img width="692" alt="Screenshot 2025-04-02 at 3 55 35 PM" src="https://github.com/user-attachments/assets/9160c61a-9b5a-4e33-a1b5-2ef13e03dfa9" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19607]: https://bitwarden.atlassian.net/browse/PM-19607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ