### PR TITLE
[PM-22536] add encrypted collection name to confirmUser request

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user/organization-user.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user/organization-user.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from "@angular/core";
+import { combineLatest, filter, map, Observable, switchMap } from "rxjs";
+
+import {
+  OrganizationUserConfirmRequest,
+  OrganizationUserApiService,
+} from "@bitwarden/admin-console/common";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+
+import { OrganizationUserView } from "../../../core/views/organization-user.view";
+
+@Injectable({
+  providedIn: "root",
+})
+export class OrganizationUserService {
+  constructor(
+    protected keyService: KeyService,
+    private encryptService: EncryptService,
+    private organizationUserApiService: OrganizationUserApiService,
+    private accountService: AccountService,
+    private i18nService: I18nService,
+  ) {}
+
+  private orgKey$(organization: Organization) {
+    return this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) => this.keyService.orgKeys$(userId)),
+      filter((orgKeys) => !!orgKeys),
+      map((organizationKeysById) => organizationKeysById[organization.id as OrganizationId]),
+    );
+  }
+
+  confirmUser(
+    organization: Organization,
+    user: OrganizationUserView,
+    publicKey: Uint8Array,
+  ): Observable<void> {
+    const encryptedCollectionName$ = this.orgKey$(organization).pipe(
+      switchMap((orgKey) =>
+        this.encryptService.encryptString(this.i18nService.t("My Itmes"), orgKey),
+      ),
+    );
+
+    const encryptedKey$ = this.orgKey$(organization).pipe(
+      switchMap((orgKey) => this.encryptService.encapsulateKeyUnsigned(orgKey, publicKey)),
+    );
+
+    return combineLatest([encryptedKey$, encryptedCollectionName$]).pipe(
+      switchMap(([key, collectionName]) => {
+        const request: OrganizationUserConfirmRequest = {
+          key: key.encryptedString,
+          defaultUserCollectionName: collectionName.encryptedString,
+        };
+
+        return this.organizationUserApiService.postOrganizationUserConfirm(
+          organization.id,
+          user.id,
+          request,
+        );
+      }),
+    );
+  }
+}

--- a/libs/admin-console/src/common/organization-user/models/requests/organization-user-confirm.request.ts
+++ b/libs/admin-console/src/common/organization-user/models/requests/organization-user-confirm.request.ts
@@ -1,5 +1,6 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
+import { EncryptedString } from "@bitwarden/common/platform/models/domain/enc-string";
+
 export class OrganizationUserConfirmRequest {
-  key: string;
+  key: EncryptedString | undefined;
+  defaultUserCollectionName: EncryptedString | undefined;
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -13,6 +13,7 @@ export enum FeatureFlag {
   /* Admin Console Team */
   SeparateCustomRolePermissions = "pm-19917-separate-custom-role-permissions",
   OptimizeNestedTraverseTypescript = "pm-21695-optimize-nested-traverse-typescript",
+  CreateDefaultLocation = "pm-19467-create-default-location",
 
   /* Auth */
   PM16117_ChangeExistingPasswordRefactor = "pm-16117-change-existing-password-refactor",
@@ -76,6 +77,7 @@ export const DefaultFeatureFlagValue = {
   /* Admin Console Team */
   [FeatureFlag.SeparateCustomRolePermissions]: FALSE,
   [FeatureFlag.OptimizeNestedTraverseTypescript]: FALSE,
+  [FeatureFlag.CreateDefaultLocation]: FALSE,
 
   /* Autofill */
   [FeatureFlag.BlockBrowserInjectionsByDomain]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22536
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This pr: 
- Copies the member component's `confirmUser` function into its own service
- Adds encrypted `defaultUserCollectionName` property to the `OrganizationUserConfirmRequest` model. 
- Calls the new `orgKeys$(userId)` in favor of deprecated method.
- Adds feature flag

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
