### PR TITLE
Adjust spacing to place new login button below other items

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -1,4 +1,4 @@
-<div class="tw-flex tw-flex-col tw-h-full">
+<div class="tw-flex tw-flex-col tw-h-full tw-bg-background-alt">
   <bit-section
     disableMargin
     class="passkey-header-sticky tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
@@ -24,7 +24,7 @@
     </bit-section-header>
   </bit-section>
 
-  <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col tw-grow">
+  <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col">
     <bit-item *ngFor="let c of ciphers$ | async" class="">
       <button type="button" bit-item-content (click)="addPasskeyToCipher(c)">
         <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
@@ -35,8 +35,6 @@
         <span bitBadge slot="end">Save</span>
       </button>
     </bit-item>
-  </bit-section>
-  <bit-section class="tw-bg-background-alt tw-p-4">
     <bit-item class="">
       <button bitLink linkType="primary" type="button" bit-item-content (click)="confirmPasskey()">
         <a bitLink linkType="primary" class="tw-font-medium tw-text-base">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21869](https://bitwarden.atlassian.net/browse/PM-21869)

## 📔 Objective

Update the styling so the `Save as New Login` button is directly below the available ciphers and not at the bottom of the modal.

## 📸 Screenshots

Before:
<img width="608" alt="Screenshot 2025-05-22 at 2 22 52 PM" src="https://github.com/user-attachments/assets/35b2e424-c826-46ac-9946-3aa14e7c467e" />

After:
<img width="611" alt="Screenshot 2025-05-22 at 1 51 11 PM" src="https://github.com/user-attachments/assets/1acde01f-141b-4ec3-8d3d-9c7be9996953" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
