### PR TITLE
[PM-8492] Fix flatpak autostart disabling

### DIFF
--- a/apps/desktop/src/main/messaging.main.ts
+++ b/apps/desktop/src/main/messaging.main.ts
@@ -8,6 +8,7 @@ import { firstValueFrom } from "rxjs";
 
 import { Main } from "../main";
 import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
+import { isFlatpak, isLinux, isSnapStore } from "../utils";
 
 import { MenuUpdateRequest } from "./menu/menu.updater";
 
@@ -23,8 +24,11 @@ export class MessagingMain {
 
   async init() {
     this.scheduleNextSync();
-    if (process.platform === "linux") {
-      await this.desktopSettingsService.setOpenAtLogin(fs.existsSync(this.linuxStartupFile()));
+    if (isLinux()) {
+      // Flatpak and snap don't have access to or use the startup file. On flatpak, the autostart portal is used
+      if (!isFlatpak() && !isSnapStore()) {
+        await this.desktopSettingsService.setOpenAtLogin(fs.existsSync(this.linuxStartupFile()));
+      }
     } else {
       const loginSettings = app.getLoginItemSettings();
       await this.desktopSettingsService.setOpenAtLogin(loginSettings.openAtLogin);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8492

## 📔 Objective

Flatpak and snaps don't have access to the desktop autostart file or use it. In the case of flatpak, the autostart portal is used instead. On unsandboxed linux, the default behavior is to - on start - disable autostart in the settings if the autostart file is not found. This is not required or useful on flatpak because it disables the setting, even if autostart was correctly enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
