### PR TITLE
Revert "fix menu trigger fallback position (#14040)"

### DIFF
--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -48,12 +48,11 @@ export class MenuTriggerForDirective implements OnDestroy {
           overlayX: "start",
           overlayY: "top",
         },
-        // Fallback position: show above the trigger
         {
-          originX: "start",
-          originY: "top",
-          overlayX: "start",
-          overlayY: "bottom",
+          originX: "end",
+          originY: "bottom",
+          overlayX: "end",
+          overlayY: "top",
         },
       ])
       .withLockedPosition(true)


### PR DESCRIPTION
This reverts commit b0ccadcc0f11594351484a2b6eab5556b8580c38.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-19847](https://bitwarden.atlassian.net/browse/PM-19847)
[CL-617](https://bitwarden.atlassian.net/browse/CL-617)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
PR #14040 introduced a regression to the default positioning of some menus, which were reported as bugs in our latest `main` build. Design has indicated that the new regressions are less desirable than the original issue that the PR fixed, so we are reverting the PR to get back to production behavior and will re-address the original ticket separately.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before Revert | After Revert |
|--------|--------|
| ![Screenshot 2025-04-03 at 1 59 02 PM](https://github.com/user-attachments/assets/778f008d-4546-49fe-a52d-df8ff2cec1b5) |  ![Screenshot 2025-04-03 at 2 00 03 PM](https://github.com/user-attachments/assets/5caaa968-f2e1-44bd-ad49-7c95e06230bd) |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19847]: https://bitwarden.atlassian.net/browse/PM-19847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-617]: https://bitwarden.atlassian.net/browse/CL-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ