### PR TITLE
[PM-21723] Failure to save a cipher with a security task shows success content alongside the error message

### DIFF
--- a/apps/browser/src/autofill/content/components/notification/confirmation/body.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation/body.ts
@@ -37,7 +37,7 @@ export function NotificationConfirmationBody({
   theme,
   handleOpenVault,
 }: NotificationConfirmationBodyProps) {
-  const IconComponent = tasksAreComplete ? Keyhole : !error ? Celebrate : Warning;
+  const IconComponent = error ? Warning : tasksAreComplete ? Celebrate : Keyhole;
 
   const showConfirmationMessage = confirmationMessage || buttonText || messageDetails;
 
@@ -48,8 +48,7 @@ export function NotificationConfirmationBody({
         ? NotificationConfirmationMessage({
             buttonAria,
             buttonText,
-            error,
-            itemName,
+            itemName: error ? undefined : itemName,
             message: confirmationMessage,
             messageDetails,
             theme,

--- a/apps/browser/src/autofill/content/components/notification/confirmation/container.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation/container.ts
@@ -51,9 +51,9 @@ export function NotificationConfirmationContainer({
 
   let messageDetails: string | undefined;
   let remainingTasksCount: number | undefined;
-  let tasksAreComplete: boolean = false;
+  let tasksAreComplete: boolean = true;
 
-  if (task) {
+  if (task && !error) {
     remainingTasksCount = task.remainingTasksCount || 0;
     tasksAreComplete = remainingTasksCount === 0;
 
@@ -85,7 +85,7 @@ export function NotificationConfirmationContainer({
         theme,
         handleOpenVault,
       })}
-      ${remainingTasksCount
+      ${!error && remainingTasksCount
         ? NotificationConfirmationFooter({
             i18n,
             theme,

--- a/apps/browser/src/autofill/content/components/notification/confirmation/message.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation/message.ts
@@ -8,7 +8,6 @@ import { spacing, themes, typography } from "../../constants/styles";
 export type NotificationConfirmationMessageProps = {
   buttonAria?: string;
   buttonText?: string;
-  error?: string;
   itemName?: string;
   message?: string;
   messageDetails?: string;
@@ -19,7 +18,6 @@ export type NotificationConfirmationMessageProps = {
 export function NotificationConfirmationMessage({
   buttonAria,
   buttonText,
-  error,
   itemName,
   message,
   messageDetails,
@@ -31,7 +29,7 @@ export function NotificationConfirmationMessage({
       ${message || buttonText
         ? html`
             <div class=${singleLineWrapperStyles}>
-              ${!error && itemName
+              ${itemName
                 ? html`
                     <span class=${itemNameStyles(theme)} title=${itemName}> ${itemName} </span>
                   `


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21723](https://bitwarden.atlassian.net/browse/PM-21723)

## 📔 Objective

If a security task is associated with a cipher that just failed to save, security task success information is included with the error message

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-16 at 1 04 16 PM](https://github.com/user-attachments/assets/fa7402dc-32f8-405d-81bb-982f03e330c2) ![Screenshot 2025-05-16 at 1 04 06 PM](https://github.com/user-attachments/assets/61fe0f24-e125-4f4d-b82e-4b10f7bd48d1) | ![Screenshot 2025-05-16 at 1 03 09 PM](https://github.com/user-attachments/assets/954e8196-9e03-46a9-bcf5-687f829a0cf3) |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21723]: https://bitwarden.atlassian.net/browse/PM-21723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ