### PR TITLE
Make passkey header sticky

### DIFF
--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.html
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.html
@@ -1,7 +1,7 @@
 <div class="tw-flex tw-flex-col tw-h-full">
   <bit-section
     disableMargin
-    class="tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
+    class="passkey-header-sticky tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
     <bit-section-header class="passkey-header tw-bg-background">
       <div class="tw-flex tw-items-center">

--- a/apps/desktop/src/modal/passkeys/fido2-vault.component.html
+++ b/apps/desktop/src/modal/passkeys/fido2-vault.component.html
@@ -1,7 +1,7 @@
 <div class="tw-flex tw-flex-col tw-h-full">
   <bit-section
     disableMargin
-    class="tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
+    class="passkey-header-sticky tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
     <bit-section-header class="passkey-header tw-bg-background">
       <div class="tw-flex tw-items-center">

--- a/apps/desktop/src/scss/header.scss
+++ b/apps/desktop/src/scss/header.scss
@@ -240,3 +240,9 @@
 .passkey-header-close {
   -webkit-app-region: no-drag;
 }
+
+.passkey-header-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20346](https://bitwarden.atlassian.net/browse/PM-20346)

## 📔 Objective

Set the passkey header to be sticky in the modal for creating or selecting a passkey.

## 📸 Screenshots


https://github.com/user-attachments/assets/272a830d-69c9-4e56-b285-4438f463d467


https://github.com/user-attachments/assets/916a3bb1-05b9-46b6-b500-0b4e79ddab05



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20346]: https://bitwarden.atlassian.net/browse/PM-20346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ