### PR TITLE
[PM 21666]If there is more than one Sponsorship in the table, you cannot remove 'Sent' or 'Active' sponsorships

### DIFF
--- a/apps/web/src/app/billing/members/free-bitwarden-families.component.ts
+++ b/apps/web/src/app/billing/members/free-bitwarden-families.component.ts
@@ -179,7 +179,10 @@ export class FreeBitwardenFamiliesComponent implements OnInit {
       return;
     }
 
-    await this.organizationSponsorshipApiService.deleteRevokeSponsorship(this.organizationId, true);
+    await this.organizationSponsorshipApiService.deleteAdminInitiatedRevokeSponsorship(
+      this.organizationId,
+      sponsorship.friendlyName,
+    );
 
     this.toastService.showToast({
       variant: "success",

--- a/libs/common/src/billing/abstractions/organizations/organization-sponsorship-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/organizations/organization-sponsorship-api.service.abstraction.ts
@@ -11,8 +11,10 @@ export abstract class OrganizationSponsorshipApiServiceAbstraction {
     friendlyName?: string,
   ): Promise<void>;
 
-  abstract deleteRevokeSponsorship: (
+  abstract deleteRevokeSponsorship: (sponsoringOrganizationId: string) => Promise<void>;
+
+  abstract deleteAdminInitiatedRevokeSponsorship: (
     sponsoringOrganizationId: string,
-    isAdminInitiated?: boolean,
+    sponsoredFriendlyName: string,
   ) => Promise<void>;
 }

--- a/libs/common/src/billing/services/organization/organization-sponsorship-api.service.ts
+++ b/libs/common/src/billing/services/organization/organization-sponsorship-api.service.ts
@@ -44,11 +44,30 @@ export class OrganizationSponsorshipApiService
   ): Promise<void> {
     const basePath = "/organization/sponsorship/";
     const hostPath = this.platformUtilsService.isSelfHost() ? "self-hosted/" : "";
-    const queryParam = `?isAdminInitiated=${isAdminInitiated}`;
 
     return await this.apiService.send(
       "DELETE",
-      basePath + hostPath + sponsoringOrganizationId + queryParam,
+      basePath + hostPath + sponsoringOrganizationId,
+      null,
+      true,
+      false,
+    );
+  }
+
+  async deleteAdminInitiatedRevokeSponsorship(
+    sponsoringOrganizationId: string,
+    sponsoredFriendlyName: string,
+  ): Promise<void> {
+    const basePath = "/organization/sponsorship/";
+    const hostPath = this.platformUtilsService.isSelfHost() ? "self-hosted/" : "";
+    return await this.apiService.send(
+      "DELETE",
+      basePath +
+        hostPath +
+        sponsoringOrganizationId +
+        "/" +
+        encodeURIComponent(sponsoredFriendlyName) +
+        "/revoke",
       null,
       true,
       false,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21666

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
If there is more than one sponsorship in the table, when you attempt to remove a sponsorship in a ‘Sent’ or ‘Active’ status, it does not respond. The Sponsorship remains in a ‘Sent’ and can be redeemed, remains in an ‘Active’ status.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/b13d94ba-033b-4286-ae2e-e877d9784bca


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
