### PR TITLE
[PM-18721][PM-21272] Integrate InputPasswordComponent in AccountRecoveryDialogComponent

### DIFF
--- a/apps/web/src/app/admin-console/common/base-members.component.ts
+++ b/apps/web/src/app/admin-console/common/base-members.component.ts
@@ -86,7 +86,7 @@ export abstract class BaseMembersComponent<UserView extends UserViewTypes> {
     protected i18nService: I18nService,
     protected keyService: KeyService,
     protected validationService: ValidationService,
-    private logService: LogService,
+    protected logService: LogService,
     protected userNamePipe: UserNamePipe,
     protected dialogService: DialogService,
     protected organizationManagementPreferencesService: OrganizationManagementPreferencesService,

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -7,19 +7,11 @@
     <auth-input-password
       [flow]="inputPasswordFlow"
       [masterPasswordPolicyOptions]="masterPasswordPolicyOptions$ | async"
-      (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
-      (isSubmitting)="handleIsSubmittingChange($event)"
     ></auth-input-password>
   </ng-container>
 
   <ng-container bitDialogFooter>
-    <button
-      type="button"
-      bitButton
-      buttonType="primary"
-      [disabled]="submitting$ | async"
-      (click)="handlePrimaryButtonClick()"
-    >
+    <button type="button" bitButton buttonType="primary" [bitAction]="handlePrimaryButtonClick">
       {{ "save" | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -9,27 +9,19 @@
       [message]="'resetPasswordMasterPasswordPolicyInEffect'"
       [masterPasswordPolicyOptions]="masterPasswordPolicyOptions$ | async"
       (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
+      (isSubmitting)="handleIsSubmittingChange($event)"
     ></auth-input-password>
   </ng-container>
 
   <ng-container bitDialogFooter>
     <button
-      class="tw-relative"
       type="button"
       bitButton
       buttonType="primary"
-      [disabled]="submitting"
+      [disabled]="submitting$ | async"
       (click)="handlePrimaryButtonClick()"
     >
-      <span
-        [ngClass]="{ 'tw-invisible': !submitting }"
-        class="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
-      >
-        <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
-      </span>
-      <span [ngClass]="{ 'tw-invisible': submitting }">
-        {{ "save" | i18n }}
-      </span>
+      {{ "save" | i18n }}
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>
       {{ "cancel" | i18n }}

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -1,0 +1,22 @@
+<bit-dialog [title]="'recoverAccount' | i18n" [subtitle]="dialogData.name">
+  <ng-container bitDialogContent>
+    <bit-callout type="warning"
+      >{{ "resetPasswordLoggedOutWarning" | i18n: loggedOutWarningName }}
+    </bit-callout>
+
+    <auth-input-password
+      [flow]="inputPasswordFlow"
+      [masterPasswordPolicyOptions]="masterPasswordPolicyOptions"
+      (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
+    ></auth-input-password>
+  </ng-container>
+
+  <ng-container bitDialogFooter>
+    <button type="button" bitButton buttonType="primary" (click)="submit()">
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
+</bit-dialog>

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -6,6 +6,7 @@
 
     <auth-input-password
       [flow]="inputPasswordFlow"
+      [message]="'resetPasswordMasterPasswordPolicyInEffect'"
       [masterPasswordPolicyOptions]="masterPasswordPolicyOptions"
       (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
     ></auth-input-password>

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -6,7 +6,6 @@
 
     <auth-input-password
       [flow]="inputPasswordFlow"
-      [message]="'resetPasswordMasterPasswordPolicyInEffect'"
       [masterPasswordPolicyOptions]="masterPasswordPolicyOptions$ | async"
       (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
       (isSubmitting)="handleIsSubmittingChange($event)"

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -13,8 +13,23 @@
   </ng-container>
 
   <ng-container bitDialogFooter>
-    <button type="button" bitButton buttonType="primary" (click)="submit()">
-      {{ "save" | i18n }}
+    <button
+      class="tw-relative"
+      type="button"
+      bitButton
+      buttonType="primary"
+      [disabled]="submitting"
+      (click)="handlePrimaryButtonClick()"
+    >
+      <span
+        [ngClass]="{ 'tw-invisible': !submitting }"
+        class="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
+      >
+        <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
+      </span>
+      <span [ngClass]="{ 'tw-invisible': submitting }">
+        {{ "save" | i18n }}
+      </span>
     </button>
     <button type="button" bitButton buttonType="secondary" bitDialogClose>
       {{ "cancel" | i18n }}

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.html
@@ -7,7 +7,7 @@
     <auth-input-password
       [flow]="inputPasswordFlow"
       [message]="'resetPasswordMasterPasswordPolicyInEffect'"
-      [masterPasswordPolicyOptions]="masterPasswordPolicyOptions"
+      [masterPasswordPolicyOptions]="masterPasswordPolicyOptions$ | async"
       (onPasswordFormSubmit)="handlePasswordFormSubmit($event)"
     ></auth-input-password>
   </ng-container>

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -8,7 +8,6 @@ import {
   PasswordInputResult,
 } from "@bitwarden/auth/angular";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -84,7 +83,6 @@ export class AccountRecoveryDialogComponent {
   inputPasswordComponent!: InputPasswordComponent;
 
   inputPasswordFlow = InputPasswordFlow.ChangePasswordDelegation;
-  masterPasswordPolicyOptions?: MasterPasswordPolicyOptions;
   receivedPasswordInputResult = false;
   submitting = false;
 

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from "@angular/common";
-import { Component, Inject, OnInit, ViewChild } from "@angular/core";
-import { firstValueFrom } from "rxjs";
+import { Component, Inject, ViewChild } from "@angular/core";
+import { switchMap } from "rxjs";
 
 import {
   InputPasswordComponent,
@@ -79,7 +79,7 @@ type AccountRecoveryDialogResultType =
     InputPasswordComponent,
   ],
 })
-export class AccountRecoveryDialogComponent implements OnInit {
+export class AccountRecoveryDialogComponent {
   @ViewChild(InputPasswordComponent)
   inputPasswordComponent!: InputPasswordComponent;
 
@@ -87,6 +87,11 @@ export class AccountRecoveryDialogComponent implements OnInit {
   masterPasswordPolicyOptions?: MasterPasswordPolicyOptions;
   receivedPasswordInputResult = false;
   submitting = false;
+
+  masterPasswordPolicyOptions$ = this.accountService.activeAccount$.pipe(
+    getUserId,
+    switchMap((userId) => this.policyService.masterPasswordPolicyOptions$(userId)),
+  );
 
   get loggedOutWarningName() {
     return this.dialogData.name != null ? this.dialogData.name : this.i18nService.t("thisUser");
@@ -102,14 +107,6 @@ export class AccountRecoveryDialogComponent implements OnInit {
     private resetPasswordService: OrganizationUserResetPasswordService,
     private toastService: ToastService,
   ) {}
-
-  async ngOnInit() {
-    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-
-    this.masterPasswordPolicyOptions = await firstValueFrom(
-      this.policyService.masterPasswordPolicyOptions$(userId),
-    );
-  }
 
   handlePrimaryButtonClick = async () => {
     try {

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -152,9 +152,12 @@ export class AccountRecoveryDialogComponent {
    */
   static open = (
     dialogService: DialogService,
-    dialogConfig: DialogConfig<AccountRecoveryDialogData>,
+    dialogConfig: DialogConfig<
+      AccountRecoveryDialogData,
+      DialogRef<AccountRecoveryDialogResultType, unknown>
+    >,
   ) => {
-    return dialogService.open<AccountRecoveryDialogResultType>(
+    return dialogService.open<AccountRecoveryDialogResultType, AccountRecoveryDialogData>(
       AccountRecoveryDialogComponent,
       dialogConfig,
     );

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -80,7 +80,7 @@ type AccountRecoveryDialogResultType =
 })
 export class AccountRecoveryDialogComponent {
   @ViewChild(InputPasswordComponent)
-  inputPasswordComponent!: InputPasswordComponent;
+  inputPasswordComponent: InputPasswordComponent | undefined = undefined;
 
   private parentSubmittingBehaviorSubject = new BehaviorSubject(false);
   parentSubmitting$ = this.parentSubmittingBehaviorSubject.asObservable();
@@ -115,6 +115,10 @@ export class AccountRecoveryDialogComponent {
   ) {}
 
   handlePrimaryButtonClick = async () => {
+    if (!this.inputPasswordComponent) {
+      throw new Error("InputPasswordComponent is not initialized");
+    }
+
     await this.inputPasswordComponent.submit();
   };
 

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -52,9 +52,12 @@ export type AccountRecoveryDialogData = {
   organizationId: string;
 };
 
-export enum AccountRecoveryDialogResult {
-  Ok = "ok",
-}
+export const AccountRecoveryDialogResultTypes = {
+  Ok: "ok",
+} as const;
+
+type AccountRecoveryDialogResultType =
+  (typeof AccountRecoveryDialogResultTypes)[keyof typeof AccountRecoveryDialogResultTypes];
 
 /**
  * Used in a dialog for initiating the account recovery process against a
@@ -81,7 +84,7 @@ export class AccountRecoveryDialogComponent implements OnInit {
   constructor(
     @Inject(DIALOG_DATA) protected dialogData: AccountRecoveryDialogData,
     private accountService: AccountService,
-    private dialogRef: DialogRef<AccountRecoveryDialogResult>,
+    private dialogRef: DialogRef<AccountRecoveryDialogResultType>,
     private i18nService: I18nService,
     private logService: LogService,
     private policyService: PolicyService,
@@ -119,7 +122,7 @@ export class AccountRecoveryDialogComponent implements OnInit {
       this.logService.error(e);
     }
 
-    this.dialogRef.close(AccountRecoveryDialogResult.Ok);
+    this.dialogRef.close(AccountRecoveryDialogResultTypes.Ok);
   }
 
   /**
@@ -131,7 +134,7 @@ export class AccountRecoveryDialogComponent implements OnInit {
     dialogService: DialogService,
     dialogConfig: DialogConfig<AccountRecoveryDialogData>,
   ) => {
-    return dialogService.open<AccountRecoveryDialogResult>(
+    return dialogService.open<AccountRecoveryDialogResultType>(
       AccountRecoveryDialogComponent,
       dialogConfig,
     );

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -1,0 +1,139 @@
+import { Component, Inject, OnInit, ViewChild } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import {
+  InputPasswordComponent,
+  InputPasswordFlow,
+  PasswordInputResult,
+} from "@bitwarden/auth/angular";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import {
+  ButtonModule,
+  CalloutModule,
+  DIALOG_DATA,
+  DialogConfig,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  ToastService,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { OrganizationUserResetPasswordService } from "../../services/organization-user-reset-password/organization-user-reset-password.service";
+
+/**
+ * Encapsulates a few key data inputs needed to initiate an account recovery
+ * process for the organization user in question.
+ */
+export type AccountRecoveryDialogData = {
+  /**
+   * The organization user's full name
+   */
+  name: string;
+
+  /**
+   * The organization user's email address
+   */
+  email: string;
+
+  /**
+   * The `organizationUserId` for the user
+   */
+  id: string;
+
+  /**
+   * The organization's `organizationId`
+   */
+  organizationId: string;
+};
+
+export enum AccountRecoveryDialogResult {
+  Ok = "ok",
+}
+
+/**
+ * Used in a dialog for initiating the account recovery process against a
+ * given organization user. An admin will access this form when they want to
+ * reset a user's password and log them out of sessions.
+ */
+@Component({
+  standalone: true,
+  selector: "app-account-recovery-dialog",
+  templateUrl: "account-recovery-dialog.component.html",
+  imports: [ButtonModule, CalloutModule, DialogModule, I18nPipe, InputPasswordComponent],
+})
+export class AccountRecoveryDialogComponent implements OnInit {
+  @ViewChild(InputPasswordComponent)
+  inputPasswordComponent: InputPasswordComponent;
+
+  inputPasswordFlow = InputPasswordFlow.ChangePasswordDelegation;
+  masterPasswordPolicyOptions?: MasterPasswordPolicyOptions;
+
+  get loggedOutWarningName() {
+    return this.dialogData.name != null ? this.dialogData.name : this.i18nService.t("thisUser");
+  }
+
+  constructor(
+    @Inject(DIALOG_DATA) protected dialogData: AccountRecoveryDialogData,
+    private accountService: AccountService,
+    private dialogRef: DialogRef<AccountRecoveryDialogResult>,
+    private i18nService: I18nService,
+    private logService: LogService,
+    private policyService: PolicyService,
+    private resetPasswordService: OrganizationUserResetPasswordService,
+    private toastService: ToastService,
+  ) {}
+
+  async ngOnInit() {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+
+    this.masterPasswordPolicyOptions = await firstValueFrom(
+      this.policyService.masterPasswordPolicyOptions$(userId),
+    );
+  }
+
+  submit = async () => {
+    await this.inputPasswordComponent.submit();
+  };
+
+  async handlePasswordFormSubmit(passwordInputResult: PasswordInputResult) {
+    try {
+      await this.resetPasswordService.resetMasterPassword(
+        passwordInputResult.newPassword,
+        this.dialogData.email,
+        this.dialogData.id,
+        this.dialogData.organizationId,
+      );
+
+      this.toastService.showToast({
+        variant: "success",
+        title: "",
+        message: this.i18nService.t("resetPasswordSuccess"),
+      });
+    } catch (e) {
+      this.logService.error(e);
+    }
+
+    this.dialogRef.close(AccountRecoveryDialogResult.Ok);
+  }
+
+  /**
+   * Strongly typed helper to open an `AccountRecoveryDialogComponent`
+   * @param dialogService Instance of the dialog service that will be used to open the dialog
+   * @param dialogConfig Configuration for the dialog
+   */
+  static open = (
+    dialogService: DialogService,
+    dialogConfig: DialogConfig<AccountRecoveryDialogData>,
+  ) => {
+    return dialogService.open<AccountRecoveryDialogResult>(
+      AccountRecoveryDialogComponent,
+      dialogConfig,
+    );
+  };
+}

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -1,19 +1,15 @@
 import { CommonModule } from "@angular/common";
 import { Component, Inject, ViewChild } from "@angular/core";
-import { BehaviorSubject, combineLatest, map, switchMap } from "rxjs";
+import { switchMap } from "rxjs";
 
-import {
-  InputPasswordComponent,
-  InputPasswordFlow,
-  PasswordInputResult,
-} from "@bitwarden/auth/angular";
+import { InputPasswordComponent, InputPasswordFlow } from "@bitwarden/auth/angular";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
+  AsyncActionsModule,
   ButtonModule,
   CalloutModule,
   DIALOG_DATA,
@@ -70,6 +66,7 @@ export type AccountRecoveryDialogResultType =
   selector: "app-account-recovery-dialog",
   templateUrl: "account-recovery-dialog.component.html",
   imports: [
+    AsyncActionsModule,
     ButtonModule,
     CalloutModule,
     CommonModule,
@@ -81,16 +78,6 @@ export type AccountRecoveryDialogResultType =
 export class AccountRecoveryDialogComponent {
   @ViewChild(InputPasswordComponent)
   inputPasswordComponent: InputPasswordComponent | undefined = undefined;
-
-  private parentSubmittingBehaviorSubject = new BehaviorSubject(false);
-  parentSubmitting$ = this.parentSubmittingBehaviorSubject.asObservable();
-
-  private childSubmittingBehaviorSubject = new BehaviorSubject(false);
-  childSubmitting$ = this.childSubmittingBehaviorSubject.asObservable();
-
-  submitting$ = combineLatest([this.parentSubmitting$, this.childSubmitting$]).pipe(
-    map(([parentIsSubmitting, childIsSubmitting]) => parentIsSubmitting || childIsSubmitting),
-  );
 
   masterPasswordPolicyOptions$ = this.accountService.activeAccount$.pipe(
     getUserId,
@@ -108,7 +95,6 @@ export class AccountRecoveryDialogComponent {
     private accountService: AccountService,
     private dialogRef: DialogRef<AccountRecoveryDialogResultType>,
     private i18nService: I18nService,
-    private logService: LogService,
     private policyService: PolicyService,
     private resetPasswordService: OrganizationUserResetPasswordService,
     private toastService: ToastService,
@@ -119,37 +105,26 @@ export class AccountRecoveryDialogComponent {
       throw new Error("InputPasswordComponent is not initialized");
     }
 
-    await this.inputPasswordComponent.submit();
-  };
-
-  async handlePasswordFormSubmit(passwordInputResult: PasswordInputResult) {
-    this.parentSubmittingBehaviorSubject.next(true);
-
-    try {
-      await this.resetPasswordService.resetMasterPassword(
-        passwordInputResult.newPassword,
-        this.dialogData.email,
-        this.dialogData.organizationUserId,
-        this.dialogData.organizationId,
-      );
-
-      this.toastService.showToast({
-        variant: "success",
-        title: "",
-        message: this.i18nService.t("resetPasswordSuccess"),
-      });
-    } catch (e) {
-      this.logService.error(e);
-    } finally {
-      this.parentSubmittingBehaviorSubject.next(false);
+    const passwordInputResult = await this.inputPasswordComponent.submit();
+    if (!passwordInputResult) {
+      return;
     }
 
-    this.dialogRef.close(AccountRecoveryDialogResultType.Ok);
-  }
+    await this.resetPasswordService.resetMasterPassword(
+      passwordInputResult.newPassword,
+      this.dialogData.email,
+      this.dialogData.organizationUserId,
+      this.dialogData.organizationId,
+    );
 
-  protected handleIsSubmittingChange(isSubmitting: boolean) {
-    this.childSubmittingBehaviorSubject.next(isSubmitting);
-  }
+    this.toastService.showToast({
+      variant: "success",
+      title: "",
+      message: this.i18nService.t("resetPasswordSuccess"),
+    });
+
+    this.dialogRef.close(AccountRecoveryDialogResultType.Ok);
+  };
 
   /**
    * Strongly typed helper to open an `AccountRecoveryDialogComponent`

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -53,12 +53,12 @@ export type AccountRecoveryDialogData = {
   organizationId: OrganizationId;
 };
 
-export const AccountRecoveryDialogResultTypes = {
+export const AccountRecoveryDialogResultType = {
   Ok: "ok",
 } as const;
 
-type AccountRecoveryDialogResultType =
-  (typeof AccountRecoveryDialogResultTypes)[keyof typeof AccountRecoveryDialogResultTypes];
+export type AccountRecoveryDialogResultType =
+  (typeof AccountRecoveryDialogResultType)[keyof typeof AccountRecoveryDialogResultType];
 
 /**
  * Used in a dialog for initiating the account recovery process against a
@@ -144,7 +144,7 @@ export class AccountRecoveryDialogComponent {
       this.parentSubmittingBehaviorSubject.next(false);
     }
 
-    this.dialogRef.close(AccountRecoveryDialogResultTypes.Ok);
+    this.dialogRef.close(AccountRecoveryDialogResultType.Ok);
   }
 
   protected handleIsSubmittingChange(isSubmitting: boolean) {

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -13,6 +13,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   ButtonModule,
   CalloutModule,
@@ -45,12 +46,12 @@ export type AccountRecoveryDialogData = {
   /**
    * The `organizationUserId` for the user
    */
-  id: string;
+  organizationUserId: string;
 
   /**
    * The organization's `organizationId`
    */
-  organizationId: string;
+  organizationId: OrganizationId;
 };
 
 export const AccountRecoveryDialogResultTypes = {
@@ -133,7 +134,7 @@ export class AccountRecoveryDialogComponent implements OnInit {
       await this.resetPasswordService.resetMasterPassword(
         passwordInputResult.newPassword,
         this.dialogData.email,
-        this.dialogData.id,
+        this.dialogData.organizationUserId,
         this.dialogData.organizationId,
       );
 

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/index.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/index.ts
@@ -1,0 +1,1 @@
+export * from "./account-recovery-dialog.component";

--- a/apps/web/src/app/admin-console/organizations/members/components/reset-password.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/reset-password.component.ts
@@ -57,16 +57,18 @@ export enum ResetPasswordDialogResult {
   Ok = "ok",
 }
 
+/**
+ * Used in a dialog for initiating the account recovery process against a
+ * given organization user. An admin will access this form when they want to
+ * reset a user's password and log them out of sessions.
+ *
+ * @deprecated Use the `AccountRecoveryDialogComponent` instead.
+ */
 @Component({
   selector: "app-reset-password",
   templateUrl: "reset-password.component.html",
   standalone: false,
 })
-/**
- * Used in a dialog for initiating the account recovery process against a
- * given organization user. An admin will access this form when they want to
- * reset a user's password and log them out of sessions.
- */
 export class ResetPasswordComponent implements OnInit, OnDestroy {
   formGroup = this.formBuilder.group({
     newPassword: ["", Validators.required],

--- a/apps/web/src/app/admin-console/organizations/members/components/reset-password.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/reset-password.component.ts
@@ -13,6 +13,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -47,7 +48,7 @@ export type ResetPasswordDialogData = {
   /**
    * The organization's `organizationId`
    */
-  organizationId: string;
+  organizationId: OrganizationId;
 };
 
 // FIXME: update to use a const object instead of a typescript enum

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -68,7 +68,7 @@ import { openEntityEventsDialog } from "../manage/entity-events.component";
 
 import {
   AccountRecoveryDialogComponent,
-  AccountRecoveryDialogResult,
+  AccountRecoveryDialogResultTypes,
 } from "./components/account-recovery/account-recovery-dialog.component";
 import { BulkConfirmDialogComponent } from "./components/bulk/bulk-confirm-dialog.component";
 import { BulkDeleteDialogComponent } from "./components/bulk/bulk-delete-dialog.component";
@@ -768,7 +768,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       });
 
       const result = await lastValueFrom(dialogRef.closed);
-      if (result === AccountRecoveryDialogResult.Ok) {
+      if (result === AccountRecoveryDialogResultTypes.Ok) {
         await this.load();
       }
     } else {

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -69,7 +69,7 @@ import { openEntityEventsDialog } from "../manage/entity-events.component";
 
 import {
   AccountRecoveryDialogComponent,
-  AccountRecoveryDialogResultTypes,
+  AccountRecoveryDialogResultType,
 } from "./components/account-recovery/account-recovery-dialog.component";
 import { BulkConfirmDialogComponent } from "./components/bulk/bulk-confirm-dialog.component";
 import { BulkDeleteDialogComponent } from "./components/bulk/bulk-delete-dialog.component";
@@ -769,7 +769,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       });
 
       const result = await lastValueFrom(dialogRef.closed);
-      if (result === AccountRecoveryDialogResultTypes.Ok) {
+      if (result === AccountRecoveryDialogResultType.Ok) {
         await this.load();
       }
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -780,7 +780,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       data: {
         name: this.userNamePipe.transform(user),
         email: user != null ? user.email : null,
-        organizationId: this.organization.id,
+        organizationId: this.organization.id as OrganizationId,
         id: user != null ? user.id : null,
       },
     });

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -66,6 +66,10 @@ import { GroupApiService } from "../core";
 import { OrganizationUserView } from "../core/views/organization-user.view";
 import { openEntityEventsDialog } from "../manage/entity-events.component";
 
+import {
+  AccountRecoveryDialogComponent,
+  AccountRecoveryDialogResult,
+} from "./components/account-recovery/account-recovery-dialog.component";
 import { BulkConfirmDialogComponent } from "./components/bulk/bulk-confirm-dialog.component";
 import { BulkDeleteDialogComponent } from "./components/bulk/bulk-delete-dialog.component";
 import { BulkEnableSecretsManagerDialogComponent } from "./components/bulk/bulk-enable-sm-dialog.component";
@@ -749,18 +753,38 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
   }
 
   async resetPassword(user: OrganizationUserView) {
-    const dialogRef = ResetPasswordComponent.open(this.dialogService, {
-      data: {
-        name: this.userNamePipe.transform(user),
-        email: user != null ? user.email : null,
-        organizationId: this.organization.id,
-        id: user != null ? user.id : null,
-      },
-    });
+    const changePasswordRefactorFlag = await this.configService.getFeatureFlag(
+      FeatureFlag.PM16117_ChangeExistingPasswordRefactor,
+    );
 
-    const result = await lastValueFrom(dialogRef.closed);
-    if (result === ResetPasswordDialogResult.Ok) {
-      await this.load();
+    if (changePasswordRefactorFlag) {
+      const dialogRef = AccountRecoveryDialogComponent.open(this.dialogService, {
+        data: {
+          name: this.userNamePipe.transform(user),
+          email: user != null ? user.email : null,
+          organizationId: this.organization.id,
+          id: user != null ? user.id : null,
+        },
+      });
+
+      const result = await lastValueFrom(dialogRef.closed);
+      if (result === AccountRecoveryDialogResult.Ok) {
+        await this.load();
+      }
+    } else {
+      const dialogRef = ResetPasswordComponent.open(this.dialogService, {
+        data: {
+          name: this.userNamePipe.transform(user),
+          email: user != null ? user.email : null,
+          organizationId: this.organization.id,
+          id: user != null ? user.id : null,
+        },
+      });
+
+      const result = await lastValueFrom(dialogRef.closed);
+      if (result === ResetPasswordDialogResult.Ok) {
+        await this.load();
+      }
     }
   }
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -772,20 +772,22 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       if (result === AccountRecoveryDialogResultTypes.Ok) {
         await this.load();
       }
-    } else {
-      const dialogRef = ResetPasswordComponent.open(this.dialogService, {
-        data: {
-          name: this.userNamePipe.transform(user),
-          email: user != null ? user.email : null,
-          organizationId: this.organization.id,
-          id: user != null ? user.id : null,
-        },
-      });
 
-      const result = await lastValueFrom(dialogRef.closed);
-      if (result === ResetPasswordDialogResult.Ok) {
-        await this.load();
-      }
+      return;
+    }
+
+    const dialogRef = ResetPasswordComponent.open(this.dialogService, {
+      data: {
+        name: this.userNamePipe.transform(user),
+        email: user != null ? user.email : null,
+        organizationId: this.organization.id,
+        id: user != null ? user.id : null,
+      },
+    });
+
+    const result = await lastValueFrom(dialogRef.closed);
+    if (result === ResetPasswordDialogResult.Ok) {
+      await this.load();
     }
   }
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -757,17 +757,18 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       FeatureFlag.PM16117_ChangeExistingPasswordRefactor,
     );
 
-    if (!user || !user.email || !user.id) {
-      this.toastService.showToast({
-        variant: "error",
-        title: this.i18nService.t("errorOccurred"),
-        message: this.i18nService.t("orgUserDetailsNotFound"),
-      });
-
-      return;
-    }
-
     if (changePasswordRefactorFlag) {
+      if (!user || !user.email || !user.id) {
+        this.toastService.showToast({
+          variant: "error",
+          title: this.i18nService.t("errorOccurred"),
+          message: this.i18nService.t("orgUserDetailsNotFound"),
+        });
+        this.logService.error("Org user details not found when attempting account recovery");
+
+        return;
+      }
+
       const dialogRef = AccountRecoveryDialogComponent.open(this.dialogService, {
         data: {
           name: this.userNamePipe.transform(user),
@@ -788,9 +789,9 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
     const dialogRef = ResetPasswordComponent.open(this.dialogService, {
       data: {
         name: this.userNamePipe.transform(user),
-        email: user.email,
+        email: user != null ? user.email : null,
         organizationId: this.organization.id as OrganizationId,
-        id: user.id,
+        id: user != null ? user.id : null,
       },
     });
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -96,6 +96,7 @@ class MembersTableDataSource extends PeopleTableDataSource<OrganizationUserView>
 
 @Component({
   templateUrl: "members.component.html",
+  standalone: false,
 })
 export class MembersComponent extends BaseMembersComponent<OrganizationUserView> {
   userType = OrganizationUserType;

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -52,6 +52,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService, SimpleDialogOptions, ToastService } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
@@ -762,8 +763,8 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
         data: {
           name: this.userNamePipe.transform(user),
           email: user != null ? user.email : null,
-          organizationId: this.organization.id,
-          id: user != null ? user.id : null,
+          organizationId: this.organization.id as OrganizationId,
+          organizationUserId: user != null ? user.id : null,
         },
       });
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -96,7 +96,6 @@ class MembersTableDataSource extends PeopleTableDataSource<OrganizationUserView>
 
 @Component({
   templateUrl: "members.component.html",
-  standalone: false,
 })
 export class MembersComponent extends BaseMembersComponent<OrganizationUserView> {
   userType = OrganizationUserType;
@@ -758,13 +757,23 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       FeatureFlag.PM16117_ChangeExistingPasswordRefactor,
     );
 
+    if (!user || !user.email || !user.id) {
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("orgUserDetailsNotFound"),
+      });
+
+      return;
+    }
+
     if (changePasswordRefactorFlag) {
       const dialogRef = AccountRecoveryDialogComponent.open(this.dialogService, {
         data: {
           name: this.userNamePipe.transform(user),
-          email: user != null ? user.email : null,
+          email: user.email,
           organizationId: this.organization.id as OrganizationId,
-          organizationUserId: user != null ? user.id : null,
+          organizationUserId: user.id,
         },
       });
 
@@ -779,9 +788,9 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
     const dialogRef = ResetPasswordComponent.open(this.dialogService, {
       data: {
         name: this.userNamePipe.transform(user),
-        email: user != null ? user.email : null,
+        email: user.email,
         organizationId: this.organization.id as OrganizationId,
-        id: user != null ? user.id : null,
+        id: user.id,
       },
     });
 

--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
@@ -14,7 +14,7 @@ import { EncryptService } from "@bitwarden/common/key-management/crypto/abstract
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncryptedString, EncString } from "@bitwarden/common/platform/models/domain/enc-string";
-import { UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
   Argon2KdfConfig,
@@ -96,7 +96,7 @@ export class OrganizationUserResetPasswordService
     newMasterPassword: string,
     email: string,
     orgUserId: string,
-    orgId: string,
+    orgId: OrganizationId,
   ): Promise<void> {
     const response = await this.organizationUserApiService.getOrganizationUserResetPasswordDetails(
       orgId,

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2226,7 +2226,7 @@
     "message": "Turn off"
   },
   "orgUserDetailsNotFound": {
-    "message": "Org user details not found"
+    "message": "Member details not found."
   },
   "revokeAccess": {
     "message": "Revoke access"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2225,6 +2225,9 @@
   "disable": {
     "message": "Turn off"
   },
+  "orgUserDetailsNotFound": {
+    "message": "Org user details not found"
+  },
   "revokeAccess": {
     "message": "Revoke access"
   },

--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -49,14 +49,6 @@
         (click)="generatePassword()"
       ></button>
       <button
-        *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation"
-        type="button"
-        bitSuffix
-        bitIconButton="bwi-clone"
-        appA11yTitle="{{ 'copyPassword' | i18n }}"
-        (click)="copy()"
-      ></button>
-      <button
         type="button"
         bitIconButton
         bitSuffix

--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -40,22 +40,22 @@
         type="password"
         formControlName="newPassword"
       />
-      <ng-container *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation">
-        <button
-          type="button"
-          bitIconButton="bwi-generate"
-          bitSuffix
-          [appA11yTitle]="'generatePassword' | i18n"
-          (click)="generatePassword()"
-        ></button>
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-clone"
-          appA11yTitle="{{ 'copyPassword' | i18n }}"
-          (click)="copy()"
-        ></button>
-      </ng-container>
+      <button
+        *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation"
+        type="button"
+        bitIconButton="bwi-generate"
+        bitSuffix
+        [appA11yTitle]="'generatePassword' | i18n"
+        (click)="generatePassword()"
+      ></button>
+      <button
+        *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation"
+        type="button"
+        bitSuffix
+        bitIconButton="bwi-clone"
+        appA11yTitle="{{ 'copyPassword' | i18n }}"
+        (click)="copy()"
+      ></button>
       <button
         type="button"
         bitIconButton

--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -40,14 +40,22 @@
         type="password"
         formControlName="newPassword"
       />
-      <button
-        *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation"
-        type="button"
-        bitIconButton="bwi-generate"
-        bitSuffix
-        [appA11yTitle]="'generatePassword' | i18n"
-        (click)="generatePassword()"
-      ></button>
+      <ng-container *ngIf="flow === InputPasswordFlow.ChangePasswordDelegation">
+        <button
+          type="button"
+          bitIconButton="bwi-generate"
+          bitSuffix
+          [appA11yTitle]="'generatePassword' | i18n"
+          (click)="generatePassword()"
+        ></button>
+        <button
+          type="button"
+          bitSuffix
+          bitIconButton="bwi-clone"
+          appA11yTitle="{{ 'copyPassword' | i18n }}"
+          (click)="copy()"
+        ></button>
+      </ng-container>
       <button
         type="button"
         bitIconButton

--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -261,7 +261,7 @@ export class InputPasswordComponent implements OnInit {
     }
   }
 
-  submit = async () => {
+  submit = async (): Promise<PasswordInputResult | undefined> => {
     try {
       this.isSubmitting.emit(true);
 
@@ -280,8 +280,7 @@ export class InputPasswordComponent implements OnInit {
       const checkForBreaches = this.formGroup.controls.checkForBreaches?.value ?? true;
 
       if (this.flow === InputPasswordFlow.ChangePasswordDelegation) {
-        await this.handleChangePasswordDelegationFlow(newPassword);
-        return;
+        return await this.handleChangePasswordDelegationFlow(newPassword);
       }
 
       if (!this.email) {
@@ -388,6 +387,7 @@ export class InputPasswordComponent implements OnInit {
 
       // 5. Emit cryptographic keys and other password related properties
       this.onPasswordFormSubmit.emit(passwordInputResult);
+      return passwordInputResult;
     } catch (e) {
       this.validationService.showError(e);
     } finally {
@@ -441,7 +441,9 @@ export class InputPasswordComponent implements OnInit {
     }
   }
 
-  private async handleChangePasswordDelegationFlow(newPassword: string) {
+  private async handleChangePasswordDelegationFlow(
+    newPassword: string,
+  ): Promise<PasswordInputResult | undefined> {
     const newPasswordVerified = await this.verifyNewPassword(
       newPassword,
       this.passwordStrengthScore,
@@ -456,6 +458,7 @@ export class InputPasswordComponent implements OnInit {
     };
 
     this.onPasswordFormSubmit.emit(passwordInputResult);
+    return passwordInputResult;
   }
 
   /**

--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -652,7 +652,7 @@ export class InputPasswordComponent implements OnInit {
     this.platformUtilsService.copyToClipboard(value, { window: window });
     this.toastService.showToast({
       variant: "info",
-      title: "",
+      title: null,
       message: this.i18nService.t("valueCopied", this.i18nService.t("password")),
     });
   }

--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -652,7 +652,7 @@ export class InputPasswordComponent implements OnInit {
     this.platformUtilsService.copyToClipboard(value, { window: window });
     this.toastService.showToast({
       variant: "info",
-      title: null,
+      title: "",
       message: this.i18nService.t("valueCopied", this.i18nService.t("password")),
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18721](https://bitwarden.atlassian.net/browse/PM-18721)
[PM-21272](https://bitwarden.atlassian.net/browse/PM-21272)

This PR stacks on top of these two PRs:
- https://github.com/bitwarden/clients/pull/14636
- https://github.com/bitwarden/clients/pull/14226

## 📔 Objective

This PR integrates the `InputPasswordComponent` within the `AccountRecoveryDialogComponent` (formerly called `ResetPasswordComponent`).

The result is that:
- The `InputPasswordComponent` will now handle form field UI display and validation that is common to all of our set/change password flows
- The `AccountRecoveryDialogComponent` will now just be responsible for displaying the dialog and calling `resetPasswordService.resetMasterPassword()` to perform the password reset operation.

The showing of the new dialog component is behind the `PM16117_ChangeExistingPasswordRefactor` feature flag.

## 📸 Screenshots

`PM16117_ChangeExistingPasswordRefactor` flag ON ✅

https://github.com/user-attachments/assets/45a82faf-668a-45d7-a6ea-131f13df03f3

`PM16117_ChangeExistingPasswordRefactor` flag OFF ❌

https://github.com/user-attachments/assets/4fe07143-0608-4fe9-8cb5-cf8ec88b1cc8

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18721]: https://bitwarden.atlassian.net/browse/PM-18721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-21272]: https://bitwarden.atlassian.net/browse/PM-21272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ