### PR TITLE
[PM-22390] Fix manage device approval permission gate

### DIFF
--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -302,8 +302,15 @@ export class Organization {
     return this.isAdmin || this.permissions.manageResetPassword;
   }
 
+  /**
+   * @returns True if the user can manage device approvals. To maintain backwards compatibility with the legacy coupling of manageResetPassword and manageUsers permission,
+   * the latter has been added as a prerequisite.
+   */
   get canManageDeviceApprovals() {
-    return (this.isAdmin || this.permissions.manageResetPassword) && this.useSso;
+    return (
+      (this.isAdmin || (this.permissions.manageResetPassword && this.permissions.manageUsers)) &&
+      this.useSso
+    );
   }
 
   get isExemptFromPolicies() {

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -307,10 +307,15 @@ export class Organization {
    * the latter has been added as a prerequisite.
    */
   get canManageDeviceApprovals() {
-    return (
-      (this.isAdmin || (this.permissions.manageResetPassword && this.permissions.manageUsers)) &&
-      this.useSso
-    );
+    if (!this.useSso) {
+      return false;
+    }
+
+    if (this.isAdmin) {
+      return true;
+    }
+
+    return this.permissions.manageResetPassword && this.permissions.manageUsers;
   }
 
   get isExemptFromPolicies() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22390

## 📔 Objective

> To maintain backwards compatibility with the legacy custom permission coupling of the `manageResetPassword` and `manageUsers`, add the latter to the check for whether a use can manage device approvals


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
