### PR TITLE
[PM-21546] Migrate from `enum` to constant object

### DIFF
--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -97,7 +97,9 @@ export class CipherContextMenuHandler {
   private async updateForCipher(cipher: CipherView) {
     if (
       cipher == null ||
-      !new Set([CipherType.Login, CipherType.Card, CipherType.Identity]).has(cipher.type)
+      !new Set([CipherType.Login, CipherType.Card, CipherType.Identity] as number[]).has(
+        cipher.type,
+      )
     ) {
       return;
     }

--- a/apps/browser/src/autofill/types/index.ts
+++ b/apps/browser/src/autofill/types/index.ts
@@ -54,4 +54,7 @@ export type FormFieldElement = FillableFormFieldElement | HTMLSpanElement;
 
 export type FormElementWithAttribute = FormFieldElement & Record<string, string | null | undefined>;
 
-export type AutofillCipherTypeId = CipherType.Login | CipherType.Card | CipherType.Identity;
+export type AutofillCipherTypeId =
+  | typeof CipherType.Login
+  | typeof CipherType.Card
+  | typeof CipherType.Identity;

--- a/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-carousel-dialog/at-risk-carousel-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, signal } from "@angular/core";
 
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DialogRef,
   ButtonModule,
@@ -10,11 +11,11 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { DarkImageSourceDirective, VaultCarouselModule } from "@bitwarden/vault";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum AtRiskCarouselDialogResult {
-  Dismissed = "dismissed",
-}
+export const AtRiskCarouselDialogResult = {
+  Dismissed: "dismissed",
+} as const;
+
+type AtRiskCarouselDialogResult = UnionOfValues<typeof AtRiskCarouselDialogResult>;
 
 @Component({
   selector: "vault-at-risk-carousel-dialog",

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-generator-dialog/vault-generator-dialog.component.ts
@@ -5,6 +5,7 @@ import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -30,12 +31,12 @@ export interface GeneratorDialogResult {
   generatedValue?: string;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum GeneratorDialogAction {
-  Selected = "selected",
-  Canceled = "canceled",
-}
+export const GeneratorDialogAction = {
+  Selected: "selected",
+  Canceled: "canceled",
+} as const;
+
+type GeneratorDialogAction = UnionOfValues<typeof GeneratorDialogAction>;
 
 @Component({
   selector: "app-vault-generator-dialog",

--- a/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-v2.component.ts
@@ -24,6 +24,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { CipherId, CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   ButtonModule,
   DialogService,
@@ -55,13 +56,13 @@ import { VaultHeaderV2Component } from "./vault-header/vault-header-v2.component
 
 import { AutofillVaultListItemsComponent, VaultListItemsContainerComponent } from ".";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-enum VaultState {
-  Empty,
-  NoResults,
-  DeactivatedOrg,
-}
+const VaultState = {
+  Empty: 0,
+  NoResults: 1,
+  DeactivatedOrg: 2,
+} as const;
+
+type VaultState = UnionOfValues<typeof VaultState>;
 
 @Component({
   selector: "app-vault",

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, Inject } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   ButtonModule,
@@ -31,12 +32,12 @@ export interface CredentialGeneratorDialogResult {
   generatedValue?: string;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CredentialGeneratorDialogAction {
-  Selected = "selected",
-  Canceled = "canceled",
-}
+export const CredentialGeneratorDialogAction = {
+  Selected: "selected",
+  Canceled: "canceled",
+} as const;
+
+type CredentialGeneratorDialogAction = UnionOfValues<typeof CredentialGeneratorDialogAction>;
 
 @Component({
   standalone: true,

--- a/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.ts
@@ -18,7 +18,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherType, CipherTypeNames } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   DIALOG_DATA,
@@ -163,7 +163,7 @@ export class DeleteOrganizationDialogComponent implements OnInit, OnDestroy {
         organizationContentSummary.itemCountByType.push(
           new OrganizationContentSummaryItem(
             count,
-            this.getOrganizationItemLocalizationKeysByType(CipherType[cipherType]),
+            this.getOrganizationItemLocalizationKeysByType(CipherTypeNames[cipherType]),
           ),
         );
       }

--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.spec.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt.component.spec.ts
@@ -16,7 +16,7 @@ describe("BrowserExtensionPromptComponent", () => {
   let component: BrowserExtensionPromptComponent;
   const start = jest.fn();
   const openExtension = jest.fn();
-  const pageState$ = new BehaviorSubject(BrowserPromptState.Loading);
+  const pageState$ = new BehaviorSubject<BrowserPromptState>(BrowserPromptState.Loading);
   const setAttribute = jest.fn();
   const getAttribute = jest.fn().mockReturnValue("width=1010");
 

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -29,6 +29,7 @@ import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogRef,
@@ -95,29 +96,29 @@ export interface VaultItemDialogParams {
   restore?: (c: CipherView) => Promise<boolean>;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum VaultItemDialogResult {
+export const VaultItemDialogResult = {
   /**
    * A cipher was saved (created or updated).
    */
-  Saved = "saved",
+  Saved: "saved",
 
   /**
    * A cipher was deleted.
    */
-  Deleted = "deleted",
+  Deleted: "deleted",
 
   /**
    * The dialog was closed to navigate the user the premium upgrade page.
    */
-  PremiumUpgrade = "premiumUpgrade",
+  PremiumUpgrade: "premiumUpgrade",
 
   /**
    * A cipher was restored
    */
-  Restored = "restored",
-}
+  Restored: "restored",
+} as const;
+
+export type VaultItemDialogResult = UnionOfValues<typeof VaultItemDialogResult>;
 
 @Component({
   selector: "app-vault-item-dialog",

--- a/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.ts
+++ b/apps/web/src/app/vault/components/web-generator-dialog/web-generator-dialog.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -26,12 +27,12 @@ export interface WebVaultGeneratorDialogResult {
   generatedValue?: string;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum WebVaultGeneratorDialogAction {
-  Selected = "selected",
-  Canceled = "canceled",
-}
+export const WebVaultGeneratorDialogAction = {
+  Selected: "selected",
+  Canceled: "canceled",
+} as const;
+
+type WebVaultGeneratorDialogAction = UnionOfValues<typeof WebVaultGeneratorDialogAction>;
 
 @Component({
   selector: "web-vault-generator-dialog",

--- a/apps/web/src/app/vault/individual-vault/add-edit-v2.component.ts
+++ b/apps/web/src/app/vault/individual-vault/add-edit-v2.component.ts
@@ -11,6 +11,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { CipherId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -35,13 +36,13 @@ import { WebCipherFormGenerationService } from "../services/web-cipher-form-gene
 /**
  * The result of the AddEditCipherDialogV2 component.
  */
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum AddEditCipherDialogResult {
-  Edited = "edited",
-  Added = "added",
-  Canceled = "canceled",
-}
+export const AddEditCipherDialogResult = {
+  Edited: "edited",
+  Added: "added",
+  Canceled: "canceled",
+} as const;
+
+type AddEditCipherDialogResult = UnionOfValues<typeof AddEditCipherDialogResult>;
 
 /**
  * The close result of the AddEditCipherDialogV2 component.

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -12,6 +12,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherBulkDeleteRequest } from "@bitwarden/common/vault/models/request/cipher-bulk-delete.request";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -29,12 +30,12 @@ export interface BulkDeleteDialogParams {
   unassignedCiphers?: string[];
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum BulkDeleteDialogResult {
-  Deleted = "deleted",
-  Canceled = "canceled",
-}
+export const BulkDeleteDialogResult = {
+  Deleted: "deleted",
+  Canceled: "canceled",
+} as const;
+
+type BulkDeleteDialogResult = UnionOfValues<typeof BulkDeleteDialogResult>;
 
 /**
  * Strongly typed helper to open a BulkDeleteDialog

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.ts
@@ -11,6 +11,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DialogConfig,
   DialogRef,
@@ -23,12 +24,12 @@ export interface BulkMoveDialogParams {
   cipherIds?: string[];
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum BulkMoveDialogResult {
-  Moved = "moved",
-  Canceled = "canceled",
-}
+export const BulkMoveDialogResult = {
+  Moved: "moved",
+  Canceled: "canceled",
+} as const;
+
+type BulkMoveDialogResult = UnionOfValues<typeof BulkMoveDialogResult>;
 
 /**
  * Strongly typed helper to open a BulkMoveDialog

--- a/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
@@ -11,6 +11,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogConfig,
@@ -114,13 +115,13 @@ export interface FolderAddEditDialogParams {
   folderId: string;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum FolderAddEditDialogResult {
-  Deleted = "deleted",
-  Canceled = "canceled",
-  Saved = "saved",
-}
+export const FolderAddEditDialogResult = {
+  Deleted: "deleted",
+  Canceled: "canceled",
+  Saved: "saved",
+} as const;
+
+export type FolderAddEditDialogResult = UnionOfValues<typeof FolderAddEditDialogResult>;
 
 /**
  * Strongly typed helper to open a FolderAddEdit dialog

--- a/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
@@ -15,17 +15,18 @@ import {
 } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import { PBKDF2KdfConfig, KdfConfigService, KdfType } from "@bitwarden/key-management";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum VisibleVaultBanner {
-  KDFSettings = "kdf-settings",
-  OutdatedBrowser = "outdated-browser",
-  Premium = "premium",
-  VerifyEmail = "verify-email",
-  PendingAuthRequest = "pending-auth-request",
-}
+export const VisibleVaultBanner = {
+  KDFSettings: "kdf-settings",
+  OutdatedBrowser: "outdated-browser",
+  Premium: "premium",
+  VerifyEmail: "verify-email",
+  PendingAuthRequest: "pending-auth-request",
+} as const;
+
+export type VisibleVaultBanner = UnionOfValues<typeof VisibleVaultBanner>;
 
 type PremiumBannerReprompt = {
   numberOfDismissals: number;
@@ -34,7 +35,7 @@ type PremiumBannerReprompt = {
 };
 
 /** Banners that will be re-shown on a new session */
-type SessionBanners = Omit<VisibleVaultBanner, VisibleVaultBanner.Premium>;
+type SessionBanners = Omit<VisibleVaultBanner, typeof VisibleVaultBanner.Premium>;
 
 export const PREMIUM_BANNER_REPROMPT_KEY = new UserKeyDefinition<PremiumBannerReprompt>(
   PREMIUM_BANNER_DISK_LOCAL,

--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
@@ -99,7 +99,7 @@ export class VaultBannersComponent implements OnInit {
       showVerifyEmail ? VisibleVaultBanner.VerifyEmail : null,
       showLowKdf ? VisibleVaultBanner.KDFSettings : null,
       showPendingAuthRequest ? VisibleVaultBanner.PendingAuthRequest : null,
-    ].filter((banner): banner is VisibleVaultBanner => banner !== null); // ensures the filtered array contains only VisibleVaultBanner values
+    ].filter((banner) => banner !== null);
   }
 
   freeTrialMessage(organization: FreeTrial) {

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/vault-filter-section.type.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/vault-filter-section.type.ts
@@ -1,6 +1,7 @@
 import { Observable } from "rxjs";
 
 import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 
 import {
   CipherTypeFilter,
@@ -15,15 +16,15 @@ export type VaultFilterType =
   | FolderFilter
   | CollectionFilter;
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum VaultFilterLabel {
-  OrganizationFilter = "organizationFilter",
-  TypeFilter = "typeFilter",
-  FolderFilter = "folderFilter",
-  CollectionFilter = "collectionFilter",
-  TrashFilter = "trashFilter",
-}
+export const VaultFilterLabel = {
+  OrganizationFilter: "organizationFilter",
+  TypeFilter: "typeFilter",
+  FolderFilter: "folderFilter",
+  CollectionFilter: "collectionFilter",
+  TrashFilter: "trashFilter",
+} as const;
+
+type VaultFilterLabel = UnionOfValues<typeof VaultFilterLabel>;
 
 export type VaultFilterSection = {
   data$: Observable<TreeNode<VaultFilterType>>;

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/vault-filter.model.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/vault-filter.model.ts
@@ -77,7 +77,7 @@ export class VaultFilter {
   }
 
   get cipherType(): CipherType {
-    return this.selectedCipherTypeNode?.node.type in CipherType
+    return this.selectedCipherTypeNode?.node.type in Object.values(CipherType)
       ? (this.selectedCipherTypeNode?.node.type as CipherType)
       : null;
   }

--- a/apps/web/src/app/vault/individual-vault/view.component.ts
+++ b/apps/web/src/app/vault/individual-vault/view.component.ts
@@ -20,6 +20,7 @@ import { ViewPasswordHistoryService } from "@bitwarden/common/vault/abstractions
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogRef,
@@ -54,13 +55,13 @@ export interface ViewCipherDialogParams {
   disableEdit?: boolean;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum ViewCipherDialogResult {
-  Edited = "edited",
-  Deleted = "deleted",
-  PremiumUpgrade = "premiumUpgrade",
-}
+export const ViewCipherDialogResult = {
+  Edited: "edited",
+  Deleted: "deleted",
+  PremiumUpgrade: "premiumUpgrade",
+} as const;
+
+type ViewCipherDialogResult = UnionOfValues<typeof ViewCipherDialogResult>;
 
 export interface ViewCipherDialogCloseResult {
   action: ViewCipherDialogResult;

--- a/apps/web/src/app/vault/services/browser-extension-prompt.service.ts
+++ b/apps/web/src/app/vault/services/browser-extension-prompt.service.ts
@@ -6,18 +6,19 @@ import { AnonLayoutWrapperDataService } from "@bitwarden/auth/angular";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum BrowserPromptState {
-  Loading = "loading",
-  Error = "error",
-  Success = "success",
-  ManualOpen = "manualOpen",
-  MobileBrowser = "mobileBrowser",
-}
+export const BrowserPromptState = {
+  Loading: "loading",
+  Error: "error",
+  Success: "success",
+  ManualOpen: "manualOpen",
+  MobileBrowser: "mobileBrowser",
+} as const;
 
-type PromptErrorStates = BrowserPromptState.Error | BrowserPromptState.ManualOpen;
+export type BrowserPromptState = UnionOfValues<typeof BrowserPromptState>;
+
+type PromptErrorStates = typeof BrowserPromptState.Error | typeof BrowserPromptState.ManualOpen;
 
 @Injectable({
   providedIn: "root",

--- a/bitwarden_license/bit-web/src/app/vault/services/abstractions/admin-task.abstraction.ts
+++ b/bitwarden_license/bit-web/src/app/vault/services/abstractions/admin-task.abstraction.ts
@@ -8,7 +8,7 @@ import { SecurityTask, SecurityTaskStatus, SecurityTaskType } from "@bitwarden/c
  */
 export type CreateTasksRequest = Readonly<{
   cipherId?: CipherId;
-  type: SecurityTaskType.UpdateAtRiskCredential;
+  type: typeof SecurityTaskType.UpdateAtRiskCredential;
 }>;
 
 export abstract class AdminTaskService {

--- a/libs/angular/src/vault/services/nudges.service.ts
+++ b/libs/angular/src/vault/services/nudges.service.ts
@@ -5,6 +5,7 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { UserKeyDefinition, NUDGES_DISK } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 
 import {
   HasItemsNudgeService,
@@ -24,25 +25,23 @@ export type NudgeStatus = {
 /**
  * Enum to list the various nudge types, to be used by components/badges to show/hide the nudge
  */
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum NudgeType {
-  /** Nudge to show when user has no items in their vault
-   * Add future nudges here
-   */
-  EmptyVaultNudge = "empty-vault-nudge",
-  HasVaultItems = "has-vault-items",
-  AutofillNudge = "autofill-nudge",
-  AccountSecurity = "account-security",
-  DownloadBitwarden = "download-bitwarden",
-  NewLoginItemStatus = "new-login-item-status",
-  NewCardItemStatus = "new-card-item-status",
-  NewIdentityItemStatus = "new-identity-item-status",
-  NewNoteItemStatus = "new-note-item-status",
-  NewSshItemStatus = "new-ssh-item-status",
-  GeneratorNudgeStatus = "generator-nudge-status",
-  SendNudgeStatus = "send-nudge-status",
-}
+export const NudgeType = {
+  /** Nudge to show when user has no items in their vault */
+  EmptyVaultNudge: "empty-vault-nudge",
+  HasVaultItems: "has-vault-items",
+  AutofillNudge: "autofill-nudge",
+  AccountSecurity: "account-security",
+  DownloadBitwarden: "download-bitwarden",
+  NewLoginItemStatus: "new-login-item-status",
+  NewCardItemStatus: "new-card-item-status",
+  NewIdentityItemStatus: "new-identity-item-status",
+  NewNoteItemStatus: "new-note-item-status",
+  NewSshItemStatus: "new-ssh-item-status",
+  GeneratorNudgeStatus: "generator-nudge-status",
+  SendNudgeStatus: "send-nudge-status",
+} as const;
+
+export type NudgeType = UnionOfValues<typeof NudgeType>;
 
 export const NUDGE_DISMISSED_DISK_KEY = new UserKeyDefinition<
   Partial<Record<NudgeType, NudgeStatus>>

--- a/libs/common/src/vault/enums/cipher-reprompt-type.ts
+++ b/libs/common/src/vault/enums/cipher-reprompt-type.ts
@@ -1,6 +1,8 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CipherRepromptType {
-  None = 0,
-  Password = 1,
-}
+import { UnionOfValues } from "../types/union-of-values";
+
+export const CipherRepromptType = {
+  None: 0,
+  Password: 1,
+} as const;
+
+export type CipherRepromptType = UnionOfValues<typeof CipherRepromptType>;

--- a/libs/common/src/vault/enums/cipher-type.ts
+++ b/libs/common/src/vault/enums/cipher-type.ts
@@ -1,9 +1,24 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CipherType {
-  Login = 1,
-  SecureNote = 2,
-  Card = 3,
-  Identity = 4,
-  SshKey = 5,
-}
+import { UnionOfValues } from "../types/union-of-values";
+
+export const CipherType = {
+  Login: 1,
+  SecureNote: 2,
+  Card: 3,
+  Identity: 4,
+  SshKey: 5,
+} as const;
+
+/**
+ * Reverse mapping of Cipher Types to their associated names.
+ * When represented as an enum in TypeScript, this mapping was provided
+ * by default. Now using a constant object it needs to be defined manually.
+ */
+export const CipherTypeNames = {
+  1: "Login",
+  2: "Secure Note",
+  3: "Card",
+  4: "Identity",
+  5: "SSH Key",
+} as const;
+
+export type CipherType = UnionOfValues<typeof CipherType>;

--- a/libs/common/src/vault/enums/cipher-type.ts
+++ b/libs/common/src/vault/enums/cipher-type.ts
@@ -15,10 +15,10 @@ export const CipherType = {
  */
 export const CipherTypeNames = {
   1: "Login",
-  2: "Secure Note",
+  2: "SecureNote",
   3: "Card",
   4: "Identity",
-  5: "SSH Key",
+  5: "SshKey",
 } as const;
 
 export type CipherType = UnionOfValues<typeof CipherType>;

--- a/libs/common/src/vault/enums/field-type.enum.ts
+++ b/libs/common/src/vault/enums/field-type.enum.ts
@@ -1,8 +1,10 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum FieldType {
-  Text = 0,
-  Hidden = 1,
-  Boolean = 2,
-  Linked = 3,
-}
+import { UnionOfValues } from "../types/union-of-values";
+
+export const FieldType = {
+  Text: 0,
+  Hidden: 1,
+  Boolean: 2,
+  Linked: 3,
+} as const;
+
+export type FieldType = UnionOfValues<typeof FieldType>;

--- a/libs/common/src/vault/enums/linked-id-type.enum.ts
+++ b/libs/common/src/vault/enums/linked-id-type.enum.ts
@@ -1,46 +1,48 @@
+import { UnionOfValues } from "../types/union-of-values";
+
 export type LinkedIdType = LoginLinkedId | CardLinkedId | IdentityLinkedId;
 
 // LoginView
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum LoginLinkedId {
-  Username = 100,
-  Password = 101,
-}
+export const LoginLinkedId = {
+  Username: 100,
+  Password: 101,
+} as const;
+
+export type LoginLinkedId = UnionOfValues<typeof LoginLinkedId>;
 
 // CardView
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CardLinkedId {
-  CardholderName = 300,
-  ExpMonth = 301,
-  ExpYear = 302,
-  Code = 303,
-  Brand = 304,
-  Number = 305,
-}
+export const CardLinkedId = {
+  CardholderName: 300,
+  ExpMonth: 301,
+  ExpYear: 302,
+  Code: 303,
+  Brand: 304,
+  Number: 305,
+} as const;
+
+export type CardLinkedId = UnionOfValues<typeof CardLinkedId>;
 
 // IdentityView
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum IdentityLinkedId {
-  Title = 400,
-  MiddleName = 401,
-  Address1 = 402,
-  Address2 = 403,
-  Address3 = 404,
-  City = 405,
-  State = 406,
-  PostalCode = 407,
-  Country = 408,
-  Company = 409,
-  Email = 410,
-  Phone = 411,
-  Ssn = 412,
-  Username = 413,
-  PassportNumber = 414,
-  LicenseNumber = 415,
-  FirstName = 416,
-  LastName = 417,
-  FullName = 418,
-}
+export const IdentityLinkedId = {
+  Title: 400,
+  MiddleName: 401,
+  Address1: 402,
+  Address2: 403,
+  Address3: 404,
+  City: 405,
+  State: 406,
+  PostalCode: 407,
+  Country: 408,
+  Company: 409,
+  Email: 410,
+  Phone: 411,
+  Ssn: 412,
+  Username: 413,
+  PassportNumber: 414,
+  LicenseNumber: 415,
+  FirstName: 416,
+  LastName: 417,
+  FullName: 418,
+} as const;
+
+export type IdentityLinkedId = UnionOfValues<typeof IdentityLinkedId>;

--- a/libs/common/src/vault/enums/secure-note-type.enum.ts
+++ b/libs/common/src/vault/enums/secure-note-type.enum.ts
@@ -1,5 +1,7 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum SecureNoteType {
-  Generic = 0,
-}
+import { UnionOfValues } from "../types/union-of-values";
+
+export const SecureNoteType = {
+  Generic: 0,
+} as const;
+
+export type SecureNoteType = UnionOfValues<typeof SecureNoteType>;

--- a/libs/common/src/vault/models/data/cipher.data.ts
+++ b/libs/common/src/vault/models/data/cipher.data.ts
@@ -57,7 +57,7 @@ export class CipherData {
     this.organizationUseTotp = response.organizationUseTotp;
     this.favorite = response.favorite;
     this.revisionDate = response.revisionDate;
-    this.type = response.type;
+    this.type = response.type as CipherType;
     this.name = response.name;
     this.notes = response.notes;
     this.collectionIds = collectionIds != null ? collectionIds : response.collectionIds;

--- a/libs/common/src/vault/tasks/enums/security-task-status.enum.ts
+++ b/libs/common/src/vault/tasks/enums/security-task-status.enum.ts
@@ -1,13 +1,15 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum SecurityTaskStatus {
+import { UnionOfValues } from "../../types/union-of-values";
+
+export const SecurityTaskStatus = {
   /**
    * Default status for newly created tasks that have not been completed.
    */
-  Pending = 0,
+  Pending: 0,
 
   /**
    * Status when a task is considered complete and has no remaining actions
    */
-  Completed = 1,
-}
+  Completed: 1,
+} as const;
+
+export type SecurityTaskStatus = UnionOfValues<typeof SecurityTaskStatus>;

--- a/libs/common/src/vault/tasks/enums/security-task-type.enum.ts
+++ b/libs/common/src/vault/tasks/enums/security-task-type.enum.ts
@@ -1,8 +1,10 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum SecurityTaskType {
+import { UnionOfValues } from "../../types/union-of-values";
+
+export const SecurityTaskType = {
   /**
    * Task to update a cipher's password that was found to be at-risk by an administrator
    */
-  UpdateAtRiskCredential = 0,
-}
+  UpdateAtRiskCredential: 0,
+} as const;
+
+export type SecurityTaskType = UnionOfValues<typeof SecurityTaskType>;

--- a/libs/common/src/vault/types/union-of-values.ts
+++ b/libs/common/src/vault/types/union-of-values.ts
@@ -1,0 +1,2 @@
+/** Creates a union type consisting of all values within the record. */
+export type UnionOfValues<T extends Record<string, unknown>> = T[keyof T];

--- a/libs/importer/src/importers/bitwarden/bitwarden-csv-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-csv-importer.ts
@@ -44,7 +44,7 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
         cipher.reprompt = parseInt(
           this.getValueOrDefault(value.reprompt, CipherRepromptType.None.toString()),
           10,
-        );
+        ) as CipherRepromptType;
       } catch (e) {
         // eslint-disable-next-line
         console.error("Unable to parse reprompt value", e);

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -21,7 +21,7 @@ import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.serv
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherType, CipherTypeNames } from "@bitwarden/common/vault/enums";
 import { CipherRequest } from "@bitwarden/common/vault/models/request/cipher.request";
 import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -426,7 +426,7 @@ export class ImportService implements ImportServiceAbstraction {
       switch (key.match(/^\w+/)[0]) {
         case "Ciphers":
           item = importResult.ciphers[i];
-          itemType = CipherType[item.type];
+          itemType = CipherTypeNames[item.type];
           break;
         case "Folders":
           item = importResult.folders[i];

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -156,7 +156,7 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
     // Populate options for linked custom fields
     this.linkedFieldOptions = optionsArray.map(([id, linkedFieldOption]) => ({
       name: this.i18nService.t(linkedFieldOption.i18nKey),
-      value: id,
+      value: id as LinkedIdType,
     }));
 
     const prefillCipher = this.cipherFormContainer.getInitialCipherView();

--- a/libs/vault/src/cipher-view/attachments/attachments-v2.component.ts
+++ b/libs/vault/src/cipher-view/attachments/attachments-v2.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
 
 import { CipherId, OrganizationId } from "@bitwarden/common/types/guid";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   ButtonModule,
   DialogModule,
@@ -24,13 +25,13 @@ export interface AttachmentsDialogParams {
 /**
  * Enum representing the possible results of the attachment dialog.
  */
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum AttachmentDialogResult {
-  Uploaded = "uploaded",
-  Removed = "removed",
-  Closed = "closed",
-}
+export const AttachmentDialogResult = {
+  Uploaded: "uploaded",
+  Removed: "removed",
+  Closed: "closed",
+} as const;
+
+export type AttachmentDialogResult = UnionOfValues<typeof AttachmentDialogResult>;
 
 export interface AttachmentDialogCloseResult {
   action: AttachmentDialogResult;

--- a/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
+++ b/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
@@ -19,6 +19,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   DIALOG_DATA,
   DialogRef,
@@ -34,12 +35,12 @@ import {
 } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum AddEditFolderDialogResult {
-  Created = "created",
-  Deleted = "deleted",
-}
+export const AddEditFolderDialogResult = {
+  Created: "created",
+  Deleted: "deleted",
+} as const;
+
+export type AddEditFolderDialogResult = UnionOfValues<typeof AddEditFolderDialogResult>;
 
 export type AddEditFolderDialogData = {
   /** When provided, dialog will display edit folder variant */

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -40,6 +40,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { CipherId, CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
   AsyncActionsModule,
   BitSubmitDirective,
@@ -82,12 +83,12 @@ export interface CollectionAssignmentParams {
   isSingleCipherAdmin?: boolean;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CollectionAssignmentResult {
-  Saved = "saved",
-  Canceled = "canceled",
-}
+export const CollectionAssignmentResult = {
+  Saved: "saved",
+  Canceled: "canceled",
+} as const;
+
+export type CollectionAssignmentResult = UnionOfValues<typeof CollectionAssignmentResult>;
 
 const MY_VAULT_ID = "MyVault";
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21546](https://bitwarden.atlassian.net/browse/PM-21546)

## 📔 Objective

Following the enablement of [@bitwarden/platform/no-enums](https://github.com/bitwarden/clients/pull/14650/files#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2), FIXME comments were added to silence all  enum related errors. This PR resolves all eslint errors for vault files by converting all `enum`s to constant objects and creates the respective type.
- TypeScript allows types and constants to be the same name as the types are stripped away when compiled to JS. This is beneficial here because consuming entities do not have to update the naming of their imports.
- There are a couple of locations where functional code was changed due to the nature of the switch from `enum` to `const`.
- TypeScript creates a bidirectional mapping for an `enum`, this allow code to refer to an Enum by the `key` or `value` and get the respective result. These locations need to be updated to consume a new constant that has the reverse mapping manually. [TypeScript Playground of bidirectional mapping](https://www.typescriptlang.org/play/?ts=5.8.3#code/KYOwrgtgBAwglgBwBbAE4BUCeDhQN4BQUUAMgPYDmcIUAvFAIwA0RUAysAMZirAByZAC656AJhbEYAQ1QATOlADMEqAElZoQXEGYFAFhVsAzkgDSwXfQCsLAL4BuAgU5kQRsgBtgAOg+UAFPDIaFg4ANoARORUIBEAugCUUAD0yYzOru5evgFBKBjYwGEMiSlpUZTUEUA)
I called out these locations below.
- I added `UnionOfValues` utility type to avoid having to `(typeof T)[keyof typeof T]` repeatedly and gives an intentional purpose via the name. The utility type is relatively small and could be argued that it doesn't save that many keystrokes. I can go either way.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
