### PR TITLE
[PM-21569] - sshkey view - replace bit-card with read-only-cipher-card

### DIFF
--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -2,7 +2,7 @@
   <bit-section-header>
     <h2 bitTypography="h6">{{ "typeSshKey" | i18n }}</h2>
   </bit-section-header>
-  <bit-card class="[&_bit-form-field:last-of-type]:tw-mb-0">
+  <read-only-cipher-card class="[&_bit-form-field:last-of-type]:tw-mb-0">
     <bit-form-field>
       <bit-label>{{ "sshPrivateKey" | i18n }}</bit-label>
       <input
@@ -65,5 +65,5 @@
         [appA11yTitle]="'copyValue' | i18n"
       ></button>
     </bit-form-field>
-  </bit-card>
+  </read-only-cipher-card>
 </section>

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
@@ -6,15 +6,13 @@ import { Component, Input } from "@angular/core";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
 import {
-  CardComponent,
-  SectionComponent,
   SectionHeaderComponent,
   TypographyModule,
   FormFieldModule,
   IconButtonModule,
 } from "@bitwarden/components";
 
-import { OrgIconDirective } from "../../components/org-icon.directive";
+import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-cipher-card.component";
 
 @Component({
   selector: "app-sshkey-view",
@@ -23,11 +21,9 @@ import { OrgIconDirective } from "../../components/org-icon.directive";
   imports: [
     CommonModule,
     JslibModule,
-    CardComponent,
-    SectionComponent,
     SectionHeaderComponent,
+    ReadOnlyCipherCardComponent,
     TypographyModule,
-    OrgIconDirective,
     FormFieldModule,
     IconButtonModule,
   ],


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21569

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In the `sshkey-view.component` this PR replaces the  `<bit-card>` component with `<read-only-cipher-card>` to take advantage of the disabling of the bottom border in the latter component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|![Screenshot 2025-05-15 at 3 58 47 PM](https://github.com/user-attachments/assets/7fcdea73-07a1-40e3-856c-dbc628a92974)|![Screenshot 2025-05-15 at 3 58 09 PM](https://github.com/user-attachments/assets/aa3d100f-d998-479d-8d95-4bb1f945f140)|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
