### PR TITLE
[PM-20118] Capitalize risk insights

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4074,7 +4074,7 @@
     "message": "Update browser"
   },
   "generatingRiskInsights": {
-    "message": "Generating your risk insights..."
+    "message": "Generating your Risk Insights..."
   },
   "updateBrowserDesc": {
     "message": "You are using an unsupported web browser. The web vault may not function properly."

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4073,7 +4073,7 @@
   "updateBrowser": {
     "message": "Update browser"
   },
-  "generatingRiskInsights": {
+  "generatingYourRiskInsights": {
     "message": "Generating your Risk Insights..."
   },
   "updateBrowserDesc": {

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights-loading.component.html
@@ -4,5 +4,5 @@
     title="{{ 'loading' | i18n }}"
     aria-hidden="true"
   ></i>
-  <h2 bitTypography="h1">{{ "generatingRiskInsights" | i18n }}</h2>
+  <h2 bitTypography="h1">{{ "generatingYourRiskInsights" | i18n }}</h2>
 </div>

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/risk-insights.component.html
@@ -8,6 +8,7 @@
       {{ "reviewAtRiskPasswords" | i18n }}
     </div>
     <div
+      *ngIf="dataLastUpdated$ | async"
       class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
     >
       <i


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/issues/PM-20118?filter=11401

## 📔 Objective

Two changes:
1. Capitalize "Risk Insights" (for english)
2. Hide the "Data refresh..." block until there is data to be displayed

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/136c0155-9a32-4a2e-a217-b391e08d8def)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
