### PR TITLE
[PM-20540] Unable to deep-link when using Two Factor authentication with SSO

### DIFF
--- a/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.spec.ts
+++ b/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.spec.ts
@@ -342,6 +342,9 @@ describe("TwoFactorAuthComponent", () => {
     describe("submit", () => {
       const token = "testToken";
       const remember = false;
+      const currentAuthTypeSubject = new BehaviorSubject<AuthenticationType>(
+        AuthenticationType.Sso,
+      );
 
       describe("Trusted Device Encryption scenarios", () => {
         describe("Given Trusted Device Encryption is enabled and user needs to set a master password", () => {
@@ -356,6 +359,7 @@ describe("TwoFactorAuthComponent", () => {
           });
 
           it("navigates to the login-initiated route and sets correct flag when user doesn't have a MP and key connector isn't enabled", async () => {
+            mockLoginStrategyService.currentAuthType$ = currentAuthTypeSubject.asObservable();
             // Act
             await component.submit(token, remember);
 
@@ -382,6 +386,7 @@ describe("TwoFactorAuthComponent", () => {
           });
 
           it("navigates to the login-initiated route when login is successful", async () => {
+            mockLoginStrategyService.currentAuthType$ = currentAuthTypeSubject.asObservable();
             await component.submit(token, remember);
 
             expect(mockRouter.navigate).toHaveBeenCalledTimes(1);

--- a/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.ts
+++ b/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.ts
@@ -143,6 +143,13 @@ export class TwoFactorAuthComponent implements OnInit, OnDestroy {
   DuoLaunchAction = DuoLaunchAction;
 
   webAuthInNewTab = false;
+  /**
+   * For the loginSuccessHandlerService to determine the default route after successful authentication.
+   * We track this since the loginStrategyService clears the cache on a successful auth result
+   * but, to determine the success route we need to know the authType which is cleared by the
+   * loginStrategyService.clearCache() method.
+   */
+  successRoute: string | undefined = undefined;
 
   private authenticationSessionTimeoutRoute = "authentication-timeout";
 
@@ -333,6 +340,7 @@ export class TwoFactorAuthComponent implements OnInit, OnDestroy {
     });
 
     try {
+      this.successRoute = await this.determineDefaultSuccessRoute();
       this.formPromise = this.loginStrategyService.logInTwoFactor(
         new TokenTwoFactorRequest(this.selectedProviderType, tokenValue, rememberValue),
         "", // TODO: PM-15162 - deprecate captchaResponse
@@ -500,9 +508,7 @@ export class TwoFactorAuthComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const defaultSuccessRoute = await this.determineDefaultSuccessRoute();
-
-    await this.router.navigate([defaultSuccessRoute], {
+    await this.router.navigate([this.successRoute], {
       queryParams: {
         identifier: this.orgSsoIdentifier,
       },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-20540](https://bitwarden.atlassian.net/browse/PM-20540)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

User should be able to deep link no matter the auth flow.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Successful deep link with SSO and Two Factor Authentication
https://github.com/user-attachments/assets/e02a5fb5-d8f7-4a5e-a155-fd1188f1d734

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20540]: https://bitwarden.atlassian.net/browse/PM-20540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ