### PR TITLE
[PM-22594] Cipher In Trash Disable No Item Menu

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-cipher-row.component.ts
@@ -166,7 +166,7 @@ export class VaultCipherRowComponent implements OnInit {
       this.showAttachments ||
       this.showClone ||
       this.canEditCipher ||
-      this.cipher.isDeleted
+      (this.cipher.isDeleted && this.canRestoreCipher)
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22594](https://bitwarden.atlassian.net/browse/PM-22594)

## 📔 Objective

Added a check for `canRestore` to a cipher in the trash. If the cipher does not have any menu items and cannot restore we will disable the menu. 

## 📸 Screenshots

![Screenshot 2025-06-12 at 10 13 31 AM](https://github.com/user-attachments/assets/c98b1a3a-013d-4f01-ba82-0e61ccc85f96)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22594]: https://bitwarden.atlassian.net/browse/PM-22594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ