### PR TITLE
[PM-20283] Route to vault page when user doesn't have access

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -5302,5 +5302,8 @@
   },
   "newSshNudgeBody": {
     "message": "Store your keys and connect with the SSH agent for fast, encrypted authentication."
+  },
+  "noPermissionsViewPage": {
+    "message": "You do not have permissions to view this page. Try logging in with a different account."
   }
 }

--- a/apps/browser/src/vault/guards/at-risk-passwords.guard.ts
+++ b/apps/browser/src/vault/guards/at-risk-passwords.guard.ts
@@ -1,6 +1,6 @@
 import { inject } from "@angular/core";
-import { CanActivateFn } from "@angular/router";
-import { switchMap, tap } from "rxjs";
+import { CanActivateFn, Router } from "@angular/router";
+import { map, switchMap } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -13,18 +13,22 @@ export const canAccessAtRiskPasswords: CanActivateFn = () => {
   const taskService = inject(TaskService);
   const toastService = inject(ToastService);
   const i18nService = inject(I18nService);
+  const router = inject(Router);
 
   return accountService.activeAccount$.pipe(
     filterOutNullish(),
     switchMap((user) => taskService.tasksEnabled$(user.id)),
-    tap((tasksEnabled) => {
+    map((tasksEnabled) => {
       if (!tasksEnabled) {
         toastService.showToast({
           variant: "error",
           title: "",
-          message: i18nService.t("accessDenied"),
+          message: i18nService.t("noPermissionsViewPage"),
         });
+
+        return router.createUrlTree(["/tabs/vault"]);
       }
+      return true;
     }),
   );
 };


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-20283
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
If a user doesn't have access to the `at-risk password` screen, the browser extension prompt launches a blank at-risk password screen in the browser extension
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/d1f073b1-f8e0-4c36-81c8-eb952c0a8ca4


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
