### PR TITLE
[PM-16202] Replace `VaultProfileService`

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/new-settings-callout/new-settings-callout.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-settings-callout/new-settings-callout.component.ts
@@ -4,7 +4,7 @@ import { Router } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -28,12 +28,12 @@ export class NewSettingsCalloutComponent implements OnInit, OnDestroy {
 
   constructor(
     private accountService: AccountService,
-    private vaultProfileService: VaultProfileService,
     private vaultPageService: VaultPageService,
     private router: Router,
     private logService: LogService,
     private copyButtonService: VaultPopupCopyButtonsService,
     private vaultSettingsService: VaultSettingsService,
+    private apiService: ApiService,
   ) {}
 
   async ngOnInit() {
@@ -47,7 +47,9 @@ export class NewSettingsCalloutComponent implements OnInit, OnDestroy {
     let profileCreatedDate: Date;
 
     try {
-      profileCreatedDate = await this.vaultProfileService.getProfileCreationDate(this.activeUserId);
+      const profile = await this.apiService.getProfile();
+
+      profileCreatedDate = new Date(profile.creationDate);
     } catch (e) {
       this.logService.error("Error getting profile creation date", e);
       // Default to before the cutoff date to ensure the callout is shown


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16202](https://bitwarden.atlassian.net/browse/PM-16202)

## 📔 Objective

Replace the usage of [VaultProfileService](https://github.com/bitwarden/clients/blob/63524af27aa8bf2c9ac2ede1114660ea16108648/libs/angular/src/vault/services/vault-profile.service.ts#L17) outside the New Device Verification work.
- The original purpose of the `VaultProfileService` was to retrieve user details that were:
  - not available on the account object 
  - not available until a sync occurred 
- With the rollout out of the unuthenicated work, a sync now occurs when the user logs in and thus the creation date of the account can be stored on the account object and be available to consumers. 
  - I added `creationDate` to the `Account` type and saved the property upon syncing.  
  - This had a rather large impact to satisfy all locations that the `Account` type is used. 
- All code associated with `VaultProfileService` and `NewDeviceVerificationNoticeGuard` will be removed all together in [PM-18485](https://bitwarden.atlassian.net/browse/PM-18485) and stacked on this work. 

## 📸 Screenshots

N/A

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16202]: https://bitwarden.atlassian.net/browse/PM-16202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-18485]: https://bitwarden.atlassian.net/browse/PM-18485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ