### PR TITLE
[PM-21003] Update package.json to require node v23 and resolve #6689

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "*.ts": "eslint --cache --cache-strategy content --fix"
   },
   "engines": {
-    "node": "~20",
+    "node": "~23",
     "npm": "~10"
   }
 }


### PR DESCRIPTION
As described in #6689 switching from nodejs 22 to nodejs 23 resolves the punycode deprecation warning:

```
❯ bw status
(node:76380) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
{"serverUrl":null,"lastSync":"2025-02-07T13:18:54.878Z","userEmail":"**********","userId":"*******-f096-43c2-a8a1-****","status":"unlocked"}
```

Switched to node 23 using NVM:
```
❯ nvm use 23
Now using node v23.7.0 (npm v10.9.2)
❯ nvm alias default 23
default -> 23 (-> v23.7.0)
```

Error is gone:
```
❯ bw status
{"serverUrl":null,"lastSync":"2025-02-07T13:18:54.878Z","userEmail":"********* ","userId":"******-f096-43c2-a8a1-*******","status":"unlocked"}
``` 