### PR TITLE
Chrome Extension: Smaller banners

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-footer.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-footer.component.html
@@ -1,11 +1,11 @@
 <footer
-  class="tw-p-3 bit-compact:tw-p-2 tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-bg-background"
+  class="tw-p-1.5 bit-compact:tw-p-1 tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-bg-background"
 >
   <div class="tw-max-w-screen-sm tw-mx-auto tw-flex tw-justify-between tw-w-full tw-items-center">
-    <div class="tw-flex tw-justify-start tw-gap-2">
+    <div class="tw-flex tw-justify-start tw-gap-1.5">
       <ng-content></ng-content>
     </div>
-    <div class="tw-inline-flex tw-items-center tw-gap-2 tw-h-9">
+    <div class="tw-inline-flex tw-items-center tw-gap-1.5 tw-h-7">
       <ng-content select="[slot=end]"></ng-content>
     </div>
   </div>

--- a/apps/browser/src/platform/popup/layout/popup-header.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.html
@@ -1,5 +1,5 @@
 <header
-  class="tw-p-3 bit-compact:tw-p-2 tw-pl-4 bit-compact:tw-pl-3 tw-transition-colors tw-duration-200 tw-border-0 tw-border-b tw-border-solid"
+  class="tw-p-1.5 bit-compact:tw-p-1 tw-pl-2 bit-compact:tw-pl-1.5 tw-transition-colors tw-duration-200 tw-border-0 tw-border-b tw-border-solid"
   [ngClass]="{
     'tw-bg-background-alt tw-border-transparent':
       this.background === 'alt' && !pageContentScrolled(),
@@ -8,9 +8,9 @@
   }"
 >
   <div class="tw-max-w-screen-sm tw-mx-auto tw-flex tw-justify-between tw-w-full">
-    <div class="tw-inline-flex tw-items-center tw-gap-2 tw-h-9">
+    <div class="tw-inline-flex tw-items-center tw-gap-1.5 tw-h-5">
       <button
-        class="-tw-ml-1"
+        class="-tw-ml-0.5"
         bitIconButton="bwi-back"
         type="button"
         *ngIf="showBackButton"
@@ -18,12 +18,12 @@
         [attr.aria-label]="'back' | i18n"
         [bitAction]="backAction"
       ></button>
-      <h1 *ngIf="pageTitle" bitTypography="h3" class="!tw-mb-0.5">
+      <h1 *ngIf="pageTitle" bitTypography="h4" class="!tw-mb-0">
         {{ pageTitle }}
       </h1>
       <ng-content></ng-content>
     </div>
-    <div class="tw-inline-flex tw-items-center tw-gap-2 tw-h-9">
+    <div class="tw-inline-flex tw-items-center tw-gap-1.5 tw-h-5">
       <ng-content select="[slot=end]"></ng-content>
     </div>
   </div>

--- a/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.html
@@ -7,7 +7,7 @@
       <ul class="tw-flex tw-flex-1 tw-mb-0 tw-p-0">
         <li *ngFor="let button of navButtons" class="tw-flex-1 tw-list-none tw-relative">
           <button
-            class="tw-w-full tw-flex tw-flex-col tw-items-center tw-gap-0.25 tw-px-0.25 tw-pb-0.25 bit-compact:tw-pb-0.125 tw-pt-0.5 bit-compact:tw-pt-0.25 tw-text-2xs tw-bg-transparent tw-no-underline hover:tw-no-underline hover:tw-text-primary-600 hover:tw-bg-primary-100 tw-border-2 tw-border-solid tw-border-transparent focus-visible:tw-rounded-lg focus-visible:tw-border-primary-600"
+            class="tw-w-full tw-flex tw-flex-col tw-items-center tw-gap-1 tw-px-1 tw-pb-1 bit-compact:tw-pb-0.5 tw-pt-0.5 bit-compact:tw-pt-1 tw-text-xs tw-bg-transparent tw-no-underline hover:tw-no-underline hover:tw-text-primary-600 hover:tw-bg-primary-100 tw-border-2 tw-border-solid tw-border-transparent focus-visible:tw-rounded-lg focus-visible:tw-border-primary-600"
             [ngClass]="rla.isActive ? 'tw-font-bold tw-text-primary-600' : 'tw-text-muted'"
             title="{{ button.label | i18n }}"
             [routerLink]="button.page"

--- a/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-tab-navigation.component.html
@@ -7,7 +7,7 @@
       <ul class="tw-flex tw-flex-1 tw-mb-0 tw-p-0">
         <li *ngFor="let button of navButtons" class="tw-flex-1 tw-list-none tw-relative">
           <button
-            class="tw-w-full tw-flex tw-flex-col tw-items-center tw-gap-1 tw-px-0.5 tw-pb-2 bit-compact:tw-pb-1 tw-pt-3 bit-compact:tw-pt-2 tw-text-sm tw-bg-transparent tw-no-underline hover:tw-no-underline hover:tw-text-primary-600 hover:tw-bg-primary-100 tw-border-2 tw-border-solid tw-border-transparent focus-visible:tw-rounded-lg focus-visible:tw-border-primary-600"
+            class="tw-w-full tw-flex tw-flex-col tw-items-center tw-gap-0.25 tw-px-0.25 tw-pb-0.25 bit-compact:tw-pb-0.125 tw-pt-0.5 bit-compact:tw-pt-0.25 tw-text-2xs tw-bg-transparent tw-no-underline hover:tw-no-underline hover:tw-text-primary-600 hover:tw-bg-primary-100 tw-border-2 tw-border-solid tw-border-transparent focus-visible:tw-rounded-lg focus-visible:tw-border-primary-600"
             [ngClass]="rla.isActive ? 'tw-font-bold tw-text-primary-600' : 'tw-text-muted'"
             title="{{ button.label | i18n }}"
             [routerLink]="button.page"
@@ -20,12 +20,12 @@
           >
             <i
               *ngIf="!rla.isActive"
-              class="bwi bwi-lg bwi-{{ button.iconKey }}"
+              class="bwi bwi-md bwi-{{ button.iconKey }}"
               aria-hidden="true"
             ></i>
             <i
               *ngIf="rla.isActive"
-              class="bwi bwi-lg bwi-{{ button.iconKeyActive }}"
+              class="bwi bwi-md bwi-{{ button.iconKeyActive }}"
               aria-hidden="true"
             ></i>
             <span class="tw-truncate tw-max-w-full">

--- a/libs/components/src/icon-button/icon-button.component.ts
+++ b/libs/components/src/icon-button/icon-button.component.ts
@@ -144,8 +144,8 @@ const disabledStyles: Record<IconButtonType, string[]> = {
 export type IconButtonSize = "default" | "small";
 
 const sizes: Record<IconButtonSize, string[]> = {
-  default: ["tw-px-2.5", "tw-py-1.5"],
-  small: ["tw-leading-none", "tw-text-base", "tw-p-1"],
+  default: ["tw-px-1.5", "tw-py-1"], // Reduced from px-2.5 py-1.5
+  small: ["tw-leading-none", "tw-text-sm", "tw-p-0.5"], // Reduced from text-base p-1
 };
 
 @Component({


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Suggesting changes to the Chrome extension banners to match other browser elements. This would reduce the sizing on the top and bottom banners to make the extension more space efficient

## 📸 Screenshots

![Screenshot 2025-04-30 at 11 43 21 AM](https://github.com/user-attachments/assets/d6fbc1ba-0aaf-4825-8c84-cf18a80a478b)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
