### PR TITLE
[PM-21586] Return null in decryptUserKeyWithMasterKey if decrypt fails

### DIFF
--- a/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
+++ b/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
@@ -37,13 +37,13 @@ export abstract class MasterPasswordServiceAbstraction {
    * @param userKey The user's encrypted symmetric key
    * @throws If either the MasterKey or UserKey are not resolved, or if the UserKey encryption type
    *         is neither AesCbc256_B64 nor AesCbc256_HmacSha256_B64
-   * @returns The user key
+   * @returns The user key or null if the masterkey is wrong
    */
   abstract decryptUserKeyWithMasterKey: (
     masterKey: MasterKey,
     userId: string,
     userKey?: EncString,
-  ) => Promise<UserKey>;
+  ) => Promise<UserKey | null>;
 }
 
 export abstract class InternalMasterPasswordServiceAbstraction extends MasterPasswordServiceAbstraction {

--- a/libs/common/src/key-management/master-password/services/master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.ts
@@ -180,6 +180,7 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
       try {
         decUserKey = await this.encryptService.unwrapSymmetricKey(userKey, masterKey);
       } catch {
+        this.logService.warning("Failed to decrypt user key with master key.");
         return null;
       }
     } else if (userKey.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
@@ -187,6 +188,7 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
         const newKey = await this.keyGenerationService.stretchKey(masterKey);
         decUserKey = await this.encryptService.unwrapSymmetricKey(userKey, newKey);
       } catch {
+        this.logService.warning("Failed to decrypt user key with stretched master key.");
         return null;
       }
     } else {
@@ -194,7 +196,7 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
     }
 
     if (decUserKey == null) {
-      this.logService.warning("Failed to decrypt user key with master key.");
+      this.logService.warning("Failed to decrypt user key with master key, user key is null.");
       return null;
     }
 

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -556,6 +556,15 @@ export class LockComponent implements OnInit, OnDestroy {
       masterPasswordVerificationResponse!.masterKey,
       this.activeAccount.id,
     );
+    if (userKey == null) {
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("invalidMasterPassword"),
+      });
+      return;
+    }
+
     await this.setUserKeyAndContinue(userKey, true);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21586

## 📔 Objective

https://github.com/bitwarden/clients/commit/5408a62b7df4631564601fb5fc056e718b6c74f9#diff-cc453f6e4a1aa6a10902799593c7fc471252ae21f5b4d5c664948dd50f238fa8L201
changed the behavior to where the decrypt function now throws if it fails to decrypt. This was not communicated to consumers, and is an unintentional change. Further our API does not explicitly state that it can return null.

This forces a return null on error by catching any errors to keep compatibility, until we *want* to explicitly break this behavior. Further, this makes the behavior explict by changing the type to include null.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
