### PR TITLE
[PM-21663] nudge service name refactor

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -4,14 +4,14 @@ import { CommonModule } from "@angular/common";
 import { Component, DestroyRef, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
   FormsModule,
   ReactiveFormsModule,
-  FormBuilder,
-  FormGroup,
-  FormControl,
 } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { Observable, filter, firstValueFrom, map, switchMap } from "rxjs";
+import { filter, firstValueFrom, Observable, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -55,7 +55,7 @@ import {
   SelectModule,
   TypographyModule,
 } from "@bitwarden/components";
-import { SpotlightComponent, NudgesService, NudgeType } from "@bitwarden/vault";
+import { NudgesService, NudgeType, SpotlightComponent } from "@bitwarden/vault";
 
 import { AutofillBrowserSettingsService } from "../../../autofill/services/autofill-browser-settings.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
@@ -108,9 +108,7 @@ export class AutofillComponent implements OnInit {
   protected showSpotlightNudge$: Observable<boolean> = this.accountService.activeAccount$.pipe(
     filter((account): account is Account => account !== null),
     switchMap((account) =>
-      this.vaultNudgesService
-        .showNudge$(NudgeType.AutofillNudge, account.id)
-        .pipe(map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed)),
+      this.nudgesService.showNudgeSpotlight$(NudgeType.AutofillNudge, account.id),
     ),
   );
 
@@ -155,7 +153,7 @@ export class AutofillComponent implements OnInit {
     private configService: ConfigService,
     private formBuilder: FormBuilder,
     private destroyRef: DestroyRef,
-    private vaultNudgesService: NudgesService,
+    private nudgesService: NudgesService,
     private accountService: AccountService,
     private autofillBrowserSettingsService: AutofillBrowserSettingsService,
   ) {
@@ -343,7 +341,7 @@ export class AutofillComponent implements OnInit {
   }
 
   async dismissSpotlight() {
-    await this.vaultNudgesService.dismissNudge(
+    await this.nudgesService.dismissNudge(
       NudgeType.AutofillNudge,
       await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId)),
     );

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -55,7 +55,7 @@ import {
   SelectModule,
   TypographyModule,
 } from "@bitwarden/components";
-import { SpotlightComponent, VaultNudgesService, VaultNudgeType } from "@bitwarden/vault";
+import { SpotlightComponent, NudgesService, NudgeType } from "@bitwarden/vault";
 
 import { AutofillBrowserSettingsService } from "../../../autofill/services/autofill-browser-settings.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
@@ -109,7 +109,7 @@ export class AutofillComponent implements OnInit {
     filter((account): account is Account => account !== null),
     switchMap((account) =>
       this.vaultNudgesService
-        .showNudge$(VaultNudgeType.AutofillNudge, account.id)
+        .showNudge$(NudgeType.AutofillNudge, account.id)
         .pipe(map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed)),
     ),
   );
@@ -155,7 +155,7 @@ export class AutofillComponent implements OnInit {
     private configService: ConfigService,
     private formBuilder: FormBuilder,
     private destroyRef: DestroyRef,
-    private vaultNudgesService: VaultNudgesService,
+    private vaultNudgesService: NudgesService,
     private accountService: AccountService,
     private autofillBrowserSettingsService: AutofillBrowserSettingsService,
   ) {
@@ -344,7 +344,7 @@ export class AutofillComponent implements OnInit {
 
   async dismissSpotlight() {
     await this.vaultNudgesService.dismissNudge(
-      VaultNudgeType.AutofillNudge,
+      NudgeType.AutofillNudge,
       await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId)),
     );
   }

--- a/apps/browser/src/popup/tabs-v2.component.ts
+++ b/apps/browser/src/popup/tabs-v2.component.ts
@@ -6,7 +6,7 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Icons } from "@bitwarden/components";
-import { VaultNudgesService } from "@bitwarden/vault";
+import { NudgesService } from "@bitwarden/vault";
 
 import { NavButton } from "../platform/popup/layout/popup-tab-navigation.component";
 
@@ -53,7 +53,7 @@ export class TabsV2Component {
     }),
   );
   constructor(
-    private vaultNudgesService: VaultNudgesService,
+    private vaultNudgesService: NudgesService,
     private accountService: AccountService,
     private readonly configService: ConfigService,
   ) {}

--- a/apps/browser/src/popup/tabs-v2.component.ts
+++ b/apps/browser/src/popup/tabs-v2.component.ts
@@ -18,7 +18,7 @@ import { NavButton } from "../platform/popup/layout/popup-tab-navigation.compone
 export class TabsV2Component {
   private hasActiveBadges$ = this.accountService.activeAccount$
     .pipe(getUserId)
-    .pipe(switchMap((userId) => this.vaultNudgesService.hasActiveBadges$(userId)));
+    .pipe(switchMap((userId) => this.nudgesService.hasActiveBadges$(userId)));
   protected navButtons$: Observable<NavButton[]> = combineLatest([
     this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge),
     this.hasActiveBadges$,
@@ -54,7 +54,7 @@ export class TabsV2Component {
     }),
   );
   constructor(
-    private vaultNudgesService: NudgesService,
+    private nudgesService: NudgesService,
     private accountService: AccountService,
     private readonly configService: ConfigService,
   ) {}

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -41,7 +41,7 @@
       <a
         bit-item-content
         routerLink="/vault-settings"
-        (click)="dismissBadge(VaultNudgeType.EmptyVaultNudge)"
+        (click)="dismissBadge(NudgeType.EmptyVaultNudge)"
       >
         <i slot="start" class="bwi bwi-vault" aria-hidden="true"></i>
         <div class="tw-flex tw-items-center tw-justify-center">

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -51,7 +51,7 @@
             Will make this dynamic when more nudges are added
           -->
           <span
-            *ngIf="!(showVaultBadge$ | async)?.hasBadgeDismissed"
+            *ngIf="showVaultBadge$ | async"
             bitBadge
             variant="notification"
             [attr.aria-label]="'nudgeBadgeAria' | i18n"
@@ -82,7 +82,7 @@
         <div class="tw-flex tw-items-center tw-justify-center">
           <p class="tw-pr-2">{{ "downloadBitwardenOnAllDevices" | i18n }}</p>
           <span
-            *ngIf="(downloadBitwardenNudgeStatus$ | async)?.hasBadgeDismissed === false"
+            *ngIf="downloadBitwardenNudgeStatus$ | async"
             bitBadge
             variant="notification"
             [attr.aria-label]="'nudgeBadgeAria' | i18n"

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -17,7 +17,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BadgeComponent, ItemModule } from "@bitwarden/components";
-import { NudgeStatus, VaultNudgesService, VaultNudgeType } from "@bitwarden/vault";
+import { NudgeStatus, NudgesService, NudgeType } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../auth/popup/account-switching/current-account.component";
 import { AutofillBrowserSettingsService } from "../../../autofill/services/autofill-browser-settings.service";
@@ -42,7 +42,7 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
   ],
 })
 export class SettingsV2Component implements OnInit {
-  VaultNudgeType = VaultNudgeType;
+  VaultNudgeType = NudgeType;
   activeUserId: UserId | null = null;
   protected isBrowserAutofillSettingOverridden = false;
 
@@ -53,13 +53,13 @@ export class SettingsV2Component implements OnInit {
 
   downloadBitwardenNudgeStatus$: Observable<NudgeStatus> = this.authenticatedAccount$.pipe(
     switchMap((account) =>
-      this.vaultNudgesService.showNudge$(VaultNudgeType.DownloadBitwarden, account.id),
+      this.vaultNudgesService.showNudge$(NudgeType.DownloadBitwarden, account.id),
     ),
   );
 
   showVaultBadge$: Observable<NudgeStatus> = this.authenticatedAccount$.pipe(
     switchMap((account) =>
-      this.vaultNudgesService.showNudge$(VaultNudgeType.EmptyVaultNudge, account.id),
+      this.vaultNudgesService.showNudge$(NudgeType.EmptyVaultNudge, account.id),
     ),
   );
 
@@ -68,7 +68,7 @@ export class SettingsV2Component implements OnInit {
     this.authenticatedAccount$,
   ]).pipe(
     switchMap(([defaultBrowserAutofillDisabled, account]) =>
-      this.vaultNudgesService.showNudge$(VaultNudgeType.AutofillNudge, account.id).pipe(
+      this.vaultNudgesService.showNudge$(NudgeType.AutofillNudge, account.id).pipe(
         map((nudgeStatus) => {
           return !defaultBrowserAutofillDisabled && nudgeStatus.hasBadgeDismissed === false;
         }),
@@ -81,7 +81,7 @@ export class SettingsV2Component implements OnInit {
   );
 
   constructor(
-    private readonly vaultNudgesService: VaultNudgesService,
+    private readonly vaultNudgesService: NudgesService,
     private readonly accountService: AccountService,
     private readonly autofillBrowserSettingsService: AutofillBrowserSettingsService,
     private readonly configService: ConfigService,
@@ -94,7 +94,7 @@ export class SettingsV2Component implements OnInit {
       );
   }
 
-  async dismissBadge(type: VaultNudgeType) {
+  async dismissBadge(type: NudgeType) {
     if (!(await firstValueFrom(this.showVaultBadge$)).hasBadgeDismissed) {
       const account = await firstValueFrom(this.authenticatedAccount$);
       await this.vaultNudgesService.dismissNudge(type, account.id as UserId, true);

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -17,7 +17,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BadgeComponent, ItemModule } from "@bitwarden/components";
-import { NudgeStatus, NudgesService, NudgeType } from "@bitwarden/vault";
+import { NudgesService, NudgeType } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../auth/popup/account-switching/current-account.component";
 import { AutofillBrowserSettingsService } from "../../../autofill/services/autofill-browser-settings.service";
@@ -51,15 +51,15 @@ export class SettingsV2Component implements OnInit {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  downloadBitwardenNudgeStatus$: Observable<NudgeStatus> = this.authenticatedAccount$.pipe(
+  downloadBitwardenNudgeStatus$: Observable<boolean> = this.authenticatedAccount$.pipe(
     switchMap((account) =>
-      this.vaultNudgesService.showNudge$(NudgeType.DownloadBitwarden, account.id),
+      this.nudgesService.showNudgeBadge$(NudgeType.DownloadBitwarden, account.id),
     ),
   );
 
-  showVaultBadge$: Observable<NudgeStatus> = this.authenticatedAccount$.pipe(
+  showVaultBadge$: Observable<boolean> = this.authenticatedAccount$.pipe(
     switchMap((account) =>
-      this.vaultNudgesService.showNudge$(NudgeType.EmptyVaultNudge, account.id),
+      this.nudgesService.showNudgeBadge$(NudgeType.EmptyVaultNudge, account.id),
     ),
   );
 
@@ -68,9 +68,9 @@ export class SettingsV2Component implements OnInit {
     this.authenticatedAccount$,
   ]).pipe(
     switchMap(([defaultBrowserAutofillDisabled, account]) =>
-      this.vaultNudgesService.showNudge$(NudgeType.AutofillNudge, account.id).pipe(
-        map((nudgeStatus) => {
-          return !defaultBrowserAutofillDisabled && nudgeStatus.hasBadgeDismissed === false;
+      this.nudgesService.showNudgeBadge$(NudgeType.AutofillNudge, account.id).pipe(
+        map((badgeStatus) => {
+          return !defaultBrowserAutofillDisabled && badgeStatus;
         }),
       ),
     ),
@@ -81,7 +81,7 @@ export class SettingsV2Component implements OnInit {
   );
 
   constructor(
-    private readonly vaultNudgesService: NudgesService,
+    private readonly nudgesService: NudgesService,
     private readonly accountService: AccountService,
     private readonly autofillBrowserSettingsService: AutofillBrowserSettingsService,
     private readonly configService: ConfigService,
@@ -95,9 +95,9 @@ export class SettingsV2Component implements OnInit {
   }
 
   async dismissBadge(type: NudgeType) {
-    if (!(await firstValueFrom(this.showVaultBadge$)).hasBadgeDismissed) {
+    if (!(await firstValueFrom(this.showVaultBadge$))) {
       const account = await firstValueFrom(this.authenticatedAccount$);
-      await this.vaultNudgesService.dismissNudge(type, account.id as UserId, true);
+      await this.nudgesService.dismissNudge(type, account.id as UserId, true);
     }
   }
 }

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -42,7 +42,7 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
   ],
 })
 export class SettingsV2Component implements OnInit {
-  VaultNudgeType = NudgeType;
+  NudgeType = NudgeType;
   activeUserId: UserId | null = null;
   protected isBrowserAutofillSettingOverridden = false;
 
@@ -95,7 +95,7 @@ export class SettingsV2Component implements OnInit {
   }
 
   async dismissBadge(type: NudgeType) {
-    if (!(await firstValueFrom(this.showVaultBadge$))) {
+    if (await firstValueFrom(this.showVaultBadge$)) {
       const account = await firstValueFrom(this.authenticatedAccount$);
       await this.nudgesService.dismissNudge(type, account.id as UserId, true);
     }

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -36,7 +36,7 @@
         [subtitle]="'emptyVaultNudgeBody' | i18n"
         [buttonText]="'emptyVaultNudgeButton' | i18n"
         (onButtonClick)="navigateToImport()"
-        (onDismiss)="dismissVaultNudgeSpotlight(VaultNudgeType.EmptyVaultNudge)"
+        (onDismiss)="dismissVaultNudgeSpotlight(NudgeType.EmptyVaultNudge)"
       >
       </bit-spotlight>
     </ng-container>
@@ -44,7 +44,7 @@
       <div class="tw-mb-4" *ngIf="showHasItemsVaultSpotlight$ | async">
         <bit-spotlight
           [title]="'hasItemsVaultNudgeTitle' | i18n"
-          (onDismiss)="dismissVaultNudgeSpotlight(VaultNudgeType.HasVaultItems)"
+          (onDismiss)="dismissVaultNudgeSpotlight(NudgeType.HasVaultItems)"
         >
           <ul class="tw-pl-4 tw-text-main" bitTypography="body2">
             <li>{{ "hasItemsVaultNudgeBodyOne" | i18n }}</li>

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -34,8 +34,8 @@ import {
   DecryptionFailureDialogComponent,
   SpotlightComponent,
   VaultIcons,
-  VaultNudgesService,
-  VaultNudgeType,
+  NudgesService,
+  NudgeType,
 } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../../auth/popup/account-switching/current-account.component";
@@ -96,17 +96,15 @@ enum VaultState {
 export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(CdkVirtualScrollableElement) virtualScrollElement?: CdkVirtualScrollableElement;
 
-  VaultNudgeType = VaultNudgeType;
+  VaultNudgeType = NudgeType;
   cipherType = CipherType;
   private activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
   showEmptyVaultSpotlight$: Observable<boolean> = this.activeUserId$.pipe(
-    switchMap((userId) =>
-      this.vaultNudgesService.showNudge$(VaultNudgeType.EmptyVaultNudge, userId),
-    ),
+    switchMap((userId) => this.vaultNudgesService.showNudge$(NudgeType.EmptyVaultNudge, userId)),
     map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed),
   );
   showHasItemsVaultSpotlight$: Observable<boolean> = this.activeUserId$.pipe(
-    switchMap((userId) => this.vaultNudgesService.showNudge$(VaultNudgeType.HasVaultItems, userId)),
+    switchMap((userId) => this.vaultNudgesService.showNudge$(NudgeType.HasVaultItems, userId)),
     map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed),
   );
 
@@ -159,7 +157,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     private dialogService: DialogService,
     private vaultCopyButtonsService: VaultPopupCopyButtonsService,
     private introCarouselService: IntroCarouselService,
-    private vaultNudgesService: VaultNudgesService,
+    private vaultNudgesService: NudgesService,
     private router: Router,
     private i18nService: I18nService,
   ) {
@@ -229,7 +227,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  async dismissVaultNudgeSpotlight(type: VaultNudgeType) {
+  async dismissVaultNudgeSpotlight(type: NudgeType) {
     await this.vaultNudgesService.dismissNudge(type, this.activeUserId as UserId);
   }
 

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -96,7 +96,7 @@ enum VaultState {
 export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(CdkVirtualScrollableElement) virtualScrollElement?: CdkVirtualScrollableElement;
 
-  VaultNudgeType = NudgeType;
+  NudgeType = NudgeType;
   cipherType = CipherType;
   private activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
   showEmptyVaultSpotlight$: Observable<boolean> = this.activeUserId$.pipe(

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -32,10 +32,10 @@ import {
 } from "@bitwarden/components";
 import {
   DecryptionFailureDialogComponent,
-  SpotlightComponent,
-  VaultIcons,
   NudgesService,
   NudgeType,
+  SpotlightComponent,
+  VaultIcons,
 } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../../auth/popup/account-switching/current-account.component";
@@ -100,12 +100,12 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   cipherType = CipherType;
   private activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
   showEmptyVaultSpotlight$: Observable<boolean> = this.activeUserId$.pipe(
-    switchMap((userId) => this.vaultNudgesService.showNudge$(NudgeType.EmptyVaultNudge, userId)),
-    map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed),
+    switchMap((userId) =>
+      this.nudgesService.showNudgeSpotlight$(NudgeType.EmptyVaultNudge, userId),
+    ),
   );
   showHasItemsVaultSpotlight$: Observable<boolean> = this.activeUserId$.pipe(
-    switchMap((userId) => this.vaultNudgesService.showNudge$(NudgeType.HasVaultItems, userId)),
-    map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed),
+    switchMap((userId) => this.nudgesService.showNudgeSpotlight$(NudgeType.HasVaultItems, userId)),
   );
 
   activeUserId: UserId | null = null;
@@ -157,7 +157,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
     private dialogService: DialogService,
     private vaultCopyButtonsService: VaultPopupCopyButtonsService,
     private introCarouselService: IntroCarouselService,
-    private vaultNudgesService: NudgesService,
+    private nudgesService: NudgesService,
     private router: Router,
     private i18nService: I18nService,
   ) {
@@ -228,7 +228,7 @@ export class VaultV2Component implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async dismissVaultNudgeSpotlight(type: NudgeType) {
-    await this.vaultNudgesService.dismissNudge(type, this.activeUserId as UserId);
+    await this.nudgesService.dismissNudge(type, this.activeUserId as UserId);
   }
 
   protected readonly FeatureFlag = FeatureFlag;

--- a/apps/browser/src/vault/popup/settings/download-bitwarden.component.ts
+++ b/apps/browser/src/vault/popup/settings/download-bitwarden.component.ts
@@ -32,12 +32,12 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
 })
 export class DownloadBitwardenComponent implements OnInit {
   constructor(
-    private vaultNudgeService: NudgesService,
+    private nudgesService: NudgesService,
     private accountService: AccountService,
   ) {}
 
   async ngOnInit() {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    await this.vaultNudgeService.dismissNudge(NudgeType.DownloadBitwarden, userId);
+    await this.nudgesService.dismissNudge(NudgeType.DownloadBitwarden, userId);
   }
 }

--- a/apps/browser/src/vault/popup/settings/download-bitwarden.component.ts
+++ b/apps/browser/src/vault/popup/settings/download-bitwarden.component.ts
@@ -7,7 +7,7 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { CardComponent, LinkModule, TypographyModule } from "@bitwarden/components";
-import { VaultNudgesService, VaultNudgeType } from "@bitwarden/vault";
+import { NudgesService, NudgeType } from "@bitwarden/vault";
 
 import { CurrentAccountComponent } from "../../../auth/popup/account-switching/current-account.component";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
@@ -32,12 +32,12 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
 })
 export class DownloadBitwardenComponent implements OnInit {
   constructor(
-    private vaultNudgeService: VaultNudgesService,
+    private vaultNudgeService: NudgesService,
     private accountService: AccountService,
   ) {}
 
   async ngOnInit() {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    await this.vaultNudgeService.dismissNudge(VaultNudgeType.DownloadBitwarden, userId);
+    await this.vaultNudgeService.dismissNudge(NudgeType.DownloadBitwarden, userId);
   }
 }

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -199,7 +199,7 @@ export const VAULT_APPEARANCE = new StateDefinition("vaultAppearance", "disk");
 export const SECURITY_TASKS_DISK = new StateDefinition("securityTasks", "disk");
 export const AT_RISK_PASSWORDS_PAGE_DISK = new StateDefinition("atRiskPasswordsPage", "disk");
 export const NOTIFICATION_DISK = new StateDefinition("notifications", "disk");
-export const VAULT_NUDGES_DISK = new StateDefinition("vaultNudges", "disk", { web: "disk-local" });
+export const NUDGES_DISK = new StateDefinition("vaultNudges", "disk", { web: "disk-local" });
 export const VAULT_BROWSER_INTRO_CAROUSEL = new StateDefinition(
   "vaultBrowserIntroCarousel",
   "disk",

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -199,7 +199,7 @@ export const VAULT_APPEARANCE = new StateDefinition("vaultAppearance", "disk");
 export const SECURITY_TASKS_DISK = new StateDefinition("securityTasks", "disk");
 export const AT_RISK_PASSWORDS_PAGE_DISK = new StateDefinition("atRiskPasswordsPage", "disk");
 export const NOTIFICATION_DISK = new StateDefinition("notifications", "disk");
-export const NUDGES_DISK = new StateDefinition("vaultNudges", "disk", { web: "disk-local" });
+export const NUDGES_DISK = new StateDefinition("nudges", "disk", { web: "disk-local" });
 export const VAULT_BROWSER_INTRO_CAROUSEL = new StateDefinition(
   "vaultBrowserIntroCarousel",
   "disk",

--- a/libs/vault/src/cipher-form/cipher-form.stories.ts
+++ b/libs/vault/src/cipher-form/cipher-form.stories.ts
@@ -36,7 +36,7 @@ import {
   CipherFormGenerationService,
   NudgeStatus,
   PasswordRepromptService,
-  VaultNudgesService,
+  NudgesService,
 } from "@bitwarden/vault";
 // FIXME: remove `/apps` import from `/libs`
 // FIXME: remove `src` and fix import
@@ -144,7 +144,7 @@ export default {
       ],
       providers: [
         {
-          provide: VaultNudgesService,
+          provide: NudgesService,
           useValue: {
             showNudge$: new BehaviorSubject({
               hasBadgeDismissed: true,

--- a/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.spec.ts
@@ -8,7 +8,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/sdk-internal";
 
-import { VaultNudgesService, VaultNudgeType } from "../../../services/vault-nudges.service";
+import { NudgesService, NudgeType } from "../../../services/nudges.service";
 
 import { NewItemNudgeComponent } from "./new-item-nudge.component";
 
@@ -18,19 +18,19 @@ describe("NewItemNudgeComponent", () => {
 
   let i18nService: MockProxy<I18nService>;
   let accountService: MockProxy<AccountService>;
-  let vaultNudgesService: MockProxy<VaultNudgesService>;
+  let nudgesService: MockProxy<NudgesService>;
 
   beforeEach(async () => {
     i18nService = mock<I18nService>({ t: (key: string) => key });
     accountService = mock<AccountService>();
-    vaultNudgesService = mock<VaultNudgesService>();
+    nudgesService = mock<NudgesService>();
 
     await TestBed.configureTestingModule({
       imports: [NewItemNudgeComponent, CommonModule],
       providers: [
         { provide: I18nService, useValue: i18nService },
         { provide: AccountService, useValue: accountService },
-        { provide: VaultNudgesService, useValue: vaultNudgesService },
+        { provide: NudgesService, useValue: nudgesService },
       ],
     }).compileComponents();
   });
@@ -58,7 +58,7 @@ describe("NewItemNudgeComponent", () => {
     expect(component.nudgeBody).toBe(
       "newLoginNudgeBodyOne <strong>newLoginNudgeBodyBold</strong> newLoginNudgeBodyTwo",
     );
-    expect(component.dismissalNudgeType).toBe(VaultNudgeType.newLoginItemStatus);
+    expect(component.dismissalNudgeType).toBe(NudgeType.NewLoginItemStatus);
   });
 
   it("should set nudge title and body for CipherType.Card type", async () => {
@@ -71,7 +71,7 @@ describe("NewItemNudgeComponent", () => {
     expect(component.showNewItemSpotlight).toBe(true);
     expect(component.nudgeTitle).toBe("newCardNudgeTitle");
     expect(component.nudgeBody).toBe("newCardNudgeBody");
-    expect(component.dismissalNudgeType).toBe(VaultNudgeType.newCardItemStatus);
+    expect(component.dismissalNudgeType).toBe(NudgeType.NewCardItemStatus);
   });
 
   it("should not show anything if spotlight has been dismissed", async () => {
@@ -82,22 +82,19 @@ describe("NewItemNudgeComponent", () => {
     await component.ngOnInit();
 
     expect(component.showNewItemSpotlight).toBe(false);
-    expect(component.dismissalNudgeType).toBe(VaultNudgeType.newIdentityItemStatus);
+    expect(component.dismissalNudgeType).toBe(NudgeType.NewIdentityItemStatus);
   });
 
   it("should set showNewItemSpotlight to false when user dismisses spotlight", async () => {
     component.showNewItemSpotlight = true;
-    component.dismissalNudgeType = VaultNudgeType.newLoginItemStatus;
+    component.dismissalNudgeType = NudgeType.NewLoginItemStatus;
     component.activeUserId = "test-user-id" as UserId;
 
-    const dismissSpy = jest.spyOn(vaultNudgesService, "dismissNudge").mockResolvedValue();
+    const dismissSpy = jest.spyOn(nudgesService, "dismissNudge").mockResolvedValue();
 
     await component.dismissNewItemSpotlight();
 
     expect(component.showNewItemSpotlight).toBe(false);
-    expect(dismissSpy).toHaveBeenCalledWith(
-      VaultNudgeType.newLoginItemStatus,
-      component.activeUserId,
-    );
+    expect(dismissSpy).toHaveBeenCalledWith(NudgeType.NewLoginItemStatus, component.activeUserId);
   });
 });

--- a/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
+++ b/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
@@ -28,7 +28,7 @@ export class NewItemNudgeComponent implements OnInit {
   constructor(
     private i18nService: I18nService,
     private accountService: AccountService,
-    private vaultNudgesService: NudgesService,
+    private nudgesService: NudgesService,
   ) {}
 
   async ngOnInit() {
@@ -82,16 +82,12 @@ export class NewItemNudgeComponent implements OnInit {
 
   async dismissNewItemSpotlight() {
     if (this.dismissalNudgeType && this.activeUserId) {
-      await this.vaultNudgesService.dismissNudge(
-        this.dismissalNudgeType,
-        this.activeUserId as UserId,
-      );
+      await this.nudgesService.dismissNudge(this.dismissalNudgeType, this.activeUserId as UserId);
       this.showNewItemSpotlight = false;
     }
   }
 
   async checkHasSpotlightDismissed(nudgeType: NudgeType, userId: UserId): Promise<boolean> {
-    return !(await firstValueFrom(this.vaultNudgesService.showNudge$(nudgeType, userId)))
-      .hasSpotlightDismissed;
+    return await firstValueFrom(this.nudgesService.showNudgeSpotlight$(nudgeType, userId));
   }
 }

--- a/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
+++ b/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
@@ -9,7 +9,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/sdk-internal";
 
 import { SpotlightComponent } from "../../../components/spotlight/spotlight.component";
-import { VaultNudgesService, VaultNudgeType } from "../../../services/vault-nudges.service";
+import { NudgesService, NudgeType } from "../../../services/nudges.service";
 
 @Component({
   selector: "vault-new-item-nudge",
@@ -23,12 +23,12 @@ export class NewItemNudgeComponent implements OnInit {
   showNewItemSpotlight: boolean = false;
   nudgeTitle: string = "";
   nudgeBody: string = "";
-  dismissalNudgeType: VaultNudgeType | null = null;
+  dismissalNudgeType: NudgeType | null = null;
 
   constructor(
     private i18nService: I18nService,
     private accountService: AccountService,
-    private vaultNudgesService: VaultNudgesService,
+    private vaultNudgesService: NudgesService,
   ) {}
 
   async ngOnInit() {
@@ -39,25 +39,25 @@ export class NewItemNudgeComponent implements OnInit {
         const nudgeBodyOne = this.i18nService.t("newLoginNudgeBodyOne");
         const nudgeBodyBold = this.i18nService.t("newLoginNudgeBodyBold");
         const nudgeBodyTwo = this.i18nService.t("newLoginNudgeBodyTwo");
-        this.dismissalNudgeType = VaultNudgeType.newLoginItemStatus;
+        this.dismissalNudgeType = NudgeType.NewLoginItemStatus;
         this.nudgeTitle = this.i18nService.t("newLoginNudgeTitle");
         this.nudgeBody = `${nudgeBodyOne} <strong>${nudgeBodyBold}</strong> ${nudgeBodyTwo}`;
         break;
       }
       case CipherType.Card:
-        this.dismissalNudgeType = VaultNudgeType.newCardItemStatus;
+        this.dismissalNudgeType = NudgeType.NewCardItemStatus;
         this.nudgeTitle = this.i18nService.t("newCardNudgeTitle");
         this.nudgeBody = this.i18nService.t("newCardNudgeBody");
         break;
 
       case CipherType.Identity:
-        this.dismissalNudgeType = VaultNudgeType.newIdentityItemStatus;
+        this.dismissalNudgeType = NudgeType.NewIdentityItemStatus;
         this.nudgeTitle = this.i18nService.t("newIdentityNudgeTitle");
         this.nudgeBody = this.i18nService.t("newIdentityNudgeBody");
         break;
 
       case CipherType.SecureNote:
-        this.dismissalNudgeType = VaultNudgeType.newNoteItemStatus;
+        this.dismissalNudgeType = NudgeType.NewNoteItemStatus;
         this.nudgeTitle = this.i18nService.t("newNoteNudgeTitle");
         this.nudgeBody = this.i18nService.t("newNoteNudgeBody");
         break;
@@ -66,7 +66,7 @@ export class NewItemNudgeComponent implements OnInit {
         const sshPartOne = this.i18nService.t("newSshNudgeBodyOne");
         const sshPartTwo = this.i18nService.t("newSshNudgeBodyTwo");
 
-        this.dismissalNudgeType = VaultNudgeType.newSshItemStatus;
+        this.dismissalNudgeType = NudgeType.NewSshItemStatus;
         this.nudgeTitle = this.i18nService.t("newSshNudgeTitle");
         this.nudgeBody = `${sshPartOne} <a href="https://bitwarden.com/help/ssh-agent" class="tw-text-primary-600 tw-font-bold" target="_blank">${sshPartTwo}</a>`;
         break;
@@ -75,7 +75,7 @@ export class NewItemNudgeComponent implements OnInit {
         throw new Error("Unsupported cipher type");
     }
     this.showNewItemSpotlight = await this.checkHasSpotlightDismissed(
-      this.dismissalNudgeType as VaultNudgeType,
+      this.dismissalNudgeType as NudgeType,
       this.activeUserId,
     );
   }
@@ -90,7 +90,7 @@ export class NewItemNudgeComponent implements OnInit {
     }
   }
 
-  async checkHasSpotlightDismissed(nudgeType: VaultNudgeType, userId: UserId): Promise<boolean> {
+  async checkHasSpotlightDismissed(nudgeType: NudgeType, userId: UserId): Promise<boolean> {
     return !(await firstValueFrom(this.vaultNudgesService.showNudge$(nudgeType, userId)))
       .hasSpotlightDismissed;
   }

--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -21,7 +21,7 @@ export * from "./components/add-edit-folder-dialog/add-edit-folder-dialog.compon
 export * from "./components/carousel";
 
 export * as VaultIcons from "./icons";
-export * from "./services/vault-nudges.service";
+export * from "./services/nudges.service";
 export * from "./services/custom-nudges-services";
 
 export { DefaultSshImportPromptService } from "./services/default-ssh-import-prompt.service";

--- a/libs/vault/src/services/custom-nudges-services/autofill-nudge.service.ts
+++ b/libs/vault/src/services/custom-nudges-services/autofill-nudge.service.ts
@@ -7,7 +7,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { UserId } from "@bitwarden/common/types/guid";
 
 import { DefaultSingleNudgeService } from "../default-single-nudge.service";
-import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
+import { NudgeStatus, NudgeType } from "../nudges.service";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -21,7 +21,7 @@ export class AutofillNudgeService extends DefaultSingleNudgeService {
   vaultProfileService = inject(VaultProfileService);
   logService = inject(LogService);
 
-  nudgeStatus$(_: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(_: NudgeType, userId: UserId): Observable<NudgeStatus> {
     const profileDate$ = from(this.vaultProfileService.getProfileCreationDate(userId)).pipe(
       catchError(() => {
         this.logService.error("Error getting profile creation date");
@@ -32,7 +32,7 @@ export class AutofillNudgeService extends DefaultSingleNudgeService {
 
     return combineLatest([
       profileDate$,
-      this.getNudgeStatus$(VaultNudgeType.AutofillNudge, userId),
+      this.getNudgeStatus$(NudgeType.AutofillNudge, userId),
       of(Date.now() - THIRTY_DAYS_MS),
     ]).pipe(
       map(([profileCreationDate, status, profileCutoff]) => {

--- a/libs/vault/src/services/custom-nudges-services/download-bitwarden-nudge.service.ts
+++ b/libs/vault/src/services/custom-nudges-services/download-bitwarden-nudge.service.ts
@@ -7,7 +7,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { UserId } from "@bitwarden/common/types/guid";
 
 import { DefaultSingleNudgeService } from "../default-single-nudge.service";
-import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
+import { NudgeStatus, NudgeType } from "../nudges.service";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -16,7 +16,7 @@ export class DownloadBitwardenNudgeService extends DefaultSingleNudgeService {
   private vaultProfileService = inject(VaultProfileService);
   private logService = inject(LogService);
 
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     const profileDate$ = from(this.vaultProfileService.getProfileCreationDate(userId)).pipe(
       catchError(() => {
         this.logService.error("Failed to load profile date:");

--- a/libs/vault/src/services/custom-nudges-services/empty-vault-nudge.service.ts
+++ b/libs/vault/src/services/custom-nudges-services/empty-vault-nudge.service.ts
@@ -7,7 +7,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 
 import { DefaultSingleNudgeService } from "../default-single-nudge.service";
-import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
+import { NudgeStatus, NudgeType } from "../nudges.service";
 
 /**
  * Custom Nudge Service Checking Nudge Status For Empty Vault
@@ -20,7 +20,7 @@ export class EmptyVaultNudgeService extends DefaultSingleNudgeService {
   organizationService = inject(OrganizationService);
   collectionService = inject(CollectionService);
 
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     return combineLatest([
       this.getNudgeStatus$(nudgeType, userId),
       this.cipherService.cipherViews$(userId),

--- a/libs/vault/src/services/custom-nudges-services/has-items-nudge.service.ts
+++ b/libs/vault/src/services/custom-nudges-services/has-items-nudge.service.ts
@@ -8,7 +8,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 
 import { DefaultSingleNudgeService } from "../default-single-nudge.service";
-import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
+import { NudgeStatus, NudgeType } from "../nudges.service";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -23,7 +23,7 @@ export class HasItemsNudgeService extends DefaultSingleNudgeService {
   vaultProfileService = inject(VaultProfileService);
   logService = inject(LogService);
 
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     const profileDate$ = from(this.vaultProfileService.getProfileCreationDate(userId)).pipe(
       catchError(() => {
         this.logService.error("Error getting profile creation date");
@@ -51,7 +51,7 @@ export class HasItemsNudgeService extends DefaultSingleNudgeService {
           };
           // permanently dismiss both the Empty Vault Nudge and Has Items Vault Nudge if the profile is older than 30 days
           await this.setNudgeStatus(nudgeType, dismissedStatus, userId);
-          await this.setNudgeStatus(VaultNudgeType.EmptyVaultNudge, dismissedStatus, userId);
+          await this.setNudgeStatus(NudgeType.EmptyVaultNudge, dismissedStatus, userId);
           return dismissedStatus;
         } else if (nudgeStatus.hasSpotlightDismissed) {
           return nudgeStatus;

--- a/libs/vault/src/services/custom-nudges-services/new-item-nudge.service.ts
+++ b/libs/vault/src/services/custom-nudges-services/new-item-nudge.service.ts
@@ -6,7 +6,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { CipherType } from "@bitwarden/common/vault/enums";
 
 import { DefaultSingleNudgeService } from "../default-single-nudge.service";
-import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
+import { NudgeStatus, NudgeType } from "../nudges.service";
 
 /**
  * Custom Nudge Service Checking Nudge Status For Vault New Item Types
@@ -17,7 +17,7 @@ import { NudgeStatus, VaultNudgeType } from "../vault-nudges.service";
 export class NewItemNudgeService extends DefaultSingleNudgeService {
   cipherService = inject(CipherService);
 
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     return combineLatest([
       this.getNudgeStatus$(nudgeType, userId),
       this.cipherService.cipherViews$(userId),
@@ -30,19 +30,19 @@ export class NewItemNudgeService extends DefaultSingleNudgeService {
         let currentType: CipherType;
 
         switch (nudgeType) {
-          case VaultNudgeType.newLoginItemStatus:
+          case NudgeType.NewLoginItemStatus:
             currentType = CipherType.Login;
             break;
-          case VaultNudgeType.newCardItemStatus:
+          case NudgeType.NewCardItemStatus:
             currentType = CipherType.Card;
             break;
-          case VaultNudgeType.newIdentityItemStatus:
+          case NudgeType.NewIdentityItemStatus:
             currentType = CipherType.Identity;
             break;
-          case VaultNudgeType.newNoteItemStatus:
+          case NudgeType.NewNoteItemStatus:
             currentType = CipherType.SecureNote;
             break;
-          case VaultNudgeType.newSshItemStatus:
+          case NudgeType.NewSshItemStatus:
             currentType = CipherType.SshKey;
             break;
         }

--- a/libs/vault/src/services/default-single-nudge.service.ts
+++ b/libs/vault/src/services/default-single-nudge.service.ts
@@ -4,19 +4,15 @@ import { map, Observable } from "rxjs";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 
-import {
-  NudgeStatus,
-  VAULT_NUDGE_DISMISSED_DISK_KEY,
-  VaultNudgeType,
-} from "./vault-nudges.service";
+import { NudgeStatus, NUDGE_DISMISSED_DISK_KEY, NudgeType } from "./nudges.service";
 
 /**
  * Base interface for handling a nudge's status
  */
 export interface SingleNudgeService {
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus>;
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus>;
 
-  setNudgeStatus(nudgeType: VaultNudgeType, newStatus: NudgeStatus, userId: UserId): Promise<void>;
+  setNudgeStatus(nudgeType: NudgeType, newStatus: NudgeStatus, userId: UserId): Promise<void>;
 }
 
 /**
@@ -28,9 +24,9 @@ export interface SingleNudgeService {
 export class DefaultSingleNudgeService implements SingleNudgeService {
   stateProvider = inject(StateProvider);
 
-  protected getNudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  protected getNudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     return this.stateProvider
-      .getUser(userId, VAULT_NUDGE_DISMISSED_DISK_KEY)
+      .getUser(userId, NUDGE_DISMISSED_DISK_KEY)
       .state$.pipe(
         map(
           (nudges) =>
@@ -39,16 +35,12 @@ export class DefaultSingleNudgeService implements SingleNudgeService {
       );
   }
 
-  nudgeStatus$(nudgeType: VaultNudgeType, userId: UserId): Observable<NudgeStatus> {
+  nudgeStatus$(nudgeType: NudgeType, userId: UserId): Observable<NudgeStatus> {
     return this.getNudgeStatus$(nudgeType, userId);
   }
 
-  async setNudgeStatus(
-    nudgeType: VaultNudgeType,
-    status: NudgeStatus,
-    userId: UserId,
-  ): Promise<void> {
-    await this.stateProvider.getUser(userId, VAULT_NUDGE_DISMISSED_DISK_KEY).update((nudges) => {
+  async setNudgeStatus(nudgeType: NudgeType, status: NudgeStatus, userId: UserId): Promise<void> {
+    await this.stateProvider.getUser(userId, NUDGE_DISMISSED_DISK_KEY).update((nudges) => {
       nudges ??= {};
       nudges[nudgeType] = status;
       return nudges;

--- a/libs/vault/src/services/nudges.service.spec.ts
+++ b/libs/vault/src/services/nudges.service.spec.ts
@@ -110,7 +110,7 @@ describe("Vault Nudges Service", () => {
     });
   });
 
-  describe("VaultNudgesService", () => {
+  describe("NudgesService", () => {
     it("should return true, the proper value from the custom nudge service nudgeStatus$", async () => {
       TestBed.overrideProvider(HasItemsNudgeService, {
         useValue: { nudgeStatus$: () => of(true) },
@@ -118,7 +118,7 @@ describe("Vault Nudges Service", () => {
       const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(
-        service.showNudge$(NudgeType.HasVaultItems, "user-id" as UserId),
+        service.showNudgeStatus$(NudgeType.HasVaultItems, "user-id" as UserId),
       );
 
       expect(result).toBe(true);
@@ -131,7 +131,37 @@ describe("Vault Nudges Service", () => {
       const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(
-        service.showNudge$(NudgeType.HasVaultItems, "user-id" as UserId),
+        service.showNudgeStatus$(NudgeType.HasVaultItems, "user-id" as UserId),
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should return showNudgeSpotlight$ false if hasSpotLightDismissed is true", async () => {
+      TestBed.overrideProvider(HasItemsNudgeService, {
+        useValue: {
+          nudgeStatus$: () => of({ hasSpotlightDismissed: true, hasBadgeDismissed: true }),
+        },
+      });
+      const service = testBed.inject(NudgesService);
+
+      const result = await firstValueFrom(
+        service.showNudgeSpotlight$(NudgeType.HasVaultItems, "user-id" as UserId),
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should return showNudgeBadge$ false when hasBadgeDismissed is true", async () => {
+      TestBed.overrideProvider(HasItemsNudgeService, {
+        useValue: {
+          nudgeStatus$: () => of({ hasSpotlightDismissed: true, hasBadgeDismissed: true }),
+        },
+      });
+      const service = testBed.inject(NudgesService);
+
+      const result = await firstValueFrom(
+        service.showNudgeBadge$(NudgeType.HasVaultItems, "user-id" as UserId),
       );
 
       expect(result).toBe(false);

--- a/libs/vault/src/services/nudges.service.ts
+++ b/libs/vault/src/services/nudges.service.ts
@@ -82,6 +82,11 @@ export class NudgesService {
     return this.customNudgeServices[nudge] ?? this.defaultNudgeService;
   }
 
+  /**
+   * Check if a nudge Spotlight should be shown to the user
+   * @param nudge
+   * @param userId
+   */
   showNudgeSpotlight$(nudge: NudgeType, userId: UserId): Observable<boolean> {
     return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
       switchMap((hasVaultNudgeFlag) => {
@@ -95,6 +100,11 @@ export class NudgesService {
     );
   }
 
+  /**
+   * Check if a nudge Badge should be shown to the user
+   * @param nudge
+   * @param userId
+   */
   showNudgeBadge$(nudge: NudgeType, userId: UserId): Observable<boolean> {
     return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
       switchMap((hasVaultNudgeFlag) => {
@@ -113,7 +123,7 @@ export class NudgesService {
    * @param nudge
    * @param userId
    */
-  showNudge$(nudge: NudgeType, userId: UserId) {
+  showNudgeStatus$(nudge: NudgeType, userId: UserId) {
     return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
       switchMap((hasVaultNudgeFlag) => {
         if (!hasVaultNudgeFlag) {

--- a/libs/vault/src/services/nudges.service.ts
+++ b/libs/vault/src/services/nudges.service.ts
@@ -3,7 +3,7 @@ import { combineLatest, map, Observable, of, shareReplay, switchMap } from "rxjs
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { UserKeyDefinition, VAULT_NUDGES_DISK } from "@bitwarden/common/platform/state";
+import { UserKeyDefinition, NUDGES_DISK } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 
 import {
@@ -25,7 +25,7 @@ export type NudgeStatus = {
  */
 // FIXME: update to use a const object instead of a typescript enum
 // eslint-disable-next-line @bitwarden/platform/no-enums
-export enum VaultNudgeType {
+export enum NudgeType {
   /** Nudge to show when user has no items in their vault
    * Add future nudges here
    */
@@ -33,16 +33,16 @@ export enum VaultNudgeType {
   HasVaultItems = "has-vault-items",
   AutofillNudge = "autofill-nudge",
   DownloadBitwarden = "download-bitwarden",
-  newLoginItemStatus = "new-login-item-status",
-  newCardItemStatus = "new-card-item-status",
-  newIdentityItemStatus = "new-identity-item-status",
-  newNoteItemStatus = "new-note-item-status",
-  newSshItemStatus = "new-ssh-item-status",
+  NewLoginItemStatus = "new-login-item-status",
+  NewCardItemStatus = "new-card-item-status",
+  NewIdentityItemStatus = "new-identity-item-status",
+  NewNoteItemStatus = "new-note-item-status",
+  NewSshItemStatus = "new-ssh-item-status",
 }
 
-export const VAULT_NUDGE_DISMISSED_DISK_KEY = new UserKeyDefinition<
-  Partial<Record<VaultNudgeType, NudgeStatus>>
->(VAULT_NUDGES_DISK, "vaultNudgeDismissed", {
+export const NUDGE_DISMISSED_DISK_KEY = new UserKeyDefinition<
+  Partial<Record<NudgeType, NudgeStatus>>
+>(NUDGES_DISK, "vaultNudgeDismissed", {
   deserializer: (nudge) => nudge,
   clearOn: [], // Do not clear dismissals
 });
@@ -50,7 +50,7 @@ export const VAULT_NUDGE_DISMISSED_DISK_KEY = new UserKeyDefinition<
 @Injectable({
   providedIn: "root",
 })
-export class VaultNudgesService {
+export class NudgesService {
   private newItemNudgeService = inject(NewItemNudgeService);
 
   /**
@@ -58,16 +58,16 @@ export class VaultNudgesService {
    * Each nudge type can have its own service to determine when to show the nudge
    * @private
    */
-  private customNudgeServices: Partial<Record<VaultNudgeType, SingleNudgeService>> = {
-    [VaultNudgeType.HasVaultItems]: inject(HasItemsNudgeService),
-    [VaultNudgeType.EmptyVaultNudge]: inject(EmptyVaultNudgeService),
-    [VaultNudgeType.AutofillNudge]: inject(AutofillNudgeService),
-    [VaultNudgeType.DownloadBitwarden]: inject(DownloadBitwardenNudgeService),
-    [VaultNudgeType.newLoginItemStatus]: this.newItemNudgeService,
-    [VaultNudgeType.newCardItemStatus]: this.newItemNudgeService,
-    [VaultNudgeType.newIdentityItemStatus]: this.newItemNudgeService,
-    [VaultNudgeType.newNoteItemStatus]: this.newItemNudgeService,
-    [VaultNudgeType.newSshItemStatus]: this.newItemNudgeService,
+  private customNudgeServices: Partial<Record<NudgeType, SingleNudgeService>> = {
+    [NudgeType.HasVaultItems]: inject(HasItemsNudgeService),
+    [NudgeType.EmptyVaultNudge]: inject(EmptyVaultNudgeService),
+    [NudgeType.AutofillNudge]: inject(AutofillNudgeService),
+    [NudgeType.DownloadBitwarden]: inject(DownloadBitwardenNudgeService),
+    [NudgeType.NewLoginItemStatus]: this.newItemNudgeService,
+    [NudgeType.NewCardItemStatus]: this.newItemNudgeService,
+    [NudgeType.NewIdentityItemStatus]: this.newItemNudgeService,
+    [NudgeType.NewNoteItemStatus]: this.newItemNudgeService,
+    [NudgeType.NewSshItemStatus]: this.newItemNudgeService,
   };
 
   /**
@@ -78,8 +78,34 @@ export class VaultNudgesService {
   private defaultNudgeService = inject(DefaultSingleNudgeService);
   private configService = inject(ConfigService);
 
-  private getNudgeService(nudge: VaultNudgeType): SingleNudgeService {
+  private getNudgeService(nudge: NudgeType): SingleNudgeService {
     return this.customNudgeServices[nudge] ?? this.defaultNudgeService;
+  }
+
+  showNudgeSpotlight$(nudge: NudgeType, userId: UserId): Observable<boolean> {
+    return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
+      switchMap((hasVaultNudgeFlag) => {
+        if (!hasVaultNudgeFlag) {
+          return of(false);
+        }
+        return this.getNudgeService(nudge)
+          .nudgeStatus$(nudge, userId)
+          .pipe(map((nudgeStatus) => !nudgeStatus.hasSpotlightDismissed));
+      }),
+    );
+  }
+
+  showNudgeBadge$(nudge: NudgeType, userId: UserId): Observable<boolean> {
+    return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
+      switchMap((hasVaultNudgeFlag) => {
+        if (!hasVaultNudgeFlag) {
+          return of(false);
+        }
+        return this.getNudgeService(nudge)
+          .nudgeStatus$(nudge, userId)
+          .pipe(map((nudgeStatus) => !nudgeStatus.hasBadgeDismissed));
+      }),
+    );
   }
 
   /**
@@ -87,7 +113,7 @@ export class VaultNudgesService {
    * @param nudge
    * @param userId
    */
-  showNudge$(nudge: VaultNudgeType, userId: UserId) {
+  showNudge$(nudge: NudgeType, userId: UserId) {
     return this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge).pipe(
       switchMap((hasVaultNudgeFlag) => {
         if (!hasVaultNudgeFlag) {
@@ -103,7 +129,7 @@ export class VaultNudgesService {
    * @param nudge
    * @param userId
    */
-  async dismissNudge(nudge: VaultNudgeType, userId: UserId, onlyBadge: boolean = false) {
+  async dismissNudge(nudge: NudgeType, userId: UserId, onlyBadge: boolean = false) {
     const dismissedStatus = onlyBadge
       ? { hasBadgeDismissed: true, hasSpotlightDismissed: false }
       : { hasBadgeDismissed: true, hasSpotlightDismissed: true };
@@ -116,7 +142,7 @@ export class VaultNudgesService {
    */
   hasActiveBadges$(userId: UserId): Observable<boolean> {
     // Add more nudge types here if they have the settings badge feature
-    const nudgeTypes = [VaultNudgeType.EmptyVaultNudge, VaultNudgeType.DownloadBitwarden];
+    const nudgeTypes = [NudgeType.EmptyVaultNudge, NudgeType.DownloadBitwarden];
 
     const nudgeTypesWithBadge$ = nudgeTypes.map((nudge) => {
       return this.getNudgeService(nudge)

--- a/libs/vault/src/services/vault-nudges.service.spec.ts
+++ b/libs/vault/src/services/vault-nudges.service.spec.ts
@@ -18,7 +18,7 @@ import {
   DownloadBitwardenNudgeService,
 } from "./custom-nudges-services";
 import { DefaultSingleNudgeService } from "./default-single-nudge.service";
-import { VaultNudgesService, VaultNudgeType } from "./vault-nudges.service";
+import { NudgesService, NudgeType } from "./nudges.service";
 
 describe("Vault Nudges Service", () => {
   let fakeStateProvider: FakeStateProvider;
@@ -29,7 +29,7 @@ describe("Vault Nudges Service", () => {
     getFeatureFlag: jest.fn().mockReturnValue(true),
   };
 
-  const vaultNudgeServices = [EmptyVaultNudgeService, DownloadBitwardenNudgeService];
+  const nudgeServices = [EmptyVaultNudgeService, DownloadBitwardenNudgeService];
 
   beforeEach(async () => {
     fakeStateProvider = new FakeStateProvider(mockAccountServiceWith("user-id" as UserId));
@@ -38,7 +38,7 @@ describe("Vault Nudges Service", () => {
       imports: [],
       providers: [
         {
-          provide: VaultNudgesService,
+          provide: NudgesService,
         },
         {
           provide: DefaultSingleNudgeService,
@@ -83,13 +83,13 @@ describe("Vault Nudges Service", () => {
       const service = testBed.inject(DefaultSingleNudgeService);
 
       await service.setNudgeStatus(
-        VaultNudgeType.EmptyVaultNudge,
+        NudgeType.EmptyVaultNudge,
         { hasBadgeDismissed: true, hasSpotlightDismissed: true },
         "user-id" as UserId,
       );
 
       const result = await firstValueFrom(
-        service.nudgeStatus$(VaultNudgeType.EmptyVaultNudge, "user-id" as UserId),
+        service.nudgeStatus$(NudgeType.EmptyVaultNudge, "user-id" as UserId),
       );
       expect(result).toEqual({ hasBadgeDismissed: true, hasSpotlightDismissed: true });
     });
@@ -98,13 +98,13 @@ describe("Vault Nudges Service", () => {
       const service = testBed.inject(DefaultSingleNudgeService);
 
       await service.setNudgeStatus(
-        VaultNudgeType.EmptyVaultNudge,
+        NudgeType.EmptyVaultNudge,
         { hasBadgeDismissed: false, hasSpotlightDismissed: false },
         "user-id" as UserId,
       );
 
       const result = await firstValueFrom(
-        service.nudgeStatus$(VaultNudgeType.EmptyVaultNudge, "user-id" as UserId),
+        service.nudgeStatus$(NudgeType.EmptyVaultNudge, "user-id" as UserId),
       );
       expect(result).toEqual({ hasBadgeDismissed: false, hasSpotlightDismissed: false });
     });
@@ -115,10 +115,10 @@ describe("Vault Nudges Service", () => {
       TestBed.overrideProvider(HasItemsNudgeService, {
         useValue: { nudgeStatus$: () => of(true) },
       });
-      const service = testBed.inject(VaultNudgesService);
+      const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(
-        service.showNudge$(VaultNudgeType.HasVaultItems, "user-id" as UserId),
+        service.showNudge$(NudgeType.HasVaultItems, "user-id" as UserId),
       );
 
       expect(result).toBe(true);
@@ -128,10 +128,10 @@ describe("Vault Nudges Service", () => {
       TestBed.overrideProvider(HasItemsNudgeService, {
         useValue: { nudgeStatus$: () => of(false) },
       });
-      const service = testBed.inject(VaultNudgesService);
+      const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(
-        service.showNudge$(VaultNudgeType.HasVaultItems, "user-id" as UserId),
+        service.showNudge$(NudgeType.HasVaultItems, "user-id" as UserId),
       );
 
       expect(result).toBe(false);
@@ -140,7 +140,7 @@ describe("Vault Nudges Service", () => {
 
   describe("HasActiveBadges", () => {
     it("should return true if a nudgeType with hasBadgeDismissed === false", async () => {
-      vaultNudgeServices.forEach((service) => {
+      nudgeServices.forEach((service) => {
         TestBed.overrideProvider(service, {
           useValue: {
             nudgeStatus$: () => of({ hasBadgeDismissed: false, hasSpotlightDismissed: false }),
@@ -148,21 +148,21 @@ describe("Vault Nudges Service", () => {
         });
       });
 
-      const service = testBed.inject(VaultNudgesService);
+      const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(service.hasActiveBadges$("user-id" as UserId));
 
       expect(result).toBe(true);
     });
     it("should return false if all nudgeTypes have hasBadgeDismissed === true", async () => {
-      vaultNudgeServices.forEach((service) => {
+      nudgeServices.forEach((service) => {
         TestBed.overrideProvider(service, {
           useValue: {
             nudgeStatus$: () => of({ hasBadgeDismissed: true, hasSpotlightDismissed: false }),
           },
         });
       });
-      const service = testBed.inject(VaultNudgesService);
+      const service = testBed.inject(NudgesService);
 
       const result = await firstValueFrom(service.hasActiveBadges$("user-id" as UserId));
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21663](https://bitwarden.atlassian.net/browse/PM-21663)

## 📔 Objective

This PR refactors:

- `VaultNudgesService` -> `NudgesService` and other related names (state, type, status)
- NudgesService updates: New observables added for `showNudgeBadge$` and `showNudgeSpotlight`. Added Unit Test
- Components that used `showNudge$` to get the `NudgeStatus` have been updated to target the new observables and get a boolean value in return.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21663]: https://bitwarden.atlassian.net/browse/PM-21663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ