### PR TITLE
[PM-22812]  Attachments get corrupted when downgrading from cipherkeys

### DIFF
--- a/libs/common/src/vault/models/view/attachment.view.spec.ts
+++ b/libs/common/src/vault/models/view/attachment.view.spec.ts
@@ -26,6 +26,8 @@ describe("AttachmentView", () => {
     });
 
     it("should return an AttachmentView from an SdkAttachmentView", () => {
+      jest.spyOn(SymmetricCryptoKey, "fromString").mockReturnValue("mockKey" as any);
+
       const sdkAttachmentView = {
         id: "id",
         url: "url",
@@ -33,6 +35,7 @@ describe("AttachmentView", () => {
         sizeName: "sizeName",
         fileName: "fileName",
         key: "encKeyB64_fromString",
+        decryptedKey: "decryptedKey_B64",
       } as SdkAttachmentView;
 
       const result = AttachmentView.fromSdkAttachmentView(sdkAttachmentView);
@@ -43,14 +46,20 @@ describe("AttachmentView", () => {
         size: "size",
         sizeName: "sizeName",
         fileName: "fileName",
-        key: null,
+        key: "mockKey",
         encryptedKey: new EncString(sdkAttachmentView.key as string),
       });
+
+      expect(SymmetricCryptoKey.fromString).toHaveBeenCalledWith("decryptedKey_B64");
     });
   });
 
   describe("toSdkAttachmentView", () => {
     it("should convert AttachmentView to SdkAttachmentView", () => {
+      const mockKey = {
+        toBase64: jest.fn().mockReturnValue("keyB64"),
+      } as any;
+
       const attachmentView = new AttachmentView();
       attachmentView.id = "id";
       attachmentView.url = "url";
@@ -58,8 +67,10 @@ describe("AttachmentView", () => {
       attachmentView.sizeName = "sizeName";
       attachmentView.fileName = "fileName";
       attachmentView.encryptedKey = new EncString("encKeyB64");
+      attachmentView.key = mockKey;
 
       const result = attachmentView.toSdkAttachmentView();
+
       expect(result).toEqual({
         id: "id",
         url: "url",
@@ -67,6 +78,7 @@ describe("AttachmentView", () => {
         sizeName: "sizeName",
         fileName: "fileName",
         key: "encKeyB64",
+        decryptedKey: "keyB64",
       });
     });
   });

--- a/libs/common/src/vault/models/view/attachment.view.ts
+++ b/libs/common/src/vault/models/view/attachment.view.ts
@@ -59,6 +59,8 @@ export class AttachmentView implements View {
       sizeName: this.sizeName,
       fileName: this.fileName,
       key: this.encryptedKey?.toJSON(),
+      // TODO: PM-23005 - Temporary field, should be removed when encrypted migration is complete
+      decryptedKey: this.key ? this.key.toBase64() : null,
     };
   }
 
@@ -76,6 +78,8 @@ export class AttachmentView implements View {
     view.size = obj.size ?? null;
     view.sizeName = obj.sizeName ?? null;
     view.fileName = obj.fileName ?? null;
+    // TODO: PM-23005 - Temporary field, should be removed when encrypted migration is complete
+    view.key = obj.key ? SymmetricCryptoKey.fromString(obj.decryptedKey) : null;
     view.encryptedKey = new EncString(obj.key);
 
     return view;


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22812

related to this [PR](https://github.com/bitwarden/sdk-internal/pull/328)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Editing a cipher with attachments causes attachment corruption when switching between cipher-key encryption and user-key encryption in either direction. The SDK's AttachmentView was not providing the decrypted attachment key needed for re-encryption scenarios. When the cipher gets re-encrypted between different encryption contexts (cipher-key ↔ user-key) during save, the client needs the decrypted attachment key to properly re-encrypt it under the new encryption context. Without this, null gets posted for the attachment key, breaking decryption.

This is a temporary solution during the migration from TypeScript to the SDK. The decrypted_key field should be removed once all encryption logic is handled within the SDK.

Cleanup tracked in: https://bitwarden.atlassian.net/browse/PM-23005
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
