### PR TITLE
[PM-20610] migrate webauthn mobile.html

### DIFF
--- a/apps/web/src/connectors/webauthn-mobile.html
+++ b/apps/web/src/connectors/webauthn-mobile.html
@@ -11,19 +11,21 @@
     <title>Bitwarden WebAuthn Connector</title>
   </head>
 
-  <body style="background: transparent">
-    <div class="row justify-content-md-center mt-5">
-      <div>
-        <img src="../images/logo-dark@2x.png" class="logo mb-2" alt="Bitwarden" />
-        <p id="webauthn-header" class="lead text-center mx-4 mb-4"></p>
-        <picture>
-          <source srcset="../images/u2fkey-mobile.avif" type="image/avif" />
-          <source srcset="../images/u2fkey-mobile.webp" type="image/webp" />
-          <img src="../images/u2fkey-mobile.jpg" class="rounded img-fluid" />
-        </picture>
-        <div class="text-center mt-4">
-          <button type="button" id="webauthn-button" class="btn btn-primary btn-lg"></button>
-        </div>
+  <body class="tw-bg-transparent">
+    <div class="tw-flex tw-mt-5 tw-flex-col tw-items-center">
+      <img src="../images/logo-dark@2x.png" class="logo tw-mb-2" alt="Bitwarden" />
+      <p id="webauthn-header" class="tw-text-center tw-mx-4 tw-mb-4 tw-text-xl"></p>
+      <picture>
+        <source srcset="../images/u2fkey-mobile.avif" type="image/avif" />
+        <source srcset="../images/u2fkey-mobile.webp" type="image/webp" />
+        <img src="../images/u2fkey-mobile.jpg" class="tw-rounded tw-max-w-full tw-h-auto" />
+      </picture>
+      <div class="tw-text-center tw-mt-4">
+        <button
+          type="button"
+          id="webauthn-button"
+          class="tw-cursor-pointer tw-bg-primary-600 tw-border-transparent tw-px-4 tw-py-2 tw-rounded-md hover:tw-bg-primary-700 tw-transition-colors tw-font-semibold tw-text-contrast tw-text-lg"
+        ></button>
       </div>
     </div>
   </body>

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -112,7 +112,7 @@ const plugins = [
   new HtmlWebpackPlugin({
     template: "./src/connectors/webauthn-mobile.html",
     filename: "webauthn-mobile-connector.html",
-    chunks: ["connectors/webauthn"],
+    chunks: ["connectors/webauthn", "styles"],
   }),
   new HtmlWebpackPlugin({
     template: "./src/connectors/webauthn-fallback.html",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-20610?atlOrigin=eyJpIjoiY2VlY2VkNjg1ZDJkNGU3ZThmM2M5YzEyZjg4OGE5ZDUiLCJwIjoiaiJ9

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Replaces Bootstrap styles with Tailwind styles in the migrate-webauthn-mobile.html connector.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Note:

I was not able to test this feature end-to-end. I attempted to test via the production iPhone app pointed at my local IP address on my network with an unknown failure. I also tried building the iOS app via Xcode but encountered issues when trying to launch WebAuthn. I was seeing the following errors:

```
ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
Error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier [LTZ2PFU5D6.com](http://ltz2pfu5d6.com/).8bit.bitwarden is not associated with domain localhost" UserInfo={NSLocalizedFailureReason=Application with identifier [LTZ2PFU5D6.com](http://ltz2pfu5d6.com/).8bit.bitwarden is not associated with domain localhost}
:no_entry:️ Error: attempted to present an alert on top of another alert!
Error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier [LTZ2PFU5D6.com](http://ltz2pfu5d6.com/).8bit.bitwarden is not associated with domain localhost" UserInfo={NSLocalizedFailureReason=Application with identifier [LTZ2PFU5D6.com](http://ltz2pfu5d6.com/).8bit.bitwarden is not associated with domain localhost}
-[RTIInputSystemClient remoteTextInputSessionWithID:performInputOperation:] perform input operation requires a valid sessionID. inputModality = Keyboard, inputOperation = <null selector>, customInfoType = UIEmojiSearchOperations (edited)
```

I attempted to work around this by adding a `./well-known/apple-app-site-association` file and configuring the app to use  `applinks:localhost?mode=developer` as an associated domain without success.

Looking at the template directly gave me an idea of what classes need to be updated, and in theory this should work. I just was never able to test the real before or after states so it feels like this could benefit from an actual test from within the mobile app. I believe this screen is only present when completing sign in or 2FA with a passkey on a self-hosted instance.

### Before

(when accessed directly at https://localhost:8080/webauthn-mobile-connector.html)

![Screenshot 2025-05-14 at 9 22 03 AM](https://github.com/user-attachments/assets/57f94890-9013-4a57-bfc8-751d7b41abd4)


### After

(when accessed directly at https://localhost:8080/webauthn-mobile-connector.html)

![Screenshot 2025-05-14 at 3 14 59 PM](https://github.com/user-attachments/assets/375fcf83-b5b1-4318-89c7-3b0f15110827)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
