### PR TITLE
[CL-609] Close side nav when breakpoint changes

### DIFF
--- a/libs/components/src/navigation/side-nav.component.ts
+++ b/libs/components/src/navigation/side-nav.component.ts
@@ -1,8 +1,11 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CdkTrapFocus } from "@angular/cdk/a11y";
+import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
 import { CommonModule } from "@angular/common";
-import { Component, ElementRef, Input, ViewChild } from "@angular/core";
+import { Component, ElementRef, Input, ViewChild, OnInit, OnDestroy } from "@angular/core";
+import { Subject } from "rxjs";
+import { takeUntil, distinctUntilChanged } from "rxjs/operators";
 
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -18,13 +21,35 @@ export type SideNavVariant = "primary" | "secondary";
   templateUrl: "side-nav.component.html",
   imports: [CommonModule, CdkTrapFocus, NavDividerComponent, BitIconButtonComponent, I18nPipe],
 })
-export class SideNavComponent {
+export class SideNavComponent implements OnInit, OnDestroy {
   @Input() variant: SideNavVariant = "primary";
 
   @ViewChild("toggleButton", { read: ElementRef, static: true })
   private toggleButton: ElementRef<HTMLButtonElement>;
 
-  constructor(protected sideNavService: SideNavService) {}
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    protected sideNavService: SideNavService,
+    private breakpointObserver: BreakpointObserver,
+  ) {}
+
+  ngOnInit() {
+    // Monitor breakpoint changes and close nav when switching to small viewport
+    this.breakpointObserver
+      .observe([Breakpoints.Small, Breakpoints.XSmall])
+      .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe((result) => {
+        if (result.matches) {
+          this.sideNavService.setClose();
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   protected handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {

--- a/libs/components/src/navigation/side-nav.component.ts
+++ b/libs/components/src/navigation/side-nav.component.ts
@@ -37,7 +37,7 @@ export class SideNavComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Monitor breakpoint changes and close nav when switching to small viewport
     this.breakpointObserver
-      .observe([Breakpoints.Small, Breakpoints.XSmall])
+      .observe([Breakpoints.XSmall])
       .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
       .subscribe((result) => {
         if (result.matches) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Automatically close the side navbar if the breakpoint changes to a smaller viewport

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/4a82870b-24d1-459f-b1db-7933aab0af10

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
