### PR TITLE
Add DuckDuckGo to web app for selection when creating a Github issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/browser.yml
+++ b/.github/ISSUE_TEMPLATE/browser.yml
@@ -1,4 +1,4 @@
-name: Browser Bug Report
+name: Browser Extension Bug Report
 description: File a bug report
 labels: [bug, browser]
 body:
@@ -77,7 +77,6 @@ body:
         - Opera
         - Brave
         - Vivaldi
-        - DuckDuckGo
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/browser.yml
+++ b/.github/ISSUE_TEMPLATE/browser.yml
@@ -77,6 +77,7 @@ body:
         - Opera
         - Brave
         - Vivaldi
+        - DuckDuckGo
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/web.yml
+++ b/.github/ISSUE_TEMPLATE/web.yml
@@ -1,4 +1,4 @@
-name: Web Bug Report
+name: Web App Bug Report
 description: File a bug report
 labels: [bug, web]
 body:
@@ -77,6 +77,7 @@ body:
         - Opera
         - Brave
         - Vivaldi
+        - DuckDuckGo
     validations:
       required: true
   - type: input


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/15104

## 📔 Objective

In https://github.com/bitwarden/clients/issues/15104, the reporter noted that we do not offer the DuckDuckGo browser in the selection list when creating a Github issue.

This PR adds it to the list.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
