### PR TITLE
PM-19424: React to IPC disconnect

### DIFF
--- a/apps/desktop/desktop_native/macos_provider/src/lib.rs
+++ b/apps/desktop/desktop_native/macos_provider/src/lib.rs
@@ -49,6 +49,12 @@ trait Callback: Send + Sync {
     fn error(&self, error: BitwardenError);
 }
 
+#[derive(uniffi::Enum, Debug)]
+pub enum ConnectionStatus {
+    Connected,
+    Disconnected,
+}
+
 #[derive(uniffi::Object)]
 pub struct MacOSProviderClient {
     to_server_send: tokio::sync::mpsc::Sender<String>,
@@ -57,6 +63,9 @@ pub struct MacOSProviderClient {
     response_callbacks_counter: AtomicU32,
     #[allow(clippy::type_complexity)]
     response_callbacks_queue: Arc<Mutex<HashMap<u32, (Box<dyn Callback>, Instant)>>>,
+    
+    // Flag to track connection status - atomic for thread safety without locks
+    connection_status: Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[uniffi::export]
@@ -74,11 +83,13 @@ impl MacOSProviderClient {
             to_server_send,
             response_callbacks_counter: AtomicU32::new(0),
             response_callbacks_queue: Arc::new(Mutex::new(HashMap::new())),
+            connection_status: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let path = desktop_core::ipc::path("autofill");
 
         let queue = client.response_callbacks_queue.clone();
+        let connection_status = client.connection_status.clone();
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
@@ -96,9 +107,11 @@ impl MacOSProviderClient {
                     match serde_json::from_str::<SerializedMessage>(&message) {
                         Ok(SerializedMessage::Command(CommandMessage::Connected)) => {
                             info!("Connected to server");
+                            connection_status.store(true, std::sync::atomic::Ordering::SeqCst);
                         }
                         Ok(SerializedMessage::Command(CommandMessage::Disconnected)) => {
                             info!("Disconnected from server");
+                            connection_status.store(false, std::sync::atomic::Ordering::SeqCst);
                         }
                         Ok(SerializedMessage::Message {
                             sequence_number,
@@ -158,6 +171,15 @@ impl MacOSProviderClient {
         callback: Arc<dyn PreparePasskeyAssertionCallback>,
     ) {
         self.send_message(request, Box::new(callback));
+    }
+    
+    pub fn get_connection_status(&self) -> ConnectionStatus {
+        let is_connected = self.connection_status.load(std::sync::atomic::Ordering::SeqCst);
+        if is_connected {
+            ConnectionStatus::Connected
+        } else {
+            ConnectionStatus::Disconnected
+        }
     }
 }
 

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -59,9 +59,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         
         logger.log("[autofill-extension] Connecting to Bitwarden over IPC")    
 
-        // Just create the client for now - we'll start monitoring later
-        let client = MacOsProviderClient.connect()
-        return client
+        return MacOsProviderClient.connect()
     }()
     
     // Timer for checking connection status
@@ -89,7 +87,11 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         
         // Only post notification if state changed
         if currentStatus != lastConnectionStatus {
-            logger.log("[autofill-extension] Connection status changed: \(currentStatus == .connected ? "Connected" : "Disconnected")")
+            if(currentStatus == .connected) {
+                logger.log("[autofill-extension] Connection status changed: Connected")
+            } else {
+                logger.log("[autofill-extension] Connection status changed: Disconnected")
+            }
             
             // Save the new status
             lastConnectionStatus = currentStatus

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "postinstall": "electron-rebuild",
     "start": "cross-env ELECTRON_IS_DEV=0 ELECTRON_NO_UPDATER=1 electron ./build",
+    "build-native-macos": "cd desktop_native/macos_provider && ./build.sh && cd ../napi && npm run build && cd .. && node build.js cross-platform",
     "build-native": "cd desktop_native && node build.js",
     "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" concurrently -n Main,Rend,Prel -c yellow,cyan \"npm run build:main\" \"npm run build:renderer\" \"npm run build:preload\"",
     "build:dev": "concurrently -n Main,Rend -c yellow,cyan \"npm run build:main:dev\" \"npm run build:renderer:dev\"",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "postinstall": "electron-rebuild",
     "start": "cross-env ELECTRON_IS_DEV=0 ELECTRON_NO_UPDATER=1 electron ./build",
-    "build-native-macos": "cd desktop_native/macos_provider && ./build.sh && cd ../napi && npm run build && cd .. && node build.js cross-platform",
+    "build-native-macos": "cd desktop_native && ./macos_provider/build.sh && node build.js cross-platform",
     "build-native": "cd desktop_native && node build.js",
     "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" concurrently -n Main,Rend,Prel -c yellow,cyan \"npm run build:main\" \"npm run build:renderer\" \"npm run build:preload\"",
     "build:dev": "concurrently -n Main,Rend -c yellow,cyan \"npm run build:main:dev\" \"npm run build:renderer:dev\"",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19424

## 📔 Objective

This PR adds support for tracking the IPC connection and exits the passkey flow if the IPC connection is dropped (e.g. the bitwarden app is terminated).

I originally tried a callback based approach, but I kept running into rust-panics so opted for this simpler approach.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
