### PR TITLE
PM-20546 pass folder to openAddEditVaultItemPopout

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -801,7 +801,7 @@ export default class NotificationBackground {
     message: NotificationBackgroundExtensionMessage,
     senderTab: chrome.tabs.Tab,
   ) {
-    const { cipherId, organizationId } = message;
+    const { cipherId, organizationId, folder } = message;
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getOptionalUserId));
     if (cipherId) {
       await this.openAddEditVaultItemPopout(senderTab, { cipherId });
@@ -813,6 +813,7 @@ export default class NotificationBackground {
     if (queueItem?.type === NotificationQueueMessageType.AddLogin) {
       const cipherView = this.convertAddLoginQueueMessageToCipherView(queueItem);
       cipherView.organizationId = organizationId;
+      cipherView.folderId = folder;
 
       if (userId) {
         await this.cipherService.setAddEditCipherInfo({ cipher: cipherView }, userId);

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -263,15 +263,15 @@ function handleCloseNotification(e: Event) {
 
 function handleSaveAction(e: Event) {
   const selectedVault = selectedVaultSignal.get();
+  const selectedFolder = selectedFolderSignal.get();
+
   if (selectedVault.length > 1) {
-    openAddEditVaultItemPopout(e, { organizationId: selectedVault });
+    openAddEditVaultItemPopout(e, { organizationId: selectedVault, folder: selectedFolder });
     handleCloseNotification(e);
     return;
   }
 
   e.preventDefault();
-
-  const selectedFolder = selectedFolderSignal.get();
 
   sendSaveCipherMessage(removeIndividualVault(), selectedFolder);
   if (removeIndividualVault()) {
@@ -370,7 +370,7 @@ function handleSaveCipherAttemptCompletedMessage(message: NotificationBarWindowM
 
 function openAddEditVaultItemPopout(
   e: Event,
-  options: { cipherId?: string; organizationId?: string },
+  options: { cipherId?: string; organizationId?: string; folder?: string },
 ) {
   e.preventDefault();
   sendPlatformMessage({


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20546
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a user selects a vault and a folderId, open the add edit vault view to facilitate adding a new login with a vault
## 📸 Screenshots

https://github.com/user-attachments/assets/3e4af163-aa77-4de9-9568-dbd9f7d69c9a



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
