### PR TITLE
[PM-17361] Migrating providers.component.html to TW

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers.component.html
@@ -1,22 +1,22 @@
 <app-header></app-header>
 
 <bit-container>
-  <p *ngIf="!loaded" class="text-muted">
+  <p *ngIf="!loaded" class="tw-text-muted">
     <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
     <span class="tw-sr-only">{{ "loading" | i18n }}</span>
   </p>
-  <ng-container *ngIf="loaded">
-    <table class="table table-hover table-list" *ngIf="providers && providers.length">
-      <tbody>
-        <tr *ngFor="let p of providers">
-          <td width="30">
+  <ng-container *ngIf="loaded && providers && providers.length">
+    <bit-table>
+      <ng-template body>
+        <tr bitRow *ngFor="let p of providers">
+          <td bitCell>
             <bit-avatar [text]="p.name" [id]="p.id" size="small"></bit-avatar>
           </td>
-          <td>
+          <td bitCell>
             <a href="#" [routerLink]="['/providers', p.id]">{{ p.name }}</a>
             <ng-container *ngIf="!p.enabled">
               <i
-                class="bwi bwi-exclamation-triangle text-danger"
+                class="bwi bwi-exclamation-triangle tw-text-danger"
                 title="{{ 'providerIsDisabled' | i18n }}"
                 aria-hidden="true"
               ></i>
@@ -24,7 +24,7 @@
             </ng-container>
           </td>
         </tr>
-      </tbody>
-    </table>
+      </ng-template>
+    </bit-table>
   </ng-container>
 </bit-container>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers.component.html
@@ -9,7 +9,7 @@
     <bit-table>
       <ng-template body>
         <tr bitRow *ngFor="let p of providers">
-          <td bitCell>
+          <td bitCell class="tw-w-1">
             <bit-avatar [text]="p.name" [id]="p.id" size="small"></bit-avatar>
           </td>
           <td bitCell>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-17361](https://bitwarden.atlassian.net/browse/PM-17361)

## 📔 Objective
This is another step in removing references to bootstrap.

## 📸 Screenshots
Before:
![image](https://github.com/user-attachments/assets/d81b0ed8-0748-41b1-947f-62fb10400e12)

After:
![image](https://github.com/user-attachments/assets/9dc6a82c-a9b8-4d51-aa16-b4d952d4efa2)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17361]: https://bitwarden.atlassian.net/browse/PM-17361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ