### PR TITLE
[PM-21280] - hide setings UI changes behind feature flag

### DIFF
--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
@@ -23,6 +23,12 @@
         <i slot="end" class="bwi bwi-external-link" aria-hidden="true"></i>
       </button>
     </bit-item>
+    <bit-item *ngIf="!(isNudgeFeatureEnabled$ | async)">
+      <a bit-item-content routerLink="/more-from-bitwarden">
+        {{ "moreFromBitwarden" | i18n }}
+        <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
+      </a>
+    </bit-item>
     <bit-item>
       <button type="button" bit-item-content (click)="rate()">
         {{ "rateExtension" | i18n }}

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { firstValueFrom, map } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DeviceType } from "@bitwarden/common/enums";
@@ -56,9 +56,9 @@ export class AboutPageV2Component {
     this.dialogService.open(AboutDialogComponent);
   }
 
-  isNudgeFeatureEnabled$ = this.configService
-    .getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge)
-    .pipe(map((isEnabled) => isEnabled));
+  protected isNudgeFeatureEnabled$ = this.configService.getFeatureFlag$(
+    FeatureFlag.PM8851_BrowserOnboardingNudge,
+  );
 
   async launchHelp() {
     const confirmed = await this.dialogService.openSimpleDialog({

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -1,10 +1,12 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DeviceType } from "@bitwarden/common/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { DialogService, ItemModule } from "@bitwarden/components";
@@ -47,11 +49,16 @@ export class AboutPageV2Component {
     private dialogService: DialogService,
     private environmentService: EnvironmentService,
     private platformUtilsService: PlatformUtilsService,
+    private configService: ConfigService,
   ) {}
 
   about() {
     this.dialogService.open(AboutDialogComponent);
   }
+
+  isNudgeFeatureEnabled$ = this.configService
+    .getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge)
+    .pipe(map((isEnabled) => isEnabled));
 
   async launchHelp() {
     const confirmed = await this.dialogService.openSimpleDialog({

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -66,7 +66,7 @@
         <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </a>
     </bit-item>
-    <bit-item>
+    <bit-item *ngIf="isNudgeFeatureEnabled$ | async">
       <a bit-item-content routerLink="/download-bitwarden">
         <i slot="start" class="bwi bwi-mobile" aria-hidden="true"></i>
         <div class="tw-flex tw-items-center tw-justify-center">
@@ -81,7 +81,7 @@
         <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </a>
     </bit-item>
-    <bit-item>
+    <bit-item *ngIf="isNudgeFeatureEnabled$ | async">
       <a bit-item-content routerLink="/more-from-bitwarden">
         <i slot="start" class="bwi bwi-filter" aria-hidden="true"></i>
         {{ "moreFromBitwarden" | i18n }}

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { filter, firstValueFrom, map, Observable, shareReplay, switchMap } from "rxjs";
+import { filter, firstValueFrom, Observable, shareReplay, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -51,9 +51,9 @@ export class SettingsV2Component {
     ),
   );
 
-  isNudgeFeatureEnabled$ = this.configService
-    .getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge)
-    .pipe(map((isEnabled) => isEnabled));
+  protected isNudgeFeatureEnabled$ = this.configService.getFeatureFlag$(
+    FeatureFlag.PM8851_BrowserOnboardingNudge,
+  );
 
   constructor(
     private readonly vaultNudgesService: VaultNudgesService,

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -1,10 +1,12 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { filter, firstValueFrom, Observable, shareReplay, switchMap } from "rxjs";
+import { filter, firstValueFrom, map, Observable, shareReplay, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BadgeComponent, ItemModule } from "@bitwarden/components";
 import { NudgeStatus, VaultNudgesService, VaultNudgeType } from "@bitwarden/vault";
@@ -49,9 +51,14 @@ export class SettingsV2Component {
     ),
   );
 
+  isNudgeFeatureEnabled$ = this.configService
+    .getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge)
+    .pipe(map((isEnabled) => isEnabled));
+
   constructor(
     private readonly vaultNudgesService: VaultNudgesService,
     private readonly accountService: AccountService,
+    private readonly configService: ConfigService,
   ) {}
 
   async dismissBadge(type: VaultNudgeType) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21280

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR hides the nudge epic settings page UI changes behind the feature flag.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![Screenshot 2025-05-07 at 8 45 33 AM](https://github.com/user-attachments/assets/55403590-b8e6-473d-bc12-8eb1e3ffe694)
![Screenshot 2025-05-07 at 8 45 10 AM](https://github.com/user-attachments/assets/3893e857-4880-49a4-9f9c-72a54513107d)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
