### PR TITLE
[PM-22392] Fix CLI device approval permission gate

### DIFF
--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/approve-all.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/approve-all.command.ts
@@ -35,7 +35,7 @@ export class ApproveAllCommand {
         .organizations$(userId)
         .pipe(map((organizations) => organizations.find((o) => o.id === organizationId))),
     );
-    if (!organization?.canManageUsersPassword) {
+    if (!organization?.canManageDeviceApprovals) {
       return Response.error(
         "You do not have permission to approve pending device authorization requests.",
       );

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/approve.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/approve.command.ts
@@ -44,7 +44,7 @@ export class ApproveCommand {
         .organizations$(userId)
         .pipe(map((organizations) => organizations?.find((o) => o.id === organizationId))),
     );
-    if (!organization?.canManageUsersPassword) {
+    if (!organization?.canManageDeviceApprovals) {
       return Response.error(
         "You do not have permission to approve pending device authorization requests.",
       );

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/deny-all.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/deny-all.command.ts
@@ -39,7 +39,7 @@ export class DenyAllCommand {
         .organizations$(userId)
         .pipe(map((organizations) => organizations.find((o) => o.id === organizationId))),
     );
-    if (!organization?.canManageUsersPassword) {
+    if (!organization?.canManageDeviceApprovals) {
       return Response.error(
         "You do not have permission to approve pending device authorization requests.",
       );

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/deny.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/deny.command.ts
@@ -43,7 +43,7 @@ export class DenyCommand {
         .organizations$(userId)
         .pipe(map((organizations) => organizations.find((o) => o.id === organizationId))),
     );
-    if (!organization?.canManageUsersPassword) {
+    if (!organization?.canManageDeviceApprovals) {
       return Response.error(
         "You do not have permission to approve pending device authorization requests.",
       );

--- a/bitwarden_license/bit-cli/src/admin-console/device-approval/list.command.ts
+++ b/bitwarden_license/bit-cli/src/admin-console/device-approval/list.command.ts
@@ -39,7 +39,7 @@ export class ListCommand {
         .organizations$(userId)
         .pipe(map((organizations) => organizations.find((o) => o.id === organizationId))),
     );
-    if (!organization?.canManageUsersPassword) {
+    if (!organization?.canManageDeviceApprovals) {
       return Response.error(
         "You do not have permission to approve pending device authorization requests.",
       );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22392

## 📔 Objective

> Update the current permission gate for managing device approvals from `canManageUsersPassword` to `canManageDeviceApprovals` which is inherently more explicit with the required permissions.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
