### PR TITLE
[BRE-784] Fixing web vault build to pull valid server ref

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -133,8 +133,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Get Latest Core Version
-        id: get-core
+      - name: Get Latest Server Version
+        id: latest-server-version
         uses: bitwarden/gh-actions/get-release-version@main
         with:
           repository: bitwarden/server
@@ -143,7 +143,7 @@ jobs:
       - name: Set Server Ref
         id: set-server-ref
         run: |
-          SERVER_REF="${{ steps.get-core.outputs.version }}"
+          SERVER_REF="${{ steps.latest-server-version.outputs.version }}"
           echo "Latest server release version: $SERVER_REF"
           if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             SERVER_REF="$GITHUB_REF"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-784](https://bitwarden.atlassian.net/browse/BRE-784)

## 📔 Objective

Fix the server ref that's used when cloning the server repository so that a valid ref is always used:
| Client ref | Server ref |
| -------- | ------- |
| main  | main    |
| rc | rc     |
| PR | main |
| tags/branches/etc. | `<latest server release tag>` |

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-784]: https://bitwarden.atlassian.net/browse/BRE-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ