### PR TITLE
PM-22114

### DIFF
--- a/libs/importer/src/importers/roboform-csv-importer.ts
+++ b/libs/importer/src/importers/roboform-csv-importer.ts
@@ -30,8 +30,10 @@ export class RoboFormCsvImporter extends BaseImporter implements Importer {
       cipher.login.password = this.getValueOrDefault(value.Pwd);
       cipher.login.uris = this.makeUriArray(value.Url);
 
-      if (!this.isNullOrWhitespace(value.Rf_fields)) {
-        let fields: string[] = [value.Rf_fields];
+      if (!this.isNullOrWhitespace(value.Rf_fields) || !this.isNullOrWhitespace(value.RfFieldsV2)) {
+        let fields: string[] = [value.Rf_fields, value.RfFieldsV2].filter(
+          (f) => !this.isNullOrWhitespace(f),
+        );
         if (value.__parsed_extra != null && value.__parsed_extra.length > 0) {
           fields = fields.concat(value.__parsed_extra);
         }

--- a/libs/importer/src/importers/roboform-csv-importer.ts
+++ b/libs/importer/src/importers/roboform-csv-importer.ts
@@ -30,10 +30,8 @@ export class RoboFormCsvImporter extends BaseImporter implements Importer {
       cipher.login.password = this.getValueOrDefault(value.Pwd);
       cipher.login.uris = this.makeUriArray(value.Url);
 
-      if (!this.isNullOrWhitespace(value.Rf_fields) || !this.isNullOrWhitespace(value.RfFieldsV2)) {
-        let fields: string[] = [value.Rf_fields, value.RfFieldsV2].filter(
-          (f) => !this.isNullOrWhitespace(f),
-        );
+      if (!this.isNullOrWhitespace(value.Rf_fields)) {
+        let fields: string[] = [value.Rf_fields];
         if (value.__parsed_extra != null && value.__parsed_extra.length > 0) {
           fields = fields.concat(value.__parsed_extra);
         }
@@ -44,6 +42,28 @@ export class RoboFormCsvImporter extends BaseImporter implements Importer {
           }
           const key = parts[0] === "-no-name-" ? null : parts[0];
           const val = parts.length === 4 && parts[2] === "rck" ? parts[1] : parts[2];
+          this.processKvp(cipher, key, val);
+        });
+      } else if (!this.isNullOrWhitespace(value.RfFieldsV2)) {
+        let fields: string[] = [value.RfFieldsV2];
+        if (value.__parsed_extra != null && value.__parsed_extra.length > 0) {
+          fields = fields.concat(value.__parsed_extra);
+        }
+        fields.forEach((field: string) => {
+          const parts = field.split(",");
+          if (parts.length < 3) {
+            return;
+          }
+          const key = parts[0] === "-no-name-" ? null : parts[0];
+          if (
+            key === "User ID$" ||
+            key === "Password$" ||
+            key === "TOTP KEY$" ||
+            key === "Script$"
+          ) {
+            return;
+          }
+          const val = parts[4];
           this.processKvp(cipher, key, val);
         });
       }

--- a/libs/importer/src/importers/roboform-csv-importer.ts
+++ b/libs/importer/src/importers/roboform-csv-importer.ts
@@ -55,14 +55,6 @@ export class RoboFormCsvImporter extends BaseImporter implements Importer {
             return;
           }
           const key = parts[0] === "-no-name-" ? null : parts[0];
-          if (
-            key === "User ID$" ||
-            key === "Password$" ||
-            key === "TOTP KEY$" ||
-            key === "Script$"
-          ) {
-            return;
-          }
           const val = parts[4];
           this.processKvp(cipher, key, val);
         });


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/14965

## 📔 Objective

After the introduction of a new `RfFieldsV2` field in the Roboform export csv, the Bitwarden import is broken - custom fields are not being imported.

This PR aims to fix the import of custom fields, whilst keeping support for the old `Rf_fields` field.
 
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
