### PR TITLE
[PM-17877] Add Device-Identifier header to unauthenticated requests

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1861,6 +1861,8 @@ export class ApiService implements ApiServiceAbstraction {
       const authHeader = await this.getActiveBearerToken();
       headers.set("Authorization", "Bearer " + authHeader);
     } else {
+      // For unauthenticated requests, we need to tell the server what the device is for flag targeting,
+      // since it won't be able to get it from the access token.
       const appId = await this.appIdService.getAppId();
       headers.set("Device-Identifier", appId);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17877

## 📔 Objective

In order to provide LaunchDarkly context for [targeting based on device identifier](https://github.com/bitwarden/server/blob/db77201ca47412653f506ac2d8880e2241a03a44/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs#L162), we need to ensure that the server always has the correct device identifier for the request context.  For authenticated requests, we already have that from the access token.  For unauthenticated requests, however, we do not have that information.  To provide it to the server, we will include `Device-Identifier` on all unauthenticated API requests. This is accomplished by adding the header at the ApiService level. As the AppIdService will generate the `appId` if it does not yet exist, there is not a check for existence before adding the header.

Note that I elected not to remove the `X-Device-Header` from the `/knowndevice` endpoint, used [here](https://github.com/bitwarden/server/blob/db77201ca47412653f506ac2d8880e2241a03a44/src/Api/Controllers/DevicesController.cs#L243), as it felt better addressed as part of tech debt (https://bitwarden.atlassian.net/browse/PM-6086).

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/3c0f7326-2094-40ab-82ad-91138c0593ed)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
