### PR TITLE
[PM-20597] Fix linux desktop_native script

### DIFF
--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -72,5 +72,5 @@ if (process.platform === "linux") {
 
 platformTargets.forEach(([target, _]) => {
     buildNapiModule(target);
-    buildProxyBin(target, true);
+    buildProxyBin(target);
 });

--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -64,6 +64,12 @@ if (target) {
 let platformTargets = Object.entries(rustTargetsMap).filter(([_, { platform: p }]) => p === process.platform);
 console.log("Cross building native modules for the targets: ", platformTargets.map(([target, _]) => target).join(", "));
 
+// When building for Linux, we need to set some environment variables to allow cross-compilation
+if (process.platform === "linux") {
+    process.env["PKG_CONFIG_ALLOW_CROSS"] = "1";
+    process.env["PKG_CONFIG_ALL_STATIC"] = "1";
+}
+
 platformTargets.forEach(([target, _]) => {
     buildNapiModule(target);
     buildProxyBin(target, true);

--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -1,8 +1,24 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const child_process = require("child_process");
 const fs = require("fs");
+const { platform } = require("os");
 const path = require("path");
 const process = require("process");
+
+// Map of the Node arch equivalents for the rust target triplets, used to move the file to the correct location
+const rustTargetsMap = {
+    "i686-pc-windows-msvc":       { nodeArch: 'ia32', platform: 'win32'  },
+    "x86_64-pc-windows-msvc":     { nodeArch:'x64',   platform: 'win32'  },
+    "aarch64-pc-windows-msvc":    { nodeArch:'arm64', platform: 'win32'  },
+    "x86_64-apple-darwin":        { nodeArch:'x64',   platform: 'darwin' },
+    "aarch64-apple-darwin":       { nodeArch:'arm64', platform: 'darwin' },
+    'x86_64-unknown-linux-musl':  { nodeArch: 'x64',  platform: 'linux'  },
+    'aarch64-unknown-linux-musl': { nodeArch:'arm64', platform: 'linux'  },
+}
+
+// Ensure the dist directory exists
+fs.mkdirSync(path.join(__dirname, "dist"), { recursive: true });
+
 const args = process.argv.slice(2); // Get arguments passed to the script
 const mode = args.includes("--release") ? "release" : "debug";
 const targetArg = args.find(arg => arg.startsWith("--target="));
@@ -13,13 +29,21 @@ let crossPlatform = process.argv.length > 2 && process.argv[2] === "cross-platfo
 function buildNapiModule(target, release = true) {
     const targetArg = target ? `--target ${target}` : "";
     const releaseArg = release ? "--release" : "";
-    return child_process.execSync(`npm run build -- ${releaseArg} ${targetArg}`, { stdio: 'inherit', cwd: path.join(__dirname, "napi") });
+    child_process.execSync(`npm run build -- ${releaseArg} ${targetArg}`, { stdio: 'inherit', cwd: path.join(__dirname, "napi") });
 }
 
 function buildProxyBin(target, release = true) {
     const targetArg = target ? `--target ${target}` : "";
     const releaseArg = release ? "--release" : "";
-    return child_process.execSync(`cargo build --bin desktop_proxy ${releaseArg} ${targetArg}`, {stdio: 'inherit', cwd: path.join(__dirname, "proxy")});
+    child_process.execSync(`cargo build --bin desktop_proxy ${releaseArg} ${targetArg}`, {stdio: 'inherit', cwd: path.join(__dirname, "proxy")});
+    
+    if (target) {
+        // Copy the resulting binary to the dist folder
+        const targetFolder = release ? "release" : "debug";
+        const ext = process.platform === "win32" ? ".exe" : "";
+        const nodeArch = rustTargetsMap[target].nodeArch;
+        fs.copyFileSync(path.join(__dirname, "target", target, targetFolder, `desktop_proxy${ext}`), path.join(__dirname, "dist", `desktop_proxy.${process.platform}-${nodeArch}${ext}`));
+    }
 }
 
 if (!crossPlatform && !target) {
@@ -36,45 +60,11 @@ if (target) {
     return;
 }
 
-// Note that targets contains pairs of [rust target, node arch]
-// We do this to move the output binaries to a location that can
-// be easily accessed from electron-builder using ${os} and ${arch}
-let targets = [];
-switch (process.platform) {
-    case "win32":
-        targets = [
-            ["i686-pc-windows-msvc", 'ia32'],
-            ["x86_64-pc-windows-msvc", 'x64'],
-            ["aarch64-pc-windows-msvc", 'arm64']
-        ];
-    break;
+// Filter the targets based on the current platform, and build for each of them
+let platformTargets = Object.entries(rustTargetsMap).filter(([_, { platform: p }]) => p === process.platform);
+console.log("Cross building native modules for the targets: ", platformTargets.map(([target, _]) => target).join(", "));
 
-    case "darwin":
-        targets = [
-            ["x86_64-apple-darwin", 'x64'],
-            ["aarch64-apple-darwin", 'arm64']
-        ];
-    break;
-
-    default:
-        targets = [
-            ['x86_64-unknown-linux-musl', 'x64'],
-            ['aarch64-unknown-linux-musl', 'arm64']
-        ];
-
-        process.env["PKG_CONFIG_ALLOW_CROSS"] = "1";
-        process.env["PKG_CONFIG_ALL_STATIC"] = "1";
-    break;
-}
-
-console.log("Cross building native modules for the targets: ", targets.map(([target, _]) => target).join(", "));
-
-fs.mkdirSync(path.join(__dirname, "dist"), { recursive: true });
-
-targets.forEach(([target, nodeArch]) => {
+platformTargets.forEach(([target, _]) => {
     buildNapiModule(target);
-    buildProxyBin(target);
-
-    const ext = process.platform === "win32" ? ".exe" : "";
-    fs.copyFileSync(path.join(__dirname, "target", target, "release", `desktop_proxy${ext}`), path.join(__dirname, "dist", `desktop_proxy.${process.platform}-${nodeArch}${ext}`));
+    buildProxyBin(target, true);
 });

--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const child_process = require("child_process");
 const fs = require("fs");
-const { platform } = require("os");
 const path = require("path");
 const process = require("process");
 

--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -6,13 +6,13 @@ const process = require("process");
 
 // Map of the Node arch equivalents for the rust target triplets, used to move the file to the correct location
 const rustTargetsMap = {
-    "i686-pc-windows-msvc":       { nodeArch: 'ia32', platform: 'win32'  },
-    "x86_64-pc-windows-msvc":     { nodeArch:'x64',   platform: 'win32'  },
-    "aarch64-pc-windows-msvc":    { nodeArch:'arm64', platform: 'win32'  },
-    "x86_64-apple-darwin":        { nodeArch:'x64',   platform: 'darwin' },
-    "aarch64-apple-darwin":       { nodeArch:'arm64', platform: 'darwin' },
-    'x86_64-unknown-linux-musl':  { nodeArch: 'x64',  platform: 'linux'  },
-    'aarch64-unknown-linux-musl': { nodeArch:'arm64', platform: 'linux'  },
+    "i686-pc-windows-msvc":       { nodeArch: 'ia32',  platform: 'win32'  },
+    "x86_64-pc-windows-msvc":     { nodeArch: 'x64',   platform: 'win32'  },
+    "aarch64-pc-windows-msvc":    { nodeArch: 'arm64', platform: 'win32'  },
+    "x86_64-apple-darwin":        { nodeArch: 'x64',   platform: 'darwin' },
+    "aarch64-apple-darwin":       { nodeArch: 'arm64', platform: 'darwin' },
+    'x86_64-unknown-linux-musl':  { nodeArch: 'x64',   platform: 'linux'  },
+    'aarch64-unknown-linux-musl': { nodeArch: 'arm64', platform: 'linux'  },
 }
 
 // Ensure the dist directory exists


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20597

## 📔 Objective

We want the final binary to be copied to the `dist` folder even when we're compiling a specific target only, currently we're only doing it for the `cross-platform` command. 

To be able to do it without duplicating the targets array (which maps rust targets to node targets), I've extracted it to a shared object.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
