### PR TITLE
Better handle array buffers that are too long to be a GUID

### DIFF
--- a/libs/common/src/platform/services/fido2/guid-utils.spec.ts
+++ b/libs/common/src/platform/services/fido2/guid-utils.spec.ts
@@ -1,28 +1,63 @@
-import { guidToRawFormat } from "./guid-utils";
+import { guidToRawFormat, guidToStandardFormat } from "./guid-utils";
+
+const workingExamples: [string, Uint8Array][] = [
+  [
+    "00000000-0000-0000-0000-000000000000",
+    new Uint8Array([
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00,
+    ]),
+  ],
+  [
+    "08d70b74-e9f5-4522-a425-e5dcd40107e7",
+    new Uint8Array([
+      0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
+      0xe7,
+    ]),
+  ],
+];
 
 describe("guid-utils", () => {
   describe("guidToRawFormat", () => {
+    it.each(workingExamples)(
+      "returns UUID in binary format when given a valid UUID string",
+      (input, expected) => {
+        const result = guidToRawFormat(input);
+
+        expect(result).toEqual(expected);
+      },
+    );
+
     it.each([
-      [
-        "00000000-0000-0000-0000-000000000000",
-        [
-          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x00,
-        ],
-        "08d70b74-e9f5-4522-a425-e5dcd40107e7",
-        [
-          0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
-          0xe7,
-        ],
-      ],
-    ])("returns UUID in binary format when given a valid UUID string", (input, expected) => {
-      const result = guidToRawFormat(input);
-
-      expect(result).toEqual(new Uint8Array(expected));
+      "invalid",
+      "",
+      "",
+      "00000000-0000-0000-0000-0000000000000000",
+      "00000000-0000-0000-0000-000000",
+    ])("throws an error when given an invalid UUID string", (input) => {
+      expect(() => guidToRawFormat(input)).toThrow(TypeError);
     });
+  });
 
-    it("throws an error when given an invalid UUID string", () => {
-      expect(() => guidToRawFormat("invalid")).toThrow(TypeError);
+  describe("guidToStandardFormat", () => {
+    it.each(workingExamples)(
+      "returns UUID in standard format when given a valid UUID array buffer",
+      (expected, input) => {
+        const result = guidToStandardFormat(input);
+
+        expect(result).toEqual(expected);
+      },
+    );
+
+    it.each([
+      new Uint8Array(),
+      new Uint8Array([]),
+      new Uint8Array([
+        0x08, 0xd7, 0x0b, 0x74, 0xe9, 0xf5, 0x45, 0x22, 0xa4, 0x25, 0xe5, 0xdc, 0xd4, 0x01, 0x07,
+        0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7, 0xe7,
+      ]),
+    ])("throws an error when given an invalid UUID array buffer", (input) => {
+      expect(() => guidToStandardFormat(input)).toThrow(TypeError);
     });
   });
 });

--- a/libs/common/src/platform/services/fido2/guid-utils.ts
+++ b/libs/common/src/platform/services/fido2/guid-utils.ts
@@ -51,6 +51,10 @@ export function guidToRawFormat(guid: string) {
 
 /** Convert raw 16 byte array to standard format (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX) UUID. */
 export function guidToStandardFormat(bufferSource: BufferSource) {
+  if (bufferSource.byteLength !== 16) {
+    throw TypeError("BufferSource length is invalid");
+  }
+
   const arr =
     bufferSource instanceof ArrayBuffer
       ? new Uint8Array(bufferSource)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Autofill found a bug where converting a too long array buffer to a GUID would just improperly return a truncated result

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
