### PR TITLE
Autofill/pm 22821 center vault modal

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -67,6 +67,7 @@
       ],
       "CFBundleDevelopmentRegion": "en"
     },
+    "provisioningProfile": "bitwarden_desktop_developer_id.provisionprofile",
     "singleArchFiles": "node_modules/@bitwarden/desktop-napi/desktop_napi.darwin-*.node",
     "extraFiles": [
       {
@@ -141,7 +142,8 @@
     "extendInfo": {
       "LSMinimumSystemVersion": "12",
       "ElectronTeamID": "LTZ2PFU5D6"
-    }
+    },
+    "provisioningProfile": "bitwarden_desktop_appstore.provisionprofile"
   },
   "nsisWeb": {
     "oneClick": false,

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -67,7 +67,6 @@
       ],
       "CFBundleDevelopmentRegion": "en"
     },
-    "provisioningProfile": "bitwarden_desktop_developer_id.provisionprofile",
     "singleArchFiles": "node_modules/@bitwarden/desktop-napi/desktop_napi.darwin-*.node",
     "extraFiles": [
       {
@@ -142,8 +141,7 @@
     "extendInfo": {
       "LSMinimumSystemVersion": "12",
       "ElectronTeamID": "LTZ2PFU5D6"
-    },
-    "provisioningProfile": "bitwarden_desktop_appstore.provisionprofile"
+    }
   },
   "nsisWeb": {
     "oneClick": false,

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -147,11 +147,11 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         // passkey modals are 600x600.
         let modalHeight: CGFloat = 600;
         let modalWidth: CGFloat = 600;
-        let centerX = Int32(round(frame.origin.x + estimatedWidth/2))
-        let centerY = Int32(round(screenHeight - (frame.origin.y + estimatedHeight/2)))
+        let centerX = round(frame.origin.x + estimatedWidth/2)
+        let centerY = round(screenHeight - (frame.origin.y + estimatedHeight/2))
         // Check if centerX or centerY are beyond either edge of the screen.  If they are find the center of the screen, otherwise use the original value.
-        let positionX = CGFloat(centerX) + modalWidth >= screenWidth || CGFloat(centerX) - modalWidth <= 0 ? Int32(screenWidth/2) : centerX
-        let positionY = CGFloat(centerY) + modalHeight >= screenHeight || CGFloat(centerY) - modalHeight <= 0 ? Int32(screenHeight/2) : centerY
+        let positionX = centerX + modalWidth >= screenWidth || CGFloat(centerX) - modalWidth <= 0 ? Int32(screenWidth/2) : Int32(centerX)
+        let positionY = centerY + modalHeight >= screenHeight || CGFloat(centerY) - modalHeight <= 0 ? Int32(screenHeight/2) : Int32(centerY)
         return Position(x: positionX, y: positionY)
     }
     

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -144,10 +144,12 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         // frame.width and frame.height is always 0. Estimating works OK for now.
         let estimatedWidth:CGFloat = 400;
         let estimatedHeight:CGFloat = 200;
+        // passkey modals are 600x600.
         let modalHeight: CGFloat = 600;
         let modalWidth: CGFloat = 600;
         let centerX = Int32(round(frame.origin.x + estimatedWidth/2))
         let centerY = Int32(round(screenHeight - (frame.origin.y + estimatedHeight/2)))
+        // Check if centerX or centerY are beyond either edge of the screen.  If they are find the center of the screen, otherwise use the original value.
         let positionX = CGFloat(centerX) + modalWidth >= screenWidth || CGFloat(centerX) - modalWidth <= 0 ? Int32(screenWidth/2) : centerX
         let positionY = CGFloat(centerY) + modalHeight >= screenHeight || CGFloat(centerY) - modalHeight <= 0 ? Int32(screenHeight/2) : centerY
         return Position(x: positionX, y: positionY)

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -139,13 +139,18 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     private func getWindowPosition() -> Position {
         let frame = self.view.window?.frame ?? .zero
         let screenHeight = NSScreen.main?.frame.height ?? 0
+        let screenWidth = NSScreen.main?.frame.width ?? 0
 
         // frame.width and frame.height is always 0. Estimating works OK for now.
         let estimatedWidth:CGFloat = 400;
         let estimatedHeight:CGFloat = 200;
+        let modalHeight: CGFloat = 600;
+        let modalWidth: CGFloat = 600;
         let centerX = Int32(round(frame.origin.x + estimatedWidth/2))
         let centerY = Int32(round(screenHeight - (frame.origin.y + estimatedHeight/2)))
-        return Position(x: centerX, y:centerY)
+        let positionX = CGFloat(centerX) + modalWidth >= screenWidth || CGFloat(centerX) - modalWidth <= 0 ? Int32(screenWidth/2) : centerX
+        let positionY = CGFloat(centerY) + modalHeight >= screenHeight || CGFloat(centerY) - modalHeight <= 0 ? Int32(screenHeight/2) : centerY
+        return Position(x: positionX, y: positionY)
     }
     
     override func loadView() {


### PR DESCRIPTION
## 🎟️ Tracking
[PM-22181](https://bitwarden.atlassian.net/browse/PM-22821)

## 📔 Objective

Centers the passkey vault modal when it is on the edge of the screen or offscreen. 

## 📸 Screenshots

**Before:**
<img width="1599" alt="Screenshot 2025-06-18 at 3 58 25 PM" src="https://github.com/user-attachments/assets/a0f17b28-e45f-4dc5-83e5-a172fb85c88e" />

**After:**
<img width="1600" alt="Screenshot 2025-06-18 at 3 48 28 PM" src="https://github.com/user-attachments/assets/989e8918-2cb1-4cf9-9811-b50c40d0e702" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22181]: https://bitwarden.atlassian.net/browse/PM-22181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ