### PR TITLE
[PM-19254] Update image tag generation for builds from forked PRs

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -190,6 +190,7 @@ jobs:
       - name: Generate container image tag
         id: tag
         run: |
+          echo "Triggered by ${GITHUB_EVENT_NAME}"
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s#/#-#g")
             echo "Image tag from head ref: $IMAGE_TAG"

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -196,6 +196,10 @@ jobs:
             IMAGE_TAG=$(echo "${GITHUB_REF_NAME}" | sed "s#/#-#g")
           fi
 
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            IMAGE_TAG=$(echo "${{ github.event.pull_request.head.repo.full_name }}" | sed "s#/#-#g")-$IMAGE_TAG
+          fi
+
           if [[ "$IMAGE_TAG" == "main" ]]; then
             IMAGE_TAG=dev
           fi

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   _AZ_REGISTRY: bitwardenprod.azurecr.io
-
+  _GITHUB_PR_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
 
 jobs:
   setup:
@@ -197,7 +197,7 @@ jobs:
           fi
 
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
-            SANITIZED_REPO_NAME=$(echo "${{ github.event.pull_request.head.repo.full_name }}" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
+            SANITIZED_REPO_NAME=$(echo "$_GITHUB_PR_REPO_NAME" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
             IMAGE_TAG=$SANITIZED_REPO_NAME-$IMAGE_TAG # Add repo name to the tag
             IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           fi

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -192,8 +192,14 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s#/#-#g")
+            echo "Image tag from head ref: $IMAGE_TAG"
           else
             IMAGE_TAG=$(echo "${GITHUB_REF_NAME}" | sed "s#/#-#g")
+            echo "Image tag from ref name: $IMAGE_TAG"
+          fi
+
+          if [[ "${{ github.event.repository.fork }}" == "true" ]]; then
+              IMAGE_TAG="$(echo "${{ github.repository }}" | sed 's#/#-#g')-${IMAGE_TAG}"
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -191,13 +191,14 @@ jobs:
         id: tag
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" || "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
-            IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s#/#-#g")
+            IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize branch name to alphanumeric only
           else
             IMAGE_TAG=$(echo "${GITHUB_REF_NAME}" | sed "s#/#-#g")
           fi
 
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
-            IMAGE_TAG=$(echo "${{ github.event.pull_request.head.repo.full_name }}" | sed "s#/#-#g")-$IMAGE_TAG
+            SANITIZED_REPO_NAME=$(echo "${{ github.event.pull_request.head.repo.full_name }}" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
+            IMAGE_TAG=$SANITIZED_REPO_NAME-$IMAGE_TAG # Add repo name to the tag
             IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           fi
 

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -198,6 +198,7 @@ jobs:
 
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
             IMAGE_TAG=$(echo "${{ github.event.pull_request.head.repo.full_name }}" | sed "s#/#-#g")-$IMAGE_TAG
+            IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -190,17 +190,10 @@ jobs:
       - name: Generate container image tag
         id: tag
         run: |
-          echo "Triggered by ${GITHUB_EVENT_NAME}"
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" || "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
             IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s#/#-#g")
-            echo "Image tag from head ref: $IMAGE_TAG"
           else
             IMAGE_TAG=$(echo "${GITHUB_REF_NAME}" | sed "s#/#-#g")
-            echo "Image tag from ref name: $IMAGE_TAG"
-          fi
-
-          if [[ "${{ github.event.repository.fork }}" == "true" ]]; then
-              IMAGE_TAG="$(echo "${{ github.repository }}" | sed 's#/#-#g')-${IMAGE_TAG}"
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19254

## 📔 Objective

This PR makes two changes to the workflow for building the web client, to allow QA to test the docker image for a community PR:

1. Changes the check for `pull_request` trigger to also include `pull_request_target`, as we are now triggering this workflow from `pull_request_target` and want to treat it like a PR.
2. If we are triggering this from a fork, include the fork `username/repo` in the image tag, so that QA can disambiguate this tag when finding the image in ACR.

For example, for a PR from the `test-pr-changes` branch of the `odieman44/bitwarden-test` fork:

![image](https://github.com/user-attachments/assets/022d764b-5484-4165-9ad0-58a068761dc3)

And from a branch that includes symbols - `branch%symbols$test`
![image](https://github.com/user-attachments/assets/405ee734-8066-4b10-a3d4-6d586c5e37c4)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
