### PR TITLE
[PM-19574] Bugfix - Add optional chaining to possibly nullish orgKeys

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -448,12 +448,12 @@ export class CipherService implements CipherServiceAbstraction {
           if (await this.configService.getFeatureFlag(FeatureFlag.PM4154_BulkEncryptionService)) {
             return await this.bulkEncryptService.decryptItems(
               groupedCiphers,
-              keys.orgKeys[orgId as OrganizationId] ?? keys.userKey,
+              keys.orgKeys?.[orgId as OrganizationId] ?? keys.userKey,
             );
           } else {
             return await this.encryptService.decryptItems(
               groupedCiphers,
-              keys.orgKeys[orgId as OrganizationId] ?? keys.userKey,
+              keys.orgKeys?.[orgId as OrganizationId] ?? keys.userKey,
             );
           }
         }),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22636](https://bitwarden.atlassian.net/browse/PM-22636)

## 📔 Objective

Possibly nullish `orgKeys` values are not ultimately handled by nullish coalescing operator. This causes both the browser and web client to hang in a loading state after logging into a self-hosted environment that doesn't have an org set up.

Making the changes in this PR (tested with a side-loaded web client build) resolves the loading hang and normal functionality is restored.
 
## 📸 Screenshots

![Screenshot 2025-06-12 at 3 55 23 PM](https://github.com/user-attachments/assets/1d438e24-9f2c-4550-871e-6f123dcd7bf1)

![Screenshot 2025-06-12 at 3 55 34 PM](https://github.com/user-attachments/assets/cae75f1d-9125-4b1e-9b48-bd470ea97911)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22636]: https://bitwarden.atlassian.net/browse/PM-22636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ