### PR TITLE
[PM-21040] Update Ciphers after editing in Reports

### DIFF
--- a/apps/web/src/app/tools/reports/pages/cipher-report.component.spec.ts
+++ b/apps/web/src/app/tools/reports/pages/cipher-report.component.spec.ts
@@ -1,0 +1,123 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService } from "@bitwarden/components";
+import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
+
+import { VaultItemDialogResult } from "../../../vault/components/vault-item-dialog/vault-item-dialog.component";
+import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
+
+import { CipherReportComponent } from "./cipher-report.component";
+
+describe("CipherReportComponent", () => {
+  let component: CipherReportComponent;
+  let mockAccountService: MockProxy<AccountService>;
+  let mockAdminConsoleCipherFormConfigService: MockProxy<AdminConsoleCipherFormConfigService>;
+  const mockCipher = {
+    id: "122-333-444",
+    type: CipherType.Login,
+    orgId: "222-444-555",
+    login: {
+      username: "test-username",
+      password: "test-password",
+      totp: "123",
+    },
+    decrypt: jest.fn().mockResolvedValue({ id: "cipher1", name: "Updated" }),
+  } as unknown as Cipher;
+  const mockCipherService = mock<CipherService>();
+  mockCipherService.get.mockResolvedValue(mockCipher as unknown as Cipher);
+  mockCipherService.getKeyForCipherKeyDecryption.mockResolvedValue({});
+  mockCipherService.deleteWithServer.mockResolvedValue(undefined);
+  mockCipherService.softDeleteWithServer.mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    // mockCipherService = mock<CipherService>();
+    mockAccountService = mock<AccountService>();
+    mockAccountService.activeAccount$ = of({ id: "user1" } as any);
+    mockAdminConsoleCipherFormConfigService = mock<AdminConsoleCipherFormConfigService>();
+
+    component = new CipherReportComponent(
+      mockCipherService,
+      mock<DialogService>(),
+      mock<PasswordRepromptService>(),
+      mock<OrganizationService>(),
+      mockAccountService,
+      mock<I18nService>(),
+      mock<SyncService>(),
+      mock<CipherFormConfigService>(),
+      mockAdminConsoleCipherFormConfigService,
+    );
+    component.ciphers = [];
+    component.allCiphers = [];
+  });
+
+  it("should remove the cipher from the report if it was deleted", async () => {
+    const cipherToDelete = { id: "cipher1" } as any;
+    component.ciphers = [cipherToDelete, { id: "cipher2" } as any];
+
+    jest.spyOn(component, "determinedUpdatedCipherReportStatus").mockResolvedValue(null);
+
+    await component.refresh(VaultItemDialogResult.Deleted, cipherToDelete);
+
+    expect(component.ciphers).toEqual([{ id: "cipher2" }]);
+    expect(component.determinedUpdatedCipherReportStatus).toHaveBeenCalledWith(
+      VaultItemDialogResult.Deleted,
+      cipherToDelete,
+    );
+  });
+
+  it("should update the cipher in the report if it was saved", async () => {
+    const cipherViewToUpdate = { ...mockCipher } as unknown as CipherView;
+    const updatedCipher = { ...mockCipher, name: "Updated" } as unknown as Cipher;
+    const updatedCipherView = { ...updatedCipher } as unknown as CipherView;
+
+    component.ciphers = [cipherViewToUpdate];
+    mockCipherService.get.mockResolvedValue(updatedCipher);
+    mockCipherService.getKeyForCipherKeyDecryption.mockResolvedValue("key");
+
+    jest.spyOn(updatedCipher, "decrypt").mockResolvedValue(updatedCipherView);
+
+    jest
+      .spyOn(component, "determinedUpdatedCipherReportStatus")
+      .mockResolvedValue(updatedCipherView);
+
+    await component.refresh(VaultItemDialogResult.Saved, updatedCipherView);
+
+    expect(component.ciphers).toEqual([updatedCipherView]);
+    expect(component.determinedUpdatedCipherReportStatus).toHaveBeenCalledWith(
+      VaultItemDialogResult.Saved,
+      updatedCipherView,
+    );
+  });
+
+  it("should remove the cipher from the report if it no longer meets the criteria after saving", async () => {
+    const cipherViewToUpdate = { ...mockCipher } as unknown as CipherView;
+    const updatedCipher = { ...mockCipher, name: "Updated" } as unknown as Cipher;
+    const updatedCipherView = { ...updatedCipher } as unknown as CipherView;
+
+    component.ciphers = [cipherViewToUpdate];
+
+    mockCipherService.get.mockResolvedValue(updatedCipher);
+    mockCipherService.getKeyForCipherKeyDecryption.mockResolvedValue("key");
+
+    jest.spyOn(updatedCipher, "decrypt").mockResolvedValue(updatedCipherView);
+
+    jest.spyOn(component, "determinedUpdatedCipherReportStatus").mockResolvedValue(null);
+
+    await component.refresh(VaultItemDialogResult.Saved, updatedCipherView);
+
+    expect(component.ciphers).toEqual([]);
+    expect(component.determinedUpdatedCipherReportStatus).toHaveBeenCalledWith(
+      VaultItemDialogResult.Saved,
+      updatedCipherView,
+    );
+  });
+});

--- a/apps/web/src/app/tools/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/cipher-report.component.ts
@@ -215,8 +215,68 @@ export class CipherReportComponent implements OnDestroy {
     this.allCiphers = [];
   }
 
-  protected async refresh(result: VaultItemDialogResult, cipher: CipherView) {
-    await this.load();
+  async refresh(result: VaultItemDialogResult, cipher: CipherView) {
+    if (result === VaultItemDialogResult.Deleted) {
+      // update downstream report status if the cipher was deleted
+      await this.determinedUpdatedCipherReportStatus(result, cipher);
+
+      // the cipher was deleted, filter it out from the report.
+      this.ciphers = this.ciphers.filter((ciph) => ciph.id !== cipher.id);
+      this.filterCiphersByOrg(this.ciphers);
+      return;
+    }
+
+    if (result == VaultItemDialogResult.Saved) {
+      // Ensure we have the latest cipher data after saving.
+      const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      let updatedCipher = await this.cipherService.get(cipher.id, activeUserId);
+
+      if (this.isAdminConsoleActive) {
+        updatedCipher = await this.adminConsoleCipherFormConfigService.getCipher(
+          cipher.id as CipherId,
+          this.organization,
+        );
+      }
+
+      // convert cipher to cipher view model
+      const updatedCipherView = await updatedCipher.decrypt(
+        await this.cipherService.getKeyForCipherKeyDecryption(updatedCipher, activeUserId),
+      );
+
+      // determine the index of the updated cipher in the report
+      const index = this.ciphers.findIndex((c) => c.id === updatedCipherView.id);
+
+      // request downstream report status if the cipher was updated
+      // this will return a null if the updated cipher does not meet the criteria for the report
+      const updatedReportResult = await this.determinedUpdatedCipherReportStatus(
+        result,
+        updatedCipherView,
+      );
+
+      // the updated cipher does not meet the criteria for the report, it returns a null
+      if (updatedReportResult === null) {
+        this.ciphers.splice(index, 1);
+      }
+
+      // the cipher is already in the report, update it.
+      if (updatedReportResult !== null && index > -1) {
+        this.ciphers[index] = updatedReportResult;
+      }
+
+      // apply filters and set the data source
+      this.filterCiphersByOrg(this.ciphers);
+    }
+  }
+
+  async determinedUpdatedCipherReportStatus(
+    result: VaultItemDialogResult,
+    updatedCipherView: CipherView,
+  ): Promise<CipherView | null> {
+    // Implement the logic to determine if the updated cipher is still in the report.
+    // This could be checking if the password is still weak or exposed, etc.
+    // For now, we will return the updated cipher view as is.
+    // Replace this with your actual logic in the child classes.
+    return updatedCipherView;
   }
 
   protected async repromptCipher(c: CipherView) {

--- a/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/exposed-passwords-report.component.ts
@@ -10,6 +10,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
+import { VaultItemDialogResult } from "@bitwarden/web-vault/app/vault/components/vault-item-dialog/vault-item-dialog.component";
 
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
@@ -72,10 +73,15 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
         return;
       }
 
-      const promise = this.auditService.passwordLeaked(login.password).then((exposedCount) => {
-        if (exposedCount > 0) {
-          const row = { ...ciph, exposedXTimes: exposedCount } as ReportResult;
-          exposedPasswordCiphers.push(row);
+      // const promise = this.auditService.passwordLeaked(login.password).then((exposedCount) => {
+      //   if (exposedCount > 0) {
+      //     const row = { ...ciph, exposedXTimes: exposedCount } as ReportResult;
+      //     exposedPasswordCiphers.push(row);
+      //   }
+      // });
+      const promise = this.isPasswordExposed(ciph).then((result) => {
+        if (result) {
+          exposedPasswordCiphers.push(result);
         }
       });
       promises.push(promise);
@@ -86,8 +92,25 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     this.dataSource.sort = { column: "exposedXTimes", direction: "desc" };
   }
 
+  private async isPasswordExposed(cv: CipherView): Promise<ReportResult | null> {
+    const { login } = cv;
+    return await this.auditService.passwordLeaked(login.password).then((exposedCount) => {
+      if (exposedCount > 0) {
+        return { ...cv, exposedXTimes: exposedCount } as ReportResult;
+      }
+      return null;
+    });
+  }
+
   protected canManageCipher(c: CipherView): boolean {
     // this will only ever be false from the org view;
     return true;
+  }
+
+  async determinedUpdatedCipherReportStatus(
+    result: VaultItemDialogResult,
+    updatedCipherView: CipherView,
+  ): Promise<CipherView | null> {
+    return await this.isPasswordExposed(updatedCipherView);
   }
 }

--- a/apps/web/src/app/tools/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/inactive-two-factor-report.component.ts
@@ -13,6 +13,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
+import { VaultItemDialogResult } from "@bitwarden/web-vault/app/vault/components/vault-item-dialog/vault-item-dialog.component";
 
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
@@ -70,32 +71,12 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
       this.filterStatus = [0];
 
       allCiphers.forEach((ciph) => {
-        const { type, login, isDeleted, edit, id, viewPassword } = ciph;
-        if (
-          type !== CipherType.Login ||
-          (login.totp != null && login.totp !== "") ||
-          !login.hasUris ||
-          isDeleted ||
-          (!this.organization && !edit) ||
-          !viewPassword
-        ) {
-          return;
-        }
+        const [docFor2fa, isInactive2faCipher] = this.isInactive2faCipher(ciph);
 
-        for (let i = 0; i < login.uris.length; i++) {
-          const u = login.uris[i];
-          if (u.uri != null && u.uri !== "") {
-            const uri = u.uri.replace("www.", "");
-            const domain = Utils.getDomain(uri);
-            if (domain != null && this.services.has(domain)) {
-              if (this.services.get(domain) != null) {
-                docs.set(id, this.services.get(domain));
-              }
-              // If the uri is in the 2fa list. Add the cipher to the inactive
-              // collection. No need to check any additional uris for the cipher.
-              inactive2faCiphers.push(ciph);
-              return;
-            }
+        if (isInactive2faCipher) {
+          inactive2faCiphers.push(ciph);
+          if (docFor2fa !== "") {
+            docs.set(ciph.id, docFor2fa);
           }
         }
       });
@@ -103,6 +84,39 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
       this.filterCiphersByOrg(inactive2faCiphers);
       this.cipherDocs = docs;
     }
+  }
+
+  private isInactive2faCipher(cipher: CipherView): [string, boolean] {
+    let docFor2fa: string = "";
+    let isInactive2faCipher: boolean = false;
+
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      (login.totp != null && login.totp !== "") ||
+      !login.hasUris ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
+      return [docFor2fa, isInactive2faCipher];
+    }
+
+    for (let i = 0; i < login.uris.length; i++) {
+      const u = login.uris[i];
+      if (u.uri != null && u.uri !== "") {
+        const uri = u.uri.replace("www.", "");
+        const domain = Utils.getDomain(uri);
+        if (domain != null && this.services.has(domain)) {
+          if (this.services.get(domain) != null) {
+            docFor2fa = this.services.get(domain) || "";
+          }
+          isInactive2faCipher = true;
+          break;
+        }
+      }
+    }
+    return [docFor2fa, isInactive2faCipher];
   }
 
   private async load2fa() {
@@ -140,5 +154,23 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
   protected canManageCipher(c: CipherView): boolean {
     // this will only ever be false from the org view;
     return true;
+  }
+
+  async determinedUpdatedCipherReportStatus(
+    result: VaultItemDialogResult,
+    updatedCipherView: CipherView,
+  ): Promise<CipherView | null> {
+    if (result === VaultItemDialogResult.Deleted) {
+      return null;
+    }
+
+    const [docFor2fa, isInactive2faCipher] = this.isInactive2faCipher(updatedCipherView);
+
+    if (isInactive2faCipher) {
+      this.cipherDocs.set(updatedCipherView.id, docFor2fa);
+      return updatedCipherView;
+    }
+
+    return null;
   }
 }

--- a/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/unsecured-websites-report.component.ts
@@ -10,6 +10,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
+import { VaultItemDialogResult } from "@bitwarden/web-vault/app/vault/components/vault-item-dialog/vault-item-dialog.component";
 
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
@@ -91,5 +92,21 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
   protected canManageCipher(c: CipherView): boolean {
     // this will only ever be false from the org view;
     return true;
+  }
+
+  async determinedUpdatedCipherReportStatus(
+    result: VaultItemDialogResult,
+    updatedCipherView: CipherView,
+  ): Promise<CipherView | null> {
+    if (result === VaultItemDialogResult.Deleted) {
+      return null;
+    }
+
+    // If the cipher still contains unsecured URIs, return it as is
+    if (this.cipherContainsUnsecured(updatedCipherView)) {
+      return updatedCipherView;
+    }
+
+    return null;
   }
 }

--- a/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/tools/reports/pages/weak-passwords-report.component.ts
@@ -1,15 +1,12 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
-import { firstValueFrom } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
-import { CipherId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -70,46 +67,26 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     this.findWeakPasswords(allCiphers);
   }
 
-  protected async refresh(result: VaultItemDialogResult, cipher: CipherView) {
+  async determinedUpdatedCipherReportStatus(
+    result: VaultItemDialogResult,
+    updatedCipherView: CipherView,
+  ): Promise<CipherView | null> {
     if (result === VaultItemDialogResult.Deleted) {
-      // remove the cipher from the list
-      this.weakPasswordCiphers = this.weakPasswordCiphers.filter((c) => c.id !== cipher.id);
-      this.filterCiphersByOrg(this.weakPasswordCiphers);
-      return;
-    }
-
-    if (result == VaultItemDialogResult.Saved) {
-      const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-      let updatedCipher = await this.cipherService.get(cipher.id, activeUserId);
-
-      if (this.isAdminConsoleActive) {
-        updatedCipher = await this.adminConsoleCipherFormConfigService.getCipher(
-          cipher.id as CipherId,
-          this.organization,
-        );
-      }
-
-      const updatedCipherView = await updatedCipher.decrypt(
-        await this.cipherService.getKeyForCipherKeyDecryption(updatedCipher, activeUserId),
+      this.weakPasswordCiphers = this.weakPasswordCiphers.filter(
+        (c) => c.id !== updatedCipherView.id,
       );
-      // update the cipher views
-      const updatedReportResult = this.determineWeakPasswordScore(updatedCipherView);
-      const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
-
-      if (updatedReportResult == null) {
-        // the password is no longer weak
-        // remove the cipher from the list
-        this.weakPasswordCiphers.splice(index, 1);
-        this.filterCiphersByOrg(this.weakPasswordCiphers);
-        return;
-      }
-
-      if (index > -1) {
-        // update the existing cipher
-        this.weakPasswordCiphers[index] = updatedReportResult;
-        this.filterCiphersByOrg(this.weakPasswordCiphers);
-      }
+      return null;
     }
+
+    const updatedReportStatus = await this.determineWeakPasswordScore(updatedCipherView);
+
+    const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
+
+    if (index !== -1) {
+      this.weakPasswordCiphers[index] = updatedReportStatus;
+    }
+
+    return updatedReportStatus;
   }
 
   protected findWeakPasswords(ciphers: CipherView[]): void {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21040

## 📔 Objective

The following reports were changed to refresh the cypher after it has been edited:
- weak-passwords 
- Reused passwords
- Exposed passwords
- Unsecure websites 
- Inactive two step login
- member access 

## 📸 Screenshots

None at this time

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
