### PR TITLE
Remove the blank popup when passkey enabled in MacOS settings

### DIFF
--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -148,13 +148,6 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         return Position(x: centerX, y:centerY)
     }
     
-    override func loadView() {
-        let view = NSView()
-        // Hide the native window since we only need the IPC connection
-        view.isHidden = true    
-        self.view = view
-    }
-    
     override func prepareInterfaceForExtensionConfiguration() {
         client.sendNativeStatus(key: "request-sync", value: "")
         self.extensionContext.completeExtensionConfigurationRequest()

--- a/apps/desktop/macos/autofill-extension/Info.plist
+++ b/apps/desktop/macos/autofill-extension/Info.plist
@@ -11,7 +11,7 @@
 				<key>ProvidesPasskeys</key>
 				<true />
 				<key>ShowsConfigurationUI</key>
-				<true />
+				<false />
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-22476](https://bitwarden.atlassian.net/browse/PM-22476)

## 📔 Objective

Remove the white modal that briefly displays when enabling Bitwarden as a passkey provider in MacOS System Settings.  Also removes the override code for `loadView` since it wasn't used.

## 📸 Screenshots

Before:

https://github.com/user-attachments/assets/90ff02e0-eab7-47c0-be0a-62805aadd011

After:

https://github.com/user-attachments/assets/84fffaf1-cca6-467a-b478-be56e4d6cb6d

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22476]: https://bitwarden.atlassian.net/browse/PM-22476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ