### PR TITLE
[PM-22336] Access Intelligence display and access permissions

### DIFF
--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
@@ -4,7 +4,7 @@
     <org-switcher [filter]="orgFilter" [hideNewButton]="hideNewOrgButton$ | async"></org-switcher>
     <bit-nav-group
       icon="bwi-filter"
-      *ngIf="organization.useRiskInsights"
+      *ngIf="organization.useRiskInsights && organization.canAccessReports"
       [text]="'accessIntelligence' | i18n"
       route="access-intelligence"
     >

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/organizations-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/organizations-routing.module.ts
@@ -79,6 +79,7 @@ const routes: Routes = [
       },
       {
         path: "access-intelligence",
+        canActivate: [organizationPermissionsGuard((org) => org.canAccessReports)],
         loadChildren: () =>
           import("../../dirt/access-intelligence/access-intelligence.module").then(
             (m) => m.AccessIntelligenceModule,

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence-routing.module.ts
@@ -9,7 +9,9 @@ const routes: Routes = [
   { path: "", pathMatch: "full", redirectTo: "risk-insights" },
   {
     path: "risk-insights",
-    canActivate: [organizationPermissionsGuard((org) => org.useRiskInsights)],
+    canActivate: [
+      organizationPermissionsGuard((org) => org.useRiskInsights && org.canAccessReports),
+    ],
     component: RiskInsightsComponent,
     data: {
       titleId: "RiskInsights",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22336

## 📔 Objective

Added org permission guards for the routes and removed the display of access intelligence if the `canAccessReports` permission isn't set. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
