### PR TITLE
[PM-22592] Deleted Ciphers with Security Tasks

### DIFF
--- a/apps/browser/src/vault/popup/components/at-risk-callout/at-risk-password-callout.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-callout/at-risk-password-callout.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { map, switchMap } from "rxjs";
+import { combineLatest, map, switchMap } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SecurityTaskType, TaskService } from "@bitwarden/common/vault/tasks";
 import { AnchorLinkDirective, CalloutModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -16,10 +17,26 @@ import { I18nPipe } from "@bitwarden/ui-common";
 })
 export class AtRiskPasswordCalloutComponent {
   private taskService = inject(TaskService);
+  private cipherService = inject(CipherService);
   private activeAccount$ = inject(AccountService).activeAccount$.pipe(getUserId);
 
   protected pendingTasks$ = this.activeAccount$.pipe(
-    switchMap((userId) => this.taskService.pendingTasks$(userId)),
-    map((tasks) => tasks.filter((t) => t.type === SecurityTaskType.UpdateAtRiskCredential)),
+    switchMap((userId) =>
+      combineLatest([
+        this.taskService.pendingTasks$(userId),
+        this.cipherService.cipherViews$(userId),
+      ]),
+    ),
+    map(([tasks, ciphers]) =>
+      tasks.filter((t) => {
+        const associatedCipher = ciphers.find((c) => c.id === t.cipherId);
+
+        return (
+          t.type === SecurityTaskType.UpdateAtRiskCredential &&
+          associatedCipher &&
+          !associatedCipher.isDeleted
+        );
+      }),
+    ),
   );
 }

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.spec.ts
@@ -203,6 +203,20 @@ describe("AtRiskPasswordsComponent", () => {
       expect(items).toHaveLength(1);
       expect(items[0].name).toBe("Item 1");
     });
+
+    it("should not show tasks associated with deleted ciphers", async () => {
+      mockCiphers$.next([
+        {
+          id: "cipher",
+          organizationId: "org",
+          name: "Item 1",
+          isDeleted: true,
+        } as CipherView,
+      ]);
+
+      const items = await firstValueFrom(component["atRiskItems$"]);
+      expect(items).toHaveLength(0);
+    });
   });
 
   describe("pageDescription$", () => {

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
@@ -155,7 +155,8 @@ export class AtRiskPasswordsComponent implements OnInit {
           (t) =>
             t.type === SecurityTaskType.UpdateAtRiskCredential &&
             t.cipherId != null &&
-            ciphers[t.cipherId] != null,
+            ciphers[t.cipherId] != null &&
+            !ciphers[t.cipherId].isDeleted,
         )
         .map((t) => ciphers[t.cipherId!]),
     ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22592](https://bitwarden.atlassian.net/browse/PM-22592)

## 📔 Objective

When a pending security task is associated with a cipher that is deleted it should not be shown in the UI.
Note: There is some duplicated logic here across components, it feels minimal and more boilerplate to add a service to centralize it. But that's not a hill I would die on, happy to add one if we feel it's needed!

## 📸 Screenshots

|Soft Delete|Permanent Delete|
|-|-|
|<video src="https://github.com/user-attachments/assets/99623bb8-776c-469a-9051-ec235493841d" />|<video src="https://github.com/user-attachments/assets/512b2ccd-851d-4131-853d-41df8d4580e4" />
## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
