### PR TITLE
Refactor `PendingSecurityTasks` to `RefreshSecurityTasks`

### DIFF
--- a/libs/common/src/enums/notification-type.enum.ts
+++ b/libs/common/src/enums/notification-type.enum.ts
@@ -29,5 +29,5 @@ export enum NotificationType {
   Notification = 20,
   NotificationStatus = 21,
 
-  PendingSecurityTasks = 22,
+  RefreshSecurityTasks = 22,
 }

--- a/libs/common/src/vault/tasks/services/default-task.service.spec.ts
+++ b/libs/common/src/vault/tasks/services/default-task.service.spec.ts
@@ -390,7 +390,7 @@ describe("Default task service", () => {
         const subscription = service.listenForTaskNotifications();
 
         const notification = {
-          type: NotificationType.PendingSecurityTasks,
+          type: NotificationType.RefreshSecurityTasks,
         } as NotificationResponse;
         mockNotifications$.next([notification, userId]);
 
@@ -415,7 +415,7 @@ describe("Default task service", () => {
         const subscription = service.listenForTaskNotifications();
 
         const notification = {
-          type: NotificationType.PendingSecurityTasks,
+          type: NotificationType.RefreshSecurityTasks,
         } as NotificationResponse;
         mockNotifications$.next([notification, "other-user-id" as UserId]);
 

--- a/libs/common/src/vault/tasks/services/default-task.service.ts
+++ b/libs/common/src/vault/tasks/services/default-task.service.ts
@@ -160,7 +160,7 @@ export class DefaultTaskService implements TaskService {
     return this.notificationService.notifications$.pipe(
       filter(
         ([notification, userId]) =>
-          notification.type === NotificationType.PendingSecurityTasks &&
+          notification.type === NotificationType.RefreshSecurityTasks &&
           filterByUserIds.includes(userId),
       ),
       map(([, userId]) => userId),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Server PR: https://github.com/bitwarden/server/pull/5903

As a part of https://github.com/bitwarden/server/pull/5896, I utilized the `PendingSecurityTasks` push type to trigger a refresh of the security tasks. This is currently on the notification is utilized but now the name `PendingSecurityTasks` won't match the all of the use cases.

This renames `PendingSecurityTasks` to `RefreshSecurityTasks` to align for more general use cases of security task notifications.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
