### PR TITLE
[PM-21286] add aria label to nudge settings badge

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -5267,6 +5267,9 @@
   "secureDevicesBody": {
     "message": "Save unlimited passwords across unlimited devices with Bitwarden mobile, browser, and desktop apps."
   },
+  "nudgeBadgeAria": {
+    "message": "1 notification"
+  },
   "emptyVaultNudgeTitle": {
     "message": "Import existing passwords"
   },

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -23,6 +23,7 @@
             *ngIf="!isBrowserAutofillSettingOverridden && (showAutofillBadge$ | async)"
             bitBadge
             variant="notification"
+            [attr.aria-label]="'nudgeBadgeAria' | i18n"
             >1</span
           >
         </div>
@@ -53,6 +54,7 @@
             *ngIf="!(showVaultBadge$ | async)?.hasBadgeDismissed"
             bitBadge
             variant="notification"
+            [attr.aria-label]="'nudgeBadgeAria' | i18n"
             >1</span
           >
         </div>
@@ -83,6 +85,7 @@
             *ngIf="(downloadBitwardenNudgeStatus$ | async)?.hasBadgeDismissed === false"
             bitBadge
             variant="notification"
+            [attr.aria-label]="'nudgeBadgeAria' | i18n"
             >1
           </span>
         </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21286](https://bitwarden.atlassian.net/browse/PM-21286)

## 📔 Objective

Add an Aria label to the nudge settings badge. Currently there is only 1 nudge notification for these label badges. If there are custom nudges added in the future that increases the badge numbers of a label we can update the code be take dynamic numbers. 

## 📸 Screen Recording For Mac Voiceover


https://github.com/user-attachments/assets/c3d4c7e8-5d69-44e3-8ec3-b30b06a04c63



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21286]: https://bitwarden.atlassian.net/browse/PM-21286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ