### PR TITLE
[PM-22645] Rename Windows Desktop Pack & Sign Workflow

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -502,7 +502,7 @@ jobs:
         run: |
           npm run pack:win
 
-      - name: Pack & Sign (dev)
+      - name: Pack & Sign
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         env:
           ELECTRON_BUILDER_SIGN: 1


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22645

## 📔 Objective

When reading through the Windows Desktop build & release workflows, I came across this name: `Pack & Sign (dev)`. It doesn't seem like a dev workflow, though I could be wrong. It seems like the only difference is if there are secrets available at this point in the workflow, and then we either pack or pack and sign based on that.

In this PR, the workflow is renamed, to reduce future confusion.

Maybe there is a historic reason `(dev)` was added? It was added a while ago, back in this PR: https://github.com/bitwarden/clients/pull/2533/files

Please let me know if I'm missing something here.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
