### PR TITLE
Add typescript-eslint to be owned by arch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -129,6 +129,8 @@
     {
       matchPackageNames: [
         "@angular-eslint/schematics",
+        "@typescript-eslint/rule-tester",
+        "@typescript-eslint/utils",
         "angular-eslint",
         "eslint-config-prettier",
         "eslint-import-resolver-typescript",


### PR DESCRIPTION

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

https://github.com/bitwarden/clients/pull/14580 moved some linting dependencies to architecture but only added them to the group and not did not assign reviewers correctly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
