### PR TITLE
Reset modals so subsequent creates work

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -120,6 +120,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
       return;
     }
 
+    await this.resetModalState();
     this.session.notifyConfirmCreateCredential(isConfirmed, cipher);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22474](https://bitwarden.atlassian.net/browse/PM-22474)

## 📔 Objective

When a passkey is overwritten the function called does not reset the modal correctly which causes subsequent actions like creating a new passkey to fail.  This adds a call to reset the modal after overwriting a passkey.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22474]: https://bitwarden.atlassian.net/browse/PM-22474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ