### PR TITLE
PM-14517 Browser Badge - At Risk Passwords "!"

### DIFF
--- a/apps/browser/src/platform/listeners/update-badge.ts
+++ b/apps/browser/src/platform/listeners/update-badge.ts
@@ -96,7 +96,7 @@ export class UpdateBadge {
       return;
     }
 
-    const pendingSecurityTasks = await firstValueFrom(
+    const atRiskPasswordTasks = await firstValueFrom(
       this.taskService
         .pendingTasks$(activeUserId)
         .pipe(
@@ -104,8 +104,8 @@ export class UpdateBadge {
         ),
     );
 
-    // Pending security tasks do not depend on the badge counter setting and should always be shown
-    if (pendingSecurityTasks.length > 0) {
+    // Pending at risk tasks do not depend on the badge counter setting and should always be shown
+    if (atRiskPasswordTasks.length > 0) {
       await this.setBadgeText("!");
       await this.setBadgeBackgroundColor("#cb263a"); // equivalent to danger-600
       return;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14571](https://bitwarden.atlassian.net/browse/PM-14571)

## 📔 Objective

When there are pending at risk password tasks for a user, display "!" for the extension badge over any other badge content.
- This visual will help draw users to the extension to remediate the security task. 
- This is not dependent on the show badge counter setting.

@bitwarden/team-platform-dev Based on the existing code it looks like the browsers control the shape of the badge. We can only set the color and text. Is that accurate? 

## 📸 Screenshots

### Screenshots:
|Chrome|FireFox|Safari|
|-|-|-|
|<img width="199" alt="Screenshot 2025-05-14 at 10 38 09 AM" src="https://github.com/user-attachments/assets/9d525c66-a90c-45aa-aebf-1d50238fc1ee" />|<img width="207" alt="Screenshot 2025-05-14 at 10 37 59 AM" src="https://github.com/user-attachments/assets/ad10da11-6f95-4a9c-9ef3-45aaa1df8506" />|<img width="147" alt="Screenshot 2025-05-14 at 11 33 15 AM" src="https://github.com/user-attachments/assets/37ee9ed1-7dad-44c3-9fae-f4d83a8e6b63" />|

### Demo:
<video src="https://github.com/user-attachments/assets/cccbcc7d-2265-4f5f-9519-306a1f667b60" ></video>

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14571]: https://bitwarden.atlassian.net/browse/PM-14571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ