### PR TITLE
[PM-13404] Weak passwords report - sort on Weakness column

### DIFF
--- a/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.html
@@ -38,7 +38,7 @@
           <th bitCell bitSortable="organizationId" *ngIf="!isAdminConsoleActive">
             {{ "owner" | i18n }}
           </th>
-          <th bitCell class="tw-text-right" bitSortable="score" default>
+          <th bitCell class="tw-text-right" bitSortable="scoreKey" default>
             {{ "weakness" | i18n }}
           </th>
         </ng-container>

--- a/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
@@ -18,8 +18,8 @@ import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/se
 
 import { CipherReportComponent } from "./cipher-report.component";
 
-type ReportScore = { label: string; badgeVariant: BadgeVariant };
-type ReportResult = CipherView & { score: number; reportValue: ReportScore };
+type ReportScore = { label: string; badgeVariant: BadgeVariant; sortOrder: number };
+type ReportResult = CipherView & { score: number; reportValue: ReportScore; scoreKey: number };
 
 @Component({
   selector: "app-weak-passwords-report",
@@ -110,7 +110,12 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
       if (result.score != null && result.score <= 2) {
         const scoreValue = this.scoreKey(result.score);
-        const row = { ...ciph, score: result.score, reportValue: scoreValue } as ReportResult;
+        const row = {
+          ...ciph,
+          score: result.score,
+          reportValue: scoreValue,
+          scoreKey: scoreValue.sortOrder,
+        } as ReportResult;
         this.weakPasswordCiphers.push(row);
       }
     });
@@ -129,13 +134,13 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   private scoreKey(score: number): ReportScore {
     switch (score) {
       case 4:
-        return { label: "strong", badgeVariant: "success" };
+        return { label: "strong", badgeVariant: "success", sortOrder: 1 };
       case 3:
-        return { label: "good", badgeVariant: "primary" };
+        return { label: "good", badgeVariant: "primary", sortOrder: 2 };
       case 2:
-        return { label: "weak", badgeVariant: "warning" };
+        return { label: "weak", badgeVariant: "warning", sortOrder: 3 };
       default:
-        return { label: "veryWeak", badgeVariant: "danger" };
+        return { label: "veryWeak", badgeVariant: "danger", sortOrder: 4 };
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13404

## 📔 Objective

Fix the sorting in the weak passwords report.
It should sort by alphabet - ascending => a -> z and descending => z - a

## 📸 Screenshots

Ascending order:
![image](https://github.com/user-attachments/assets/c69266ef-0579-43bd-89f0-8eeaba60cef5)

Descending order:
![image](https://github.com/user-attachments/assets/eb4940a8-43df-48c7-b259-60e770e73648)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
