### PR TITLE
[PM-19986] Change background color from white to background-alt to match design

### DIFF
--- a/libs/tools/card/src/card.component.ts
+++ b/libs/tools/card/src/card.component.ts
@@ -13,7 +13,7 @@ import { TypographyModule } from "@bitwarden/components";
   imports: [CommonModule, TypographyModule, JslibModule],
   host: {
     class:
-      "tw-box-border tw-bg-background tw-block tw-text-main tw-border-solid tw-border tw-border-secondary-300 tw-border [&:not(bit-layout_*)]:tw-rounded-lg tw-rounded-lg tw-p-6",
+      "tw-box-border tw-bg-background-alt tw-block tw-text-main tw-border-solid tw-border tw-border-secondary-300 tw-border [&:not(bit-layout_*)]:tw-rounded-lg tw-rounded-lg tw-p-6",
   },
 })
 export class CardComponent {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19986](https://bitwarden.atlassian.net/browse/PM-19986?atlOrigin=eyJpIjoiY2FjMzRlZjk5YTg5NGE0M2E0YzNkYzFlNGI2ZWU0MTEiLCJwIjoiaiJ9)

## 📔 Objective

Change background color from white to background-alt to match design specs

## 📸 Screenshots

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/ef670607-e8f9-45b4-ade1-0fc66720aff4" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
