### PR TITLE
[PM-21090] Vault - Repeated Syncs

### DIFF
--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -195,5 +195,50 @@ describe("DefaultSyncService", () => {
       expect(apiService.refreshIdentityToken).toHaveBeenCalledTimes(1);
       expect(apiService.getSync).toHaveBeenCalledTimes(1);
     });
+
+    describe("in-flight syncs", () => {
+      let mockFullSync: jest.SpyInstance;
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+
+        // Mock the _fullSync method so the tests can control the promise resolution
+        // the internal implementation isn't what is tested here.
+        mockFullSync = jest.spyOn(sut as any, "_fullSync").mockImplementation(() => {
+          return new Promise((resolve) => setTimeout(() => resolve(true), 50));
+        });
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+      });
+
+      it("does not call internal sync when one is already in progress", async () => {
+        const fullSyncPromises = [sut.fullSync(true), sut.fullSync(false), sut.fullSync(false)];
+
+        jest.advanceTimersByTime(100);
+
+        const [result1, result2, result3] = await Promise.all(fullSyncPromises);
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(true);
+        expect(result3).toBe(true);
+
+        expect(mockFullSync).toHaveBeenCalledTimes(1);
+      });
+
+      it("resets the in-flight sync when the complete", async () => {
+        const fullSyncPromises = [sut.fullSync(true), sut.fullSync(false)];
+
+        expect(sut["inFlightSync"]).not.toBeNull();
+
+        jest.advanceTimersByTime(50);
+
+        await Promise.all(fullSyncPromises);
+
+        expect(sut["inFlightSync"]).toBeNull();
+      });
+    });
   });
 });


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21090](https://bitwarden.atlassian.net/browse/PM-21090)

## 📔 Objective

When a user logs in fresh (no stored application state in the browser/session storage/etc.), three entities within the application call `fullSync` and force 3 calls to go out in parallel. This can be taxing especially for large vaults.

Those three locations are:
- [DefaultLoginSuccessHandlerService.run](https://github.com/bitwarden/clients/blob/main/libs/auth/src/common/services/login-success-handler/default-login-success-handler.service.ts#L15)
- [UserLayoutComponent.ngOnInit](https://github.com/bitwarden/clients/blob/07725853a287c679964a608f3b23695c54030575/apps/web/src/app/layouts/user-layout.component.ts#L52)
- [VaultComponent.firstSetup$](https://github.com/bitwarden/clients/blob/07725853a287c679964a608f3b23695c54030575/apps/web/src/app/vault/individual-vault/vault.component.ts#L287)

To remediate:
- Move the internal workings of `fullSync` to a private method `_fullSync`
- Store the inflight promise as a class property. When any calls to `fullSync` are made and there is currently one in flight the in-flight promise will be returned.

### Assumptions

This change currently ignores the parameters of `fullSync`, the three implementations don't utilize the options parameter and this is on an initial login so it should be a fresh sync.
- This could be limiting or a source of complexity in the future so I see how this could be problematic. I don't have the depth of knowledge around how/when a full sync should be performed so I started with the easiest path to start the discussion. I'm happy to add on as needed.

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="1726" alt="Screenshot 2025-05-12 at 9 58 21 AM" src="https://github.com/user-attachments/assets/75e6d598-782f-426f-a7ca-26ad037e5c43" />|<video src="https://github.com/user-attachments/assets/d177d3f3-f247-41c0-8c54-6e196e772cdf" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
