### PR TITLE
Failsafe for Brave's chromium forced rendering of opaque bkgd

### DIFF
--- a/apps/browser/src/autofill/notification/bar.html
+++ b/apps/browser/src/autofill/notification/bar.html
@@ -3,6 +3,7 @@
   <head>
     <title>Bitwarden</title>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
   </head>
 
   <body>


### PR DESCRIPTION

## 🎟️ Tracking

[PM-22431](https://bitwarden.atlassian.net/browse/PM-22431)

## 📔 Objective

Failsafe for Brave's chromium forced rendering of opaque background when theme color of site is mismatched with iframe content.

Per WC3, if color scheme differs from parent, an opaque background is forced. 'light dark' prevents a possible mismatch

Source: https://github.com/w3c/csswg-drafts/issues/4772#issuecomment-591553929

## 📸 Screenshots

### Before

<img width="550" src="https://github.com/user-attachments/assets/2497163c-c4ed-47df-972c-d35f77a7b556" />

### After

<img width="481" alt="Screenshot 2025-06-05 at 4 02 19 PM" src="https://github.com/user-attachments/assets/320ceee3-b111-4b8c-abfd-f13ed6ec0f5d" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
