### PR TITLE
Hide card option from context menu when user is affected by card policy

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -204,6 +204,7 @@ import { DefaultCipherEncryptionService } from "@bitwarden/common/vault/services
 import { CipherFileUploadService } from "@bitwarden/common/vault/services/file-upload/cipher-file-upload.service";
 import { FolderApiService } from "@bitwarden/common/vault/services/folder/folder-api.service";
 import { FolderService } from "@bitwarden/common/vault/services/folder/folder.service";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/services/vault-settings/vault-settings.service";
 import { DefaultTaskService, TaskService } from "@bitwarden/common/vault/tasks";
@@ -434,6 +435,8 @@ export default class MainBackground {
   private nativeMessagingBackground: NativeMessagingBackground;
 
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
+
+  private restrictedItemTypesService: RestrictedItemTypesService;
 
   constructor() {
     // Services
@@ -1296,6 +1299,13 @@ export default class MainBackground {
       this.stateProvider,
     );
 
+    this.restrictedItemTypesService = new RestrictedItemTypesService(
+      this.configService,
+      this.accountService,
+      this.organizationService,
+      this.policyService,
+    );
+
     this.mainContextMenuHandler = new MainContextMenuHandler(
       this.stateService,
       this.autofillSettingsService,
@@ -1303,6 +1313,7 @@ export default class MainBackground {
       this.logService,
       this.billingAccountProfileStateService,
       this.accountService,
+      this.restrictedItemTypesService,
     );
 
     this.cipherContextMenuHandler = new CipherContextMenuHandler(

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -151,8 +151,6 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
   private clearClipboardDelayState: ActiveUserState<ClearClipboardDelaySetting>;
   readonly clearClipboardDelay$: Observable<ClearClipboardDelaySetting>;
 
-  readonly showCardSettings: Observable<boolean>;
-
   constructor(
     private stateProvider: StateProvider,
     private policyService: PolicyService,
@@ -209,13 +207,6 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     this.clearClipboardDelayState = this.stateProvider.getActive(CLEAR_CLIPBOARD_DELAY);
     this.clearClipboardDelay$ = this.clearClipboardDelayState.state$.pipe(
       map((x) => x ?? ClearClipboardDelay.Never),
-    );
-
-    this.showCardSettings = this.accountService.activeAccount$.pipe(
-      getUserId,
-      switchMap((userId) =>
-        this.policyService.policyAppliesToUser$(PolicyType.RestrictedItemTypes, userId),
-      ),
     );
   }
 

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -151,6 +151,8 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
   private clearClipboardDelayState: ActiveUserState<ClearClipboardDelaySetting>;
   readonly clearClipboardDelay$: Observable<ClearClipboardDelaySetting>;
 
+  readonly showCardSettings: Observable<boolean>;
+
   constructor(
     private stateProvider: StateProvider,
     private policyService: PolicyService,
@@ -207,6 +209,13 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
     this.clearClipboardDelayState = this.stateProvider.getActive(CLEAR_CLIPBOARD_DELAY);
     this.clearClipboardDelay$ = this.clearClipboardDelayState.state$.pipe(
       map((x) => x ?? ClearClipboardDelay.Never),
+    );
+
+    this.showCardSettings = this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) =>
+        this.policyService.policyAppliesToUser$(PolicyType.RestrictedItemTypes, userId),
+      ),
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20625](https://bitwarden.atlassian.net/browse/PM-20625)

## 📔 Objective

Remove the 'Autofill card' option from the context menu if a user is part of an organization with the 'Remove card item type' policy on.

## 📸 Screenshots

https://github.com/user-attachments/assets/e7d04b9d-a182-4f6f-ba6e-9c1ee6802c0b


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20625]: https://bitwarden.atlassian.net/browse/PM-20625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ