### PR TITLE
[PM-21480] - check for privacy granted in isBrowserAutofillSettingOverridden

### DIFF
--- a/apps/browser/src/autofill/services/autofill-browser-settings.service.ts
+++ b/apps/browser/src/autofill/services/autofill-browser-settings.service.ts
@@ -16,7 +16,6 @@ export class AutofillBrowserSettingsService {
   async isBrowserAutofillSettingOverridden(browserClient: BrowserClientVendor) {
     return (
       browserClient !== BrowserClientVendors.Unknown &&
-      (await BrowserApi.permissionsGranted(["privacy"])) &&
       (await BrowserApi.browserAutofillSettingsOverridden())
     );
   }

--- a/apps/browser/src/autofill/services/autofill-browser-settings.service.ts
+++ b/apps/browser/src/autofill/services/autofill-browser-settings.service.ts
@@ -16,6 +16,7 @@ export class AutofillBrowserSettingsService {
   async isBrowserAutofillSettingOverridden(browserClient: BrowserClientVendor) {
     return (
       browserClient !== BrowserClientVendors.Unknown &&
+      (await BrowserApi.permissionsGranted(["privacy"])) &&
       (await BrowserApi.browserAutofillSettingsOverridden())
     );
   }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -664,6 +664,10 @@ export class BrowserApi {
    * Identifies if the browser autofill settings are overridden by the extension.
    */
   static async browserAutofillSettingsOverridden(): Promise<boolean> {
+    if (!(await BrowserApi.permissionsGranted(["privacy"]))) {
+      return false;
+    }
+
     const checkOverrideStatus = (details: chrome.types.ChromeSettingGetResult<boolean>) =>
       details.levelOfControl === "controlled_by_this_extension" && !details.value;
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21480

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where `BrowserApi.browserAutofillSettingsOverridden` wasn't properly checking for privacy permission grant before checking for `chrome.privacy`.

Previously the assumption that this was being checked before calling `browserAutofillSettingsOverridden` but this is prone to bugs like this one.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
