### PR TITLE
Send limit reached icon + message now show

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1071,10 +1071,6 @@
     },
     "description": "Aria label for the view button in notification bar confirmation message"
   },
-  "notificationNewItemAria": {
-    "message": "New Item, opens in new window",
-    "description": "Aria label for the new item button in notification bar confirmation message when error is prompted"
-  },
   "notificationEditTooltip": {
     "message": "Edit before saving",
     "description": "Tooltip and Aria label for edit button on cipher item"
@@ -1092,25 +1088,23 @@
       }
     }
   },
-  "notificationLoginSaveConfirmation": {
-    "message": "saved to Bitwarden.",
+  "loginSaveConfirmation": {
+    "message": "$ITEMNAME$ saved to Bitwarden.",
+    "placeholders": {
+      "itemName": {
+        "content": "$1"
+      }
+    },
     "description": "Shown to user after item is saved."
   },
-  "notificationLoginUpdatedConfirmation": {
-    "message": "updated in Bitwarden.",
-    "description": "Shown to user after item is updated."
-  },
-  "selectItemAriaLabel": {
-    "message": "Select $ITEMTYPE$, $ITEMNAME$",
-    "description": "Used by screen readers. $1 is the item type (like vault or folder), $2 is the selected item name.",
+  "loginUpdatedConfirmation": {
+    "message": "$ITEMNAME$ updated in Bitwarden.",
     "placeholders": {
-      "itemType": {
-        "content": "$1"
-      },
       "itemName": {
-        "content": "$2"
+        "content": "$1"
       }
-    }
+    },
+    "description": "Shown to user after item is updated."
   },
   "saveAsNewLoginAction": {
     "message": "Save as new login",
@@ -1119,10 +1113,6 @@
   "updateLoginAction": {
     "message": "Update login",
     "description": "Button text for updating an existing login entry."
-  },
-  "unlockToSave": {
-    "message": "Unlock to save this login",
-    "description": "User prompt to take action in order to save the login they just entered."
   },
   "saveLogin": {
     "message": "Save login",
@@ -2227,6 +2217,15 @@
   "vaultTimeoutAction1": {
     "message": "Timeout action"
   },
+  "newCustomizationOptionsCalloutTitle": {
+    "message": "New customization options"
+  },
+  "newCustomizationOptionsCalloutContent": {
+    "message": "Customize your vault experience with quick copy actions, compact mode, and more!"
+  },
+  "newCustomizationOptionsCalloutLink": {
+    "message": "View all Appearance settings"
+  },
   "lock": {
     "message": "Lock",
     "description": "Verb form: to make secure or inaccessible by"
@@ -2674,6 +2673,10 @@
     "message": "All Sends",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "maxAccessCountReached": {
+    "message": "Max access count reached",
+    "description": "This text will be displayed after a Send has been accessed the maximum amount of times."
+  },
   "hideTextByDefault": {
     "message": "Hide text by default"
   },
@@ -3014,14 +3017,14 @@
   "copyCustomFieldNameNotUnique": {
     "message": "No unique identifier found."
   },
-  "removeMasterPasswordForOrganizationUserKeyConnector": {
-    "message": "A master password is no longer required for members of the following organization. Please confirm the domain below with your organization administrator."
-  },
-  "organizationName": {
-    "message": "Organization name"
-  },
-  "keyConnectorDomain": {
-    "message": "Key Connector domain"
+  "convertOrganizationEncryptionDesc": {
+    "message": "$ORGANIZATION$ is using SSO with a self-hosted key server. A master password is no longer required to log in for members of this organization.",
+    "placeholders": {
+      "organization": {
+        "content": "$1",
+        "example": "My Org Name"
+      }
+    }
   },
   "leaveOrganization": {
     "message": "Leave organization"
@@ -3604,7 +3607,7 @@
   "orgTrustWarning1": {
     "message": "This organization has an Enterprise policy that will enroll you in account recovery. Enrollment will allow organization administrators to change your password. Only proceed if you recognize this organization and the fingerprint phrase displayed below matches the organization's fingerprint."
   },
-  "trustUser": {
+  "trustUser":{
     "message": "Trust user"
   },
   "sendsNoItemsTitle": {
@@ -5019,15 +5022,6 @@
   "biometricsStatusHelptextUnavailableReasonUnknown": {
     "message": "Biometric unlock is currently unavailable for an unknown reason."
   },
-  "unlockVault": {
-    "message": "Unlock your vault in seconds"
-  },
-  "unlockVaultDesc": {
-    "message": "You can customize your unlock and timeout settings to more quickly access your vault."
-  },
-  "unlockPinSet": {
-    "message": "Unlock PIN set"
-  },
   "authenticating": {
     "message": "Authenticating"
   },
@@ -5277,9 +5271,6 @@
   "secureDevicesBody": {
     "message": "Save unlimited passwords across unlimited devices with Bitwarden mobile, browser, and desktop apps."
   },
-  "nudgeBadgeAria": {
-    "message": "1 notification"
-  },
   "emptyVaultNudgeTitle": {
     "message": "Import existing passwords"
   },
@@ -5292,14 +5283,8 @@
   "hasItemsVaultNudgeTitle": {
     "message": "Welcome to your vault!"
   },
-  "hasItemsVaultNudgeBodyOne": {
-    "message": "Autofill items for the current page"
-  },
-  "hasItemsVaultNudgeBodyTwo": {
-    "message": "Favorite items for easy access"
-  },
-  "hasItemsVaultNudgeBodyThree": {
-    "message": "Search your vault for something else"
+  "hasItemsVaultNudgeBody": {
+      "message": "Autofill items for the current page\nFavorite items for easy access\nSearch your vault for something else"
   },
   "newLoginNudgeTitle": {
     "message": "Save time with autofill"
@@ -5349,8 +5334,5 @@
     "message": "Learn more about SSH agent",
     "description": "Two part message",
     "example": "Store your keys and connect with the SSH agent for fast, encrypted authentication. Learn more about SSH agent"
-  },
-  "noPermissionsViewPage": {
-    "message": "You do not have permissions to view this page. Try logging in with a different account."
   }
 }

--- a/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
+++ b/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
@@ -26,6 +26,16 @@
           ></i>
         </div>
         {{ send.name }}
+        <ng-container *ngIf="send.maxAccessCountReached">
+          <i
+            class="bwi bwi-exclamation-triangle"
+            appStopProp
+            title="{{ 'maxAccessCountReached' | i18n }}"
+            aria-hidden="true"
+          ></i>
+          <span class="tw-sr-only">{{ "maxAccessCountReached" | i18n }}</span>
+        </ng-container>
+
         <span slot="secondary">
           {{ "deletionDate" | i18n }}:&nbsp;{{ send.deletionDate | date: "mediumDate" }}
         </span>


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/14064

## 📔 Objective

Fixing the bug from [this issue](https://github.com/bitwarden/clients/issues/14064).
The icon + message have been restored when a Send has reached its use-limit.

## 📸 Screenshots

![bw-sends-maxAccess-sn](https://github.com/user-attachments/assets/c3cfc67b-977a-4c4d-928f-1d9c2a6db075)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
