### PR TITLE
encapsulate kludge property

### DIFF
--- a/libs/common/src/tools/state/user-state-subject.ts
+++ b/libs/common/src/tools/state/user-state-subject.ts
@@ -161,6 +161,12 @@ export class UserStateSubject<
     this.outputSubscription = userState$
       .pipe(
         switchMap((userState) => userState.state$),
+        map((stored) => {
+          if (typeof stored === "object" && ALWAYS_UPDATE_KLUDGE in stored) {
+            // related: ALWAYS_UPDATE_KLUDGE FIXME
+            delete stored[ALWAYS_UPDATE_KLUDGE];
+          }
+        }),
         this.declassify(encryptor$),
         this.adjust(combineLatestWith(constraints$)),
         takeUntil(anyComplete(account$)),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The user state subject injects a property into the objects it stores so that the state provider emits for every update. This property escaped containment, which caused reflection over the stored object to break. Deleting the property before outputting it should preserve the update behavior without breaking reflection.


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
