### PR TITLE
[PM-23071] Remove legacy key support in vault code

### DIFF
--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -169,7 +169,7 @@ export class CreateCommand {
 
   private async createFolder(req: FolderExport) {
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    const userKey = await this.keyService.getUserKeyWithLegacySupport(activeUserId);
+    const userKey = await this.keyService.getUserKey(activeUserId);
     const folder = await this.folderService.encrypt(FolderExport.toView(req), userKey);
     try {
       await this.folderApiService.save(folder, activeUserId);

--- a/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
+++ b/apps/web/src/app/vault/individual-vault/folder-add-edit.component.ts
@@ -93,7 +93,7 @@ export class FolderAddEditComponent extends BaseFolderAddEditComponent {
 
     try {
       const activeAccountId = await firstValueFrom(this.activeUserId$);
-      const userKey = await this.keyService.getUserKeyWithLegacySupport(activeAccountId);
+      const userKey = await this.keyService.getUserKey(activeAccountId);
       const folder = await this.folderService.encrypt(this.folder, userKey);
       this.formPromise = this.folderApiService.save(folder, activeAccountId);
       await this.formPromise;

--- a/libs/angular/src/vault/components/folder-add-edit.component.ts
+++ b/libs/angular/src/vault/components/folder-add-edit.component.ts
@@ -63,7 +63,7 @@ export class FolderAddEditComponent implements OnInit {
 
     try {
       const activeUserId = await firstValueFrom(this.activeUserId$);
-      const userKey = await this.keyService.getUserKeyWithLegacySupport(activeUserId);
+      const userKey = await this.keyService.getUserKey(activeUserId);
       const folder = await this.folderService.encrypt(this.folder, userKey);
       this.formPromise = this.folderApiService.save(folder, activeUserId);
       await this.formPromise;

--- a/libs/common/src/vault/models/domain/attachment.spec.ts
+++ b/libs/common/src/vault/models/domain/attachment.spec.ts
@@ -109,7 +109,7 @@ describe("Attachment", () => {
 
         await attachment.decrypt(null, "", providedKey);
 
-        expect(keyService.getUserKeyWithLegacySupport).not.toHaveBeenCalled();
+        expect(keyService.getUserKey).not.toHaveBeenCalled();
         expect(encryptService.unwrapSymmetricKey).toHaveBeenCalledWith(attachment.key, providedKey);
       });
 
@@ -125,11 +125,11 @@ describe("Attachment", () => {
 
       it("gets the user's decryption key if required", async () => {
         const userKey = mock<UserKey>();
-        keyService.getUserKeyWithLegacySupport.mockResolvedValue(userKey);
+        keyService.getUserKey.mockResolvedValue(userKey);
 
         await attachment.decrypt(null, "", null);
 
-        expect(keyService.getUserKeyWithLegacySupport).toHaveBeenCalled();
+        expect(keyService.getUserKey).toHaveBeenCalled();
         expect(encryptService.unwrapSymmetricKey).toHaveBeenCalledWith(attachment.key, userKey);
       });
     });

--- a/libs/common/src/vault/models/domain/attachment.ts
+++ b/libs/common/src/vault/models/domain/attachment.ts
@@ -79,9 +79,7 @@ export class Attachment extends Domain {
 
   private async getKeyForDecryption(orgId: string) {
     const keyService = Utils.getContainerService().getKeyService();
-    return orgId != null
-      ? await keyService.getOrgKey(orgId)
-      : await keyService.getUserKeyWithLegacySupport();
+    return orgId != null ? await keyService.getOrgKey(orgId) : await keyService.getUserKey();
   }
 
   toAttachmentData(): AttachmentData {

--- a/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.spec.ts
+++ b/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.spec.ts
@@ -29,7 +29,7 @@ describe("AddEditFolderDialogComponent", () => {
   const save = jest.fn().mockResolvedValue(null);
   const deleteFolder = jest.fn().mockResolvedValue(null);
   const openSimpleDialog = jest.fn().mockResolvedValue(true);
-  const getUserKeyWithLegacySupport = jest.fn().mockResolvedValue("");
+  const getUserKey = jest.fn().mockResolvedValue("");
   const error = jest.fn();
   const close = jest.fn();
   const showToast = jest.fn();
@@ -66,7 +66,7 @@ describe("AddEditFolderDialogComponent", () => {
         {
           provide: KeyService,
           useValue: {
-            getUserKeyWithLegacySupport,
+            getUserKey,
           },
         },
         { provide: LogService, useValue: { error } },

--- a/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
+++ b/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
@@ -121,7 +121,7 @@ export class AddEditFolderDialogComponent implements AfterViewInit, OnInit {
 
     try {
       const activeUserId = await firstValueFrom(this.activeUserId$);
-      const userKey = await this.keyService.getUserKeyWithLegacySupport(activeUserId!);
+      const userKey = await this.keyService.getUserKey(activeUserId!);
       const folder = await this.folderService.encrypt(this.folder, userKey);
       await this.folderApiService.save(folder, activeUserId!);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23071

## 📔 Objective

Legacy users (no userkey) are no longer supported. Further, for vault code this causes a race condition, where if the userkey is not set to state fast enough, private key decryption fails and the vault shows as empty, because the cipherDecryptionKeys subscription breaks.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
