### PR TITLE
[PM-22534] Reduce IO by moving account_activity to memory instead of disk

### DIFF
--- a/libs/common/src/auth/services/account.service.ts
+++ b/libs/common/src/auth/services/account.service.ts
@@ -24,6 +24,7 @@ import { MessagingService } from "../../platform/abstractions/messaging.service"
 import { Utils } from "../../platform/misc/utils";
 import {
   ACCOUNT_DISK,
+  ACCOUNT_MEMORY,
   GlobalState,
   GlobalStateProvider,
   KeyDefinition,
@@ -44,7 +45,7 @@ export const ACCOUNT_ACTIVE_ACCOUNT_ID = new KeyDefinition(ACCOUNT_DISK, "active
   deserializer: (id: UserId) => id,
 });
 
-export const ACCOUNT_ACTIVITY = KeyDefinition.record<Date, UserId>(ACCOUNT_DISK, "activity", {
+export const ACCOUNT_ACTIVITY = KeyDefinition.record<Date, UserId>(ACCOUNT_MEMORY, "activity", {
   deserializer: (activity) => new Date(activity),
 });
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22534

## 📔 Objective

Moves the account activity timestamp to memory instead of disk. This value is [read every 250 ms](https://github.com/bitwarden/clients/blob/05cd1859a9b3600589f0ee625507fa7e6e464f3e/apps/web/src/app/app.component.ts#L335), and so moving it to memory drastically reduces disk I/O.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
