### PR TITLE
Filter available cipher results

### DIFF
--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit, OnDestroy } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
+import { autofill } from "desktop_native/napi";
 import { BehaviorSubject, firstValueFrom, map, Observable } from "rxjs";
 
-import { autofill } from "desktop_native/napi";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { BitwardenShield } from "@bitwarden/auth/angular";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -112,9 +112,6 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
           this.ciphersSubject.next(excludedCiphers);
         } else {
           const relevantCiphers = ciphers.filter((cipher) => {
-            const credentialId = cipher.login.hasFido2Credentials
-              ? Array.from(parseCredentialId(cipher.login.fido2Credentials[0]?.credentialId))
-              : [];
             if (this.eligibleFido2Credential(cipher, lastRegistrationRequest)) {
               return true;
             }
@@ -151,7 +148,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
 
   /* Check if cipher's username matches the form input. */
   cipherMatchesUserName(cipher: CipherView, userName: string): boolean {
-    return cipher.login.username === userName;
+    return cipher.login.username === userName && !cipher.login.fido2Credentials;
   }
 
   async addPasskeyToCipher(cipher: CipherView) {

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -131,18 +131,22 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     return !cipher.login || !cipher.login.hasUris || cipher.deletedDate;
   }
 
-  /* Determines whether a cipher contains a FIDO2 credential that is eligible for registration. */
+  /*
+   * Determines whether a cipher contains a FIDO2 credential that is eligible for registration.
+   * If the userHandle values are both empty they are not eligible, so ignore them.
+   * */
   eligibleFido2Credential(
     cipher: CipherView,
     lastRegistrationRequest: autofill.PasskeyRegistrationRequest,
   ) {
     return (
-      (cipher.login.fido2Credentials.some((passkey) => {
+      cipher.login.fido2Credentials.some((passkey) => {
         const passkeyUserHandle = Fido2Utils.stringToBuffer(passkey.userHandle) || new Uint8Array();
-        compareCredentialIds(passkeyUserHandle, new Uint8Array(lastRegistrationRequest.userHandle));
-      }) ||
-        this.cipherMatchesUserName(cipher, lastRegistrationRequest.userName)) &&
-      !this.invalidFido2Credential(cipher)
+        const lastRegistrationUserHandle = new Uint8Array(lastRegistrationRequest.userHandle);
+        if (passkeyUserHandle.length > 0 || lastRegistrationUserHandle.length > 0) {
+          compareCredentialIds(passkeyUserHandle, lastRegistrationUserHandle);
+        }
+      }) && !this.invalidFido2Credential(cipher)
     );
   }
 

--- a/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
+++ b/apps/desktop/src/modal/passkeys/create/fido2-create.component.ts
@@ -150,11 +150,6 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     );
   }
 
-  /* Check if cipher's username matches the form input. */
-  cipherMatchesUserName(cipher: CipherView, userName: string): boolean {
-    return cipher.login.username === userName && !cipher.login.fido2Credentials;
-  }
-
   async addPasskeyToCipher(cipher: CipherView) {
     let isConfirmed = true;
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20347](https://bitwarden.atlassian.net/browse/PM-20347)

## 📔 Objective

Filter the available ciphers so we only display ciphers that are valid and match the username or userhandle.

Previously all available ciphers were being displayed and we weren't filtering on validity, or a userHandle/username match.

Now, two checks are made against a cipher to make sure it matches the `lastRegistrationRequest`.
* The cipher is valid to use with Fido2.  It is a login cipher, matches the uri, and and is not in the trash.
* Matches the `userHandle` (or matches the `username` for logins that don't have Fido2 credentials).

To Test this create a login cipher, for example `pm20347` for webauthn.io.
* Move the cipher to the trash
* Visit webauthn.io and use `pm20347` in the field.
* Choose `register`.  You should not see the cipher available.  Cancel out of the process.
* Restore the cipher from the trash and follow the previous flow.  Now the cipher should be available to add a passkey.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20347]: https://bitwarden.atlassian.net/browse/PM-20347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ