### PR TITLE
[PM-21554] - Creating a new item while editing edits the item

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -538,6 +538,7 @@ export class VaultV2Component implements OnInit, OnDestroy {
     }
     this.addType = type || this.activeFilter.cipherType;
     this.cipher = new CipherView();
+    this.cipherId = null;
     await this.buildFormConfig("add");
     this.action = "add";
     this.prefillCipherFromFilter();

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -538,7 +538,6 @@ export class VaultV2Component implements OnInit, OnDestroy {
     }
     this.addType = type || this.activeFilter.cipherType;
     this.cipher = new CipherView();
-    this.cipherId = null;
     await this.buildFormConfig("add");
     this.action = "add";
     this.prefillCipherFromFilter();

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -275,11 +275,6 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
     if (this.updatedCipherView.id === cachedCipher.id) {
       this.updatedCipherView = cachedCipher;
     }
-
-    // `id` is null when a cipher is being added
-    if (this.updatedCipherView.id === null && cachedCipher.id === null) {
-      this.updatedCipherView = cachedCipher;
-    }
   }
 
   constructor(

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -277,7 +277,7 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
     }
 
     // `id` is null when a cipher is being added
-    if (this.updatedCipherView.id === null) {
+    if (this.updatedCipherView.id === null && cachedCipher.id === null) {
       this.updatedCipherView = cachedCipher;
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where, (only on prod builds), if while editing a cipher and then creating a new one, the edited cipher would be overwritten with the new cipher. This was due to the `updatedCipherView` being set to the `cachedCipher` even when the `cachedCipher` didn't match the existing cipher. It also fixes an issue where the `cipherId` wasn't being set to `null` in before saving the cipher which caused the `config.originalCipher` to be set to the previous cipher, occasionally causing an error when saving the cipher.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
