### PR TITLE
[PM -20329] browser auth approval client api service

### DIFF
--- a/apps/web/src/app/auth/settings/security/device-management.component.ts
+++ b/apps/web/src/app/auth/settings/security/device-management.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { firstValueFrom } from "rxjs";
 
 import { LoginApprovalComponent } from "@bitwarden/auth/angular";
-import { AuthRequestApiService } from "@bitwarden/auth/common";
+import { AuthRequestApiServiceAbstraction } from "@bitwarden/auth/common";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import {
   DevicePendingAuthRequest,
@@ -61,7 +61,7 @@ export class DeviceManagementComponent {
     private toastService: ToastService,
     private validationService: ValidationService,
     private messageListener: MessageListener,
-    private authRequestApiService: AuthRequestApiService,
+    private authRequestApiService: AuthRequestApiServiceAbstraction,
     private destroyRef: DestroyRef,
   ) {
     void this.initializeDevices();

--- a/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/services/vault-banners.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from "@angular/core";
 import { Observable, combineLatest, firstValueFrom, map, filter, mergeMap, take } from "rxjs";
 
-import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import {
+  AuthRequestServiceAbstraction,
+  UserDecryptionOptionsServiceAbstraction,
+} from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
@@ -65,21 +67,19 @@ export class VaultBannersService {
     private kdfConfigService: KdfConfigService,
     private syncService: SyncService,
     private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
-    private devicesService: DevicesServiceAbstraction,
+    private authRequestService: AuthRequestServiceAbstraction,
   ) {}
 
   /** Returns true when the pending auth request banner should be shown */
   async shouldShowPendingAuthRequestBanner(userId: UserId): Promise<boolean> {
-    const devices = await firstValueFrom(this.devicesService.getDevices$());
-    const hasPendingRequest = devices.some(
-      (device) => device.response?.devicePendingAuthRequest != null,
+    const pendingAuthRequests = await firstValueFrom(
+      this.authRequestService.getPendingAuthRequests$(),
     );
-
     const alreadyDismissed = (await this.getBannerDismissedState(userId)).includes(
       VisibleVaultBanner.PendingAuthRequest,
     );
 
-    return hasPendingRequest && !alreadyDismissed;
+    return pendingAuthRequests.length > 0 && !alreadyDismissed;
   }
 
   shouldShowPremiumBanner$(userId: UserId): Observable<boolean> {

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -37,7 +37,7 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import {
-  AuthRequestApiService,
+  AuthRequestApiServiceAbstraction,
   AuthRequestService,
   AuthRequestServiceAbstraction,
   DefaultAuthRequestApiService,
@@ -1169,6 +1169,11 @@ const safeProviders: SafeProvider[] = [
     deps: [DevicesApiServiceAbstraction, AppIdServiceAbstraction],
   }),
   safeProvider({
+    provide: AuthRequestApiServiceAbstraction,
+    useClass: DefaultAuthRequestApiService,
+    deps: [ApiServiceAbstraction, LogService],
+  }),
+  safeProvider({
     provide: DeviceTrustServiceAbstraction,
     useClass: DeviceTrustService,
     deps: [
@@ -1192,12 +1197,12 @@ const safeProviders: SafeProvider[] = [
     useClass: AuthRequestService,
     deps: [
       AppIdServiceAbstraction,
-      AccountServiceAbstraction,
       InternalMasterPasswordServiceAbstraction,
       KeyService,
       EncryptService,
       ApiServiceAbstraction,
       StateProvider,
+      AuthRequestApiServiceAbstraction,
     ],
   }),
   safeProvider({
@@ -1468,11 +1473,6 @@ const safeProviders: SafeProvider[] = [
       AccountServiceAbstraction,
       ConfigService,
     ],
-  }),
-  safeProvider({
-    provide: AuthRequestApiService,
-    useClass: DefaultAuthRequestApiService,
-    deps: [ApiServiceAbstraction, LogService],
   }),
   safeProvider({
     provide: LoginApprovalComponentServiceAbstraction,

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -39,7 +39,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { ButtonModule, LinkModule, ToastService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 
-import { AuthRequestApiService } from "../../common/abstractions/auth-request-api.service";
+import { AuthRequestApiServiceAbstraction } from "../../common/abstractions/auth-request-api.service";
 import { LoginViaAuthRequestCacheService } from "../../common/services/auth-request/default-login-via-auth-request-cache.service";
 
 // FIXME: update to use a const object instead of a typescript enum
@@ -85,7 +85,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
     private accountService: AccountService,
     private anonymousHubService: AnonymousHubService,
     private appIdService: AppIdService,
-    private authRequestApiService: AuthRequestApiService,
+    private authRequestApiService: AuthRequestApiServiceAbstraction,
     private authRequestService: AuthRequestServiceAbstraction,
     private authService: AuthService,
     private cryptoFunctionService: CryptoFunctionService,

--- a/libs/auth/src/common/abstractions/auth-request-api.service.ts
+++ b/libs/auth/src/common/abstractions/auth-request-api.service.ts
@@ -1,7 +1,16 @@
 import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
 
-export abstract class AuthRequestApiService {
+export abstract class AuthRequestApiServiceAbstraction {
+  /**
+   * Gets a list of pending auth requests based on the user. There will only be one AuthRequest per device and the
+   * AuthRequest will be the most recent pending request.
+   *
+   * @returns A promise that resolves to a list response containing auth request responses.
+   */
+  abstract getPendingAuthRequests(): Promise<ListResponse<AuthRequestResponse>>;
+
   /**
    * Gets an auth request by its ID.
    *

--- a/libs/auth/src/common/abstractions/auth-request.service.abstraction.ts
+++ b/libs/auth/src/common/abstractions/auth-request.service.abstraction.ts
@@ -42,6 +42,12 @@ export abstract class AuthRequestServiceAbstraction {
    */
   abstract clearAdminAuthRequest: (userId: UserId) => Promise<void>;
   /**
+   * Gets a list of standard pending auth requests for the user.
+   * @returns An observable of an array of auth request.
+   * The array will be empty if there are no pending auth requests.
+   */
+  abstract getPendingAuthRequests$(): Observable<Array<AuthRequestResponse>>;
+  /**
    * Approve or deny an auth request.
    * @param approve True to approve, false to deny.
    * @param authRequest The auth request to approve or deny, must have an id and key.

--- a/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
@@ -1,15 +1,22 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
-import { AuthRequestApiService } from "../../abstractions/auth-request-api.service";
+import { AuthRequestApiServiceAbstraction } from "../../abstractions/auth-request-api.service";
 
-export class DefaultAuthRequestApiService implements AuthRequestApiService {
+export class DefaultAuthRequestApiService implements AuthRequestApiServiceAbstraction {
   constructor(
     private apiService: ApiService,
     private logService: LogService,
   ) {}
+
+  async getPendingAuthRequests(): Promise<ListResponse<AuthRequestResponse>> {
+    const path = `/auth-requests/pending`;
+    const r = await this.apiService.send("GET", path, null, true, true);
+    return new ListResponse(r, AuthRequestResponse);
+  }
 
   async getAuthRequest(requestId: string): Promise<AuthRequestResponse> {
     try {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-20329](https://bitwarden.atlassian.net/browse/PM-20329)

Server PR

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

To update the banner service and the Desktop vault notification calls. These two locations now call the `auth-request/pending` endpoint to fetch pending auth requests.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Login with device between two browsers, and desktop doesn't show auth-request as pending when logged in

https://github.com/user-attachments/assets/5e9b8ae7-3b9b-4987-8493-a08ba9aa728b

A user uses the web auth approvals flow to approve their login request. The login request is approved from another browser. The user then accesses their locked vault from the desktop and they are not shown the auth-request from the aforementioned login with device requests. 

### Web Vault Banner is populated correctly when auth-request is pending

https://github.com/user-attachments/assets/66cccac4-ca37-41a0-b02c-ee8fe5e3d1f2

A user makes a login with device request. The other web browser approved the login with device request. Request is approved and user is allowed into vault. The vault banner does not show any pending auth-requests.

### A user makes multiple auth-rquests for a single login

https://github.com/user-attachments/assets/53c681ac-2a21-4455-a20e-1e22fd7d5275

A user creates multiple login with device requests. Request is approved from Desktop. When navigating to the vault the banner does not show any pending auth requests.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
