### PR TITLE
[BEEEP] Add write cache to desktop

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -121,6 +121,9 @@ export class Main {
 
     const storageDefaults: any = {};
     this.storageService = new ElectronStorageService(app.getPath("userData"), storageDefaults);
+    app.on("before-quit", () => {
+      this.storageService.flush();
+    });
     this.memoryStorageService = new MemoryStorageService();
     this.memoryStorageForStateProviders = new MemoryStorageServiceForStateProviders();
     const storageServiceProvider = new StorageServiceProvider(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Follow-up to: https://github.com/bitwarden/clients/pull/14337

## 📔 Objective

> Conf reads the entire data.json for each access of a single key on the state. This means that for a 25 MiB data.json (10000 ciphers), just a single unlock->lock->unlock->lock cycle will read 9GiB from disk and write 1GiB to disk. This makes the client very slow.
Additionally the main thread is now busy parsing and serializing json, so even access to in-memory state becomes slow.

In total, a unlock-lock-unlock-lock cycle has the following disk access metrics:
```
No cache: Read: 9.3GiB, Written: 1.1GiB
Cache: Read: 327MiB, Write: 227MiB
```

Further, unlock and lock are significantly snappier, especially combined with SDK decrypt.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
