### PR TITLE
[PM-22269] Refactor aria-label to use screen reader only text

### DIFF
--- a/libs/tools/generator/components/src/nudge-generator-spotlight.component.html
+++ b/libs/tools/generator/components/src/nudge-generator-spotlight.component.html
@@ -3,11 +3,10 @@
     [title]="'generatorNudgeTitle' | i18n"
     (onDismiss)="dismissGeneratorSpotlight(NudgeType.GeneratorNudgeStatus)"
   >
-    <p
-      class="tw-text-main tw-mb-0"
-      bitTypography="body2"
-      [attr.aria-label]="'generatorNudgeBodyAria' | i18n"
-    >
+    <p class="tw-text-main tw-mb-0" bitTypography="body2">
+      <span class="tw-sr-only">
+        {{ "generatorNudgeBodyAria" | i18n }}
+      </span>
       <span aria-hidden="true">
         {{ "generatorNudgeBodyOne" | i18n }} <i class="bwi bwi-generate"></i>
         {{ "generatorNudgeBodyTwo" | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22269](https://bitwarden.atlassian.net/browse/PM-22269)

## 📔 Objective

Fix screen reader text for generator spotlight. The pattern used in [this pr](https://github.com/bitwarden/clients/pull/10490/files) helps with inconsistencies between browsers/screen readers from the `aria-label` usage. 

## 📸 Screenshots

<img width="500" alt="Screenshot 2025-06-09 at 9 50 34 AM" src="https://github.com/user-attachments/assets/34409cd1-fa92-4a08-b853-79df0b6f51c6" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22269]: https://bitwarden.atlassian.net/browse/PM-22269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ