### PR TITLE
[PM-21433] fix(browser): use appCopyField instead of appCopyClick for singleCopiableLogin

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.html
@@ -40,12 +40,9 @@
         type="button"
         bitIconButton="bwi-clone"
         size="small"
-        [appA11yTitle]="
-          'copyFieldValue' | i18n: singleCopiableLogin.key : singleCopiableLogin.value
-        "
-        [appCopyClick]="singleCopiableLogin.value"
-        [valueLabel]="singleCopiableLogin.key"
-        showToast
+        [appA11yTitle]="singleCopiableLogin.key"
+        [appCopyField]="$any(singleCopiableLogin.field)"
+        [cipher]="cipher"
       ></button>
       <ng-container *ngIf="!singleCopiableLogin">
         <button

--- a/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-copy-action/item-copy-actions.component.ts
@@ -15,6 +15,7 @@ import { VaultPopupCopyButtonsService } from "../../../services/vault-popup-copy
 type CipherItem = {
   value: string;
   key: string;
+  field?: string;
 };
 
 @Component({
@@ -43,15 +44,23 @@ export class ItemCopyActionsComponent {
     );
   }
 
+  /*
+   * singleCopiableLogin uses appCopyField instead of appCopyClick. This allows for the TOTP
+   * code to be copied correctly. See #14167
+   */
   get singleCopiableLogin() {
     const loginItems: CipherItem[] = [
-      { value: this.cipher.login.username, key: "username" },
-      { value: this.cipher.login.password, key: "password" },
-      { value: this.cipher.login.totp, key: "totp" },
+      { value: this.cipher.login.username, key: "copyUsername", field: "username" },
+      { value: this.cipher.login.password, key: "copyPassword", field: "password" },
+      { value: this.cipher.login.totp, key: "copyVerificationCode", field: "totp" },
     ];
     // If both the password and username are visible but the password is hidden, return the username
     if (!this.cipher.viewPassword && this.cipher.login.username && this.cipher.login.password) {
-      return { value: this.cipher.login.username, key: this.i18nService.t("username") };
+      return {
+        value: this.cipher.login.username,
+        key: this.i18nService.t("copyUsername"),
+        field: "username",
+      };
     }
     return this.findSingleCopiableItem(loginItems);
   }
@@ -78,12 +87,10 @@ export class ItemCopyActionsComponent {
    * Given a list of CipherItems, if there is only one item with a value,
    * return it with the translated key. Otherwise return null
    */
-  findSingleCopiableItem(items: { value: string; key: string }[]): CipherItem | null {
-    const singleItemWithValue = items.find(
-      (key) => key.value && items.every((f) => f === key || !f.value),
-    );
-    return singleItemWithValue
-      ? { value: singleItemWithValue.value, key: this.i18nService.t(singleItemWithValue.key) }
+  findSingleCopiableItem(items: CipherItem[]): CipherItem | null {
+    const itemsWithValue = items.filter(({ value }) => !!value);
+    return itemsWithValue.length === 1
+      ? { ...itemsWithValue[0], key: this.i18nService.t(itemsWithValue[0].key) }
       : null;
   }
 


### PR DESCRIPTION
Fixes #14167

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
#14167 

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- When TOTP secret is the only login item, use `appCopyField` to copy the TOTP code instead of copying the authenticator secret with `appCopyClick`
- Also refactored the `findSingleCopiableItem` method to be more efficient (`O(n^2)` -> `O(n)`)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
