### PR TITLE
[CL-473] Adjust popup page max width and scroll containers

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-layout.mdx
+++ b/apps/browser/src/platform/popup/layout/popup-layout.mdx
@@ -54,6 +54,9 @@ page looks nice when the extension is popped out.
     `false`.
 - `loadingText`
   - Custom text to be applied to the loading element for screenreaders only. Defaults to "Loading".
+- `disablePadding`
+  - When `true`, disables the padding of the scrollable region inside of `main`. You will need to
+    add your own padding to the element you place inside of this area.
 
 Basic usage example:
 
@@ -168,6 +171,23 @@ Examples of using just the `popup-page` component, without and with a footer.
 When the browser extension is popped out, the "popout" button should not be passed to the header.
 
 <Canvas of={stories.PoppedOut} />
+
+## With Virtual Scroll
+
+If you are using a virtual scrolling container inside of the popup page (aka replacing the default
+popup page scrolling container with a virtual scroll container), you'll want to configure the
+component in the following ways:
+
+- Use the `disablePadding` input on the `popup-page`
+- Add padding and scrollbar to the virtual scrolling element to match the default behavior of the
+  popup page scroll container, which ensures that the scrollbar is at the far right edge of the
+  popup
+- Add max width to the child of the virtual scroll element, matching the max width breakpoints used
+  in the `popup-page`
+
+See the code in the example below.
+
+<Canvas of={stories.WithVirtualScrollChild} />
 
 # Other stories
 

--- a/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
+++ b/apps/browser/src/platform/popup/layout/popup-layout.stories.ts
@@ -1,5 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
 import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
@@ -39,6 +40,17 @@ import { PopupTabNavigationComponent } from "./popup-tab-navigation.component";
   standalone: true,
 })
 class ExtensionContainerComponent {}
+
+@Component({
+  selector: "extension-popped-container",
+  template: `
+    <div class="tw-h-[640px] tw-w-[900px] tw-border tw-border-solid tw-border-secondary-300">
+      <ng-content></ng-content>
+    </div>
+  `,
+  standalone: true,
+})
+class ExtensionPoppedContainerComponent {}
 
 @Component({
   selector: "vault-placeholder",
@@ -318,6 +330,7 @@ export default {
         CommonModule,
         RouterModule,
         ExtensionContainerComponent,
+        ExtensionPoppedContainerComponent,
         MockBannerComponent,
         MockSearchComponent,
         MockVaultSubpageComponent,
@@ -328,6 +341,11 @@ export default {
         MockVaultPagePoppedComponent,
         NoItemsModule,
         VaultComponent,
+        ScrollingModule,
+        ItemModule,
+        SectionComponent,
+        IconButtonModule,
+        BadgeModule,
       ],
       providers: [
         {
@@ -526,9 +544,9 @@ export const PoppedOut: Story = {
   render: (args) => ({
     props: args,
     template: /* HTML */ `
-      <div class="tw-h-[640px] tw-w-[900px] tw-border tw-border-solid tw-border-secondary-300">
+      <extension-popped-container>
         <mock-vault-page-popped></mock-vault-page-popped>
-      </div>
+      </extension-popped-container>
     `,
   }),
 };
@@ -576,10 +594,9 @@ export const TransparentHeader: Story = {
     template: /* HTML */ `
       <extension-container>
         <popup-page>
-          <popup-header slot="header" background="alt"
-            ><span class="tw-italic tw-text-main">🤠 Custom Content</span></popup-header
-          >
-
+          <popup-header slot="header" background="alt">
+            <span class="tw-italic tw-text-main">🤠 Custom Content</span>
+          </popup-header>
           <vault-placeholder></vault-placeholder>
         </popup-page>
       </extension-container>
@@ -621,6 +638,64 @@ export const WidthOptions: Story = {
           <mock-vault-page></mock-vault-page>
         </div>
       </div>
+    `,
+  }),
+};
+
+export const WithVirtualScrollChild: Story = {
+  render: (args) => ({
+    props: { ...args, data: Array.from(Array(20).keys()) },
+    template: /* HTML */ `
+      <extension-popped-container>
+        <popup-page disablePadding>
+          <popup-header slot="header" pageTitle="Test"> </popup-header>
+          <mock-search slot="above-scroll-area"></mock-search>
+          <div
+            cdkVirtualScrollingElement
+            class="tw-h-full tw-p-3 bit-compact:tw-p-2 tw-styled-scrollbar"
+          >
+            <div class="tw-max-w-screen-sm tw-mx-auto">
+              <bit-section>
+                <bit-item-group aria-label="Mock Vault Items">
+                  <cdk-virtual-scroll-viewport itemSize="55">
+                    <bit-item *cdkVirtualFor="let item of data; index as i">
+                      <button type="button" bit-item-content>
+                        <i
+                          slot="start"
+                          class="bwi bwi-globe tw-text-3xl tw-text-muted"
+                          aria-hidden="true"
+                        ></i>
+                        {{ i }} of {{ data.length - 1 }}
+                        <span slot="secondary">Bar</span>
+                      </button>
+
+                      <ng-container slot="end">
+                        <bit-item-action>
+                          <button type="button" bitBadge variant="primary">Fill</button>
+                        </bit-item-action>
+                        <bit-item-action>
+                          <button
+                            type="button"
+                            bitIconButton="bwi-clone"
+                            aria-label="Copy item"
+                          ></button>
+                        </bit-item-action>
+                        <bit-item-action>
+                          <button
+                            type="button"
+                            bitIconButton="bwi-ellipsis-v"
+                            aria-label="More options"
+                          ></button>
+                        </bit-item-action>
+                      </ng-container>
+                    </bit-item>
+                  </cdk-virtual-scroll-viewport>
+                </bit-item-group>
+              </bit-section>
+            </div>
+          </div>
+        </popup-page>
+      </extension-popped-container>
     `,
   }),
 };

--- a/apps/browser/src/platform/popup/layout/popup-page.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.html
@@ -2,25 +2,28 @@
 <main class="tw-flex-1 tw-overflow-hidden tw-flex tw-flex-col tw-relative tw-bg-background-alt">
   <ng-content select="[slot=full-width-notice]"></ng-content>
   <div
-    #nonScrollable
     class="tw-transition-colors tw-duration-200 tw-border-0 tw-border-b tw-border-solid tw-p-3 bit-compact:tw-p-2"
     [ngClass]="{
-      'tw-invisible !tw-p-0': loading || nonScrollable.childElementCount === 0,
+      'tw-invisible !tw-p-0 !tw-border-none': loading || nonScrollable.childElementCount === 0,
       'tw-border-secondary-300': scrolled(),
       'tw-border-transparent': !scrolled(),
     }"
   >
-    <ng-content select="[slot=above-scroll-area]"></ng-content>
+    <div class="tw-max-w-screen-sm tw-mx-auto tw-w-full" #nonScrollable>
+      <ng-content select="[slot=above-scroll-area]"></ng-content>
+    </div>
   </div>
   <div
-    class="tw-max-w-screen-sm tw-mx-auto tw-overflow-y-auto tw-flex tw-flex-col tw-size-full tw-styled-scrollbar"
+    class="tw-mx-auto tw-overflow-y-auto tw-flex tw-flex-col tw-size-full tw-styled-scrollbar"
     data-testid="popup-layout-scroll-region"
     (scroll)="handleScroll($event)"
-    [ngClass]="{ 'tw-invisible': loading }"
+    [ngClass]="{
+      'tw-invisible': loading,
+      'tw-p-3 bit-compact:tw-p-2': !disablePadding,
+    }"
   >
     <div
-      class="tw-max-w-screen-sm tw-mx-auto tw-flex-1 tw-flex tw-flex-col tw-w-full"
-      [ngClass]="{ 'tw-p-3 bit-compact:tw-p-2': !disablePadding }"
+      class="has-[[cdkvirtualscrollingelement]]:tw-max-w-full tw-max-w-screen-sm tw-mx-auto tw-flex-1 tw-flex tw-flex-col tw-w-full"
     >
       <ng-content></ng-content>
     </div>

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -381,14 +381,6 @@ app-root {
   }
 }
 
-// Adds padding on each side of the content if opened in a tab
-@media only screen and (min-width: 601px) {
-  header,
-  main {
-    padding: 0 calc((100% - 500px) / 2);
-  }
-}
-
 main:not(popup-page main) {
   position: absolute;
   top: 44px;

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.html
@@ -91,20 +91,22 @@
       cdkVirtualScrollingElement
       class="tw-h-full tw-p-3 bit-compact:tw-p-2 tw-styled-scrollbar"
     >
-      <app-autofill-vault-list-items></app-autofill-vault-list-items>
-      <app-vault-list-items-container
-        [title]="'favorites' | i18n"
-        [ciphers]="(favoriteCiphers$ | async) || []"
-        id="favorites"
-        collapsibleKey="favorites"
-      ></app-vault-list-items-container>
-      <app-vault-list-items-container
-        [title]="'allItems' | i18n"
-        [ciphers]="(remainingCiphers$ | async) || []"
-        id="allItems"
-        disableSectionMargin
-        collapsibleKey="allItems"
-      ></app-vault-list-items-container>
+      <div class="tw-max-w-screen-sm tw-mx-auto">
+        <app-autofill-vault-list-items></app-autofill-vault-list-items>
+        <app-vault-list-items-container
+          [title]="'favorites' | i18n"
+          [ciphers]="(favoriteCiphers$ | async) || []"
+          id="favorites"
+          collapsibleKey="favorites"
+        ></app-vault-list-items-container>
+        <app-vault-list-items-container
+          [title]="'allItems' | i18n"
+          [ciphers]="(remainingCiphers$ | async) || []"
+          id="allItems"
+          disableSectionMargin
+          collapsibleKey="allItems"
+        ></app-vault-list-items-container>
+      </div>
     </div>
   </ng-container>
 </popup-page>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-473](https://bitwarden.atlassian.net/browse/CL-473)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The popup page had strange jumping behavior at its max width breakpoint, and the scrollbar was appearing at that content max width instead of on the righthand side of the window. This PR fixes these issues by:
- Removing legacy breakpoint css
- Adding a wrapper as a child of the `popup-page` nonscrollable region to set the max width
- Hiding the 1px border on the nonscrollable region because it was bothering me to have it be 1px in height when the region was empty
- Adjusting the `popup-page` scrollable container to have the padding appear on the container that has the scrollbar, and setting the max width on the child of that container depending on whether or not a virtual scroll child is present (we want it full width if there's a virtual scroll child so that the virtual scroll child can set its own padding and max width, since it has its own scrollbar that needs to stick to the right side of the page)
- Adjusting the vault page's virtual scroll implementation to have another wrapper layer with a max width to match the `popup-page`'s scrollable container implementation
- Add storybook docs and story for virtual scroll implementation example

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:


https://github.com/user-attachments/assets/90437e79-9d52-4d1a-ba28-967d20be9c12



After:

https://github.com/user-attachments/assets/d682be99-81da-46f0-bf88-d63c53c47580





## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
