### PR TITLE
Add more specific api key error message

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -187,9 +187,12 @@ export class LoginCommand {
 
       let response: AuthResult = null;
       if (clientId != null && clientSecret != null) {
-        if (!clientId.startsWith("user")) {
-          return Response.error("Invalid API Key; Organization API Key currently not supported");
-        }
+        if (!clientId.startsWith("user") && !clientId.startsWith("organization")) {
+          return Response.error("Invalid API Key");
+        }  else if (clientId.startsWith("organization")) {
+          // remove this else if block when organization api key support is added
+          return Response.error("Organization API Key currently not supported");
+        }        
         try {
           response = await this.loginStrategyService.logIn(
             new UserApiLoginCredentials(clientId, clientSecret),


### PR DESCRIPTION
## 🎟️ Tracking

Community

## 📔 Objective

Organization api key is currently not supported but either when you provide a bad clientId or a "valid" organization clientId bw cli respond with `Invalid API Key; Organization API Key currently not supported`. I would love to see api organization key support soon but in the meantime, I propose to be more precise on error message to help user understand want's going on.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
