### PR TITLE
Fix Safari pinned tabs causing autofill to be wrong

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -574,4 +574,113 @@ describe("BrowserApi", () => {
       );
     });
   });
+
+  /*
+   * Safari sometimes returns >1 tabs unexpectedly even when
+   * specificing a `windowId` or `currentWindow: true` query option.
+   *
+   * For example, when there are >=2 windows with an active pinned tab,
+   * the pinned tab will always be included as the first entry in the array,
+   * while the correct tab is included as the second entry.
+   *
+   * These tests can remain as verification when Safari fixes this bug.
+   */
+  describe.each([{ isSafariApi: true }, { isSafariApi: false }])(
+    "SafariTabsQuery %p",
+    ({ isSafariApi }) => {
+      let originalIsSafariApi = BrowserApi.isSafariApi;
+      const expectedWindowId = 10;
+      const wrongWindowId = expectedWindowId + 1;
+      const raceConditionWindowId = expectedWindowId + 2;
+      const mismatchedWindowId = expectedWindowId + 3;
+
+      const resolvedTabsQueryResult = [
+        mock<chrome.tabs.Tab>({
+          title: "tab[0] is a pinned tab from another window",
+          pinned: true,
+          windowId: wrongWindowId,
+        }),
+        mock<chrome.tabs.Tab>({
+          title: "tab[1] is the tab with the correct foreground window",
+          windowId: expectedWindowId,
+        }),
+      ];
+
+      function mockCurrentWindowId(id: number | null) {
+        jest
+          .spyOn(BrowserApi, "getCurrentWindow")
+          .mockResolvedValue(mock<chrome.windows.Window>({ id }));
+      }
+
+      beforeEach(() => {
+        originalIsSafariApi = BrowserApi.isSafariApi;
+        BrowserApi.isSafariApi = isSafariApi;
+        mockCurrentWindowId(expectedWindowId);
+        jest.spyOn(BrowserApi, "tabsQuery").mockResolvedValue(resolvedTabsQueryResult);
+      });
+
+      afterEach(() => {
+        BrowserApi.isSafariApi = originalIsSafariApi;
+        jest.restoreAllMocks();
+      });
+
+      describe.each([BrowserApi.getTabFromCurrentWindow, BrowserApi.getTabFromCurrentWindowId])(
+        "%p",
+        (getCurrTabFn) => {
+          it("returns the first tab when the query result has one tab", async () => {
+            const expectedSingleTab = resolvedTabsQueryResult[0];
+            jest.spyOn(BrowserApi, "tabsQuery").mockResolvedValue([expectedSingleTab]);
+            const actualTab = await getCurrTabFn();
+            expect(actualTab).toBe(expectedSingleTab);
+          });
+
+          it("returns the first tab when the current window ID is mismatched", async () => {
+            mockCurrentWindowId(mismatchedWindowId);
+            const actualTab = await getCurrTabFn();
+            expect(actualTab).toBe(resolvedTabsQueryResult[0]);
+          });
+
+          it("returns the first tab when the current window ID is unavailable", async () => {
+            mockCurrentWindowId(null);
+            const actualTab = await getCurrTabFn();
+            expect(actualTab).toBe(resolvedTabsQueryResult[0]);
+          });
+
+          if (isSafariApi) {
+            it("returns the tab with the current window ID", async () => {
+              const actualTab = await getCurrTabFn();
+              expect(actualTab.windowId).toBe(expectedWindowId);
+            });
+
+            it(`returns the tab with the current window ID at the time of calling [Function ${getCurrTabFn.name}]`, async () => {
+              jest.spyOn(BrowserApi, "tabsQuery").mockImplementation(() => {
+                /*
+                 * Simulate rapid clicking/switching between windows, e.g.
+                 * 1. From Window A, call `getCurrTabFn()`
+                 * 2. getCurrTabFn() calls `await BrowserApi.tabsQuery()`
+                 * 3. Users switches to Window B before the `await` returns
+                 * 4. getCurrTabFn() calls `await BrowserApi.getCurrentWindow()`
+                 * ^ This now returns Window B and filters the results erroneously
+                 */
+                mockCurrentWindowId(raceConditionWindowId);
+
+                return Promise.resolve(resolvedTabsQueryResult);
+              });
+
+              const actualTab = await getCurrTabFn();
+              expect(actualTab.windowId).toBe(expectedWindowId);
+            });
+          } /* !isSafariApi */ else {
+            it("falls back to tabsQueryFirst", async () => {
+              const tabsQueryFirstSpy = jest.spyOn(BrowserApi, "tabsQueryFirst");
+              const actualTab = await getCurrTabFn();
+
+              expect(tabsQueryFirstSpy).toHaveBeenCalled();
+              expect(actualTab).toBe(resolvedTabsQueryResult[0]);
+            });
+          }
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

bitwarden branch PR placeholder for safari build

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
