### PR TITLE
[PM-22635] Only Show Assign to Collections Bulk Menu Option When Item Selected Is Editable

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -382,7 +382,7 @@ export class VaultItemsComponent {
     }
 
     if (this.selection.selected.length === 0) {
-      return true;
+      return false;
     }
 
     const hasPersonalItems = this.hasPersonalItems();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22635](https://bitwarden.atlassian.net/browse/PM-22635)

## 📔 Objective

assign to collections option in bulk menu only shows when editable item selected

## 📸 Screen Recording


https://github.com/user-attachments/assets/f390b4a0-ae9b-494a-883b-9ca141724959

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
