### PR TITLE
Uif/remove a11y manual flag

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -28,10 +28,6 @@ const preview: Preview = {
   parameters: {
     a11y: {
       element: "#storybook-root",
-      manual: true,
-      options: {
-        runOnly: ["section508", "wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"],
-      },
     },
     controls: {
       matchers: {

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,7 +1,4 @@
-import {
-  //   waitForPageReady,
-  type TestRunnerConfig,
-} from "@storybook/test-runner";
+import { type TestRunnerConfig } from "@storybook/test-runner";
 import { injectAxe, checkA11y } from "axe-playwright";
 
 const testRunnerConfig: TestRunnerConfig = {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Remove manual a11y testing flag. 
- There was a bug in `"@storybook/addon-a11y": "8.5"`, that broke automatic testing. So, I added the manual flag.
- We auto-updated the dep and now there is a bug in `"@storybook/addon-a11y": "8.6.12"` that breaks manual testing. But, automatic testing is fixed

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
