### PR TITLE
[PM-18980] Switch userVisibleOnly to `false`

### DIFF
--- a/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
+++ b/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.ts
@@ -134,7 +134,7 @@ class MyWebPushConnector implements WebPushConnector {
 
   private async pushManagerSubscribe(key: string) {
     return await this.serviceWorkerRegistration.pushManager.subscribe({
-      userVisibleOnly: true,
+      userVisibleOnly: false,
       applicationServerKey: key,
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18980

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`userVisisbleOnly` should only be true when the reception of the notification will result in UI visible to the user ([see docs](https://developer.mozilla.org/en-US/docs/Web/API/PushSubscriptionOptions/userVisibleOnly)). Many of our notifications do not do that and instead result in us syncing data behind the scenes to keep the client up to date with the latest information in case the client goes offline.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
