### PR TITLE
[PM-21896] - prevent double reprompt for copy password in desktop cipher form

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault.component.html
+++ b/apps/desktop/src/vault/app/vault/vault.component.html
@@ -15,6 +15,7 @@
     *ngIf="cipherId && action === 'view'"
     [cipherId]="cipherId"
     [collectionId]="activeFilter?.selectedCollectionId"
+    [passwordPrompted]="cipherRepromptId === cipherId"
     (onCloneCipher)="cloneCipherWithoutPasswordPrompt($event)"
     (onEditCipher)="editCipher($event)"
     (onViewCipherPasswordHistory)="viewCipherPasswordHistory($event)"

--- a/apps/desktop/src/vault/app/vault/vault.component.html
+++ b/apps/desktop/src/vault/app/vault/vault.component.html
@@ -15,7 +15,7 @@
     *ngIf="cipherId && action === 'view'"
     [cipherId]="cipherId"
     [collectionId]="activeFilter?.selectedCollectionId"
-    [passwordPrompted]="cipherRepromptId === cipherId"
+    [masterPasswordAlreadyPrompted]="cipherRepromptId === cipherId"
     (onCloneCipher)="cloneCipherWithoutPasswordPrompt($event)"
     (onEditCipher)="editCipher($event)"
     (onViewCipherPasswordHistory)="viewCipherPasswordHistory($event)"

--- a/apps/desktop/src/vault/app/vault/view.component.ts
+++ b/apps/desktop/src/vault/app/vault/view.component.ts
@@ -47,7 +47,7 @@ const BroadcasterSubscriptionId = "ViewComponent";
 })
 export class ViewComponent extends BaseViewComponent implements OnInit, OnDestroy, OnChanges {
   @Output() onViewCipherPasswordHistory = new EventEmitter<CipherView>();
-  @Input() passwordPrompted: boolean = false;
+  @Input() masterPasswordAlreadyPrompted: boolean = false;
 
   constructor(
     cipherService: CipherService,
@@ -122,7 +122,7 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
         }
       });
     });
-    this.passwordReprompted = this.passwordPrompted;
+    this.passwordReprompted = this.masterPasswordAlreadyPrompted;
   }
 
   ngOnDestroy() {
@@ -137,7 +137,7 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
       });
       return;
     }
-    this.passwordReprompted = this.passwordPrompted;
+    this.passwordReprompted = this.masterPasswordAlreadyPrompted;
   }
 
   viewHistory() {

--- a/apps/desktop/src/vault/app/vault/view.component.ts
+++ b/apps/desktop/src/vault/app/vault/view.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  Input,
   NgZone,
   OnChanges,
   OnDestroy,
@@ -46,6 +47,7 @@ const BroadcasterSubscriptionId = "ViewComponent";
 })
 export class ViewComponent extends BaseViewComponent implements OnInit, OnDestroy, OnChanges {
   @Output() onViewCipherPasswordHistory = new EventEmitter<CipherView>();
+  @Input() passwordPrompted: boolean = false;
 
   constructor(
     cipherService: CipherService,
@@ -120,6 +122,7 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
         }
       });
     });
+    this.passwordReprompted = this.passwordPrompted;
   }
 
   ngOnDestroy() {
@@ -134,6 +137,7 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
       });
       return;
     }
+    this.passwordReprompted = this.passwordPrompted;
   }
 
   viewHistory() {

--- a/libs/angular/src/vault/components/view.component.ts
+++ b/libs/angular/src/vault/components/view.component.ts
@@ -95,7 +95,7 @@ export class ViewComponent implements OnDestroy, OnInit {
   cipherType = CipherType;
 
   private previousCipherId: string;
-  private passwordReprompted = false;
+  protected passwordReprompted = false;
 
   /**
    * Represents TOTP information including display formatting and timing


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21896

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR prevents double password prompt when copying a password in the desktop cipher form for a MP protected cipher.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/53a1899a-ab73-4cf4-8259-74f9e9a0be31



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
