### PR TITLE
[PM-17501] Migrate send.component on web to use tailwind

### DIFF
--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -183,7 +183,7 @@
         </tr>
       </ng-template>
     </bit-table>
-    <div class="no-items" *ngIf="filteredSends && !filteredSends.length">
+    <div *ngIf="filteredSends && !filteredSends.length">
       <ng-container *ngIf="!loaded">
         <i
           class="bwi bwi-spinner bwi-spin tw-text-muted"

--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -3,7 +3,7 @@
     <small #actionSpinner [appApiAction]="actionPromise">
       <ng-container *ngIf="$any(actionSpinner).loading">
         <i
-          class="bwi bwi-spinner bwi-spin text-muted"
+          class="bwi bwi-spinner bwi-spin tw-text-muted"
           title="{{ 'loading' | i18n }}"
           aria-hidden="true"
         ></i>
@@ -186,7 +186,7 @@
     <div class="no-items" *ngIf="filteredSends && !filteredSends.length">
       <ng-container *ngIf="!loaded">
         <i
-          class="bwi bwi-spinner bwi-spin text-muted"
+          class="bwi bwi-spinner bwi-spin tw-text-muted"
           title="{{ 'loading' | i18n }}"
           aria-hidden="true"
         ></i>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17501

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
As part of a larger initiative to replace all usage of bootstrap/custom css with tailwind, the `send.component` on web was still using some small parts. This migrates the remaining places to unblock the initiative. 

```
  6:11  error  Classname 'text-muted' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
  186:10  error  Classname 'no-items' is not a Tailwind CSS class!    tailwindcss/no-custom-classname
  189:11  error  Classname 'text-muted' is not a Tailwind CSS class!  tailwindcss/no-custom-classname
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
