### PR TITLE
[PM-22721] Update sdk for breaking init change

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -212,6 +212,7 @@ export class DefaultSdkService implements SdkService {
               },
             },
       privateKey,
+      signingKey: undefined,
     });
 
     // We initialize the org crypto even if the org_keys are

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/platform-browser": "19.2.14",
         "@angular/platform-browser-dynamic": "19.2.14",
         "@angular/router": "19.2.14",
-        "@bitwarden/sdk-internal": "0.2.0-main.198",
+        "@bitwarden/sdk-internal": "0.2.0-main.203",
         "@electron/fuses": "1.8.0",
         "@emotion/css": "11.13.5",
         "@koa/multer": "3.1.0",
@@ -4378,9 +4378,9 @@
       "link": true
     },
     "node_modules/@bitwarden/sdk-internal": {
-      "version": "0.2.0-main.198",
-      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.198.tgz",
-      "integrity": "sha512-/MRdlcBqGxFEK/p6bU4hu5ZRoa+PqU88S+xnQaFrCXsWCTXrC8Nvm46iiz6gAqdbfFQWFNLCtmoNx6LFUdRuNg==",
+      "version": "0.2.0-main.203",
+      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.203.tgz",
+      "integrity": "sha512-AcRX2odnabnx16VF+K7naEZ3R4Tv/o8mVsVhrvwOTG+TEBUxR1BzCoE2r+l0+iz1zV32UV2YHeLZvyCB2/KftA==",
       "license": "GPL-3.0",
       "dependencies": {
         "type-fest": "^4.41.0"

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "@angular/platform-browser": "19.2.14",
     "@angular/platform-browser-dynamic": "19.2.14",
     "@angular/router": "19.2.14",
-    "@bitwarden/sdk-internal": "0.2.0-main.198",
+    "@bitwarden/sdk-internal": "0.2.0-main.203",
     "@electron/fuses": "1.8.0",
     "@emotion/css": "11.13.5",
     "@koa/multer": "3.1.0",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22721

## 📔 Objective

Init now takes an optional signing key. This is set to undefined for now, to unblock SDK updates.

SDK PR:
https://github.com/bitwarden/sdk-internal/pull/207

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
