### PR TITLE
[PM-17091][PM-17043] Support system zoom in browser extension

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -62,6 +62,10 @@ export class PopupSizeService {
      * render as too tall. So if the screen height is smaller than the max possible extension height,
      * we should use that to set our extension height. Otherwise, we want to use the window.innerHeight
      * to support browser zoom.
+     *
+     * This is basically a workaround for what we consider a bug with browsers reporting the wrong
+     * available innerHeight when system zoom is turned on. If that gets fixed, we can remove the code
+     * checking the screen height.
      */
     const MAX_EXT_HEIGHT = 600;
     const extensionInnerHeight = window.innerHeight;

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -58,9 +58,10 @@ export class PopupSizeService {
     /**
      * To support both browser default zoom and system default zoom, we need to take into account
      * the full screen height. When system default zoom is >100%, window.innerHeight still outputs
-     * a height equivalent to what it would be at 100%. So if the screen height is smaller than the
-     * max possible extension height, we should use that to set our extension height. Otherwise, we
-     * want to use the window.innerHeight to support browser zoom.
+     * a height equivalent to what it would be at 100%, which can cause the extension window to
+     * render as too tall. So if the screen height is smaller than the max possible extension height,
+     * we should use that to set our extension height. Otherwise, we want to use the window.innerHeight
+     * to support browser zoom.
      */
     const MAX_EXT_HEIGHT = 600;
     const extensionInnerHeight = window.innerHeight;
@@ -70,18 +71,14 @@ export class PopupSizeService {
       screenAvailHeight < MAX_EXT_HEIGHT ? screenAvailHeight : extensionInnerHeight;
 
     if (!BrowserPopupUtils.inPopup(window) || isInChromeTab) {
-      window.document.body.classList.add("body-full");
+      window.document.documentElement.classList.add("body-full");
     } else if (availHeight < 300) {
-      window.document.body.classList.add("body-3xs");
       window.document.documentElement.classList.add("body-3xs");
     } else if (availHeight < 400) {
-      window.document.body.classList.add("body-xxs");
       window.document.documentElement.classList.add("body-xxs");
     } else if (availHeight < 500) {
-      window.document.body.classList.add("body-xs");
       window.document.documentElement.classList.add("body-xs");
     } else if (availHeight < 600) {
-      window.document.body.classList.add("body-sm");
       window.document.documentElement.classList.add("body-sm");
     }
   }

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -72,12 +72,16 @@ export class PopupSizeService {
       window.document.body.classList.add("body-full");
     } else if (availHeight < 300) {
       window.document.body.classList.add("body-3xs");
+      window.document.documentElement.classList.add("body-3xs");
     } else if (availHeight < 400) {
       window.document.body.classList.add("body-xxs");
+      window.document.documentElement.classList.add("body-xxs");
     } else if (availHeight < 500) {
       window.document.body.classList.add("body-xs");
+      window.document.documentElement.classList.add("body-xs");
     } else if (availHeight < 600) {
       window.document.body.classList.add("body-sm");
+      window.document.documentElement.classList.add("body-sm");
     }
   }
 

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -50,16 +50,33 @@ export class PopupSizeService {
       PopupSizeService.setStyle(width);
       localStorage.setItem(PopupSizeService.LocalStorageKey, width);
     });
+  }
 
+  async setHeight() {
     const isInChromeTab = await BrowserPopupUtils.isInTab();
+
+    /**
+     * To support both browser default zoom and system default zoom, we need to take into account
+     * the full screen height. When system default zoom is >100%, window.innerHeight still outputs
+     * a height equivalent to what it would be at 100%. So if the screen height is smaller than the
+     * max possible extension height, we should use that to set our extension height. Otherwise, we
+     * want to use the window.innerHeight to support browser zoom.
+     */
+    const MAX_EXT_HEIGHT = 600;
+    const extensionInnerHeight = window.innerHeight;
+    const screenAvailHeight = window.screen.availHeight;
+    const availHeight =
+      screenAvailHeight < MAX_EXT_HEIGHT ? screenAvailHeight : extensionInnerHeight;
 
     if (!BrowserPopupUtils.inPopup(window) || isInChromeTab) {
       window.document.body.classList.add("body-full");
-    } else if (window.innerHeight < 400) {
+    } else if (availHeight < 300) {
+      window.document.body.classList.add("body-3xs");
+    } else if (availHeight < 400) {
       window.document.body.classList.add("body-xxs");
-    } else if (window.innerHeight < 500) {
+    } else if (availHeight < 500) {
       window.document.body.classList.add("body-xs");
-    } else if (window.innerHeight < 600) {
+    } else if (availHeight < 600) {
       window.document.body.classList.add("body-sm");
     }
   }

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -64,10 +64,10 @@ export class PopupSizeService {
      */
     const MAX_EXT_HEIGHT = 600;
     const extensionInnerHeight = window.innerHeight;
-    const screenAvailHeight = window.screen.availHeight;
     // Use a 100px offset when calculating screen height to account for browser container elements
+    const screenAvailHeight = window.screen.availHeight - 100;
     const availHeight =
-      screenAvailHeight < MAX_EXT_HEIGHT - 100 ? screenAvailHeight - 100 : extensionInnerHeight;
+      screenAvailHeight < MAX_EXT_HEIGHT ? screenAvailHeight : extensionInnerHeight;
 
     if (!BrowserPopupUtils.inPopup(window) || isInChromeTab) {
       window.document.body.classList.add("body-full");

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -65,8 +65,9 @@ export class PopupSizeService {
     const MAX_EXT_HEIGHT = 600;
     const extensionInnerHeight = window.innerHeight;
     const screenAvailHeight = window.screen.availHeight;
+    // Use a 100px offset when calculating screen height to account for browser container elements
     const availHeight =
-      screenAvailHeight < MAX_EXT_HEIGHT ? screenAvailHeight : extensionInnerHeight;
+      screenAvailHeight < MAX_EXT_HEIGHT - 100 ? screenAvailHeight - 100 : extensionInnerHeight;
 
     if (!BrowserPopupUtils.inPopup(window) || isInChromeTab) {
       window.document.body.classList.add("body-full");

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -26,6 +26,7 @@ import {
 import { BiometricsService, BiometricStateService } from "@bitwarden/key-management";
 
 import { PopupCompactModeService } from "../platform/popup/layout/popup-compact-mode.service";
+import { PopupSizeService } from "../platform/popup/layout/popup-size.service";
 import { initPopupClosedListener } from "../platform/services/popup-view-cache-background.service";
 import { VaultBrowserStateService } from "../vault/services/vault-browser-state.service";
 
@@ -71,6 +72,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private biometricStateService: BiometricStateService,
     private biometricsService: BiometricsService,
     private deviceTrustToastService: DeviceTrustToastService,
+    private popupSizeService: PopupSizeService,
   ) {
     this.deviceTrustToastService.setupListeners$.pipe(takeUntilDestroyed()).subscribe();
   }
@@ -79,6 +81,7 @@ export class AppComponent implements OnInit, OnDestroy {
     initPopupClosedListener();
 
     this.compactModeService.init();
+    await this.popupSizeService.setHeight();
 
     // Component states must not persist between closing and reopening the popup, otherwise they become dead objects
     // Clear them aggressively to make sure this doesn't occur

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -44,6 +44,10 @@ body {
     height: 300px;
   }
 
+  &.body-3xs {
+    height: 240px;
+  }
+
   &.body-full {
     width: 100%;
     height: 100%;

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -50,7 +50,7 @@ body {
   width: 380px;
   height: 100%;
   position: relative;
-  min-height: 100vh;
+  min-height: inherit;
   overflow: hidden;
   color: $text-color;
   background-color: $background-color;

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -8,6 +8,22 @@
 
 html {
   overflow: hidden;
+
+  &.body-sm {
+    height: 500px;
+  }
+
+  &.body-xs {
+    height: 400px;
+  }
+
+  &.body-xxs {
+    height: 300px;
+  }
+
+  &.body-3xs {
+    height: 240px;
+  }
 }
 
 html,

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -8,22 +8,34 @@
 
 html {
   overflow: hidden;
+  min-height: 600px;
+  height: 100%;
 
-  // &.body-sm {
-  //   height: 500px;
-  // }
+  &.body-sm {
+    min-height: 500px;
+  }
 
-  // &.body-xs {
-  //   height: 400px;
-  // }
+  &.body-xs {
+    min-height: 400px;
+  }
 
-  // &.body-xxs {
-  //   height: 300px;
-  // }
+  &.body-xxs {
+    min-height: 300px;
+  }
 
-  // &.body-3xs {
-  //   height: 240px;
-  // }
+  &.body-3xs {
+    min-height: 240px;
+  }
+
+  &.body-full {
+    min-height: unset;
+    width: 100%;
+    height: 100%;
+
+    & body {
+      width: 100%;
+    }
+  }
 }
 
 html,
@@ -36,7 +48,7 @@ body {
 
 body {
   width: 380px;
-  height: 600px !important;
+  height: 100%;
   position: relative;
   min-height: 100vh;
   overflow: hidden;
@@ -46,27 +58,6 @@ body {
   @include themify($themes) {
     color: themed("textColor");
     background-color: themed("backgroundColor");
-  }
-
-  &.body-sm {
-    height: 500px !important;
-  }
-
-  &.body-xs {
-    height: 400px !important;
-  }
-
-  &.body-xxs {
-    height: 300px !important;
-  }
-
-  &.body-3xs {
-    height: 240px !important;
-  }
-
-  &.body-full {
-    width: 100%;
-    height: 100%;
   }
 }
 

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -9,21 +9,21 @@
 html {
   overflow: hidden;
 
-  &.body-sm {
-    height: 500px;
-  }
+  // &.body-sm {
+  //   height: 500px;
+  // }
 
-  &.body-xs {
-    height: 400px;
-  }
+  // &.body-xs {
+  //   height: 400px;
+  // }
 
-  &.body-xxs {
-    height: 300px;
-  }
+  // &.body-xxs {
+  //   height: 300px;
+  // }
 
-  &.body-3xs {
-    height: 240px;
-  }
+  // &.body-3xs {
+  //   height: 240px;
+  // }
 }
 
 html,
@@ -36,7 +36,7 @@ body {
 
 body {
   width: 380px;
-  height: 600px;
+  height: 600px !important;
   position: relative;
   min-height: 100vh;
   overflow: hidden;
@@ -49,19 +49,19 @@ body {
   }
 
   &.body-sm {
-    height: 500px;
+    height: 500px !important;
   }
 
   &.body-xs {
-    height: 400px;
+    height: 400px !important;
   }
 
   &.body-xxs {
-    height: 300px;
+    height: 300px !important;
   }
 
   &.body-3xs {
-    height: 240px;
+    height: 240px !important;
   }
 
   &.body-full {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-17091](https://bitwarden.atlassian.net/browse/PM-17091)
[PM-17043](https://bitwarden.atlassian.net/browse/PM-17043)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR does two things:
- Moves the setting of the extension height to the `app.component.ts` `init` function instead of the root `init.service.ts`. There have been intermittent reports of the extension opening at half-height in Firefox and Chrome, although internally we have not been able to reproduce this in some time. There is likely a race condition where the extension height class (`body-xxs`) was being set before the browser had returned the available window height. By moving the function call to a later `init` function, this may help prevent the race condition. We are unable to test if it solves the problem given that we cannot reproduce it.
- Adds logic to consider the available screen height when setting the extension height class. If there is a high system zoom (supported in Windows and Linux), it is possible that the screen has less than 600px available in which to render the extension. In this situation, the browser still returns that it has the full 600px available, so we cannot rely on that alone. Resizing the extension based on the screen height in this case will prevent the issue where the user cannot access the bottom tab navigation. Please note that when both system and browser zoom are applied together, the extension will still have a second scrollbar.

This PR does not solve:
- An issue where the extension's bottom tab navigation is unavailable in Firefox when the browser window is vertically shrunken and positioned on the screen in such a way that the extension cannot fit above or below it. There is a bug within Firefox that returns the incorrect available height and this renders the extension height improperly, causing the bottom nav bar to be cut off. 

## Testing

This PR was tested in the following OS/browser combos for regressions as well as verifying the fixes above:
- Mac Chrome
- Mac Firefox
- Mac Safari
- Linux Firefox (Mac VM)
- Windows Chrome
- Windows Firefox

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17091]: https://bitwarden.atlassian.net/browse/PM-17091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-17043]: https://bitwarden.atlassian.net/browse/PM-17043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ