### PR TITLE
[PM-22134] Migrate to `CipherListView`

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -30,6 +30,7 @@ import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
   DIALOG_DATA,
   DialogRef,
@@ -93,7 +94,7 @@ export interface VaultItemDialogParams {
   /**
    * Function to restore a cipher from the trash.
    */
-  restore?: (c: CipherView) => Promise<boolean>;
+  restore?: (c: CipherViewLike) => Promise<boolean>;
 }
 
 export const VaultItemDialogResult = {

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -4,7 +4,7 @@
     type="checkbox"
     bitCheckbox
     appStopProp
-    [disabled]="disabled || cipher.decryptionFailure"
+    [disabled]="disabled"
     [checked]="checked"
     (change)="$event ? this.checkedToggled.next() : null"
     [attr.aria-label]="'vaultItemSelect' | i18n"
@@ -30,7 +30,7 @@
     >
       {{ cipher.name }}
     </button>
-    <ng-container *ngIf="cipher.hasAttachments">
+    <ng-container *ngIf="hasAttachments">
       <i
         class="bwi bwi-paperclip tw-ml-2 tw-leading-normal"
         appStopProp
@@ -50,7 +50,7 @@
     </ng-container>
   </div>
   <br />
-  <span class="tw-text-sm tw-text-muted" appStopProp>{{ cipher.subTitle }}</span>
+  <span class="tw-text-sm tw-text-muted" appStopProp>{{ subtitle }}</span>
 </td>
 <td bitCell [ngClass]="RowHeightClass" *ngIf="showOwner" class="tw-hidden lg:tw-table-cell">
   <app-org-badge
@@ -76,7 +76,7 @@
 </td>
 <td bitCell [ngClass]="RowHeightClass" class="tw-text-right">
   <button
-    *ngIf="cipher.decryptionFailure"
+    *ngIf="false"
     [disabled]="disabled || !canManageCollection"
     [bitMenuTriggerFor]="corruptedCipherOptions"
     size="small"
@@ -94,12 +94,12 @@
     >
       <span class="tw-text-danger">
         <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
-        {{ (cipher.isDeleted ? "permanentlyDelete" : "delete") | i18n }}
+        {{ (isDeleted ? "permanentlyDelete" : "delete") | i18n }}
       </span>
     </button>
   </bit-menu>
   <button
-    *ngIf="!cipher.decryptionFailure"
+    *ngIf="!false"
     [disabled]="disabled || disableMenu"
     [bitMenuTriggerFor]="cipherOptions"
     size="small"
@@ -124,9 +124,9 @@
       </button>
       <a
         bitMenuItem
-        *ngIf="cipher.login.canLaunch"
+        *ngIf="canLaunch"
         type="button"
-        [href]="cipher.login.launchUri"
+        [href]="launchUri"
         target="_blank"
         rel="noreferrer"
       >
@@ -160,7 +160,7 @@
       bitMenuItem
       (click)="restore()"
       type="button"
-      *ngIf="(limitItemDeletion$ | async) ? cipher.isDeleted && canRestoreCipher : cipher.isDeleted"
+      *ngIf="(limitItemDeletion$ | async) ? isDeleted && canRestoreCipher : isDeleted"
     >
       <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
       {{ "restore" | i18n }}
@@ -173,7 +173,7 @@
     >
       <span class="tw-text-danger">
         <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
-        {{ (cipher.isDeleted ? "permanentlyDelete" : "delete") | i18n }}
+        {{ (isDeleted ? "permanentlyDelete" : "delete") | i18n }}
       </span>
     </button>
   </bit-menu>

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.html
@@ -4,7 +4,7 @@
     type="checkbox"
     bitCheckbox
     appStopProp
-    [disabled]="disabled"
+    [disabled]="disabled || decryptionFailure"
     [checked]="checked"
     (change)="$event ? this.checkedToggled.next() : null"
     [attr.aria-label]="'vaultItemSelect' | i18n"
@@ -76,7 +76,7 @@
 </td>
 <td bitCell [ngClass]="RowHeightClass" class="tw-text-right">
   <button
-    *ngIf="false"
+    *ngIf="decryptionFailure"
     [disabled]="disabled || !canManageCollection"
     [bitMenuTriggerFor]="corruptedCipherOptions"
     size="small"
@@ -99,7 +99,7 @@
     </button>
   </bit-menu>
   <button
-    *ngIf="!false"
+    *ngIf="!decryptionFailure"
     [disabled]="disabled || disableMenu"
     [bitMenuTriggerFor]="cipherOptions"
     size="small"

--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
@@ -7,7 +7,6 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { SafeUrls } from "@bitwarden/common/platform/misc/safe-urls";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import {
   CipherViewLike,
@@ -84,7 +83,7 @@ export class VaultCipherRowComponent<C extends CipherViewLike> implements OnInit
   }
 
   protected get clickAction() {
-    if ("decryptionFailure" in this.cipher && this.cipher.decryptionFailure) {
+    if (this.decryptionFailure) {
       return "showFailedToDecrypt";
     }
 
@@ -105,7 +104,7 @@ export class VaultCipherRowComponent<C extends CipherViewLike> implements OnInit
       return this.cipher.hasOldAttachments && this.cipher.organizationId != null;
     }
 
-    // Need to handle CipherListView case
+    // TODO: Handle CipherListView case, possibly not needed?
     return false;
   }
 
@@ -131,6 +130,11 @@ export class VaultCipherRowComponent<C extends CipherViewLike> implements OnInit
 
   protected get isDeleted() {
     return CipherViewLikeUtils.isDeleted(this.cipher);
+  }
+
+  protected get decryptionFailure() {
+    // TODO: Handle `CipherListView` case when available in the SDK.
+    return "decryptionFailure" in this.cipher && this.cipher.decryptionFailure;
   }
 
   protected get showAssignToCollections() {

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -5,6 +5,7 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { CollectionAdminView, Unassigned, CollectionView } from "@bitwarden/admin-console/common";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { GroupView } from "../../../admin-console/organizations/core";
 
@@ -20,7 +21,7 @@ import { RowHeightClass } from "./vault-items.component";
   templateUrl: "vault-collection-row.component.html",
   standalone: false,
 })
-export class VaultCollectionRowComponent {
+export class VaultCollectionRowComponent<C extends CipherViewLike> {
   protected RowHeightClass = RowHeightClass;
   protected Unassigned = "unassigned";
 
@@ -36,7 +37,7 @@ export class VaultCollectionRowComponent {
   @Input() groups: GroupView[];
   @Input() showPermissionsColumn: boolean;
 
-  @Output() onEvent = new EventEmitter<VaultItemEvent>();
+  @Output() onEvent = new EventEmitter<VaultItemEvent<C>>();
 
   @Input() checked: boolean;
   @Output() checkedToggled = new EventEmitter<void>();

--- a/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
@@ -1,17 +1,17 @@
 import { CollectionView } from "@bitwarden/admin-console/common";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { VaultItem } from "./vault-item";
 
-export type VaultItemEvent =
-  | { type: "viewAttachments"; item: CipherView }
+export type VaultItemEvent<C extends CipherViewLike> =
+  | { type: "viewAttachments"; item: C }
   | { type: "bulkEditCollectionAccess"; items: CollectionView[] }
   | { type: "viewCollectionAccess"; item: CollectionView; readonly: boolean }
-  | { type: "viewEvents"; item: CipherView }
+  | { type: "viewEvents"; item: C }
   | { type: "editCollection"; item: CollectionView; readonly: boolean }
-  | { type: "clone"; item: CipherView }
-  | { type: "restore"; items: CipherView[] }
-  | { type: "delete"; items: VaultItem[] }
-  | { type: "copyField"; item: CipherView; field: "username" | "password" | "totp" }
-  | { type: "moveToFolder"; items: CipherView[] }
-  | { type: "assignToCollections"; items: CipherView[] };
+  | { type: "clone"; item: C }
+  | { type: "restore"; items: C[] }
+  | { type: "delete"; items: VaultItem<C>[] }
+  | { type: "copyField"; item: C; field: "username" | "password" | "totp" }
+  | { type: "moveToFolder"; items: C[] }
+  | { type: "assignToCollections"; items: C[] };

--- a/apps/web/src/app/vault/components/vault-items/vault-item.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-item.ts
@@ -1,7 +1,7 @@
 import { CollectionView } from "@bitwarden/admin-console/common";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
-export interface VaultItem {
+export interface VaultItem<C extends CipherViewLike> {
   collection?: CollectionView;
-  cipher?: CipherView;
+  cipher?: C;
 }

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -8,8 +8,11 @@ import { CollectionView, Unassigned, CollectionAdminView } from "@bitwarden/admi
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { SortDirection, TableDataSource } from "@bitwarden/components";
 
 import { GroupView } from "../../../admin-console/organizations/core";
@@ -34,7 +37,7 @@ type ItemPermission = CollectionPermission | "NoAccess";
   templateUrl: "vault-items.component.html",
   standalone: false,
 })
-export class VaultItemsComponent {
+export class VaultItemsComponent<C extends CipherViewLike> {
   protected RowHeight = RowHeight;
 
   @Input() disabled: boolean;
@@ -58,11 +61,11 @@ export class VaultItemsComponent {
   @Input() addAccessToggle: boolean;
   @Input() activeCollection: CollectionView | undefined;
 
-  private _ciphers?: CipherView[] = [];
-  @Input() get ciphers(): CipherView[] {
+  private _ciphers?: C[] = [];
+  @Input() get ciphers(): C[] {
     return this._ciphers;
   }
-  set ciphers(value: CipherView[] | undefined) {
+  set ciphers(value: C[] | undefined) {
     this._ciphers = value ?? [];
     this.refreshItems();
   }
@@ -76,12 +79,12 @@ export class VaultItemsComponent {
     this.refreshItems();
   }
 
-  @Output() onEvent = new EventEmitter<VaultItemEvent>();
+  @Output() onEvent = new EventEmitter<VaultItemEvent<C>>();
 
   protected limitItemDeletion$ = this.configService.getFeatureFlag$(FeatureFlag.LimitItemDeletion);
-  protected editableItems: VaultItem[] = [];
-  protected dataSource = new TableDataSource<VaultItem>();
-  protected selection = new SelectionModel<VaultItem>(true, [], true);
+  protected editableItems: VaultItem<C>[] = [];
+  protected dataSource = new TableDataSource<VaultItem<C>>();
+  protected selection = new SelectionModel<VaultItem<C>>(true, [], true);
   protected canDeleteSelected$: Observable<boolean>;
   protected canRestoreSelected$: Observable<boolean>;
   protected disableMenu$: Observable<boolean>;
@@ -251,7 +254,7 @@ export class VaultItemsComponent {
       : this.selection.select(...this.editableItems.slice(0, MaxSelectionCount));
   }
 
-  protected event(event: VaultItemEvent) {
+  protected event(event: VaultItemEvent<C>) {
     this.onEvent.emit(event);
   }
 
@@ -281,7 +284,7 @@ export class VaultItemsComponent {
   }
 
   // TODO: PM-13944 Refactor to use cipherAuthorizationService.canClone$ instead
-  protected canClone(vaultItem: VaultItem) {
+  protected canClone(vaultItem: VaultItem<C>) {
     if (vaultItem.cipher.organizationId == null) {
       return true;
     }
@@ -305,7 +308,7 @@ export class VaultItemsComponent {
     return false;
   }
 
-  protected canEditCipher(cipher: CipherView) {
+  protected canEditCipher(cipher: C) {
     if (cipher.organizationId == null) {
       return true;
     }
@@ -314,14 +317,15 @@ export class VaultItemsComponent {
     return (organization.canEditAllCiphers && this.viewingOrgVault) || cipher.edit;
   }
 
-  protected canAssignCollections(cipher: CipherView) {
+  protected canAssignCollections(cipher: C) {
     const organization = this.allOrganizations.find((o) => o.id === cipher.organizationId);
     return (
-      (organization?.canEditAllCiphers && this.viewingOrgVault) || cipher.canAssignToCollections
+      (organization?.canEditAllCiphers && this.viewingOrgVault) ||
+      CipherViewLikeUtils.canAssignToCollections(cipher)
     );
   }
 
-  protected canManageCollection(cipher: CipherView) {
+  protected canManageCollection(cipher: C) {
     // If the cipher is not part of an organization (personal item), user can manage it
     if (cipher.organizationId == null) {
       return true;
@@ -353,9 +357,11 @@ export class VaultItemsComponent {
   }
 
   private refreshItems() {
-    const collections: VaultItem[] = this.collections.map((collection) => ({ collection }));
-    const ciphers: VaultItem[] = this.ciphers.map((cipher) => ({ cipher }));
-    const items: VaultItem[] = [].concat(collections).concat(ciphers);
+    const collections: VaultItem<C>[] = this.collections.map((collection) => ({ collection }));
+    const ciphers: VaultItem<C>[] = this.ciphers.map((cipher) => ({
+      cipher,
+    }));
+    const items: VaultItem<C>[] = [].concat(collections).concat(ciphers);
 
     this.selection.clear();
 
@@ -429,7 +435,7 @@ export class VaultItemsComponent {
   /**
    * Sorts VaultItems, grouping collections before ciphers, and sorting each group alphabetically by name.
    */
-  protected sortByName = (a: VaultItem, b: VaultItem, direction: SortDirection) => {
+  protected sortByName = (a: VaultItem<C>, b: VaultItem<C>, direction: SortDirection) => {
     // Collections before ciphers
     const collectionCompare = this.prioritizeCollections(a, b, direction);
     if (collectionCompare !== 0) {
@@ -442,7 +448,7 @@ export class VaultItemsComponent {
   /**
    * Sorts VaultItems based on group names
    */
-  protected sortByGroups = (a: VaultItem, b: VaultItem, direction: SortDirection) => {
+  protected sortByGroups = (a: VaultItem<C>, b: VaultItem<C>, direction: SortDirection) => {
     if (
       !(a.collection instanceof CollectionAdminView) &&
       !(b.collection instanceof CollectionAdminView)
@@ -483,8 +489,8 @@ export class VaultItemsComponent {
    * Sorts VaultItems based on their permissions, with higher permissions taking precedence.
    * If permissions are equal, it falls back to sorting by name.
    */
-  protected sortByPermissions = (a: VaultItem, b: VaultItem, direction: SortDirection) => {
-    const getPermissionPriority = (item: VaultItem): number => {
+  protected sortByPermissions = (a: VaultItem<C>, b: VaultItem<C>, direction: SortDirection) => {
+    const getPermissionPriority = (item: VaultItem<C>): number => {
       const permission = item.collection
         ? this.getCollectionPermission(item.collection)
         : this.getCipherPermission(item.cipher);
@@ -518,8 +524,8 @@ export class VaultItemsComponent {
     return this.compareNames(a, b);
   };
 
-  private compareNames(a: VaultItem, b: VaultItem): number {
-    const getName = (item: VaultItem) => item.collection?.name || item.cipher?.name;
+  private compareNames(a: VaultItem<C>, b: VaultItem<C>): number {
+    const getName = (item: VaultItem<C>) => item.collection?.name || item.cipher?.name;
     return getName(a).localeCompare(getName(b));
   }
 
@@ -527,7 +533,11 @@ export class VaultItemsComponent {
    * Sorts VaultItems by prioritizing collections over ciphers.
    * Collections are always placed before ciphers, regardless of the sorting direction.
    */
-  private prioritizeCollections(a: VaultItem, b: VaultItem, direction: SortDirection): number {
+  private prioritizeCollections(
+    a: VaultItem<C>,
+    b: VaultItem<C>,
+    direction: SortDirection,
+  ): number {
     if (a.collection && !b.collection) {
       return direction === "asc" ? -1 : 1;
     }
@@ -571,7 +581,7 @@ export class VaultItemsComponent {
     return "NoAccess";
   }
 
-  private getCipherPermission(cipher: CipherView): ItemPermission {
+  private getCipherPermission(cipher: C): ItemPermission {
     if (!cipher.organizationId || cipher.collectionIds.length === 0) {
       return CollectionPermission.Manage;
     }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
@@ -1,40 +1,46 @@
 import { Unassigned } from "@bitwarden/admin-console/common";
 import { CipherType } from "@bitwarden/common/vault/enums";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { All, RoutedVaultFilterModel } from "./routed-vault-filter.model";
 
-export type FilterFunction = (cipher: CipherView) => boolean;
+export type FilterFunction = (cipher: CipherViewLike) => boolean;
 
 export function createFilterFunction(filter: RoutedVaultFilterModel): FilterFunction {
   return (cipher) => {
+    const type = CipherViewLikeUtils.getType(cipher);
+    const isDeleted = CipherViewLikeUtils.isDeleted(cipher);
+
     if (filter.type === "favorites" && !cipher.favorite) {
       return false;
     }
-    if (filter.type === "card" && cipher.type !== CipherType.Card) {
+    if (filter.type === "card" && type !== CipherType.Card) {
       return false;
     }
-    if (filter.type === "identity" && cipher.type !== CipherType.Identity) {
+    if (filter.type === "identity" && type !== CipherType.Identity) {
       return false;
     }
-    if (filter.type === "login" && cipher.type !== CipherType.Login) {
+    if (filter.type === "login" && type !== CipherType.Login) {
       return false;
     }
-    if (filter.type === "note" && cipher.type !== CipherType.SecureNote) {
+    if (filter.type === "note" && type !== CipherType.SecureNote) {
       return false;
     }
-    if (filter.type === "sshKey" && cipher.type !== CipherType.SshKey) {
+    if (filter.type === "sshKey" && type !== CipherType.SshKey) {
       return false;
     }
-    if (filter.type === "trash" && !cipher.isDeleted) {
+    if (filter.type === "trash" && !isDeleted) {
       return false;
     }
     // Hide trash unless explicitly selected
-    if (filter.type !== "trash" && cipher.isDeleted) {
+    if (filter.type !== "trash" && isDeleted) {
       return false;
     }
     // No folder
-    if (filter.folderId === Unassigned && cipher.folderId !== null) {
+    if (filter.folderId === Unassigned && cipher.folderId != null) {
       return false;
     }
     // Folder

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
@@ -24,7 +24,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { LinkModule } from "@bitwarden/components";
 
 import { OnboardingModule } from "../../../shared/components/onboarding/onboarding.module";
@@ -44,7 +44,7 @@ import { VaultOnboardingService, VaultOnboardingTasks } from "./services/vault-o
   templateUrl: "vault-onboarding.component.html",
 })
 export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() ciphers: CipherView[];
+  @Input() ciphers: CipherViewLike[];
   @Input() orgs: Organization[];
   @Output() onAddCipher = new EventEmitter<CipherType>();
 

--- a/libs/angular/src/vault/components/icon.component.ts
+++ b/libs/angular/src/vault/components/icon.component.ts
@@ -13,7 +13,7 @@ import {
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { buildCipherIcon, CipherIconDetails } from "@bitwarden/common/vault/icon/build-cipher-icon";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 @Component({
   selector: "app-vault-icon",
@@ -25,7 +25,7 @@ export class IconComponent {
   /**
    * The cipher to display the icon for.
    */
-  cipher = input.required<CipherView>();
+  cipher = input.required<CipherViewLike>();
 
   imageLoaded = signal(false);
 

--- a/libs/common/src/abstractions/search.service.ts
+++ b/libs/common/src/abstractions/search.service.ts
@@ -5,6 +5,7 @@ import { Observable } from "rxjs";
 import { SendView } from "../tools/send/models/view/send.view";
 import { IndexedEntityId, UserId } from "../types/guid";
 import { CipherView } from "../vault/models/view/cipher.view";
+import { CipherViewLike } from "../vault/utils/cipher-view-like-utils";
 
 export abstract class SearchService {
   indexedEntityId$: (userId: UserId) => Observable<IndexedEntityId | null>;
@@ -16,12 +17,16 @@ export abstract class SearchService {
     ciphersToIndex: CipherView[],
     indexedEntityGuid?: string,
   ) => Promise<void>;
-  searchCiphers: (
+  searchCiphers: <C extends CipherViewLike>(
     userId: UserId,
     query: string,
-    filter?: ((cipher: CipherView) => boolean) | ((cipher: CipherView) => boolean)[],
-    ciphers?: CipherView[],
-  ) => Promise<CipherView[]>;
-  searchCiphersBasic: (ciphers: CipherView[], query: string, deleted?: boolean) => CipherView[];
+    filter?: ((cipher: C) => boolean) | ((cipher: C) => boolean)[],
+    ciphers?: C[],
+  ) => Promise<C[]>;
+  searchCiphersBasic: <C extends CipherViewLike>(
+    ciphers: C[],
+    query: string,
+    deleted?: boolean,
+  ) => C[];
   searchSends: (sends: SendView[], query: string) => SendView[];
 }

--- a/libs/common/src/services/search.service.ts
+++ b/libs/common/src/services/search.service.ts
@@ -19,6 +19,7 @@ import { IndexedEntityId, UserId } from "../types/guid";
 import { FieldType } from "../vault/enums";
 import { CipherType } from "../vault/enums/cipher-type";
 import { CipherView } from "../vault/models/view/cipher.view";
+import { CipherViewLike, CipherViewLikeUtils } from "../vault/utils/cipher-view-like-utils";
 
 export type SerializedLunrIndex = {
   version: string;
@@ -195,13 +196,13 @@ export class SearchService implements SearchServiceAbstraction {
     );
   }
 
-  async searchCiphers(
+  async searchCiphers<C extends CipherViewLike>(
     userId: UserId,
     query: string,
-    filter: ((cipher: CipherView) => boolean) | ((cipher: CipherView) => boolean)[] = null,
-    ciphers: CipherView[],
-  ): Promise<CipherView[]> {
-    const results: CipherView[] = [];
+    filter: ((cipher: C) => boolean) | ((cipher: C) => boolean)[] = null,
+    ciphers: C[],
+  ): Promise<C[]> {
+    const results: C[] = [];
     if (query != null) {
       query = SearchService.normalizeSearchQuery(query.trim().toLowerCase());
     }
@@ -216,7 +217,7 @@ export class SearchService implements SearchServiceAbstraction {
     if (filter != null && Array.isArray(filter) && filter.length > 0) {
       ciphers = ciphers.filter((c) => filter.every((f) => f == null || f(c)));
     } else if (filter != null) {
-      ciphers = ciphers.filter(filter as (cipher: CipherView) => boolean);
+      ciphers = ciphers.filter(filter as (cipher: C) => boolean);
     }
 
     if (!(await this.isSearchable(userId, query))) {
@@ -236,7 +237,7 @@ export class SearchService implements SearchServiceAbstraction {
       return this.searchCiphersBasic(ciphers, query);
     }
 
-    const ciphersMap = new Map<string, CipherView>();
+    const ciphersMap = new Map<string, C>();
     ciphers.forEach((c) => ciphersMap.set(c.id, c));
 
     let searchResults: lunr.Index.Result[] = null;
@@ -270,10 +271,10 @@ export class SearchService implements SearchServiceAbstraction {
     return results;
   }
 
-  searchCiphersBasic(ciphers: CipherView[], query: string, deleted = false) {
+  searchCiphersBasic<C extends CipherViewLike>(ciphers: C[], query: string, deleted = false) {
     query = SearchService.normalizeSearchQuery(query.trim().toLowerCase());
     return ciphers.filter((c) => {
-      if (deleted !== c.isDeleted) {
+      if (deleted !== CipherViewLikeUtils.isDeleted(c)) {
         return false;
       }
       if (c.name != null && c.name.toLowerCase().indexOf(query) > -1) {
@@ -282,13 +283,17 @@ export class SearchService implements SearchServiceAbstraction {
       if (query.length >= 8 && c.id.startsWith(query)) {
         return true;
       }
-      if (c.subTitle != null && c.subTitle.toLowerCase().indexOf(query) > -1) {
+      const subtitle = CipherViewLikeUtils.subtitle(c);
+      if (subtitle != null && subtitle.toLowerCase().indexOf(query) > -1) {
         return true;
       }
+
+      const login = CipherViewLikeUtils.getCipherViewLikeLogin(c);
+
       if (
-        c.login &&
-        c.login.hasUris &&
-        c.login.uris.some((loginUri) => loginUri?.uri?.toLowerCase().indexOf(query) > -1)
+        login &&
+        login.uris.length &&
+        login.uris.some((loginUri) => loginUri?.uri?.toLowerCase().indexOf(query) > -1)
       ) {
         return true;
       }

--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -5,6 +5,7 @@ import { Observable } from "rxjs";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { UserKeyRotationDataProvider } from "@bitwarden/key-management";
+import { CipherListView } from "@bitwarden/sdk-internal";
 
 import { UriMatchStrategySetting } from "../../models/domain/domain-service";
 import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
@@ -29,6 +30,7 @@ export type EncryptionContext = {
 
 export abstract class CipherService implements UserKeyRotationDataProvider<CipherWithIdRequest> {
   abstract cipherViews$(userId: UserId): Observable<CipherView[]>;
+  abstract cipherListViews$(userId: UserId): Observable<CipherListView[]>;
   abstract ciphers$(userId: UserId): Observable<Record<CipherId, CipherData>>;
   abstract localData$(userId: UserId): Observable<Record<CipherId, LocalData>>;
   /**

--- a/libs/common/src/vault/icon/build-cipher-icon.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.ts
@@ -1,6 +1,6 @@
 import { Utils } from "../../platform/misc/utils";
 import { CipherType } from "../enums/cipher-type";
-import { CipherView } from "../models/view/cipher.view";
+import { CipherViewLike, CipherViewLikeUtils } from "../utils/cipher-view-like-utils";
 
 export interface CipherIconDetails {
   imageEnabled: boolean;
@@ -14,7 +14,7 @@ export interface CipherIconDetails {
 
 export function buildCipherIcon(
   iconsServerUrl: string | null,
-  cipher: CipherView,
+  cipher: CipherViewLike,
   showFavicon: boolean,
 ): CipherIconDetails {
   let icon: string = "bwi-globe";
@@ -36,12 +36,15 @@ export function buildCipherIcon(
     showFavicon = false;
   }
 
-  switch (cipher.type) {
+  const cipherType = CipherViewLikeUtils.getType(cipher);
+  const login = CipherViewLikeUtils.getCipherViewLikeLogin(cipher);
+
+  switch (cipherType) {
     case CipherType.Login:
       icon = "bwi-globe";
 
-      if (cipher.login.uri) {
-        let hostnameUri = cipher.login.uri;
+      if (login?.uris?.length) {
+        let hostnameUri = login.uris[0]?.uri || "";
         let isWebsite = false;
 
         if (hostnameUri.indexOf("androidapp://") === 0) {
@@ -84,7 +87,7 @@ export function buildCipherIcon(
       break;
     case CipherType.Card:
       icon = "bwi-credit-card";
-      if (showFavicon && cipher.card.brand in cardIcons) {
+      if (showFavicon && "card" in cipher && cipher.card.brand in cardIcons) {
         icon = `credit-card-icon ${cardIcons[cipher.card.brand]}`;
       }
       break;

--- a/libs/common/src/vault/services/cipher-authorization.service.ts
+++ b/libs/common/src/vault/services/cipher-authorization.service.ts
@@ -11,12 +11,12 @@ import { CollectionId } from "@bitwarden/common/types/guid";
 import { getUserId } from "../../auth/services/account.service";
 import { FeatureFlag } from "../../enums/feature-flag.enum";
 import { Cipher } from "../models/domain/cipher";
-import { CipherView } from "../models/view/cipher.view";
+import { CipherViewLike } from "../utils/cipher-view-like-utils";
 
 /**
  * Represents either a cipher or a cipher view.
  */
-type CipherLike = Cipher | CipherView;
+type CipherLike = Cipher | CipherViewLike;
 
 /**
  * Service for managing user cipher authorization.
@@ -108,7 +108,7 @@ export class DefaultCipherAuthorizationService implements CipherAuthorizationSer
         }
 
         if (featureFlagEnabled) {
-          return of(cipher.permissions.delete);
+          return of(!!cipher.permissions?.delete);
         }
 
         if (cipher.organizationId == null) {
@@ -150,7 +150,7 @@ export class DefaultCipherAuthorizationService implements CipherAuthorizationSer
           }
         }
 
-        return cipher.permissions.restore;
+        return !!cipher.permissions?.restore;
       }),
     );
   }

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -1,0 +1,125 @@
+import { SafeUrls } from "@bitwarden/common/platform/misc/safe-urls";
+import { CipherListView } from "@bitwarden/sdk-internal";
+
+import { CipherType } from "../enums";
+import { CipherView } from "../models/view/cipher.view";
+
+/**
+ * Type union of {@link CipherView} and {@link CipherListView}.
+ */
+export type CipherViewLike = CipherView | CipherListView;
+
+/**
+ * Utility class for working with ciphers that can be either a {@link CipherView} or a {@link CipherListView}.
+ */
+export class CipherViewLikeUtils {
+  /** @returns true when the given cipher is an instance of {@link CipherListView}. */
+  static isCipherListView = (cipher: CipherViewLike): cipher is CipherListView => {
+    return typeof cipher.type !== "number";
+  };
+
+  /** @returns The login object from the input cipher. If the cipher is not of type Login, returns null. */
+  static getCipherViewLikeLogin = (cipher: CipherViewLike) => {
+    if (this.isCipherListView(cipher)) {
+      if (typeof cipher.type !== "object") {
+        return null;
+      }
+
+      return cipher.type.login;
+    }
+
+    return cipher.type === CipherType.Login ? cipher.login : null;
+  };
+
+  /**  @returns `true` when the cipher has been deleted, `false` otherwise. */
+  static isDeleted = (cipher: CipherViewLike): boolean => {
+    if (this.isCipherListView(cipher)) {
+      return !!cipher.deletedDate;
+    }
+
+    return cipher.isDeleted;
+  };
+
+  /** @returns `true` when the user can assign the cipher to a collection, `false` otherwise. */
+  static canAssignToCollections = (cipher: CipherViewLike): boolean => {
+    if (this.isCipherListView(cipher)) {
+      if (!cipher.organizationId) {
+        return true;
+      }
+
+      return cipher.edit && cipher.viewPassword;
+    }
+
+    return cipher.canAssignToCollections;
+  };
+
+  /**
+   * Returns the type of the cipher.
+   * For consistency, when the given cipher is a {@link CipherListView} the {@link CipherType} equivalent will be returned.
+   */
+  static getType = (cipher: CipherViewLike): CipherType => {
+    if (!this.isCipherListView(cipher)) {
+      return cipher.type;
+    }
+
+    // CipherListViewType is a string, so we need to map it to CipherType.
+    switch (cipher.type) {
+      case "secureNote":
+        return CipherType.SecureNote;
+      case "card":
+        return CipherType.Card;
+      case "identity":
+        return CipherType.Identity;
+      case "sshKey":
+        return CipherType.SshKey;
+      default:
+        return CipherType.Login;
+    }
+  };
+
+  /** @returns The subtitle of the cipher. */
+  static subtitle = (cipher: CipherViewLike): string | undefined => {
+    if (!this.isCipherListView(cipher)) {
+      return cipher.subTitle;
+    }
+
+    return cipher.subtitle;
+  };
+
+  /** @returns `true` when the cipher has attachments, false otherwise. */
+  static hasAttachments = (cipher: CipherViewLike): boolean => {
+    if (this.isCipherListView(cipher)) {
+      return typeof cipher.attachments === "number" && cipher.attachments > 0;
+    }
+
+    return cipher.hasAttachments;
+  };
+
+  /**
+   * @returns `true` when one of the URIs for the cipher can be launched.
+   * When a non-login cipher is passed, it will return false.
+   */
+  static canLaunch = (cipher: CipherViewLike): boolean => {
+    const login = this.getCipherViewLikeLogin(cipher);
+
+    if (!login) {
+      return false;
+    }
+
+    return !!login.uris?.map((u) => u.uri).some((uri) => uri && SafeUrls.canLaunch(uri));
+  };
+
+  /**
+   * @returns The first launch-able URI for the cipher.
+   * When a non-login cipher is passed or none of the URLs, it will return undefined.
+   */
+  static getLaunchUri = (cipher: CipherViewLike): string | undefined => {
+    const login = this.getCipherViewLikeLogin(cipher);
+
+    if (!login) {
+      return undefined;
+    }
+
+    return login.uris?.map((u) => u.uri).find((uri) => uri && SafeUrls.canLaunch(uri));
+  };
+}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Only for internal discussion.

### Approach

Create a `CipherViewLike` type that can either be a `CipherView` or `CipherViewList` 
- There are subtle differences between the two types, I created a class with static methods to handle both types. This saves us from having to create new components that support one CipherView type. For instance, the `type` isn't numeric it's an enum with associated value. 
- I could also see how this adds some complexity to each consuming component. Another idea I had is to create an internal `CipherViewList` model that matches the structure of `CipherView` for the needed attribute/methods. This felt like more computation and could cause confusion so I opted not to from the start.

Create `cipherListViews$` on the cipher service that returns the ciphers from the SDK.
- I think there is still some more work to do here like re-indexing.
  