### PR TITLE
[PM-19996] Add icons to app-icons

### DIFF
--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/models/password-health.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/models/password-health.ts
@@ -31,6 +31,7 @@ export type ApplicationHealthReportDetail = {
   atRiskMemberCount: number;
   memberDetails: MemberDetailsFlat[];
   atRiskMemberDetails: MemberDetailsFlat[];
+  cipher: CipherView;
 };
 
 export type ApplicationHealthReportDetailWithCriticalFlag = ApplicationHealthReportDetail & {
@@ -48,6 +49,7 @@ export type CipherHealthReportUriDetail = {
   exposedPasswordDetail: ExposedPasswordDetail;
   cipherMembers: MemberDetailsFlat[];
   trimmedUri: string;
+  cipher: CipherView;
 };
 
 /**

--- a/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/tools/reports/risk-insights/services/risk-insights-report.service.ts
@@ -355,6 +355,7 @@ export class RiskInsightsReportService {
       atRiskMemberDetails: existingUriDetail ? existingUriDetail.atRiskMemberDetails : [],
       atRiskPasswordCount: existingUriDetail ? existingUriDetail.atRiskPasswordCount : 0,
       atRiskMemberCount: existingUriDetail ? existingUriDetail.atRiskMemberDetails.length : 0,
+      cipher: newUriDetail.cipher,
     } as ApplicationHealthReportDetail;
 
     if (isAtRisk) {
@@ -399,6 +400,7 @@ export class RiskInsightsReportService {
       exposedPasswordDetail: detail.exposedPasswordDetail,
       cipherMembers: detail.cipherMembers,
       trimmedUri: uri,
+      cipher: detail as CipherView,
     };
   }
 

--- a/bitwarden_license/bit-web/src/app/tools/access-intelligence/app-table-row-scrollable.component.html
+++ b/bitwarden_license/bit-web/src/app/tools/access-intelligence/app-table-row-scrollable.component.html
@@ -6,6 +6,7 @@
   >
     <ng-container header>
       <th *ngIf="isCriticalAppsFeatureEnabled"></th>
+      <th bitCell></th>
       <th bitSortable="applicationName" bitCell>{{ "application" | i18n }}</th>
       <th bitSortable="atRiskPasswordCount" bitCell>{{ "atRiskPasswords" | i18n }}</th>
       <th bitSortable="passwordCount" bitCell>{{ "totalPasswords" | i18n }}</th>
@@ -33,6 +34,9 @@
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
       >
         <i class="bwi bwi-star-f" *ngIf="row.isMarkedAsCritical"></i>
+      </td>
+      <td bitCell>
+        <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
       </td>
       <td
         class="tw-cursor-pointer"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19996

## 📔 Objective

Add App icons to the Risk-insights tabs (all applications and critical apps)

## 📸 Screenshots

Icons on all apps
![image](https://github.com/user-attachments/assets/36a46793-1aa9-42d9-ab4a-9dc309cf28ce)

Icons on critical apps
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/aa5b5a2a-6f3a-43ad-b51d-e5878961ecff" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
