### PR TITLE
Remove unneeded setup code for import.service tests

### DIFF
--- a/libs/importer/src/services/import.service.spec.ts
+++ b/libs/importer/src/services/import.service.spec.ts
@@ -112,10 +112,6 @@ describe("ImportService", () => {
     mockImportTargetFolder.name = "myImportTarget";
 
     it("passing importTarget adds it to folders", async () => {
-      folderService.getAllDecryptedFromState.mockReturnValue(
-        Promise.resolve([mockImportTargetFolder]),
-      );
-
       await importService["setImportTarget"](importResult, null, mockImportTargetFolder);
       expect(importResult.folders.length).toBe(1);
       expect(importResult.folders[0]).toBe(mockImportTargetFolder);
@@ -130,12 +126,6 @@ describe("ImportService", () => {
     mockFolder2.name = "folder2";
 
     it("passing importTarget sets it as new root for all existing folders", async () => {
-      folderService.getAllDecryptedFromState.mockResolvedValue([
-        mockImportTargetFolder,
-        mockFolder1,
-        mockFolder2,
-      ]);
-
       importResult.folders.push(mockFolder1);
       importResult.folders.push(mockFolder2);
 
@@ -166,11 +156,6 @@ describe("ImportService", () => {
     mockCollection1.organizationId = organizationId;
 
     it("passing importTarget adds it to collections", async () => {
-      collectionService.getAllDecrypted.mockResolvedValue([
-        mockImportTargetCollection,
-        mockCollection1,
-      ]);
-
       await importService["setImportTarget"](
         importResult,
         organizationId,
@@ -181,12 +166,6 @@ describe("ImportService", () => {
     });
 
     it("passing importTarget sets it as new root for all existing collections", async () => {
-      collectionService.getAllDecrypted.mockResolvedValue([
-        mockImportTargetCollection,
-        mockCollection1,
-        mockCollection2,
-      ]);
-
       importResult.collections.push(mockCollection1);
       importResult.collections.push(mockCollection2);
 
@@ -226,12 +205,6 @@ describe("ImportService", () => {
     });
 
     it("passing importTarget, collectionRelationship has the expected values", async () => {
-      collectionService.getAllDecrypted.mockResolvedValue([
-        mockImportTargetCollection,
-        mockCollection1,
-        mockCollection2,
-      ]);
-
       importResult.ciphers.push(createCipher({ name: "cipher1" }));
       importResult.ciphers.push(createCipher({ name: "cipher2" }));
       importResult.collectionRelationships.push([0, 0]);
@@ -249,12 +222,6 @@ describe("ImportService", () => {
     });
 
     it("passing importTarget, folderRelationship has the expected values", async () => {
-      folderService.getAllDecryptedFromState.mockResolvedValue([
-        mockImportTargetFolder,
-        mockFolder1,
-        mockFolder2,
-      ]);
-
       importResult.folders.push(mockFolder1);
       importResult.folders.push(mockFolder2);
 


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While reviewing https://github.com/bitwarden/clients/pull/14871 I noticed that some of the setup/mock code wasn't actually needed anymore. This PR removes those unneeded mock setups (arrange).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
