### PR TITLE
[PM-21116] Add SSO org identifier option for SSO on CLI

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -117,8 +117,9 @@ export class LoginCommand {
       ssoCodeVerifier = await this.passwordGenerationService.generatePassword(passwordOptions);
       const codeVerifierHash = await this.cryptoFunctionService.hash(ssoCodeVerifier, "sha256");
       const codeChallenge = Utils.fromBufferToUrlB64(codeVerifierHash);
+      const identifier = options.identifier ?? null;
       try {
-        const ssoParams = await this.openSsoPrompt(codeChallenge, state);
+        const ssoParams = await this.openSsoPrompt(codeChallenge, state, identifier);
         ssoCode = ssoParams.ssoCode;
         orgIdentifier = ssoParams.orgIdentifier;
       } catch {
@@ -729,6 +730,7 @@ export class LoginCommand {
   private async openSsoPrompt(
     codeChallenge: string,
     state: string,
+    identifier: string,
   ): Promise<{ ssoCode: string; orgIdentifier: string }> {
     const env = await firstValueFrom(this.environmentService.environment$);
 
@@ -777,6 +779,8 @@ export class LoginCommand {
               this.ssoRedirectUri,
               state,
               codeChallenge,
+              null,
+              identifier,
             );
             this.platformUtilsService.launchUri(webAppSsoUrl);
           });

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -105,6 +105,8 @@ export class LoginCommand {
         return Response.badRequest("client_secret is required.");
       }
     } else if (options.sso != null && this.canInteract) {
+      // If the optional identifier isn't provided, the option value is `true`.
+      const identifier = options.sso === true ? null : options.sso;
       const passwordOptions: any = {
         type: "password",
         length: 64,
@@ -117,7 +119,6 @@ export class LoginCommand {
       ssoCodeVerifier = await this.passwordGenerationService.generatePassword(passwordOptions);
       const codeVerifierHash = await this.cryptoFunctionService.hash(ssoCodeVerifier, "sha256");
       const codeChallenge = Utils.fromBufferToUrlB64(codeVerifierHash);
-      const identifier = options.identifier ?? null;
       try {
         const ssoParams = await this.openSsoPrompt(codeChallenge, state, identifier);
         ssoCode = ssoParams.ssoCode;

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -106,7 +106,7 @@ export class LoginCommand {
       }
     } else if (options.sso != null && this.canInteract) {
       // If the optional identifier isn't provided, the option value is `true`.
-      const identifier = options.sso === true ? null : options.sso;
+      const orgSsoIdentifier = options.sso === true ? null : options.sso;
       const passwordOptions: any = {
         type: "password",
         length: 64,
@@ -120,7 +120,7 @@ export class LoginCommand {
       const codeVerifierHash = await this.cryptoFunctionService.hash(ssoCodeVerifier, "sha256");
       const codeChallenge = Utils.fromBufferToUrlB64(codeVerifierHash);
       try {
-        const ssoParams = await this.openSsoPrompt(codeChallenge, state, identifier);
+        const ssoParams = await this.openSsoPrompt(codeChallenge, state, orgSsoIdentifier);
         ssoCode = ssoParams.ssoCode;
         orgIdentifier = ssoParams.orgIdentifier;
       } catch {
@@ -731,7 +731,7 @@ export class LoginCommand {
   private async openSsoPrompt(
     codeChallenge: string,
     state: string,
-    identifier: string,
+    orgSsoIdentifier: string,
   ): Promise<{ ssoCode: string; orgIdentifier: string }> {
     const env = await firstValueFrom(this.environmentService.environment$);
 
@@ -781,7 +781,7 @@ export class LoginCommand {
               state,
               codeChallenge,
               null,
-              identifier,
+              orgSsoIdentifier,
             );
             this.platformUtilsService.launchUri(webAppSsoUrl);
           });

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -105,7 +105,7 @@ export class LoginCommand {
         return Response.badRequest("client_secret is required.");
       }
     } else if (options.sso != null && this.canInteract) {
-      // If the optional identifier isn't provided, the option value is `true`.
+      // If the optional Org SSO Identifier isn't provided, the option value is `true`.
       const orgSsoIdentifier = options.sso === true ? null : options.sso;
       const passwordOptions: any = {
         type: "password",

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -118,8 +118,10 @@ export class Program extends BaseProgram {
       .description("Log into a user account.")
       .option("--method <method>", "Two-step login method.")
       .option("--code <code>", "Two-step login code.")
-      .option("--sso", "Log in with Single-Sign On.")
-      .option("--identifier <identifier>", "Identifier for SSO login.")
+      .option(
+        "--sso [identifier]",
+        "Log in with Single-Sign On with optional organization identifier.",
+      )
       .option("--apikey", "Log in with an Api Key.")
       .option("--passwordenv <passwordenv>", "Environment variable storing your password")
       .option(

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -119,6 +119,7 @@ export class Program extends BaseProgram {
       .option("--method <method>", "Two-step login method.")
       .option("--code <code>", "Two-step login code.")
       .option("--sso", "Log in with Single-Sign On.")
+      .option("--identifier <identifier>", "Identifier for SSO login.")
       .option("--apikey", "Log in with an Api Key.")
       .option("--passwordenv <passwordenv>", "Environment variable storing your password")
       .option(

--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -155,6 +155,13 @@ export class SsoComponent implements OnInit {
       return;
     }
 
+    // Detect if we are on the first portion of the SSO flow
+    // and have been sent here from another client with the info in query params.
+    // If so, we want to initialize the SSO flow with those values.
+    if (this.hasParametersFromOtherClientRedirect(qParams)) {
+      this.initializeFromRedirectFromOtherClient(qParams);
+    }
+
     // Detect if we have landed here but only have an SSO identifier in the URL.
     // This is used by integrations that want to "short-circuit" the login to send users
     // directly to their IdP to simulate IdP-initiated SSO, so we submit automatically.
@@ -163,13 +170,6 @@ export class SsoComponent implements OnInit {
       this.loggingIn = true;
       await this.submit();
       return;
-    }
-
-    // Detect if we are on the first portion of the SSO flow
-    // and have been sent here from another client with the info in query params.
-    // If so, we want to initialize the SSO flow with those values.
-    if (this.hasParametersFromOtherClientRedirect(qParams)) {
-      this.initializeFromRedirectFromOtherClient(qParams);
     }
 
     // Try to determine the identifier using claimed domain or local state

--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -162,7 +162,7 @@ export class SsoComponent implements OnInit {
       this.initializeFromRedirectFromOtherClient(qParams);
     }
 
-    // Detect if we have landed here but only have an SSO identifier in the URL.
+    // Detect if we have landed here with an SSO identifier in the URL.
     // This is used by integrations that want to "short-circuit" the login to send users
     // directly to their IdP to simulate IdP-initiated SSO, so we submit automatically.
     if (qParams.identifier != null) {

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
@@ -92,4 +92,27 @@ describe("SsoUrlService", () => {
     );
     expect(result).toBe(expectedUrl);
   });
+
+  it("should build CLI SSO URL with identifier correctly", () => {
+    const baseUrl = "https://web-vault.bitwarden.com";
+    const clientType = ClientType.Cli;
+    const redirectUri = "https://localhost:1000";
+    const state = "abc123";
+    const codeChallenge = "xyz789";
+    const email = "test@bitwarden.com";
+    const identifier = "test-org";
+
+    const expectedUrl = `${baseUrl}/#/sso?clientId=cli&redirectUri=${encodeURIComponent(redirectUri)}&state=${state}&codeChallenge=${codeChallenge}&email=${encodeURIComponent(email)}&identifier=${encodeURIComponent(identifier)}`;
+
+    const result = service.buildSsoUrl(
+      baseUrl,
+      clientType,
+      redirectUri,
+      state,
+      codeChallenge,
+      email,
+      identifier,
+    );
+    expect(result).toBe(expectedUrl);
+  });
 });

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
@@ -93,16 +93,16 @@ describe("SsoUrlService", () => {
     expect(result).toBe(expectedUrl);
   });
 
-  it("should build CLI SSO URL with identifier correctly", () => {
+  it("should build CLI SSO URL with Org SSO Identifier correctly", () => {
     const baseUrl = "https://web-vault.bitwarden.com";
     const clientType = ClientType.Cli;
     const redirectUri = "https://localhost:1000";
     const state = "abc123";
     const codeChallenge = "xyz789";
     const email = "test@bitwarden.com";
-    const identifier = "test-org";
+    const orgSsoIdentifier = "test-org";
 
-    const expectedUrl = `${baseUrl}/#/sso?clientId=cli&redirectUri=${encodeURIComponent(redirectUri)}&state=${state}&codeChallenge=${codeChallenge}&email=${encodeURIComponent(email)}&identifier=${encodeURIComponent(identifier)}`;
+    const expectedUrl = `${baseUrl}/#/sso?clientId=cli&redirectUri=${encodeURIComponent(redirectUri)}&state=${state}&codeChallenge=${codeChallenge}&email=${encodeURIComponent(email)}&identifier=${encodeURIComponent(orgSsoIdentifier)}`;
 
     const result = service.buildSsoUrl(
       baseUrl,
@@ -111,7 +111,7 @@ describe("SsoUrlService", () => {
       state,
       codeChallenge,
       email,
-      identifier,
+      orgSsoIdentifier,
     );
     expect(result).toBe(expectedUrl);
   });

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
@@ -11,6 +11,7 @@ export class SsoUrlService {
    * @param state A state value that will be peristed through the SSO flow
    * @param codeChallenge A challenge value that will be used to verify the SSO code after authentication
    * @param email The optional email adddress of the user initiating SSO, which will be used to look up the org SSO identifier
+   * @param identifier The optional SSO identifier of the org that is initiating SSO
    * @returns The URL for redirecting users to the web app SSO component
    */
   buildSsoUrl(
@@ -20,6 +21,7 @@ export class SsoUrlService {
     state: string,
     codeChallenge: string,
     email?: string,
+    identifier?: string,
   ): string {
     let url =
       webAppUrl +
@@ -34,6 +36,10 @@ export class SsoUrlService {
 
     if (email) {
       url += "&email=" + encodeURIComponent(email);
+    }
+
+    if (identifier) {
+      url += "&identifier=" + encodeURIComponent(identifier);
     }
 
     return url;

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
@@ -11,7 +11,7 @@ export class SsoUrlService {
    * @param state A state value that will be peristed through the SSO flow
    * @param codeChallenge A challenge value that will be used to verify the SSO code after authentication
    * @param email The optional email adddress of the user initiating SSO, which will be used to look up the org SSO identifier
-   * @param identifier The optional SSO identifier of the org that is initiating SSO
+   * @param orgSsoIdentifier The optional SSO identifier of the org that is initiating SSO
    * @returns The URL for redirecting users to the web app SSO component
    */
   buildSsoUrl(
@@ -21,7 +21,7 @@ export class SsoUrlService {
     state: string,
     codeChallenge: string,
     email?: string,
-    identifier?: string,
+    orgSsoIdentifier?: string,
   ): string {
     let url =
       webAppUrl +
@@ -38,8 +38,8 @@ export class SsoUrlService {
       url += "&email=" + encodeURIComponent(email);
     }
 
-    if (identifier) {
-      url += "&identifier=" + encodeURIComponent(identifier);
+    if (orgSsoIdentifier) {
+      url += "&identifier=" + encodeURIComponent(orgSsoIdentifier);
     }
 
     return url;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21116

## 📔 Objective

The `bw login --sso` option did not support any way to pass the SSO org identifier as a command line argument.  Doing so allows us to leverage the "auto-submit" functionality that is built in to the SSO component; when the SSO component detects that an org identifier is in the query string, it automatically progresses the user to the IdP.

Intended usage:
```
bw --sso {Identifier}
```
While still supporting the old usage:
```
bw --sso
```

This required 2 sets of changes:
1. The most straightforward - exposing the new configuration option in the CLI, and passing it in to the redirect URL builder.  Note the parsing of an optional parameter value, as documented in the Commander docs [here](https://github.com/tj/commander.js/blob/HEAD/examples/options-boolean-or-value.js).
2. The less obvious - modifying the `SsoComponent` to initialize the parameters from other clients _before_ handling the `identifier` parameter.  The reason this is necessary is that this is the first time we're allowing use of the `identifier` query string parameter from a client other than the web app.  For the first time, we're supporting a redirect to the `SsoComponent` from another client (CLI) _and_ passing across the identifier.  If we didn't invert the order of the initialization, the auto-submit would occur before we set the appropriate information in state.


## 📸 Screenshots

### Login with `--identifier`

https://github.com/user-attachments/assets/4b01e282-3108-41d2-9078-0c4211c940de

### Login without identifier (still works)

https://github.com/user-attachments/assets/a7e7f166-eb95-4c8a-bbdf-f400396646e7

### Login on web app still works with SSO

https://github.com/user-attachments/assets/e25d8b56-5181-4a59-b30e-095bd0762bef

### Login on redirect-based app (browser extension) still works with SSO

https://github.com/user-attachments/assets/94776ccc-c662-48a8-a4fe-d14e84dc5c64

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
