### PR TITLE
[SM-916] Changing the text for creating a new access token from "add access to…

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7696,8 +7696,8 @@
     "message": "Access tokens",
     "description": "Title for the section displaying access tokens."
   },
-  "newAccessToken": {
-    "message": "New access token",
+  "createAccessToken": {
+    "message": "Create access token",
     "description": "Button label for creating a new access token."
   },
   "expires": {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-list.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-list.component.html
@@ -13,7 +13,7 @@
     (click)="newAccessTokenEvent.emit()"
   >
     <i class="bwi bwi-plus" aria-hidden="true"></i>
-    {{ "newAccessToken" | i18n }}
+    {{ "createAccessToken" | i18n }}
   </button>
 </bit-no-items>
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit">
   <bit-dialog dialogSize="default">
     <ng-container bitDialogTitle>
-      <span>{{ "newAccessToken" | i18n }}</span>
+      <span>{{ "createAccessToken" | i18n }}</span>
       <span class="tw-text-sm tw-normal-case tw-text-muted">
         {{ data.serviceAccountView.name }}
       </span>
@@ -21,7 +21,7 @@
 
     <ng-container bitDialogFooter>
       <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "newAccessToken" | i18n }}
+        {{ "createAccessToken" | i18n }}
       </button>
       <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -1,4 +1,4 @@
-<bit-dialog dialogSize="default" [title]="'newAccessToken' | i18n" [subtitle]="data.subTitle">
+<bit-dialog dialogSize="default" [title]="'createAccessToken' | i18n" [subtitle]="data.subTitle">
   <div bitDialogContent>
     <bit-callout type="info" [title]="'accessTokenCallOutTitle' | i18n">
       {{ "downloadAccessToken" | i18n }}<br />

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.html
@@ -39,7 +39,7 @@
     (click)="openNewAccessTokenDialog()"
   >
     <i class="bwi bwi-plus" aria-hidden="true"></i>
-    {{ "newAccessToken" | i18n }}
+    {{ "createAccessToken" | i18n }}
   </button>
 </app-header>
 <router-outlet></router-outlet>


### PR DESCRIPTION
to "Create access token"

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-916

## 📔 Objective

Dialog header should be updated to be “Create access token”

Dialog button should be updated to be “Create access token”

Top Bar  “+ New access token“ should be updated to be “+ Create access token”

## 📸 Screenshots

https://www.loom.com/share/84b126e2216244f3836b23f6f7f1b592?sid=2f8d1fd8-9b2c-4f66-ab36-ed306fbb2bc5
![image](https://github.com/user-attachments/assets/78c0a0a3-d783-41d5-a7ee-ab247948b72a)
![image](https://github.com/user-attachments/assets/1e52b674-4174-4883-9aa7-12e75015075f)
![image](https://github.com/user-attachments/assets/9fa01a2c-f1bf-4994-9fbd-ffad7ca8b97d)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
