### PR TITLE
Add tests for passkey components

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -1,0 +1,241 @@
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
+
+import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService } from "@bitwarden/components";
+import { PasswordRepromptService } from "@bitwarden/vault";
+
+import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
+import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
+import {
+  DesktopFido2UserInterfaceService,
+  DesktopFido2UserInterfaceSession,
+} from "../../services/desktop-fido2-user-interface.service";
+
+import { Fido2CreateComponent } from "./fido2-create.component";
+
+describe("Fido2CreateComponent", () => {
+  let component: Fido2CreateComponent;
+  let mockDesktopSettingsService: MockProxy<DesktopSettingsService>;
+  let mockFido2UserInterfaceService: MockProxy<DesktopFido2UserInterfaceService>;
+  let mockAccountService: MockProxy<AccountService>;
+  let mockCipherService: MockProxy<CipherService>;
+  let mockDesktopAutofillService: MockProxy<DesktopAutofillService>;
+  let mockDialogService: MockProxy<DialogService>;
+  let mockDomainSettingsService: MockProxy<DomainSettingsService>;
+  let mockLogService: MockProxy<LogService>;
+  let mockPasswordRepromptService: MockProxy<PasswordRepromptService>;
+  let mockRouter: MockProxy<Router>;
+  let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
+  let mockI18nService: MockProxy<I18nService>;
+
+  const activeAccountSubject = new BehaviorSubject<Account | null>({
+    id: "test-user-id" as UserId,
+    email: "test@example.com",
+    emailVerified: true,
+    name: "Test User",
+  });
+
+  beforeEach(async () => {
+    mockDesktopSettingsService = mock<DesktopSettingsService>();
+    mockFido2UserInterfaceService = mock<DesktopFido2UserInterfaceService>();
+    mockAccountService = mock<AccountService>();
+    mockCipherService = mock<CipherService>();
+    mockDesktopAutofillService = mock<DesktopAutofillService>();
+    mockDialogService = mock<DialogService>();
+    mockDomainSettingsService = mock<DomainSettingsService>();
+    mockLogService = mock<LogService>();
+    mockPasswordRepromptService = mock<PasswordRepromptService>();
+    mockRouter = mock<Router>();
+    mockSession = mock<DesktopFido2UserInterfaceSession>();
+    mockI18nService = mock<I18nService>();
+
+    mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
+    mockAccountService.activeAccount$ = activeAccountSubject;
+
+    await TestBed.configureTestingModule({
+      providers: [
+        Fido2CreateComponent,
+        { provide: DesktopSettingsService, useValue: mockDesktopSettingsService },
+        { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
+        { provide: AccountService, useValue: mockAccountService },
+        { provide: CipherService, useValue: mockCipherService },
+        { provide: DesktopAutofillService, useValue: mockDesktopAutofillService },
+        { provide: DialogService, useValue: mockDialogService },
+        { provide: DomainSettingsService, useValue: mockDomainSettingsService },
+        { provide: LogService, useValue: mockLogService },
+        { provide: PasswordRepromptService, useValue: mockPasswordRepromptService },
+        { provide: Router, useValue: mockRouter },
+        { provide: I18nService, useValue: mockI18nService },
+      ],
+    }).compileComponents();
+
+    component = TestBed.inject(Fido2CreateComponent);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createMockCiphers(): CipherView[] {
+    const cipher1 = new CipherView();
+    cipher1.id = "cipher-1";
+    cipher1.name = "Test Cipher 1";
+    cipher1.type = CipherType.Login;
+    cipher1.login = {
+      username: "test1@example.com",
+      uris: [{ uri: "https://example.com", match: null }],
+      matchesUri: jest.fn().mockReturnValue(true),
+      get hasFido2Credentials() {
+        return false;
+      },
+    } as any;
+    cipher1.reprompt = CipherRepromptType.None;
+    cipher1.deletedDate = null;
+
+    return [cipher1];
+  }
+
+  describe("ngOnInit", () => {
+    beforeEach(() => {
+      mockSession.getRpId.mockResolvedValue("example.com");
+      Object.defineProperty(mockDesktopAutofillService, "lastRegistrationRequest", {
+        get: jest.fn().mockReturnValue({
+          userHandle: new Uint8Array([1, 2, 3]),
+        }),
+        configurable: true,
+      });
+      mockDomainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
+    });
+
+    it("should initialize session and set show header to false", async () => {
+      const mockCiphers = createMockCiphers();
+      mockCipherService.getAllDecrypted.mockResolvedValue(mockCiphers);
+
+      await component.ngOnInit();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(false);
+      expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
+      expect(component.session).toBe(mockSession);
+    });
+
+    it("should throw error when no active session found", async () => {
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(null);
+
+      await expect(component.ngOnInit()).rejects.toThrow(
+        "Cannot read properties of null (reading 'getRpId')",
+      );
+    });
+  });
+
+  describe("ngOnDestroy", () => {
+    it("should restore header visibility", async () => {
+      await component.ngOnDestroy();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("addPasskeyToCipher", () => {
+    beforeEach(() => {
+      component.session = mockSession;
+    });
+
+    it("should add passkey to cipher", async () => {
+      const cipher = createMockCiphers()[0];
+
+      await component.addPasskeyToCipher(cipher);
+
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(true, cipher);
+    });
+
+    it("should not add passkey when password reprompt is cancelled", async () => {
+      const cipher = createMockCiphers()[0];
+      cipher.reprompt = CipherRepromptType.Password;
+      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+      await component.addPasskeyToCipher(cipher);
+
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false, cipher);
+    });
+
+    it("should call openSimpleDialog when cipher already has a fido2 credential", async () => {
+      const cipher = createMockCiphers()[0];
+      Object.defineProperty(cipher.login, "hasFido2Credentials", {
+        get: jest.fn().mockReturnValue(true),
+      });
+      mockDialogService.openSimpleDialog.mockResolvedValue(true);
+
+      await component.addPasskeyToCipher(cipher);
+
+      expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
+        title: { key: "overwritePasskey" },
+        content: { key: "alreadyContainsPasskey" },
+        type: "warning",
+      });
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(true, cipher);
+    });
+
+    it("should not add passkey when user cancels overwrite dialog", async () => {
+      const cipher = createMockCiphers()[0];
+      Object.defineProperty(cipher.login, "hasFido2Credentials", {
+        get: jest.fn().mockReturnValue(true),
+      });
+      mockDialogService.openSimpleDialog.mockResolvedValue(false);
+
+      await component.addPasskeyToCipher(cipher);
+
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false, cipher);
+    });
+  });
+
+  describe("confirmPasskey", () => {
+    beforeEach(() => {
+      component.session = mockSession;
+    });
+
+    it("should confirm passkey creation successfully", async () => {
+      await component.confirmPasskey();
+
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(true);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+    });
+
+    it("should call openSimpleDialog when session is null", async () => {
+      component.session = null;
+
+      await component.confirmPasskey();
+
+      expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
+        title: { key: "unexpectedErrorShort" },
+        content: { key: "closeThisBitwardenWindow" },
+        type: "danger",
+        acceptButtonText: { key: "closeBitwarden" },
+        cancelButtonText: null,
+      });
+    });
+  });
+
+  describe("closeModal", () => {
+    it("should close modal and notify session", async () => {
+      component.session = mockSession;
+
+      await component.closeModal();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
@@ -1,0 +1,87 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
+import {
+  DesktopFido2UserInterfaceService,
+  DesktopFido2UserInterfaceSession,
+} from "../../services/desktop-fido2-user-interface.service";
+
+import { Fido2ExcludedCiphersComponent } from "./fido2-excluded-ciphers.component";
+
+describe("Fido2ExcludedCiphersComponent", () => {
+  let component: Fido2ExcludedCiphersComponent;
+  let fixture: ComponentFixture<Fido2ExcludedCiphersComponent>;
+  let mockDesktopSettingsService: MockProxy<DesktopSettingsService>;
+  let mockFido2UserInterfaceService: MockProxy<DesktopFido2UserInterfaceService>;
+  let mockAccountService: MockProxy<AccountService>;
+  let mockRouter: MockProxy<Router>;
+  let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
+  let mockI18nService: MockProxy<I18nService>;
+
+  beforeEach(async () => {
+    mockDesktopSettingsService = mock<DesktopSettingsService>();
+    mockFido2UserInterfaceService = mock<DesktopFido2UserInterfaceService>();
+    mockAccountService = mock<AccountService>();
+    mockRouter = mock<Router>();
+    mockSession = mock<DesktopFido2UserInterfaceSession>();
+    mockI18nService = mock<I18nService>();
+
+    mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
+
+    await TestBed.configureTestingModule({
+      imports: [Fido2ExcludedCiphersComponent],
+      providers: [
+        { provide: DesktopSettingsService, useValue: mockDesktopSettingsService },
+        { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
+        { provide: AccountService, useValue: mockAccountService },
+        { provide: Router, useValue: mockRouter },
+        { provide: I18nService, useValue: mockI18nService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Fido2ExcludedCiphersComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("ngOnInit", () => {
+    it("should initialize session and set show header to false", async () => {
+      await component.ngOnInit();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(false);
+      expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
+      expect(component.session).toBe(mockSession);
+    });
+  });
+
+  describe("ngOnDestroy", () => {
+    it("should restore header visibility", async () => {
+      await component.ngOnDestroy();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("closeModal", () => {
+    it("should close modal and notify session when session exists", async () => {
+      component.session = mockSession;
+
+      await component.closeModal();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
@@ -1,0 +1,203 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
+import { PasswordRepromptService } from "@bitwarden/vault";
+
+import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
+import {
+  DesktopFido2UserInterfaceService,
+  DesktopFido2UserInterfaceSession,
+} from "../../services/desktop-fido2-user-interface.service";
+
+import { Fido2VaultComponent } from "./fido2-vault.component";
+
+describe("Fido2VaultComponent", () => {
+  let component: Fido2VaultComponent;
+  let fixture: ComponentFixture<Fido2VaultComponent>;
+  let mockDesktopSettingsService: MockProxy<DesktopSettingsService>;
+  let mockFido2UserInterfaceService: MockProxy<DesktopFido2UserInterfaceService>;
+  let mockCipherService: MockProxy<CipherService>;
+  let mockAccountService: MockProxy<AccountService>;
+  let mockLogService: MockProxy<LogService>;
+  let mockPasswordRepromptService: MockProxy<PasswordRepromptService>;
+  let mockRouter: MockProxy<Router>;
+  let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
+  let mockI18nService: MockProxy<I18nService>;
+
+  const mockActiveAccount = { id: "test-user-id", email: "test@example.com" };
+  const mockCipherIds = ["cipher-1", "cipher-2", "cipher-3"];
+
+  beforeEach(async () => {
+    mockDesktopSettingsService = mock<DesktopSettingsService>();
+    mockFido2UserInterfaceService = mock<DesktopFido2UserInterfaceService>();
+    mockCipherService = mock<CipherService>();
+    mockAccountService = mock<AccountService>();
+    mockLogService = mock<LogService>();
+    mockPasswordRepromptService = mock<PasswordRepromptService>();
+    mockRouter = mock<Router>();
+    mockSession = mock<DesktopFido2UserInterfaceSession>();
+    mockI18nService = mock<I18nService>();
+
+    mockAccountService.activeAccount$ = of(mockActiveAccount as Account);
+    mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
+    mockSession.availableCipherIds$ = of(mockCipherIds);
+    mockCipherService.getAllDecryptedForIds.mockResolvedValue([]);
+
+    await TestBed.configureTestingModule({
+      imports: [Fido2VaultComponent],
+      providers: [
+        { provide: DesktopSettingsService, useValue: mockDesktopSettingsService },
+        { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
+        { provide: CipherService, useValue: mockCipherService },
+        { provide: AccountService, useValue: mockAccountService },
+        { provide: LogService, useValue: mockLogService },
+        { provide: PasswordRepromptService, useValue: mockPasswordRepromptService },
+        { provide: Router, useValue: mockRouter },
+        { provide: I18nService, useValue: mockI18nService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Fido2VaultComponent);
+    component = fixture.componentInstance;
+  });
+
+  function createMockCiphers(): CipherView[] {
+    const cipher1 = new CipherView();
+    cipher1.id = "cipher-1";
+    cipher1.name = "Test Cipher 1";
+    cipher1.type = CipherType.Login;
+    cipher1.login = new LoginView();
+    cipher1.login.username = "test1@example.com";
+    cipher1.reprompt = CipherRepromptType.None;
+    cipher1.deletedDate = null;
+
+    const cipher2 = new CipherView();
+    cipher2.id = "cipher-2";
+    cipher2.name = "Test Cipher 2";
+    cipher2.type = CipherType.Login;
+    cipher2.login = new LoginView();
+    cipher2.login.username = "test2@example.com";
+    cipher2.reprompt = CipherRepromptType.None;
+    cipher2.deletedDate = null;
+
+    const cipher3 = new CipherView();
+    cipher3.id = "cipher-3";
+    cipher3.name = "Test Cipher 3";
+    cipher3.type = CipherType.Login;
+    cipher3.login = new LoginView();
+    cipher3.login.username = "test3@example.com";
+    cipher3.reprompt = CipherRepromptType.Password;
+    cipher3.deletedDate = null;
+
+    return [cipher1, cipher2, cipher3];
+  }
+
+  describe("ngOnInit", () => {
+    it("should initialize session and load ciphers successfully", async () => {
+      const mockCiphers = createMockCiphers();
+      mockCipherService.getAllDecryptedForIds.mockResolvedValue(mockCiphers);
+
+      await component.ngOnInit();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(false);
+      expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
+      expect(component.session).toBe(mockSession);
+      expect(component.cipherIds$).toBe(mockSession.availableCipherIds$);
+    });
+
+    it("should handle error when no active session found", async () => {
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(null);
+
+      await expect(component.ngOnInit()).rejects.toThrow();
+    });
+
+    it("should filter out deleted ciphers", async () => {
+      const mockCiphers = createMockCiphers();
+      mockCiphers[1].deletedDate = new Date();
+      mockCipherService.getAllDecryptedForIds.mockResolvedValue(mockCiphers);
+
+      await component.ngOnInit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      let ciphersResult: CipherView[] = [];
+      component.ciphers$.subscribe((ciphers) => {
+        ciphersResult = ciphers;
+      });
+
+      expect(ciphersResult).toHaveLength(2);
+      expect(ciphersResult.every((cipher) => !cipher.deletedDate)).toBe(true);
+    });
+  });
+
+  describe("ngOnDestroy", () => {
+    it("should restore header visibility and clean up", async () => {
+      await component.ngOnInit();
+      await component.ngOnDestroy();
+
+      expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("chooseCipher", () => {
+    beforeEach(() => {
+      component.session = mockSession;
+    });
+
+    it("should choose cipher when access is validated", async () => {
+      const cipher = createMockCiphers()[0];
+      cipher.reprompt = CipherRepromptType.None;
+
+      await component.chooseCipher(cipher);
+
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, true);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+    });
+
+    it("should prompt for password when cipher requires reprompt", async () => {
+      const cipher = createMockCiphers()[0];
+      cipher.reprompt = CipherRepromptType.Password;
+      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+      await component.chooseCipher(cipher);
+
+      expect(mockPasswordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, true);
+    });
+
+    it("should not choose cipher when password reprompt is cancelled", async () => {
+      const cipher = createMockCiphers()[0];
+      cipher.reprompt = CipherRepromptType.Password;
+      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+      await component.chooseCipher(cipher);
+
+      expect(mockPasswordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, false);
+    });
+  });
+
+  describe("closeModal", () => {
+    it("should close modal and notify session", async () => {
+      component.session = mockSession;
+
+      await component.closeModal();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -53,7 +53,6 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
   private ciphersSubject = new BehaviorSubject<CipherView[]>([]);
   ciphers$: Observable<CipherView[]> = this.ciphersSubject.asObservable();
   private cipherIdsSubject = new BehaviorSubject<string[]>([]);
-  protected containsExcludedCiphers: boolean = false;
   cipherIds$: Observable<string[]>;
   readonly Icons = { BitwardenShield };
 
@@ -92,9 +91,7 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
   }
 
   async chooseCipher(cipher: CipherView) {
-    if (this.containsExcludedCiphers) {
-      this.session?.confirmChosenCipher(cipher.id, false);
-    } else if (
+    if (
       cipher.reprompt !== CipherRepromptType.None &&
       !(await this.passwordRepromptService.showPasswordPrompt())
     ) {


### PR DESCRIPTION
## 📔 Objective

Add tests for the new Passkey modals.  While testing I found there was an unused `containsExcludedCiphers` that I also removed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
