### PR TITLE
[PM-20344] Export: Attachments with the same name are not included/overwritten

### DIFF
--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
@@ -380,18 +380,18 @@ describe("VaultExportService", () => {
       expect(attachment).toBeDefined();
     });
 
-    it("If a ciphers attachments filename is already present in the zipfile then append underscore and attachmentId for the new filename", async () => {
+    it("For each cipher attachment create a dedicated folder with the attachmentId as the name to put the attachment in", async () => {
       const cipherData = new CipherData();
       cipherData.id = "mock-id";
       const cipherView = new CipherView(new Cipher(cipherData));
       // Create 1st attachment with the same filename for the cipher
       const attachmentView = new AttachmentView(new Attachment(new AttachmentData()));
       attachmentView.id = "id-of-file-1";
-      attachmentView.fileName = "mock-file-name";
+      attachmentView.fileName = "mock-file-name.txt";
       // Create 2nd attachment with the same filename for the cipher
       const attachmentView2 = new AttachmentView(new Attachment(new AttachmentData()));
       attachmentView2.id = "id-of-file-2";
-      attachmentView2.fileName = "mock-file-name";
+      attachmentView2.fileName = "mock-file-name.txt";
       cipherView.attachments = [attachmentView, attachmentView2];
       cipherService.getAllDecrypted.mockResolvedValue([cipherView]);
       folderService.getAllDecryptedFromState.mockResolvedValue([]);
@@ -409,10 +409,12 @@ describe("VaultExportService", () => {
       expect(exportedVault.type).toBe("application/zip");
       const exportZip = exportedVault as ExportedVaultAsBlob;
       const zip = await JSZip.loadAsync(exportZip.data);
-      const attachment = await zip.file("attachments/mock-id/mock-file-name")?.async("blob");
+      const attachment = await zip
+        .file("attachments/mock-id/id-of-file-1/mock-file-name.txt")
+        ?.async("blob");
       expect(attachment).toBeDefined();
       const attachment2 = await zip
-        .file("attachments/mock-id/mock-file-name_id-of-file-2")
+        .file("attachments/mock-id/id-of-file-2/mock-file-name.txt")
         ?.async("blob");
       expect(attachment2).toBeDefined();
     });

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.spec.ts
@@ -379,6 +379,43 @@ describe("VaultExportService", () => {
       const attachment = await zip.file("attachments/mock-id/mock-file-name")?.async("blob");
       expect(attachment).toBeDefined();
     });
+
+    it("If a ciphers attachments filename is already present in the zipfile then append underscore and attachmentId for the new filename", async () => {
+      const cipherData = new CipherData();
+      cipherData.id = "mock-id";
+      const cipherView = new CipherView(new Cipher(cipherData));
+      // Create 1st attachment with the same filename for the cipher
+      const attachmentView = new AttachmentView(new Attachment(new AttachmentData()));
+      attachmentView.id = "id-of-file-1";
+      attachmentView.fileName = "mock-file-name";
+      // Create 2nd attachment with the same filename for the cipher
+      const attachmentView2 = new AttachmentView(new Attachment(new AttachmentData()));
+      attachmentView2.id = "id-of-file-2";
+      attachmentView2.fileName = "mock-file-name";
+      cipherView.attachments = [attachmentView, attachmentView2];
+      cipherService.getAllDecrypted.mockResolvedValue([cipherView]);
+      folderService.getAllDecryptedFromState.mockResolvedValue([]);
+      encryptService.decryptToBytes.mockResolvedValue(new Uint8Array(255));
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(255)),
+        }),
+      ) as any;
+      global.Request = jest.fn(() => {}) as any;
+
+      const exportedVault = await exportService.getExport("zip");
+
+      expect(exportedVault.type).toBe("application/zip");
+      const exportZip = exportedVault as ExportedVaultAsBlob;
+      const zip = await JSZip.loadAsync(exportZip.data);
+      const attachment = await zip.file("attachments/mock-id/mock-file-name")?.async("blob");
+      expect(attachment).toBeDefined();
+      const attachment2 = await zip
+        .file("attachments/mock-id/mock-file-name_id-of-file-2")
+        ?.async("blob");
+      expect(attachment2).toBeDefined();
+    });
   });
 
   describe("password protected export", () => {

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
@@ -117,6 +117,12 @@ export class IndividualVaultExportService
       for (const attachment of cipher.attachments) {
         const response = await this.downloadAttachment(cipher.id, attachment.id);
         const decBuf = await this.decryptAttachment(cipher, attachment, response);
+
+        // To prevent files with the same name from overwriting each other, we append the attachment id to the file name,
+        // if a file with the same name already exists in the folder
+        if (cipherFolder.file(attachment.fileName) != null) {
+          attachment.fileName += `_${attachment.id}`;
+        }
         cipherFolder.file(attachment.fileName, decBuf);
       }
     }

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
@@ -118,12 +118,10 @@ export class IndividualVaultExportService
         const response = await this.downloadAttachment(cipher.id, attachment.id);
         const decBuf = await this.decryptAttachment(cipher, attachment, response);
 
-        // To prevent files with the same name from overwriting each other, we append the attachment id to the file name,
-        // if a file with the same name already exists in the folder
-        if (cipherFolder.file(attachment.fileName) != null) {
-          attachment.fileName += `_${attachment.id}`;
-        }
-        cipherFolder.file(attachment.fileName, decBuf);
+        // To prevent files with the same name from overwriting each other, a folder with the attachmentId is created and then the attachment is saved within it
+        // This also has the benefit of retaining the attachmentId, which is useful when restoring backups
+        const attachmentIdFolder = cipherFolder.folder(attachment.id);
+        attachmentIdFolder.file(attachment.fileName, decBuf);
       }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20344

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In case a cipher has 2 attachments with the same filename, they were overwritten within the zip export

~~This appends an underscore as a separator and the attachmentId to truly distinguish the files by name~~
This create a folder for each attachment and uses the `attachmentId` as the folder-name. The previous solution did not take file extensions into account, which occurred to me late last night. The solution proposed by @kpiris down below, is nice and simple. It also has the added benefit of retaining the attachmentId which might be handy when restoring a backup.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
