### PR TITLE
[PM-22756] Send minimizeOnCopy message during copy on Desktop platform

### DIFF
--- a/libs/components/src/copy-click/copy-click.directive.spec.ts
+++ b/libs/components/src/copy-click/copy-click.directive.spec.ts
@@ -1,7 +1,9 @@
 import { Component, ElementRef, ViewChild } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
+import { ClientType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
 import { ToastService } from "../";
@@ -34,6 +36,8 @@ describe("CopyClickDirective", () => {
   let fixture: ComponentFixture<TestCopyClickComponent>;
   const copyToClipboard = jest.fn();
   const showToast = jest.fn();
+  const sendMessage = jest.fn();
+  const getClientType = jest.fn().mockReturnValue(ClientType.Web);
 
   beforeEach(async () => {
     copyToClipboard.mockClear();
@@ -53,8 +57,9 @@ describe("CopyClickDirective", () => {
             },
           },
         },
-        { provide: PlatformUtilsService, useValue: { copyToClipboard } },
+        { provide: PlatformUtilsService, useValue: { copyToClipboard, getClientType } },
         { provide: ToastService, useValue: { showToast } },
+        { provide: MessagingService, useValue: { send: sendMessage } },
       ],
     }).compileComponents();
 
@@ -118,5 +123,13 @@ describe("CopyClickDirective", () => {
       title: null,
       variant: "success",
     });
+  });
+
+  it("sends minimize message when client is desktop", () => {
+    getClientType.mockReturnValue(ClientType.Desktop);
+    const successToastButton = fixture.componentInstance.successToastButton.nativeElement;
+
+    successToastButton.click();
+    expect(sendMessage).toHaveBeenCalledWith("minimizeOnCopy");
   });
 });

--- a/libs/components/src/copy-click/copy-click.directive.ts
+++ b/libs/components/src/copy-click/copy-click.directive.ts
@@ -2,7 +2,9 @@
 // @ts-strict-ignore
 import { Directive, HostListener, Input } from "@angular/core";
 
+import { ClientType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
 import { ToastService, ToastVariant } from "../";
@@ -18,6 +20,7 @@ export class CopyClickDirective {
     private platformUtilsService: PlatformUtilsService,
     private toastService: ToastService,
     private i18nService: I18nService,
+    private messagingService: MessagingService,
   ) {}
 
   @Input("appCopyClick") valueToCopy = "";
@@ -53,6 +56,10 @@ export class CopyClickDirective {
 
   @HostListener("click") onClick() {
     this.platformUtilsService.copyToClipboard(this.valueToCopy);
+
+    if (this.platformUtilsService.getClientType() === ClientType.Desktop) {
+      this.messagingService.send("minimizeOnCopy");
+    }
 
     if (this._showToast) {
       const message = this.valueLabel


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22756](https://bitwarden.atlassian.net/browse/PM-22756)

## 📔 Objective

Re-enable the minimize on close functionality on Desktop.

## 📸 Screenshots


https://github.com/user-attachments/assets/40ad9a14-c166-49e8-9578-56372e4b3523


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22756]: https://bitwarden.atlassian.net/browse/PM-22756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ