### PR TITLE
[PM-21213] - replace bit-section with section for all shared cipher form and views

### DIFF
--- a/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
+++ b/libs/vault/src/cipher-form/components/additional-options/additional-options-section.component.html
@@ -1,6 +1,7 @@
-<bit-section
+<section
+  class="tw-mb-5 bit-compact:tw-mb-4"
+  [ngClass]="{ 'tw-mb-0': disableSectionMargin && !hasCustomFields }"
   [formGroup]="additionalOptionsForm"
-  [disableMargin]="disableSectionMargin && !hasCustomFields"
 >
   <bit-section-header>
     <h2 bitTypography="h6">{{ "additionalOptions" | i18n }}</h2>
@@ -30,7 +31,7 @@
       {{ "addField" | i18n }}
     </button>
   </bit-card>
-</bit-section>
+</section>
 
 <vault-custom-fields
   (numberOfFieldsChange)="handleCustomFieldChange($event)"

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -1,4 +1,4 @@
-<bit-section [formGroup]="autofillOptionsForm">
+<section class="tw-mb-5 bit-compact:tw-mb-4" [formGroup]="autofillOptionsForm">
   <bit-section-header>
     <h2 bitTypography="h6">
       {{ "autofillOptions" | i18n }}
@@ -38,4 +38,4 @@
       <bit-select formControlName="autofillOnPageLoad" [items]="autofillOptions"></bit-select>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.html
@@ -1,4 +1,4 @@
-<bit-section [formGroup]="cardDetailsForm">
+<section [formGroup]="cardDetailsForm" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">
       {{ getSectionHeading() }}
@@ -71,4 +71,4 @@
       ></button>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -1,4 +1,8 @@
-<bit-section *ngIf="hasCustomFields" [disableMargin]="disableSectionMargin">
+<section
+  class="tw-mb-5 bit-compact:tw-mb-4"
+  *ngIf="hasCustomFields"
+  [ngClass]="{ 'tw-mb-0': disableSectionMargin }"
+>
   <bit-section-header>
     <h2 bitTypography="h6">{{ "customFields" | i18n }}</h2>
   </bit-section-header>
@@ -116,4 +120,4 @@
       </button>
     </bit-card>
   </form>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.html
@@ -1,4 +1,4 @@
-<bit-section [formGroup]="itemDetailsForm">
+<section [formGroup]="itemDetailsForm" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "itemDetails" | i18n }}</h2>
     <button
@@ -57,4 +57,4 @@
       </bit-select>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -1,4 +1,4 @@
-<bit-section [formGroup]="loginDetailsForm">
+<section [formGroup]="loginDetailsForm" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">
       {{ "loginCredentials" | i18n }}
@@ -127,6 +127,6 @@
       ></button>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>
 
 <vault-autofill-options></vault-autofill-options>

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
@@ -1,4 +1,4 @@
-<bit-section [formGroup]="sshKeyForm">
+<section [formGroup]="sshKeyForm" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">
       {{ "typeSshKey" | i18n }}
@@ -35,4 +35,4 @@
       <input id="keyFingerprint" bitInput formControlName="keyFingerprint" />
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/additional-options/additional-options.component.html
+++ b/libs/vault/src/cipher-view/additional-options/additional-options.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "additionalOptions" | i18n }}</h2>
   </bit-section-header>
@@ -18,4 +18,4 @@
       ></button>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/attachments/attachments-v2-view.component.html
+++ b/libs/vault/src/cipher-view/attachments/attachments-v2-view.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "attachments" | i18n }}</h2>
   </bit-section-header>
@@ -21,4 +21,4 @@
       </ng-container>
     </bit-item>
   </bit-item-group>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
+++ b/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "autofillOptions" | i18n }}</h2>
   </bit-section-header>
@@ -41,4 +41,4 @@
       </bit-form-field>
     </ng-container>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/card-details/card-details-view.component.html
+++ b/libs/vault/src/cipher-view/card-details/card-details-view.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ setSectionTitle }}</h2>
   </bit-section-header>
@@ -91,4 +91,4 @@
       ></button>
     </bit-form-field>
   </read-only-cipher-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "customFields" | i18n }}</h2>
   </bit-section-header>
@@ -115,4 +115,4 @@
       </bit-form-field>
     </div>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "itemDetails" | i18n }}</h2>
   </bit-section-header>
@@ -80,4 +80,4 @@
       </li>
     </ul>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "loginCredentials" | i18n }}</h2>
   </bit-section-header>
@@ -163,4 +163,4 @@
       ></button>
     </bit-form-field>
   </read-only-cipher-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -1,4 +1,4 @@
-<bit-section>
+<section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "typeSshKey" | i18n }}</h2>
   </bit-section-header>
@@ -66,4 +66,4 @@
       ></button>
     </bit-form-field>
   </bit-card>
-</bit-section>
+</section>

--- a/libs/vault/src/cipher-view/view-identity-sections/view-identity-sections.component.html
+++ b/libs/vault/src/cipher-view/view-identity-sections/view-identity-sections.component.html
@@ -1,4 +1,4 @@
-<bit-section *ngIf="hasPersonalDetails">
+<section *ngIf="hasPersonalDetails" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "personalDetails" | i18n }}</h2>
   </bit-section-header>
@@ -64,9 +64,9 @@
       ></button>
     </bit-form-field>
   </read-only-cipher-card>
-</bit-section>
+</section>
 
-<bit-section *ngIf="hasIdentificationDetails">
+<section *ngIf="hasIdentificationDetails" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "identification" | i18n }}</h2>
   </bit-section-header>
@@ -153,9 +153,9 @@
       ></button>
     </bit-form-field>
   </read-only-cipher-card>
-</bit-section>
+</section>
 
-<bit-section *ngIf="hasContactDetails">
+<section *ngIf="hasContactDetails" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">{{ "contactInfo" | i18n }}</h2>
   </bit-section-header>
@@ -212,4 +212,4 @@
       ></button>
     </bit-form-field>
   </read-only-cipher-card>
-</bit-section>
+</section>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21213

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR replaces all instances of `<bit-section` for all the components that are nested in the the cipher-view and cipher-form components. The reason being the section component uses the following class

`tw-mb-5 bit-compact:tw-mb-4 [&:not(bit-dialog_*):not(popup-page_*)]:md:tw-mb-12`

Since we cannot target desktop with a class like we are with `popup-page_*` and `bit-dialog_*` we're getting `tw-mb-12` in the desktop client and was deemed unacceptable by QA/design. The solution was suggested by UIF team.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Updated Cipher Form
|Before|After|
---|---
|![Screenshot 2025-05-09 at 11 24 17 AM](https://github.com/user-attachments/assets/f75f2a38-c580-4378-a2e6-a0dbada06e1f)|![Screenshot 2025-05-09 at 11 09 31 AM](https://github.com/user-attachments/assets/3932b518-b9ea-4c5c-9ce4-38ac81daafcc)|

### Updated Cipher View
|Before|After|
---|---
|![Screenshot 2025-05-09 at 11 24 08 AM](https://github.com/user-attachments/assets/42973640-558b-4f1f-b8b1-4cb44e83ba84)|![Screenshot 2025-05-09 at 11 09 26 AM](https://github.com/user-attachments/assets/5b5b4739-4d61-4a4a-b7b4-1e7ac7fd2f74)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
