### PR TITLE
[PM-21844] - set default values for navButtons$ observable

### DIFF
--- a/apps/browser/src/popup/tabs-v2.component.ts
+++ b/apps/browser/src/popup/tabs-v2.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { combineLatest, map, Observable, switchMap } from "rxjs";
+import { combineLatest, map, Observable, startWith, switchMap } from "rxjs";
 
 import { NudgesService } from "@bitwarden/angular/vault";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -23,6 +23,7 @@ export class TabsV2Component {
     this.configService.getFeatureFlag$(FeatureFlag.PM8851_BrowserOnboardingNudge),
     this.hasActiveBadges$,
   ]).pipe(
+    startWith([false, false]),
     map(([onboardingFeatureEnabled, hasBadges]) => {
       return [
         {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21844

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds default values as `false` for both the config service `getFeatureFlag$` and nudge service `hasActiveBadges$` observables to avoid any delay of rendering of the navigation tabs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before

https://github.com/user-attachments/assets/c351e179-48ff-4001-af17-4626b78c1fc0

### After

https://github.com/user-attachments/assets/db475ecd-8ac6-4f3f-90ae-c9687bf52ef1



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
