### PR TITLE
[PM-21059] Fix Typo: Update 'include' to 'includes' on Free Bitwarden Families Sponsored Tab and Org Sponsored Page

### DIFF
--- a/apps/web/src/app/billing/members/free-bitwarden-families.component.html
+++ b/apps/web/src/app/billing/members/free-bitwarden-families.component.html
@@ -11,7 +11,7 @@
       {{ "sponsorshipFreeBitwardenFamilies" | i18n }}
     </p>
     <div bitTypography="body1">
-      {{ "sponsoredFamiliesInclude" | i18n }}:
+      {{ "sponsoredFamiliesIncludeMessage" | i18n }}:
       <ul class="tw-list-outside">
         <li>{{ "sponsoredFamiliesPremiumAccess" | i18n }}</li>
         <li>{{ "sponsoredFamiliesSharedCollectionsMessage" | i18n }}</li>

--- a/apps/web/src/app/billing/settings/sponsored-families.component.html
+++ b/apps/web/src/app/billing/settings/sponsored-families.component.html
@@ -10,7 +10,7 @@
       {{ "sponsoredFamiliesEligible" | i18n }}
     </p>
     <div bitTypography="body1">
-      {{ "sponsoredFamiliesInclude" | i18n }}:
+      {{ "sponsoredFamiliesIncludeMessage" | i18n }}:
       <ul class="tw-list-outside">
         <li>{{ "sponsoredFamiliesPremiumAccess" | i18n }}</li>
         <li>{{ "sponsoredFamiliesSharedCollectionsMessage" | i18n }}</li>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6321,8 +6321,8 @@
   "sponsoredFamiliesEligibleCard": {
     "message": "Redeem your Free Bitwarden for Families plan today to keep your data secure even when you are not at work."
   },
-  "sponsoredFamiliesInclude": {
-    "message": "The Bitwarden for Families plan include"
+  "sponsoredFamiliesIncludeMessage": {
+    "message": "The Bitwarden for Families plan includes"
   },
   "sponsoredFamiliesPremiumAccess": {
     "message": "Premium access for up to 6 users"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21059
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The purpose of this PR is to fix a grammatical error in the text displayed on the Free Bitwarden Families > Sponsored Families tab. Specifically, it updates the phrase "The Bitwarden for Families plan include:" to "The Bitwarden for Families plan includes:" by adding an 's' to the end of the word "include."

Additionally, this PR also updates the same incorrect text instance on the Password Manager (/vault) > Settings > Free Bitwarden Families page, ensuring consistency and correctness across both pages where the text appears.

This change improves the readability and accuracy of the content for users.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="1728" alt="Screenshot 2025-05-01 at 16 49 52" src="https://github.com/user-attachments/assets/4f3ba421-0682-44f6-a507-2a770b6dbb1b" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
