### PR TITLE
[PM-20431] Add bit-web to build-web workflow paths

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -12,12 +12,13 @@ on:
       - 'cf-pages'
     paths:
       - 'apps/cli/**'
+      - 'bitwarden_license/bit-cli/**'
+      - 'bitwarden_license/bit-common/**'
       - 'libs/**'
       - '*'
       - '!*.md'
       - '!*.txt'
       - '.github/workflows/build-cli.yml'
-      - 'bitwarden_license/bit-cli/**'
   push:
     branches:
       - 'main'
@@ -25,12 +26,13 @@ on:
       - 'hotfix-rc-cli'
     paths:
       - 'apps/cli/**'
+      - 'bitwarden_license/bit-cli/**'
+      - 'bitwarden_license/bit-common/**'
       - 'libs/**'
       - '*'
       - '!*.md'
       - '!*.txt'
       - '.github/workflows/build-cli.yml'
-      - 'bitwarden_license/bit-cli/**'
   workflow_call:
     inputs: {}
   workflow_dispatch:

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -12,7 +12,8 @@ on:
       - 'cf-pages'
     paths:
       - 'apps/web/**'
-      - 'apps/bitwarden_license/bit-web/**'
+      - 'bitwarden_license/bit-common/**'
+      - 'bitwarden_license/bit-web/**'
       - 'libs/**'
       - '*'
       - '!*.md'
@@ -25,7 +26,8 @@ on:
       - 'hotfix-rc-web'
     paths:
       - 'apps/web/**'
-      - 'apps/bitwarden_license/bit-web/**'
+      - 'bitwarden_license/bit-common/**'
+      - 'bitwarden_license/bit-web/**'
       - 'libs/**'
       - '*'
       - '!*.md'

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -12,6 +12,7 @@ on:
       - 'cf-pages'
     paths:
       - 'apps/web/**'
+      - 'apps/bitwarden_license/bit-web/**'
       - 'libs/**'
       - '*'
       - '!*.md'
@@ -24,6 +25,7 @@ on:
       - 'hotfix-rc-web'
     paths:
       - 'apps/web/**'
+      - 'apps/bitwarden_license/bit-web/**'
       - 'libs/**'
       - '*'
       - '!*.md'


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20431

## 📔 Objective

Changes to code in bit-web should trigger the web build in CI.  See https://github.com/bitwarden/clients/pull/14324 for an example of a PR that should have triggered a web artifact build.

This matches what was done for the CLI here: https://github.com/bitwarden/clients/pull/9491.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
