### PR TITLE
[PM-20505] Weak-passwords-report: refresh rows after edit

### DIFF
--- a/apps/web/src/app/tools/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/cipher-report.component.ts
@@ -205,14 +205,24 @@ export class CipherReportComponent implements OnDestroy {
       return;
     }
 
+    await this.refresh(result, cipher, formConfig);
     // If the dialog was closed by deleting the cipher, refresh the report.
     if (result === VaultItemDialogResult.Deleted || result === VaultItemDialogResult.Saved) {
-      await this.load();
+      // await this.load();
+      await this.refresh(result, cipher, formConfig);
     }
   }
 
   protected async setCiphers() {
     this.allCiphers = [];
+  }
+
+  protected async refresh(
+    result: VaultItemDialogResult,
+    cipher: CipherView,
+    formConfig: CipherFormConfig,
+  ) {
+    await this.load();
   }
 
   protected async repromptCipher(c: CipherView) {

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -363,6 +363,8 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
       this.formConfig.mode = "edit";
       this.formConfig.initialValues = null;
     }
+
+    // NOTE: cipherService returns cached data not the updated data
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     let cipher = await this.cipherService.get(cipherView.id, activeUserId);
 
@@ -381,6 +383,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
 
     // Store the updated cipher so any following edits use the most up to date cipher
     this.formConfig.originalCipher = cipher;
+    this.formConfig.updatedCipherView = await this.getCipherViewFromCipher(cipher);
     this._cipherModified = true;
     await this.changeMode("view");
   }
@@ -501,9 +504,14 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     if (config.originalCipher == null) {
       return;
     }
+
+    return await this.getCipherViewFromCipher(config.originalCipher);
+  }
+
+  private async getCipherViewFromCipher(cipher: Cipher) {
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    return await config.originalCipher.decrypt(
-      await this.cipherService.getKeyForCipherKeyDecryption(config.originalCipher, activeUserId),
+    return await cipher.decrypt(
+      await this.cipherService.getKeyForCipherKeyDecryption(cipher, activeUserId),
     );
   }
 

--- a/libs/vault/src/cipher-form/abstractions/cipher-form-config.service.ts
+++ b/libs/vault/src/cipher-form/abstractions/cipher-form-config.service.ts
@@ -3,6 +3,7 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 
 /**
@@ -109,6 +110,9 @@ type BaseCipherFormConfig = {
 
   /** True when the config is built within the context of the Admin Console */
   isAdminConsole?: true;
+
+  /* updated CipherView */
+  updatedCipherView?: CipherView;
 };
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20505

## 📔 Objective

In the weak-passwords report - after any cipher is edited, the entire report loads again.
The objective of this PR is to avoid reload of the entire dataset, rather, refresh the report with the updated data for the edited record.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
