### PR TITLE
Display traffic light MacOS buttons when the vault is locked

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -138,7 +138,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       // make the cipherIds available to the UI.
       this.availableCipherIdsSubject.next(cipherIds);
 
-      await this.showUi("/fido2-assertion", this.windowObject.windowXy);
+      await this.showUi("/fido2-assertion", this.windowObject.windowXy, false);
 
       const chosenCipherResponse = await this.waitForUiChosenCipher();
 
@@ -224,7 +224,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     this.rpId.next(rpId);
 
     try {
-      await this.showUi("/fido2-creation", this.windowObject.windowXy);
+      await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
       // Wait for the UI to wrap up
       const confirmation = await this.waitForUiNewCredentialConfirmation();
@@ -260,10 +260,11 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   private async showUi(
     route: string,
     position?: { x: number; y: number },
+    showTrafficButtons?: boolean,
     disableRedirect?: boolean,
   ): Promise<void> {
     // Load the UI:
-    await this.desktopSettingsService.setModalMode(true, position);
+    await this.desktopSettingsService.setModalMode(true, showTrafficButtons, position);
     await this.router.navigate([
       route,
       {
@@ -332,7 +333,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     // make the cipherIds available to the UI.
     this.availableCipherIdsSubject.next(existingCipherIds);
 
-    await this.showUi("/fido2-excluded", this.windowObject.windowXy);
+    await this.showUi("/fido2-excluded", this.windowObject.windowXy, false);
   }
 
   async ensureUnlockedVault(): Promise<void> {
@@ -340,7 +341,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
     const status = await firstValueFrom(this.authService.activeAccountStatus$);
     if (status !== AuthenticationStatus.Unlocked) {
-      await this.showUi("/lock", this.windowObject.windowXy, true);
+      await this.showUi("/lock", this.windowObject.windowXy, true, true);
 
       let status2: AuthenticationStatus;
       try {

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -90,7 +90,7 @@ export class WindowMain {
           } else if (!lastValue.isModalModeActive && newValue.isModalModeActive) {
             // Apply the popup modal styles
             this.logService.info("Applying popup modal styles", newValue.modalPosition);
-            applyPopupModalStyles(this.win, newValue.modalPosition);
+            applyPopupModalStyles(this.win, newValue.showTrafficButtons, newValue.modalPosition);
             this.win.show();
           }
         }),

--- a/apps/desktop/src/platform/models/domain/window-state.ts
+++ b/apps/desktop/src/platform/models/domain/window-state.ts
@@ -14,5 +14,6 @@ export class WindowState {
 
 export class ModalModeState {
   isModalModeActive: boolean;
+  showTrafficButtons?: boolean;
   modalPosition?: { x: number; y: number }; // Modal position is often passed from the native UI
 }

--- a/apps/desktop/src/platform/popup-modal-styles.ts
+++ b/apps/desktop/src/platform/popup-modal-styles.ts
@@ -8,10 +8,14 @@ const popupHeight = 600;
 
 type Position = { x: number; y: number };
 
-export function applyPopupModalStyles(window: BrowserWindow, position?: Position) {
+export function applyPopupModalStyles(
+  window: BrowserWindow,
+  showTrafficButtons: boolean = true,
+  position?: Position,
+) {
   window.unmaximize();
   window.setSize(popupWidth, popupHeight);
-  window.setWindowButtonVisibility?.(false);
+  window.setWindowButtonVisibility?.(showTrafficButtons);
   window.setMenuBarVisibility?.(false);
   window.setResizable(false);
   window.setAlwaysOnTop(true);

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -306,9 +306,14 @@ export class DesktopSettingsService {
    * Sets the modal mode of the application. Setting this changes the windows-size and other properties.
    * @param value `true` if the application is in modal mode, `false` if it is not.
    */
-  async setModalMode(value: boolean, modalPosition?: { x: number; y: number }) {
+  async setModalMode(
+    value: boolean,
+    showTrafficButtons?: boolean,
+    modalPosition?: { x: number; y: number },
+  ) {
     await this.modalModeState.update(() => ({
       isModalModeActive: value,
+      showTrafficButtons,
       modalPosition,
     }));
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20409](https://bitwarden.atlassian.net/browse/PM-20409)

## 📔 Objective

Currently when the vault is locked the user is unable to cancel out of the passkey flow.  With this change the traffic light buttons are restored (Close/Minimize/Maximize) and the flow can be exited without causing issues.

## 📸 Screenshots

<img width="620" alt="Screenshot 2025-05-08 at 2 23 27 PM" src="https://github.com/user-attachments/assets/56ae80f5-2d7f-42d8-a8fa-fe3c89d538d3" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20409]: https://bitwarden.atlassian.net/browse/PM-20409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ