### PR TITLE
[PM-21848] Rework empty vault spotlight logic

### DIFF
--- a/libs/angular/src/vault/services/custom-nudges-services/empty-vault-nudge.service.ts
+++ b/libs/angular/src/vault/services/custom-nudges-services/empty-vault-nudge.service.ts
@@ -47,18 +47,22 @@ export class EmptyVaultNudgeService extends DefaultSingleNudgeService {
         const hasManageCollections = collections.some(
           (c) => c.manage && orgIds.has(c.organizationId),
         );
-        // Do not show nudge when
-        // user has previously dismissed nudge
-        // OR
-        // user belongs to an organization and cannot create collections || manage collections
-        if (
-          nudgeStatus.hasBadgeDismissed ||
-          nudgeStatus.hasSpotlightDismissed ||
-          hasManageCollections ||
-          canCreateCollections
-        ) {
+
+        // When the user has dismissed the nudge or spotlight, return the nudge status directly
+        if (nudgeStatus.hasBadgeDismissed || nudgeStatus.hasSpotlightDismissed) {
           return of(nudgeStatus);
         }
+
+        // When the user belongs to an organization and cannot create collections or manage collections,
+        // hide the nudge and spotlight
+        if (!hasManageCollections && !canCreateCollections) {
+          return of({
+            hasSpotlightDismissed: true,
+            hasBadgeDismissed: true,
+          });
+        }
+
+        // Otherwise, return the nudge status based on the vault contents
         return of({
           hasSpotlightDismissed: vaultHasContents,
           hasBadgeDismissed: vaultHasContents,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21848](https://bitwarden.atlassian.net/browse/PM-21848)

## 📔 Objective


### Issue
Previously when both `hasManageCollections` and `canCreateCollections` were both false, the nudge/spotlight logic would default to the number of contents in a vault. When the vault is empty this causes the import spotlight/vault to show inaccurately. 

### Fix
When both `hasManageCollections` and `canCreateCollections` return early and hide both the nudge and spotlight.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/18d9e80d-0d3b-46c4-b009-0c9067e28f6a" />|<video src="https://github.com/user-attachments/assets/26024a84-cb0f-4874-bbd9-7f8d29d08a1e" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21848]: https://bitwarden.atlassian.net/browse/PM-21848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ