### PR TITLE
[PM-21975] Move SecurityStamp state to disk to persist through application close

### DIFF
--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -42,7 +42,7 @@ import {
   EMAIL_TWO_FACTOR_TOKEN_RECORD_DISK_LOCAL,
   REFRESH_TOKEN_DISK,
   REFRESH_TOKEN_MEMORY,
-  SECURITY_STAMP_MEMORY,
+  SECURITY_STAMP_DISK,
 } from "./token.state";
 
 // FIXME: update to use a const object instead of a typescript enum
@@ -1045,7 +1045,7 @@ export class TokenService implements TokenServiceAbstraction {
       throw new Error("User id not found. Cannot get security stamp.");
     }
 
-    const securityStamp = await this.getStateValueByUserIdAndKeyDef(userId, SECURITY_STAMP_MEMORY);
+    const securityStamp = await this.getStateValueByUserIdAndKeyDef(userId, SECURITY_STAMP_DISK);
 
     return securityStamp;
   }
@@ -1058,7 +1058,7 @@ export class TokenService implements TokenServiceAbstraction {
     }
 
     await this.singleUserStateProvider
-      .get(userId, SECURITY_STAMP_MEMORY)
+      .get(userId, SECURITY_STAMP_DISK)
       .update((_) => securityStamp);
   }
 

--- a/libs/common/src/auth/services/token.state.spec.ts
+++ b/libs/common/src/auth/services/token.state.spec.ts
@@ -10,7 +10,7 @@ import {
   EMAIL_TWO_FACTOR_TOKEN_RECORD_DISK_LOCAL,
   REFRESH_TOKEN_DISK,
   REFRESH_TOKEN_MEMORY,
-  SECURITY_STAMP_MEMORY,
+  SECURITY_STAMP_DISK,
 } from "./token.state";
 
 describe.each([
@@ -23,7 +23,7 @@ describe.each([
   [API_KEY_CLIENT_ID_MEMORY, "apiKeyClientIdMemory"],
   [API_KEY_CLIENT_SECRET_DISK, "apiKeyClientSecretDisk"],
   [API_KEY_CLIENT_SECRET_MEMORY, "apiKeyClientSecretMemory"],
-  [SECURITY_STAMP_MEMORY, "securityStamp"],
+  [SECURITY_STAMP_DISK, "securityStamp"],
 ])(
   "deserializes state key definitions",
   (

--- a/libs/common/src/auth/services/token.state.ts
+++ b/libs/common/src/auth/services/token.state.ts
@@ -70,7 +70,7 @@ export const API_KEY_CLIENT_SECRET_MEMORY = new UserKeyDefinition<string>(
   },
 );
 
-export const SECURITY_STAMP_MEMORY = new UserKeyDefinition<string>(TOKEN_MEMORY, "securityStamp", {
+export const SECURITY_STAMP_DISK = new UserKeyDefinition<string>(TOKEN_DISK, "securityStamp", {
   deserializer: (securityStamp) => securityStamp,
   clearOn: ["logout"],
 });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21975

## 📔 Objective

When a user deauthorizes all sessions (or performs other account actions that invalidate the authentication guarantees of their account), we update the user's `SecurityStamp`.

It is expected that on subsequent `/sync` calls, we detect that the security stamp has changed and log the user out.

However, we were storing the security stamp in memory, which meant that when the application was close and re-opened, we did not have a previous security stamp to compare against; we therefore do not log the user out.

In practice, this means that if a user's `SecurityStamp` changes while the application is closed, we do not have a way to detect that change immediately after the application is opened.  We never detect it, actually, because the first `/sync` sets the _new_ `SecurityStamp` in state, and it never changes from that value.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
