### PR TITLE
[PM-21719] Remove Assign To Collections Modal When No Editable Collections

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
@@ -31,7 +31,11 @@
       <a bitMenuItem (click)="clone()" *ngIf="canClone$ | async">
         {{ "clone" | i18n }}
       </a>
-      <a bitMenuItem *ngIf="hasOrganizations" (click)="conditionallyNavigateToAssignCollections()">
+      <a
+        bitMenuItem
+        *ngIf="canAssignCollections$ | async"
+        (click)="conditionallyNavigateToAssignCollections()"
+      >
         {{ "assignToCollections" | i18n }}
       </a>
     </ng-container>

--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -73,14 +73,15 @@ export class ItemMoreOptionsComponent {
   );
 
   /** Observable Boolean dependent on the current user having access to an organization and editable collections */
-  protected canAssignCollections$ = this.accountService.activeAccount$.pipe(getUserId).pipe(
+  protected canAssignCollections$ = this.accountService.activeAccount$.pipe(
+    getUserId,
     switchMap((userId) => {
       return combineLatest([
         this.organizationService.hasOrganizations(userId),
         this.collectionService.decryptedCollections$,
       ]).pipe(
         map(([hasOrgs, collections]) => {
-          const canEditCollections = collections.filter((c) => !c.readOnly).length > 0;
+          const canEditCollections = collections.some((c) => !c.readOnly);
           return hasOrgs && canEditCollections;
         }),
       );

--- a/apps/desktop/src/vault/app/vault/add-edit.component.html
+++ b/apps/desktop/src/vault/app/vault/add-edit.component.html
@@ -788,7 +788,13 @@
       <button
         type="button"
         (click)="share()"
-        *ngIf="editMode && cipher && !cipher.organizationId && !cloneMode"
+        *ngIf="
+          editMode &&
+          cipher &&
+          !cipher.organizationId &&
+          !cloneMode &&
+          writeableCollections.length > 0
+        "
       >
         {{ "move" | i18n }}
       </button>

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -298,8 +298,11 @@ export class VaultItemsComponent {
 
   protected canAssignCollections(cipher: CipherView) {
     const organization = this.allOrganizations.find((o) => o.id === cipher.organizationId);
+    const editableCollections = this.allCollections.filter((c) => !c.readOnly);
+
     return (
-      (organization?.canEditAllCiphers && this.viewingOrgVault) || cipher.canAssignToCollections
+      (organization?.canEditAllCiphers && this.viewingOrgVault) ||
+      (cipher.canAssignToCollections && editableCollections.length > 0)
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21719](https://bitwarden.atlassian.net/browse/PM-21719)

## 📔 Objective

Remove assign to collections option when user does not have editable collections
Remove Move button in desktop when no editable collections

## 📸 Screen Recording

https://github.com/user-attachments/assets/ecc7f47f-a81f-4458-9f47-e4e788797026


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21719]: https://bitwarden.atlassian.net/browse/PM-21719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ