### PR TITLE
[PM-20988][PM-20986][PM-20983] - Multiple defect fixes for desktop cipher form update

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2007,6 +2007,21 @@
     "message": "Premium",
     "description": "Premium membership"
   },
+  "freeOrgsCannotUseAttachments": {
+    "message": "Free organizations cannot use attachments"
+  },
+  "singleFieldNeedsAttention": {
+    "message": "1 field needs your attention."
+  },
+  "multipleFieldsNeedAttention": {
+    "message": "$COUNT$ fields need your attention.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
   "cardExpiredTitle": {
     "message": "Expired card"
   },

--- a/apps/desktop/src/vault/app/vault/item-footer.component.html
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.html
@@ -44,7 +44,7 @@
     <button
       type="button"
       class="primary"
-      *ngIf="cipher.id && !cipher?.organizationId && !cipher.isDeleted && action !== 'clone'"
+      *ngIf="cipher.id && !cipher?.organizationId && !cipher.isDeleted && action === 'view'"
       (click)="clone()"
       appA11yTitle="{{ 'clone' | i18n }}"
     >

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -13,7 +13,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { firstValueFrom, Subject, takeUntil, switchMap } from "rxjs";
 import { filter, map, take } from "rxjs/operators";
 
-import { CollectionView } from "@bitwarden/admin-console/common";
+import { CollectionService, CollectionView } from "@bitwarden/admin-console/common";
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { VaultViewPasswordHistoryService } from "@bitwarden/angular/services/view-password-history.service";
@@ -29,7 +29,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
-import { CipherId, UserId } from "@bitwarden/common/types/guid";
+import { CipherId, CollectionId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
@@ -175,6 +175,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
     private cipherService: CipherService,
     private formConfigService: CipherFormConfigService,
     private premiumUpgradePromptService: PremiumUpgradePromptService,
+    private collectionService: CollectionService,
   ) {}
 
   async ngOnInit() {
@@ -356,7 +357,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
     this.cipherId = cipher.id;
     this.cipher = cipher;
     this.collections =
-      this.vaultFilterComponent?.collections.fullList.filter((c) =>
+      this.vaultFilterComponent?.collections?.fullList.filter((c) =>
         cipher.collectionIds.includes(c.id),
       ) ?? null;
     this.action = "view";
@@ -559,6 +560,9 @@ export class VaultV2Component implements OnInit, OnDestroy {
     this.cipherId = null;
     this.action = "view";
     await this.vaultItemsComponent?.refresh().catch(() => {});
+    this.collections = await firstValueFrom(
+      this.collectionService.decryptedCollectionViews$(cipher.collectionIds as CollectionId[]),
+    );
     this.cipherId = cipher.id;
     this.cipher = cipher;
     if (this.activeUserId) {

--- a/libs/vault/src/cipher-view/view-identity-sections/view-identity-sections.component.ts
+++ b/libs/vault/src/cipher-view/view-identity-sections/view-identity-sections.component.ts
@@ -1,5 +1,5 @@
 import { NgIf } from "@angular/common";
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Input, OnChanges, OnInit } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -28,7 +28,7 @@ import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-
     ReadOnlyCipherCardComponent,
   ],
 })
-export class ViewIdentitySectionsComponent implements OnInit {
+export class ViewIdentitySectionsComponent implements OnInit, OnChanges {
   @Input({ required: true }) cipher: CipherView | null = null;
 
   showPersonalDetails: boolean = false;
@@ -36,9 +36,17 @@ export class ViewIdentitySectionsComponent implements OnInit {
   showContactDetails: boolean = false;
 
   ngOnInit(): void {
+    this.init();
+  }
+
+  init() {
     this.showPersonalDetails = this.hasPersonalDetails();
     this.showIdentificationDetails = this.hasIdentificationDetails();
     this.showContactDetails = this.hasContactDetails();
+  }
+
+  async ngOnChanges() {
+    this.init();
   }
 
   /** Returns all populated address fields */


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20986
https://bitwarden.atlassian.net/browse/PM-20988
https://bitwarden.atlassian.net/browse/PM-20983
https://bitwarden.atlassian.net/browse/PM-20971

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes the following bugs:

- missing translation key for missing field(s)
- cipher collections state not updating after saving or viewing a different cipher
- identity type cipher field state inconsistent when viewing different ciphers
- "clone" button being shown while editing cipher

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
