### PR TITLE
[PM-20236] intro carousel popout login dismiss

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -593,6 +593,7 @@ const routes: Routes = [
     path: "intro-carousel",
     component: ExtensionAnonLayoutWrapperComponent,
     canActivate: [],
+    data: { elevation: 0, doNotSaveUrl: true } satisfies RouteDataProperties,
     children: [
       {
         path: "",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20236](https://bitwarden.atlassian.net/browse/PM-20236)

## 📔 Objective

update routing so path is not saved during popout. If a user pops the extension out and selects `Log In` and/or logs in, the next time the extension is open it should not show the intro carousel

## 📸 Screenshots

User pops out extension and navigates to login

https://github.com/user-attachments/assets/6ee0e0c6-06d3-494d-9c98-9c10c74e8af8


User pops out extension and logs into account

https://github.com/user-attachments/assets/875c74b5-6adc-464e-a81a-149977af821e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20236]: https://bitwarden.atlassian.net/browse/PM-20236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ