### PR TITLE
[PM-22178] Add `WebBrowserInteractionService`

### DIFF
--- a/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
@@ -1,4 +1,4 @@
-import { PopupPageUrls } from "@bitwarden/common/vault/enums";
+import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 
 type ContentMessageWindowData = {
   command: string;
@@ -7,7 +7,7 @@ type ContentMessageWindowData = {
   state?: string;
   data?: string;
   remember?: boolean;
-  page?: PopupPageUrls;
+  page?: ExtensionPageUrls;
 };
 type ContentMessageWindowEventParams = {
   data: ContentMessageWindowData;

--- a/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
@@ -7,7 +7,7 @@ type ContentMessageWindowData = {
   state?: string;
   data?: string;
   remember?: boolean;
-  page?: ExtensionPageUrls;
+  url?: ExtensionPageUrls;
 };
 type ContentMessageWindowEventParams = {
   data: ContentMessageWindowData;

--- a/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
@@ -1,3 +1,5 @@
+import { PopupPageUrls } from "@bitwarden/common/vault/enums";
+
 type ContentMessageWindowData = {
   command: string;
   lastpass?: boolean;
@@ -5,6 +7,7 @@ type ContentMessageWindowData = {
   state?: string;
   data?: string;
   remember?: boolean;
+  page?: PopupPageUrls;
 };
 type ContentMessageWindowEventParams = {
   data: ContentMessageWindowData;

--- a/apps/browser/src/autofill/content/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.ts
@@ -1,3 +1,4 @@
+import { PopupPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 
 import {
@@ -18,6 +19,8 @@ const windowMessageHandlers: ContentMessageWindowEventHandlers = {
   duoResult: ({ data, referrer }: { data: any; referrer: string }) =>
     handleDuoResultMessage(data, referrer),
   [VaultMessages.OpenAtRiskPasswords]: () => handleOpenAtRiskPasswordsMessage(),
+  [VaultMessages.OpenBrowserExtensionToPage]: ({ data }) =>
+    handleOpenBrowserExtensionToPageMessage(data),
 };
 
 /**
@@ -75,6 +78,10 @@ function handleWebAuthnResultMessage(data: ContentMessageWindowData, referrer: s
 
 function handleOpenAtRiskPasswordsMessage() {
   sendExtensionRuntimeMessage({ command: VaultMessages.OpenAtRiskPasswords });
+}
+
+function handleOpenBrowserExtensionToPageMessage({ page }: { page?: PopupPageUrls }) {
+  sendExtensionRuntimeMessage({ command: VaultMessages.OpenBrowserExtensionToPage, page });
 }
 
 /**

--- a/apps/browser/src/autofill/content/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.ts
@@ -1,4 +1,4 @@
-import { PopupPageUrls } from "@bitwarden/common/vault/enums";
+import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 
 import {
@@ -80,7 +80,7 @@ function handleOpenAtRiskPasswordsMessage() {
   sendExtensionRuntimeMessage({ command: VaultMessages.OpenAtRiskPasswords });
 }
 
-function handleOpenBrowserExtensionToPageMessage({ page }: { page?: PopupPageUrls }) {
+function handleOpenBrowserExtensionToPageMessage({ page }: { page?: ExtensionPageUrls }) {
   sendExtensionRuntimeMessage({ command: VaultMessages.OpenBrowserExtensionToPage, page });
 }
 

--- a/apps/browser/src/autofill/content/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.ts
@@ -19,8 +19,8 @@ const windowMessageHandlers: ContentMessageWindowEventHandlers = {
   duoResult: ({ data, referrer }: { data: any; referrer: string }) =>
     handleDuoResultMessage(data, referrer),
   [VaultMessages.OpenAtRiskPasswords]: () => handleOpenAtRiskPasswordsMessage(),
-  [VaultMessages.OpenBrowserExtensionToPage]: ({ data }) =>
-    handleOpenBrowserExtensionToPageMessage(data),
+  [VaultMessages.OpenBrowserExtensionToUrl]: ({ data }) =>
+    handleOpenBrowserExtensionToUrlMessage(data),
 };
 
 /**
@@ -80,8 +80,8 @@ function handleOpenAtRiskPasswordsMessage() {
   sendExtensionRuntimeMessage({ command: VaultMessages.OpenAtRiskPasswords });
 }
 
-function handleOpenBrowserExtensionToPageMessage({ page }: { page?: ExtensionPageUrls }) {
-  sendExtensionRuntimeMessage({ command: VaultMessages.OpenBrowserExtensionToPage, page });
+function handleOpenBrowserExtensionToUrlMessage({ url }: { url?: ExtensionPageUrls }) {
+  sendExtensionRuntimeMessage({ command: VaultMessages.OpenBrowserExtensionToUrl, url });
 }
 
 /**

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1684,16 +1684,16 @@ export default class MainBackground {
       // Reset the popup route to the default route so any subsequent
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
-        popup: ExtensionPageUrls.Default,
+        popup: ExtensionPageUrls.Index,
       });
     }
   }
 
   /**
    * Opens the popup to the given page
-   * @default ExtensionPageUrls.Default
+   * @default ExtensionPageUrls.Index
    */
-  async openTheExtensionToPage(page: ExtensionPageUrls = ExtensionPageUrls.Default) {
+  async openTheExtensionToPage(page: ExtensionPageUrls = ExtensionPageUrls.Index) {
     const browserAction = BrowserApi.getBrowserAction();
 
     try {
@@ -1707,7 +1707,7 @@ export default class MainBackground {
       // Reset the popup route to the default route so any subsequent
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
-        popup: ExtensionPageUrls.Default,
+        popup: ExtensionPageUrls.Index,
       });
     }
   }

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -190,7 +190,7 @@ import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstraction
 import { InternalFolderService as InternalFolderServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { TotpService as TotpServiceAbstraction } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService as VaultSettingsServiceAbstraction } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
-import { PopupPageUrls } from "@bitwarden/common/vault/enums";
+import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   DefaultEndUserNotificationService,
@@ -1677,23 +1677,23 @@ export default class MainBackground {
       // Set route of the popup before attempting to open it.
       // If the vault is locked, this won't have an effect as the auth guards will
       // redirect the user to the login page.
-      await browserAction.setPopup({ popup: PopupPageUrls.AtRiskPasswords });
+      await browserAction.setPopup({ popup: ExtensionPageUrls.AtRiskPasswords });
 
       await this.openPopup();
     } finally {
       // Reset the popup route to the default route so any subsequent
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
-        popup: PopupPageUrls.Default,
+        popup: ExtensionPageUrls.Default,
       });
     }
   }
 
   /**
    * Opens the popup to the given page
-   * @default PopupPageUrls.Default
+   * @default ExtensionPageUrls.Default
    */
-  async openTheExtensionToPage(page: PopupPageUrls = PopupPageUrls.Default) {
+  async openTheExtensionToPage(page: ExtensionPageUrls = ExtensionPageUrls.Default) {
     const browserAction = BrowserApi.getBrowserAction();
 
     try {
@@ -1707,7 +1707,7 @@ export default class MainBackground {
       // Reset the popup route to the default route so any subsequent
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
-        popup: PopupPageUrls.Default,
+        popup: ExtensionPageUrls.Default,
       });
     }
   }

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1693,14 +1693,14 @@ export default class MainBackground {
    * Opens the popup to the given page
    * @default ExtensionPageUrls.Index
    */
-  async openTheExtensionToPage(page: ExtensionPageUrls = ExtensionPageUrls.Index) {
+  async openTheExtensionToPage(url: ExtensionPageUrls = ExtensionPageUrls.Index) {
     const browserAction = BrowserApi.getBrowserAction();
 
     try {
       // Set route of the popup before attempting to open it.
       // If the vault is locked, this won't have an effect as the auth guards will
       // redirect the user to the login page.
-      await browserAction.setPopup({ popup: page });
+      await browserAction.setPopup({ popup: url });
 
       await this.openPopup();
     } finally {

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1677,21 +1677,21 @@ export default class MainBackground {
       // Set route of the popup before attempting to open it.
       // If the vault is locked, this won't have an effect as the auth guards will
       // redirect the user to the login page.
-      await browserAction.setPopup({ popup: "popup/index.html#/at-risk-passwords" });
+      await browserAction.setPopup({ popup: PopupPageUrls.AtRiskPasswords });
 
       await this.openPopup();
     } finally {
       // Reset the popup route to the default route so any subsequent
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
-        popup: "popup/index.html#/",
+        popup: PopupPageUrls.Default,
       });
     }
   }
 
   /**
    * Opens the popup to the given page
-   * @default "popup/index.html"
+   * @default PopupPageUrls.Default
    */
   async openTheExtensionToPage(page: PopupPageUrls = PopupPageUrls.Default) {
     const browserAction = BrowserApi.getBrowserAction();

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -190,6 +190,7 @@ import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstraction
 import { InternalFolderService as InternalFolderServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { TotpService as TotpServiceAbstraction } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService as VaultSettingsServiceAbstraction } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { PopupPageUrls } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   DefaultEndUserNotificationService,
@@ -1684,6 +1685,29 @@ export default class MainBackground {
       // popup openings will not open to the at-risk-passwords page.
       await browserAction.setPopup({
         popup: "popup/index.html#/",
+      });
+    }
+  }
+
+  /**
+   * Opens the popup to the given page
+   * @default "popup/index.html"
+   */
+  async openTheExtensionToPage(page: PopupPageUrls = PopupPageUrls.Default) {
+    const browserAction = BrowserApi.getBrowserAction();
+
+    try {
+      // Set route of the popup before attempting to open it.
+      // If the vault is locked, this won't have an effect as the auth guards will
+      // redirect the user to the login page.
+      await browserAction.setPopup({ popup: page });
+
+      await this.openPopup();
+    } finally {
+      // Reset the popup route to the default route so any subsequent
+      // popup openings will not open to the at-risk-passwords page.
+      await browserAction.setPopup({
+        popup: PopupPageUrls.Default,
       });
     }
   }

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -296,6 +296,10 @@ export default class RuntimeBackground {
         await this.main.openAtRisksPasswordsPage();
         this.announcePopupOpen();
         break;
+      case VaultMessages.OpenBrowserExtensionToPage:
+        await this.main.openTheExtensionToPage(msg.page);
+        this.announcePopupOpen();
+        break;
       case "bgUpdateContextMenu":
       case "editedCipher":
       case "addedCipher":

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -296,8 +296,8 @@ export default class RuntimeBackground {
         await this.main.openAtRisksPasswordsPage();
         this.announcePopupOpen();
         break;
-      case VaultMessages.OpenBrowserExtensionToPage:
-        await this.main.openTheExtensionToPage(msg.page);
+      case VaultMessages.OpenBrowserExtensionToUrl:
+        await this.main.openTheExtensionToPage(msg.url);
         this.announcePopupOpen();
         break;
       case "bgUpdateContextMenu":

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -81,11 +81,11 @@ describe("WebBrowserInteractionService", () => {
     });
 
     it("posts a message with the passed page", async () => {
-      service.openExtension(ExtensionPageUrls.Default).catch(() => {});
+      service.openExtension(ExtensionPageUrls.Index).catch(() => {});
 
       expect(postMessage).toHaveBeenCalledWith({
         command: VaultMessages.OpenBrowserExtensionToPage,
-        page: ExtensionPageUrls.Default,
+        page: ExtensionPageUrls.Index,
       });
 
       jest.advanceTimersByTime(1000);

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from "@angular/core/testing";
 
+import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 
 import { WebBrowserInteractionService } from "./web-browser-interaction.service";
@@ -74,6 +75,17 @@ describe("WebBrowserInteractionService", () => {
 
       expect(postMessage).toHaveBeenCalledWith({
         command: VaultMessages.OpenBrowserExtensionToPage,
+      });
+
+      jest.advanceTimersByTime(1000);
+    });
+
+    it("posts a message with the passed page", async () => {
+      service.openExtension(ExtensionPageUrls.Default).catch(() => {});
+
+      expect(postMessage).toHaveBeenCalledWith({
+        command: VaultMessages.OpenBrowserExtensionToPage,
+        page: ExtensionPageUrls.Default,
       });
 
       jest.advanceTimersByTime(1000);

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from "@angular/core/testing";
+
+import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
+
+import { WebBrowserInteractionService } from "./web-browser-interaction.service";
+
+describe("WebBrowserInteractionService", () => {
+  let service: WebBrowserInteractionService;
+  const postMessage = jest.fn();
+  window.postMessage = postMessage;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [WebBrowserInteractionService],
+    });
+
+    jest.useFakeTimers();
+    postMessage.mockClear();
+
+    service = TestBed.inject(WebBrowserInteractionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe("extensionInstalled$", () => {
+    it("posts a message to check for the extension", () => {
+      service.extensionInstalled$.subscribe();
+
+      expect(postMessage).toHaveBeenCalledWith({
+        command: VaultMessages.checkBwInstalled,
+      });
+    });
+
+    it("returns false after the timeout", (done) => {
+      service.extensionInstalled$.subscribe((installed) => {
+        expect(installed).toBe(false);
+        done();
+      });
+
+      jest.advanceTimersByTime(1000);
+    });
+
+    it("returns true when the extension is installed", (done) => {
+      service.extensionInstalled$.subscribe((installed) => {
+        expect(installed).toBe(true);
+        done();
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { command: VaultMessages.HasBwInstalled } }),
+      );
+    });
+
+    it("clears the timeout when extension installed message is received", (done) => {
+      service.extensionInstalled$.subscribe(() => {
+        expect(service["checkForExtensionTimeout"]).toBeUndefined();
+        done();
+      });
+
+      expect(service["checkForExtensionTimeout"]).toBeDefined();
+
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { command: VaultMessages.HasBwInstalled } }),
+      );
+    });
+
+    it("only calls postMessage once when an extension state is determined", (done) => {
+      service.extensionInstalled$.subscribe();
+
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { command: VaultMessages.HasBwInstalled } }),
+      );
+
+      service.extensionInstalled$.subscribe(() => {
+        expect(postMessage).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -67,4 +67,37 @@ describe("WebBrowserInteractionService", () => {
       });
     });
   });
+
+  describe("openExtension", () => {
+    it("posts a message to open the extension", async () => {
+      service.openExtension().catch(() => {});
+
+      expect(postMessage).toHaveBeenCalledWith({
+        command: VaultMessages.OpenBrowserExtensionToPage,
+      });
+
+      jest.advanceTimersByTime(1000);
+    });
+
+    it("resolves when the extension opens", async () => {
+      const openExtensionPromise = service.openExtension().catch(() => {
+        fail();
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { command: VaultMessages.PopupOpened } }),
+      );
+
+      await openExtensionPromise;
+    });
+
+    it("rejects if the extension does not open within the timeout", (done) => {
+      service.openExtension().catch((error) => {
+        expect(error).toBe("Extension failed to open");
+        done();
+      });
+
+      jest.advanceTimersByTime(1000);
+    });
+  });
 });

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from "@angular/core/testing";
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 
 import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
@@ -15,15 +15,9 @@ describe("WebBrowserInteractionService", () => {
       providers: [WebBrowserInteractionService],
     });
 
-    jest.useFakeTimers();
     postMessage.mockClear();
 
     service = TestBed.inject(WebBrowserInteractionService);
-  });
-
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
   });
 
   describe("extensionInstalled$", () => {
@@ -35,14 +29,13 @@ describe("WebBrowserInteractionService", () => {
       });
     });
 
-    it("returns false after the timeout", (done) => {
+    it("returns false after the timeout", fakeAsync(() => {
       service.extensionInstalled$.subscribe((installed) => {
         expect(installed).toBe(false);
-        done();
       });
 
-      jest.advanceTimersByTime(1000);
-    });
+      tick(1500);
+    }));
 
     it("returns true when the extension is installed", (done) => {
       service.extensionInstalled$.subscribe((installed) => {
@@ -70,17 +63,17 @@ describe("WebBrowserInteractionService", () => {
   });
 
   describe("openExtension", () => {
-    it("posts a message to open the extension", async () => {
+    it("posts a message to open the extension", fakeAsync(() => {
       service.openExtension().catch(() => {});
 
       expect(postMessage).toHaveBeenCalledWith({
         command: VaultMessages.OpenBrowserExtensionToPage,
       });
 
-      jest.advanceTimersByTime(1000);
-    });
+      tick(1500);
+    }));
 
-    it("posts a message with the passed page", async () => {
+    it("posts a message with the passed page", fakeAsync(() => {
       service.openExtension(ExtensionPageUrls.Index).catch(() => {});
 
       expect(postMessage).toHaveBeenCalledWith({
@@ -88,8 +81,8 @@ describe("WebBrowserInteractionService", () => {
         page: ExtensionPageUrls.Index,
       });
 
-      jest.advanceTimersByTime(1000);
-    });
+      tick(1500);
+    }));
 
     it("resolves when the extension opens", async () => {
       const openExtensionPromise = service.openExtension().catch(() => {
@@ -103,13 +96,12 @@ describe("WebBrowserInteractionService", () => {
       await openExtensionPromise;
     });
 
-    it("rejects if the extension does not open within the timeout", (done) => {
+    it("rejects if the extension does not open within the timeout", fakeAsync(() => {
       service.openExtension().catch((error) => {
-        expect(error).toBe("Extension failed to open");
-        done();
+        expect(error).toBe("Failed to open the extension");
       });
 
-      jest.advanceTimersByTime(1000);
-    });
+      tick(1500);
+    }));
   });
 });

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -54,19 +54,6 @@ describe("WebBrowserInteractionService", () => {
       );
     });
 
-    it("clears the timeout when extension installed message is received", (done) => {
-      service.extensionInstalled$.subscribe(() => {
-        expect(service["checkForExtensionTimeout"]).toBeUndefined();
-        done();
-      });
-
-      expect(service["checkForExtensionTimeout"]).toBeDefined();
-
-      window.dispatchEvent(
-        new MessageEvent("message", { data: { command: VaultMessages.HasBwInstalled } }),
-      );
-    });
-
     it("only calls postMessage once when an extension state is determined", (done) => {
       service.extensionInstalled$.subscribe();
 

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.spec.ts
@@ -67,7 +67,7 @@ describe("WebBrowserInteractionService", () => {
       service.openExtension().catch(() => {});
 
       expect(postMessage).toHaveBeenCalledWith({
-        command: VaultMessages.OpenBrowserExtensionToPage,
+        command: VaultMessages.OpenBrowserExtensionToUrl,
       });
 
       tick(1500);
@@ -77,8 +77,8 @@ describe("WebBrowserInteractionService", () => {
       service.openExtension(ExtensionPageUrls.Index).catch(() => {});
 
       expect(postMessage).toHaveBeenCalledWith({
-        command: VaultMessages.OpenBrowserExtensionToPage,
-        page: ExtensionPageUrls.Index,
+        command: VaultMessages.OpenBrowserExtensionToUrl,
+        url: ExtensionPageUrls.Index,
       });
 
       tick(1500);

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.ts
@@ -31,7 +31,7 @@ export class WebBrowserInteractionService {
   );
 
   /** Attempts to open the extension, rejects if the extension is not installed or it fails to open.  */
-  openExtension = (page?: ExtensionPageUrls) => {
+  openExtension = (url?: ExtensionPageUrls) => {
     return new Promise<void>((resolve, reject) => {
       if (this._extensionInstalled$.getValue() === false) {
         return reject("Extension is not installed");
@@ -53,7 +53,7 @@ export class WebBrowserInteractionService {
           resolve();
         });
 
-      window.postMessage({ command: VaultMessages.OpenBrowserExtensionToPage, page });
+      window.postMessage({ command: VaultMessages.OpenBrowserExtensionToUrl, url });
     });
   };
 

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.ts
@@ -1,0 +1,59 @@
+import { DestroyRef, inject, Injectable } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { BehaviorSubject, filter, fromEvent, tap } from "rxjs";
+
+import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
+
+@Injectable()
+export class WebBrowserInteractionService {
+  destroyRef = inject(DestroyRef);
+
+  private _extensionInstalled$ = new BehaviorSubject<boolean | null>(null);
+
+  private checkForExtensionTimeout: number | undefined;
+
+  constructor() {
+    fromEvent<MessageEvent>(window, "message")
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => {
+        void this.processMessages(event);
+      });
+  }
+
+  extensionInstalled$ = this._extensionInstalled$.pipe(
+    tap(this.checkForExtension.bind(this)),
+    filter((installed) => installed !== null),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  /** Sends a message via the window object to check if the extension is installed */
+  private checkForExtension(isExtensionInstalled: boolean | null) {
+    if (isExtensionInstalled !== null) {
+      this.clearExtensionTimeout();
+      return;
+    }
+
+    window.postMessage({ command: VaultMessages.checkBwInstalled });
+
+    this.clearExtensionTimeout();
+    this.checkForExtensionTimeout = window.setTimeout(() => {
+      this._extensionInstalled$.next(false);
+      this.clearExtensionTimeout();
+    }, 1000);
+  }
+
+  /** Process window message events */
+  private processMessages(event: any) {
+    if (event.data.command === VaultMessages.HasBwInstalled) {
+      this._extensionInstalled$.next(true);
+    }
+  }
+
+  /** When populated, clears the check extension timeout and clears the value */
+  private clearExtensionTimeout() {
+    if (this.checkForExtensionTimeout) {
+      window.clearTimeout(this.checkForExtensionTimeout);
+      this.checkForExtensionTimeout = undefined;
+    }
+  }
+}

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.ts
@@ -2,7 +2,7 @@ import { DestroyRef, inject, Injectable } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { BehaviorSubject, filter, first, fromEvent, takeUntil, tap, timer } from "rxjs";
 
-import { PopupPageUrls } from "@bitwarden/common/vault/enums";
+import { ExtensionPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 
 @Injectable({
@@ -27,7 +27,7 @@ export class WebBrowserInteractionService {
   );
 
   /** Attempts to open the extension, rejects if the extension is not installed or it fails to open.  */
-  openExtension = (page?: PopupPageUrls) => {
+  openExtension = (page?: ExtensionPageUrls) => {
     return new Promise<void>((resolve, reject) => {
       if (this._extensionInstalled$.getValue() === false) {
         return reject("Extension is not installed");

--- a/apps/web/src/app/vault/services/web-browser-interaction.service.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.ts
@@ -1,10 +1,13 @@
 import { DestroyRef, inject, Injectable } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { BehaviorSubject, filter, fromEvent, tap } from "rxjs";
+import { BehaviorSubject, filter, first, fromEvent, takeUntil, tap, timer } from "rxjs";
 
+import { PopupPageUrls } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 
-@Injectable()
+@Injectable({
+  providedIn: "root",
+})
 export class WebBrowserInteractionService {
   destroyRef = inject(DestroyRef);
 
@@ -16,11 +19,38 @@ export class WebBrowserInteractionService {
     takeUntilDestroyed(this.destroyRef),
   );
 
+  /** Emits the installation status of the extension. */
   extensionInstalled$ = this._extensionInstalled$.pipe(
     tap(this.checkForExtension.bind(this)),
     filter((installed) => installed !== null),
     takeUntilDestroyed(this.destroyRef),
   );
+
+  /** Attempts to open the extension, rejects if the extension is not installed or it fails to open.  */
+  openExtension = (page?: PopupPageUrls) => {
+    return new Promise<void>((resolve, reject) => {
+      if (this._extensionInstalled$.getValue() === false) {
+        return reject("Extension is not installed");
+      }
+
+      this.messages$
+        .pipe(
+          filter((event) => event.data.command === VaultMessages.PopupOpened),
+          first(),
+          takeUntil(timer(1000)), // only wait a second for the extension to respond.
+        )
+        .subscribe({
+          next: () => {
+            resolve();
+          },
+          complete: () => {
+            return reject("Extension failed to open");
+          },
+        });
+
+      window.postMessage({ command: VaultMessages.OpenBrowserExtensionToPage, page });
+    });
+  };
 
   /** Sends a message via the window object to check if the extension is installed */
   private checkForExtension(isExtensionInstalled: boolean | null) {

--- a/libs/common/src/vault/enums/extension-page-urls.enum.ts
+++ b/libs/common/src/vault/enums/extension-page-urls.enum.ts
@@ -1,12 +1,12 @@
 import { UnionOfValues } from "../types/union-of-values";
 
 /**
- * Available pages within the popup by their URL.
+ * Available pages within the extension by their URL.
  * Useful when opening a specific page within the popup.
  */
-export const PopupPageUrls: Record<string, `popup/index.html#/${string}`> = {
+export const ExtensionPageUrls: Record<string, `popup/index.html#/${string}`> = {
   Default: "popup/index.html#/",
   AtRiskPasswords: "popup/index.html#/at-risk-passwords",
 } as const;
 
-export type PopupPageUrls = UnionOfValues<typeof PopupPageUrls>;
+export type ExtensionPageUrls = UnionOfValues<typeof ExtensionPageUrls>;

--- a/libs/common/src/vault/enums/extension-page-urls.enum.ts
+++ b/libs/common/src/vault/enums/extension-page-urls.enum.ts
@@ -5,7 +5,7 @@ import { UnionOfValues } from "../types/union-of-values";
  * Useful when opening a specific page within the popup.
  */
 export const ExtensionPageUrls: Record<string, `popup/index.html#/${string}`> = {
-  Default: "popup/index.html#/",
+  Index: "popup/index.html#/",
   AtRiskPasswords: "popup/index.html#/at-risk-passwords",
 } as const;
 

--- a/libs/common/src/vault/enums/index.ts
+++ b/libs/common/src/vault/enums/index.ts
@@ -3,3 +3,4 @@ export * from "./cipher-type";
 export * from "./field-type.enum";
 export * from "./linked-id-type.enum";
 export * from "./secure-note-type.enum";
+export * from "./popup-page-urls.enum";

--- a/libs/common/src/vault/enums/index.ts
+++ b/libs/common/src/vault/enums/index.ts
@@ -3,4 +3,4 @@ export * from "./cipher-type";
 export * from "./field-type.enum";
 export * from "./linked-id-type.enum";
 export * from "./secure-note-type.enum";
-export * from "./popup-page-urls.enum";
+export * from "./extension-page-urls.enum";

--- a/libs/common/src/vault/enums/popup-page-urls.enum.ts
+++ b/libs/common/src/vault/enums/popup-page-urls.enum.ts
@@ -1,0 +1,11 @@
+import { UnionOfValues } from "../types/union-of-values";
+
+/**
+ * Available pages within the popup by their URL.
+ * Useful when opening a specific page within the popup.
+ */
+export const PopupPageUrls: Record<string, `popup/index.html#/${string}`> = {
+  Default: "popup/index.html#/",
+} as const;
+
+export type PopupPageUrls = UnionOfValues<typeof PopupPageUrls>;

--- a/libs/common/src/vault/enums/popup-page-urls.enum.ts
+++ b/libs/common/src/vault/enums/popup-page-urls.enum.ts
@@ -6,6 +6,7 @@ import { UnionOfValues } from "../types/union-of-values";
  */
 export const PopupPageUrls: Record<string, `popup/index.html#/${string}`> = {
   Default: "popup/index.html#/",
+  AtRiskPasswords: "popup/index.html#/at-risk-passwords",
 } as const;
 
 export type PopupPageUrls = UnionOfValues<typeof PopupPageUrls>;

--- a/libs/common/src/vault/enums/vault-messages.enum.ts
+++ b/libs/common/src/vault/enums/vault-messages.enum.ts
@@ -2,7 +2,7 @@ const VaultMessages = {
   HasBwInstalled: "hasBwInstalled",
   checkBwInstalled: "checkIfBWExtensionInstalled",
   OpenAtRiskPasswords: "openAtRiskPasswords",
-  OpenBrowserExtensionToPage: "openBrowserExtensionToPage",
+  OpenBrowserExtensionToUrl: "openBrowserExtensionToUrl",
   PopupOpened: "popupOpened",
 } as const;
 

--- a/libs/common/src/vault/enums/vault-messages.enum.ts
+++ b/libs/common/src/vault/enums/vault-messages.enum.ts
@@ -2,6 +2,7 @@ const VaultMessages = {
   HasBwInstalled: "hasBwInstalled",
   checkBwInstalled: "checkIfBWExtensionInstalled",
   OpenAtRiskPasswords: "openAtRiskPasswords",
+  OpenBrowserExtensionToPage: "openBrowserExtensionToPage",
   PopupOpened: "popupOpened",
 } as const;
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22178](https://bitwarden.atlassian.net/browse/PM-22178)

## 📔 Objective

In preparation with some upcoming work and to make some existing work, the vault now has a `WebBrowserInteractionService` that can handle communications from the web to the browser. 
- `extensionInstalled$` emits true or false if the extension is installed
- `openExtension` attempts to open the extension. Optionally to a specific url otherwise the extension will open to the index.
  - Added additional logic to the message handlers in the extension to consume the message + open the extension.
- Added `ExtensionPageUrls` constant so the extension page urls aren't hardcoded strings

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/c630570c-28f7-42e2-9100-3bc7e6389554" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
