### PR TITLE
[CL-715] - [Defect] SSH key Private Key field visibility should toggle to hidden when switching items to view in desktop

### DIFF
--- a/libs/vault/src/cipher-view/cipher-view.component.html
+++ b/libs/vault/src/cipher-view/cipher-view.component.html
@@ -59,10 +59,7 @@
   </app-view-identity-sections>
 
   <!-- SshKEY SECTIONS -->
-  <!-- Force teardown on cipher change to ensure key visibility state is reset -->
-  <ng-container *ngFor="let key of [cipher.id]">
-    <app-sshkey-view *ngIf="hasSshKey" [sshKey]="cipher.sshKey"></app-sshkey-view>
-  </ng-container>
+  <app-sshkey-view *ngIf="hasSshKey" [sshKey]="cipher.sshKey"></app-sshkey-view>
 
   <!-- ADDITIONAL OPTIONS -->
   <ng-container *ngIf="cipher.notes">

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -19,6 +19,7 @@
         bitIconButton
         bitPasswordInputToggle
         data-testid="toggle-privateKey"
+        [(toggled)]="revealSshKey"
       ></button>
       <button
         bitIconButton="bwi-clone"

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
@@ -27,6 +27,14 @@ import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-
     IconButtonModule,
   ],
 })
-export class SshKeyViewComponent {
+export class SshKeyViewComponent implements OnChanges {
   @Input() sshKey: SshKeyView;
+
+  revealSshKey = false;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["sshKey"]) {
+      this.revealSshKey = false;
+    }
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/CL-715

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where the sshKey visibility was being persisted across different ssh keys instead of being reset. This was due to the use of the new use of cipher-view in desktop where it's not being torn down between ciphers like it is in the web so extra steps must be taken like this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/7f30d00a-689e-4409-b277-1ea5d4eba51d




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
