### PR TITLE
[PM-21073] No error when submitting empty form

### DIFF
--- a/apps/web/src/app/billing/members/add-sponsorship-dialog.component.html
+++ b/apps/web/src/app/billing/members/add-sponsorship-dialog.component.html
@@ -7,7 +7,7 @@
         <div class="tw-grid tw-grid-cols-12 tw-gap-4">
           <div class="tw-col-span-12">
             <bit-form-field>
-              <bit-label>{{ "email" | i18n }}:</bit-label>
+              <bit-label>{{ "email" | i18n }}</bit-label>
               <input
                 bitInput
                 inputmode="email"
@@ -19,13 +19,12 @@
           </div>
           <div class="tw-col-span-12">
             <bit-form-field>
-              <bit-label>{{ "notes" | i18n }}:</bit-label>
+              <bit-label>{{ "notes" | i18n }}</bit-label>
               <input
                 bitInput
                 inputmode="text"
                 formControlName="sponsorshipNote"
                 [attr.aria-invalid]="sponsorshipNoteControl.invalid"
-                appInputStripSpaces
               />
             </bit-form-field>
           </div>

--- a/apps/web/src/app/billing/members/add-sponsorship-dialog.component.ts
+++ b/apps/web/src/app/billing/members/add-sponsorship-dialog.component.ts
@@ -74,7 +74,9 @@ export class AddSponsorshipDialogComponent {
         asyncValidators: [this.isOrganizationMember.bind(this)],
         updateOn: "change",
       }),
-      sponsorshipNote: new FormControl<string | null>("", {}),
+      sponsorshipNote: new FormControl<string | null>("", {
+        validators: [Validators.maxLength(1000)],
+      }),
     });
   }
 
@@ -86,6 +88,8 @@ export class AddSponsorshipDialogComponent {
   }
 
   protected async save() {
+    this.sponsorshipEmailControl.markAllAsTouched();
+
     if (this.sponsorshipForm.invalid) {
       return;
     }

--- a/apps/web/src/app/billing/settings/sponsoring-org-row.component.html
+++ b/apps/web/src/app/billing/settings/sponsoring-org-row.component.html
@@ -1,5 +1,5 @@
 <td bitCell>
-  {{ sponsoringOrg.familySponsorshipFriendlyName }}
+  {{ sponsoringOrg.friendlyName }}
 </td>
 <td bitCell>{{ sponsoringOrg.name }}</td>
 <td bitCell>
@@ -7,7 +7,7 @@
 </td>
 <td bitCell>
   <button
-    *ngIf="!sponsoringOrg.familySponsorshipToDelete"
+    *ngIf="!sponsoringOrg.toDelete"
     type="button"
     bitIconButton="bwi-ellipsis-v"
     buttonType="main"
@@ -18,13 +18,9 @@
     <button
       type="button"
       bitMenuItem
-      *ngIf="
-        !isSelfHosted &&
-        !sponsoringOrg.familySponsorshipValidUntil &&
-        !(isFreeFamilyPolicyEnabled$ | async)
-      "
+      *ngIf="!isSelfHosted && !sponsoringOrg.validUntil && !(isFreeFamilyPolicyEnabled$ | async)"
       (click)="resendEmail()"
-      [attr.aria-label]="'resendEmailLabel' | i18n: sponsoringOrg.familySponsorshipFriendlyName"
+      [attr.aria-label]="'resendEmailLabel' | i18n: sponsoringOrg.friendlyName"
     >
       {{ "resendEmail" | i18n }}
     </button>
@@ -32,7 +28,7 @@
       type="button"
       bitMenuItem
       (click)="revokeSponsorship()"
-      [attr.aria-label]="'revokeAccountMessage' | i18n: sponsoringOrg.familySponsorshipFriendlyName"
+      [attr.aria-label]="'revokeAccountMessage' | i18n: sponsoringOrg.friendlyName"
     >
       <span class="tw-text-danger">{{ "remove" | i18n }}</span>
     </button>

--- a/apps/web/src/app/billing/settings/sponsoring-org-row.component.html
+++ b/apps/web/src/app/billing/settings/sponsoring-org-row.component.html
@@ -1,5 +1,5 @@
 <td bitCell>
-  {{ sponsoringOrg.friendlyName }}
+  {{ sponsoringOrg.familySponsorshipFriendlyName }}
 </td>
 <td bitCell>{{ sponsoringOrg.name }}</td>
 <td bitCell>
@@ -7,7 +7,7 @@
 </td>
 <td bitCell>
   <button
-    *ngIf="!sponsoringOrg.toDelete"
+    *ngIf="!sponsoringOrg.familySponsorshipToDelete"
     type="button"
     bitIconButton="bwi-ellipsis-v"
     buttonType="main"
@@ -18,9 +18,13 @@
     <button
       type="button"
       bitMenuItem
-      *ngIf="!isSelfHosted && !sponsoringOrg.validUntil && !(isFreeFamilyPolicyEnabled$ | async)"
+      *ngIf="
+        !isSelfHosted &&
+        !sponsoringOrg.familySponsorshipValidUntil &&
+        !(isFreeFamilyPolicyEnabled$ | async)
+      "
       (click)="resendEmail()"
-      [attr.aria-label]="'resendEmailLabel' | i18n: sponsoringOrg.friendlyName"
+      [attr.aria-label]="'resendEmailLabel' | i18n: sponsoringOrg.familySponsorshipFriendlyName"
     >
       {{ "resendEmail" | i18n }}
     </button>
@@ -28,7 +32,7 @@
       type="button"
       bitMenuItem
       (click)="revokeSponsorship()"
-      [attr.aria-label]="'revokeAccountMessage' | i18n: sponsoringOrg.friendlyName"
+      [attr.aria-label]="'revokeAccountMessage' | i18n: sponsoringOrg.familySponsorshipFriendlyName"
     >
       <span class="tw-text-danger">{{ "remove" | i18n }}</span>
     </button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21114
https://bitwarden.atlassian.net/browse/PM-21073
https://bitwarden.atlassian.net/browse/PM-21094
https://bitwarden.atlassian.net/browse/PM-21113

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
1. This PR fixes an issue where submitting a sponsorship with more than 1000 characters in the Notes field results in a generic and unclear error:
"Modal state is invalid."
2. This PR fixes a bug where the “Notes” field in the Add Sponsorship modal does not allow users to input spaces in their text.
3.  This PR addresses a validation issue in the Add Sponsorship modal on the Free Sponsored Families page.
4. This PR updates the Add Sponsorship modal to align with app-wide form labeling conventions by removing colons (:) after field names.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" alt="Screenshot 2025-05-02 at 09 30 30" src="https://github.com/user-attachments/assets/13a09d01-0224-4932-8767-10f316f3764e" />
<img width="1728" alt="Screenshot 2025-05-02 at 09 30 37" src="https://github.com/user-attachments/assets/e45ef1ca-7a6c-47d2-a57b-3635a86196aa" />
<img width="1728" alt="Screenshot 2025-05-02 at 11 17 12" src="https://github.com/user-attachments/assets/e2b66cb4-f383-4bd9-81c9-5ac6b89b7235" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
