### PR TITLE
Autofill/pm 21903 use translations everywhere for passkeys

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -19,7 +19,7 @@
         class="passkey-header-close tw-mb-4 tw-mr-2"
         (click)="closeModal()"
       >
-        Close
+        {{ "close" | i18n }}
       </button>
     </bit-section-header>
   </bit-section>
@@ -44,7 +44,7 @@
             {{ c.name }}
           </button>
           <span slot="secondary">{{ c.subTitle }}</span>
-          <span bitBadge slot="end">Save</span>
+          <span bitBadge slot="end">{{ "save" | i18n }}</span>
         </button>
       </bit-item>
       <bit-item class="">

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -1,4 +1,4 @@
-<div class="tw-flex tw-flex-col tw-h-full">
+<div class="tw-flex tw-flex-col tw-h-full tw-bg-background-alt">
   <bit-section
     disableMargin
     class="passkey-header-sticky tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
@@ -24,7 +24,7 @@
     </bit-section-header>
   </bit-section>
 
-  <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col tw-grow">
+  <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col">
     <bit-item *ngFor="let c of ciphers$ | async" class="">
       <button type="button" bit-item-content (click)="addPasskeyToCipher(c)">
         <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
@@ -35,8 +35,6 @@
         <span bitBadge slot="end">Save</span>
       </button>
     </bit-item>
-  </bit-section>
-  <bit-section class="tw-bg-background-alt tw-p-4">
     <bit-item class="">
       <button bitLink linkType="primary" type="button" bit-item-content (click)="confirmPasskey()">
         <a bitLink linkType="primary" class="tw-font-medium tw-text-base">

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -25,22 +25,41 @@
   </bit-section>
 
   <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col">
-    <bit-item *ngFor="let c of ciphers$ | async" class="">
-      <button type="button" bit-item-content (click)="addPasskeyToCipher(c)">
-        <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
-        <button bitLink [title]="c.name" type="button">
-          {{ c.name }}
+    <div *ngIf="(ciphers$ | async)?.length === 0; else hasCiphers">
+      <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
+        <bit-icon [icon]="fido2PasskeyExistsIcon"></bit-icon>
+        <div class="tw-flex tw-flex-col tw-gap-2">
+          {{ "noMatchingLoginsForSite" | i18n }}
+        </div>
+        <button bitButton type="button" buttonType="primary" (click)="confirmPasskey()">
+          {{ "savePasskeyNewLogin" | i18n }}
         </button>
-        <span slot="secondary">{{ c.subTitle }}</span>
-        <span bitBadge slot="end">Save</span>
-      </button>
-    </bit-item>
-    <bit-item class="">
-      <button bitLink linkType="primary" type="button" bit-item-content (click)="confirmPasskey()">
-        <a bitLink linkType="primary" class="tw-font-medium tw-text-base">
-          {{ "saveNewPasskey" | i18n }}
-        </a>
-      </button>
-    </bit-item>
+      </div>
+    </div>
+    <ng-template #hasCiphers>
+      <bit-item *ngFor="let c of ciphers$ | async" class="">
+        <button type="button" bit-item-content (click)="addPasskeyToCipher(c)">
+          <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
+          <button bitLink [title]="c.name" type="button">
+            {{ c.name }}
+          </button>
+          <span slot="secondary">{{ c.subTitle }}</span>
+          <span bitBadge slot="end">Save</span>
+        </button>
+      </bit-item>
+      <bit-item class="">
+        <button
+          bitLink
+          linkType="primary"
+          type="button"
+          bit-item-content
+          (click)="confirmPasskey()"
+        >
+          <a bitLink linkType="primary" class="tw-font-medium tw-text-base">
+            {{ "saveNewPasskey" | i18n }}
+          </a>
+        </button>
+      </bit-item>
+    </ng-template>
   </bit-section>
 </div>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -32,6 +32,8 @@ import {
   DesktopFido2UserInterfaceSession,
 } from "../../services/desktop-fido2-user-interface.service";
 
+import { Fido2PasskeyExistsIcon } from "./fido2-passkey-exists-icon";
+
 @Component({
   standalone: true,
   imports: [
@@ -55,6 +57,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   private ciphersSubject = new BehaviorSubject<CipherView[]>([]);
   ciphers$: Observable<CipherView[]> = this.ciphersSubject.asObservable();
   readonly Icons = { BitwardenShield };
+  protected fido2PasskeyExistsIcon = Fido2PasskeyExistsIcon;
 
   constructor(
     private readonly desktopSettingsService: DesktopSettingsService,

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
@@ -19,7 +19,7 @@
         class="passkey-header-close tw-mb-4 tw-mr-2"
         (click)="closeModal()"
       >
-        Close
+        {{ "close" | i18n }}
       </button>
     </bit-section-header>
   </bit-section>
@@ -34,7 +34,9 @@
           <b>{{ "passkeyAlreadyExists" | i18n }}</b>
           {{ "applicationDoesNotSupportDuplicates" | i18n }}
         </div>
-        <button bitButton type="button" buttonType="primary" (click)="closeModal()">Close</button>
+        <button bitButton type="button" buttonType="primary" (click)="closeModal()">
+          {{ "close" | i18n }}
+        </button>
       </div>
     </bit-section>
   </div>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
@@ -16,7 +16,7 @@
         class="passkey-header-close tw-mb-4 tw-mr-2"
         (click)="closeModal()"
       >
-        Close
+        {{ "close" | i18n }}
       </button>
     </bit-section-header>
   </bit-section>
@@ -29,7 +29,7 @@
           {{ c.name }}
         </button>
         <span slot="secondary">{{ c.subTitle }}</span>
-        <span bitBadge slot="end">Select</span>
+        <span bitBadge slot="end">{{ "select" | i18n }}</span>
       </button>
     </bit-item>
   </bit-section>

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -620,6 +620,9 @@
   "close": {
     "message": "Close"
   },
+  "select": {
+    "message": "Select"
+  },
   "minNumbers": {
     "message": "Minimum numbers"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3704,6 +3704,12 @@
   "saveNewPasskey": {
     "message": "Save as new login"
   },
+  "savePasskeyNewLogin": {
+    "message": "Save passkey as new login"
+  },
+  "noMatchingLoginsForSite": {
+    "message": "No matching logins for this site"
+  },
   "overwritePasskey": {
     "message": "Overwrite passkey?"
   },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21903](https://bitwarden.atlassian.net/browse/PM-21903)

## 📔 Objective

Remove hard coded strings and use translations across the entire Passkey flow on MacOS

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
