### PR TITLE
[PM-18955] Improve performance of Billing invocations on Collections page

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -641,7 +641,11 @@ export class VaultComponent implements OnInit, OnDestroy {
         ]),
       ),
       map(([org, sub, metadata]) =>
-        this.trialFlowService.organizationHasUpcomingPaymentIssues(org, sub, metadata),
+        this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
+          org,
+          sub,
+          metadata.isPaymentMethodConfigured,
+        ),
       ),
       filter((result) => result !== null),
     );

--- a/apps/web/src/app/billing/organizations/payment-method/organization-payment-method.component.ts
+++ b/apps/web/src/app/billing/organizations/payment-method/organization-payment-method.component.ts
@@ -144,7 +144,7 @@ export class OrganizationPaymentMethodComponent implements OnDestroy {
         this.freeTrialData = this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
           this.organization,
           this.organizationSubscriptionResponse,
-          paymentSource,
+          !!paymentSource,
         );
       }
       this.isUnpaid = this.subscriptionStatus === "unpaid" ?? false;

--- a/apps/web/src/app/billing/services/trial-flow.service.ts
+++ b/apps/web/src/app/billing/services/trial-flow.service.ts
@@ -51,6 +51,28 @@ export class TrialFlowService {
     };
   }
 
+  organizationHasUpcomingPaymentIssues(
+    organization: Organization,
+    organizationSubscription: OrganizationSubscriptionResponse,
+    metadata: OrganizationBillingMetadataResponse,
+  ): FreeTrial {
+    const trialEndDate = organizationSubscription?.subscription?.trialEndDate;
+    const displayBanner =
+      metadata.isPaymentMethodConfigured === false &&
+      organization?.isOwner &&
+      organizationSubscription?.subscription?.status === "trialing";
+    const trialRemainingDays = trialEndDate ? this.calculateTrialRemainingDays(trialEndDate) : 0;
+    const freeTrialMessage = this.getFreeTrialMessage(trialRemainingDays);
+
+    return {
+      remainingDays: trialRemainingDays,
+      message: freeTrialMessage,
+      shownBanner: displayBanner,
+      organizationId: organization.id,
+      organizationName: organization.name,
+    };
+  }
+
   calculateTrialRemainingDays(trialEndDate: string): number | undefined {
     const today = new Date();
     const trialEnd = new Date(trialEndDate);

--- a/apps/web/src/app/billing/services/trial-flow.service.ts
+++ b/apps/web/src/app/billing/services/trial-flow.service.ts
@@ -7,10 +7,8 @@ import { lastValueFrom } from "rxjs";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
-import { BillingSourceResponse } from "@bitwarden/common/billing/models/response/billing.response";
 import { OrganizationBillingMetadataResponse } from "@bitwarden/common/billing/models/response/organization-billing-metadata.response";
 import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/models/response/organization-subscription.response";
-import { PaymentSourceResponse } from "@bitwarden/common/billing/models/response/payment-source.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService } from "@bitwarden/components";
 
@@ -32,33 +30,11 @@ export class TrialFlowService {
   checkForOrgsWithUpcomingPaymentIssues(
     organization: Organization,
     organizationSubscription: OrganizationSubscriptionResponse,
-    paymentSource: BillingSourceResponse | PaymentSourceResponse,
+    isPaymentConfigured: boolean,
   ): FreeTrial {
     const trialEndDate = organizationSubscription?.subscription?.trialEndDate;
     const displayBanner =
-      !paymentSource &&
-      organization?.isOwner &&
-      organizationSubscription?.subscription?.status === "trialing";
-    const trialRemainingDays = trialEndDate ? this.calculateTrialRemainingDays(trialEndDate) : 0;
-    const freeTrialMessage = this.getFreeTrialMessage(trialRemainingDays);
-
-    return {
-      remainingDays: trialRemainingDays,
-      message: freeTrialMessage,
-      shownBanner: displayBanner,
-      organizationId: organization.id,
-      organizationName: organization.name,
-    };
-  }
-
-  organizationHasUpcomingPaymentIssues(
-    organization: Organization,
-    organizationSubscription: OrganizationSubscriptionResponse,
-    metadata: OrganizationBillingMetadataResponse,
-  ): FreeTrial {
-    const trialEndDate = organizationSubscription?.subscription?.trialEndDate;
-    const displayBanner =
-      metadata.isPaymentMethodConfigured === false &&
+      isPaymentConfigured === false &&
       organization?.isOwner &&
       organizationSubscription?.subscription?.status === "trialing";
     const trialRemainingDays = trialEndDate ? this.calculateTrialRemainingDays(trialEndDate) : 0;

--- a/apps/web/src/app/billing/shared/payment-method.component.ts
+++ b/apps/web/src/app/billing/shared/payment-method.component.ts
@@ -209,7 +209,7 @@ export class PaymentMethodComponent implements OnInit, OnDestroy {
     this.freeTrialData = this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
       this.organization,
       this.org,
-      this.billing?.paymentSource,
+      !!this.billing?.paymentSource,
     );
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -225,7 +225,7 @@ export class VaultComponent implements OnInit, OnDestroy {
               this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
                 org,
                 subscription,
-                paymentSource,
+                !!paymentSource,
               ),
             ),
           ),

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -174,7 +174,11 @@ export class OverviewComponent implements OnInit, OnDestroy {
         ]),
       ),
       map(([org, sub, paymentSource]) => {
-        return this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(org, sub, paymentSource);
+        return this.trialFlowService.checkForOrgsWithUpcomingPaymentIssues(
+          org,
+          sub,
+          !!paymentSource,
+        );
       }),
       filter((result) => result !== null),
       takeUntil(this.destroy$),

--- a/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
+++ b/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
@@ -11,6 +11,7 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
   invoiceCreatedDate: Date | null;
   subPeriodEndDate: Date | null;
   isSubscriptionCanceled: boolean;
+  isPaymentMethodConfigured: boolean;
 
   constructor(response: any) {
     super(response);
@@ -25,6 +26,7 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
     this.invoiceCreatedDate = this.parseDate(this.getResponseProperty("InvoiceCreatedDate"));
     this.subPeriodEndDate = this.parseDate(this.getResponseProperty("SubPeriodEndDate"));
     this.isSubscriptionCanceled = this.getResponseProperty("IsSubscriptionCanceled");
+    this.isPaymentMethodConfigured = this.getResponseProperty("IsPaymentMethodConfigured");
   }
 
   private parseDate(dateString: any): Date | null {


### PR DESCRIPTION
…ions

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18955

## 📔 Objective

There were two options to solve checking whether a payment method already exists for a trial subscription:

- Whether country and postal code are entered for a customer, both of which are required for sales tax compliance. Already exposed by the metadata endpoint. However, it's not a guarantee that the payment method still exists once the billing information has been entered

- customer.invoice_settings has a property with the default payment id. We would have to return it with the metadata endpoint. Is more thorough than bullet point #1.

## 📸 Screenshots


https://github.com/user-attachments/assets/3cf22f17-3216-4e12-9fe4-7afa015ac766



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
