### PR TITLE
[PM-21456] Notification bar does not appear when user is adding a new login when vault is locked

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1116,6 +1116,10 @@
     "message": "Update login",
     "description": "Button text for updating an existing login entry."
   },
+  "unlockToSave": {
+    "message": "Unlock your vault to save this login",
+    "description": "User prompt to take action in order to save the login they just entered."
+  },
   "saveLogin": {
     "message": "Save login",
     "description": "Prompt asking the user if they want to save their login details."

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1117,7 +1117,7 @@
     "description": "Button text for updating an existing login entry."
   },
   "unlockToSave": {
-    "message": "Unlock your vault to save this login",
+    "message": "Unlock to save this login",
     "description": "User prompt to take action in order to save the login they just entered."
   },
   "saveLogin": {

--- a/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
@@ -134,6 +134,7 @@ export const mockI18n = {
   saveLogin: "Save login",
   selectItemAriaLabel: "Select $ITEMTYPE$, $ITEMNAME$",
   typeLogin: "Login",
+  unlockToSave: "Unlock to save this login",
   updateLoginAction: "Update login",
   updateLogin: "Update existing login",
   vault: "Vault",

--- a/apps/browser/src/autofill/content/components/notification/container.ts
+++ b/apps/browser/src/autofill/content/components/notification/container.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import { html } from "lit";
+import { html, nothing } from "lit";
 
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 
@@ -47,14 +47,13 @@ export function NotificationContainer({
   type,
 }: NotificationContainerProps) {
   const headerMessage = getHeaderMessage(i18n, type);
-  const showBody = true;
+  const showBody = type !== NotificationTypes.Unlock;
 
   return html`
     <div class=${notificationContainerStyles(theme)}>
       ${NotificationHeader({
         handleCloseNotification,
         message: headerMessage,
-        standalone: showBody,
         theme,
       })}
       ${showBody
@@ -65,7 +64,7 @@ export function NotificationContainer({
             theme,
             i18n,
           })
-        : null}
+        : nothing}
       ${NotificationFooter({
         handleSaveAction,
         collections,

--- a/apps/browser/src/autofill/content/components/notification/container.ts
+++ b/apps/browser/src/autofill/content/components/notification/container.ts
@@ -106,7 +106,7 @@ function getHeaderMessage(i18n: I18n, type?: NotificationType) {
     case NotificationTypes.Change:
       return i18n.updateLogin;
     case NotificationTypes.Unlock:
-      return "";
+      return i18n.unlockToSave;
     default:
       return undefined;
   }

--- a/apps/browser/src/autofill/content/components/notification/footer.ts
+++ b/apps/browser/src/autofill/content/components/notification/footer.ts
@@ -34,7 +34,13 @@ export function NotificationFooter({
   handleSaveAction,
 }: NotificationFooterProps) {
   const isChangeNotification = notificationType === NotificationTypes.Change;
-  const primaryButtonText = i18n.saveAction;
+  const isUnlockNotification = notificationType === NotificationTypes.Unlock;
+
+  let primaryButtonText = i18n.saveAction;
+
+  if (isUnlockNotification) {
+    primaryButtonText = i18n.notificationUnlock;
+  }
 
   return html`
     <div class=${notificationFooterStyles({ isChangeNotification })}>

--- a/apps/browser/src/autofill/content/components/notification/header.ts
+++ b/apps/browser/src/autofill/content/components/notification/header.ts
@@ -56,8 +56,8 @@ const notificationHeaderStyles = ({
   white-space: nowrap;
 
   ${standalone
-    ? css`
+    ? css``
+    : css`
         border-bottom: 0.5px solid ${themes[theme].secondary["300"]};
-      `
-    : css``}
+      `}
 `;

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -146,6 +146,11 @@ async function initNotificationBar(message: NotificationBarWindowMessage) {
   const resolvedTheme = getResolvedTheme(theme ?? ThemeTypes.Light);
 
   if (useComponentBar) {
+    if (isVaultLocked) {
+      sendSaveCipherMessage(false);
+      return;
+    }
+
     document.body.innerHTML = "";
     // Current implementations utilize a require for scss files which creates the need to remove the node.
     document.head.querySelectorAll('link[rel="stylesheet"]').forEach((node) => node.remove());

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -85,6 +85,7 @@ function getI18n() {
     saveFailureDetails: chrome.i18n.getMessage("saveFailureDetails"),
     saveLogin: chrome.i18n.getMessage("saveLogin"),
     typeLogin: chrome.i18n.getMessage("typeLogin"),
+    unlockToSave: chrome.i18n.getMessage("unlockToSave"),
     updateLoginAction: chrome.i18n.getMessage("updateLoginAction"),
     updateLogin: chrome.i18n.getMessage("updateLogin"),
     vault: chrome.i18n.getMessage("vault"),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21456](https://bitwarden.atlassian.net/browse/PM-21456)

## 📔 Objective

With the v3 notification experience, when the vault is locked and a user logs in, they do not receive the usual prompt to unlock and save the cipher.

## 📸 Screenshots

**After Changes**

https://github.com/user-attachments/assets/1cbb14af-a59b-4593-b53d-516c56dda24f

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21456]: https://bitwarden.atlassian.net/browse/PM-21456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ