### PR TITLE
build(ci): remove the need to cherry pick version bumps to rc

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -36,8 +36,7 @@ on:
         description: "New version override (leave blank for automatic calculation, example: '2024.1.0')"
         required: false
         type: string
-
-
+permissions: {}
 jobs:
   setup:
     name: Setup
@@ -57,51 +56,11 @@ jobs:
           fi
 
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-
-
-  cut_branch:
-    name: Cut branch
-    if: ${{ needs.setup.outputs.branch == 'rc' }}
-    needs: setup
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
-        id: app-token
-        with:
-          app-id: ${{ secrets.BW_GHAPP_ID }}
-          private-key: ${{ secrets.BW_GHAPP_KEY }}
-
-      - name: Check out target ref
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.target_ref }}
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Check if ${{ needs.setup.outputs.branch }} branch exists
-        env:
-          BRANCH_NAME: ${{ needs.setup.outputs.branch }}
-        run: |
-          if [[ $(git ls-remote --heads origin $BRANCH_NAME) ]]; then
-            echo "$BRANCH_NAME already exists! Please delete $BRANCH_NAME before running again." >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
-
-      - name: Cut branch
-        env:
-          BRANCH_NAME: ${{ needs.setup.outputs.branch }}
-        run: |
-          git switch --quiet --create $BRANCH_NAME
-          git push --quiet --set-upstream origin $BRANCH_NAME
-
-
   bump_version:
     name: Bump Version
     if: ${{ always() }}
     runs-on: ubuntu-24.04
-    needs:
-      - cut_branch
-      - setup
+    needs: setup
     outputs:
       version_browser: ${{ steps.set-final-version-output.outputs.version_browser }}
       version_cli: ${{ steps.set-final-version-output.outputs.version_cli }}
@@ -441,15 +400,13 @@ jobs:
       - name: Push changes
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         run: git push
-
-
-  cherry_pick:
-    name: Cherry-Pick Commit(s)
+  cut_branch:
+    name: Cut branch
     if: ${{ needs.setup.outputs.branch == 'rc' }}
-    runs-on: ubuntu-24.04
     needs:
-      - bump_version
       - setup
+      - bump_version
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate GH App token
         uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
@@ -458,43 +415,24 @@ jobs:
           app-id: ${{ secrets.BW_GHAPP_ID }}
           private-key: ${{ secrets.BW_GHAPP_KEY }}
 
-      - name: Check out main branch
+      - name: Check out target ref
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
-          ref: main
+          ref: ${{ inputs.target_ref }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Configure Git
+      - name: Check if ${{ needs.setup.outputs.branch }} branch exists
+        env:
+          BRANCH_NAME: ${{ needs.setup.outputs.branch }}
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
+          if [[ $(git ls-remote --heads origin $BRANCH_NAME) ]]; then
+            echo "$BRANCH_NAME already exists! Please delete $BRANCH_NAME before running again." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
 
-      - name: Perform cherry-pick(s)
+      - name: Cut branch
+        env:
+          BRANCH_NAME: ${{ needs.setup.outputs.branch }}
         run: |
-          # Function for cherry-picking
-          cherry_pick () {
-            local package_path="apps/$1/package.json"
-            local source_branch=$2
-            local destination_branch=$3
-
-            # Get project commit/version from source branch
-            git switch $source_branch
-            SOURCE_COMMIT=$(git log --reverse --pretty=format:"%H" --max-count=1 $package_path)
-            SOURCE_VERSION=$(cat $package_path | jq -r '.version')
-
-            # Get project commit/version from destination branch
-            git switch $destination_branch
-            DESTINATION_VERSION=$(cat $package_path | jq -r '.version')
-
-            if [[ "$DESTINATION_VERSION" != "$SOURCE_VERSION" ]]; then
-              git cherry-pick --strategy-option=theirs -x $SOURCE_COMMIT
-              git push -u origin $destination_branch
-            fi
-          }
-
-          # Cherry-pick from 'main' into 'rc'
-          cherry_pick browser main rc
-          cherry_pick cli main rc
-          cherry_pick desktop main rc
-          cherry_pick web main rc
+          git switch --quiet --create $BRANCH_NAME
+          git push --quiet --set-upstream origin $BRANCH_NAME


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19392

## 📔 Objective

The repository management job has an inefficiency in that its logic flow does this:

1. Cuts an `rc` branch
2. Bumps the version for all clients on `main`
3. Cherry picks that commit to rc

This could be simpler, so I've reorder things. Now it:

1. Bumps the version for all clients on `main`
2. Cuts an rc branch

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
