### PR TITLE
Revert event-driven .show, in order for bootstrap/hide-to-tray to work

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -292,11 +292,7 @@ export class WindowMain {
       this.win.maximize();
     }
 
-    // Show it later since it might need to be maximized.
-    // use once event to avoid flash on unstyled content.
-    this.win.once("ready-to-show", () => {
-      this.win.show();
-    });
+    this.win.show();
 
     if (template === "full-app") {
       // and load the index.html of the app.


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19869

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR reverts the event driven call to .show() to introduced in the Desktop Modal Experiment PR ([line](https://github.com/bitwarden/clients/pull/11484/files#diff-329e0465d1ce6029fa8b2d5138f854b6c3f39117e2fa55148a6062edce664c34R267))

When using the event, the bootstrap code that subscribes to "hide-to-tray" settings being loaded fired before this event, which caused the window to be hidden first, the shown again. This changes makes the operation sync, so the window is shown, then hidden.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
