### PR TITLE
Fix base64url decode on MacOS passkeys

### DIFF
--- a/apps/desktop/desktop_native/objc/src/native/utils.m
+++ b/apps/desktop/desktop_native/objc/src/native/utils.m
@@ -18,11 +18,27 @@ NSString *serializeJson(NSDictionary *dictionary, NSError *error) {
 }
 
 NSData *decodeBase64URL(NSString *base64URLString) {
+  if (base64URLString.length == 0) {
+    return nil;
+  }
+  
+  // Replace URL-safe characters with standard base64 characters
   NSString *base64String = [base64URLString stringByReplacingOccurrencesOfString:@"-" withString:@"+"];
   base64String = [base64String stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
-
+  
+  // Add padding if needed
+  NSUInteger paddingLength = 4 - (base64String.length % 4);
+  if (paddingLength < 4) {
+    NSMutableString *paddedString = [NSMutableString stringWithString:base64String];
+    for (NSUInteger i = 0; i < paddingLength; i++) {
+      [paddedString appendString:@"="];
+    }
+    base64String = paddedString;
+  }
+  
+  // Decode the string
   NSData *nsdataFromBase64String = [[NSData alloc]
     initWithBase64EncodedString:base64String options:0];
-
+    
   return nsdataFromBase64String;
 }

--- a/apps/desktop/desktop_native/objc/src/native/utils.m
+++ b/apps/desktop/desktop_native/objc/src/native/utils.m
@@ -39,6 +39,6 @@ NSData *decodeBase64URL(NSString *base64URLString) {
   // Decode the string
   NSData *nsdataFromBase64String = [[NSData alloc]
     initWithBase64EncodedString:base64String options:0];
-    
+  
   return nsdataFromBase64String;
 }

--- a/apps/desktop/desktop_native/objc/src/native/utils.m
+++ b/apps/desktop/desktop_native/objc/src/native/utils.m
@@ -39,6 +39,6 @@ NSData *decodeBase64URL(NSString *base64URLString) {
   // Decode the string
   NSData *nsdataFromBase64String = [[NSData alloc]
     initWithBase64EncodedString:base64String options:0];
-  
+
   return nsdataFromBase64String;
 }


### PR DESCRIPTION


<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR fix a bug in the base64url decoding when syncing credentials to MacOS.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
