### PR TITLE
[PM-22421] update copy for set pin modal

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2153,8 +2153,8 @@
   "setYourPinCode": {
     "message": "Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if you ever fully log out of the application."
   },
-  "setYourPinCode1": {
-    "message": "Your PIN will be used to unlock Bitwarden instead of your master password. Your PIN will reset if you ever fully log out of Bitwarden."
+  "setPinCode": {
+    "message": "You can use this PIN to unlock Bitwarden. Your PIN will be reset if you ever fully log out of the application."
   },
   "pinRequired": {
     "message": "PIN code is required."

--- a/apps/browser/src/auth/popup/components/set-pin.component.html
+++ b/apps/browser/src/auth/popup/components/set-pin.component.html
@@ -5,7 +5,7 @@
     </div>
     <div bitDialogContent>
       <p>
-        {{ "setYourPinCode1" | i18n }}
+        {{ "setPinCode" | i18n }}
       </p>
       <bit-form-field>
         <bit-label>{{ "pin" | i18n }}</bit-label>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22421](https://bitwarden.atlassian.net/browse/PM-22421)

## 📔 Objective

update copy of Set Pin Modal in Browser

## 📸 Screenshots

![Screenshot 2025-06-09 at 11 13 46 AM](https://github.com/user-attachments/assets/ddeb02f0-9674-4320-8e30-7efe365e51c2)

![Screenshot 2025-06-09 at 11 16 02 AM](https://github.com/user-attachments/assets/17accf44-7f97-4517-ae54-d7c3952b57da)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22421]: https://bitwarden.atlassian.net/browse/PM-22421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ