### PR TITLE
[PM-21016] - various fixes to desktop cipher form

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -427,6 +427,12 @@
   "addField": {
     "message": "Add field"
   },
+  "editField": {
+    "message": "Edit field"
+  },
+  "permanentlyDeleteAttachmentConfirmation": {
+    "message": "Are you sure you want to permanently delete this attachment?"
+  },
   "fieldType": {
     "message": "Field type"
   },

--- a/apps/desktop/src/vault/app/vault/item-footer.component.html
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.html
@@ -2,14 +2,13 @@
   <ng-container *ngIf="!cipher.decryptionFailure">
     <button
       #submitBtn
-      bitButton
       form="cipherForm"
       type="submit"
       *ngIf="action !== 'view'"
       class="primary"
       appA11yTitle="{{ 'save' | i18n }}"
     >
-      <i class="bwi bwi-save-changes bwi-lg bwi-fw" [hidden]="isSubmitting" aria-hidden="true"></i>
+      <span [hidden]="isSubmitting">{{ "save" | i18n }}</span>
       <i
         class="bwi bwi-spinner bwi-spin bwi-lg bwi-fw"
         [hidden]="!isSubmitting"

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.html
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.html
@@ -20,6 +20,7 @@
       (onClone)="cloneCipher($event)"
       (onDelete)="deleteCipher()"
       (onCancel)="cancelCipher($event)"
+      [isSubmitting]="isSubmitting"
     ></app-vault-item-footer>
     <div class="content">
       <div class="inner-content">
@@ -32,6 +33,7 @@
             formId="cipherForm"
             [config]="config"
             (cipherSaved)="savedCipher($event)"
+            [beforeSubmit]="onSubmit"
             [submitBtn]="footer?.submitBtn"
           >
             <bit-item slot="attachment-button">

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -141,6 +141,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
   cipher: CipherView | null = new CipherView();
   collections: CollectionView[] | null = null;
   config: CipherFormConfig | null = null;
+  isSubmitting = false;
 
   protected canAccessAttachments$ = this.accountService.activeAccount$.pipe(
     filter((account): account is Account => !!account),
@@ -567,6 +568,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
     await this.vaultItemsComponent?.load(this.activeFilter.buildFilter()).catch(() => {});
     await this.go().catch(() => {});
     await this.vaultItemsComponent?.refresh().catch(() => {});
+    this.isSubmitting = false;
   }
 
   async deleteCipher() {
@@ -741,6 +743,11 @@ export class VaultV2Component implements OnInit, OnDestroy {
       this.changeDetectorRef.detectChanges();
     });
   }
+
+  protected onSubmit = async () => {
+    this.isSubmitting = true;
+    return Promise.resolve(true);
+  };
 
   private prefillCipherFromFilter() {
     if (this.activeFilter.selectedCollectionId != null && this.vaultFilterComponent != null) {

--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.html
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.html
@@ -7,7 +7,7 @@
         bitTypography="helper"
         >{{ totpInfo.totpSec }}</span
       >
-      <svg class="tw-size-7" transform="rotate(-90)">
+      <svg class="tw-size-7" transform="rotate(-90)" viewBox="0 0 28 28">
         <g>
           <circle
             class="tw-fill-none"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21016

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a number of UI defects that came from the [desktop cipher from update](https://github.com/bitwarden/clients/pull/13992)

## 📸 Screenshots

### Change Item footer button "Save" button from icon to text
![Screenshot 2025-05-05 at 10 34 43 AM](https://github.com/user-attachments/assets/cb814db7-d876-4988-aab7-3a4f486a8e28)

### Center align TOTP countdown
![Screenshot 2025-05-05 at 10 39 51 AM](https://github.com/user-attachments/assets/e761cd30-c1cd-4465-9bf6-39386332a498)

###  Add missing i18n key in custom field edit dialog
![Screenshot 2025-05-05 at 10 47 13 AM](https://github.com/user-attachments/assets/bfec1efe-fdf8-4418-81cb-ef7485b368e4)

### Add missing i18n key in delete attachment dialog
![Screenshot 2025-05-05 at 10 48 31 AM](https://github.com/user-attachments/assets/62303657-a9f9-42e3-8489-bd39d27aba0e)





<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
