### PR TITLE
[PM-21957][Defect][Web] "Add payment method" modal does not pop-up

### DIFF
--- a/apps/web/src/app/billing/organizations/payment-method/organization-payment-method.component.ts
+++ b/apps/web/src/app/billing/organizations/payment-method/organization-payment-method.component.ts
@@ -87,6 +87,9 @@ export class OrganizationPaymentMethodComponent implements OnDestroy {
     const state = this.router.getCurrentNavigation()?.extras?.state;
     // incase the above state is undefined or null we use redundantState
     const redundantState: any = location.getState();
+    const queryParam = this.activatedRoute.snapshot.queryParamMap.get(
+      "launchPaymentModalAutomatically",
+    );
     if (state && Object.prototype.hasOwnProperty.call(state, "launchPaymentModalAutomatically")) {
       this.launchPaymentModalAutomatically = state.launchPaymentModalAutomatically;
     } else if (
@@ -94,6 +97,8 @@ export class OrganizationPaymentMethodComponent implements OnDestroy {
       Object.prototype.hasOwnProperty.call(redundantState, "launchPaymentModalAutomatically")
     ) {
       this.launchPaymentModalAutomatically = redundantState.launchPaymentModalAutomatically;
+    } else if (queryParam === "true") {
+      this.launchPaymentModalAutomatically = true;
     } else {
       this.launchPaymentModalAutomatically = false;
     }

--- a/apps/web/src/app/billing/services/trial-flow.service.ts
+++ b/apps/web/src/app/billing/services/trial-flow.service.ts
@@ -133,6 +133,7 @@ export class TrialFlowService {
   private async navigateToPaymentMethod(orgId: string) {
     await this.router.navigate(["organizations", `${orgId}`, "billing", "payment-method"], {
       state: { launchPaymentModalAutomatically: true },
+      queryParams: { launchPaymentModalAutomatically: true },
     });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21957
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Precondition: Have an organization in suspended mode by having invoices past due. 
Payment method can be removed and can generate invoices via stripe. 

1.Log into web (USQA)
2.On the vaults page under all vaults select the suspended organization (indicated by a red triangle warning sign)
3.On the “The X is suspended” pop-up select continue 

**Expected:** When a user selects a suspended org via the vault page they are redirected to the “Add payment method” modal 
Example: video shows expected redirect to modal 
(note: suspended org was selected via admin console instead of the vaults page) 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/35e8c97a-c35b-4228-92a9-cb21950c09fb


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
