### PR TITLE
[PM-19810] Member Access Report - CSV export fix

### DIFF
--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
@@ -264,6 +264,6 @@ export const memberAccessWithoutAccessDetailsReportsMock: MemberAccessResponse[]
     totalItemCount: 20,
     userGuid: "5678",
     usesKeyConnector: false,
-    accessDetails: [],
+    accessDetails: [] as MemberAccessDetails[],
   } as MemberAccessResponse,
 ];

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.mock.ts
@@ -229,3 +229,41 @@ export const memberAccessReportsMock: MemberAccessResponse[] = [
     ],
   } as MemberAccessResponse,
 ];
+
+export const memberAccessWithoutAccessDetailsReportsMock: MemberAccessResponse[] = [
+  {
+    userName: "Alice Smith",
+    email: "asmith@email.com",
+    twoFactorEnabled: true,
+    accountRecoveryEnabled: true,
+    groupsCount: 2,
+    collectionsCount: 4,
+    totalItemCount: 20,
+    userGuid: "1234",
+    usesKeyConnector: false,
+    accessDetails: [
+      {
+        groupId: "",
+        collectionId: "c1",
+        collectionName: new EncString("Collection 1"),
+        groupName: "Alice Group 1",
+        itemCount: 10,
+        readOnly: false,
+        hidePasswords: false,
+        manage: false,
+      } as MemberAccessDetails,
+    ],
+  } as MemberAccessResponse,
+  {
+    userName: "Robert Brown",
+    email: "rbrown@email.com",
+    twoFactorEnabled: false,
+    accountRecoveryEnabled: false,
+    groupsCount: 2,
+    collectionsCount: 4,
+    totalItemCount: 20,
+    userGuid: "5678",
+    usesKeyConnector: false,
+    accessDetails: [],
+  } as MemberAccessResponse,
+];

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.spec.ts
@@ -4,7 +4,10 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { OrganizationId } from "@bitwarden/common/types/guid";
 
 import { MemberAccessReportApiService } from "./member-access-report-api.service";
-import { memberAccessReportsMock } from "./member-access-report.mock";
+import {
+  memberAccessReportsMock,
+  memberAccessWithoutAccessDetailsReportsMock,
+} from "./member-access-report.mock";
 import { MemberAccessReportService } from "./member-access-report.service";
 describe("ImportService", () => {
   const mockOrganizationId = "mockOrgId" as OrganizationId;
@@ -108,6 +111,35 @@ describe("ImportService", () => {
             accountRecovery: "memberAccessReportAuthenticationEnabledFalse",
             group: "Group 4",
             totalItems: "5",
+          }),
+        ]),
+      );
+    });
+
+    it("should generate user report export items and include users with no access", async () => {
+      reportApiService.getMemberAccessData.mockImplementation(() =>
+        Promise.resolve(memberAccessWithoutAccessDetailsReportsMock),
+      );
+      const result =
+        await memberAccessReportService.generateUserReportExportItems(mockOrganizationId);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            email: "asmith@email.com",
+            name: "Alice Smith",
+            twoStepLogin: "memberAccessReportTwoFactorEnabledTrue",
+            accountRecovery: "memberAccessReportAuthenticationEnabledTrue",
+            group: "Alice Group 1",
+            totalItems: "10",
+          }),
+          expect.objectContaining({
+            email: "rbrown@email.com",
+            name: "Robert Brown",
+            twoStepLogin: "memberAccessReportTwoFactorEnabledFalse",
+            accountRecovery: "memberAccessReportAuthenticationEnabledFalse",
+            group: "memberAccessReportNoGroup",
+            totalItems: "0",
           }),
         ]),
       );

--- a/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.ts
+++ b/bitwarden_license/bit-web/src/app/tools/reports/member-access-report/services/member-access-report.service.ts
@@ -65,6 +65,26 @@ export class MemberAccessReportService {
     }
 
     const exportItems = memberAccessReports.flatMap((report) => {
+      // to include users without access details
+      // which means a user has no groups, collections or items
+      if (report.accessDetails.length === 0) {
+        return [
+          {
+            email: report.email,
+            name: report.userName,
+            twoStepLogin: report.twoFactorEnabled
+              ? this.i18nService.t("memberAccessReportTwoFactorEnabledTrue")
+              : this.i18nService.t("memberAccessReportTwoFactorEnabledFalse"),
+            accountRecovery: report.accountRecoveryEnabled
+              ? this.i18nService.t("memberAccessReportAuthenticationEnabledTrue")
+              : this.i18nService.t("memberAccessReportAuthenticationEnabledFalse"),
+            group: this.i18nService.t("memberAccessReportNoGroup"),
+            collection: this.i18nService.t("memberAccessReportNoCollection"),
+            collectionPermission: this.i18nService.t("memberAccessReportNoCollectionPermission"),
+            totalItems: "0",
+          },
+        ];
+      }
       const userDetails = report.accessDetails.map((detail) => {
         const collectionName = collectionNameMap.get(detail.collectionName.encryptedString);
         return {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19810

## 📔 Objective

In a member access report, when a user has no collections or groups, the record shows up the UI but not in the CSV file.
That's because the record is not included in the CSV export.
This PR should now take into account all those records without a collection or group and include them in the CSV export.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/28551bb2-1934-43be-9454-1d610edccba4)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
