### PR TITLE
[PM-20404]Copy update: don't reference "real" event logs

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/events.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/events.component.html
@@ -63,7 +63,7 @@
 </div>
 <bit-callout
   type="info"
-  [title]="'upgradeEventLogTitle' | i18n"
+  [title]="'upgradeEventLogTitleMessage' | i18n"
   *ngIf="loaded && usePlaceHolderEvents"
 >
   {{ "upgradeEventLogMessage" | i18n }}
@@ -125,10 +125,10 @@
       <i class="bwi bwi-2x bwi-business tw-text-primary-600"></i>
 
       <p class="tw-font-bold tw-mt-2">
-        {{ "limitedEventLogs" | i18n: ProductTierType[organization?.productTierType] }}
+        {{ "upgradeEventLogTitleMessage" | i18n }}
       </p>
       <p>
-        {{ "upgradeForFullEvents" | i18n }}
+        {{ "upgradeForFullEventsMessage" | i18n }}
       </p>
 
       <button type="button" class="tw-mt-1" bitButton buttonType="primary" (click)="changePlan()">

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -10608,20 +10608,11 @@
   "removeUnlockWithPinPolicyDesc": {
     "message": "Do not allow members to unlock their account with a PIN."
   },
-  "limitedEventLogs": {
-    "message": "$PRODUCT_TYPE$ plans do not have access to real event logs",
-    "placeholders": {
-      "product_type": {
-        "content": "$1",
-        "example": "Teams"
-      }
-    }
+  "upgradeForFullEventsMessage": {
+    "message": "Event logs are not stored for your organization. Upgrade to a Teams or Enterprise plan to get full access to organization event logs."
   },
-  "upgradeForFullEvents": {
-    "message": "Get full access to organization event logs by upgrading to a Teams or Enterprise plan."
-  },
-  "upgradeEventLogTitle" : {
-    "message" : "Upgrade for real event log data"
+  "upgradeEventLogTitleMessage" : {
+    "message" : "Upgrade to see event logs from your organization."
   },
   "upgradeEventLogMessage":{
     "message" : "These events are examples only and do not reflect real events within your Bitwarden organization."


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20404
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Internal feedback was that the term “real event logs” was confusing. We will update the copy on the informational callout and the upgrade prompt to remove references to that term.

Updated copy is shown in the annotated screenshot below:

Open Screenshot 2025-04-18 at 09.33.56.png
Screenshot 2025-04-18 at 09.33.56.png
These copy updates should show for both Free and Families organizations. 

“Upgrade to see event logs from your organization”

“Event logs are not stored for your organization. Upgrade to a Teams or Enterprise plan to get full access to organizations event logs.”
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" alt="Screenshot 2025-04-25 at 10 12 03" src="https://github.com/user-attachments/assets/06bab025-51e4-49e5-b3d0-6aef1cc46452" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
