### PR TITLE
Fix angular performance issue on color-password.component

### DIFF
--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -1,6 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-
 import { Component, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -41,6 +38,9 @@ export class ColorPasswordComponent {
   }
 
   get passwordArray() {
+    if (this.password() == null) {
+      return [];
+    }
     // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
     return Array.from(this.password());
   }

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -27,7 +27,7 @@ export class ColorPasswordComponent {
 
   // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
   passwordCharArray = computed(() => {
-    return (this.password() ?? []) ? Array.from(this.password()) : [];
+    return Array.from(this.password() ?? "");
   });
 
   characterStyles: Record<CharacterType, string[]> = {

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 
-import { Component, HostBinding, Input } from "@angular/core";
+import { Component, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
@@ -17,7 +17,7 @@ enum CharacterType {
   template: `@for (character of passwordArray; track $index; let i = $index) {
     <span [class]="getCharacterClass(character)">
       <span>{{ character }}</span>
-      @if (showCount) {
+      @if (showCount()) {
         <span class="tw-whitespace-nowrap tw-text-xs tw-leading-5 tw-text-main">{{ i + 1 }}</span>
       }
     </span>
@@ -25,8 +25,8 @@ enum CharacterType {
   standalone: true,
 })
 export class ColorPasswordComponent {
-  @Input() password: string = null;
-  @Input() showCount = false;
+  password = input<string>("");
+  showCount = input<boolean>(false);
 
   characterStyles: Record<CharacterType, string[]> = {
     [CharacterType.Emoji]: [],
@@ -42,14 +42,14 @@ export class ColorPasswordComponent {
 
   get passwordArray() {
     // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
-    return Array.from(this.password);
+    return Array.from(this.password());
   }
 
   getCharacterClass(character: string) {
     const charType = this.getCharacterType(character);
     const charClass = this.characterStyles[charType];
 
-    if (this.showCount) {
+    if (this.showCount()) {
       return charClass.concat([
         "tw-inline-flex",
         "tw-flex-col",

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -25,8 +25,8 @@ export class ColorPasswordComponent {
   password = input<string>("");
   showCount = input<boolean>(false);
 
+  // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
   passwordCharArray = computed(() => {
-    // // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
     return (this.password() ?? []) ? Array.from(this.password()) : [];
   });
 

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, input } from "@angular/core";
+import { Component, computed, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
@@ -11,7 +11,7 @@ enum CharacterType {
 
 @Component({
   selector: "bit-color-password",
-  template: `@for (character of passwordArray; track $index; let i = $index) {
+  template: `@for (character of passwordCharArray(); track $index; let i = $index) {
     <span [class]="getCharacterClass(character)">
       <span>{{ character }}</span>
       @if (showCount()) {
@@ -25,6 +25,11 @@ export class ColorPasswordComponent {
   password = input<string>("");
   showCount = input<boolean>(false);
 
+  passwordCharArray = computed(() => {
+    // // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
+    return (this.password() ?? []) ? Array.from(this.password()) : [];
+  });
+
   characterStyles: Record<CharacterType, string[]> = {
     [CharacterType.Emoji]: [],
     [CharacterType.Letter]: ["tw-text-main"],
@@ -35,14 +40,6 @@ export class ColorPasswordComponent {
   @HostBinding("class")
   get classList() {
     return ["tw-min-w-0", "tw-whitespace-pre-wrap", "tw-break-all"];
-  }
-
-  get passwordArray() {
-    if (this.password() == null) {
-      return [];
-    }
-    // Convert to an array to handle cases that strings have special characters, i.e.: emoji.
-    return Array.from(this.password());
   }
 
   getCharacterClass(character: string) {

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -14,7 +14,7 @@ enum CharacterType {
 
 @Component({
   selector: "bit-color-password",
-  template: `@for (character of passwordArray; track character; let i = $index) {
+  template: `@for (character of passwordArray; track $index; let i = $index) {
     <span [class]="getCharacterClass(character)">
       <span>{{ character }}</span>
       @if (showCount) {

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.spec.ts
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.spec.ts
@@ -168,7 +168,7 @@ describe("LoginCredentialsViewComponent", () => {
 
         const passwordColor = passwordField.query(By.directive(ColorPasswordComponent));
 
-        expect(passwordColor.componentInstance.password).toBe(cipher.login.password);
+        expect(passwordColor.componentInstance.password()).toBe(cipher.login.password);
       });
 
       it("records event", () => {

--- a/libs/vault/src/components/password-history-view/password-history-view.component.spec.ts
+++ b/libs/vault/src/components/password-history-view/password-history-view.component.spec.ts
@@ -68,7 +68,7 @@ describe("PasswordHistoryViewComponent", () => {
     it("renders all passwords", () => {
       const passwords = fixture.debugElement.queryAll(By.directive(ColorPasswordComponent));
 
-      expect(passwords.map((password) => password.componentInstance.password)).toEqual([
+      expect(passwords.map((password) => password.componentInstance.password())).toEqual([
         "bad-password-1",
         "bad-password-2",
       ]);


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The color-password component was converted to use @for over NgFor with https://github.com/bitwarden/clients/pull/12390

This has caused a performance issue as the component is tracking the characters, but these are by design most likely not going to be unique. This causes the component to re-render and throw the following warning on the console:

```
NG0955: The provided track expression resulted in duplicated keys for a given collection. 
Adjust the tracking expression such that it uniquely identifies all the items in the collection. 
Duplicated keys were: 
key "3" at index "2" and "3". Find more at 
```

By using `$index` instead of character for tracking changes, this is prevented.

In addition the component was migrated to use Angular Signal inputs and I made it ts-strict compliant.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
