### PR TITLE
[PM-22355] Use members table data to find number of invited users

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -110,12 +110,6 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
   protected rowHeight = 69;
   protected rowHeightClass = `tw-h-[69px]`;
 
-  private organizationUsersCount = 0;
-
-  get occupiedSeatCount(): number {
-    return this.organizationUsersCount;
-  }
-
   constructor(
     apiService: ApiService,
     i18nService: I18nService,
@@ -220,7 +214,6 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
           );
 
           this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
-          this.organizationUsersCount = billingMetadata.organizationOccupiedSeats;
 
           await this.load();
 
@@ -498,7 +491,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
         kind: "Add",
         organizationId: this.organization.id,
         allOrganizationUserEmails: this.dataSource.data?.map((user) => user.email) ?? [],
-        occupiedSeatCount: this.occupiedSeatCount,
+        occupiedSeatCount: this.dataSource.data.length,
         isOnSecretsManagerStandalone: this.orgIsOnSecretsManagerStandalone,
       },
     });
@@ -532,7 +525,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
   }
 
   async invite() {
-    if (this.organization.hasReseller && this.organization.seats === this.occupiedSeatCount) {
+    if (this.organization.hasReseller && this.organization.seats === this.dataSource.data.length) {
       this.toastService.showToast({
         variant: "error",
         title: this.i18nService.t("seatLimitReached"),
@@ -543,11 +536,10 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
     }
 
     if (
-      this.occupiedSeatCount === this.organization.seats &&
+      this.dataSource.data.length === this.organization.seats &&
       isFixedSeatPlan(this.organization.productTierType)
     ) {
       await this.handleSeatLimitForFixedTiers();
-
       return;
     }
 

--- a/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
+++ b/libs/common/src/billing/models/response/organization-billing-metadata.response.ts
@@ -11,7 +11,6 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
   invoiceCreatedDate: Date | null;
   subPeriodEndDate: Date | null;
   isSubscriptionCanceled: boolean;
-  organizationOccupiedSeats: number;
 
   constructor(response: any) {
     super(response);
@@ -26,7 +25,6 @@ export class OrganizationBillingMetadataResponse extends BaseResponse {
     this.invoiceCreatedDate = this.parseDate(this.getResponseProperty("InvoiceCreatedDate"));
     this.subPeriodEndDate = this.parseDate(this.getResponseProperty("SubPeriodEndDate"));
     this.isSubscriptionCanceled = this.getResponseProperty("IsSubscriptionCanceled");
-    this.organizationOccupiedSeats = this.getResponseProperty("OrganizationOccupiedSeats");
   }
 
   private parseDate(dateString: any): Date | null {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-22355

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

A previous implementation added a backend DB fetch to the organization metadata resolver to identify how many occupied seats an organization had when figuring out whether to pop the upgrade modal on the AC Members page. 

This was not necessary since we can just use the Members component's table data source length, which contains the same data.

This PR reverts the original changes and uses the table data source to enforce that check. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
