### PR TITLE
[PM-20287] Initialize login email state when email is remembered

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -536,6 +536,10 @@ export class LoginComponent implements OnInit, OnDestroy {
     if (storedEmail) {
       this.formGroup.controls.email.setValue(storedEmail);
       this.formGroup.controls.rememberEmail.setValue(true);
+      // If we load an email into the form, we need to initialize it for the login process as well
+      // so that other login components can use it.
+      // We do this here as it's possible that a user doesn't edit the email field before submitting.
+      this.loginEmailService.setLoginEmail(storedEmail);
     } else {
       this.formGroup.controls.rememberEmail.setValue(false);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20287

## 📔 Objective

We currently set the email state when a there is input on the email or remember me form fields.  However, this doesn't work if the user has "Remember Me" selected and attempts a subsequent login _without editing the email address_.  This never fires the email input event and so the `loginEmail` is never persisted to state for that login flow.

This change sets the `loginEmail` if an email is remembered, ensuring that the field is initialized in sync with the remembered email if one exists.

## 📸 Screenshots

https://github.com/user-attachments/assets/58550c8e-f3b1-4754-b242-f9ce62669d24

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
