### PR TITLE
[PM-20090] Check whether subscription is canceled before restarting s…

### DIFF
--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -479,6 +479,10 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  protected get canRestartSubscription(): boolean {
+    return this.sub.subscription.status === "canceled";
+  }
+
   get upgradeRequiresPaymentMethod() {
     const isFreeTier = this.organization?.productTierType === ProductTierType.Free;
     const shouldHideFree = !this.showFree;
@@ -744,7 +748,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
 
     const doSubmit = async (): Promise<string> => {
       let orgId: string = null;
-      if (this.isSubscriptionCanceled) {
+      if (this.canRestartSubscription) {
         await this.restartSubscription();
         orgId = this.organizationId;
       } else {

--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -480,7 +480,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
   }
 
   protected get canRestartSubscription(): boolean {
-    return this.sub.subscription.status === "canceled";
+    return !!this.sub?.subscription && this.sub.subscription.status === "canceled";
   }
 
   get upgradeRequiresPaymentMethod() {
@@ -861,6 +861,10 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
         this.organizationId,
         updatePaymentMethodRequest,
       );
+
+      if (!!this.sub?.subscription && this.sub.subscription.status === "unpaid") {
+        return;
+      }
     }
 
     // Backfill pub/priv key if necessary


### PR DESCRIPTION
…ubscription

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20090

## 📔 Objective

The `isSubscriptionCanceled` property is actually calculated based on the subscription status in Stripe and evaluates to `true` when the subscription has one the statuses:
- "canceled"
- "unpaid"
- "incomplete_expired"

However, when the subscription is in an `unpaid` or `incomplete_expired` status, the customer would end up with a second subscription which isn't in a canceled status, causing possibly to be billed for 2 subscriptions.

The endpoint to restart a canceled subscription (in reality creating a new active subscription), has received extra validation in pull request https://github.com/bitwarden/server/pull/5635 to avoid a customer ending up in this undesired state.

This pull request will also allow the payment method to be updated using the upgrade plan dialog for organizations under `Billing > Subscription` without returning error messages to the customer.

## 📸 Screenshots

Video available in Jira due to exceeding 100MB.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
