### PR TITLE
[PM-22469] [PM-22468] fix: unhandled access token decryption failure case

### DIFF
--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -311,6 +311,14 @@ export class TokenService implements TokenServiceAbstraction {
       accessTokenKey,
     );
 
+    // We throw the error here to handle logging out the user in the try catch block of getAccessToken
+    // The catch block mentions "If an error occurs during decryption" - which is the case here.
+    if (!decryptedAccessToken) {
+      throw new Error(
+        "decryptAccessToken: Access token decryption failed. Access token key might be expired or invalid.",
+      );
+    }
+
     return decryptedAccessToken;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://github.com/bitwarden/clients/issues/15110

## 📔 Objective
This PR is a fix for the case where the Unknown Error repeatedly occurs on Windows machines. This appears to be a case where outdated or invalid Access Tokens are still being attempted to be accessed once someone logs in on another client on the same machine using the master password. Once invalidated by the login elsewhere, the client will always fail decryption on devices that are set up to use Windows Hello authentication and will repeatedly show the unknown error popups even upon restarts.

## 📸 Screenshots
None

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
