### PR TITLE
fix: remove unsafe from extern functions

### DIFF
--- a/apps/desktop/desktop_native/objc/src/lib.rs
+++ b/apps/desktop/desktop_native/objc/src/lib.rs
@@ -68,13 +68,13 @@ mod objc {
 
     use super::*;
 
-    unsafe extern "C" {
-        pub unsafe fn runCommand(context: *mut c_void, value: *const c_char);
-        pub unsafe fn freeObjCString(value: &ObjCString);
+    extern "C" {
+        pub fn runCommand(context: *mut c_void, value: *const c_char);
+        pub fn freeObjCString(value: &ObjCString);
     }
 
     /// This function is called from the ObjC code to return the output of the command
-    #[unsafe(no_mangle)]
+    #[no_mangle]
     pub extern "C" fn commandReturn(context: &mut CommandContext, value: ObjCString) -> bool {
         let value: String = match value.try_into() {
             Ok(value) => value,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

I was getting errors about this being unsupported. Extern functions seem to be unsafe be definition anyways so no need to explicitly state it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
