### PR TITLE
[PM-21213] - fix margin in identity component

### DIFF
--- a/libs/vault/src/cipher-form/components/identity/identity.component.html
+++ b/libs/vault/src/cipher-form/components/identity/identity.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="identityForm">
-  <bit-section>
+  <section class="tw-mb-5 bit-compact:tw-mb-4">
     <bit-section-header>
       <h2 bitTypography="h6">{{ "personalDetails" | i18n }}</h2>
     </bit-section-header>
@@ -48,8 +48,8 @@
         <input bitInput formControlName="company" />
       </bit-form-field>
     </bit-card>
-  </bit-section>
-  <bit-section>
+  </section>
+  <section class="tw-mb-5 bit-compact:tw-mb-4">
     <bit-section-header>
       <h2 bitTypography="h6">{{ "identification" | i18n }}</h2>
     </bit-section-header>
@@ -87,8 +87,8 @@
         <input bitInput formControlName="licenseNumber" />
       </bit-form-field>
     </bit-card>
-  </bit-section>
-  <bit-section>
+  </section>
+  <section class="tw-mb-5 bit-compact:tw-mb-4">
     <bit-section-header>
       <h2 bitTypography="h6">{{ "contactInfo" | i18n }}</h2>
     </bit-section-header>
@@ -106,8 +106,8 @@
         <input bitInput formControlName="phone" />
       </bit-form-field>
     </bit-card>
-  </bit-section>
-  <bit-section>
+  </section>
+  <section class="tw-mb-5 bit-compact:tw-mb-4">
     <bit-section-header>
       <h2 bitTypography="h6">{{ "address" | i18n }}</h2>
     </bit-section-header>
@@ -155,5 +155,5 @@
         <input bitInput formControlName="country" />
       </bit-form-field>
     </bit-card>
-  </bit-section>
+  </section>
 </form>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21213

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR is part of a [larger body of work](https://github.com/bitwarden/clients/pull/14710) to ensure the margin in the cipher form in the desktop matches that of the other clients. The consensus was to replace all instances of `<bit-section>` with a `<section>` with only the desired class names. This PR in particular targets the `identity.component.html` template that was missed in the previous PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Screenshot 2025-05-15 at 2 23 41 PM](https://github.com/user-attachments/assets/0746f8a4-7c83-413f-b945-b42b14e84660)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
