### PR TITLE
Autofill/pm 22843 display vault for single credential

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -261,7 +261,7 @@ export class DesktopAutofillService implements OnDestroy {
           }
 
           const response = await this.fido2AuthenticatorService.getAssertion(
-            this.convertAssertionRequest(request),
+            this.convertAssertionRequest(request, true),
             { windowXy: request.windowXy },
             controller,
           );
@@ -359,6 +359,7 @@ export class DesktopAutofillService implements OnDestroy {
     request:
       | autofill.PasskeyAssertionRequest
       | autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+    assumeUserPresence: boolean = false,
   ): Fido2AuthenticatorGetAssertionParams {
     let allowedCredentials;
     if ("credentialId" in request) {
@@ -383,7 +384,7 @@ export class DesktopAutofillService implements OnDestroy {
       requireUserVerification:
         request.userVerification === "required" || request.userVerification === "preferred",
       fallbackSupported: false,
-      assumeUserPresence: true, // For desktop assertions, it's safe to assume UP has been checked by OS dialogues
+      assumeUserPresence,
     };
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22843](https://bitwarden.atlassian.net/browse/PM-22843)

## 📔 Objective

When the user selects the `Bitwarden...` option from the autofill menu they should see the Vault pop up to select a passkey when there is a single option.  Only when you select a specific passkey from the dropdown do we want the user to automatically skip the vault and use the selected option.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22843]: https://bitwarden.atlassian.net/browse/PM-22843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ