### PR TITLE
fix(policy-enforcement): [PM-21085] Fix Bug with Policy Enforcement

### DIFF
--- a/apps/web/src/app/auth/core/services/login/web-login-component.service.ts
+++ b/apps/web/src/app/auth/core/services/login/web-login-component.service.ts
@@ -98,7 +98,7 @@ export class WebLoginComponentService
       const enforcedPasswordPolicyOptions = await firstValueFrom(
         this.accountService.activeAccount$.pipe(
           getUserId,
-          switchMap((userId) => this.policyService.masterPasswordPolicyOptions$(userId)),
+          switchMap((userId) => this.policyService.masterPasswordPolicyOptions$(userId, policies)),
         ),
       );
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21085

## 📔 Objective

So this issue was occuring because we were consuming the policy api incorrectly. We were not passing in the policies that we had retrieved and instead relying on the default policy service to provide us the policies but none had been set yet.

In the ticket I've asked for some clarification from Thomas to see if they have ongoing efforts with regards to the default policy service because it seems like there could be other occurrences across the app where we are trying to leverage the cached policies when none are set.

* Fixed up code that was not properly using the policy api.

## 📸 Screenshots

https://github.com/user-attachments/assets/badc2efc-da38-428d-9fad-155ef73542cd

https://github.com/user-attachments/assets/e5a3aa1d-4aee-452b-a677-2aa1ab9711f1

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
