### PR TITLE
[PM-19022] Separate Manage Account Recovery and Manage Users custom role

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -460,7 +460,13 @@ export class MemberDialogComponent implements OnDestroy {
     return Object.assign(p, partialPermissions);
   }
 
-  handleDependentPermissions() {
+  async handleDependentPermissions() {
+    const separateCustomRolePermissions = await this.configService.getFeatureFlag(
+      FeatureFlag.SeparateCustomRolePermissions,
+    );
+    if (separateCustomRolePermissions) {
+      return;
+    }
     // Manage Password Reset (Account Recovery) must have Manage Users enabled
     if (
       this.permissionsGroup.value.manageResetPassword &&

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -14,6 +14,7 @@ export enum FeatureFlag {
   LimitItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission",
   SsoExternalIdVisibility = "pm-18630-sso-external-id-visibility",
   AccountDeprovisioningBanner = "pm-17120-account-deprovisioning-admin-console-banner",
+  SeparateCustomRolePermissions = "pm-19917-separate-custom-role-permissions",
 
   /* Auth */
   PM9112_DeviceApprovalPersistence = "pm-9112-device-approval-persistence",
@@ -85,6 +86,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.LimitItemDeletion]: FALSE,
   [FeatureFlag.SsoExternalIdVisibility]: FALSE,
   [FeatureFlag.AccountDeprovisioningBanner]: FALSE,
+  [FeatureFlag.SeparateCustomRolePermissions]: FALSE,
 
   /* Autofill */
   [FeatureFlag.BlockBrowserInjectionsByDomain]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19022

## 📔 Objective

> In the member dialog, enabling Manage Account Recovery currently auto-enables Manage Users. This task aims to decouple the two, allowing Manage Account Recovery to be set independently.

## 📸 Screenshots

https://github.com/user-attachments/assets/4c4f10b4-8af7-4ca7-b789-d56d0939a2d6

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
