### PR TITLE
[PM-20126] Bugfix - Remove duplicate message catalog keys

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -149,27 +149,6 @@
       }
     }
   },
-  "atRiskMembersWithCount": {
-    "message": "At-risk members ($COUNT$)",
-    "placeholders": {
-      "count": {
-        "content": "$1",
-        "example": "3"
-      }
-    }
-  },
-  "atRiskMembersDescription": {
-    "message": "These members are logging into applications with weak, exposed, or reused passwords."
-  },
-  "atRiskMembersDescriptionWithApp": {
-    "message": "These members are logging into $APPNAME$ with weak, exposed, or reused passwords.",
-    "placeholders": {
-      "appname": {
-        "content": "$1",
-        "example": "Salesforce"
-      }
-    }
-  },
   "totalMembers": {
     "message": "Total members"
   },
@@ -9313,9 +9292,6 @@
   },
   "sdksDesc": {
     "message": "Use Bitwarden Secrets Manager SDK in the following programming languages to build your own applications."
-  },
-  "singleSignOn": {
-    "message": "Single sign-on"
   },
   "ssoDescStart": {
     "message": "Configure",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20126](https://bitwarden.atlassian.net/browse/PM-20126)

## 📔 Objective

Remove duplicate message catalog keys:

```
atRiskMembersWithCount
atRiskMembersDescription
atRiskMembersDescriptionWithApp
singleSignOn
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20126]: https://bitwarden.atlassian.net/browse/PM-20126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ