### PR TITLE
[PM-19223] - Aggregate by domain (with file move)

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
@@ -50,7 +50,7 @@ describe("RiskInsightsReportService", () => {
     let testCase = testCaseResults[0];
     expect(testCase).toBeTruthy();
     expect(testCase.cipherMembers).toHaveLength(2);
-    expect(testCase.trimmedUris).toHaveLength(3);
+    expect(testCase.trimmedUris).toHaveLength(2);
     expect(testCase.weakPasswordDetail).toBeTruthy();
     expect(testCase.exposedPasswordDetail).toBeTruthy();
     expect(testCase.reusedPasswordCount).toEqual(2);
@@ -69,7 +69,7 @@ describe("RiskInsightsReportService", () => {
   it("should generate the raw data + uri report correctly", async () => {
     const result = await firstValueFrom(service.generateRawDataUriReport$("orgId"));
 
-    expect(result).toHaveLength(9);
+    expect(result).toHaveLength(8);
 
     // Two ciphers that have google.com as their uri. There should be 2 results
     const googleResults = result.filter((x) => x.trimmedUri === "google.com");
@@ -88,7 +88,7 @@ describe("RiskInsightsReportService", () => {
   it("should generate applications health report data correctly", async () => {
     const result = await firstValueFrom(service.generateApplicationsReport$("orgId"));
 
-    expect(result).toHaveLength(6);
+    expect(result).toHaveLength(5);
 
     // Two ciphers have google.com associated with them. The first cipher
     // has 2 members and the second has 4. However, the 2 members in the first
@@ -132,7 +132,7 @@ describe("RiskInsightsReportService", () => {
 
     expect(reportSummary.totalMemberCount).toEqual(7);
     expect(reportSummary.totalAtRiskMemberCount).toEqual(6);
-    expect(reportSummary.totalApplicationCount).toEqual(6);
-    expect(reportSummary.totalAtRiskApplicationCount).toEqual(5);
+    expect(reportSummary.totalApplicationCount).toEqual(5);
+    expect(reportSummary.totalAtRiskApplicationCount).toEqual(4);
   });
 });

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -428,7 +428,6 @@ export class RiskInsightsReportService {
     const cipherUris: string[] = [];
     const uris = cipher.login?.uris ?? [];
     uris.map((u: { uri: string }) => {
-      // const uri = Utils.getHostname(u.uri).replace("www.", "");
       const uri = Utils.getDomain(u.uri);
       if (!cipherUris.includes(uri)) {
         cipherUris.push(uri);

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -428,7 +428,8 @@ export class RiskInsightsReportService {
     const cipherUris: string[] = [];
     const uris = cipher.login?.uris ?? [];
     uris.map((u: { uri: string }) => {
-      const uri = Utils.getHostname(u.uri).replace("www.", "");
+      // const uri = Utils.getHostname(u.uri).replace("www.", "");
+      const uri = Utils.getDomain(u.uri);
       if (!cipherUris.includes(uri)) {
         cipherUris.push(uri);
       }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19223

## 📔 Objective

This is a duplicate of: https://github.com/bitwarden/clients/pull/14009

The report service and the spec files were moved into the new team dirt location and complicated the PR with conflicts. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
