### PR TITLE
[CL-680] Fix broken popup layout docs page

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.mdx
+++ b/apps/browser/src/platform/popup/layout/popup-layout.mdx
@@ -153,7 +153,7 @@ View the story source code to see examples of how to construct these types of pa
 
 Example of wrapping an extension page in the `popup-tab-navigation` component.
 
-<Canvas of={stories.PopupTabNavigation} />
+<Canvas of={stories.DefaultPopupTabNavigation} />
 
 ## Extension Page
 
@@ -182,3 +182,10 @@ An example of how to center the default content.
 An example of what the loading state looks like.
 
 <Canvas of={stories.Loading} />
+
+## Tab Navigation with Berry
+
+An example of what it looks like to show a notification berry on one of the popup tab navigation
+buttons.
+
+<Canvas of={stories.PopupTabNavigationWithBerry} />


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-680](https://bitwarden.atlassian.net/browse/CL-680)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
A previous PR changed the name of a story, which caused the docs page that referenced that story to error out.

In this PR, I also added a docs reference to a new story that was added in the previous PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See Storybook Publish action for the Popup Layout docs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-680]: https://bitwarden.atlassian.net/browse/CL-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ