### PR TITLE
[PM 20321] Payment is never optional when trial length is zero

### DIFF
--- a/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.html
+++ b/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.html
@@ -38,13 +38,17 @@
           [loading]="loading && (trialPaymentOptional$ | async)"
           (click)="orgNameEntrySubmit()"
         >
-          {{ (trialPaymentOptional$ | async) ? ("startTrial" | i18n) : ("next" | i18n) }}
+          {{
+            (trialPaymentOptional$ | async) && trialLength > 0
+              ? ("startTrial" | i18n)
+              : ("next" | i18n)
+          }}
         </button>
       </app-vertical-step>
       <app-vertical-step
         label="Billing"
         [subLabel]="billingSubLabel"
-        *ngIf="!(trialPaymentOptional$ | async) && !isSecretsManagerFree"
+        *ngIf="(trialPaymentOptional$ | async) && trialLength === 0 && !isSecretsManagerFree"
       >
         <app-trial-billing-step
           *ngIf="stepper.selectedIndex === 2"

--- a/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
+++ b/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
@@ -225,7 +225,8 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
   async orgNameEntrySubmit(): Promise<void> {
     const isTrialPaymentOptional = await firstValueFrom(this.trialPaymentOptional$);
 
-    if (isTrialPaymentOptional) {
+    /** Only skip payment if the flag is on AND trialLength > 0 */
+    if (isTrialPaymentOptional && this.trialLength > 0) {
       await this.createOrganizationOnTrial();
     } else {
       await this.conditionallyCreateOrganization();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20321
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR ensures that when the payment optional feature flag is enabled and a zero-day trial is specified (i.e., trialLength = 0 in the /trial/send-verification-email request), the system does not skip the payment step during the trial signup flow.

**Background**
Previously, enabling the payment-optional feature could allow users to bypass payment setup during the trial flow. However, when the trial length is explicitly set to 0 days, the expectation is that the user must provide a payment method upfront to proceed. Skipping payment in this case would lead to invalid or unintended behavior.

**What this PR changes**
Introduces logic to prevent skipping the payment step when:

The payment-optional feature flag is on, AND

The trial length is set to 0.

Ensures users are prompted for payment when no trial period is granted, regardless of the feature flag.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/c63f3e22-b7a6-4573-a596-e7b3fa653ea8


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
