### PR TITLE
PM-21553: Added support for credential.toJSON()

### DIFF
--- a/apps/browser/src/autofill/fido2/utils/webauthn-utils.ts
+++ b/apps/browser/src/autofill/fido2/utils/webauthn-utils.ts
@@ -88,6 +88,7 @@ export class WebauthnUtils {
       getClientExtensionResults: () => ({
         credProps: result.extensions.credProps,
       }),
+      toJSON: () => Fido2Utils.createResultToJson(result),
     } as PublicKeyCredential;
 
     // Modify prototype chains to fix `instanceof` calls.
@@ -134,6 +135,7 @@ export class WebauthnUtils {
       } as AuthenticatorAssertionResponse,
       getClientExtensionResults: () => ({}),
       authenticatorAttachment: "platform",
+      toJSON: () => Fido2Utils.getResultToJson(result),
     } as PublicKeyCredential;
 
     // Modify prototype chains to fix `instanceof` calls.

--- a/libs/common/src/platform/services/fido2/fido2-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-utils.ts
@@ -1,6 +1,46 @@
 // FIXME: Update this file to be type safe and remove this and next line
+
+import {
+  AssertCredentialResult,
+  CreateCredentialResult,
+} from "../../abstractions/fido2/fido2-client.service.abstraction";
+
 // @ts-strict-ignore
 export class Fido2Utils {
+  static createResultToJson(result: CreateCredentialResult): any {
+    return {
+      id: result.credentialId,
+      rawId: result.credentialId,
+      response: {
+        clientDataJSON: result.clientDataJSON,
+        authenticatorData: result.authData,
+        transports: result.transports,
+        publicKey: result.publicKey,
+        publicKeyAlgorithm: result.publicKeyAlgorithm,
+        attestationObject: result.attestationObject,
+      },
+      authenticatorAttachment: "platform",
+      clientExtensionResults: result.extensions,
+      type: "public-key",
+    };
+  }
+
+  static getResultToJson(result: AssertCredentialResult): any {
+    return {
+      id: result.credentialId,
+      rawId: result.credentialId,
+      response: {
+        clientDataJSON: result.clientDataJSON,
+        authenticatorData: result.authenticatorData,
+        signature: result.signature,
+        userHandle: result.userHandle,
+      },
+      authenticatorAttachment: "platform",
+      clientExtensionResults: {},
+      type: "public-key",
+    };
+  }
+
   static bufferToString(bufferSource: BufferSource): string {
     return Fido2Utils.fromBufferToB64(Fido2Utils.bufferSourceToUint8Array(bufferSource))
       .replace(/\+/g, "-")

--- a/libs/common/src/platform/services/fido2/fido2-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-utils.ts
@@ -1,6 +1,5 @@
 // FIXME: Update this file to be type safe and remove this and next line
-
-import {
+import type {
   AssertCredentialResult,
   CreateCredentialResult,
 } from "../../abstractions/fido2/fido2-client.service.abstraction";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21553

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR adds support for [.toJSON()](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/toJSON).

It's part of the spec, and also resolves #14334. 

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
