### PR TITLE
[PM-19677] Browser integration verification always re-prompts after desktop app is locked

### DIFF
--- a/apps/desktop/src/services/biometric-message-handler.service.spec.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.spec.ts
@@ -1,6 +1,6 @@
 import { NgZone } from "@angular/core";
 import { mock, MockProxy } from "jest-mock-extended";
-import { of } from "rxjs";
+import { BehaviorSubject, filter, firstValueFrom, of, take, timeout, timer } from "rxjs";
 
 import { AccountInfo, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -73,10 +73,13 @@ describe("BiometricMessageHandlerService", () => {
     ngZone = mock<NgZone>();
     i18nService = mock<I18nMockService>();
 
+    desktopSettingsService.browserIntegrationEnabled$ = of(false);
+    desktopSettingsService.browserIntegrationFingerprintEnabled$ = of(false);
+
     (global as any).ipc = {
       platform: {
         ephemeralStore: {
-          listEphemeralValueKeys: jest.fn(),
+          listEphemeralValueKeys: jest.fn(() => Promise.resolve([])),
           getEphemeralValue: jest.fn(),
           removeEphemeralValue: jest.fn(),
           setEphemeralValue: jest.fn(),
@@ -105,6 +108,129 @@ describe("BiometricMessageHandlerService", () => {
       ngZone,
       i18nService,
     );
+  });
+
+  describe("constructor", () => {
+    let browserIntegrationEnabled = new BehaviorSubject<boolean>(true);
+    let browserIntegrationFingerprintEnabled = new BehaviorSubject<boolean>(true);
+
+    beforeEach(async () => {
+      (global as any).ipc = {
+        platform: {
+          ephemeralStore: {
+            listEphemeralValueKeys: jest.fn(() =>
+              Promise.resolve(["connectedApp_appId1", "connectedApp_appId2"]),
+            ),
+            getEphemeralValue: jest.fn((key) => {
+              if (key === "connectedApp_appId1") {
+                return Promise.resolve(
+                  JSON.stringify({
+                    publicKey: Utils.fromUtf8ToB64("publicKeyApp1"),
+                    sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp1"),
+                    trusted: true,
+                  }),
+                );
+              } else if (key === "connectedApp_appId2") {
+                return Promise.resolve(
+                  JSON.stringify({
+                    publicKey: Utils.fromUtf8ToB64("publicKeyApp2"),
+                    sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp2"),
+                    trusted: false,
+                  }),
+                );
+              }
+              return Promise.resolve(null);
+            }),
+            removeEphemeralValue: jest.fn(),
+            setEphemeralValue: jest.fn(),
+          },
+        },
+      };
+
+      desktopSettingsService.browserIntegrationEnabled$ = browserIntegrationEnabled.asObservable();
+      desktopSettingsService.browserIntegrationFingerprintEnabled$ =
+        browserIntegrationFingerprintEnabled.asObservable();
+
+      service = new BiometricMessageHandlerService(
+        cryptoFunctionService,
+        keyService,
+        encryptService,
+        logService,
+        messagingService,
+        desktopSettingsService,
+        biometricStateService,
+        biometricsService,
+        dialogService,
+        accountService,
+        authService,
+        ngZone,
+        i18nService,
+      );
+    });
+
+    afterEach(() => {
+      browserIntegrationEnabled = new BehaviorSubject<boolean>(true);
+      browserIntegrationFingerprintEnabled = new BehaviorSubject<boolean>(true);
+
+      desktopSettingsService.browserIntegrationEnabled$ = browserIntegrationEnabled.asObservable();
+      desktopSettingsService.browserIntegrationFingerprintEnabled$ =
+        browserIntegrationFingerprintEnabled.asObservable();
+    });
+
+    it("should clear connected apps when browser integration disabled", async () => {
+      browserIntegrationEnabled.next(false);
+
+      await firstValueFrom(
+        timer(0, 100).pipe(
+          filter(
+            () =>
+              (global as any).ipc.platform.ephemeralStore.removeEphemeralValue.mock.calls.length ==
+              2,
+          ),
+          take(1),
+          timeout(1000),
+        ),
+      );
+
+      expect((global as any).ipc.platform.ephemeralStore.removeEphemeralValue).toHaveBeenCalledWith(
+        "connectedApp_appId1",
+      );
+      expect((global as any).ipc.platform.ephemeralStore.removeEphemeralValue).toHaveBeenCalledWith(
+        "connectedApp_appId2",
+      );
+    });
+
+    it("should un-trust connected apps when browser integration verification fingerprint disabled", async () => {
+      browserIntegrationFingerprintEnabled.next(false);
+
+      await firstValueFrom(
+        timer(0, 100).pipe(
+          filter(
+            () =>
+              (global as any).ipc.platform.ephemeralStore.setEphemeralValue.mock.calls.length == 2,
+          ),
+          take(1),
+          timeout(1000),
+        ),
+      );
+
+      expect((global as any).ipc.platform.ephemeralStore.setEphemeralValue).toHaveBeenCalledWith(
+        "connectedApp_appId1",
+        JSON.stringify({
+          publicKey: Utils.fromUtf8ToB64("publicKeyApp1"),
+          sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp1"),
+          trusted: false,
+        }),
+      );
+      expect((global as any).ipc.platform.ephemeralStore.setEphemeralValue).toHaveBeenCalledWith(
+        "connectedApp_appId2",
+        JSON.stringify({
+          publicKey: Utils.fromUtf8ToB64("publicKeyApp2"),
+          sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp2"),
+          trusted: false,
+        }),
+      );
+    });
   });
 
   describe("setup encryption", () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19677

## 📔 Objective

Browser integration verification always re-prompts after desktop app is locked.
Can also be reproduced by disabling and re-enabling the fingerprint verification in Desktop app.

When a browser integration setting or fingerprint verification setting changes in Desktop app, we have a mechanism to remove any existing browser extension connections.
The idea is correct, but the implementation needs to be a bit different:
- We should only remove existing connections when browser integration is disabled - The bug happens because the observable that holds the browser integration setting (or the fingerprint verification setting) changes value causing the subscription to be called, and since we do not check for the value, we remove existing connections
- We should un-trust the existing connections when fingerprint verification setting is disabled. When it's re-enabled, browser extension will be asked to confirm the fingerprint again - at the moment we remove existing connections, which is incorrect.

## 📸 Screenshots

Fingerprint verification setting enabled at 1 minute 10 seconds. No subsequent fingerprint popup confirmation needed at Unlock after desktop app and browser extension locked at 1 minute 38 seconds.

https://github.com/user-attachments/assets/f072bfb4-ba1e-4b58-9cdb-611324c8af4e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
