### PR TITLE
[CL-421] add new notification variant to badge

### DIFF
--- a/libs/components/src/badge/badge.component.ts
+++ b/libs/components/src/badge/badge.component.ts
@@ -5,7 +5,14 @@ import { Component, ElementRef, HostBinding, Input } from "@angular/core";
 
 import { FocusableElement } from "../shared/focusable-element";
 
-export type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info";
+export type BadgeVariant =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "danger"
+  | "warning"
+  | "info"
+  | "notification";
 
 const styles: Record<BadgeVariant, string[]> = {
   primary: ["tw-bg-primary-100", "tw-border-primary-700", "!tw-text-primary-700"],
@@ -14,6 +21,11 @@ const styles: Record<BadgeVariant, string[]> = {
   danger: ["tw-bg-danger-100", "tw-border-danger-700", "!tw-text-danger-700"],
   warning: ["tw-bg-warning-100", "tw-border-warning-700", "!tw-text-warning-700"],
   info: ["tw-bg-info-100", "tw-border-info-700", "!tw-text-info-700"],
+  notification: [
+    "tw-bg-notification-100",
+    "tw-border-notification-600",
+    "!tw-text-notification-600",
+  ],
 };
 
 const hoverStyles: Record<BadgeVariant, string[]> = {
@@ -27,6 +39,11 @@ const hoverStyles: Record<BadgeVariant, string[]> = {
   danger: ["hover:tw-bg-danger-600", "hover:tw-border-danger-600", "hover:!tw-text-contrast"],
   warning: ["hover:tw-bg-warning-600", "hover:tw-border-warning-600", "hover:!tw-text-black"],
   info: ["hover:tw-bg-info-600", "hover:tw-border-info-600", "hover:!tw-text-black"],
+  notification: [
+    "hover:tw-bg-notification-600",
+    "hover:tw-border-notification-600",
+    "hover:!tw-text-contrast",
+  ],
 };
 
 @Component({

--- a/libs/components/src/badge/badge.stories.ts
+++ b/libs/components/src/badge/badge.stories.ts
@@ -36,6 +36,7 @@ export const Variants: Story = {
       <button class="tw-mx-1" bitBadge variant="danger" [truncate]="truncate">Danger</button>
       <button class="tw-mx-1" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <button class="tw-mx-1" bitBadge variant="notification" [truncate]="truncate">Notification</button>
       <br/><br/>
       <span class="tw-text-main tw-mx-1">Hover</span>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="primary" [truncate]="truncate">Primary</button>
@@ -44,6 +45,7 @@ export const Variants: Story = {
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="danger" [truncate]="truncate">Danger</button>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1 tw-test-hover" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <button class="tw-mx-1 tw-test-hover" bitBadge variant="notification" [truncate]="truncate">Notification</button>
       <br/><br/>
       <span class="tw-text-main tw-mx-1">Focus Visible</span>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="primary" [truncate]="truncate">Primary</button>
@@ -52,6 +54,7 @@ export const Variants: Story = {
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="danger" [truncate]="truncate">Danger</button>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <button class="tw-mx-1 tw-test-focus-visible" bitBadge variant="notification" [truncate]="truncate">Notification</button>
       <br/><br/>
       <span class="tw-text-main tw-mx-1">Disabled</span>
       <button disabled class="tw-mx-1" bitBadge variant="primary" [truncate]="truncate">Primary</button>
@@ -60,6 +63,7 @@ export const Variants: Story = {
       <button disabled class="tw-mx-1" bitBadge variant="danger" [truncate]="truncate">Danger</button>
       <button disabled class="tw-mx-1" bitBadge variant="warning" [truncate]="truncate">Warning</button>
       <button disabled class="tw-mx-1" bitBadge variant="info" [truncate]="truncate">Info</button>
+      <button disabled class="tw-mx-1" bitBadge variant="notification" [truncate]="truncate">Notification</button>
     `,
   }),
 };
@@ -109,6 +113,13 @@ export const Info: Story = {
   ...Primary,
   args: {
     variant: "info",
+  },
+};
+
+export const Notification: Story = {
+  ...Primary,
+  args: {
+    variant: "notification",
   },
 };
 


### PR DESCRIPTION
## 🎟️ Tracking

[CL-421](https://bitwarden.atlassian.net/browse/CL-421)

## 📔 Objective

Add new notification variant to bitbadge

## 📸 Screenshots

<img width="753" alt="Screenshot 2025-04-04 at 12 56 29 PM" src="https://github.com/user-attachments/assets/9ab704f8-429c-4b81-ade8-ba195fda54a9" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-421]: https://bitwarden.atlassian.net/browse/CL-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ