### PR TITLE
[PM-21705] Require userID for refreshAdditionalKeys() on key-service

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -519,10 +519,11 @@ export class SettingsComponent implements OnInit, OnDestroy {
     // See: https://github.com/angular/angular/issues/13063
 
     try {
+      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
       if (!enabled || !this.supportsBiometric) {
         this.form.controls.biometric.setValue(false, { emitEvent: false });
         await this.biometricStateService.setBiometricUnlockEnabled(false);
-        await this.keyService.refreshAdditionalKeys();
+        await this.keyService.refreshAdditionalKeys(userId);
         return;
       }
 
@@ -558,7 +559,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         await this.biometricStateService.setRequirePasswordOnStart(true);
         await this.biometricStateService.setDismissedRequirePasswordOnStartCallout();
       }
-      await this.keyService.refreshAdditionalKeys();
+      await this.keyService.refreshAdditionalKeys(userId);
 
       const activeUserId = await firstValueFrom(
         this.accountService.activeAccount$.pipe(map((a) => a?.id)),
@@ -598,7 +599,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
       await this.biometricStateService.setRequirePasswordOnStart(false);
     }
     await this.biometricStateService.setDismissedRequirePasswordOnStartCallout();
-    await this.keyService.refreshAdditionalKeys();
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    await this.keyService.refreshAdditionalKeys(userId);
   }
 
   async saveFavicons() {

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
@@ -88,7 +88,7 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
       clientSecret,
     ]);
 
-    await this.keyService.refreshAdditionalKeys();
+    await this.keyService.refreshAdditionalKeys(userId);
   }
 
   availableVaultTimeoutActions$(userId?: string): Observable<VaultTimeoutAction[]> {

--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -83,8 +83,11 @@ export abstract class KeyService {
    * Gets the user key from memory and sets it again,
    * kicking off a refresh of any additional keys
    * (such as auto, biometrics, or pin)
+   * @param userId The target user to refresh keys for.
+   * @throws Error when userId is null or undefined.
+   * @throws When userKey doesn't exist in memory for the target user.
    */
-  abstract refreshAdditionalKeys(): Promise<void>;
+  abstract refreshAdditionalKeys(userId: UserId): Promise<void>;
   /**
    * Observable value that returns whether or not the currently active user has ever had auser key,
    * i.e. has ever been unlocked/decrypted. This is key for differentiating between TDE locked and standard locked states.

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -88,6 +88,35 @@ describe("keyService", () => {
     expect(keyService).not.toBeFalsy();
   });
 
+  describe("refreshAdditionalKeys", () => {
+    test.each([null as unknown as UserId, undefined as unknown as UserId])(
+      "throws when the provided userId is %s",
+      async (userId) => {
+        await expect(keyService.refreshAdditionalKeys(userId)).rejects.toThrow(
+          "UserId is required",
+        );
+      },
+    );
+
+    it("throws error if user key not found", async () => {
+      stateProvider.singleUser.getFake(mockUserId, USER_KEY).nextState(null);
+
+      await expect(keyService.refreshAdditionalKeys(mockUserId)).rejects.toThrow(
+        "No user key found for: " + mockUserId,
+      );
+    });
+
+    it("refreshes additional keys when user key is available", async () => {
+      const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
+      stateProvider.singleUser.getFake(mockUserId, USER_KEY).nextState(mockUserKey);
+      const setUserKeySpy = jest.spyOn(keyService, "setUserKey");
+
+      await keyService.refreshAdditionalKeys(mockUserId);
+
+      expect(setUserKeySpy).toHaveBeenCalledWith(mockUserKey, mockUserId);
+    });
+  });
+
   describe("getUserKey", () => {
     let mockUserKey: UserKey;
 

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -128,15 +128,17 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     await this.setPrivateKey(encPrivateKey, userId);
   }
 
-  async refreshAdditionalKeys(): Promise<void> {
-    const activeUserId = await firstValueFrom(this.stateProvider.activeUserId$);
-
-    if (activeUserId == null) {
-      throw new Error("Can only refresh keys while there is an active user.");
+  async refreshAdditionalKeys(userId: UserId): Promise<void> {
+    if (userId == null) {
+      throw new Error("UserId is required.");
     }
 
-    const key = await this.getUserKey(activeUserId);
-    await this.setUserKey(key, activeUserId);
+    const key = await firstValueFrom(this.userKey$(userId));
+    if (key == null) {
+      throw new Error("No user key found for: " + userId);
+    }
+
+    await this.setUserKey(key, userId);
   }
 
   getInMemoryUserKeyFor$(userId: UserId): Observable<UserKey> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21705

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the `KeyService`'s  `refreshAdditionalKeys` to require a userId parameter. This is a part of the effort to remove the `KeyService`'s usage of `ActiveUserState` and require UserID for methods.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
