### PR TITLE
Update documentation callout syntax for Github

### DIFF
--- a/libs/angular/src/platform/view-cache/README.md
+++ b/libs/angular/src/platform/view-cache/README.md
@@ -43,12 +43,9 @@ on any component.
 The persistence layer ensures that the popup will open at the same route as was active when it
 closed, provided that none of the lifetime expiration events have occurred.
 
-:::tip Excluding a route
-
-If a particular route should be excluded from the history and not persisted, add
-`doNotSaveUrl: true` to the `data` property on the route.
-
-:::
+> [!TIP]
+> If a particular route should be excluded from the history and not persisted, add
+> `doNotSaveUrl: true` to the `data` property on the route.
 
 ### View data persistence
 
@@ -85,13 +82,10 @@ const mySignal = this.viewCacheService.signal({
 mySignal.set("value")
 ```
 
-:::note Equality comparison
-
-By default, signals use `Object.is` to determine equality, and `set()` will only trigger updates if
-the updated value is not equal to the current signal state. See documentation
-[here](https://angular.dev/guide/signals#signal-equality-functions).
-
-:::
+> [!NOTE]
+> By default, signals use `Object.is` to determine equality, and `set()` will only trigger updates if
+> the updated value is not equal to the current signal state. See documentation
+> [here](https://angular.dev/guide/signals#signal-equality-functions).
 
 Putting this together, the most common implementation pattern would be:
 


### PR DESCRIPTION
## 📔 Objective

Updated the `view-cache` documentation to use the Github syntax for callouts.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/7a09ba5d-e331-45ee-a17a-ab1d1259325d)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
