### PR TITLE
[PM-20433] Fix clearing of cached cipher form 

### DIFF
--- a/apps/browser/src/platform/popup/view-cache/popup-view-cache.service.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-view-cache.service.ts
@@ -27,6 +27,7 @@ import {
   ClEAR_VIEW_CACHE_COMMAND,
   POPUP_VIEW_CACHE_KEY,
   SAVE_VIEW_CACHE_COMMAND,
+  ViewCacheState,
 } from "../../services/popup-view-cache-background.service";
 
 /**
@@ -42,8 +43,8 @@ export class PopupViewCacheService implements ViewCacheService {
   private messageSender = inject(MessageSender);
   private router = inject(Router);
 
-  private _cache: Record<string, string>;
-  private get cache(): Record<string, string> {
+  private _cache: Record<string, ViewCacheState>;
+  private get cache(): Record<string, ViewCacheState> {
     if (!this._cache) {
       throw new Error("Dirty View Cache not initialized");
     }
@@ -64,15 +65,9 @@ export class PopupViewCacheService implements ViewCacheService {
         filter((e) => e instanceof NavigationEnd),
         /** Skip the first navigation triggered by `popupRouterCacheGuard` */
         skip(1),
-        filter((e: NavigationEnd) =>
-          // viewing/editing a cipher and navigating back to the vault list should not clear the cache
-          ["/view-cipher", "/edit-cipher", "/tabs/vault"].every(
-            (route) => !e.urlAfterRedirects.startsWith(route),
-          ),
-        ),
       )
-      .subscribe((e) => {
-        return this.clearState();
+      .subscribe(() => {
+        return this.clearState(true);
       });
   }
 
@@ -85,13 +80,20 @@ export class PopupViewCacheService implements ViewCacheService {
       key,
       injector = inject(Injector),
       initialValue,
+      persistNavigation,
     } = options;
-    const cachedValue = this.cache[key] ? deserializer(JSON.parse(this.cache[key])) : initialValue;
+    const cachedValue = this.cache[key]
+      ? deserializer(JSON.parse(this.cache[key].value))
+      : initialValue;
     const _signal = signal(cachedValue);
+
+    const viewCacheOptions = {
+      ...(persistNavigation && { persistNavigation }),
+    };
 
     effect(
       () => {
-        this.updateState(key, JSON.stringify(_signal()));
+        this.updateState(key, JSON.stringify(_signal()), viewCacheOptions);
       },
       { injector },
     );
@@ -123,15 +125,24 @@ export class PopupViewCacheService implements ViewCacheService {
     return control;
   }
 
-  private updateState(key: string, value: string) {
+  private updateState(key: string, value: string, options: ViewCacheState["options"]) {
     this.messageSender.send(SAVE_VIEW_CACHE_COMMAND, {
       key,
       value,
+      options,
     });
   }
 
-  private clearState() {
-    this._cache = {}; // clear local cache
-    this.messageSender.send(ClEAR_VIEW_CACHE_COMMAND, {});
+  private clearState(routeChange: boolean = false) {
+    if (routeChange) {
+      // Only keep entries with `persistNavigation`
+      this._cache = Object.fromEntries(
+        Object.entries(this._cache).filter(([, { options }]) => options?.persistNavigation),
+      );
+    } else {
+      // Clear all entries
+      this._cache = {};
+    }
+    this.messageSender.send(ClEAR_VIEW_CACHE_COMMAND, { routeChange: routeChange });
   }
 }

--- a/apps/browser/src/platform/popup/view-cache/popup-view-cache.spec.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-view-cache.spec.ts
@@ -14,6 +14,7 @@ import {
   ClEAR_VIEW_CACHE_COMMAND,
   POPUP_VIEW_CACHE_KEY,
   SAVE_VIEW_CACHE_COMMAND,
+  ViewCacheState,
 } from "../../services/popup-view-cache-background.service";
 
 import { PopupViewCacheService } from "./popup-view-cache.service";
@@ -35,6 +36,7 @@ export class TestComponent {
   signal = this.viewCacheService.signal({
     key: "test-signal",
     initialValue: "initial signal",
+    persistNavigation: true,
   });
 }
 
@@ -42,11 +44,11 @@ describe("popup view cache", () => {
   const configServiceMock = mock<ConfigService>();
   let testBed: TestBed;
   let service: PopupViewCacheService;
-  let fakeGlobalState: FakeGlobalState<Record<string, string>>;
+  let fakeGlobalState: FakeGlobalState<Record<string, ViewCacheState>>;
   let messageSenderMock: MockProxy<MessageSender>;
   let router: Router;
 
-  const initServiceWithState = async (state: Record<string, string>) => {
+  const initServiceWithState = async (state: Record<string, ViewCacheState>) => {
     await fakeGlobalState.update(() => state);
     await service.init();
   };
@@ -106,7 +108,11 @@ describe("popup view cache", () => {
   });
 
   it("should initialize signal from state", async () => {
-    await initServiceWithState({ "foo-123": JSON.stringify("bar") });
+    await initServiceWithState({
+      "foo-123": {
+        value: JSON.stringify("bar"),
+      },
+    });
 
     const injector = TestBed.inject(Injector);
 
@@ -120,7 +126,11 @@ describe("popup view cache", () => {
   });
 
   it("should initialize form from state", async () => {
-    await initServiceWithState({ "test-form-cache": JSON.stringify({ name: "baz" }) });
+    await initServiceWithState({
+      "test-form-cache": {
+        value: JSON.stringify({ name: "baz" }),
+      },
+    });
 
     const fixture = TestBed.createComponent(TestComponent);
     const component = fixture.componentRef.instance;
@@ -138,7 +148,11 @@ describe("popup view cache", () => {
   });
 
   it("should utilize deserializer", async () => {
-    await initServiceWithState({ "foo-123": JSON.stringify("bar") });
+    await initServiceWithState({
+      "foo-123": {
+        value: JSON.stringify("bar"),
+      },
+    });
 
     const injector = TestBed.inject(Injector);
 
@@ -178,6 +192,9 @@ describe("popup view cache", () => {
     expect(messageSenderMock.send).toHaveBeenCalledWith(SAVE_VIEW_CACHE_COMMAND, {
       key: "test-signal",
       value: JSON.stringify("Foobar"),
+      options: {
+        persistNavigation: true,
+      },
     });
   });
 
@@ -192,18 +209,63 @@ describe("popup view cache", () => {
     expect(messageSenderMock.send).toHaveBeenCalledWith(SAVE_VIEW_CACHE_COMMAND, {
       key: "test-form-cache",
       value: JSON.stringify({ name: "Foobar" }),
+      options: {},
     });
   });
 
   it("should clear on 2nd navigation", async () => {
-    await initServiceWithState({ temp: "state" });
+    await initServiceWithState({
+      temp: {
+        value: "state",
+        options: {},
+      },
+    });
 
     await router.navigate(["a"]);
     expect(messageSenderMock.send).toHaveBeenCalledTimes(0);
-    expect(service["_cache"]).toEqual({ temp: "state" });
+    expect(service["_cache"]).toEqual({
+      temp: {
+        value: "state",
+        options: {},
+      },
+    });
 
     await router.navigate(["b"]);
-    expect(messageSenderMock.send).toHaveBeenCalledWith(ClEAR_VIEW_CACHE_COMMAND, {});
+    expect(messageSenderMock.send).toHaveBeenCalledWith(ClEAR_VIEW_CACHE_COMMAND, {
+      routeChange: true,
+    });
     expect(service["_cache"]).toEqual({});
+  });
+
+  it("should respect persistNavigation setting on 2nd navigation", async () => {
+    await initServiceWithState({
+      keepState: {
+        value: "state",
+        options: {
+          persistNavigation: true,
+        },
+      },
+      removeState: {
+        value: "state",
+        options: {
+          persistNavigation: false,
+        },
+      },
+    });
+
+    await router.navigate(["a"]); // first navigation covered in previous test
+
+    await router.navigate(["b"]);
+    expect(messageSenderMock.send).toHaveBeenCalledWith(ClEAR_VIEW_CACHE_COMMAND, {
+      routeChange: true,
+    });
+    expect(service["_cache"]).toEqual({
+      keepState: {
+        value: "state",
+        options: {
+          persistNavigation: true,
+        },
+      },
+    });
   });
 });

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -50,6 +50,7 @@ export class VaultPopupItemsService {
   private cachedSearchText = inject(PopupViewCacheService).signal<string>({
     key: "vault-search-text",
     initialValue: "",
+    persistNavigation: true,
   });
 
   readonly searchText$ = toObservable(this.cachedSearchText);

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -188,6 +188,7 @@ export class VaultPopupListFiltersService {
       key: "vault-filters",
       initialValue: {},
       deserializer: (v) => v,
+      persistNavigation: true,
     });
 
     this.deserializeFilters(cachedFilters());

--- a/libs/angular/src/platform/abstractions/view-cache.service.ts
+++ b/libs/angular/src/platform/abstractions/view-cache.service.ts
@@ -18,6 +18,11 @@ type BaseCacheOptions<T> = {
 
   /** An optional injector. Required if the method is called outside of an injection context. */
   injector?: Injector;
+
+  /**
+   * Optional flag to persist the cached value between navigation events.
+   */
+  persistNavigation?: boolean;
 } & (T extends JsonValue ? Deserializer<T> : Required<Deserializer<T>>);
 
 export type SignalCacheOptions<T> = BaseCacheOptions<T> & {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20433](https://bitwarden.atlassian.net/browse/PM-20433)

## 📔 Objective

#13742 introduced a change to prevent clearing the popup view cache when navigating within the vault to persist vault filters. This inadvertently prevents clearing the cipher form cache when the user clicks the back/cancel buttons.

To address this the view cache service was internally refactored to support an optional `persistNavigation` option. When present on a cached signal/form group, the view cache service will **NOT** clear the value on navigation events in the popup/foreground. The values are still cleared automatically after the 2-minute timer.

Example usage:

```ts
const cachedFilters = this.viewCacheService.signal<CachedFilterState>({
      key: "vault-filters",
      initialValue: {},
      deserializer: (v) => v,
      persistNavigation: true,
});
```

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/942bb0d2-a64a-461e-8308-d909dafa931a" /> | <video src="https://github.com/user-attachments/assets/6ab6b6bd-85fd-44e7-8096-031b2e0b4c74" /> | 







## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20433]: https://bitwarden.atlassian.net/browse/PM-20433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ