### PR TITLE
[PM-18512] Remove pm-9112-device-approval-persistence feature flag

### DIFF
--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -23,12 +23,10 @@ import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request"
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
 import { LoginViaAuthRequestView } from "@bitwarden/common/auth/models/view/login-via-auth-request.view";
 import { ClientType, HttpStatusCode } from "@bitwarden/common/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -101,7 +99,6 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
     private validationService: ValidationService,
     private loginSuccessHandlerService: LoginSuccessHandlerService,
     private loginViaAuthRequestCacheService: LoginViaAuthRequestCacheService,
-    private configService: ConfigService,
   ) {
     this.clientType = this.platformUtilsService.getClientType();
 
@@ -132,7 +129,6 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
   async ngOnInit(): Promise<void> {
     // Get the authStatus early because we use it in both flows
     this.authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
-    await this.loginViaAuthRequestCacheService.init();
 
     const userHasAuthenticatedViaSSO = this.authStatus === AuthenticationStatus.Locked;
 
@@ -410,23 +406,21 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
       const authRequestResponse: AuthRequestResponse =
         await this.authRequestApiService.postAuthRequest(authRequest);
 
-      if (await this.configService.getFeatureFlag(FeatureFlag.PM9112_DeviceApprovalPersistence)) {
-        if (!this.authRequestKeyPair.privateKey) {
-          this.logService.error("No private key when trying to cache the login view.");
-          return;
-        }
-
-        if (!this.accessCode) {
-          this.logService.error("No access code when trying to cache the login view.");
-          return;
-        }
-
-        this.loginViaAuthRequestCacheService.cacheLoginView(
-          authRequestResponse.id,
-          this.authRequestKeyPair.privateKey,
-          this.accessCode,
-        );
+      if (!this.authRequestKeyPair.privateKey) {
+        this.logService.error("No private key when trying to cache the login view.");
+        return;
       }
+
+      if (!this.accessCode) {
+        this.logService.error("No access code when trying to cache the login view.");
+        return;
+      }
+
+      this.loginViaAuthRequestCacheService.cacheLoginView(
+        authRequestResponse.id,
+        this.authRequestKeyPair.privateKey,
+        this.accessCode,
+      );
 
       if (authRequestResponse.id) {
         await this.anonymousHubService.createHubConnection(authRequestResponse.id);

--- a/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.spec.ts
+++ b/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.spec.ts
@@ -3,7 +3,6 @@ import { TestBed } from "@angular/core/testing";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/abstractions/view-cache.service";
 import { LoginViaAuthRequestView } from "@bitwarden/common/auth/models/view/login-via-auth-request.view";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
 import { LoginViaAuthRequestCacheService } from "./default-login-via-auth-request-cache.service";
@@ -14,74 +13,40 @@ describe("LoginViaAuthRequestCache", () => {
 
   const cacheSignal = signal<LoginViaAuthRequestView | null>(null);
   const getCacheSignal = jest.fn().mockReturnValue(cacheSignal);
-  const getFeatureFlag = jest.fn().mockResolvedValue(false);
   const cacheSetMock = jest.spyOn(cacheSignal, "set");
 
   beforeEach(() => {
     getCacheSignal.mockClear();
-    getFeatureFlag.mockClear();
     cacheSetMock.mockClear();
 
     testBed = TestBed.configureTestingModule({
       providers: [
         { provide: ViewCacheService, useValue: { signal: getCacheSignal } },
-        { provide: ConfigService, useValue: { getFeatureFlag } },
         LoginViaAuthRequestCacheService,
       ],
     });
   });
 
-  describe("feature enabled", () => {
-    beforeEach(() => {
-      getFeatureFlag.mockResolvedValue(true);
-    });
+  it("`getCachedLoginViaAuthRequestView` returns the cached data", async () => {
+    cacheSignal.set({ ...buildMockState() });
+    service = testBed.inject(LoginViaAuthRequestCacheService);
 
-    it("`getCachedLoginViaAuthRequestView` returns the cached data", async () => {
-      cacheSignal.set({ ...buildMockState() });
-      service = testBed.inject(LoginViaAuthRequestCacheService);
-      await service.init();
-
-      expect(service.getCachedLoginViaAuthRequestView()).toEqual({
-        ...buildMockState(),
-      });
-    });
-
-    it("updates the signal value", async () => {
-      service = testBed.inject(LoginViaAuthRequestCacheService);
-      await service.init();
-
-      const parameters = buildAuthenticMockAuthView();
-
-      service.cacheLoginView(parameters.id, parameters.privateKey, parameters.accessCode);
-
-      expect(cacheSignal.set).toHaveBeenCalledWith({
-        id: parameters.id,
-        privateKey: Utils.fromBufferToB64(parameters.privateKey),
-        accessCode: parameters.accessCode,
-      });
+    expect(service.getCachedLoginViaAuthRequestView()).toEqual({
+      ...buildMockState(),
     });
   });
 
-  describe("feature disabled", () => {
-    beforeEach(async () => {
-      cacheSignal.set({ ...buildMockState() } as LoginViaAuthRequestView);
-      getFeatureFlag.mockResolvedValue(false);
-      cacheSetMock.mockClear();
+  it("updates the signal value", async () => {
+    service = testBed.inject(LoginViaAuthRequestCacheService);
 
-      service = testBed.inject(LoginViaAuthRequestCacheService);
-      await service.init();
-    });
+    const parameters = buildAuthenticMockAuthView();
 
-    it("`getCachedCipherView` returns null", () => {
-      expect(service.getCachedLoginViaAuthRequestView()).toBeNull();
-    });
+    service.cacheLoginView(parameters.id, parameters.privateKey, parameters.accessCode);
 
-    it("does not update the signal value", () => {
-      const params = buildAuthenticMockAuthView();
-
-      service.cacheLoginView(params.id, params.privateKey, params.accessCode);
-
-      expect(cacheSignal.set).not.toHaveBeenCalled();
+    expect(cacheSignal.set).toHaveBeenCalledWith({
+      id: parameters.id,
+      privateKey: Utils.fromBufferToB64(parameters.privateKey),
+      accessCode: parameters.accessCode,
     });
   });
 

--- a/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.ts
+++ b/libs/auth/src/common/services/auth-request/default-login-via-auth-request-cache.service.ts
@@ -2,8 +2,6 @@ import { inject, Injectable, WritableSignal } from "@angular/core";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/abstractions/view-cache.service";
 import { LoginViaAuthRequestView } from "@bitwarden/common/auth/models/view/login-via-auth-request.view";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
 const LOGIN_VIA_AUTH_CACHE_KEY = "login-via-auth-request-form-cache";
@@ -17,10 +15,6 @@ const LOGIN_VIA_AUTH_CACHE_KEY = "login-via-auth-request-form-cache";
 @Injectable()
 export class LoginViaAuthRequestCacheService {
   private viewCacheService: ViewCacheService = inject(ViewCacheService);
-  private configService: ConfigService = inject(ConfigService);
-
-  /** True when the `PM9112_DeviceApproval` flag is enabled */
-  private featureEnabled: boolean = false;
 
   private defaultLoginViaAuthRequestCache: WritableSignal<LoginViaAuthRequestView | null> =
     this.viewCacheService.signal<LoginViaAuthRequestView | null>({
@@ -32,22 +26,9 @@ export class LoginViaAuthRequestCacheService {
   constructor() {}
 
   /**
-   * Must be called once before interacting with the cached data, otherwise methods will be noop.
-   */
-  async init() {
-    this.featureEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.PM9112_DeviceApprovalPersistence,
-    );
-  }
-
-  /**
    * Update the cache with the new LoginView.
    */
   cacheLoginView(id: string, privateKey: Uint8Array, accessCode: string): void {
-    if (!this.featureEnabled) {
-      return;
-    }
-
     // When the keys get stored they should be converted to a B64 string to ensure
     // data can be properly formed when json-ified. If not done, they are not stored properly and
     // will not be parsable by the cryptography library after coming out of storage.
@@ -59,10 +40,6 @@ export class LoginViaAuthRequestCacheService {
   }
 
   clearCacheLoginView(): void {
-    if (!this.featureEnabled) {
-      return;
-    }
-
     this.defaultLoginViaAuthRequestCache.set(null);
   }
 
@@ -70,10 +47,6 @@ export class LoginViaAuthRequestCacheService {
    * Returns the cached LoginViaAuthRequestView when available.
    */
   getCachedLoginViaAuthRequestView(): LoginViaAuthRequestView | null {
-    if (!this.featureEnabled) {
-      return null;
-    }
-
     return this.defaultLoginViaAuthRequestCache();
   }
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -16,7 +16,6 @@ export enum FeatureFlag {
   SeparateCustomRolePermissions = "pm-19917-separate-custom-role-permissions",
 
   /* Auth */
-  PM9112_DeviceApprovalPersistence = "pm-9112-device-approval-persistence",
   PM9115_TwoFactorExtensionDataPersistence = "pm-9115-two-factor-extension-data-persistence",
 
   /* Autofill */
@@ -114,7 +113,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.EndUserNotifications]: FALSE,
 
   /* Auth */
-  [FeatureFlag.PM9112_DeviceApprovalPersistence]: FALSE,
   [FeatureFlag.PM9115_TwoFactorExtensionDataPersistence]: FALSE,
 
   /* Billing */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18512

## 📔 Objective

Removes the `pm-9112-device-approval-persistence` feature flag from the clients.  This also allowed the removal of the `init()` method as it was only used to set the flag value.

## 📸 Screenshots

https://github.com/user-attachments/assets/cfc8f614-050a-4819-8f4a-4f0635cd92b9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
