### PR TITLE
bb/pm-19497/replace default reset button to enable it in more browsers

### DIFF
--- a/libs/components/src/search/search.component.css
+++ b/libs/components/src/search/search.component.css
@@ -1,19 +1,17 @@
 /**
  * Tailwind doesn't have a good way to style search-cancel-button.
+ * Hide the default reset button that only appears in some browsers.
  */
 bit-search input[type="search"]::-webkit-search-cancel-button {
   -webkit-appearance: none;
   appearance: none;
-  height: 21px;
-  width: 21px;
-  margin: 0;
-  cursor: pointer;
-  background-repeat: no-repeat;
-  mask-image: url("./close-button.svg");
-  -webkit-mask-image: url("./close-button.svg");
-  background-color: rgba(var(--color-text-muted));
 }
 
-bit-search input[type="search"]::-webkit-search-cancel-button:hover {
-  background-color: rgba(var(--color-text-main));
+/**
+ * Style our custom reset button that works in all common browsers.
+ * Tailwind CSS does not natively support mask-image or -webkit-mask-image utilities (but can be extended if needed).
+ */
+.bw-reset-btn {
+  mask-image: url("./close-button.svg");
+  -webkit-mask-image: url("./close-button.svg");
 }

--- a/libs/components/src/search/search.component.html
+++ b/libs/components/src/search/search.component.html
@@ -1,23 +1,39 @@
 <label class="tw-sr-only" [for]="id">{{ "search" | i18n }}</label>
 <div class="tw-relative tw-flex tw-items-center">
-  <label
-    [for]="id"
-    aria-hidden="true"
-    class="tw-absolute tw-left-2 tw-z-20 !tw-mb-0 tw-cursor-text"
-  >
-    <i class="bwi bwi-search bwi-fw tw-text-muted"></i>
-  </label>
-  <input
-    #input
-    bitInput
-    [type]="inputType"
-    [id]="id"
-    [placeholder]="placeholder ?? ('search' | i18n)"
-    class="tw-pl-9"
-    [ngModel]="searchText"
-    (ngModelChange)="onChange($event)"
-    (blur)="onTouch()"
-    [disabled]="disabled"
-    [attr.autocomplete]="autocomplete"
-  />
+  <form class="tw-relative tw-flex tw-items-center tw-w-full">
+    <label
+      [for]="id"
+      aria-hidden="true"
+      class="tw-absolute tw-left-2 tw-z-20 !tw-mb-0 tw-cursor-text"
+    >
+      <i class="bwi bwi-search bwi-fw tw-text-muted"></i>
+    </label>
+    <input
+      #input
+      bitInput
+      [type]="inputType"
+      [id]="id"
+      [placeholder]="placeholder ?? ('search' | i18n)"
+      class="tw-pl-9"
+      [ngModel]="searchText"
+      (ngModelChange)="onChange($event)"
+      [ngModelOptions]="{ standalone: true }"
+      (focus)="isInputFocused = true"
+      (blur)="isInputFocused = false; onTouch()"
+      (mouseenter)="isInputHovered = true"
+      (mouseleave)="isInputHovered = false"
+      [disabled]="disabled"
+      [attr.autocomplete]="autocomplete"
+    />
+    <button
+      *ngIf="searchText"
+      (mouseenter)="resetHovered = true"
+      (mouseleave)="resetHovered = false"
+      [class.opacity-0]="!isInputFocused && !isInputHovered && !resetHovered"
+      [class.tw-bg-text-muted]="isInputFocused || isInputHovered || resetHovered"
+      class="bw-reset-btn tw-size-6 tw-absolute hover:tw-bg-text-main tw-right-2 tw-z-20 !tw-mb-0 tw-cursor-pointer"
+      type="reset"
+      (click)="clearSearch()"
+    ></button>
+  </form>
 </div>

--- a/libs/components/src/search/search.component.ts
+++ b/libs/components/src/search/search.component.ts
@@ -1,5 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { NgIf } from "@angular/common";
 import { Component, ElementRef, Input, ViewChild } from "@angular/core";
 import {
   ControlValueAccessor,
@@ -31,7 +32,7 @@ let nextId = 0;
     },
   ],
   standalone: true,
-  imports: [InputModule, ReactiveFormsModule, FormsModule, I18nPipe],
+  imports: [InputModule, ReactiveFormsModule, FormsModule, I18nPipe, NgIf],
 })
 export class SearchComponent implements ControlValueAccessor, FocusableElement {
   private notifyOnChange: (v: string) => void;
@@ -43,6 +44,10 @@ export class SearchComponent implements ControlValueAccessor, FocusableElement {
   protected searchText: string;
   // Use `type="text"` for Safari to improve rendering performance
   protected inputType = isBrowserSafariApi() ? ("text" as const) : ("search" as const);
+  // Optional: Track focus and hover state of the input to emulate the hiding/showing of the native reset button
+  protected isInputFocused = false;
+  protected isInputHovered = false;
+  protected resetHovered = false;
 
   @Input() disabled: boolean;
   @Input() placeholder: string;
@@ -53,8 +58,17 @@ export class SearchComponent implements ControlValueAccessor, FocusableElement {
   }
 
   onChange(searchText: string) {
+    this.searchText = searchText; // update the model when the input changes (so we can use it with *ngIf in the template)
     if (this.notifyOnChange != undefined) {
       this.notifyOnChange(searchText);
+    }
+  }
+
+  // Handle the reset button click
+  clearSearch() {
+    this.searchText = "";
+    if (this.notifyOnChange) {
+      this.notifyOnChange("");
     }
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

GitHub Issue: https://github.com/bitwarden/clients/issues/13982

Jira ticket number: PM-19497

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Update the template (search.component.html) to add a new reset button:
    - Wrap the existing label and input in a form element, which is required for our new custom reset button to work properly.
    - Add event bindings to the input for `focus`, `blur`, `mouseenter` and `mouseleave` to facilitate emulating the hiding/showing of the default reset button.
    - Add the new reset button, including:
        - An `*ngIf="searchText"` directive and event bindings to enable hiding our new button when the input is empty.
        - Class bindings to reproduce our old reset button style.
        - The (click) event handler that triggers clearing the input.
- Update the class to:
    - Track the input's focus/blur and hover states (to facilitate emulating the hiding/showing of the default reset button).
    - Update the model in the `onChange` lifecycle hook (i.e. `this.searchText = searchText;`), to enable hiding our new reset button when the input is empty.
    - Add the `clearSearch` method that clears the input, which is called by clicking our new reset button.
- Update CSS (search.component.css) to hide the default reset button, which only appears in some browsers (e.g. Chrome).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

![image](https://github.com/user-attachments/assets/41967e97-75ac-4524-8a00-63f9800fcce3)

![image](https://github.com/user-attachments/assets/efb58c6a-2376-42b3-924d-d5d2ff7e42cf)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
