### PR TITLE
[PM-19923] Update autofocus directive to be more aggressive in focusing

### DIFF
--- a/libs/components/src/input/autofocus.directive.ts
+++ b/libs/components/src/input/autofocus.directive.ts
@@ -50,8 +50,11 @@ export class AutofocusDirective implements AfterContentChecked {
       return;
     }
 
-    // Wait until the element is visible before attempting to focus it.
-    if (this.getElement()?.checkVisibility({ visibilityProperty: true })) {
+    // Wait until the element is visible before attempting to focus it. `checkVisibility` might
+    // not be available everywhere so fallback to focusing when it's missing.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility
+    const el = this.getElement();
+    if (el && (el.checkVisibility == null || el.checkVisibility({ visibilityProperty: true }))) {
       this.focused = true;
 
       if (!Utils.isMobileBrowser && this.autofocus) {

--- a/libs/components/src/input/autofocus.directive.ts
+++ b/libs/components/src/input/autofocus.directive.ts
@@ -51,7 +51,7 @@ export class AutofocusDirective implements AfterContentChecked {
     }
 
     // Wait until the element is visible before attempting to focus it. `checkVisibility` might
-    // not be available everywhere so fallback to focusing when it's missing.
+    // not be available everywhere so fallback to focusing immediately if it's missing.
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility
     const el = this.getElement();
     if (el && (el.checkVisibility == null || el.checkVisibility({ visibilityProperty: true }))) {

--- a/libs/components/src/input/autofocus.directive.ts
+++ b/libs/components/src/input/autofocus.directive.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, ElementRef, Input, NgZone, OnInit, Optional } from "@angular/core";
+import { AfterContentChecked, Directive, ElementRef, Input, NgZone, Optional } from "@angular/core";
 import { take } from "rxjs/operators";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -12,18 +12,23 @@ import { FocusableElement } from "../shared/focusable-element";
  *
  * @remarks
  *
+ * Will focus the element once, when it becomes visible.
+ *
  * If the component provides the `FocusableElement` interface, the `focus`
  * method will be called. Otherwise, the native element will be focused.
  */
 @Directive({
   selector: "[appAutofocus], [bitAutofocus]",
 })
-export class AutofocusDirective implements OnInit {
+export class AutofocusDirective implements AfterContentChecked {
   @Input() set appAutofocus(condition: boolean | string) {
     this.autofocus = condition === "" || condition === true;
   }
 
   private autofocus: boolean;
+
+  // Track if we have already focused the element.
+  private focused = false;
 
   constructor(
     private el: ElementRef,
@@ -31,21 +36,43 @@ export class AutofocusDirective implements OnInit {
     @Optional() private focusableElement: FocusableElement,
   ) {}
 
-  ngOnInit() {
-    if (!Utils.isMobileBrowser && this.autofocus) {
-      if (this.ngZone.isStable) {
-        this.focus();
-      } else {
-        this.ngZone.onStable.pipe(take(1)).subscribe(this.focus.bind(this));
+  /**
+   * Using AfterContentChecked is a hack to ensure we only focus once. This is because
+   * the element may not be in the DOM when the directive is created, and we want to
+   * wait until it is in the DOM.
+   *
+   * Note: This might break in the future since it relies on Angular change detection
+   * to trigger after the element becomes visible.
+   */
+  ngAfterContentChecked() {
+    // We only want to focus the element on initial render.
+    if (this.focused) {
+      return;
+    }
+
+    // Wait until the element is visible before attempting to focus it.
+    if (this.getElement()?.checkVisibility({ visibilityProperty: true })) {
+      this.focused = true;
+
+      if (!Utils.isMobileBrowser && this.autofocus) {
+        if (this.ngZone.isStable) {
+          this.focus();
+        } else {
+          this.ngZone.onStable.pipe(take(1)).subscribe(this.focus.bind(this));
+        }
       }
     }
   }
 
   private focus() {
+    this.getElement().focus();
+  }
+
+  private getElement() {
     if (this.focusableElement) {
-      this.focusableElement.getFocusTarget().focus();
-    } else {
-      this.el.nativeElement.focus();
+      return this.focusableElement.getFocusTarget();
     }
+
+    return this.el.nativeElement;
   }
 }

--- a/libs/components/src/search/search.component.ts
+++ b/libs/components/src/search/search.component.ts
@@ -49,7 +49,7 @@ export class SearchComponent implements ControlValueAccessor, FocusableElement {
   @Input() autocomplete: string;
 
   getFocusTarget() {
-    return this.input.nativeElement;
+    return this.input?.nativeElement;
   }
 
   onChange(searchText: string) {

--- a/libs/components/src/shared/focusable-element.ts
+++ b/libs/components/src/shared/focusable-element.ts
@@ -6,5 +6,5 @@
  * Used by the `AutofocusDirective` and `A11yGridDirective`.
  */
 export abstract class FocusableElement {
-  getFocusTarget: () => HTMLElement;
+  getFocusTarget: () => HTMLElement | undefined;
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19923

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We have a directive called autofocus which serves to automatically focus a component when it is created. However certain "page level" components supports dynamically showing a loading state. This works by hiding the actual content and displaying a spinner on top of it.

In those scenarios elements like the `SearchComponent` which uses the autofocus directive are created before they are even in the DOM and certainly before they end up being visible.

This PR aims to solve this issue by changing the autofocus implementation to continually check focus conditions when angular change detection is run. In order to prevent repeat focus certain conditions apply. Such as only focusing once and making sure the element is visible before focusing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
