### PR TITLE
Fix word-breaking in passphrase display for generator and history

### DIFF
--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -44,7 +44,7 @@ export class ColorPasswordComponent {
 
   @HostBinding("class")
   get classList() {
-    return ["tw-min-w-0", "tw-whitespace-pre-wrap", "tw-break-all"];
+    return ["tw-min-w-0", "tw-whitespace-pre-wrap", "tw-break-words"];
   }
 
   getCharacterClass(character: string) {

--- a/libs/tools/generator/components/src/credential-generator.component.html
+++ b/libs/tools/generator/components/src/credential-generator.component.html
@@ -14,7 +14,7 @@
 <nudge-generator-spotlight></nudge-generator-spotlight>
 
 <bit-card class="tw-flex tw-justify-between tw-mb-4">
-  <div class="tw-grow tw-flex tw-items-center">
+  <div class="tw-grow tw-flex tw-items-center tw-min-w-0">
     <bit-color-password class="tw-font-mono" [password]="value$ | async"></bit-color-password>
   </div>
   <div class="tw-flex tw-items-center tw-space-x-1">

--- a/libs/tools/generator/components/src/password-generator.component.html
+++ b/libs/tools/generator/components/src/password-generator.component.html
@@ -11,7 +11,7 @@
   </bit-toggle>
 </bit-toggle-group>
 <bit-card class="tw-flex tw-justify-between tw-mb-4">
-  <div class="tw-grow tw-flex tw-items-center">
+  <div class="tw-grow tw-flex tw-items-center tw-min-w-0">
     <bit-color-password class="tw-font-mono" [password]="value$ | async"></bit-color-password>
   </div>
   <div class="tw-flex tw-items-center tw-space-x-1">


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20507](https://bitwarden.atlassian.net/browse/PM-20507)
Fixes https://github.com/bitwarden/clients/issues/14376

## 📔 Objective

Ensure passphrases are wrapped only at word separators ('-', ' ', '?') to avoid splitting words across lines. 
Improves readability in both the generator screen and history, in the Extension and Web Vault.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/43c569b0-2680-4782-9ff3-a1dba62bddb8)
![image](https://github.com/user-attachments/assets/da9f56d4-4d9f-4469-9f8c-ffca0039a4f9)
![image](https://github.com/user-attachments/assets/f10e678c-fe1c-4786-95dd-299ab38389a9)
![image](https://github.com/user-attachments/assets/38876f76-dd8e-4d7a-802d-5bd1d24e498b)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
