### PR TITLE
[PM-19470] Redirect to the first tab

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/critical-applications.component.ts
@@ -95,10 +95,13 @@ export class CriticalApplicationsComponent implements OnInit {
   }
 
   goToAllAppsTab = async () => {
-    await this.router.navigate([`organizations/${this.organizationId}/risk-insights`], {
-      queryParams: { tabIndex: RiskInsightsTabType.AllApps },
-      queryParamsHandling: "merge",
-    });
+    await this.router.navigate(
+      [`organizations/${this.organizationId}/access-intelligence/risk-insights`],
+      {
+        queryParams: { tabIndex: RiskInsightsTabType.AllApps },
+        queryParamsHandling: "merge",
+      },
+    );
   };
 
   unmarkAsCriticalApp = async (hostname: string) => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19470

## 📔 Objective

The `Mark Critical Apps` button does not redirect to the right location.
This should now redirect to the `Risk Insights` page and launch the `All Applications` tab

## 📸 Screenshots

No screen shots at this time.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
