### PR TITLE
[PM-20636] Handle PersonalOwnership policy and vault selector with only one option

### DIFF
--- a/apps/browser/src/autofill/content/components/notification/container.ts
+++ b/apps/browser/src/autofill/content/components/notification/container.ts
@@ -29,6 +29,7 @@ export type NotificationContainerProps = NotificationBarIframeInitData & {
   folders?: FolderView[];
   i18n: { [key: string]: string };
   organizations?: OrgView[];
+  personalVaultIsAllowed?: boolean;
   type: NotificationType; // @TODO typing override for generic `NotificationBarIframeInitData.type`
 };
 
@@ -41,6 +42,7 @@ export function NotificationContainer({
   folders,
   i18n,
   organizations,
+  personalVaultIsAllowed = true,
   theme = ThemeTypes.Light,
   type,
 }: NotificationContainerProps) {
@@ -71,6 +73,7 @@ export function NotificationContainer({
         i18n,
         notificationType: type,
         organizations,
+        personalVaultIsAllowed,
         theme,
       })}
     </div>

--- a/apps/browser/src/autofill/content/components/notification/footer.ts
+++ b/apps/browser/src/autofill/content/components/notification/footer.ts
@@ -18,6 +18,7 @@ export type NotificationFooterProps = {
   i18n: { [key: string]: string };
   notificationType?: NotificationType;
   organizations?: OrgView[];
+  personalVaultIsAllowed: boolean;
   theme: Theme;
   handleSaveAction: (e: Event) => void;
 };
@@ -28,6 +29,7 @@ export function NotificationFooter({
   i18n,
   notificationType,
   organizations,
+  personalVaultIsAllowed,
   theme,
   handleSaveAction,
 }: NotificationFooterProps) {
@@ -46,6 +48,7 @@ export function NotificationFooter({
               handlePrimaryButtonClick: handleSaveAction,
               text: primaryButtonText,
             },
+            personalVaultIsAllowed,
             theme,
           })
         : nothing}

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -135,7 +135,11 @@ async function initNotificationBar(message: NotificationBarWindowMessage) {
   }
 
   notificationBarIframeInitData = initData;
-  const { isVaultLocked, theme } = notificationBarIframeInitData;
+  const {
+    isVaultLocked,
+    removeIndividualVault: personalVaultDisallowed, // renamed to avoid local method collision
+    theme,
+  } = notificationBarIframeInitData;
   const i18n = getI18n();
   const resolvedTheme = getResolvedTheme(theme ?? ThemeTypes.Light);
 
@@ -172,6 +176,7 @@ async function initNotificationBar(message: NotificationBarWindowMessage) {
           ...notificationBarIframeInitData,
           type: notificationBarIframeInitData.type as NotificationType,
           theme: resolvedTheme,
+          personalVaultIsAllowed: !personalVaultDisallowed,
           handleCloseNotification,
           handleSaveAction,
           handleEditOrUpdateAction,
@@ -266,7 +271,10 @@ function handleSaveAction(e: Event) {
   const selectedFolder = selectedFolderSignal.get();
 
   if (selectedVault.length > 1) {
-    openAddEditVaultItemPopout(e, { organizationId: selectedVault, folder: selectedFolder });
+    openAddEditVaultItemPopout(e, {
+      organizationId: selectedVault,
+      folder: selectedFolder,
+    });
     handleCloseNotification(e);
     return;
   }
@@ -370,7 +378,11 @@ function handleSaveCipherAttemptCompletedMessage(message: NotificationBarWindowM
 
 function openAddEditVaultItemPopout(
   e: Event,
-  options: { cipherId?: string; organizationId?: string; folder?: string },
+  options: {
+    cipherId?: string;
+    organizationId?: string;
+    folder?: string;
+  },
 ) {
   e.preventDefault();
   sendPlatformMessage({


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20636](https://bitwarden.atlassian.net/browse/PM-20636)

## 📔 Objective

GIVEN: the user is viewing the “Save login?” UI 

AND: the user is in only 1 organization, and that org has turned off the individual vault 

THEN: no vault select is displayed

WHEN: the user selects the “Save” action 

THEN: the “New item” form opens with relevant fields filled in (including folder if the user preselected a folder from the notification UI)

## 📸 Screenshots




## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20636]: https://bitwarden.atlassian.net/browse/PM-20636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ