### PR TITLE
[PM-21867] Fix send rotation broken due to incorrect types

### DIFF
--- a/libs/common/src/tools/send/services/send.service.spec.ts
+++ b/libs/common/src/tools/send/services/send.service.spec.ts
@@ -477,11 +477,9 @@ describe("SendService", () => {
     let encryptedKey: EncString;
 
     beforeEach(() => {
-      encryptService.unwrapSymmetricKey.mockResolvedValue(
-        new SymmetricCryptoKey(new Uint8Array(32)),
-      );
+      encryptService.decryptBytes.mockResolvedValue(new Uint8Array(16));
       encryptedKey = new EncString("Re-encrypted Send Key");
-      encryptService.wrapSymmetricKey.mockResolvedValue(encryptedKey);
+      encryptService.encryptBytes.mockResolvedValue(encryptedKey);
     });
 
     it("returns re-encrypted user sends", async () => {

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -292,8 +292,9 @@ export class SendService implements InternalSendServiceAbstraction {
   ) {
     const requests = await Promise.all(
       sends.map(async (send) => {
-        const sendKey = await this.encryptService.unwrapSymmetricKey(send.key, originalUserKey);
-        send.key = await this.encryptService.wrapSymmetricKey(sendKey, rotateUserKey);
+        // Send key is not a key but a 16 byte seed used to derive the key
+        const sendKey = await this.encryptService.decryptBytes(send.key, originalUserKey);
+        send.key = await this.encryptService.encryptBytes(sendKey, rotateUserKey);
         return new SendWithIdRequest(send);
       }),
     );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21867

## 📔 Objective

Despite it's name; send.key is not a key. We had documented this in a few other places, but not yet in the key-rotation code, so it was incorrectly assumed to be a key. The new validation on unwrapSymmetricKey / wrapSymmetricKey assumes a symmetric cryptokey to be passed in, which only accepts 32 / 64 / >64 byte keys which made this fail. (In any case, it is the incorrect primitive and would otherwise have lead to issues later on when switching out the implementation of wrapSymmetricKey).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
