### PR TITLE
[PM-20423] Update Empty Vault Button on Browser to follow Web

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -17,15 +17,9 @@
       <ng-container slot="description">
         <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ "emptyVaultDescription" | i18n }}</p>
       </ng-container>
-      <button
-        slot="button"
-        bitButton
-        buttonType="secondary"
-        type="button"
-        (click)="navigateToNewLoginItem()"
-      >
+      <a slot="button" bitButton buttonType="secondary" [routerLink]="['/add-cipher']">
         {{ "newLogin" | i18n }}
-      </button>
+      </a>
     </bit-no-items>
   </div>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -15,12 +15,17 @@
     <bit-no-items [icon]="vaultIcon">
       <ng-container slot="title">{{ "yourVaultIsEmpty" | i18n }}</ng-container>
       <ng-container slot="description">
-        <p bitTypography="body2" class="tw-mx-6">{{ "emptyVaultDescription" | i18n }}</p>
+        <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ "emptyVaultDescription" | i18n }}</p>
       </ng-container>
-      <app-new-item-dropdown
+      <button
         slot="button"
-        [initialValues]="newItemItemValues$ | async"
-      ></app-new-item-dropdown>
+        bitButton
+        buttonType="secondary"
+        type="button"
+        (click)="navigateToNewLoginItem()"
+      >
+        {{ "newLogin" | i18n }}
+      </button>
     </bit-no-items>
   </div>
 

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -227,5 +227,9 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     await this.vaultNudgesService.dismissNudge(type, this.activeUserId as UserId);
   }
 
+  async navigateToNewLoginItem() {
+    await this.router.navigate(["/add-cipher"]);
+  }
+
   protected readonly FeatureFlag = FeatureFlag;
 }

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -227,9 +227,5 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     await this.vaultNudgesService.dismissNudge(type, this.activeUserId as UserId);
   }
 
-  async navigateToNewLoginItem() {
-    await this.router.navigate(["/add-cipher"]);
-  }
-
   protected readonly FeatureFlag = FeatureFlag;
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20423](https://bitwarden.atlassian.net/browse/PM-20423)

## 📔 Objective

Update the `New Item` button in the browser empty vault to go directly to a `New Login` item page inside of a dropdown. This will be align closely to the flow in Web

## 📸 Screen Recording


https://github.com/user-attachments/assets/845eee96-4c5c-4b4d-b3ae-9dfa55a00401



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20423]: https://bitwarden.atlassian.net/browse/PM-20423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ