### PR TITLE
[PM-20448] Only import BrowserModule once

### DIFF
--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -4,6 +4,7 @@ import "zone.js";
 import "../platform/app/locales";
 
 import { NgModule } from "@angular/core";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
 import { ColorPasswordCountPipe } from "@bitwarden/angular/pipes/color-password-count.pipe";
 import { ColorPasswordPipe } from "@bitwarden/angular/pipes/color-password.pipe";
@@ -44,6 +45,8 @@ import { SharedModule } from "./shared/shared.module";
 
 @NgModule({
   imports: [
+    BrowserAnimationsModule,
+
     SharedModule,
     AppRoutingModule,
     VaultFilterModule,

--- a/apps/desktop/src/app/shared/shared.module.ts
+++ b/apps/desktop/src/app/shared/shared.module.ts
@@ -2,11 +2,9 @@ import { A11yModule } from "@angular/cdk/a11y";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 import { OverlayModule } from "@angular/cdk/overlay";
 import { ScrollingModule } from "@angular/cdk/scrolling";
-import { DatePipe } from "@angular/common";
+import { CommonModule, DatePipe } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { BrowserModule } from "@angular/platform-browser";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 
@@ -15,9 +13,8 @@ import { ServicesModule } from "../services/services.module";
 
 @NgModule({
   imports: [
+    CommonModule,
     A11yModule,
-    BrowserAnimationsModule,
-    BrowserModule,
     DragDropModule,
     FormsModule,
     JslibModule,
@@ -28,9 +25,8 @@ import { ServicesModule } from "../services/services.module";
   ],
   declarations: [AvatarComponent],
   exports: [
+    CommonModule,
     A11yModule,
-    BrowserAnimationsModule,
-    BrowserModule,
     DatePipe,
     DragDropModule,
     FormsModule,

--- a/apps/desktop/src/vault/app/vault/vault-filter/vault-filter.module.ts
+++ b/apps/desktop/src/vault/app/vault/vault-filter/vault-filter.module.ts
@@ -1,5 +1,5 @@
+import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
-import { BrowserModule } from "@angular/platform-browser";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DeprecatedVaultFilterService as DeprecatedVaultFilterServiceAbstraction } from "@bitwarden/angular/vault/abstractions/deprecated-vault-filter.service";
@@ -13,7 +13,7 @@ import { TypeFilterComponent } from "./filters/type-filter.component";
 import { VaultFilterComponent } from "./vault-filter.component";
 
 @NgModule({
-  imports: [BrowserModule, JslibModule],
+  imports: [CommonModule, JslibModule],
   declarations: [
     VaultFilterComponent,
     CollectionFilterComponent,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20448
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Desktop imported `BrowserModule` & `BrowserAnimationModule` multiple times which can result in compile errors. Following the patterns used in our other clients this updates the BrowserModule import to only occur in `app.module`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
