### PR TITLE
[PM-21343] - add download bitwarden to list of nudges for settings badge

### DIFF
--- a/libs/vault/src/services/vault-nudges.service.spec.ts
+++ b/libs/vault/src/services/vault-nudges.service.spec.ts
@@ -12,7 +12,11 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 
 import { FakeStateProvider, mockAccountServiceWith } from "../../../common/spec";
 
-import { HasItemsNudgeService, EmptyVaultNudgeService } from "./custom-nudges-services";
+import {
+  HasItemsNudgeService,
+  EmptyVaultNudgeService,
+  DownloadBitwardenNudgeService,
+} from "./custom-nudges-services";
 import { DefaultSingleNudgeService } from "./default-single-nudge.service";
 import { VaultNudgesService, VaultNudgeType } from "./vault-nudges.service";
 
@@ -24,6 +28,8 @@ describe("Vault Nudges Service", () => {
     getFeatureFlag$: jest.fn().mockReturnValue(of(true)),
     getFeatureFlag: jest.fn().mockReturnValue(true),
   };
+
+  const vaultNudgeServices = [EmptyVaultNudgeService, DownloadBitwardenNudgeService];
 
   beforeEach(async () => {
     fakeStateProvider = new FakeStateProvider(mockAccountServiceWith("user-id" as UserId));
@@ -45,6 +51,10 @@ describe("Vault Nudges Service", () => {
         {
           provide: HasItemsNudgeService,
           useValue: mock<HasItemsNudgeService>(),
+        },
+        {
+          provide: DownloadBitwardenNudgeService,
+          useValue: mock<DownloadBitwardenNudgeService>(),
         },
         {
           provide: EmptyVaultNudgeService,
@@ -129,11 +139,14 @@ describe("Vault Nudges Service", () => {
 
   describe("HasActiveBadges", () => {
     it("should return true if a nudgeType with hasBadgeDismissed === false", async () => {
-      TestBed.overrideProvider(EmptyVaultNudgeService, {
-        useValue: {
-          nudgeStatus$: () => of({ hasBadgeDismissed: false, hasSpotlightDismissed: false }),
-        },
+      vaultNudgeServices.forEach((service) => {
+        TestBed.overrideProvider(service, {
+          useValue: {
+            nudgeStatus$: () => of({ hasBadgeDismissed: false, hasSpotlightDismissed: false }),
+          },
+        });
       });
+
       const service = testBed.inject(VaultNudgesService);
 
       const result = await firstValueFrom(service.hasActiveBadges$("user-id" as UserId));
@@ -141,10 +154,12 @@ describe("Vault Nudges Service", () => {
       expect(result).toBe(true);
     });
     it("should return false if all nudgeTypes have hasBadgeDismissed === true", async () => {
-      TestBed.overrideProvider(EmptyVaultNudgeService, {
-        useValue: {
-          nudgeStatus$: () => of({ hasBadgeDismissed: true, hasSpotlightDismissed: true }),
-        },
+      vaultNudgeServices.forEach((service) => {
+        TestBed.overrideProvider(service, {
+          useValue: {
+            nudgeStatus$: () => of({ hasBadgeDismissed: true, hasSpotlightDismissed: false }),
+          },
+        });
       });
       const service = testBed.inject(VaultNudgesService);
 

--- a/libs/vault/src/services/vault-nudges.service.ts
+++ b/libs/vault/src/services/vault-nudges.service.ts
@@ -111,7 +111,7 @@ export class VaultNudgesService {
    */
   hasActiveBadges$(userId: UserId): Observable<boolean> {
     // Add more nudge types here if they have the settings badge feature
-    const nudgeTypes = [VaultNudgeType.EmptyVaultNudge];
+    const nudgeTypes = [VaultNudgeType.EmptyVaultNudge, VaultNudgeType.DownloadBitwarden];
 
     const nudgeTypesWithBadge$ = nudgeTypes.map((nudge) => {
       return this.getNudgeService(nudge)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21343

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the `DownloadBitwarden` nudge to `hasActiveBadges$` observable which ensures the settings tab badge will be shown if the user hasn't yet visited the download bitwarden screen.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2025-05-08 at 1 45 21 PM](https://github.com/user-attachments/assets/1f362c1b-2116-4307-a32e-e4a9e52de18e)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
