### PR TITLE
[PM-13196] Hide decorative chip select icons from screenreaders

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.html
+++ b/libs/components/src/chip-select/chip-select.component.html
@@ -28,13 +28,14 @@
     #chipSelectButton
   >
     <span class="tw-inline-flex tw-items-center tw-gap-1.5 tw-truncate">
-      <i class="bwi !tw-text-[inherit]" [ngClass]="icon"></i>
+      <i class="bwi !tw-text-[inherit]" [ngClass]="icon" aria-hidden="true"></i>
       <span class="tw-truncate">{{ label }}</span>
     </span>
     @if (!selectedOption) {
       <i
         class="bwi tw-mt-0.5"
         [ngClass]="menuTrigger.isOpen ? 'bwi-angle-up' : 'bwi-angle-down'"
+        aria-hidden="true"
       ></i>
     }
   </button>
@@ -51,7 +52,7 @@
       }"
       (click)="clear()"
     >
-      <i class="bwi bwi-close tw-text-xs"></i>
+      <i class="bwi bwi-close tw-text-xs" aria-hidden="true"></i>
     </button>
   }
 </div>
@@ -101,7 +102,7 @@
           }
           {{ option.label }}
           @if (option.children?.length) {
-            <i slot="end" class="bwi bwi-angle-right"></i>
+            <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
           }
         </button>
       }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-13196](https://bitwarden.atlassian.net/browse/PM-13196)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
There was an issue with the chip select where the screenreader would get stuck trying to read it during the read-all command. There are a number of icons in the chip select that are decorative -- hiding these from the screenreader resolves the issue.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
