### PR TITLE
[PM-21022] Remove fido2Credentials when cloning a cipher

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
@@ -1,13 +1,17 @@
 import { ChangeDetectorRef } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
+import { mock } from "jest-mock-extended";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/abstractions/view-cache.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { Fido2CredentialView } from "@bitwarden/common/vault/models/view/fido2-credential.view";
 import { ToastService } from "@bitwarden/components";
 
+import { CipherFormConfig } from "../abstractions/cipher-form-config.service";
 import { CipherFormService } from "../abstractions/cipher-form.service";
 import { CipherFormCacheService } from "../services/default-cipher-form-cache.service";
 
@@ -17,20 +21,24 @@ describe("CipherFormComponent", () => {
   let component: CipherFormComponent;
   let fixture: ComponentFixture<CipherFormComponent>;
 
+  const decryptCipher = jest.fn().mockResolvedValue(new CipherView());
+
   beforeEach(async () => {
+    decryptCipher.mockClear();
+
     await TestBed.configureTestingModule({
       imports: [CipherFormComponent, ReactiveFormsModule],
       providers: [
         { provide: ChangeDetectorRef, useValue: {} },
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: ToastService, useValue: { showToast: jest.fn() } },
-        { provide: CipherFormService, useValue: { saveCipher: jest.fn() } },
+        { provide: CipherFormService, useValue: { saveCipher: jest.fn(), decryptCipher } },
         {
           provide: CipherFormCacheService,
           useValue: { init: jest.fn(), getCachedCipherView: jest.fn() },
         },
         { provide: ViewCacheService, useValue: { signal: jest.fn(() => () => null) } },
-        { provide: ConfigService, useValue: {} },
+        { provide: ConfigService, useValue: mock<ConfigService>() },
       ],
     }).compileComponents();
   });
@@ -85,6 +93,33 @@ describe("CipherFormComponent", () => {
       component["updatedCipherView"] = new CipherView();
       component["updatedCipherView"].login = { uris: [{ uri: "https://example.com" }] } as any;
       expect(component.website).toEqual("https://example.com");
+    });
+  });
+
+  describe("clone", () => {
+    const cipherView = new CipherView();
+    cipherView.id = "test-id";
+    cipherView.login.fido2Credentials = [new Fido2CredentialView()];
+
+    beforeEach(() => {
+      component.config = {
+        mode: "clone",
+        originalCipher: new Cipher(),
+      } as CipherFormConfig;
+
+      decryptCipher.mockResolvedValue(cipherView);
+    });
+
+    it("clears id on updatedCipherView", async () => {
+      await component.ngOnInit();
+
+      expect(component["updatedCipherView"]?.id).toBeNull();
+    });
+
+    it("clears fido2Credentials on updatedCipherView", async () => {
+      await component.ngOnInit();
+
+      expect(component["updatedCipherView"]?.login.fido2Credentials).toBeNull();
     });
   });
 });

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -241,7 +241,10 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
       if (this.config.mode === "clone") {
         this.updatedCipherView.id = null;
-        this.updatedCipherView.login.fido2Credentials = null;
+
+        if (this.updatedCipherView.login) {
+          this.updatedCipherView.login.fido2Credentials = null;
+        }
       }
     } else {
       this.updatedCipherView.type = this.config.cipherType;

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -241,6 +241,7 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
       if (this.config.mode === "clone") {
         this.updatedCipherView.id = null;
+        this.updatedCipherView.login.fido2Credentials = null;
       }
     } else {
       this.updatedCipherView.type = this.config.cipherType;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21022](https://bitwarden.atlassian.net/browse/PM-21022)

## 📔 Objective

When cloning a cipher, the `fido2Credentials` should not be carried to the newly created cipher.
- Set `fido2Credentials` to null whenever a cipher is cloned to ensure they are not copied over. 

## 📸 Screenshots

|Browser|Web|Desktop|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/326d3ebe-6482-46dc-883d-490742089108" />|<video src="https://github.com/user-attachments/assets/267eeb30-e488-4ec3-8ac1-1e352abc0fbc" />|<video src="https://github.com/user-attachments/assets/9626e805-46df-48e1-b099-537b52c2124f" />


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21022]: https://bitwarden.atlassian.net/browse/PM-21022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ