### PR TITLE
[PM-14503] Add `lang` attr on desktop and browser

### DIFF
--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -1,11 +1,20 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, inject } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  inject,
+} from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { NavigationEnd, Router, RouterOutlet } from "@angular/router";
 import { Subject, takeUntil, firstValueFrom, concatMap, filter, tap } from "rxjs";
 
 import { DeviceTrustToastService } from "@bitwarden/angular/auth/services/device-trust-toast.service.abstraction";
+import { DocumentLangSetter } from "@bitwarden/angular/platform/i18n";
 import { LogoutReason } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -71,8 +80,13 @@ export class AppComponent implements OnInit, OnDestroy {
     private biometricStateService: BiometricStateService,
     private biometricsService: BiometricsService,
     private deviceTrustToastService: DeviceTrustToastService,
+    private readonly destoryRef: DestroyRef,
+    private readonly documentLangSetter: DocumentLangSetter,
   ) {
     this.deviceTrustToastService.setupListeners$.pipe(takeUntilDestroyed()).subscribe();
+
+    const langSubscription = this.documentLangSetter.start();
+    this.destoryRef.onDestroy(() => langSubscription.unsubscribe());
   }
 
   async ngOnInit() {

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import {
   Component,
+  DestroyRef,
   NgZone,
   OnDestroy,
   OnInit,
@@ -16,6 +17,7 @@ import { filter, firstValueFrom, map, Subject, switchMap, takeUntil, timeout } f
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { DeviceTrustToastService } from "@bitwarden/angular/auth/services/device-trust-toast.service.abstraction";
 import { ModalRef } from "@bitwarden/angular/components/modal/modal.ref";
+import { DocumentLangSetter } from "@bitwarden/angular/platform/i18n";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import { FingerprintDialogComponent, LoginApprovalComponent } from "@bitwarden/auth/angular";
 import { DESKTOP_SSO_CALLBACK, LogoutReason } from "@bitwarden/auth/common";
@@ -156,8 +158,13 @@ export class AppComponent implements OnInit, OnDestroy {
     private accountService: AccountService,
     private organizationService: OrganizationService,
     private deviceTrustToastService: DeviceTrustToastService,
+    private readonly destroyRef: DestroyRef,
+    private readonly documentLangSetter: DocumentLangSetter,
   ) {
     this.deviceTrustToastService.setupListeners$.pipe(takeUntilDestroyed()).subscribe();
+
+    const langSubscription = this.documentLangSetter.start();
+    this.destroyRef.onDestroy(() => langSubscription.unsubscribe());
   }
 
   ngOnInit() {

--- a/libs/angular/src/platform/i18n/document-lang.setter.spec.ts
+++ b/libs/angular/src/platform/i18n/document-lang.setter.spec.ts
@@ -1,0 +1,36 @@
+import { mock } from "jest-mock-extended";
+import { Subject } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { DocumentLangSetter } from "./document-lang.setter";
+
+describe("DocumentLangSetter", () => {
+  const document = mock<Document>();
+  const i18nService = mock<I18nService>();
+
+  const sut = new DocumentLangSetter(document, i18nService);
+
+  describe("start", () => {
+    it("reacts to locale changes while start called with a non-closed subscription", async () => {
+      const localeSubject = new Subject<string>();
+      i18nService.locale$ = localeSubject;
+
+      localeSubject.next("en");
+
+      expect(document.documentElement.lang).toBeFalsy();
+
+      const sub = sut.start();
+
+      localeSubject.next("es");
+
+      expect(document.documentElement.lang).toBe("es");
+
+      sub.unsubscribe();
+
+      localeSubject.next("ar");
+
+      expect(document.documentElement.lang).toBe("es");
+    });
+  });
+});

--- a/libs/angular/src/platform/i18n/document-lang.setter.ts
+++ b/libs/angular/src/platform/i18n/document-lang.setter.ts
@@ -1,0 +1,26 @@
+import { Subscription } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+/**
+ * A service for managing the setting of the `lang="<locale>" attribute on the
+ * main document for the application.
+ */
+export class DocumentLangSetter {
+  constructor(
+    private readonly document: Document,
+    private readonly i18nService: I18nService,
+  ) {}
+
+  /**
+   * Starts listening to an upstream source for the best locale for the user
+   * and applies it to the application document.
+   * @returns A subscription that can be unsubscribed if you wish to stop
+   * applying lang attribute updates to the application document.
+   */
+  start(): Subscription {
+    return this.i18nService.locale$.subscribe((locale) => {
+      this.document.documentElement.lang = locale;
+    });
+  }
+}

--- a/libs/angular/src/platform/i18n/index.ts
+++ b/libs/angular/src/platform/i18n/index.ts
@@ -1,0 +1,1 @@
+export { DocumentLangSetter } from "./document-lang.setter";

--- a/libs/angular/src/services/injection-tokens.ts
+++ b/libs/angular/src/services/injection-tokens.ts
@@ -18,6 +18,7 @@ import { SafeInjectionToken } from "@bitwarden/ui-common";
 export { SafeInjectionToken } from "@bitwarden/ui-common";
 
 export const WINDOW = new SafeInjectionToken<Window>("WINDOW");
+export const DOCUMENT = new SafeInjectionToken<Document>("DOCUMENT");
 export const OBSERVABLE_MEMORY_STORAGE = new SafeInjectionToken<
   AbstractStorageService & ObservableStorageService
 >("OBSERVABLE_MEMORY_STORAGE");

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -326,6 +326,7 @@ import { DeviceTrustToastService as DeviceTrustToastServiceAbstraction } from ".
 import { DeviceTrustToastService } from "../auth/services/device-trust-toast.service.implementation";
 import { FormValidationErrorsService as FormValidationErrorsServiceAbstraction } from "../platform/abstractions/form-validation-errors.service";
 import { ViewCacheService } from "../platform/abstractions/view-cache.service";
+import { DocumentLangSetter } from "../platform/i18n";
 import { FormValidationErrorsService } from "../platform/services/form-validation-errors.service";
 import { LoggingErrorHandler } from "../platform/services/logging-error-handler";
 import { NoopViewCacheService } from "../platform/services/noop-view-cache.service";
@@ -336,6 +337,7 @@ import { safeProvider, SafeProvider } from "../platform/utils/safe-provider";
 import {
   CLIENT_TYPE,
   DEFAULT_VAULT_TIMEOUT,
+  DOCUMENT,
   ENV_ADDITIONAL_REGIONS,
   INTRAPROCESS_MESSAGING_SUBJECT,
   LOCALES_DIRECTORY,
@@ -364,6 +366,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider(ModalService),
   safeProvider(PasswordRepromptService),
   safeProvider({ provide: WINDOW, useValue: window }),
+  safeProvider({ provide: DOCUMENT, useValue: document }),
   safeProvider({
     provide: LOCALE_ID as SafeInjectionToken<string>,
     useFactory: (i18nService: I18nServiceAbstraction) => i18nService.translationLocale,
@@ -1520,6 +1523,11 @@ const safeProviders: SafeProvider[] = [
     provide: MasterPasswordApiServiceAbstraction,
     useClass: MasterPasswordApiService,
     deps: [ApiServiceAbstraction, LogService],
+  }),
+  safeProvider({
+    provide: DocumentLangSetter,
+    useClass: DocumentLangSetter,
+    deps: [DOCUMENT, I18nServiceAbstraction],
   }),
 ];
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14503

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a service to listen to `I18nService` and apply the `lang` attribute to the `document`. This is then initialized in every applications app component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
