### PR TITLE
[PM-21370] Add additional dependency groupings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,7 +94,6 @@ apps/web/src/app/core @bitwarden/team-platform-dev
 apps/web/src/app/shared @bitwarden/team-platform-dev
 apps/web/src/translation-constants.ts @bitwarden/team-platform-dev
 # Workflows
-# Any changes here should also be reflected in Renovate configuration
 .github/workflows/automatic-issue-responses.yml @bitwarden/team-platform-dev
 .github/workflows/automatic-pull-request-responses.yml @bitwarden/team-platform-dev
 .github/workflows/build-browser-target.yml @bitwarden/team-platform-dev
@@ -164,7 +163,6 @@ apps/desktop/src/locales/en/messages.json
 apps/web/src/locales/en/messages.json
 
 ## BRE team owns these workflows ##
-# Any changes here should also be reflected in Renovate configuration ##
 .github/workflows/brew-bump-desktop.yml @bitwarden/dept-bre
 .github/workflows/deploy-web.yml @bitwarden/dept-bre
 .github/workflows/publish-cli.yml @bitwarden/dept-bre

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
   packageRules: [
     {
       // Group all Github Action minor updates together to reduce PR noise.
-      groupName: "Github Action Minor",
+      groupName: "Minor github-actions updates",
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["minor"],
       addLabels: ["hold"],
@@ -100,7 +100,7 @@
         "lint-staged",
         "typescript-eslint",
       ],
-      groupName: "Linting minor updates",
+      groupName: "Minor and patch linting updates",
       matchUpdateTypes: ["minor", "patch"],
     },
     {
@@ -277,7 +277,7 @@
         "webpack",
       ],
       description: "webpack-related build dependencies",
-      groupName: "webpack minor updates",
+      groupName: "Minor and patch webpack updates",
       matchUpdateTypes: ["minor", "patch"],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
     {
       // By default, we send patch updates to the Dependency Dashboard and do not generate a PR.
       // We want to generate PRs for a select number of dependencies to ensure we stay up to date on these.
-      matchPackageNames: ["browserslist", "electron", "rxjs", "typescript", "webpack"],
+      matchPackageNames: ["browserslist", "electron", "rxjs", "typescript", "webpack", "zone.js"],
       matchUpdateTypes: ["patch"],
       dependencyDashboardApproval: false,
     },
@@ -37,16 +37,6 @@
       matchUpdateTypes: ["major"],
       description: "Manually updated using ng update",
       enabled: false,
-    },
-    {
-      // Renovate should manage minor and patch updates for TypeScript, despite ignoring major.
-      matchPackageNames: ["typescript"],
-      matchUpdateTypes: ["minor", "patch"],
-    },
-    {
-      // Renovate should manage minor updates for zone.js, despite ignoring major.
-      matchPackageNames: ["zone.js"],
-      matchUpdateTypes: ["minor"],
     },
     {
       matchPackageNames: ["buffer", "bufferutil", "core-js", "process", "url", "util"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -101,7 +101,7 @@
         "typescript-eslint",
       ],
       groupName: "Linting minor updates",
-      matchUpdateTypes: ["minor"],
+      matchUpdateTypes: ["minor", "patch"],
     },
     {
       matchPackageNames: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -214,7 +214,6 @@
       matchPackageNames: [
         "@babel/core",
         "@babel/preset-env",
-        "@bitwarden/sdk-internal",
         "@electron/fuses",
         "@electron/notarize",
         "@electron/rebuild",
@@ -423,5 +422,5 @@
       reviewers: ["team:team-key-management-dev"],
     },
   ],
-  ignoreDeps: ["@types/koa-bodyparser", "bootstrap", "node-ipc", "node", "npm"],
+  ignoreDeps: ["@types/koa-bodyparser", "bootstrap", "node-ipc", "@bitwarden/sdk-internal"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,51 +4,9 @@
   enabledManagers: ["cargo", "github-actions", "npm"],
   packageRules: [
     {
-      // Group all build/test/lint workflows for GitHub Actions together for Platform.
-      // Since they are code owners we don't need to assign a review team in Renovate.
-      // Any changes here should also be reflected in CODEOWNERS.
-      groupName: "github-action",
+      groupName: "Github Action Minor",
       matchManagers: ["github-actions"],
-      matchFileNames: [
-        "./github/workflows/automatic-issue-responses.yml",
-        "./github/workflows/automatic-pull-request-responses.yml",
-        "./github/workflows/build-browser.yml",
-        "./github/workflows/build-cli.yml",
-        "./github/workflows/build-desktop.yml",
-        "./github/workflows/build-web.yml",
-        "./github/workflows/chromatic.yml",
-        "./github/workflows/crowdin-pull.yml",
-        "./github/workflows/enforce-labels.yml",
-        "./github/workflows/lint.yml",
-        "./github/workflows/locales-lint.yml",
-        "./github/workflows/repository-management.yml",
-        "./github/workflows/scan.yml",
-        "./github/workflows/stale-bot.yml",
-        "./github/workflows/test.yml",
-        "./github/workflows/version-auto-bump.yml",
-      ],
-      commitMessagePrefix: "[deps] Platform:",
-    },
-    {
-      // Group all release-related workflows for GitHub Actions together for BRE.
-      // Since they are code owners we don't need to assign a review team in Renovate.
-      // Any changes here should also be reflected in CODEOWNERS.
-      groupName: "github-action",
-      matchManagers: ["github-actions"],
-      matchFileNames: [
-        "./github/workflows/brew-bump-desktop.yml",
-        "./github/workflows/deploy-web.yml",
-        "./github/workflows/publish-cli.yml",
-        "./github/workflows/publish-desktop.yml",
-        "./github/workflows/publish-web.yml",
-        "./github/workflows/retrieve-current-desktop-rollout.yml",
-        "./github/workflows/staged-rollout-desktop.yml",
-        "./github/workflows/release-cli.yml",
-        "./github/workflows/release-desktop-beta.yml",
-        "./github/workflows/release-desktop.yml",
-        "./github/workflows/release-web.yml",
-      ],
-      commitMessagePrefix: "[deps] BRE:",
+      matchUpdateTypes: ["minor", "patch"],
       addLabels: ["hold"],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,6 +141,7 @@
       matchPackageNames: [
         "@babel/core",
         "@babel/preset-env",
+        "@bitwarden/sdk-internal",
         "@electron/fuses",
         "@electron/notarize",
         "@electron/rebuild",
@@ -327,7 +328,6 @@
     {
       matchPackageNames: [
         "@types/jest",
-        "jest",
         "jest-junit",
         "jest-mock-extended",
         "jest-preset-angular",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,9 +4,10 @@
   enabledManagers: ["cargo", "github-actions", "npm"],
   packageRules: [
     {
+      // Group all Github Action minor updates together to reduce PR noise.
       groupName: "Github Action Minor",
       matchManagers: ["github-actions"],
-      matchUpdateTypes: ["minor", "patch"],
+      matchUpdateTypes: ["minor"],
       addLabels: ["hold"],
     },
     {
@@ -38,49 +39,17 @@
       enabled: false,
     },
     {
-      // Renovate should manage patch updates for TypeScript and Zone.js, despite ignoring major and minor.
-      matchPackageNames: ["typescript", "zone.js"],
-      matchUpdateTypes: "patch",
+      // Renovate should manage minor and patch updates for TypeScript, despite ignoring major.
+      matchPackageNames: ["typescript"],
+      matchUpdateTypes: ["minor", "patch"],
     },
     {
-      // We want to update all the Jest-related packages together, to reduce PR noise.
-      groupName: "jest",
-      matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
+      // Renovate should manage minor updates for zone.js, despite ignoring major.
+      matchPackageNames: ["zone.js"],
+      matchUpdateTypes: ["minor"],
     },
     {
-      // We need to group all napi-related packages together to avoid build errors caused by version incompatibilities.
-      groupName: "napi",
-      matchPackageNames: ["napi", "napi-build", "napi-derive"],
-    },
-    {
-      // We need to group all macOS/iOS binding-related packages together to avoid build errors caused by version incompatibilities.
-      groupName: "macOS/iOS bindings",
-      matchPackageNames: ["core-foundation", "security-framework", "security-framework-sys"],
-    },
-    {
-      // We need to group all zbus-related packages together to avoid build errors caused by version incompatibilities.
-      groupName: "zbus",
-      matchPackageNames: ["zbus", "zbus_polkit"],
-    },
-    {
-      matchPackageNames: [
-        "base64-loader",
-        "buffer",
-        "bufferutil",
-        "core-js",
-        "css-loader",
-        "html-loader",
-        "mini-css-extract-plugin",
-        "postcss",
-        "postcss-loader",
-        "process",
-        "sass",
-        "sass-loader",
-        "style-loader",
-        "ts-loader",
-        "url",
-        "util",
-      ],
+      matchPackageNames: ["buffer", "bufferutil", "core-js", "process", "url", "util"],
       description: "Admin Console owned dependencies",
       commitMessagePrefix: "[deps] AC:",
       reviewers: ["team:team-admin-console-dev"],
@@ -131,8 +100,8 @@
         "lint-staged",
         "typescript-eslint",
       ],
-      groupName: "Linting minor-patch",
-      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Linting minor updates",
+      matchUpdateTypes: ["minor"],
     },
     {
       matchPackageNames: [
@@ -188,6 +157,7 @@
         "anyhow",
         "arboard",
         "babel-loader",
+        "base64-loader",
         "base64",
         "bindgen",
         "browserslist",
@@ -195,6 +165,7 @@
         "bytes",
         "core-foundation",
         "copy-webpack-plugin",
+        "css-loader",
         "dirs",
         "electron",
         "electron-builder",
@@ -206,6 +177,7 @@
         "futures",
         "hex",
         "homedir",
+        "html-loader",
         "html-webpack-injector",
         "html-webpack-plugin",
         "interprocess",
@@ -214,6 +186,7 @@
         "libc",
         "log",
         "lowdb",
+        "mini-css-extract-plugin",
         "napi",
         "napi-build",
         "napi-derive",
@@ -224,15 +197,21 @@
         "oslog",
         "pin-project",
         "pkg",
+        "postcss",
+        "postcss-loader",
         "rand",
         "rxjs",
+        "sass",
+        "sass-loader",
         "scopeguard",
         "security-framework",
         "security-framework-sys",
         "serde",
         "serde_json",
         "simplelog",
+        "style-loader",
         "sysinfo",
+        "ts-loader",
         "tsconfig-paths-webpack-plugin",
         "type-fest",
         "typenum",
@@ -253,6 +232,52 @@
       description: "Platform owned dependencies",
       commitMessagePrefix: "[deps] Platform:",
       reviewers: ["team:team-platform-dev"],
+    },
+    {
+      // We need to group all napi-related packages together to avoid build errors caused by version incompatibilities.
+      groupName: "napi",
+      matchPackageNames: ["napi", "napi-build", "napi-derive"],
+    },
+    {
+      // We need to group all macOS/iOS binding-related packages together to avoid build errors caused by version incompatibilities.
+      groupName: "macOS/iOS bindings",
+      matchPackageNames: ["core-foundation", "security-framework", "security-framework-sys"],
+    },
+    {
+      // We need to group all zbus-related packages together to avoid build errors caused by version incompatibilities.
+      groupName: "zbus",
+      matchPackageNames: ["zbus", "zbus_polkit"],
+    },
+    {
+      // We group all webpack build-related minor and patch updates together to reduce PR noise.
+      // We include patch updates here because we want PRs for webpack patch updates and it's in this group.
+      matchPackageNames: [
+        "@babel/core",
+        "@babel/preset-env",
+        "babel-loader",
+        "base64-loader",
+        "browserslist",
+        "copy-webpack-plugin",
+        "css-loader",
+        "html-loader",
+        "html-webpack-injector",
+        "html-webpack-plugin",
+        "mini-css-extract-plugin",
+        "postcss-loader",
+        "postcss",
+        "sass-loader",
+        "sass",
+        "style-loader",
+        "ts-loader",
+        "tsconfig-paths-webpack-plugin",
+        "webpack-cli",
+        "webpack-dev-server",
+        "webpack-node-externals",
+        "webpack",
+      ],
+      description: "webpack-related build dependencies",
+      groupName: "webpack minor updates",
+      matchUpdateTypes: ["minor", "patch"],
     },
     {
       matchPackageNames: [
@@ -302,6 +327,7 @@
     {
       matchPackageNames: [
         "@types/jest",
+        "jest",
         "jest-junit",
         "jest-mock-extended",
         "jest-preset-angular",
@@ -311,6 +337,11 @@
       description: "Secrets Manager owned dependencies",
       commitMessagePrefix: "[deps] SM:",
       reviewers: ["team:team-secrets-manager-dev"],
+    },
+    {
+      // We need to update several Jest-related packages together, for version compatibility.
+      groupName: "jest",
+      matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
     },
     {
       matchPackageNames: [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21370

## 📔 Objective

Introduces several QoL improvements to how we group dependencies:

- Grouped all Github Action minor updates together to reduce PR noise.
  - See https://github.com/bitwarden/server/pull/5790 for corresponding changes on `server`.
- Removed the groupings using `matchFileNames`, which was introduced to try to separate out PRs for BRE and Platform for workflow maintenance, as the Renovate [documentation](https://docs.renovatebot.com/configuration-options/#matchfilenames) and source code indicates that this only works for matching package and lock files.  In other words, this configuration wasn't doing anything.
- Removed handling of `patch` updates for `zone.js` since we are no longer creating PRs for patches automatically.
- Grouped all `webpack`-related build dependencies together into a group for minor updates.  This included moving the following from Admin Console ownership to Platform, so that the resultant PR would be owned by a single team.  This was originally done in https://github.com/bitwarden/clients/pull/13050 but since we have since moved to `renovate.json5` I reproduced the changes here.
	- `base64-loader`
	- `css-loader`
	- `html-loader`
	- `mini-css-extract-plugin`
	- `postcss-loader`
	- `postcss`
	- `sass-loader`
	- `sass`
	- `style-loader`
	- `ts-loader`
- Moved all the package groupings to be after the assignment of team reviewers in the config.  This eases the process of ensuring that we only group dependencies that are assigned to a single team.
- Added `@bitwarden/sdk-internal` to ignored dependencies.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
