### PR TITLE
[PM-21690] Bugfix - Handle cases where orgKeys are undefined at collection decryption

### DIFF
--- a/libs/admin-console/src/common/collections/services/default-collection.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection.service.ts
@@ -130,6 +130,10 @@ export class DefaultCollectionService implements CollectionService {
 
     orgKeys ??= await firstValueFrom(this.keyService.activeUserOrgKeys$);
 
+    if (orgKeys == null) {
+      return [];
+    }
+
     const promises: Promise<any>[] = [];
     collections.forEach((collection) => {
       promises.push(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21698](https://bitwarden.atlassian.net/browse/PM-21698)

## 📔 Objective

I ran into this error over and over while testing vault lock state:

![Screenshot 2025-05-13 at 5 33 28 PM](https://github.com/user-attachments/assets/1a853e04-13ac-4f22-9030-110e0a5bfac1)

I tracked it down to a case in [`decryptMany`](https://github.com/bitwarden/clients/blob/main/libs/admin-console/src/common/collections/services/default-collection.service.ts#L122) where `orgKeys` are `undefined` and so fail upon subsequent access to their properties.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21698]: https://bitwarden.atlassian.net/browse/PM-21698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ