### PR TITLE
Use small buttons in extension header

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.html
@@ -1,4 +1,4 @@
-<button bitButton [bitMenuTriggerFor]="itemOptions" buttonType="primary" type="button">
+<button bitButton size="small" [bitMenuTriggerFor]="itemOptions" buttonType="primary" type="button">
   <i class="bwi bwi-plus-f" aria-hidden="true"></i>
   {{ "new" | i18n }}
 </button>

--- a/apps/browser/src/vault/popup/settings/folders-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/folders-v2.component.html
@@ -1,7 +1,13 @@
 <popup-page>
   <popup-header slot="header" [pageTitle]="'folders' | i18n" showBackButton>
     <ng-container slot="end">
-      <button bitButton buttonType="primary" type="button" (click)="openAddEditFolderDialog()">
+      <button
+        bitButton
+        size="small"
+        buttonType="primary"
+        type="button"
+        (click)="openAddEditFolderDialog()"
+      >
         <i class="bwi bwi-plus-f" aria-hidden="true"></i>
         {{ "new" | i18n }}
       </button>

--- a/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
+++ b/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
@@ -1,4 +1,4 @@
-<button bitButton [bitMenuTriggerFor]="itemOptions" buttonType="primary" type="button">
+<button bitButton size="small" [bitMenuTriggerFor]="itemOptions" buttonType="primary" type="button">
   <i *ngIf="!hideIcon" class="bwi bwi-plus-f" aria-hidden="true"></i>
   {{ (hideIcon ? "createSend" : "new") | i18n }}
 </button>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20511

## 📔 Objective

Update extension header to use new small button variant

## 📸 Screenshots

#### Vault
<img width="390" alt="image" src="https://github.com/user-attachments/assets/7f1a3182-80d5-43ec-b69d-b11bbdb62760" />

#### Send
<img width="391" alt="image" src="https://github.com/user-attachments/assets/a99ee1cf-d54a-4b82-a16f-ec3138e9c75f" />

#### Settings > Vault > Folders
<img width="390" alt="image" src="https://github.com/user-attachments/assets/f1e28373-8df0-4ce6-9311-9eb7dbed5a3b" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
