### PR TITLE
[PM-21443] Require userId for KeyService's everHadUserKey$

### DIFF
--- a/libs/angular/src/auth/guards/lock.guard.spec.ts
+++ b/libs/angular/src/auth/guards/lock.guard.spec.ts
@@ -44,7 +44,7 @@ describe("lockGuard", () => {
 
     const keyService: MockProxy<KeyService> = mock<KeyService>();
     keyService.isLegacyUser.mockResolvedValue(setupParams.isLegacyUser);
-    keyService.everHadUserKey$ = of(setupParams.everHadUserKey);
+    keyService.everHadUserKey$.mockReturnValue(of(setupParams.everHadUserKey));
 
     const platformUtilService: MockProxy<PlatformUtilsService> = mock<PlatformUtilsService>();
     platformUtilService.getClientType.mockReturnValue(setupParams.clientType);

--- a/libs/angular/src/auth/guards/lock.guard.ts
+++ b/libs/angular/src/auth/guards/lock.guard.ts
@@ -84,7 +84,7 @@ export function lockGuard(): CanActivateFn {
     }
 
     // If authN user with TDE directly navigates to lock, reject that navigation
-    const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$);
+    const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$(activeUser.id));
     if (tdeEnabled && !everHadUserKey) {
       return false;
     }

--- a/libs/angular/src/auth/guards/tde-decryption-required.guard.ts
+++ b/libs/angular/src/auth/guards/tde-decryption-required.guard.ts
@@ -7,8 +7,10 @@ import {
 } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { KeyService } from "@bitwarden/key-management";
@@ -24,12 +26,14 @@ export function tdeDecryptionRequiredGuard(): CanActivateFn {
     const authService = inject(AuthService);
     const keyService = inject(KeyService);
     const deviceTrustService = inject(DeviceTrustServiceAbstraction);
+    const accountService = inject(AccountService);
     const logService = inject(LogService);
     const router = inject(Router);
 
     const authStatus = await authService.getAuthStatus();
     const tdeEnabled = await firstValueFrom(deviceTrustService.supportsDeviceTrust$);
-    const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$);
+    const userId = await firstValueFrom(accountService.activeAccount$.pipe(getUserId));
+    const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$(userId));
 
     // We need to determine if we should bypass the decryption options and send the user to the vault.
     // The ONLY time that we want to send a user to the decryption options is when:

--- a/libs/angular/src/auth/guards/unauth.guard.spec.ts
+++ b/libs/angular/src/auth/guards/unauth.guard.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockProxy, mock } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 
 import { EmptyComponent } from "@bitwarden/angular/platform/guard/feature-flag.guard.spec";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -43,7 +43,7 @@ describe("UnauthGuard", () => {
       authService.authStatusFor$.mockReturnValue(activeAccountStatusObservable);
     }
 
-    keyService.everHadUserKey$ = new BehaviorSubject<boolean>(everHadUserKey);
+    keyService.everHadUserKey$.mockReturnValue(of(everHadUserKey));
     deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(
       new BehaviorSubject<boolean>(tdeEnabled),
     );

--- a/libs/angular/src/auth/guards/unauth.guard.ts
+++ b/libs/angular/src/auth/guards/unauth.guard.ts
@@ -50,7 +50,7 @@ async function unauthGuard(
   const tdeEnabled = await firstValueFrom(
     deviceTrustService.supportsDeviceTrustByUserId$(activeUser.id),
   );
-  const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$);
+  const everHadUserKey = await firstValueFrom(keyService.everHadUserKey$(activeUser.id));
 
   // If locked, TDE is enabled, and the user hasn't decrypted yet, then redirect to the
   // login decryption options component.

--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -85,11 +85,13 @@ export abstract class KeyService {
    * (such as auto, biometrics, or pin)
    */
   abstract refreshAdditionalKeys(): Promise<void>;
+
   /**
-   * Observable value that returns whether or not the currently active user has ever had auser key,
+   * Observable value that returns whether or not the user has ever had a userKey,
    * i.e. has ever been unlocked/decrypted. This is key for differentiating between TDE locked and standard locked states.
    */
-  abstract everHadUserKey$: Observable<boolean>;
+  abstract everHadUserKey$(userId: UserId): Observable<boolean>;
+
   /**
    * Retrieves the user key
    * @param userId The desired user

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -32,7 +32,6 @@ import {
   FakeAccountService,
   mockAccountServiceWith,
   FakeStateProvider,
-  FakeActiveUserState,
   FakeSingleUserState,
 } from "@bitwarden/common/spec";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
@@ -188,28 +187,28 @@ describe("keyService", () => {
   });
 
   describe("everHadUserKey$", () => {
-    let everHadUserKeyState: FakeActiveUserState<boolean>;
+    let everHadUserKeyState: FakeSingleUserState<boolean>;
 
     beforeEach(() => {
-      everHadUserKeyState = stateProvider.activeUser.getFake(USER_EVER_HAD_USER_KEY);
+      everHadUserKeyState = stateProvider.singleUser.getFake(mockUserId, USER_EVER_HAD_USER_KEY);
     });
 
     it("should return true when stored value is true", async () => {
       everHadUserKeyState.nextState(true);
 
-      expect(await firstValueFrom(keyService.everHadUserKey$)).toBe(true);
+      expect(await firstValueFrom(keyService.everHadUserKey$(mockUserId))).toBe(true);
     });
 
     it("should return false when stored value is false", async () => {
       everHadUserKeyState.nextState(false);
 
-      expect(await firstValueFrom(keyService.everHadUserKey$)).toBe(false);
+      expect(await firstValueFrom(keyService.everHadUserKey$(mockUserId))).toBe(false);
     });
 
     it("should return false when stored value is null", async () => {
       everHadUserKeyState.nextState(null);
 
-      expect(await firstValueFrom(keyService.everHadUserKey$)).toBe(false);
+      expect(await firstValueFrom(keyService.everHadUserKey$(mockUserId))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21443

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the `KeyService`'s `everHadUserKey$` to require a userId parameter. This is a part of the effort to remove the `KeyService`'s usage of `ActiveUserState` and require UserID for methods.



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
