### PR TITLE
[PM-19906] Add appStopClick to prevent default navigation

### DIFF
--- a/libs/vault/src/cipher-view/cipher-view.component.html
+++ b/libs/vault/src/cipher-view/cipher-view.component.html
@@ -10,7 +10,7 @@
       [title]="''"
     >
       <i class="bwi bwi-exclamation-triangle tw-text-warning" aria-hidden="true"></i>
-      <a bitLink href="#" (click)="launchChangePassword()">
+      <a bitLink href="#" appStopClick (click)="launchChangePassword()">
         {{ "changeAtRiskPassword" | i18n }}
         <i class="bwi bwi-external-link tw-ml-1" aria-hidden="true"></i>
       </a>

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -90,7 +90,7 @@
       ></button>
     </bit-form-field>
     <bit-hint *ngIf="hadPendingChangePasswordTask">
-      <a bitLink href="#" (click)="launchChangePasswordEvent()">
+      <a bitLink href="#" appStopClick (click)="launchChangePasswordEvent()">
         {{ "changeAtRiskPassword" | i18n }}
         <i class="bwi bwi-external-link tw-ml-1" aria-hidden="true"></i>
       </a>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19906](https://bitwarden.atlassian.net/browse/PM-19906)

## 📔 Objective

Use appStopClick to prevent default navigation event which caused the extension to flash before navigating.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/71953a2a-1c09-47f6-a5d4-5e18cb297269" /> | <video src="https://github.com/user-attachments/assets/fc4e4dc8-f4d3-4e43-a265-eae98a94679f" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19906]: https://bitwarden.atlassian.net/browse/PM-19906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ