### PR TITLE
fix: clear clipboard on close

### DIFF
--- a/apps/desktop/src/platform/main/clipboard.main.ts
+++ b/apps/desktop/src/platform/main/clipboard.main.ts
@@ -1,16 +1,30 @@
-import { ipcMain } from "electron";
+import { app, ipcMain } from "electron";
 
 import { clipboards } from "@bitwarden/desktop-napi";
 
 import { ClipboardWriteMessage } from "../types/clipboard";
 
 export class ClipboardMain {
+  lastSavedValue: string | null = null;
+
   init() {
+    app.on("before-quit", async () => {
+      if (this.lastSavedValue == null) {
+        return;
+      }
+
+      const clipboardNow = await clipboards.read();
+      if (clipboardNow == this.lastSavedValue) {
+        await clipboards.write("", false);
+      }
+    });
+
     ipcMain.handle("clipboard.read", async (_event: any, _message: any) => {
       return await clipboards.read();
     });
 
     ipcMain.handle("clipboard.write", async (_event: any, message: ClipboardWriteMessage) => {
+      this.lastSavedValue = message.text;
       return await clipboards.write(message.text, message.password ?? false);
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-650

## 📔 Objective

If a value is copied to the clipboard, but the application is closed, we leave that data in the clipboard. This PR ensures that the clipboard is cleared upon closing the app if it matches a value copied from the vault.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
