### PR TITLE
[CL-627] Allow menu to open above trigger without blocking trigger

### DIFF
--- a/libs/components/src/menu/menu-trigger-for.directive.ts
+++ b/libs/components/src/menu/menu-trigger-for.directive.ts
@@ -16,11 +16,7 @@ import { filter, mergeWith } from "rxjs/operators";
 
 import { MenuComponent } from "./menu.component";
 
-@Directive({
-  selector: "[bitMenuTriggerFor]",
-  exportAs: "menuTrigger",
-  standalone: true,
-})
+@Directive({ selector: "[bitMenuTriggerFor]", exportAs: "menuTrigger", standalone: true })
 export class MenuTriggerForDirective implements OnDestroy {
   @HostBinding("attr.aria-expanded") isOpen = false;
   @HostBinding("attr.aria-haspopup") get hasPopup(): "menu" | "dialog" {
@@ -42,18 +38,10 @@ export class MenuTriggerForDirective implements OnDestroy {
       .position()
       .flexibleConnectedTo(this.elementRef)
       .withPositions([
-        {
-          originX: "start",
-          originY: "bottom",
-          overlayX: "start",
-          overlayY: "top",
-        },
-        {
-          originX: "end",
-          originY: "bottom",
-          overlayX: "end",
-          overlayY: "top",
-        },
+        { originX: "start", originY: "bottom", overlayX: "start", overlayY: "top" },
+        { originX: "end", originY: "bottom", overlayX: "end", overlayY: "top" },
+        { originX: "start", originY: "top", overlayX: "start", overlayY: "bottom" },
+        { originX: "end", originY: "top", overlayX: "end", overlayY: "bottom" },
       ])
       .withLockedPosition(true)
       .withFlexibleDimensions(false)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-627](https://bitwarden.atlassian.net/browse/CL-627)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds more menu position options. Previously, we had 2 positions (the first two), but now we will have 4:
1. Opens **below** the trigger element, anchored to the **start** of the trigger element (for LTR, the left)
2. Opens **below** the trigger element, anchored to the **end** of the trigger element (for LTR, the right)
3. Opens **above** the trigger element, anchored to the **start** of the trigger element (for LTR, the left)
4. Opens **above** the trigger element, anchored to the **end** of the trigger element (for LTR, the right)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### **Extension:**
Before:

https://github.com/user-attachments/assets/086a767b-1513-453a-8e3f-93a71df0215c

After:

https://github.com/user-attachments/assets/8a8658fd-8610-4394-ae94-843e18854b53

### **Storybook:**
Before:

https://github.com/user-attachments/assets/870cf3b8-d385-4666-a6a3-71061ffe73e1 

After:

https://github.com/user-attachments/assets/27bfd087-ccf4-476d-b73a-225c49092bfb

### **Web: (no regressions)**
Before:

https://github.com/user-attachments/assets/7785e520-526b-4825-9a57-ff297a4a0256

After:

https://github.com/user-attachments/assets/25a5bd5f-fe50-474f-a1be-dd8ac1af4634

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-627]: https://bitwarden.atlassian.net/browse/CL-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ