### PR TITLE
[PM-20587] Fix unawaited calls to set login email

### DIFF
--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
@@ -284,7 +284,6 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async approveFromOtherDevice() {
-    await this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["/login-with-device"]);
   }
 
@@ -297,7 +296,6 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async requestAdminApproval() {
-    await this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["/admin-approval-requested"]);
   }
 

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
@@ -284,7 +284,7 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async approveFromOtherDevice() {
-    this.loginEmailService.setLoginEmail(this.email);
+    await this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["/login-with-device"]);
   }
 
@@ -297,7 +297,7 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async requestAdminApproval() {
-    this.loginEmailService.setLoginEmail(this.email);
+    await this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["/admin-approval-requested"]);
   }
 

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { IsActiveMatchOptions, Router, RouterModule } from "@angular/router";
-import { concat, firstValueFrom, map } from "rxjs";
+import { concat, filter, firstValueFrom, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
@@ -185,8 +185,11 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
     // a decryption key, so we can use the active account's email.
     const activeAccountEmail$ = this.accountService.activeAccount$.pipe(map((a) => a?.email));
     this.email =
-      (await firstValueFrom(concat(this.loginEmailService.loginEmail$, activeAccountEmail$))) ||
-      undefined;
+      (await firstValueFrom(
+        concat(this.loginEmailService.loginEmail$, activeAccountEmail$).pipe(
+          filter((email) => email != null),
+        ),
+      )) || undefined;
 
     if (!this.email) {
       await this.handleMissingEmail();

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -539,7 +539,7 @@ export class LoginComponent implements OnInit, OnDestroy {
       // If we load an email into the form, we need to initialize it for the login process as well
       // so that other login components can use it.
       // We do this here as it's possible that a user doesn't edit the email field before submitting.
-      this.loginEmailService.setLoginEmail(storedEmail);
+      await this.loginEmailService.setLoginEmail(storedEmail);
     } else {
       this.formGroup.controls.rememberEmail.setValue(false);
     }

--- a/libs/auth/src/angular/password-hint/password-hint.component.ts
+++ b/libs/auth/src/angular/password-hint/password-hint.component.ts
@@ -79,7 +79,7 @@ export class PasswordHintComponent implements OnInit {
   };
 
   protected async cancel() {
-    this.loginEmailService.setLoginEmail(this.email);
+    await this.loginEmailService.setLoginEmail(this.email);
     await this.router.navigate(["login"]);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20587

## 📔 Objective

We are setting the `loginEmail` state before navigating the user to the login decryption options, so that we have the email available.  However, we were not `await`ing the call, which meant that it was not set in state when we need to access it on the routed component.  This resulted in a race condition and an error on the first attempt to navigate to the component.

We were setting the `loginEmail` state immediately before routing to the Login Decryption Options component, which felt a bit odd, since we weren't actually logging in (at this point we have already logged in).  It violated the assumptions of the state and meant that it was not cleared correctly - since clearing it is done only in the login success handler.

Instead of persisting this, I elected to look up the user's email from either the `loginEmail` or the user's account if they are logged in.  The value that `loginEmail` was set to in the Login Decryption Options component _was_ the account email, so it is functionally the same.

Separate from this, I also fixed the other (unrelated) places where `setLoginEmail` is called to make sure they were awaited.

## 📸 Screenshots

### TDE flows
https://github.com/user-attachments/assets/e72b4774-3a74-41da-b6b3-31a3ba76fc38

### Login with Device flows

https://github.com/user-attachments/assets/39346298-e9f7-41f3-8e46-3823eeebd542

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
