### PR TITLE
chore/SRE-583 Deprecate usage of Auth-Email Header

### DIFF
--- a/libs/common/src/auth/models/request/identity-token/password-token.request.ts
+++ b/libs/common/src/auth/models/request/identity-token/password-token.request.ts
@@ -37,7 +37,7 @@ export class PasswordTokenRequest extends TokenRequest implements CaptchaProtect
   }
 
   alterIdentityTokenHeaders(headers: Headers) {
-    headers.set("Auth-Email", Utils.fromUtf8ToUrlB64(this.email));
+    // Auth-Email header is deprecated and no longer needed
   }
 
   static fromJSON(json: any) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-583

## 📔 Objective

Deprecate usage of Auth-Email Header

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
