### PR TITLE
[PM-20174] Do not show validation errors on email input on LoginComponent

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -468,7 +468,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    * Continue to the master password entry state (only if email is validated)
    */
   protected async continue(): Promise<void> {
-    const isEmailValid = await this.validateEmail();
+    const isEmailValid = this.validateEmail();
 
     if (isEmailValid) {
       await this.toggleLoginUiState(LoginUiState.MASTER_PASSWORD_ENTRY);
@@ -490,7 +490,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    */
   async handleSsoClick() {
     // Make sure the email is valid
-    const isEmailValid = await this.validateEmail();
+    const isEmailValid = this.validateEmail();
     if (!isEmailValid) {
       return;
     }

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -588,25 +588,21 @@ export class LoginComponent implements OnInit, OnDestroy {
     }
   };
 
-  private async emailIsValid(): Promise<boolean> {
-    return this.formGroup.controls.email.valid;
-  }
-
   /**
    * Validates the email and displays any validation errors.
    * @returns true if the email is valid, false otherwise.
    */
-  protected async validateEmail(): Promise<boolean> {
+  protected validateEmail(): boolean {
     this.formGroup.controls.email.markAsTouched();
     this.formGroup.controls.email.updateValueAndValidity({ onlySelf: true, emitEvent: true });
-    return this.emailIsValid();
+    return this.formGroup.controls.email.valid;
   }
 
   /**
    * Persist the entered email address and the user's choice to remember it to state.
    */
   private async persistEmailIfValid(): Promise<void> {
-    if (await this.emailIsValid()) {
+    if (this.formGroup.controls.email.valid) {
       const email = this.formGroup.value.email;
       const rememberEmail = this.formGroup.value.rememberEmail ?? false;
       if (!email) {

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -400,12 +400,6 @@ export class LoginComponent implements OnInit, OnDestroy {
     await this.router.navigate(["/login-with-device"]);
   }
 
-  protected async emailIsValid(): Promise<boolean> {
-    this.formGroup.controls.email.markAsTouched();
-    this.formGroup.controls.email.updateValueAndValidity({ onlySelf: true, emitEvent: true });
-    return this.formGroup.controls.email.valid;
-  }
-
   protected async toggleLoginUiState(value: LoginUiState): Promise<void> {
     this.loginUiState = value;
 
@@ -474,7 +468,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    * Continue to the master password entry state (only if email is validated)
    */
   protected async continue(): Promise<void> {
-    const isEmailValid = await this.emailIsValid();
+    const isEmailValid = await this.validateEmail();
 
     if (isEmailValid) {
       await this.toggleLoginUiState(LoginUiState.MASTER_PASSWORD_ENTRY);
@@ -496,7 +490,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    */
   async handleSsoClick() {
     // Make sure the email is valid
-    const isEmailValid = await this.emailIsValid();
+    const isEmailValid = await this.validateEmail();
     if (!isEmailValid) {
       return;
     }
@@ -594,6 +588,20 @@ export class LoginComponent implements OnInit, OnDestroy {
     }
   };
 
+  private async emailIsValid(): Promise<boolean> {
+    return this.formGroup.controls.email.valid;
+  }
+
+  /**
+   * Validates the email and displays any validation errors.
+   * @returns true if the email is valid, false otherwise.
+   */
+  protected async validateEmail(): Promise<boolean> {
+    this.formGroup.controls.email.markAsTouched();
+    this.formGroup.controls.email.updateValueAndValidity({ onlySelf: true, emitEvent: true });
+    return this.emailIsValid();
+  }
+
   /**
    * Persist the entered email address and the user's choice to remember it to state.
    */
@@ -613,7 +621,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Set the email value from the input field.
+   * Set the email value from the input field and persists to state if valid.
    * We only update the form controls onSubmit instead of onBlur because we don't want to show validation errors until
    * the user submits. This is because currently our validation errors are shown below the input fields, and
    * displaying them causes the screen to "jump".
@@ -626,7 +634,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Set the Remember Email value from the input field.
+   * Set the Remember Email value from the input field and persists to state if valid.
    * We only update the form controls onSubmit instead of onBlur because we don't want to show validation errors until
    * the user submits. This is because currently our validation errors are shown below the input fields, and
    * displaying them causes the screen to "jump".


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20174

## 📔 Objective

In #13391, we added a check on email input to persist the email field to state if valid.  However, the validation check that was added both validated the email address _and_ displayed errors in the UI.

It is the desired experience that a user not see any validation errors until they click "Submit" (here "Continue" or "Login with SSO").

This PR refactors the `validateEmail()` method to extract the checking for validity into a new `emailIsValid()` method, which we can then call from both `validateEmail()` and from the email input.

## 📸 Screenshots

### Before

https://github.com/user-attachments/assets/acc8f6b8-4599-4b32-8529-5bb6cab71233

### After

https://github.com/user-attachments/assets/cfa52ce4-1533-4135-81a3-2751e5a4da93

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
