### PR TITLE
[PM-20428] Deprecate/remove typescript enums consumed by Autofill concerns

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -1,7 +1,5 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherTypeValue } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypeValue } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { InlineMenuFillTypes } from "../../enums/autofill-overlay.enum";
@@ -24,6 +22,8 @@ export type SubFrameOffsetData = {
 } | null;
 
 export type SubFrameOffsetsForTab = Record<
+  // FIXME: Update this file to be type safe and remove this and next line
+  // @ts-strict-ignore next-line
   chrome.runtime.MessageSender["tab"]["id"],
   Map<chrome.runtime.MessageSender["frameId"], SubFrameOffsetData>
 >;
@@ -109,7 +109,7 @@ export type NewIdentityCipherData = {
 };
 
 export type OverlayAddNewItemMessage = {
-  addNewCipherType?: CipherType;
+  addNewCipherType?: CipherTypeValue;
   login?: NewLoginCipherData;
   card?: NewCardCipherData;
   identity?: NewIdentityCipherData;
@@ -159,15 +159,15 @@ export type OverlayPortMessage = {
   command: string;
   direction?: string;
   inlineMenuCipherId?: string;
-  addNewCipherType?: CipherType;
+  addNewCipherType?: CipherTypeValue;
   usePasskey?: boolean;
 };
 
 export type InlineMenuCipherData = {
   id: string;
   name: string;
-  type: CipherType;
-  reprompt: CipherRepromptType;
+  type: CipherTypeValue;
+  reprompt: CipherRepromptTypeValue;
   favorite: boolean;
   icon: WebsiteIconData;
   accountCreationFieldType?: string;

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -1,3 +1,5 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
 import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 import { CipherRepromptTypeValue } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -22,8 +24,6 @@ export type SubFrameOffsetData = {
 } | null;
 
 export type SubFrameOffsetsForTab = Record<
-  // FIXME: Update this file to be type safe and remove this and next line
-  // @ts-strict-ignore next-line
   chrome.runtime.MessageSender["tab"]["id"],
   Map<chrome.runtime.MessageSender["frameId"], SubFrameOffsetData>
 >;

--- a/apps/browser/src/autofill/background/auto-submit-login.background.ts
+++ b/apps/browser/src/autofill/background/auto-submit-login.background.ts
@@ -8,7 +8,7 @@ import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/default-policy.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -266,7 +266,7 @@ export class AutoSubmitLoginBackground implements AutoSubmitLoginBackgroundAbstr
    * @param tabId - The ID of the tab to inject the script into.
    */
   private injectAutoSubmitLoginScript = async (tabId: number) => {
-    if ((await this.getAuthStatus()) === AuthenticationStatus.Unlocked) {
+    if ((await this.getAuthStatus()) === AuthenticationStatuses.Unlocked) {
       await this.scriptInjectorService.inject({
         tabId: tabId,
         injectDetails: {

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -29,7 +29,7 @@ import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-stat
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 import { buildCipherIcon } from "@bitwarden/common/vault/icon/build-cipher-icon";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -206,7 +206,7 @@ export default class NotificationBackground {
       return {
         id,
         name,
-        type: CipherType.Login,
+        type: CipherTypes.Login,
         reprompt,
         favorite,
         ...(organizationCategories.length ? { organizationCategories } : {}),
@@ -764,7 +764,7 @@ export default class NotificationBackground {
 
   private async getDecryptedCipherById(cipherId: string, userId: UserId) {
     const cipher = await this.cipherService.get(cipherId, userId);
-    if (cipher != null && cipher.type === CipherType.Login) {
+    if (cipher != null && cipher.type === CipherTypes.Login) {
       return await cipher.decrypt(
         await this.cipherService.getKeyForCipherKeyDecryption(cipher, userId),
       );
@@ -989,7 +989,7 @@ export default class NotificationBackground {
     const cipherView = new CipherView();
     cipherView.name = (Utils.getHostname(message.uri) || message.domain).replace(/^www\./, "");
     cipherView.folderId = folderId;
-    cipherView.type = CipherType.Login;
+    cipherView.type = CipherTypes.Login;
     cipherView.login = loginView;
 
     return cipherView;

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -16,7 +16,10 @@ import {
 } from "@bitwarden/common/autofill/constants";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { UserNotificationSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/user-notification-settings.service";
-import { ProductTierType } from "@bitwarden/common/billing/enums/product-tier-type.enum";
+import {
+  ProductTierTypes,
+  ProductTierTypeValue,
+} from "@bitwarden/common/billing/enums/product-tier-type.enum";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -193,13 +196,21 @@ export default class NotificationBackground {
       const organizationCategories: OrganizationCategory[] = [];
 
       if (
-        [ProductTierType.Teams, ProductTierType.Enterprise, ProductTierType.TeamsStarter].includes(
-          organizationType,
-        )
+        (
+          [
+            ProductTierTypes.Teams,
+            ProductTierTypes.Enterprise,
+            ProductTierTypes.TeamsStarter,
+          ] as ProductTierTypeValue[]
+        ).includes(organizationType)
       ) {
         organizationCategories.push(OrganizationCategories.business);
       }
-      if ([ProductTierType.Families, ProductTierType.Free].includes(organizationType)) {
+      if (
+        ([ProductTierTypes.Families, ProductTierTypes.Free] as ProductTierTypeValue[]).includes(
+          organizationType,
+        )
+      ) {
         organizationCategories.push(OrganizationCategories.family);
       }
 

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -7,7 +7,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId, getUserId } from "@bitwarden/common/auth/services/account.service";
 import {
   ExtensionCommand,
@@ -343,7 +343,7 @@ export default class NotificationBackground {
     sender: chrome.runtime.MessageSender,
   ) {
     const authStatus = await this.getAuthStatus();
-    if (authStatus === AuthenticationStatus.LoggedOut) {
+    if (authStatus === AuthenticationStatuses.LoggedOut) {
       return;
     }
 
@@ -356,7 +356,7 @@ export default class NotificationBackground {
 
     const addLoginIsEnabled = await this.getEnableAddedLoginPrompt();
 
-    if (authStatus === AuthenticationStatus.Locked) {
+    if (authStatus === AuthenticationStatuses.Locked) {
       if (addLoginIsEnabled) {
         await this.pushAddLoginToQueue(loginDomain, loginInfo, sender.tab, true);
       }
@@ -437,7 +437,7 @@ export default class NotificationBackground {
       return;
     }
 
-    if ((await this.getAuthStatus()) < AuthenticationStatus.Unlocked) {
+    if ((await this.getAuthStatus()) < AuthenticationStatuses.Unlocked) {
       await this.pushChangePasswordToQueue(
         null,
         loginDomain,
@@ -505,7 +505,7 @@ export default class NotificationBackground {
     }
 
     const currentAuthStatus = await this.getAuthStatus();
-    if (currentAuthStatus !== AuthenticationStatus.Locked || this.notificationQueue.length) {
+    if (currentAuthStatus !== AuthenticationStatuses.Locked || this.notificationQueue.length) {
       return;
     }
 
@@ -565,7 +565,7 @@ export default class NotificationBackground {
     message: NotificationBackgroundExtensionMessage,
     sender: chrome.runtime.MessageSender,
   ) {
-    if ((await this.getAuthStatus()) < AuthenticationStatus.Unlocked) {
+    if ((await this.getAuthStatus()) < AuthenticationStatuses.Unlocked) {
       await BrowserApi.tabSendMessageData(sender.tab, "addToLockedVaultPendingNotifications", {
         commandToRetry: {
           message: {

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -15,7 +15,10 @@ import { parse } from "tldts";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import {
+  AuthenticationStatuses,
+  AuthenticationStatusValue,
+} from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId, getUserId } from "@bitwarden/common/auth/services/account.service";
 import {
   AutofillOverlayVisibility,
@@ -332,7 +335,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    */
   async updateOverlayCiphers(updateAllCipherTypes = true, refocusField = false) {
     const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
-    if (authStatus === AuthenticationStatus.Unlocked) {
+    if (authStatus === AuthenticationStatuses.Unlocked) {
       this.inlineMenuCiphers = new Map();
       this.updateOverlayCiphers$.next({ updateAllCipherTypes, refocusField });
     }
@@ -1086,7 +1089,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     if (
       (await this.checkFocusedFieldHasValue(sender.tab)) &&
       (this.checkIsInlineMenuCiphersPopulated(sender) ||
-        (await this.getAuthStatus()) !== AuthenticationStatus.Unlocked)
+        (await this.getAuthStatus()) !== AuthenticationStatuses.Unlocked)
     ) {
       return;
     }
@@ -1736,7 +1739,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     if (
       !previousFocusedFieldData ||
       !this.isInlineMenuButtonVisible ||
-      (await this.getAuthStatus()) !== AuthenticationStatus.Unlocked
+      (await this.getAuthStatus()) !== AuthenticationStatuses.Unlocked
     ) {
       return;
     }
@@ -2057,7 +2060,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.cancelInlineMenuDelayedClose$.next(true);
     this.cancelInlineMenuFadeInAndPositionUpdate();
 
-    if ((await this.getAuthStatus()) !== AuthenticationStatus.Unlocked) {
+    if ((await this.getAuthStatus()) !== AuthenticationStatuses.Unlocked) {
       await this.unlockVault(port);
       return;
     }
@@ -3021,11 +3024,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * @param showInlineMenuAccountCreation - Identifies if the inline menu account creation should be shown
    */
   private async shouldInitInlineMenuPasswordGenerator(
-    authStatus: AuthenticationStatus,
+    authStatus: AuthenticationStatusValue,
     isInlineMenuListPort: boolean,
     showInlineMenuAccountCreation: boolean,
   ) {
-    if (!isInlineMenuListPort || authStatus !== AuthenticationStatus.Unlocked) {
+    if (!isInlineMenuListPort || authStatus !== AuthenticationStatuses.Unlocked) {
       return false;
     }
 

--- a/apps/browser/src/autofill/background/web-request.background.ts
+++ b/apps/browser/src/autofill/background/web-request.background.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -69,7 +69,7 @@ export default class WebRequestBackground {
     }
 
     const authStatus = await firstValueFrom(this.authService.authStatusFor$(activeUserId));
-    if (authStatus < AuthenticationStatus.Unlocked) {
+    if (authStatus < AuthenticationStatuses.Unlocked) {
       error();
       return;
     }

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -6,7 +6,7 @@ import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authenticatio
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes, CipherTypeValue } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { AutofillCipherTypeId } from "../types";
@@ -48,8 +48,8 @@ export class CipherContextMenuHandler {
     }
 
     const ciphers = await this.cipherService.getAllDecryptedForUrl(url, activeUserId, [
-      CipherType.Card,
-      CipherType.Identity,
+      CipherTypes.Card,
+      CipherTypes.Identity,
     ]);
     ciphers.sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
 
@@ -67,21 +67,21 @@ export class CipherContextMenuHandler {
         };
       },
       {
-        [CipherType.Login]: [],
-        [CipherType.Card]: [],
-        [CipherType.Identity]: [],
+        [CipherTypes.Login]: [],
+        [CipherTypes.Card]: [],
+        [CipherTypes.Identity]: [],
       },
     );
 
-    if (groupedCiphers[CipherType.Login].length === 0) {
+    if (groupedCiphers[CipherTypes.Login].length === 0) {
       await this.mainContextMenuHandler.noLogins();
     }
 
-    if (groupedCiphers[CipherType.Identity].length === 0) {
+    if (groupedCiphers[CipherTypes.Identity].length === 0) {
       await this.mainContextMenuHandler.noIdentities();
     }
 
-    if (groupedCiphers[CipherType.Card].length === 0) {
+    if (groupedCiphers[CipherTypes.Card].length === 0) {
       await this.mainContextMenuHandler.noCards();
     }
 
@@ -97,18 +97,26 @@ export class CipherContextMenuHandler {
   private async updateForCipher(cipher: CipherView) {
     if (
       cipher == null ||
-      !new Set([CipherType.Login, CipherType.Card, CipherType.Identity]).has(cipher.type)
+      !new Set([
+        CipherTypes.Login,
+        CipherTypes.Card,
+        CipherTypes.Identity,
+      ] as CipherTypeValue[]).has(cipher.type)
     ) {
       return;
     }
 
     let title = cipher.name;
 
-    if (cipher.type === CipherType.Login && !Utils.isNullOrEmpty(title) && cipher.login?.username) {
+    if (
+      cipher.type === CipherTypes.Login &&
+      !Utils.isNullOrEmpty(title) &&
+      cipher.login?.username
+    ) {
       title += ` (${cipher.login.username})`;
     }
 
-    if (cipher.type === CipherType.Card && cipher.card?.subTitle) {
+    if (cipher.type === CipherTypes.Card && cipher.card?.subTitle) {
       title += ` ${cipher.card.subTitle}`;
     }
 

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -2,7 +2,7 @@ import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -28,7 +28,7 @@ export class CipherContextMenuHandler {
 
     const authStatus = await this.authService.getAuthStatus();
     await MainContextMenuHandler.removeAll();
-    if (authStatus !== AuthenticationStatus.Unlocked) {
+    if (authStatus !== AuthenticationStatuses.Unlocked) {
       // Should I pass in the auth status or even have two separate methods for this
       // on MainContextMenuHandler
       await this.mainContextMenuHandler.noAccess();

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -26,8 +26,8 @@ import {
 import { EventType } from "@bitwarden/common/enums";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypes } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { openUnlockPopout } from "../../auth/popup/utils/auth-popout-window";
@@ -118,9 +118,9 @@ export class ContextMenuClickedHandler {
     } else if (menuItemId === NOOP_COMMAND_SUFFIX) {
       const additionalCiphersToGet =
         info.parentMenuItemId === AUTOFILL_IDENTITY_ID
-          ? [CipherType.Identity]
+          ? [CipherTypes.Identity]
           : info.parentMenuItemId === AUTOFILL_CARD_ID
-            ? [CipherType.Card]
+            ? [CipherTypes.Card]
             : [];
 
       // This NOOP item has come through which is generally only for no access state but since we got here
@@ -168,7 +168,7 @@ export class ContextMenuClickedHandler {
       }
       case COPY_USERNAME_ID:
         if (menuItemId === CREATE_LOGIN_ID) {
-          await openAddEditVaultItemPopout(tab, { cipherType: CipherType.Login });
+          await openAddEditVaultItemPopout(tab, { cipherType: CipherTypes.Login });
           break;
         }
 
@@ -176,7 +176,7 @@ export class ContextMenuClickedHandler {
         break;
       case COPY_PASSWORD_ID:
         if (menuItemId === CREATE_LOGIN_ID) {
-          await openAddEditVaultItemPopout(tab, { cipherType: CipherType.Login });
+          await openAddEditVaultItemPopout(tab, { cipherType: CipherTypes.Login });
           break;
         }
 
@@ -195,7 +195,7 @@ export class ContextMenuClickedHandler {
         break;
       case COPY_VERIFICATION_CODE_ID:
         if (menuItemId === CREATE_LOGIN_ID) {
-          await openAddEditVaultItemPopout(tab, { cipherType: CipherType.Login });
+          await openAddEditVaultItemPopout(tab, { cipherType: CipherTypes.Login });
           break;
         }
 
@@ -218,18 +218,18 @@ export class ContextMenuClickedHandler {
 
   private async isPasswordRepromptRequired(cipher: CipherView): Promise<boolean> {
     return (
-      cipher.reprompt === CipherRepromptType.Password &&
+      cipher.reprompt === CipherRepromptTypes.Password &&
       (await this.userVerificationService.hasMasterPasswordAndMasterKeyHash())
     );
   }
 
   private getCipherCreationType(menuItemId?: string): AutofillCipherTypeId | null {
     return menuItemId === CREATE_IDENTITY_ID
-      ? CipherType.Identity
+      ? CipherTypes.Identity
       : menuItemId === CREATE_CARD_ID
-        ? CipherType.Card
+        ? CipherTypes.Card
         : menuItemId === CREATE_LOGIN_ID
-          ? CipherType.Login
+          ? CipherTypes.Login
           : null;
   }
 

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -6,7 +6,7 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import {
   AUTOFILL_CARD_ID,
@@ -80,7 +80,7 @@ export class ContextMenuClickedHandler {
       return;
     }
 
-    if ((await this.authService.getAuthStatus()) < AuthenticationStatus.Unlocked) {
+    if ((await this.authService.getAuthStatus()) < AuthenticationStatuses.Unlocked) {
       const retryMessage: LockedVaultPendingNotificationsData = {
         commandToRetry: {
           message: { command: ExtensionCommand.NoopCommand, contextMenuOnClickData: info },

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -25,7 +25,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { InitContextMenuItems } from "./abstractions/main-context-menu-handler";
@@ -284,7 +284,7 @@ export class MainContextMenuHandler {
 
       if (
         !cipher ||
-        (cipher.type === CipherType.Login &&
+        (cipher.type === CipherTypes.Login &&
           (!Utils.isNullOrEmpty(cipher.login?.username) ||
             !Utils.isNullOrEmpty(cipher.login?.password) ||
             !Utils.isNullOrEmpty(cipher.login?.totp)))
@@ -294,7 +294,7 @@ export class MainContextMenuHandler {
 
       if (
         !cipher ||
-        (cipher.type === CipherType.Login && !Utils.isNullOrEmpty(cipher.login?.password))
+        (cipher.type === CipherTypes.Login && !Utils.isNullOrEmpty(cipher.login?.password))
       ) {
         if (cipher?.viewPassword ?? true) {
           await createChildItem(COPY_PASSWORD_ID);
@@ -303,7 +303,7 @@ export class MainContextMenuHandler {
 
       if (
         !cipher ||
-        (cipher.type === CipherType.Login && !Utils.isNullOrEmpty(cipher.login?.username))
+        (cipher.type === CipherTypes.Login && !Utils.isNullOrEmpty(cipher.login?.username))
       ) {
         await createChildItem(COPY_USERNAME_ID);
       }
@@ -316,11 +316,11 @@ export class MainContextMenuHandler {
         await createChildItem(COPY_VERIFICATION_CODE_ID);
       }
 
-      if ((!cipher || cipher.type === CipherType.Card) && optionId !== CREATE_LOGIN_ID) {
+      if ((!cipher || cipher.type === CipherTypes.Card) && optionId !== CREATE_LOGIN_ID) {
         await createChildItem(AUTOFILL_CARD_ID);
       }
 
-      if ((!cipher || cipher.type === CipherType.Identity) && optionId !== CREATE_LOGIN_ID) {
+      if ((!cipher || cipher.type === CipherTypes.Identity) && optionId !== CREATE_LOGIN_ID) {
         await createChildItem(AUTOFILL_IDENTITY_ID);
       }
     } catch (error) {

--- a/apps/browser/src/autofill/content/abstractions/autofill-init.ts
+++ b/apps/browser/src/autofill/content/abstractions/autofill-init.ts
@@ -1,4 +1,4 @@
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatusValue } from "@bitwarden/common/auth/enums/authentication-status";
 import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 
 import { AutofillOverlayElementType } from "../../enums/autofill-overlay.enum";
@@ -17,7 +17,7 @@ export type AutofillExtensionMessage = {
   isInlineMenuHidden?: boolean;
   overlayElement?: AutofillOverlayElementType;
   isFocusingFieldElement?: boolean;
-  authStatus?: AuthenticationStatus;
+  authStatus?: AuthenticationStatusValue;
   isOpeningFullInlineMenu?: boolean;
   addNewCipherType?: CipherTypeValue;
   ignoreFieldFocus?: boolean;

--- a/apps/browser/src/autofill/content/abstractions/autofill-init.ts
+++ b/apps/browser/src/autofill/content/abstractions/autofill-init.ts
@@ -1,5 +1,5 @@
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 
 import { AutofillOverlayElementType } from "../../enums/autofill-overlay.enum";
 import AutofillScript from "../../models/autofill-script";
@@ -19,7 +19,7 @@ export type AutofillExtensionMessage = {
   isFocusingFieldElement?: boolean;
   authStatus?: AuthenticationStatus;
   isOpeningFullInlineMenu?: boolean;
-  addNewCipherType?: CipherType;
+  addNewCipherType?: CipherTypeValue;
   ignoreFieldFocus?: boolean;
   data?: {
     direction?: "previous" | "next" | "current";

--- a/apps/browser/src/autofill/content/components/cipher/types.ts
+++ b/apps/browser/src/autofill/content/components/cipher/types.ts
@@ -1,18 +1,8 @@
-export const CipherTypes = {
-  Login: 1,
-  SecureNote: 2,
-  Card: 3,
-  Identity: 4,
-} as const;
-
-type CipherType = (typeof CipherTypes)[keyof typeof CipherTypes];
-
-export const CipherRepromptTypes = {
-  None: 0,
-  Password: 1,
-} as const;
-
-type CipherRepromptType = (typeof CipherRepromptTypes)[keyof typeof CipherRepromptTypes];
+import {
+  CipherTypes,
+  CipherTypeValue,
+  CipherRepromptTypeValue,
+} from "@bitwarden/common/vault/enums";
 
 export type OrganizationCategory =
   (typeof OrganizationCategories)[keyof typeof OrganizationCategories];
@@ -33,12 +23,12 @@ type BaseCipherData<CipherTypeValue> = {
   id: string;
   name: string;
   type: CipherTypeValue;
-  reprompt: CipherRepromptType;
+  reprompt: CipherRepromptTypeValue;
   favorite: boolean;
   icon: WebsiteIconData;
 };
 
-export type CipherData = BaseCipherData<CipherType> & {
+export type CipherData = BaseCipherData<CipherTypeValue> & {
   accountCreationFieldType?: string;
   login?: {
     username: string;

--- a/apps/browser/src/autofill/content/components/common-types.ts
+++ b/apps/browser/src/autofill/content/components/common-types.ts
@@ -1,6 +1,6 @@
 import { TemplateResult } from "lit";
 
-import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { ProductTierTypeValue } from "@bitwarden/common/billing/enums";
 import { Theme } from "@bitwarden/common/platform/enums";
 
 export type IconProps = {
@@ -24,5 +24,5 @@ export type FolderView = {
 export type OrgView = {
   id: string;
   name: string;
-  productTierType?: ProductTierType;
+  productTierType?: ProductTierTypeValue;
 };

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/action-button.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/action-button.mdx
@@ -20,7 +20,7 @@ It is designed with accessibility and responsive design in mind.
 | `buttonAction` | `(e: Event) => void`       | Yes          | The function to execute when the button is clicked.         |
 | `buttonText`   | `string`                   | Yes          | The text to display on the button.                          |
 | `disabled`     | `boolean` (default: false) | No           | Disables the button when set to `true`.                     |
-| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` enum. |
+| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/badge-button.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/badge-button.mdx
@@ -20,7 +20,7 @@ handling, and a disabled state. The component is optimized for accessibility and
 | `buttonAction` | `(e: Event) => void`       | Yes          | The function to execute when the button is clicked.         |
 | `buttonText`   | `string`                   | Yes          | The text to display on the badge button.                    |
 | `disabled`     | `boolean` (default: false) | No           | Disables the button when set to `true`.                     |
-| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` enum. |
+| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/body.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/body.mdx
@@ -19,7 +19,7 @@ presenting actionable information.
 | ------------------ | ------------------ | ------------ | --------------------------------------------------------------------------------------------------------- |
 | `ciphers`          | `CipherData[]`     | Yes          | An array of cipher data objects. Each cipher includes metadata such as ID, name, type, and login details. |
 | `notificationType` | `NotificationType` | Yes          | Specifies the type of notification, such as `add`, `change`, `unlock`, or `fileless-import`.              |
-| `theme`            | `Theme`            | Yes          | Defines the theme used for styling the notification. Must match the `Theme` enum.                         |
+| `theme`            | `Theme`            | Yes          | Defines the theme used for styling the notification. Must match the `Theme` type.                         |
 
 ---
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-action.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-action.mdx
@@ -19,7 +19,7 @@ provides flexibility and accessibility while supporting various notification typ
 | ------------------ | --------------------------------------------------- | ------------ | -------------------------------------------------------------- |
 | `handleAction`     | `(e: Event) => void`                                | No           | Function to execute when an action is triggered.               |
 | `notificationType` | `NotificationTypes.Change \| NotificationTypes.Add` | Yes          | Specifies the type of notification associated with the action. |
-| `theme`            | `Theme`                                             | Yes          | The theme to style the component. Must match the `Theme` enum. |
+| `theme`            | `Theme`                                             | Yes          | The theme to style the component. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-action.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-action.mdx
@@ -30,7 +30,7 @@ provides flexibility and accessibility while supporting various notification typ
 2. Pass the required props when rendering the component:
    - `handleAction`: Optional function to handle the triggered action.
    - `notificationType`: Mandatory type from `NotificationTypes` to define the action context.
-   - `theme`: The styling theme (must be a valid `Theme` enum value).
+   - `theme`: The styling theme (must be a valid `Theme` value).
 
 ## Accessibility (WCAG) Compliance
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-icon.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-icon.mdx
@@ -19,7 +19,7 @@ based on the theme and provided properties.
 | -------- | ------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `color`  | `string`            | Yes          | A contextual color override applied when the `uri` is not provided, ensuring consistent styling of the default icon.                                            |
 | `size`   | `string`            | Yes          | A valid CSS `width` value representing the width basis of the graphic. The height adjusts to maintain the original aspect ratio of the graphic.                 |
-| `theme`  | `Theme`             | Yes          | The styling theme for the icon, matching the `Theme` enum.                                                                                                      |
+| `theme`  | `Theme`             | Yes          | The styling theme for the icon, matching the `Theme` type.                                                                                                      |
 | `uri`    | `string` (optional) | No           | A URL to an external graphic. If provided, the component displays this icon. If omitted, a default icon (`Globe`) styled with the provided `color` and `theme`. |
 
 ## Installation and Setup

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-indicator-icon.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/cipher-indicator-icon.mdx
@@ -19,7 +19,7 @@ dynamically based on the provided theme.
 | ------------------ | --------- | ------------ | ----------------------------------------------------------------------- |
 | `showBusinessIcon` | `boolean` | No           | Displays the business organization icon when set to `true`.             |
 | `showFamilyIcon`   | `boolean` | No           | Displays the family organization icon when set to `true`.               |
-| `theme`            | `Theme`   | Yes          | Defines the theme used to style the icons. Must match the `Theme` enum. |
+| `theme`            | `Theme`   | Yes          | Defines the theme used to style the icons. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/close-button.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/close-button.mdx
@@ -17,7 +17,7 @@ a close icon for visual clarity. The component is designed to be intuitive and a
 | **Prop**                  | **Type**             | **Required** | **Description**                                             |
 | ------------------------- | -------------------- | ------------ | ----------------------------------------------------------- |
 | `handleCloseNotification` | `(e: Event) => void` | Yes          | The function to execute when the button is clicked.         |
-| `theme`                   | `Theme`              | Yes          | The theme to style the button. Must match the `Theme` enum. |
+| `theme`                   | `Theme`              | Yes          | The theme to style the button. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/edit-button.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/edit-button.mdx
@@ -20,7 +20,7 @@ or settings where inline editing is required.
 | `buttonAction` | `(e: Event) => void`       | Yes          | The function to execute when the button is clicked.         |
 | `buttonText`   | `string`                   | Yes          | The text displayed as the button's tooltip.                 |
 | `disabled`     | `boolean` (default: false) | No           | Disables the button when set to `true`.                     |
-| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` enum. |
+| `theme`        | `Theme`                    | Yes          | The theme to style the button. Must match the `Theme` type. |
 
 ## Installation and Setup
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/footer.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/footer.mdx
@@ -17,7 +17,7 @@ customization based on the `theme` and `notificationType`.
 | **Prop**           | **Type**           | **Required** | **Description**                                                                                    |
 | ------------------ | ------------------ | ------------ | -------------------------------------------------------------------------------------------------- |
 | `notificationType` | `NotificationType` | Yes          | The type of notification footer to display. Options: `add`, `change`, `unlock`, `fileless-import`. |
-| `theme`            | `Theme`            | Yes          | Defines the theme of the notification footer. Must match the `Theme` enum.                         |
+| `theme`            | `Theme`            | Yes          | Defines the theme of the notification footer. Must match the `Theme` type.                         |
 
 ---
 

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/header.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/header.mdx
@@ -19,7 +19,7 @@ and an optional close button. This component is versatile and can be styled dyna
 | ------------------------- | -------------------- | ------------ | ------------------------------------------------------------------- |
 | `message`                 | `string`             | Yes          | The text message to be displayed in the notification.               |
 | `standalone`              | `boolean`            | No           | Determines if the notification is displayed independently.          |
-| `theme`                   | `Theme`              | Yes          | Defines the theme of the notification. Must match the `Theme` enum. |
+| `theme`                   | `Theme`              | Yes          | Defines the theme of the notification. Must match the `Theme` type. |
 | `handleCloseNotification` | `(e: Event) => void` | No           | A callback function triggered when the close button is clicked.     |
 
 ---

--- a/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/icons.mdx
+++ b/apps/browser/src/autofill/content/components/lit-stories/.lit-docs/icons.mdx
@@ -28,7 +28,7 @@ like size, color, and theme. Each story is an example of how a specific icon can
 | `iconLink` | `URL`     | No           | Defines an external URL associated with the icon, prop exclusive to `Brand Icon`. |
 | `color`    | `string`  | No           | Sets the color of the icon.                                                       |
 | `disabled` | `boolean` | No           | Disables the icon visually and functionally.                                      |
-| `theme`    | `Theme`   | Yes          | Defines the theme used to style the icons. Must match the `Theme` enum.           |
+| `theme`    | `Theme`   | Yes          | Defines the theme used to style the icons. Must match the `Theme` type.           |
 | `size`     | `number`  | Yes          | Sets the width and height of the icon in pixels.                                  |
 
 ---

--- a/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
@@ -1,4 +1,4 @@
-import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { ProductTierTypes } from "@bitwarden/common/billing/enums";
 
 export const mockFolderData = [
   {
@@ -43,26 +43,26 @@ export const mockOrganizationData = [
   {
     id: "unique-id1",
     name: "Acme, inc",
-    productTierType: ProductTierType.Teams,
+    productTierType: ProductTierTypes.Teams,
   },
   {
     id: "unique-id2",
     name: "A Really Long Business Name That Just Kinda Goes On For A Really Long Time",
-    productTierType: ProductTierType.TeamsStarter,
+    productTierType: ProductTierTypes.TeamsStarter,
   },
   {
     id: "unique-id3",
     name: "Family Vault",
-    productTierType: ProductTierType.Families,
+    productTierType: ProductTierTypes.Families,
   },
   {
     id: "unique-id4",
     name: "Family Vault Trial",
-    productTierType: ProductTierType.Free,
+    productTierType: ProductTierTypes.Free,
   },
   {
     id: "unique-id5",
     name: "Exciting Enterprises, LLC",
-    productTierType: ProductTierType.Enterprise,
+    productTierType: ProductTierTypes.Enterprise,
   },
 ];

--- a/apps/browser/src/autofill/content/components/lit-stories/notification/body.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/notification/body.lit-stories.ts
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/web-components";
 
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums/theme-type.enum";
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypes } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 
 import { NotificationType } from "../../../../notification/abstractions/notification-bar";
 import { NotificationCipherData } from "../../cipher/types";
@@ -30,9 +30,9 @@ export default {
       {
         id: "1",
         name: "Example Cipher",
-        type: CipherType.Login,
+        type: CipherTypes.Login,
         favorite: false,
-        reprompt: CipherRepromptType.None,
+        reprompt: CipherRepromptTypes.None,
         icon: {
           imageEnabled: true,
           image: "",

--- a/apps/browser/src/autofill/content/components/lit-stories/notification/container.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/notification/container.lit-stories.ts
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from "@storybook/web-components";
 
 import { ThemeTypes } from "@bitwarden/common/platform/enums";
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypes } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 
 import { NotificationTypes } from "../../../../notification/abstractions/notification-bar";
 import { NotificationContainer, NotificationContainerProps } from "../../notification/container";
@@ -20,9 +20,9 @@ export default {
       {
         id: "1",
         name: "Example Cipher",
-        type: CipherType.Login,
+        type: CipherTypes.Login,
         favorite: false,
-        reprompt: CipherRepromptType.None,
+        reprompt: CipherRepromptTypes.None,
         icon: {
           imageEnabled: true,
           image: "",

--- a/apps/browser/src/autofill/content/components/notification/button-row.ts
+++ b/apps/browser/src/autofill/content/components/notification/button-row.ts
@@ -1,20 +1,20 @@
 import { html } from "lit";
 
-import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { ProductTierTypes, ProductTierTypeValue } from "@bitwarden/common/billing/enums";
 import { Theme } from "@bitwarden/common/platform/enums";
 
 import { Option, OrgView, FolderView } from "../common-types";
 import { Business, Family, Folder, User } from "../icons";
 import { ButtonRow } from "../rows/button-row";
 
-function getVaultIconByProductTier(productTierType?: ProductTierType): Option["icon"] {
+function getVaultIconByProductTier(productTierType?: ProductTierTypeValue): Option["icon"] {
   switch (productTierType) {
-    case ProductTierType.Free:
-    case ProductTierType.Families:
+    case ProductTierTypes.Free:
+    case ProductTierTypes.Families:
       return Family;
-    case ProductTierType.Teams:
-    case ProductTierType.Enterprise:
-    case ProductTierType.TeamsStarter:
+    case ProductTierTypes.Teams:
+    case ProductTierTypes.Enterprise:
+    case ProductTierTypes.TeamsStarter:
       return Business;
     default:
       return User;

--- a/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
+++ b/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
@@ -21,15 +21,6 @@ export const RedirectFocusDirection = {
   Next: "next",
 } as const;
 
-/**
- * @deprecated instead use `InlineMenuFillTypes` constants and `InlineMenuFillTypeValue` type over unsafe typescript enums
- **/
-export enum InlineMenuFillType {
-  AccountCreationUsername = 5,
-  PasswordGeneration = 6,
-  CurrentPasswordUpdate = 7,
-}
-
 export const InlineMenuFillTypes = {
   AccountCreationUsername: 5,
   PasswordGeneration: 6,

--- a/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
+++ b/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
@@ -1,4 +1,4 @@
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 
 export const AutofillOverlayElement = {
   Button: "autofill-inline-menu-button",
@@ -21,12 +21,25 @@ export const RedirectFocusDirection = {
   Next: "next",
 } as const;
 
+/**
+ * @deprecated instead use `InlineMenuFillTypes` constants and `InlineMenuFillTypeValue` type over unsafe typescript enums
+ **/
 export enum InlineMenuFillType {
   AccountCreationUsername = 5,
   PasswordGeneration = 6,
   CurrentPasswordUpdate = 7,
 }
-export type InlineMenuFillTypes = InlineMenuFillType | CipherType;
+
+export const InlineMenuFillTypes = {
+  AccountCreationUsername: 5,
+  PasswordGeneration: 6,
+  CurrentPasswordUpdate: 7,
+} as const;
+
+export type InlineMenuFillTypeValue =
+  (typeof InlineMenuFillTypes)[keyof typeof InlineMenuFillTypes];
+
+export type InlineMenuFillTypes = InlineMenuFillTypeValue | CipherTypeValue;
 
 export const InlineMenuAccountCreationFieldType = {
   Text: "text",

--- a/apps/browser/src/autofill/fido2/background/fido2.background.ts
+++ b/apps/browser/src/autofill/fido2/background/fido2.background.ts
@@ -4,7 +4,10 @@ import { firstValueFrom, startWith, Subscription } from "rxjs";
 import { pairwise } from "rxjs/operators";
 
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import {
+  AuthenticationStatuses,
+  AuthenticationStatusValue,
+} from "@bitwarden/common/auth/enums/authentication-status";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Fido2ActiveRequestManager } from "@bitwarden/common/platform/abstractions/fido2/fido2-active-request-manager.abstraction";
@@ -87,8 +90,8 @@ export class Fido2Background implements Fido2BackgroundInterface {
    *
    * @param authStatus - The current authentication status.
    */
-  private async handleAuthStatusUpdate(authStatus: AuthenticationStatus) {
-    if (authStatus === AuthenticationStatus.LoggedOut) {
+  private async handleAuthStatusUpdate(authStatus: AuthenticationStatusValue) {
+    if (authStatus === AuthenticationStatuses.LoggedOut) {
       return;
     }
 
@@ -132,7 +135,7 @@ export class Fido2Background implements Fido2BackgroundInterface {
     previousEnablePasskeysSetting: boolean,
     enablePasskeys: boolean,
   ) {
-    if ((await this.getAuthStatus()) === AuthenticationStatus.LoggedOut) {
+    if ((await this.getAuthStatus()) === AuthenticationStatuses.LoggedOut) {
       return;
     }
 

--- a/apps/browser/src/autofill/fido2/content/fido2-content-script.spec.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-content-script.spec.ts
@@ -6,7 +6,7 @@ import { createPortSpyMock } from "../../../autofill/spec/autofill-mocks";
 import { triggerPortOnDisconnectEvent } from "../../../autofill/spec/testing-utils";
 import { Fido2PortName } from "../enums/fido2-port-name.enum";
 
-import { InsecureCreateCredentialParams, MessageType } from "./messaging/message";
+import { InsecureCreateCredentialParams, MessageTypes } from "./messaging/message";
 import { MessageWithMetadata, Messenger } from "./messaging/messenger";
 
 jest.mock("../../../autofill/utils", () => ({
@@ -71,7 +71,7 @@ describe("Fido2 Content Script", () => {
 
   it("handles a FIDO2 credential creation request message from the window message listener, formats the message and sends the formatted message to the extension background", async () => {
     const message = mock<MessageWithMetadata>({
-      type: MessageType.CredentialCreationRequest,
+      type: MessageTypes.CredentialCreationRequest,
       data: mock<InsecureCreateCredentialParams>(),
     });
     const mockResult = { credentialId: "mock" } as CreateCredentialResult;
@@ -92,14 +92,14 @@ describe("Fido2 Content Script", () => {
       requestId: expect.any(String),
     });
     expect(response).toEqual({
-      type: MessageType.CredentialCreationResponse,
+      type: MessageTypes.CredentialCreationResponse,
       result: mockResult,
     });
   });
 
   it("handles a FIDO2 credential get request message from the window message listener, formats the message and sends the formatted message to the extension background", async () => {
     const message = mock<MessageWithMetadata>({
-      type: MessageType.CredentialGetRequest,
+      type: MessageTypes.CredentialGetRequest,
       data: mock<InsecureCreateCredentialParams>(),
     });
 
@@ -121,7 +121,7 @@ describe("Fido2 Content Script", () => {
 
   it("removes the abort handler when the FIDO2 request is complete", async () => {
     const message = mock<MessageWithMetadata>({
-      type: MessageType.CredentialCreationRequest,
+      type: MessageTypes.CredentialCreationRequest,
       data: mock<InsecureCreateCredentialParams>(),
     });
     const abortController = new AbortController();
@@ -138,16 +138,14 @@ describe("Fido2 Content Script", () => {
 
   it("sends an extension message to abort the FIDO2 request when the abort controller is signaled", async () => {
     const message = mock<MessageWithMetadata>({
-      type: MessageType.CredentialCreationRequest,
+      type: MessageTypes.CredentialCreationRequest,
       data: mock<InsecureCreateCredentialParams>(),
     });
     const abortController = new AbortController();
     const abortSpy = jest.spyOn(abortController.signal, "addEventListener");
-    jest
-      .spyOn(chrome.runtime, "sendMessage")
-      .mockImplementationOnce(async (extensionId: string, message: unknown, options: any) => {
-        abortController.abort();
-      });
+    jest.spyOn(chrome.runtime, "sendMessage").mockImplementationOnce(async () => {
+      abortController.abort();
+    });
 
     // FIXME: Remove when updating file. Eslint update
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -165,7 +163,7 @@ describe("Fido2 Content Script", () => {
   it("rejects credential requests and returns an error result", async () => {
     const errorMessage = "Test error";
     const message = mock<MessageWithMetadata>({
-      type: MessageType.CredentialCreationRequest,
+      type: MessageTypes.CredentialCreationRequest,
       data: mock<InsecureCreateCredentialParams>(),
     });
     const abortController = new AbortController();

--- a/apps/browser/src/autofill/fido2/content/fido2-content-script.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-content-script.ts
@@ -12,7 +12,7 @@ import {
   InsecureAssertCredentialParams,
   InsecureCreateCredentialParams,
   Message,
-  MessageType,
+  MessageTypes,
 } from "./messaging/message";
 import { MessageWithMetadata, Messenger } from "./messaging/messenger";
 
@@ -49,21 +49,21 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
     abortController.signal.addEventListener("abort", abortHandler);
 
     try {
-      if (message.type === MessageType.CredentialCreationRequest) {
+      if (message.type === MessageTypes.CredentialCreationRequest) {
         return handleCredentialCreationRequestMessage(
           requestId,
           message.data as InsecureCreateCredentialParams,
         );
       }
 
-      if (message.type === MessageType.CredentialGetRequest) {
+      if (message.type === MessageTypes.CredentialGetRequest) {
         return handleCredentialGetRequestMessage(
           requestId,
           message.data as InsecureAssertCredentialParams,
         );
       }
 
-      if (message.type === MessageType.AbortRequest) {
+      if (message.type === MessageTypes.AbortRequest) {
         return sendExtensionMessage("fido2AbortRequest", { abortedRequestId: requestId });
       }
     } finally {
@@ -83,7 +83,7 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
   ): Promise<Message | undefined> {
     return respondToCredentialRequest(
       "fido2RegisterCredentialRequest",
-      MessageType.CredentialCreationResponse,
+      MessageTypes.CredentialCreationResponse,
       requestId,
       data,
     );
@@ -101,7 +101,7 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
   ): Promise<Message | undefined> {
     return respondToCredentialRequest(
       "fido2GetCredentialRequest",
-      MessageType.CredentialGetResponse,
+      MessageTypes.CredentialGetResponse,
       requestId,
       data,
     );
@@ -118,7 +118,9 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
    */
   async function respondToCredentialRequest(
     command: string,
-    type: MessageType.CredentialCreationResponse | MessageType.CredentialGetResponse,
+    type:
+      | typeof MessageTypes.CredentialCreationResponse
+      | typeof MessageTypes.CredentialGetResponse,
     requestId: string,
     messageData: InsecureCreateCredentialParams | InsecureAssertCredentialParams,
   ): Promise<Message | undefined> {

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { WebauthnUtils } from "../utils/webauthn-utils";
 
-import { MessageType } from "./messaging/message";
+import { MessageTypes } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 (function (globalContext) {
@@ -100,13 +100,13 @@ import { Messenger } from "./messaging/messenger";
     try {
       const response = await messenger.request(
         {
-          type: MessageType.CredentialCreationRequest,
+          type: MessageTypes.CredentialCreationRequest,
           data: WebauthnUtils.mapCredentialCreationOptions(options, fallbackSupported),
         },
         options?.signal,
       );
 
-      if (response.type !== MessageType.CredentialCreationResponse) {
+      if (response.type !== MessageTypes.CredentialCreationResponse) {
         throw new Error("Something went wrong.");
       }
 
@@ -141,19 +141,19 @@ import { Messenger } from "./messaging/messenger";
         try {
           const abortListener = () =>
             messenger.request({
-              type: MessageType.AbortRequest,
+              type: MessageTypes.AbortRequest,
               abortedRequestId: abortSignal.toString(),
             });
           internalAbortController.signal.addEventListener("abort", abortListener);
           const response = await messenger.request(
             {
-              type: MessageType.CredentialGetRequest,
+              type: MessageTypes.CredentialGetRequest,
               data: WebauthnUtils.mapCredentialRequestOptions(options, fallbackSupported),
             },
             internalAbortController.signal,
           );
           internalAbortController.signal.removeEventListener("abort", abortListener);
-          if (response.type !== MessageType.CredentialGetResponse) {
+          if (response.type !== MessageTypes.CredentialGetResponse) {
             throw new Error("Something went wrong.");
           }
 
@@ -182,13 +182,13 @@ import { Messenger } from "./messaging/messenger";
     try {
       const response = await messenger.request(
         {
-          type: MessageType.CredentialGetRequest,
+          type: MessageTypes.CredentialGetRequest,
           data: WebauthnUtils.mapCredentialRequestOptions(options, fallbackSupported),
         },
         options?.signal,
       );
 
-      if (response.type !== MessageType.CredentialGetResponse) {
+      if (response.type !== MessageTypes.CredentialGetResponse) {
         throw new Error("Something went wrong.");
       }
 
@@ -282,7 +282,7 @@ import { Messenger } from "./messaging/messenger";
     const type = message.type;
 
     // Handle cleanup for disconnect request
-    if (type === MessageType.DisconnectRequest) {
+    if (type === MessageTypes.DisconnectRequest) {
       destroy();
     }
   };

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script.webauthn-supported.spec.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script.webauthn-supported.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../autofill/spec/fido2-testing-utils";
 import { WebauthnUtils } from "../utils/webauthn-utils";
 
-import { MessageType } from "./messaging/message";
+import { MessageTypes } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 const originalGlobalThis = globalThis;
@@ -71,7 +71,7 @@ describe("Fido2 page script with native WebAuthn support", () => {
   describe("creating WebAuthn credentials", () => {
     beforeEach(() => {
       messenger.request = jest.fn().mockResolvedValue({
-        type: MessageType.CredentialCreationResponse,
+        type: MessageTypes.CredentialCreationResponse,
         result: mockCreateCredentialsResult,
       });
     });
@@ -104,7 +104,7 @@ describe("Fido2 page script with native WebAuthn support", () => {
   describe("get WebAuthn credentials", () => {
     beforeEach(() => {
       messenger.request = jest.fn().mockResolvedValue({
-        type: MessageType.CredentialGetResponse,
+        type: MessageTypes.CredentialGetResponse,
         result: mockCredentialAssertResult,
       });
     });
@@ -147,7 +147,7 @@ describe("Fido2 page script with native WebAuthn support", () => {
     it("should destroy the message listener when receiving a disconnect request", async () => {
       jest.spyOn(globalThis.top, "removeEventListener");
       const SENDER = "bitwarden-webauthn";
-      void messenger.handler({ type: MessageType.DisconnectRequest, SENDER, senderId: "1" });
+      void messenger.handler({ type: MessageTypes.DisconnectRequest, SENDER, senderId: "1" });
 
       expect(globalThis.top.removeEventListener).toHaveBeenCalledWith("focus", undefined);
       expect(messenger.destroy).toHaveBeenCalled();

--- a/apps/browser/src/autofill/fido2/content/fido2-page-script.webauthn-unsupported.spec.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-page-script.webauthn-unsupported.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../autofill/spec/fido2-testing-utils";
 import { WebauthnUtils } from "../utils/webauthn-utils";
 
-import { MessageType } from "./messaging/message";
+import { MessageTypes } from "./messaging/message";
 import { Messenger } from "./messaging/messenger";
 
 const originalGlobalThis = globalThis;
@@ -65,7 +65,7 @@ describe("Fido2 page script without native WebAuthn support", () => {
   describe("creating WebAuthn credentials", () => {
     beforeEach(() => {
       messenger.request = jest.fn().mockResolvedValue({
-        type: MessageType.CredentialCreationResponse,
+        type: MessageTypes.CredentialCreationResponse,
         result: mockCreateCredentialsResult,
       });
     });
@@ -86,7 +86,7 @@ describe("Fido2 page script without native WebAuthn support", () => {
   describe("get WebAuthn credentials", () => {
     beforeEach(() => {
       messenger.request = jest.fn().mockResolvedValue({
-        type: MessageType.CredentialGetResponse,
+        type: MessageTypes.CredentialGetResponse,
         result: mockCredentialAssertResult,
       });
     });
@@ -108,7 +108,7 @@ describe("Fido2 page script without native WebAuthn support", () => {
     it("should destroy the message listener when receiving a disconnect request", async () => {
       jest.spyOn(globalThis.top, "removeEventListener");
       const SENDER = "bitwarden-webauthn";
-      void messenger.handler({ type: MessageType.DisconnectRequest, SENDER, senderId: "1" });
+      void messenger.handler({ type: MessageTypes.DisconnectRequest, SENDER, senderId: "1" });
 
       expect(globalThis.top.removeEventListener).toHaveBeenCalledWith("focus", undefined);
       expect(messenger.destroy).toHaveBeenCalled();

--- a/apps/browser/src/autofill/fido2/content/messaging/message.ts
+++ b/apps/browser/src/autofill/fido2/content/messaging/message.ts
@@ -5,17 +5,19 @@ import {
   AssertCredentialResult,
 } from "@bitwarden/common/platform/abstractions/fido2/fido2-client.service.abstraction";
 
-export enum MessageType {
-  CredentialCreationRequest,
-  CredentialCreationResponse,
-  CredentialGetRequest,
-  CredentialGetResponse,
-  AbortRequest,
-  DisconnectRequest,
-  ReconnectRequest,
-  AbortResponse,
-  ErrorResponse,
-}
+export const MessageTypes = {
+  CredentialCreationRequest: 0,
+  CredentialCreationResponse: 1,
+  CredentialGetRequest: 2,
+  CredentialGetResponse: 3,
+  AbortRequest: 4,
+  DisconnectRequest: 5,
+  ReconnectRequest: 6,
+  AbortResponse: 7,
+  ErrorResponse: 8,
+} as const;
+
+export type MessageType = (typeof MessageTypes)[keyof typeof MessageTypes];
 
 /**
  * The params provided by the page-script are created in an insecure environment and
@@ -28,12 +30,12 @@ export type InsecureCreateCredentialParams = Omit<
 >;
 
 export type CredentialCreationRequest = {
-  type: MessageType.CredentialCreationRequest;
+  type: typeof MessageTypes.CredentialCreationRequest;
   data: InsecureCreateCredentialParams;
 };
 
 export type CredentialCreationResponse = {
-  type: MessageType.CredentialCreationResponse;
+  type: typeof MessageTypes.CredentialCreationResponse;
   result?: CreateCredentialResult;
 };
 
@@ -48,35 +50,35 @@ export type InsecureAssertCredentialParams = Omit<
 >;
 
 export type CredentialGetRequest = {
-  type: MessageType.CredentialGetRequest;
+  type: typeof MessageTypes.CredentialGetRequest;
   data: InsecureAssertCredentialParams;
 };
 
 export type CredentialGetResponse = {
-  type: MessageType.CredentialGetResponse;
+  type: typeof MessageTypes.CredentialGetResponse;
   result?: AssertCredentialResult;
 };
 
 export type AbortRequest = {
-  type: MessageType.AbortRequest;
+  type: typeof MessageTypes.AbortRequest;
   abortedRequestId: string;
 };
 
 export type DisconnectRequest = {
-  type: MessageType.DisconnectRequest;
+  type: typeof MessageTypes.DisconnectRequest;
 };
 
 export type ReconnectRequest = {
-  type: MessageType.ReconnectRequest;
+  type: typeof MessageTypes.ReconnectRequest;
 };
 
 export type ErrorResponse = {
-  type: MessageType.ErrorResponse;
+  type: typeof MessageTypes.ErrorResponse;
   error: string;
 };
 
 export type AbortResponse = {
-  type: MessageType.AbortResponse;
+  type: typeof MessageTypes.AbortResponse;
   abortedRequestId: string;
 };
 

--- a/apps/browser/src/autofill/fido2/content/messaging/messenger.ts
+++ b/apps/browser/src/autofill/fido2/content/messaging/messenger.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Message, MessageType } from "./message";
+import { Message, MessageTypes } from "./message";
 
 const SENDER = "bitwarden-webauthn";
 
@@ -80,7 +80,7 @@ export class Messenger {
       const abortListener = () =>
         localPort.postMessage({
           metadata: { SENDER },
-          type: MessageType.AbortRequest,
+          type: MessageTypes.AbortRequest,
         });
       abortSignal?.addEventListener("abort", abortListener);
 
@@ -92,7 +92,7 @@ export class Messenger {
 
       abortSignal?.removeEventListener("abort", abortListener);
 
-      if (response.type === MessageType.ErrorResponse) {
+      if (response.type === MessageTypes.ErrorResponse) {
         const error = new Error();
         Object.assign(error, JSON.parse(response.error));
         throw error;
@@ -119,7 +119,7 @@ export class Messenger {
 
       const abortController = new AbortController();
       port.onmessage = (event: MessageEvent<MessageWithMetadata>) => {
-        if (event.data.type === MessageType.AbortRequest) {
+        if (event.data.type === MessageTypes.AbortRequest) {
           abortController.abort();
         }
       };
@@ -133,7 +133,7 @@ export class Messenger {
       } catch (error) {
         port.postMessage({
           SENDER,
-          type: MessageType.ErrorResponse,
+          type: MessageTypes.ErrorResponse,
           error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
         });
       } finally {
@@ -157,7 +157,7 @@ export class Messenger {
   }
 
   private async sendDisconnectCommand() {
-    await this.request({ type: MessageType.DisconnectRequest });
+    await this.request({ type: MessageTypes.DisconnectRequest });
   }
 
   private generateUniqueId() {

--- a/apps/browser/src/autofill/fido2/services/browser-fido2-user-interface.service.ts
+++ b/apps/browser/src/autofill/fido2/services/browser-fido2-user-interface.service.ts
@@ -17,7 +17,7 @@ import {
 } from "rxjs";
 
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { UserRequestedFallbackAbortReason } from "@bitwarden/common/platform/abstractions/fido2/fido2-client.service.abstraction";
 import {
   Fido2UserInterfaceService as Fido2UserInterfaceServiceAbstraction,
@@ -309,7 +309,7 @@ export class BrowserFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   }
 
   async ensureUnlockedVault(): Promise<void> {
-    if ((await this.authService.getAuthStatus()) !== AuthenticationStatus.Unlocked) {
+    if ((await this.authService.getAuthStatus()) !== AuthenticationStatuses.Unlocked) {
       await this.connect();
     }
   }

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-button.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-button.ts
@@ -1,9 +1,9 @@
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatusValue } from "@bitwarden/common/auth/enums/authentication-status";
 
 export type AutofillInlineMenuButtonMessage = { command: string; colorScheme?: string };
 
 export type UpdateAuthStatusMessage = AutofillInlineMenuButtonMessage & {
-  authStatus: AuthenticationStatus;
+  authStatus: AuthenticationStatusValue;
 };
 
 export type InitAutofillInlineMenuButtonMessage = UpdateAuthStatusMessage & {

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-container.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-container.ts
@@ -1,4 +1,4 @@
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatusValue } from "@bitwarden/common/auth/enums/authentication-status";
 
 import { InlineMenuCipherData } from "../../../background/abstractions/overlay.background";
 
@@ -10,7 +10,7 @@ export type AutofillInlineMenuContainerMessage = {
 export type InitAutofillInlineMenuElementMessage = AutofillInlineMenuContainerMessage & {
   iframeUrl: string;
   pageTitle: string;
-  authStatus: AuthenticationStatus;
+  authStatus: AuthenticationStatusValue;
   styleSheetUrl: string;
   theme: string;
   translations: Record<string, string>;

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
@@ -1,4 +1,4 @@
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatusValue } from "@bitwarden/common/auth/enums/authentication-status";
 
 import { InlineMenuCipherData } from "../../../background/abstractions/overlay.background";
 import { InlineMenuFillTypes } from "../../../enums/autofill-overlay.enum";
@@ -18,7 +18,7 @@ export type UpdateAutofillInlineMenuGeneratedPasswordMessage = AutofillInlineMen
 };
 
 export type InitAutofillInlineMenuListMessage = AutofillInlineMenuListMessage & {
-  authStatus: AuthenticationStatus;
+  authStatus: AuthenticationStatusValue;
   styleSheetUrl: string;
   theme: string;
   translations: Record<string, string>;

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.ts
@@ -2,7 +2,10 @@
 // @ts-strict-ignore
 import "@webcomponents/custom-elements";
 import "lit/polyfill-support.js";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import {
+  AuthenticationStatuses,
+  AuthenticationStatusValue,
+} from "@bitwarden/common/auth/enums/authentication-status";
 import { EVENTS } from "@bitwarden/common/autofill/constants";
 
 import { buildSvgDomElement } from "../../../../utils";
@@ -15,7 +18,7 @@ import {
 import { AutofillInlineMenuPageElement } from "../shared/autofill-inline-menu-page-element";
 
 export class AutofillInlineMenuButton extends AutofillInlineMenuPageElement {
-  private authStatus: AuthenticationStatus = AuthenticationStatus.LoggedOut;
+  private authStatus: AuthenticationStatusValue = AuthenticationStatuses.LoggedOut;
   private readonly buttonElement: HTMLButtonElement;
   private readonly logoIconElement: HTMLElement;
   private readonly logoLockedIconElement: HTMLElement;
@@ -84,12 +87,12 @@ export class AutofillInlineMenuButton extends AutofillInlineMenuPageElement {
    *
    * @param authStatus - The authentication status of the user
    */
-  private updateAuthStatus(authStatus: AuthenticationStatus) {
+  private updateAuthStatus(authStatus: AuthenticationStatusValue) {
     this.authStatus = authStatus;
 
     this.buttonElement.innerHTML = "";
     const iconElement =
-      this.authStatus === AuthenticationStatus.Unlocked
+      this.authStatus === AuthenticationStatuses.Unlocked
         ? this.logoIconElement
         : this.logoLockedIconElement;
     this.buttonElement.append(iconElement);

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -5,7 +5,10 @@ import "lit/polyfill-support.js";
 
 import { FocusableElement } from "tabbable";
 
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import {
+  AuthenticationStatuses,
+  AuthenticationStatusValue,
+} from "@bitwarden/common/auth/enums/authentication-status";
 import { EVENTS, UPDATE_PASSKEYS_HEADINGS_ON_SCROLL } from "@bitwarden/common/autofill/constants";
 import { CipherRepromptTypeValue, CipherTypes } from "@bitwarden/common/vault/enums";
 
@@ -53,7 +56,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
   private lastPasskeysListItemHeight: number;
   private ciphersListHeight: number;
   private isPasskeyAuthInProgress = false;
-  private authStatus: AuthenticationStatus;
+  private authStatus: AuthenticationStatusValue;
   private readonly showCiphersPerPage = 6;
   private readonly headingBorderClass = "inline-menu-list-heading--bordered";
   private readonly inlineMenuListWindowMessageHandlers: AutofillInlineMenuListWindowMessageHandlers =
@@ -113,7 +116,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
     this.shadowDom.append(linkElement, this.inlineMenuListContainer);
 
-    if (authStatus !== AuthenticationStatus.Unlocked) {
+    if (authStatus !== AuthenticationStatuses.Unlocked) {
       this.buildLockedInlineMenu();
       return;
     }
@@ -210,7 +213,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    * Handles the show save login inline menu list message that is triggered from the background script.
    */
   private handleShowSaveLoginInlineMenuList() {
-    if (this.authStatus === AuthenticationStatus.Unlocked) {
+    if (this.authStatus === AuthenticationStatuses.Unlocked) {
       this.resetInlineMenuContainer();
       this.buildSaveLoginInlineMenu();
     }
@@ -422,7 +425,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
   private handleUpdateAutofillInlineMenuGeneratedPassword(
     message: UpdateAutofillInlineMenuGeneratedPasswordMessage,
   ) {
-    if (this.authStatus !== AuthenticationStatus.Unlocked || !message.generatedPassword) {
+    if (this.authStatus !== AuthenticationStatuses.Unlocked || !message.generatedPassword) {
       return;
     }
 

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -7,7 +7,7 @@ import { FocusableElement } from "tabbable";
 
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { EVENTS, UPDATE_PASSKEYS_HEADINGS_ON_SCROLL } from "@bitwarden/common/autofill/constants";
-import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypeValue, CipherTypes } from "@bitwarden/common/vault/enums";
 
 import { InlineMenuCipherData } from "../../../../background/abstractions/overlay.background";
 import { InlineMenuFillTypes } from "../../../../enums/autofill-overlay.enum";
@@ -455,7 +455,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     }
 
     const isTotpField =
-      this.inlineMenuFillType === CipherType.Login &&
+      this.inlineMenuFillType === CipherTypes.Login &&
       ciphers.some((cipher) => cipher.login?.totpField);
 
     if (isTotpField) {
@@ -615,7 +615,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     let addNewCipherType = this.inlineMenuFillType;
 
     if (this.showInlineMenuAccountCreation) {
-      addNewCipherType = CipherType.Login;
+      addNewCipherType = CipherTypes.Login;
     }
 
     this.postMessageToParent({
@@ -1105,8 +1105,8 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
       const svgElement = buildSvgDomElement(`
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29">
-          <circle fill="none" cx="14.5" cy="14.5" r="12.5" 
-                  stroke-width="3" stroke-dasharray="78.5" 
+          <circle fill="none" cx="14.5" cy="14.5" r="12.5"
+                  stroke-width="3" stroke-dasharray="78.5"
                   stroke-dashoffset="78.5" transform="rotate(-90 14.5 14.5)"></circle>
           <circle fill="none" cx="14.5" cy="14.5" r="14" stroke-width="1"></circle>
       </svg>
@@ -1247,7 +1247,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
   private buildTotpElement(
     totpCode: string,
     username: string,
-    reprompt: CipherRepromptType,
+    reprompt: CipherRepromptTypeValue,
   ): HTMLDivElement | null {
     if (!totpCode) {
       return null;
@@ -1614,21 +1614,21 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    * Identifies if the current focused field is filled by a login cipher.
    */
   private isFilledByLoginCipher = () => {
-    return this.inlineMenuFillType === CipherType.Login;
+    return this.inlineMenuFillType === CipherTypes.Login;
   };
 
   /**
    * Identifies if the current focused field is filled by a card cipher.
    */
   private isFilledByCardCipher = () => {
-    return this.inlineMenuFillType === CipherType.Card;
+    return this.inlineMenuFillType === CipherTypes.Card;
   };
 
   /**
    * Identifies if the current focused field is filled by an identity cipher.
    */
   private isFilledByIdentityCipher = () => {
-    return this.inlineMenuFillType === CipherType.Identity;
+    return this.inlineMenuFillType === CipherTypes.Identity;
   };
 
   /**

--- a/apps/browser/src/autofill/popup/fido2/fido2.component.ts
+++ b/apps/browser/src/autofill/popup/fido2/fido2.component.ts
@@ -25,8 +25,8 @@ import { DomainSettingsService } from "@bitwarden/common/autofill/services/domai
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { SecureNoteType, CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { SecureNoteTypes, CipherTypes } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypes } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
@@ -191,7 +191,7 @@ export class Fido2Component implements OnInit, OnDestroy {
               this.accountService.activeAccount$.pipe(getUserId),
             );
             this.ciphers = (await this.cipherService.getAllDecrypted(activeUserId)).filter(
-              (cipher) => cipher.type === CipherType.Login && !cipher.isDeleted,
+              (cipher) => cipher.type === CipherTypes.Login && !cipher.isDeleted,
             );
 
             this.displayedCiphers = this.ciphers.filter(
@@ -349,7 +349,7 @@ export class Fido2Component implements OnInit, OnDestroy {
     if (data?.type === BrowserFido2MessageTypes.ConfirmNewCredentialRequest) {
       await this.router.navigate(["/add-cipher"], {
         queryParams: {
-          type: CipherType.Login.toString(),
+          type: CipherTypes.Login.toString(),
           name: data.credentialName || data.rpId,
           uri: this.url,
           uilocation: "popout",
@@ -428,7 +428,7 @@ export class Fido2Component implements OnInit, OnDestroy {
     this.cipher = new CipherView();
     this.cipher.name = name;
 
-    this.cipher.type = CipherType.Login;
+    this.cipher.type = CipherTypes.Login;
     this.cipher.login = new LoginView();
     this.cipher.login.username = username;
     this.cipher.login.uris = [new LoginUriView()];
@@ -436,8 +436,8 @@ export class Fido2Component implements OnInit, OnDestroy {
     this.cipher.card = new CardView();
     this.cipher.identity = new IdentityView();
     this.cipher.secureNote = new SecureNoteView();
-    this.cipher.secureNote.type = SecureNoteType.Generic;
-    this.cipher.reprompt = CipherRepromptType.None;
+    this.cipher.secureNote.type = SecureNoteTypes.Generic;
+    this.cipher.reprompt = CipherRepromptTypes.None;
   }
 
   private async createNewCipher(name: string, username: string) {

--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -4,7 +4,7 @@ import { Observable } from "rxjs";
 
 import { UriMatchStrategySetting } from "@bitwarden/common/models/domain/domain-service";
 import { CommandDefinition } from "@bitwarden/common/platform/messaging";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { AutofillMessageCommand } from "../../enums/autofill-message.enums";
@@ -84,7 +84,7 @@ export abstract class AutofillService {
   doAutoFillActiveTab: (
     pageDetails: PageDetail[],
     fromCommand: boolean,
-    cipherType?: CipherType,
+    cipherType?: CipherTypeValue,
   ) => Promise<string | null>;
   setAutoFillOnPageLoadOrgPolicy: () => Promise<void>;
   isPasswordRepromptRequired: (cipher: CipherView, tab: chrome.tabs.Tab) => Promise<boolean>;

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -6,7 +6,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import AutofillInit from "../content/autofill-init";
 import {
   AutofillOverlayElement,
-  InlineMenuFillType,
+  InlineMenuFillTypes,
   MAX_SUB_FRAME_DEPTH,
   RedirectFocusDirection,
 } from "../enums/autofill-overlay.enum";
@@ -1383,7 +1383,7 @@ describe("AutofillOverlayContentService", () => {
           );
           expect(autofillFieldElement.removeEventListener).toHaveBeenCalled();
           expect(inputAccountFieldData.inlineMenuFillType).toEqual(
-            InlineMenuFillType.AccountCreationUsername,
+            InlineMenuFillTypes.AccountCreationUsername,
           );
         });
 
@@ -1420,7 +1420,7 @@ describe("AutofillOverlayContentService", () => {
           await flushPromises();
 
           expect(currentPasswordFieldData.inlineMenuFillType).toEqual(
-            InlineMenuFillType.CurrentPasswordUpdate,
+            InlineMenuFillTypes.CurrentPasswordUpdate,
           );
         });
       });

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -10,7 +10,7 @@ import {
   AUTOFILL_TRIGGER_FORM_FIELD_SUBMIT,
   AUTOFILL_OVERLAY_HANDLE_SCROLL,
 } from "@bitwarden/common/autofill/constants";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
 
 import {
   FocusedFieldData,
@@ -24,7 +24,7 @@ import { AutofillFieldQualifier, AutofillFieldQualifierType } from "../enums/aut
 import {
   AutofillOverlayElement,
   InlineMenuAccountCreationFieldType,
-  InlineMenuFillType,
+  InlineMenuFillTypes,
   MAX_SUB_FRAME_DEPTH,
   RedirectFocusDirection,
 } from "../enums/autofill-overlay.enum";
@@ -244,7 +244,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     const password =
       this.userFilledFields["newPassword"]?.value || this.userFilledFields["password"]?.value;
 
-    if (addNewCipherType === CipherType.Login) {
+    if (addNewCipherType === CipherTypes.Login) {
       const login: NewLoginCipherData = {
         username: this.userFilledFields["username"]?.value || "",
         password: password || "",
@@ -257,7 +257,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return;
     }
 
-    if (addNewCipherType === CipherType.Card) {
+    if (addNewCipherType === CipherTypes.Card) {
       const card: NewCardCipherData = {
         cardholderName: this.userFilledFields["cardholderName"]?.value || "",
         number: this.userFilledFields["cardNumber"]?.value || "",
@@ -272,7 +272,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return;
     }
 
-    if (addNewCipherType === CipherType.Identity) {
+    if (addNewCipherType === CipherTypes.Identity) {
       const identity: NewIdentityCipherData = {
         title: this.userFilledFields["identityTitle"]?.value || "",
         firstName: this.userFilledFields["identityFirstName"]?.value || "",
@@ -413,7 +413,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
   ) {
     if (
       !elementIsFillableFormField(formFieldElement) ||
-      autofillFieldData.inlineMenuFillType === CipherType.Card
+      autofillFieldData.inlineMenuFillType === CipherTypes.Card
     ) {
       return;
     }
@@ -788,18 +788,18 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
 
     if (!autofillFieldData.fieldQualifier) {
       switch (autofillFieldData.inlineMenuFillType) {
-        case CipherType.Login:
-        case InlineMenuFillType.CurrentPasswordUpdate:
+        case CipherTypes.Login:
+        case InlineMenuFillTypes.CurrentPasswordUpdate:
           this.qualifyUserFilledField(autofillFieldData, this.loginFieldQualifiers);
           break;
-        case InlineMenuFillType.AccountCreationUsername:
-        case InlineMenuFillType.PasswordGeneration:
+        case InlineMenuFillTypes.AccountCreationUsername:
+        case InlineMenuFillTypes.PasswordGeneration:
           this.qualifyUserFilledField(autofillFieldData, this.accountCreationFieldQualifiers);
           break;
-        case CipherType.Card:
+        case CipherTypes.Card:
           this.qualifyUserFilledField(autofillFieldData, this.cardFieldQualifiers);
           break;
-        case CipherType.Identity:
+        case CipherTypes.Identity:
           this.qualifyUserFilledField(autofillFieldData, this.identityFieldQualifiers);
           break;
       }
@@ -1059,7 +1059,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
         pageDetails,
       )
     ) {
-      autofillFieldData.inlineMenuFillType = CipherType.Card;
+      autofillFieldData.inlineMenuFillType = CipherTypes.Card;
       return false;
     }
 
@@ -1080,7 +1080,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
         pageDetails,
       )
     ) {
-      autofillFieldData.inlineMenuFillType = CipherType.Identity;
+      autofillFieldData.inlineMenuFillType = CipherTypes.Identity;
       return false;
     }
 
@@ -1093,7 +1093,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
    * @param autofillFieldData - Autofill field data captured from the form field element.
    */
   private async setQualifiedLoginFillType(autofillFieldData: AutofillField) {
-    autofillFieldData.inlineMenuFillType = CipherType.Login;
+    autofillFieldData.inlineMenuFillType = CipherTypes.Login;
     autofillFieldData.showPasskeys = autofillFieldData.autoCompleteType.includes("webauthn");
 
     this.qualifyAccountCreationFieldType(autofillFieldData);
@@ -1106,18 +1106,18 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
    */
   private setQualifiedAccountCreationFillType(autofillFieldData: AutofillField) {
     if (this.inlineMenuFieldQualificationService.isNewPasswordField(autofillFieldData)) {
-      autofillFieldData.inlineMenuFillType = InlineMenuFillType.PasswordGeneration;
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
       this.qualifyAccountCreationFieldType(autofillFieldData);
       return;
     }
 
     if (this.inlineMenuFieldQualificationService.isUpdateCurrentPasswordField(autofillFieldData)) {
-      autofillFieldData.inlineMenuFillType = InlineMenuFillType.CurrentPasswordUpdate;
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.CurrentPasswordUpdate;
       return;
     }
 
     if (this.inlineMenuFieldQualificationService.isUsernameField(autofillFieldData)) {
-      autofillFieldData.inlineMenuFillType = InlineMenuFillType.AccountCreationUsername;
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.AccountCreationUsername;
       this.qualifyAccountCreationFieldType(autofillFieldData);
     }
   }

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -16,7 +16,7 @@ import { EventCollectionService } from "@bitwarden/common/abstractions/event/eve
 import { AccountInfo, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import {
   AutofillOverlayVisibility,
@@ -234,7 +234,7 @@ export default class AutofillService implements AutofillServiceInterface {
     // if not guarded by an active account check (e.g. the user is logged in)
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
     const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
-    const accountIsUnlocked = authStatus === AuthenticationStatus.Unlocked;
+    const accountIsUnlocked = authStatus === AuthenticationStatuses.Unlocked;
     let autoFillOnPageLoadIsEnabled = false;
 
     const injectedScripts = [await this.getBootstrapAutofillContentScript(activeAccount)];

--- a/apps/browser/src/autofill/spec/autofill-mocks.ts
+++ b/apps/browser/src/autofill/spec/autofill-mocks.ts
@@ -5,8 +5,8 @@ import { mock } from "jest-mock-extended";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { ThemeTypes } from "@bitwarden/common/platform/enums";
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
+import { CipherRepromptTypes } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import {
@@ -193,8 +193,8 @@ export function createAutofillOverlayCipherDataMock(
       username: `username${index}`,
       passkey: null,
     },
-    type: CipherType.Login,
-    reprompt: CipherRepromptType.None,
+    type: CipherTypes.Login,
+    reprompt: CipherRepromptTypes.None,
     favorite: false,
     icon: {
       imageEnabled: true,
@@ -216,7 +216,7 @@ export function createInitAutofillInlineMenuListMessageMock(
     theme: ThemeTypes.Light,
     authStatus: AuthenticationStatus.Unlocked,
     portKey: "portKey",
-    inlineMenuFillType: CipherType.Login,
+    inlineMenuFillType: CipherTypes.Login,
     ciphers: [
       createAutofillOverlayCipherDataMock(1, {
         icon: {
@@ -265,7 +265,7 @@ export function createFocusedFieldDataMock(
       paddingRight: "6px",
       paddingLeft: "6px",
     },
-    inlineMenuFillType: CipherType.Login,
+    inlineMenuFillType: CipherTypes.Login,
     tabId: 1,
     frameId: 2,
     ...customFields,

--- a/apps/browser/src/autofill/spec/autofill-mocks.ts
+++ b/apps/browser/src/autofill/spec/autofill-mocks.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { mock } from "jest-mock-extended";
 
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { AuthenticationStatuses } from "@bitwarden/common/auth/enums/authentication-status";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { ThemeTypes } from "@bitwarden/common/platform/enums";
 import { CipherTypes } from "@bitwarden/common/vault/enums";
@@ -177,7 +177,7 @@ export function createInitAutofillInlineMenuButtonMessageMock(
     command: "initAutofillInlineMenuButton",
     translations: overlayPagesTranslations,
     styleSheetUrl: "https://jest-testing-website.com",
-    authStatus: AuthenticationStatus.Unlocked,
+    authStatus: AuthenticationStatuses.Unlocked,
     portKey: "portKey",
     ...customFields,
   };
@@ -214,7 +214,7 @@ export function createInitAutofillInlineMenuListMessageMock(
     translations: overlayPagesTranslations,
     styleSheetUrl: "https://jest-testing-website.com",
     theme: ThemeTypes.Light,
-    authStatus: AuthenticationStatus.Unlocked,
+    authStatus: AuthenticationStatuses.Unlocked,
     portKey: "portKey",
     inlineMenuFillType: CipherTypes.Login,
     ciphers: [

--- a/apps/browser/src/autofill/types/index.ts
+++ b/apps/browser/src/autofill/types/index.ts
@@ -1,6 +1,6 @@
 import { VaultTimeout, VaultTimeoutAction } from "@bitwarden/common/key-management/vault-timeout";
 import { Region } from "@bitwarden/common/platform/abstractions/environment.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
 
 export type UserSettings = {
   avatarColor: string | null;
@@ -54,4 +54,7 @@ export type FormFieldElement = FillableFormFieldElement | HTMLSpanElement;
 
 export type FormElementWithAttribute = FormFieldElement & Record<string, string | null | undefined>;
 
-export type AutofillCipherTypeId = CipherType.Login | CipherType.Card | CipherType.Identity;
+export type AutofillCipherTypeId =
+  | typeof CipherTypes.Login
+  | typeof CipherTypes.Card
+  | typeof CipherTypes.Identity;

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
@@ -37,7 +37,7 @@ import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-heade
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
 import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popup-router-cache.service";
 
-import { SendV2Component, SendState } from "./send-v2.component";
+import { SendV2Component, SendStates } from "./send-v2.component";
 
 describe("SendV2Component", () => {
   let component: SendV2Component;
@@ -142,12 +142,12 @@ describe("SendV2Component", () => {
   it("should set listState to Empty when emptyList$ emits true", () => {
     sendItemsServiceEmptyList$.next(true);
     fixture.detectChanges();
-    expect(component["listState"]).toBe(SendState.Empty);
+    expect(component["listState"]).toBe(SendStates.Empty);
   });
 
   it("should set listState to NoResults when noFilteredResults$ emits true", () => {
     sendItemsServiceNoFilteredResults$.next(true);
     fixture.detectChanges();
-    expect(component["listState"]).toBe(SendState.NoResults);
+    expect(component["listState"]).toBe(SendStates.NoResults);
   });
 });

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
@@ -26,10 +26,10 @@ import { PopOutComponent } from "../../../platform/popup/components/pop-out.comp
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
 
-export const SendStates = {
+export const SendStates = Object.freeze({
   Empty: 0,
   NoResults: 1,
-};
+} as const);
 
 type SendState = (typeof SendStates)[keyof typeof SendStates];
 

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
@@ -26,10 +26,12 @@ import { PopOutComponent } from "../../../platform/popup/components/pop-out.comp
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
 
-export enum SendState {
-  Empty,
-  NoResults,
-}
+export const SendStates = {
+  Empty: 0,
+  NoResults: 1,
+};
+
+type SendState = (typeof SendStates)[keyof typeof SendStates];
 
 @Component({
   templateUrl: "send-v2.component.html",
@@ -53,7 +55,7 @@ export enum SendState {
 })
 export class SendV2Component implements OnInit, OnDestroy {
   sendType = SendType;
-  sendState = SendState;
+  sendState = SendStates;
 
   protected listState: SendState | null = null;
   protected sends$ = this.sendItemsService.filteredAndSortedSends$;
@@ -84,12 +86,12 @@ export class SendV2Component implements OnInit, OnDestroy {
         }
 
         if (emptyList) {
-          this.listState = SendState.Empty;
+          this.listState = SendStates.Empty;
           return;
         }
 
         if (noFilteredResults) {
-          this.listState = SendState.NoResults;
+          this.listState = SendStates.NoResults;
           return;
         }
 

--- a/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.ts
@@ -10,9 +10,12 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { DarkImageSourceDirective, VaultCarouselModule } from "@bitwarden/vault";
 
-export enum AtRiskCarouselDialogResult {
-  Dismissed = "dismissed",
-}
+export const AtRiskCarouselDialogResults = {
+  Dismissed: "dismissed",
+} as const;
+
+type AtRiskCarouselDialogResult =
+  (typeof AtRiskCarouselDialogResults)[keyof typeof AtRiskCarouselDialogResults];
 
 @Component({
   selector: "vault-at-risk-carousel-dialog",
@@ -33,7 +36,7 @@ export class AtRiskCarouselDialogComponent {
   protected dismissBtnEnabled = signal(false);
 
   protected async dismiss() {
-    this.dialogRef.close(AtRiskCarouselDialogResult.Dismissed);
+    this.dialogRef.close(AtRiskCarouselDialogResults.Dismissed);
   }
 
   protected onSlideChange(slideIndex: number) {

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
@@ -26,7 +26,7 @@ import {
 
 import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
-import { AtRiskCarouselDialogResult } from "../at-risk-carousel-dialog/at-risk-carousel-dialog.component";
+import { AtRiskCarouselDialogResults } from "../at-risk-carousel-dialog/at-risk-carousel-dialog.component";
 
 import { AtRiskPasswordPageService } from "./at-risk-password-page.service";
 import { AtRiskPasswordsComponent } from "./at-risk-passwords.component";
@@ -311,7 +311,7 @@ describe("AtRiskPasswordsComponent", () => {
     it("should mark the carousel as dismissed when the user dismisses it", async () => {
       mockAtRiskPasswordPageService.isGettingStartedDismissed.mockReturnValue(of(false));
       mockDialogService.open.mockReturnValue({
-        closed: of(AtRiskCarouselDialogResult.Dismissed),
+        closed: of(AtRiskCarouselDialogResults.Dismissed),
       } as any);
       await component.ngOnInit();
       expect(mockDialogService.open).toHaveBeenCalled();

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
@@ -39,7 +39,7 @@ import { PopupHeaderComponent } from "../../../../platform/popup/layout/popup-he
 import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page.component";
 import {
   AtRiskCarouselDialogComponent,
-  AtRiskCarouselDialogResult,
+  AtRiskCarouselDialogResults,
 } from "../at-risk-carousel-dialog/at-risk-carousel-dialog.component";
 
 import { AtRiskPasswordPageService } from "./at-risk-password-page.service";
@@ -176,7 +176,7 @@ export class AtRiskPasswordsComponent implements OnInit {
       const ref = AtRiskCarouselDialogComponent.open(this.dialogService);
 
       const result = await firstValueFrom(ref.closed);
-      if (result === AtRiskCarouselDialogResult.Dismissed) {
+      if (result === AtRiskCarouselDialogResults.Dismissed) {
         await this.atRiskPasswordPageService.dismissGettingStarted(userId);
       }
     }

--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -7,7 +7,7 @@ import { Router, RouterLink } from "@angular/router";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes, CipherTypeValue } from "@bitwarden/common/vault/enums";
 import { ButtonModule, DialogService, MenuModule, NoItemsModule } from "@bitwarden/components";
 import { AddEditFolderDialogComponent } from "@bitwarden/vault";
 
@@ -28,7 +28,7 @@ export interface NewItemInitialValues {
   imports: [NoItemsModule, JslibModule, CommonModule, ButtonModule, RouterLink, MenuModule],
 })
 export class NewItemDropdownV2Component implements OnInit {
-  cipherType = CipherType;
+  cipherType = CipherTypes;
   private tab?: chrome.tabs.Tab;
   /**
    * Optional initial values to pass to the add cipher form
@@ -44,14 +44,14 @@ export class NewItemDropdownV2Component implements OnInit {
     this.tab = await BrowserApi.getTabFromCurrentWindow();
   }
 
-  buildQueryParams(type: CipherType): AddEditQueryParams {
+  buildQueryParams(type: CipherTypeValue): AddEditQueryParams {
     const poppedOut = BrowserPopupUtils.inPopout(window);
 
     const loginDetails: { uri?: string; name?: string } = {};
 
     // When a Login Cipher is created and the extension is not popped out,
     // pass along the uri and name
-    if (!poppedOut && type === CipherType.Login && this.tab) {
+    if (!poppedOut && type === CipherTypes.Login && this.tab) {
       loginDetails.uri = this.tab.url;
       loginDetails.name = Utils.getHostname(this.tab.url);
     }

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.spec.ts
@@ -12,7 +12,7 @@ import { CipherFormGeneratorComponent } from "@bitwarden/vault";
 import { PopupRouterCacheService } from "../../../../../platform/popup/view-cache/popup-router-cache.service";
 
 import {
-  GeneratorDialogAction,
+  GeneratorDialogActions,
   GeneratorDialogParams,
   GeneratorDialogResult,
   VaultGeneratorDialogComponent,
@@ -129,7 +129,7 @@ describe("VaultGeneratorDialogComponent", () => {
     fixture.debugElement.query(By.css("[data-testid='select-button']")).nativeElement.click();
 
     expect(mockDialogRef.close).toHaveBeenCalledWith({
-      action: GeneratorDialogAction.Selected,
+      action: GeneratorDialogActions.Selected,
       generatedValue: "test-password",
     });
   });
@@ -137,7 +137,7 @@ describe("VaultGeneratorDialogComponent", () => {
   it("should close with canceled action when dismissed", () => {
     fixture.debugElement.query(By.css("popup-header")).componentInstance.backAction();
     expect(mockDialogRef.close).toHaveBeenCalledWith({
-      action: GeneratorDialogAction.Canceled,
+      action: GeneratorDialogActions.Canceled,
     });
   });
 });

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
@@ -30,10 +30,12 @@ export interface GeneratorDialogResult {
   generatedValue?: string;
 }
 
-export enum GeneratorDialogAction {
-  Selected = "selected",
-  Canceled = "canceled",
-}
+export const GeneratorDialogActions = {
+  Selected: "selected",
+  Canceled: "canceled",
+} as const;
+
+type GeneratorDialogAction = (typeof GeneratorDialogActions)[keyof typeof GeneratorDialogActions];
 
 @Component({
   selector: "app-vault-generator-dialog",
@@ -81,7 +83,7 @@ export class VaultGeneratorDialogComponent {
    * Close the dialog without selecting a value.
    */
   protected close = () => {
-    this.dialogRef.close({ action: GeneratorDialogAction.Canceled });
+    this.dialogRef.close({ action: GeneratorDialogActions.Canceled });
   };
 
   /**
@@ -89,7 +91,7 @@ export class VaultGeneratorDialogComponent {
    */
   protected selectValue = () => {
     this.dialogRef.close({
-      action: GeneratorDialogAction.Selected,
+      action: GeneratorDialogActions.Selected,
       generatedValue: this.generatedValue,
     });
   };

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -21,7 +21,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes } from "@bitwarden/common/vault/enums";
 import { ButtonModule, DialogService, Icons, NoItemsModule } from "@bitwarden/components";
 import { DecryptionFailureDialogComponent, VaultIcons } from "@bitwarden/vault";
 
@@ -47,11 +47,13 @@ import { VaultPageService } from "./vault-page.service";
 
 import { AutofillVaultListItemsComponent, VaultListItemsContainerComponent } from ".";
 
-enum VaultState {
-  Empty,
-  NoResults,
-  DeactivatedOrg,
-}
+const VaultStates = {
+  Empty: 0,
+  NoResults: 1,
+  DeactivatedOrg: 2,
+} as const;
+
+type VaultState = (typeof VaultStates)[keyof typeof VaultStates];
 
 @Component({
   selector: "app-vault",
@@ -80,7 +82,7 @@ enum VaultState {
 export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(CdkVirtualScrollableElement) virtualScrollElement?: CdkVirtualScrollableElement;
 
-  cipherType = CipherType;
+  cipherType = CipherTypes;
 
   protected favoriteCiphers$ = this.vaultPopupItemsService.favoriteCiphers$;
   protected remainingCiphers$ = this.vaultPopupItemsService.remainingCiphers$;
@@ -118,7 +120,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   protected deactivatedIcon = VaultIcons.DeactivatedOrg;
   protected noResultsIcon = Icons.NoResults;
 
-  protected VaultStateEnum = VaultState;
+  protected VaultStateEnum = VaultStates;
   protected showNewCustomizationSettingsCallout = false;
 
   constructor(
@@ -142,14 +144,14 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
       .subscribe(([emptyVault, noResults, deactivatedOrg]) => {
         switch (true) {
           case emptyVault:
-            this.vaultState = VaultState.Empty;
+            this.vaultState = VaultStates.Empty;
             break;
           case deactivatedOrg:
             // The deactivated org state takes precedence over the no results state
-            this.vaultState = VaultState.DeactivatedOrg;
+            this.vaultState = VaultStates.DeactivatedOrg;
             break;
           case noResults:
-            this.vaultState = VaultState.NoResults;
+            this.vaultState = VaultStates.NoResults;
             break;
           default:
             this.vaultState = null;

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -33,7 +33,7 @@ import {
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypes, CipherTypeValue } from "@bitwarden/common/vault/enums";
 import { ITreeNodeObject, TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
@@ -53,7 +53,7 @@ export interface CachedFilterState {
   organizationId?: string;
   collectionId?: string;
   folderId?: string;
-  cipherType?: CipherType | null;
+  cipherType?: CipherTypeValue | null;
 }
 
 /** All available cipher filters */
@@ -61,7 +61,7 @@ export type PopupListFilter = {
   organization: Organization | null;
   collection: CollectionView | null;
   folder: FolderView | null;
-  cipherType: CipherType | null;
+  cipherType: CipherTypeValue | null;
 };
 
 /** Delimiter that denotes a level of nesting  */
@@ -251,29 +251,29 @@ export class VaultPopupListFiltersService {
   /**
    * All available cipher types
    */
-  readonly cipherTypes: ChipSelectOption<CipherType>[] = [
+  readonly cipherTypes: ChipSelectOption<CipherTypeValue>[] = [
     {
-      value: CipherType.Login,
+      value: CipherTypes.Login,
       label: this.i18nService.t("typeLogin"),
       icon: "bwi-globe",
     },
     {
-      value: CipherType.Card,
+      value: CipherTypes.Card,
       label: this.i18nService.t("typeCard"),
       icon: "bwi-credit-card",
     },
     {
-      value: CipherType.Identity,
+      value: CipherTypes.Identity,
       label: this.i18nService.t("typeIdentity"),
       icon: "bwi-id-card",
     },
     {
-      value: CipherType.SecureNote,
+      value: CipherTypes.SecureNote,
       label: this.i18nService.t("note"),
       icon: "bwi-sticky-note",
     },
     {
-      value: CipherType.SshKey,
+      value: CipherTypes.SshKey,
       label: this.i18nService.t("typeSshKey"),
       icon: "bwi-key",
     },

--- a/apps/browser/src/vault/popup/utils/vault-popout-window.ts
+++ b/apps/browser/src/vault/popup/utils/vault-popout-window.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherTypeValue } from "@bitwarden/common/vault/enums";
 
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../platform/popup/browser-popup-utils";
@@ -90,7 +90,7 @@ async function openVaultItemPasswordRepromptPopout(
  */
 async function openAddEditVaultItemPopout(
   senderTab: chrome.tabs.Tab,
-  cipherOptions: { cipherId?: string; cipherType?: CipherType } = {},
+  cipherOptions: { cipherId?: string; cipherType?: CipherTypeValue } = {},
 ) {
   const { cipherId, cipherType } = cipherOptions;
   const { url, windowId } = senderTab;

--- a/libs/common/src/auth/enums/authentication-status.ts
+++ b/libs/common/src/auth/enums/authentication-status.ts
@@ -1,5 +1,17 @@
+/**
+ * @deprecated instead use `ThemeTypes` constants and `Theme` type over unsafe typescript enums
+ **/
 export enum AuthenticationStatus {
   LoggedOut = 0,
   Locked = 1,
   Unlocked = 2,
 }
+
+export const AuthenticationStatuses = {
+  LoggedOut: 0,
+  Locked: 1,
+  Unlocked: 2,
+} as const;
+
+export type AuthenticationStatusValue =
+  (typeof AuthenticationStatuses)[keyof typeof AuthenticationStatuses];

--- a/libs/common/src/auth/enums/authentication-status.ts
+++ b/libs/common/src/auth/enums/authentication-status.ts
@@ -1,5 +1,5 @@
 /**
- * @deprecated instead use `ThemeTypes` constants and `Theme` type over unsafe typescript enums
+ * @deprecated instead use `AuthenticationStatuses` constants and `AuthenticationStatusValue` type over unsafe typescript enums
  **/
 export enum AuthenticationStatus {
   LoggedOut = 0,

--- a/libs/common/src/billing/enums/product-tier-type.enum.ts
+++ b/libs/common/src/billing/enums/product-tier-type.enum.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated instead use `ProductTierTypes` constants and `ProductTierTypeValue` type over unsafe typescript enums
+ **/
 export enum ProductTierType {
   Free = 0,
   Families = 1,
@@ -6,10 +9,20 @@ export enum ProductTierType {
   TeamsStarter = 4,
 }
 
-export function isNotSelfUpgradable(productType: ProductTierType): boolean {
+export const ProductTierTypes = {
+  Free: 0,
+  Families: 1,
+  Teams: 2,
+  Enterprise: 3,
+  TeamsStarter: 4,
+} as const;
+
+export type ProductTierTypeValue = (typeof ProductTierTypes)[keyof typeof ProductTierTypes];
+
+export function isNotSelfUpgradable(productType: ProductTierTypeValue): boolean {
   return (
-    productType !== ProductTierType.Free &&
-    productType !== ProductTierType.TeamsStarter &&
-    productType !== ProductTierType.Families
+    productType !== ProductTierTypes.Free &&
+    productType !== ProductTierTypes.TeamsStarter &&
+    productType !== ProductTierTypes.Families
   );
 }

--- a/libs/common/src/platform/enums/theme-type.enum.ts
+++ b/libs/common/src/platform/enums/theme-type.enum.ts
@@ -1,5 +1,5 @@
 /**
- * @deprecated prefer the `ThemeTypes` constants and `Theme` type over unsafe enum types
+ * @deprecated instead use `ThemeTypes` constants and `Theme` type over unsafe typescript enums
  **/
 export enum ThemeType {
   System = "system",

--- a/libs/common/src/vault/enums/cipher-reprompt-type.ts
+++ b/libs/common/src/vault/enums/cipher-reprompt-type.ts
@@ -1,4 +1,15 @@
+/**
+ * @deprecated instead use `CipherRepromptTypes` constants and `CipherRepromptTypeValue` type over unsafe typescript enums
+ **/
 export enum CipherRepromptType {
   None = 0,
   Password = 1,
 }
+
+export const CipherRepromptTypes = {
+  None: 0,
+  Password: 1,
+} as const;
+
+export type CipherRepromptTypeValue =
+  (typeof CipherRepromptTypes)[keyof typeof CipherRepromptTypes];

--- a/libs/common/src/vault/enums/cipher-type.ts
+++ b/libs/common/src/vault/enums/cipher-type.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated instead use `CipherTypes` constants and `CipherTypeValue` type over unsafe typescript enums
+ **/
 export enum CipherType {
   Login = 1,
   SecureNote = 2,
@@ -5,3 +8,13 @@ export enum CipherType {
   Identity = 4,
   SshKey = 5,
 }
+
+export const CipherTypes = {
+  Login: 1,
+  SecureNote: 2,
+  Card: 3,
+  Identity: 4,
+  SshKey: 5,
+} as const;
+
+export type CipherTypeValue = (typeof CipherTypes)[keyof typeof CipherTypes];

--- a/libs/common/src/vault/enums/field-type.enum.ts
+++ b/libs/common/src/vault/enums/field-type.enum.ts
@@ -1,5 +1,5 @@
 /**
- * @deprecated instead use `CipherTypes` constants and `CipherTypeValue` type over unsafe typescript enums
+ * @deprecated instead use `FieldTypes` constants and `FieldTypeValue` type over unsafe typescript enums
  **/
 export enum FieldType {
   Text = 0,

--- a/libs/common/src/vault/enums/field-type.enum.ts
+++ b/libs/common/src/vault/enums/field-type.enum.ts
@@ -1,6 +1,18 @@
+/**
+ * @deprecated instead use `CipherTypes` constants and `CipherTypeValue` type over unsafe typescript enums
+ **/
 export enum FieldType {
   Text = 0,
   Hidden = 1,
   Boolean = 2,
   Linked = 3,
 }
+
+export const FieldTypes = {
+  Text: 0,
+  Hidden: 1,
+  Boolean: 2,
+  Linked: 3,
+} as const;
+
+export type FieldTypeValue = (typeof FieldTypes)[keyof typeof FieldTypes];

--- a/libs/common/src/vault/enums/secure-note-type.enum.ts
+++ b/libs/common/src/vault/enums/secure-note-type.enum.ts
@@ -1,3 +1,12 @@
+/**
+ * @deprecated instead use `SecureNoteTypes` constants and `SecureNoteTypeValue` type over unsafe typescript enums
+ **/
 export enum SecureNoteType {
   Generic = 0,
 }
+
+export const SecureNoteTypes = {
+  Generic: 0,
+} as const;
+
+export type SecureNoteTypeValue = (typeof SecureNoteTypes)[keyof typeof SecureNoteTypes];

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -4,8 +4,8 @@ import { View } from "../../../models/view/view";
 import { InitializerMetadata } from "../../../platform/interfaces/initializer-metadata.interface";
 import { InitializerKey } from "../../../platform/services/cryptography/initializer-key";
 import { DeepJsonify } from "../../../types/deep-jsonify";
-import { CipherType, LinkedIdType } from "../../enums";
-import { CipherRepromptType } from "../../enums/cipher-reprompt-type";
+import { CipherTypes, CipherTypeValue, LinkedIdType } from "../../enums";
+import { CipherRepromptTypes, CipherRepromptTypeValue } from "../../enums/cipher-reprompt-type";
 import { CipherPermissionsApi } from "../api/cipher-permissions.api";
 import { LocalData } from "../data/local.data";
 import { Cipher } from "../domain/cipher";
@@ -27,7 +27,7 @@ export class CipherView implements View, InitializerMetadata {
   folderId: string = null;
   name: string = null;
   notes: string = null;
-  type: CipherType = null;
+  type: CipherTypeValue = null;
   favorite = false;
   organizationUseTotp = false;
   permissions: CipherPermissionsApi = new CipherPermissionsApi();
@@ -46,7 +46,7 @@ export class CipherView implements View, InitializerMetadata {
   revisionDate: Date = null;
   creationDate: Date = null;
   deletedDate: Date = null;
-  reprompt: CipherRepromptType = CipherRepromptType.None;
+  reprompt: CipherRepromptTypeValue = CipherRepromptTypes.None;
 
   /**
    * Flag to indicate if the cipher decryption failed.
@@ -73,20 +73,20 @@ export class CipherView implements View, InitializerMetadata {
     this.creationDate = c.creationDate;
     this.deletedDate = c.deletedDate;
     // Old locally stored ciphers might have reprompt == null. If so set it to None.
-    this.reprompt = c.reprompt ?? CipherRepromptType.None;
+    this.reprompt = c.reprompt ?? CipherRepromptTypes.None;
   }
 
   private get item() {
     switch (this.type) {
-      case CipherType.Login:
+      case CipherTypes.Login:
         return this.login;
-      case CipherType.SecureNote:
+      case CipherTypes.SecureNote:
         return this.secureNote;
-      case CipherType.Card:
+      case CipherTypes.Card:
         return this.card;
-      case CipherType.Identity:
+      case CipherTypes.Identity:
         return this.identity;
-      case CipherType.SshKey:
+      case CipherTypes.SshKey:
         return this.sshKey;
       default:
         break;
@@ -123,7 +123,7 @@ export class CipherView implements View, InitializerMetadata {
   }
 
   get passwordRevisionDisplayDate(): Date {
-    if (this.type !== CipherType.Login || this.login == null) {
+    if (this.type !== CipherTypes.Login || this.login == null) {
       return null;
     } else if (this.login.password == null || this.login.password === "") {
       return null;
@@ -156,7 +156,7 @@ export class CipherView implements View, InitializerMetadata {
    * Determines if the cipher can be launched in a new browser tab.
    */
   get canLaunch(): boolean {
-    return this.type === CipherType.Login && this.login.canLaunch;
+    return this.type === CipherTypes.Login && this.login.canLaunch;
   }
 
   linkedFieldValue(id: LinkedIdType) {
@@ -201,19 +201,19 @@ export class CipherView implements View, InitializerMetadata {
     });
 
     switch (obj.type) {
-      case CipherType.Card:
+      case CipherTypes.Card:
         view.card = CardView.fromJSON(obj.card);
         break;
-      case CipherType.Identity:
+      case CipherTypes.Identity:
         view.identity = IdentityView.fromJSON(obj.identity);
         break;
-      case CipherType.Login:
+      case CipherTypes.Login:
         view.login = LoginView.fromJSON(obj.login);
         break;
-      case CipherType.SecureNote:
+      case CipherTypes.SecureNote:
         view.secureNote = SecureNoteView.fromJSON(obj.secureNote);
         break;
-      case CipherType.SshKey:
+      case CipherTypes.SshKey:
         view.sshKey = SshKeyView.fromJSON(obj.sshKey);
         break;
       default:

--- a/libs/common/src/vault/models/view/field.view.ts
+++ b/libs/common/src/vault/models/view/field.view.ts
@@ -3,13 +3,13 @@
 import { Jsonify } from "type-fest";
 
 import { View } from "../../../models/view/view";
-import { FieldType, LinkedIdType } from "../../enums";
+import { FieldTypeValue, LinkedIdType } from "../../enums";
 import { Field } from "../domain/field";
 
 export class FieldView implements View {
   name: string = null;
   value: string = null;
-  type: FieldType = null;
+  type: FieldTypeValue = null;
   newField = false; // Marks if the field is new and hasn't been saved
   showValue = false;
   showCount = false;

--- a/libs/importer/src/importers/bitwarden/bitwarden-csv-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-csv-importer.ts
@@ -1,7 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { FieldType, SecureNoteType, CipherType } from "@bitwarden/common/vault/enums";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { FieldTypes, SecureNoteTypes, CipherTypes } from "@bitwarden/common/vault/enums";
+import {
+  CipherRepromptTypes,
+  CipherRepromptTypeValue,
+} from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
@@ -37,18 +40,18 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
       const cipher = new CipherView();
       cipher.favorite =
         !this.organization && this.getValueOrDefault(value.favorite, "0") !== "0" ? true : false;
-      cipher.type = CipherType.Login;
+      cipher.type = CipherTypes.Login;
       cipher.notes = this.getValueOrDefault(value.notes);
       cipher.name = this.getValueOrDefault(value.name, "--");
       try {
         cipher.reprompt = parseInt(
-          this.getValueOrDefault(value.reprompt, CipherRepromptType.None.toString()),
+          this.getValueOrDefault(value.reprompt, CipherRepromptTypes.None.toString()),
           10,
-        );
+        ) as CipherRepromptTypeValue;
       } catch (e) {
         // eslint-disable-next-line
         console.error("Unable to parse reprompt value", e);
-        cipher.reprompt = CipherRepromptType.None;
+        cipher.reprompt = CipherRepromptTypes.None;
       }
 
       if (!this.isNullOrWhitespace(value.fields)) {
@@ -70,7 +73,7 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
           const field = new FieldView();
           field.name = fields[i].substr(0, delimPosition);
           field.value = null;
-          field.type = FieldType.Text;
+          field.type = FieldTypes.Text;
           if (fields[i].length > delimPosition + 2) {
             field.value = fields[i].substr(delimPosition + 2);
           }
@@ -81,12 +84,12 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
       const valueType = value.type != null ? value.type.toLowerCase() : null;
       switch (valueType) {
         case "note":
-          cipher.type = CipherType.SecureNote;
+          cipher.type = CipherTypes.SecureNote;
           cipher.secureNote = new SecureNoteView();
-          cipher.secureNote.type = SecureNoteType.Generic;
+          cipher.secureNote.type = SecureNoteTypes.Generic;
           break;
         default: {
-          cipher.type = CipherType.Login;
+          cipher.type = CipherTypes.Login;
           cipher.login = new LoginView();
           cipher.login.totp = this.getValueOrDefault(value.login_totp || value.totp);
           cipher.login.username = this.getValueOrDefault(value.login_username || value.username);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20428](https://bitwarden.atlassian.net/browse/PM-20428)

## 📔 Objective

Per architecture council meeting, let's not use typescript enums. Given the immense size of this task, I opted to start with cases used by Autofill team and where the deprecated enums were no longer in use anywhere as a consequence, I removed them. 

I've created follow up tasks [PM-20454](https://bitwarden.atlassian.net/browse/PM-20454) to look into updating our linting rules for disallowing typescript enums and [PM-20458](https://bitwarden.atlassian.net/browse/PM-20458) to ensure we're ultimately tracking the removal of the enums which were deprecated here.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20428]: https://bitwarden.atlassian.net/browse/PM-20428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-20454]: https://bitwarden.atlassian.net/browse/PM-20454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-20458]: https://bitwarden.atlassian.net/browse/PM-20458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ