### PR TITLE
[PM-21817] Remove class user-select from about-dialog.component

### DIFF
--- a/apps/browser/src/tools/popup/settings/about-dialog/about-dialog.component.html
+++ b/apps/browser/src/tools/popup/settings/about-dialog/about-dialog.component.html
@@ -6,7 +6,7 @@
   <div bitDialogContent>
     <p>&copy; Bitwarden Inc. 2015-{{ year }}</p>
 
-    <div #version class="user-select">
+    <div #version>
       <p>{{ "version" | i18n }}: {{ version$ | async }}</p>
       <p>SDK: {{ sdkVersion$ | async }}</p>
       <ng-container *ngIf="data$ | async as data">


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21817

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This removes the class `user-select` which was used to override the `user-select` from `none` to `auto`. This would enable a user to copy the version number. Since this was implemented more information has been added including a copy-button, which is now the preferred method to have all information in the clipboard.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
