### PR TITLE
[PM-21871] Search field slows down on extension when searching large vaults

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-search/vault-v2-search.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, NgZone } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
-import { Subject, Subscription, debounceTime, filter } from "rxjs";
+import { Subject, Subscription, debounceTime, distinctUntilChanged, filter } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { SearchModule } from "@bitwarden/components";
@@ -22,13 +22,16 @@ export class VaultV2SearchComponent {
 
   private searchText$ = new Subject<string>();
 
-  constructor(private vaultPopupItemsService: VaultPopupItemsService) {
+  constructor(
+    private vaultPopupItemsService: VaultPopupItemsService,
+    private ngZone: NgZone,
+  ) {
     this.subscribeToLatestSearchText();
     this.subscribeToApplyFilter();
   }
 
   onSearchTextChanged() {
-    this.vaultPopupItemsService.applyFilter(this.searchText);
+    this.searchText$.next(this.searchText);
   }
 
   subscribeToLatestSearchText(): Subscription {
@@ -44,9 +47,13 @@ export class VaultV2SearchComponent {
 
   subscribeToApplyFilter(): Subscription {
     return this.searchText$
-      .pipe(debounceTime(SearchTextDebounceInterval), takeUntilDestroyed())
+      .pipe(debounceTime(SearchTextDebounceInterval), distinctUntilChanged(), takeUntilDestroyed())
       .subscribe((data) => {
-        this.vaultPopupItemsService.applyFilter(data);
+        this.ngZone.runOutsideAngular(() => {
+          this.ngZone.run(() => {
+            this.vaultPopupItemsService.applyFilter(data);
+          });
+        });
       });
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-21871
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
On large vaults, typing in the search field remains responsive and instant. 

Improves search input responsiveness by using distinctUntilChanged to prevent duplicate filtering operations, runs filtering outside Angular's zone to prevent change detection freezes, and re-enters the zone only after filtering completes. `onSearchTextChanged` now pushes search text to the subject and decouples the user input from direct filtering operation. 
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Before  |  After |
|---|---|
|<video src="https://github.com/user-attachments/assets/9fa6ce18-ab5e-4772-8b06-8e9b8987b8a3" controls></video>|<video src="https://github.com/user-attachments/assets/105ea724-a634-4d70-b695-1d0046800a4b" controls></video>|
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
