### PR TITLE
Autofill/pm 21864 center unlock vault modal

### DIFF
--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -137,14 +137,10 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     }
     
     private func getWindowPosition() -> Position {
-        let frame = self.view.window?.frame ?? .zero
-        let screenHeight = NSScreen.main?.frame.height ?? 0      
-        
-        // frame.width and frame.height is always 0. Estimating works OK for now.
-        let estimatedWidth:CGFloat = 400;
-        let estimatedHeight:CGFloat = 200;
-        let centerX = Int32(round(frame.origin.x + estimatedWidth/2))
-        let centerY = Int32(round(screenHeight - (frame.origin.y + estimatedHeight/2)))
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        let screenWidth = NSScreen.main?.frame.width ?? 0
+        let centerX = Int32(round(screenWidth)/2)
+        let centerY = Int32(round(screenHeight)/2)
         
         return Position(x: centerX, y:centerY)
     }

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -137,11 +137,14 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     }
     
     private func getWindowPosition() -> Position {
+        let frame = self.view.window?.frame ?? .zero
         let screenHeight = NSScreen.main?.frame.height ?? 0
-        let screenWidth = NSScreen.main?.frame.width ?? 0
-        let centerX = Int32(round(screenWidth)/2)
-        let centerY = Int32(round(screenHeight)/2)
-        
+
+        // frame.width and frame.height is always 0. Estimating works OK for now.
+        let estimatedWidth:CGFloat = 400;
+        let estimatedHeight:CGFloat = 200;
+        let centerX = Int32(round(frame.origin.x + estimatedWidth/2))
+        let centerY = Int32(round(screenHeight - (frame.origin.y + estimatedHeight/2)))
         return Position(x: centerX, y:centerY)
     }
     

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -265,6 +265,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   ): Promise<void> {
     // Load the UI:
     await this.desktopSettingsService.setModalMode(true, showTrafficButtons, position);
+    await this.centerOffscreenPopup();
     await this.router.navigate([
       route,
       {
@@ -338,10 +339,12 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   async ensureUnlockedVault(): Promise<void> {
     this.logService.warning("ensureUnlockedVault");
+    //    const result = screen.getPrimaryDisplay();
+    //    console.log("SCREEN SITE: ", result);
 
     const status = await firstValueFrom(this.authService.activeAccountStatus$);
     if (status !== AuthenticationStatus.Unlocked) {
-      await this.showUi("/lock", this.windowObject.windowXy, true, true);
+      await this.showUi("/lock", undefined, true, true);
 
       let status2: AuthenticationStatus;
       try {
@@ -369,5 +372,26 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   async close() {
     this.logService.warning("close");
+  }
+
+  private async centerOffscreenPopup() {
+    if (!this.windowObject.windowXy) {
+      return;
+    }
+
+    const popupWidth = 600;
+    const popupHeight = 600;
+
+    const window = await firstValueFrom(this.desktopSettingsService.window$);
+    const { width, height } = window.displayBounds;
+    const { x, y } = this.windowObject.windowXy;
+
+    if (x < popupWidth || x > width - popupWidth || y < popupHeight || y > height - popupHeight) {
+      const popupHeightOffset = 300;
+      const { width, height } = window.displayBounds;
+      const centeredX = width / 2;
+      const centeredY = (height - popupHeightOffset) / 2;
+      this.windowObject.windowXy = { x: centeredX, y: centeredY };
+    }
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -339,8 +339,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   async ensureUnlockedVault(): Promise<void> {
     this.logService.warning("ensureUnlockedVault");
-    //    const result = screen.getPrimaryDisplay();
-    //    console.log("SCREEN SITE: ", result);
 
     const status = await firstValueFrom(this.authService.activeAccountStatus$);
     if (status !== AuthenticationStatus.Unlocked) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21864](https://bitwarden.atlassian.net/browse/PM-21864)

## 📔 Objective

Addresses an issue where the Locked Vault modal is not centered on the screen when it opens, but instead opens in the lower left with the majority off screen.  This changes centers the locked vault and all other passkey modals.

*NOTE* I do not have dual monitors so I am not able to test this scenario.

## 📸 Screenshots

Before:

https://github.com/user-attachments/assets/b69b25a9-1b12-4020-800b-0a1f7d6350d3

After:

https://github.com/user-attachments/assets/807ab4db-509a-40a0-ac1c-d2163fad742d

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes



[PM-21864]: https://bitwarden.atlassian.net/browse/PM-21864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ