### PR TITLE
[PM-20579] Add encryption/decryption for risk insights and save method

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -55,6 +55,8 @@ jobs:
     name: Release
     runs-on: ubuntu-22.04
     needs: setup
+    permissions:
+      contents: write
     steps:
       - name: Download all Release artifacts
         if: ${{ inputs.release_type != 'Dry Run' }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -24,6 +24,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     outputs:
       release_version: ${{ steps.version.outputs.version }}
       release_channel: ${{ steps.release_channel.outputs.channel }}

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -533,6 +533,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         await this.biometricStateService.setBiometricUnlockEnabled(successful);
         if (!successful) {
           await this.biometricStateService.setFingerprintValidated(false);
+          return;
         }
         this.toastService.showToast({
           variant: "success",
@@ -597,6 +598,8 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
             this.i18nService.t("errorEnableBiometricTitle"),
             this.i18nService.t("errorEnableBiometricDesc"),
           );
+          setupResult = false;
+          return;
         }
         setupResult = true;
       } catch (e) {

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -412,7 +412,7 @@ export default class MainBackground {
   inlineMenuFieldQualificationService: InlineMenuFieldQualificationService;
   taskService: TaskService;
   cipherEncryptionService: CipherEncryptionService;
-  restrictedItemTypesService: RestrictedItemTypesService;
+  private restrictedItemTypesService: RestrictedItemTypesService;
 
   ipcContentScriptManagerService: IpcContentScriptManagerService;
   ipcService: IpcService;
@@ -436,8 +436,6 @@ export default class MainBackground {
   private nativeMessagingBackground: NativeMessagingBackground;
 
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
-
-  private restrictedItemTypesService: RestrictedItemTypesService;
 
   constructor() {
     // Services
@@ -1045,13 +1043,6 @@ export default class MainBackground {
       this.pinService,
       this.accountService,
       this.sdkService,
-    );
-
-    this.restrictedItemTypesService = new RestrictedItemTypesService(
-      this.configService,
-      this.accountService,
-      this.organizationService,
-      this.policyService,
     );
 
     this.individualVaultExportService = new IndividualVaultExportService(

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -437,6 +437,8 @@ export default class MainBackground {
 
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
 
+  private restrictedItemTypesService: RestrictedItemTypesService;
+
   constructor() {
     // Services
     const lockedCallback = async (userId: UserId) => {
@@ -1307,6 +1309,13 @@ export default class MainBackground {
       this.stateProvider,
     );
 
+    this.restrictedItemTypesService = new RestrictedItemTypesService(
+      this.configService,
+      this.accountService,
+      this.organizationService,
+      this.policyService,
+    );
+
     this.mainContextMenuHandler = new MainContextMenuHandler(
       this.stateService,
       this.autofillSettingsService,
@@ -1314,6 +1323,7 @@ export default class MainBackground {
       this.logService,
       this.billingAccountProfileStateService,
       this.accountService,
+      this.restrictedItemTypesService,
     );
 
     this.cipherContextMenuHandler = new CipherContextMenuHandler(

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1087,6 +1087,7 @@ export default class MainBackground {
           this.configService,
           new WebPushNotificationsApiService(this.apiService, this.appIdService),
           registration,
+          this.stateProvider,
         );
       } else {
         this.webPushConnectionService = new UnsupportedWebPushConnectionService();

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1346,7 +1346,7 @@ export default class MainBackground {
     this.inlineMenuFieldQualificationService = new InlineMenuFieldQualificationService();
 
     this.ipcContentScriptManagerService = new IpcContentScriptManagerService(this.configService);
-    this.ipcService = new IpcBackgroundService(this.logService);
+    this.ipcService = new IpcBackgroundService(this.platformUtilsService, this.logService);
 
     this.endUserNotificationService = new DefaultEndUserNotificationService(
       this.stateProvider,

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -6,8 +6,10 @@ import { filter, firstValueFrom, map, merge, Subject, timeout } from "rxjs";
 
 import { CollectionService, DefaultCollectionService } from "@bitwarden/admin-console/common";
 import {
+  AuthRequestApiServiceAbstraction,
   AuthRequestService,
   AuthRequestServiceAbstraction,
+  DefaultAuthRequestApiService,
   DefaultLockService,
   InternalUserDecryptionOptionsServiceAbstraction,
   LoginEmailServiceAbstraction,
@@ -375,6 +377,7 @@ export default class MainBackground {
   devicesService: DevicesServiceAbstraction;
   deviceTrustService: DeviceTrustServiceAbstraction;
   authRequestService: AuthRequestServiceAbstraction;
+  authRequestApiService: AuthRequestApiServiceAbstraction;
   accountService: AccountServiceAbstraction;
   globalStateProvider: GlobalStateProvider;
   pinService: PinServiceAbstraction;
@@ -813,14 +816,16 @@ export default class MainBackground {
       this.appIdService,
     );
 
+    this.authRequestApiService = new DefaultAuthRequestApiService(this.apiService, this.logService);
+
     this.authRequestService = new AuthRequestService(
       this.appIdService,
-      this.accountService,
       this.masterPasswordService,
       this.keyService,
       this.encryptService,
       this.apiService,
       this.stateProvider,
+      this.authRequestApiService,
     );
 
     this.authService = new AuthService(

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -20,6 +20,8 @@ import {
   PinServiceAbstraction,
   UserDecryptionOptionsService,
   SsoUrlService,
+  AuthRequestApiServiceAbstraction,
+  DefaultAuthRequestApiService,
 } from "@bitwarden/auth/common";
 import { EventCollectionService as EventCollectionServiceAbstraction } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { EventUploadService as EventUploadServiceAbstraction } from "@bitwarden/common/abstractions/event/event-upload.service";
@@ -265,6 +267,7 @@ export class ServiceContainer {
   devicesApiService: DevicesApiServiceAbstraction;
   deviceTrustService: DeviceTrustServiceAbstraction;
   authRequestService: AuthRequestService;
+  authRequestApiService: AuthRequestApiServiceAbstraction;
   configApiService: ConfigApiServiceAbstraction;
   configService: ConfigService;
   accountService: AccountService;
@@ -616,14 +619,16 @@ export class ServiceContainer {
       this.stateProvider,
     );
 
+    this.authRequestApiService = new DefaultAuthRequestApiService(this.apiService, this.logService);
+
     this.authRequestService = new AuthRequestService(
       this.appIdService,
-      this.accountService,
       this.masterPasswordService,
       this.keyService,
       this.encryptService,
       this.apiService,
       this.stateProvider,
+      this.authRequestApiService,
     );
 
     this.billingAccountProfileStateService = new DefaultBillingAccountProfileStateService(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitwarden/desktop",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2025.6.1",
+  "version": "2025.6.2",
   "keywords": [
     "bitwarden",
     "password",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "clean:dist": "rimraf ./dist",
     "pack:dir": "npm run clean:dist && electron-builder --dir -p never",
     "pack:lin:flatpak": "npm run clean:dist && electron-builder --dir -p never && flatpak-builder  --repo=build/.repo build/.flatpak  ./resources/com.bitwarden.desktop.devel.yaml --install-deps-from=flathub --force-clean &&  flatpak build-bundle ./build/.repo/ ./dist/com.bitwarden.desktop.flatpak com.bitwarden.desktop",
-    "pack:lin": "npm run clean:dist && electron-builder --linux --x64 -p never && export SNAP_FILE=$(realpath ./dist/bitwarden_*.snap) && unsquashfs -d ./dist/tmp-snap/ $SNAP_FILE && mkdir -p ./dist/tmp-snap/meta/polkit/ && cp ./resources/com.bitwarden.desktop.policy  ./dist/tmp-snap/meta/polkit/polkit.com.bitwarden.desktop.policy && rm $SNAP_FILE && snapcraft pack ./dist/tmp-snap/ && mv ./*.snap ./dist/ && rm -rf ./dist/tmp-snap/",
+    "pack:lin": "npm run clean:dist && electron-builder --linux --x64 -p never && export SNAP_FILE=$(realpath ./dist/bitwarden_*.snap) && unsquashfs -d ./dist/tmp-snap/ $SNAP_FILE && mkdir -p ./dist/tmp-snap/meta/polkit/ && cp ./resources/com.bitwarden.desktop.policy  ./dist/tmp-snap/meta/polkit/polkit.com.bitwarden.desktop.policy && rm $SNAP_FILE && snap pack --compression=lzo ./dist/tmp-snap/ && mv ./*.snap ./dist/ && rm -rf ./dist/tmp-snap/",
     "pack:lin:arm64": "npm run clean:dist && electron-builder --dir -p never && tar -czvf ./dist/bitwarden_desktop_arm64.tar.gz -C ./dist/linux-arm64-unpacked/ .",
     "pack:mac": "npm run clean:dist && electron-builder --mac --universal -p never",
     "pack:mac:with-extension": "npm run clean:dist && npm run build:macos-extension:mac && electron-builder --mac --universal -p never",

--- a/apps/desktop/src/package-lock.json
+++ b/apps/desktop/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/desktop",
-  "version": "2025.6.1",
+  "version": "2025.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/desktop",
-      "version": "2025.6.1",
+      "version": "2025.6.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@bitwarden/desktop-napi": "file:../desktop_native/napi"

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -2,7 +2,7 @@
   "name": "@bitwarden/desktop",
   "productName": "Bitwarden",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2025.6.1",
+  "version": "2025.6.2",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -337,10 +337,9 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
     if (
       await firstValueFrom(this.configService.getFeatureFlag$(FeatureFlag.CreateDefaultLocation))
     ) {
-      this.organizationUserService
-        .confirmUser(this.organization, user, publicKey)
-        .pipe(takeUntilDestroyed())
-        .subscribe();
+      await firstValueFrom(
+        this.organizationUserService.confirmUser(this.organization, user, publicKey),
+      );
     } else {
       const orgKey = await this.keyService.getOrgKey(this.organization.id);
       const key = await this.encryptService.encapsulateKeyUnsigned(orgKey, publicKey);

--- a/apps/web/src/app/auth/settings/security/device-management.component.spec.ts
+++ b/apps/web/src/app/auth/settings/security/device-management.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { of, Subject } from "rxjs";
 
-import { AuthRequestApiService } from "@bitwarden/auth/common";
+import { AuthRequestApiServiceAbstraction } from "@bitwarden/auth/common";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import { DeviceView } from "@bitwarden/common/auth/abstractions/devices/views/device.view";
 import { DeviceType } from "@bitwarden/common/enums";
@@ -79,7 +79,7 @@ describe("DeviceManagementComponent", () => {
           },
         },
         {
-          provide: AuthRequestApiService,
+          provide: AuthRequestApiServiceAbstraction,
           useValue: {
             getAuthRequest: jest.fn().mockResolvedValue(mockDeviceResponse),
           },

--- a/apps/web/src/app/auth/settings/security/device-management.component.ts
+++ b/apps/web/src/app/auth/settings/security/device-management.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { firstValueFrom } from "rxjs";
 
 import { LoginApprovalComponent } from "@bitwarden/auth/angular";
-import { AuthRequestApiService } from "@bitwarden/auth/common";
+import { AuthRequestApiServiceAbstraction } from "@bitwarden/auth/common";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import {
   DevicePendingAuthRequest,
@@ -61,7 +61,7 @@ export class DeviceManagementComponent {
     private toastService: ToastService,
     private validationService: ValidationService,
     private messageListener: MessageListener,
-    private authRequestApiService: AuthRequestApiService,
+    private authRequestApiService: AuthRequestApiServiceAbstraction,
     private destroyRef: DestroyRef,
   ) {
     void this.initializeDevices();

--- a/apps/web/src/app/platform/ipc/web-ipc.service.ts
+++ b/apps/web/src/app/platform/ipc/web-ipc.service.ts
@@ -1,17 +1,20 @@
 import { inject } from "@angular/core";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { IpcMessage, IpcService, isIpcMessage } from "@bitwarden/common/platform/ipc";
 import {
   IncomingMessage,
   IpcClient,
   IpcCommunicationBackend,
+  ipcRegisterDiscoverHandler,
   OutgoingMessage,
 } from "@bitwarden/sdk-internal";
 
 export class WebIpcService extends IpcService {
   private logService = inject(LogService);
+  private platformUtilsService = inject(PlatformUtilsService);
   private communicationBackend?: IpcCommunicationBackend;
 
   override async init() {
@@ -68,6 +71,12 @@ export class WebIpcService extends IpcService {
       });
 
       await super.initWithClient(new IpcClient(this.communicationBackend));
+
+      if (this.platformUtilsService.isDev()) {
+        await ipcRegisterDiscoverHandler(this.client, {
+          version: await this.platformUtilsService.getApplicationVersion(),
+        });
+      }
     } catch (e) {
       this.logService.error("[IPC] Initialization failed", e);
     }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/password-health.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/password-health.ts
@@ -167,4 +167,32 @@ export enum DrawerType {
   OrgAtRiskApps = 3,
 }
 
+export interface RiskInsightsReport {
+  organizationId: OrganizationId;
+  date: string;
+  reportData: string;
+  reportKey: string;
+}
+
+export interface ReportInsightsReportData {
+  data: string;
+  key: string;
+}
+
+export interface SaveRiskInsightsReportRequest {
+  data: RiskInsightsReport;
+}
+
+export interface SaveRiskInsightsReportResponse {
+  id: string;
+}
+
+export interface GetRiskInsightsReportResponse {
+  id: string;
+  organizationId: OrganizationId;
+  date: string;
+  reportData: string;
+  reportKey: string;
+}
+
 export type PasswordHealthReportApplicationId = Opaque<string, "PasswordHealthReportApplicationId">;

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.spec.ts
@@ -1,0 +1,50 @@
+import { mock } from "jest-mock-extended";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+
+import { SaveRiskInsightsReportRequest } from "../models/password-health";
+
+import { RiskInsightsApiService } from "./risk-insights-api.service";
+
+describe("RiskInsightsApiService", () => {
+  let service: RiskInsightsApiService;
+  const apiService = mock<ApiService>();
+
+  beforeEach(() => {
+    service = new RiskInsightsApiService(apiService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should call apiService.send with correct parameters for saveRiskInsightsReport", (done) => {
+    const orgId = "org1" as OrganizationId;
+    const request: SaveRiskInsightsReportRequest = {
+      data: {
+        organizationId: orgId,
+        date: new Date().toISOString(),
+        reportData: "test",
+        reportKey: "test-key",
+      },
+    };
+    const response = {
+      ...request.data,
+    };
+
+    apiService.send.mockReturnValue(Promise.resolve(response));
+
+    service.saveRiskInsightsReport(request).subscribe((result) => {
+      expect(result).toEqual(response);
+      expect(apiService.send).toHaveBeenCalledWith(
+        "POST",
+        `/reports/organization-reports`,
+        request.data,
+        true,
+        true,
+      );
+      done();
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.ts
@@ -1,0 +1,44 @@
+import { from, Observable, of } from "rxjs";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+
+import {
+  GetRiskInsightsReportResponse,
+  SaveRiskInsightsReportRequest,
+  SaveRiskInsightsReportResponse,
+} from "../models/password-health";
+
+export class RiskInsightsApiService {
+  constructor(private apiService: ApiService) {}
+
+  saveRiskInsightsReport(
+    request: SaveRiskInsightsReportRequest,
+  ): Observable<SaveRiskInsightsReportResponse> {
+    const dbResponse = this.apiService.send(
+      "POST",
+      `/reports/organization-reports`,
+      request.data,
+      true,
+      true,
+    );
+
+    return from(dbResponse as Promise<SaveRiskInsightsReportResponse>);
+  }
+
+  getRiskInsightsReport(orgId: OrganizationId): Observable<GetRiskInsightsReportResponse | null> {
+    const dbResponse = this.apiService
+      .send("GET", `/reports/organization-reports/latest/${orgId.toString()}`, null, true, true)
+      .catch((error: any): any => {
+        if (error.statusCode === 404) {
+          return null; // Handle 404 by returning null or an appropriate default value
+        }
+        throw error; // Re-throw other errors
+      });
+
+    if (dbResponse instanceof Error) {
+      return of(null);
+    }
+    return from(dbResponse as Promise<GetRiskInsightsReportResponse>);
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-encryption.service.ts
@@ -1,0 +1,89 @@
+// FIXME: Update this file to be type safe
+// @ts-strict-ignore
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { KeyGenerationService } from "@bitwarden/common/platform/abstractions/key-generation.service";
+import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+
+import {
+  ApplicationHealthReportDetail,
+  ApplicationHealthReportSummary,
+  RiskInsightsReport,
+  GetRiskInsightsReportResponse,
+} from "../models/password-health";
+
+export class RiskInsightsEncryptionService {
+  constructor(
+    private keyService: KeyService,
+    private encryptService: EncryptService,
+    private keyGeneratorService: KeyGenerationService,
+  ) {}
+
+  async encryptRiskInsightsReport(
+    organizationId: OrganizationId,
+    details: ApplicationHealthReportDetail[],
+    summary: ApplicationHealthReportSummary,
+  ): Promise<RiskInsightsReport> {
+    const orgKey = await this.keyService.getOrgKey(organizationId as string);
+    if (orgKey === null) {
+      throw new Error("Organization key not found");
+    }
+
+    const reportWithSummary = { details, summary };
+
+    const reportContentEncryptionKey = await this.keyGeneratorService.createKey(512);
+
+    const reportEncrypted = await this.encryptService.encryptString(
+      JSON.stringify(reportWithSummary),
+      reportContentEncryptionKey,
+    );
+
+    const wrappedReportContentEncryptionKey = await this.encryptService.wrapSymmetricKey(
+      reportContentEncryptionKey,
+      orgKey,
+    );
+
+    const riskInsightReport = {
+      organizationId: organizationId,
+      date: new Date().toISOString(),
+      reportData: reportEncrypted.encryptedString,
+      reportKey: wrappedReportContentEncryptionKey.encryptedString,
+    };
+
+    return riskInsightReport;
+  }
+
+  async decryptRiskInsightsReport(
+    organizationId: OrganizationId,
+    riskInsightsReportResponse: GetRiskInsightsReportResponse,
+  ): Promise<[ApplicationHealthReportDetail[], ApplicationHealthReportSummary]> {
+    try {
+      const orgKey = await this.keyService.getOrgKey(organizationId as string);
+      if (orgKey === null) {
+        throw new Error("Organization key not found");
+      }
+
+      const reportEncrypted = riskInsightsReportResponse.reportData;
+      const wrappedReportContentEncryptionKey = riskInsightsReportResponse.reportKey;
+
+      const unwrappedReportContentEncryptionKey = await this.encryptService.unwrapSymmetricKey(
+        new EncString(wrappedReportContentEncryptionKey),
+        orgKey,
+      );
+
+      const reportUnencrypted = await this.encryptService.decryptString(
+        new EncString(reportEncrypted),
+        unwrappedReportContentEncryptionKey,
+      );
+
+      const reportWithSummary = JSON.parse(reportUnencrypted);
+      const reportJson = reportWithSummary.details;
+      const reportSummary = reportWithSummary.summary;
+
+      return [reportJson, reportSummary];
+    } catch {
+      return [null, null];
+    }
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
@@ -9,6 +9,8 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { mockCiphers } from "./ciphers.mock";
 import { MemberCipherDetailsApiService } from "./member-cipher-details-api.service";
 import { mockMemberCipherDetails } from "./member-cipher-details-api.service.spec";
+import { RiskInsightsApiService } from "./risk-insights-api.service";
+import { RiskInsightsEncryptionService } from "./risk-insights-encryption.service";
 import { RiskInsightsReportService } from "./risk-insights-report.service";
 
 describe("RiskInsightsReportService", () => {
@@ -32,11 +34,20 @@ describe("RiskInsightsReportService", () => {
 
     memberCipherDetailsService.getMemberCipherDetails.mockResolvedValue(mockMemberCipherDetails);
 
+    const riskInsightsApiService = mock<RiskInsightsApiService>();
+
+    const riskInsightsEncryptionService = mock<RiskInsightsEncryptionService>({
+      encryptRiskInsightsReport: jest.fn().mockResolvedValue("encryptedReportData"),
+      decryptRiskInsightsReport: jest.fn().mockResolvedValue("decryptedReportData"),
+    });
+    
     service = new RiskInsightsReportService(
       pwdStrengthService,
       auditService,
       cipherService,
       memberCipherDetailsService,
+      riskInsightsApiService,
+      riskInsightsEncryptionService,
     );
   });
 

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
@@ -40,7 +40,7 @@ describe("RiskInsightsReportService", () => {
       encryptRiskInsightsReport: jest.fn().mockResolvedValue("encryptedReportData"),
       decryptRiskInsightsReport: jest.fn().mockResolvedValue("decryptedReportData"),
     });
-    
+
     service = new RiskInsightsReportService(
       pwdStrengthService,
       auditService,

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -246,12 +246,11 @@ export class RiskInsightsReportService {
     report: ApplicationHealthReportDetail[],
     summary: ApplicationHealthReportSummary,
   ): Promise<void> {
-    const encryptedReport = await this.riskInsightsEncryptionService
-      .encryptRiskInsightsReport(
-        organizationId as OrganizationId,
-        report,
-        summary,
-      );
+    const encryptedReport = await this.riskInsightsEncryptionService.encryptRiskInsightsReport(
+      organizationId as OrganizationId,
+      report,
+      summary,
+    );
 
     const saveRequest = {
       data: encryptedReport,

--- a/libs/angular/src/auth/password-management/README.md
+++ b/libs/angular/src/auth/password-management/README.md
@@ -1,0 +1,216 @@
+# Master Password Management Flows
+
+The Auth Team manages several components that allow a user to either:
+
+1. Set an initial master password
+2. Change an existing master password
+
+This document maps all of our password management flows to the components that handle them.
+
+<br>
+
+**Table of Contents**
+
+> - [The Base `InputPasswordComponent`](#the-base-inputpasswordcomponent)
+> - [Set Initial Password Flows](#set-initial-password-flows)
+> - [Change Password Flows](#change-password-flows)
+
+<br>
+
+**Acronyms**
+
+<ul>
+  <li>MP = "master password"</li>
+  <li>MPE = "master password encryption"</li>
+  <li>TDE = "trusted device encryption"</li>
+  <li>JIT provision = "just-in-time provision"</li>
+</ul>
+
+<br>
+
+## The Base `InputPasswordComponent`
+
+Central to our master password management flows is the base [InputPasswordComponent](https://components.bitwarden.com/?path=/docs/auth-input-password--docs), which is responsible for displaying the appropriate form fields in the UI, performing form validation, and generating appropriate cryptographic properties for each flow. This keeps our UI, validation, and key generation consistent across all master password management flows.
+
+<br>
+
+## Set Initial Password Flows
+
+<table>
+  <thead>
+    <tr>
+      <td><strong>Flow</strong></td>
+      <td><strong>Route</strong><br><small>(on which user sets MP)</small></td>
+      <td><strong>Component(s)</strong></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <br>
+        <strong>Account Registration</strong>
+        <br><br>
+        <ol>
+            <li>Standard Flow</li>
+            <br>
+            <li>Self Hosted Flow</li>
+            <br>
+            <li>Email Invite Flows <small>(🌐 web only)</small></li>
+            <br>
+        </ol>
+      </td>
+      <td><code>/finish-signup</code></td>
+      <td>
+        <code>RegistrationFinishComponent</code>
+        <br>
+        <small>- embeds <code>InputPasswordComponent</code></small>
+    </tr>
+    <tr>
+      <td>
+        <strong>Trial Initiation</strong> <small>(🌐 web only)</small>
+      </td>
+      <td><code>/trial-initiation</code> or<br> <code>/secrets-manager-trial-initiation</code></td>
+      <td>
+        <code>CompleteTrialInitiationComponent</code>
+        <br>
+        <small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <br>
+        <strong>Upon Authentication</strong> (an existing authed user)
+        <br><br>
+        <ol>
+          <li><strong>User JIT provisions<small>*</small> into an MPE org</strong></li>
+          <br>
+          <li>
+            <strong>User JIT provisions<small>*</small> into a TDE org with the "manage account recovery" permission</strong>
+            <p>That is, the user was given this permission on invitation or by the time they JIT provision.</p>
+          </li>
+          <br>
+          <li>
+            <strong>TDE user permissions upgraded</strong>
+            <p>TDE user authenticates after permissions were upgraded to include "manage account recovery".</p>
+          </li>
+          <br>
+          <li>
+            <strong>TDE offboarding</strong>
+            <p>User authenticates after their org offboarded from TDE and is now a MPE org.</p>
+            <p>User must be on a trusted device to set MP, otherwise user must go through Account Recovery.</p>
+          </li>
+        </ol>
+      </td>
+      <td><code>/set-initial-password</code></td>
+      <td>
+        <code>SetInitialPasswordComponent</code>
+        <br>
+        <small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+\* A note on JIT provisioned user flows:
+
+- Even though a JIT provisioned user is a brand-new user who was “just” created, we consider them to be an “existing authed user” _from the perspective of the set initial password flow_. This is because at the time they set their initial password, their account already exists in the database (before setting their password) and they have already authenticated via SSO.
+- The same is not true in the _Account Registration_ flows above—that is, during account registration when a user reaches the `/finish-signup` or `/trial-initiation` page to set their initial password, their account does not yet exist in the database, and will only be created once they set an initial password.
+
+<br>
+
+## Change Password Flows
+
+<table>
+  <thead>
+    <tr>
+      <td><strong>Flow</strong></td>
+      <td><strong>Route</strong><br><small>(on which user changes MP)</small></td>
+      <td><strong>Component(s)</strong></td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <br>
+        <strong>Account Settings</strong>
+        (<small><a href="https://bitwarden.com/help/master-password/#change-master-password">Docs</a></small>)
+        <br>
+        <small>(🌐 web only)</small>
+        <br><br>
+        <p>User changes MP via account settings.</p>
+        <br>
+      </td>
+      <td>
+        <code>/settings/security/password</code>
+        <br>(<code>security-routing.module.ts</code>)
+      </td>
+      <td>
+        <code>PasswordSettingsComponent</code>
+        <br><small>- embeds <code>ChangePasswordComponent</code></small>
+        <br><small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <br>
+        <strong>Upon Authentication</strong>
+        <br><br>
+        <ol>
+          <li>
+            <strong>Login with non-compliant MP after email accept</strong> <small>(🌐 web only)</small>
+            <p>User clicks an org email invite link and logs in with their MP that does not meet the org’s policy requirements.</p>
+          </li>
+          <br>
+          <li>
+            <strong>Login with non-compliant MP</strong>
+            <p>Existing org user logs in with their MP that does not meet updated org policy requirements.</p>
+          </li>
+          <br>
+          <li>
+            <strong>Login after Account Recovery</strong>
+            <p>User logs in after their MP was reset via Account Recovery.</p>
+          </li>
+        </ol>
+      </td>
+      <td><code>/change-password</code></td>
+      <td>
+        <code>ChangePasswordComponent</code>
+        <br><small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <br>
+        <strong>Emergency Access Takeover</strong>
+        <small>(<a href="https://bitwarden.com/help/emergency-access/">Docs</a>)</small>
+        <br>
+        <small>(🌐 web only)</small>
+        <br><br>
+        <p>Emergency access Grantee changes the MP for the Grantor.</p>
+        <br>
+      </td>
+      <td>Grantee opens dialog while on <code>/settings/emergency-access</code></td>
+      <td>
+        <code>EmergencyAccessTakeoverDialogComponent</code>
+        <br><small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <br>
+        <strong>Account Recovery</strong>
+        <small>(<a href="https://bitwarden.com/help/account-recovery/">Docs</a>)</small>
+        <br>
+        <small>(🌐 web only)</small>
+        <br><br>
+        <p>Org member with "manage account recovery" permission changes the MP for another org user via Account Recovery.</p>
+        <br>
+      </td>
+      <td>Org member opens dialog while on <code>/organizations/{org-id}/members</code></td>
+      <td>
+        <code>AccountRecoveryDialogComponent</code>
+        <br><small>- embeds <code>InputPasswordComponent</code></small>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -35,7 +35,7 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import {
-  AuthRequestApiService,
+  AuthRequestApiServiceAbstraction,
   AuthRequestService,
   AuthRequestServiceAbstraction,
   DefaultAuthRequestApiService,
@@ -1182,6 +1182,11 @@ const safeProviders: SafeProvider[] = [
     deps: [DevicesApiServiceAbstraction, AppIdServiceAbstraction],
   }),
   safeProvider({
+    provide: AuthRequestApiServiceAbstraction,
+    useClass: DefaultAuthRequestApiService,
+    deps: [ApiServiceAbstraction, LogService],
+  }),
+  safeProvider({
     provide: DeviceTrustServiceAbstraction,
     useClass: DeviceTrustService,
     deps: [
@@ -1205,12 +1210,12 @@ const safeProviders: SafeProvider[] = [
     useClass: AuthRequestService,
     deps: [
       AppIdServiceAbstraction,
-      AccountServiceAbstraction,
       InternalMasterPasswordServiceAbstraction,
       KeyService,
       EncryptService,
       ApiServiceAbstraction,
       StateProvider,
+      AuthRequestApiServiceAbstraction,
     ],
   }),
   safeProvider({
@@ -1476,11 +1481,6 @@ const safeProviders: SafeProvider[] = [
     provide: CipherAuthorizationService,
     useClass: DefaultCipherAuthorizationService,
     deps: [CollectionService, OrganizationServiceAbstraction, AccountServiceAbstraction],
-  }),
-  safeProvider({
-    provide: AuthRequestApiService,
-    useClass: DefaultAuthRequestApiService,
-    deps: [ApiServiceAbstraction, LogService],
   }),
   safeProvider({
     provide: LoginApprovalComponentServiceAbstraction,

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -39,7 +39,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { ButtonModule, LinkModule, ToastService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 
-import { AuthRequestApiService } from "../../common/abstractions/auth-request-api.service";
+import { AuthRequestApiServiceAbstraction } from "../../common/abstractions/auth-request-api.service";
 import { LoginViaAuthRequestCacheService } from "../../common/services/auth-request/default-login-via-auth-request-cache.service";
 
 // FIXME: update to use a const object instead of a typescript enum
@@ -85,7 +85,7 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
     private accountService: AccountService,
     private anonymousHubService: AnonymousHubService,
     private appIdService: AppIdService,
-    private authRequestApiService: AuthRequestApiService,
+    private authRequestApiService: AuthRequestApiServiceAbstraction,
     private authRequestService: AuthRequestServiceAbstraction,
     private authService: AuthService,
     private cryptoFunctionService: CryptoFunctionService,

--- a/libs/auth/src/common/abstractions/auth-request-api.service.ts
+++ b/libs/auth/src/common/abstractions/auth-request-api.service.ts
@@ -1,7 +1,16 @@
 import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
 
-export abstract class AuthRequestApiService {
+export abstract class AuthRequestApiServiceAbstraction {
+  /**
+   * Gets a list of pending auth requests based on the user. There will only be one AuthRequest per device and the
+   * AuthRequest will be the most recent pending request.
+   *
+   * @returns A promise that resolves to a list response containing auth request responses.
+   */
+  abstract getPendingAuthRequests(): Promise<ListResponse<AuthRequestResponse>>;
+
   /**
    * Gets an auth request by its ID.
    *

--- a/libs/auth/src/common/abstractions/auth-request.service.abstraction.ts
+++ b/libs/auth/src/common/abstractions/auth-request.service.abstraction.ts
@@ -42,6 +42,12 @@ export abstract class AuthRequestServiceAbstraction {
    */
   abstract clearAdminAuthRequest: (userId: UserId) => Promise<void>;
   /**
+   * Gets a list of standard pending auth requests for the user.
+   * @returns An observable of an array of auth request.
+   * The array will be empty if there are no pending auth requests.
+   */
+  abstract getPendingAuthRequests$(): Observable<Array<AuthRequestResponse>>;
+  /**
    * Approve or deny an auth request.
    * @param approve True to approve, false to deny.
    * @param authRequest The auth request to approve or deny, must have an id and key.

--- a/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request-api.service.ts
@@ -1,15 +1,22 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AuthRequest } from "@bitwarden/common/auth/models/request/auth.request";
 import { AuthRequestResponse } from "@bitwarden/common/auth/models/response/auth-request.response";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
-import { AuthRequestApiService } from "../../abstractions/auth-request-api.service";
+import { AuthRequestApiServiceAbstraction } from "../../abstractions/auth-request-api.service";
 
-export class DefaultAuthRequestApiService implements AuthRequestApiService {
+export class DefaultAuthRequestApiService implements AuthRequestApiServiceAbstraction {
   constructor(
     private apiService: ApiService,
     private logService: LogService,
   ) {}
+
+  async getPendingAuthRequests(): Promise<ListResponse<AuthRequestResponse>> {
+    const path = `/auth-requests/pending`;
+    const r = await this.apiService.send("GET", path, null, true, true);
+    return new ListResponse(r, AuthRequestResponse);
+  }
 
   async getAuthRequest(requestId: string): Promise<AuthRequestResponse> {
     try {

--- a/libs/auth/src/common/services/auth-request/auth-request.service.spec.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request.service.spec.ts
@@ -10,23 +10,23 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EncString } from "@bitwarden/common/platform/models/domain/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { StateProvider } from "@bitwarden/common/platform/state";
-import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
 import { MasterKey, UserKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 
+import { DefaultAuthRequestApiService } from "./auth-request-api.service";
 import { AuthRequestService } from "./auth-request.service";
 
 describe("AuthRequestService", () => {
   let sut: AuthRequestService;
 
   const stateProvider = mock<StateProvider>();
-  let accountService: FakeAccountService;
   let masterPasswordService: FakeMasterPasswordService;
   const appIdService = mock<AppIdService>();
   const keyService = mock<KeyService>();
   const encryptService = mock<EncryptService>();
   const apiService = mock<ApiService>();
+  const authRequestApiService = mock<DefaultAuthRequestApiService>();
 
   let mockPrivateKey: Uint8Array;
   let mockPublicKey: Uint8Array;
@@ -34,17 +34,16 @@ describe("AuthRequestService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    accountService = mockAccountServiceWith(mockUserId);
     masterPasswordService = new FakeMasterPasswordService();
 
     sut = new AuthRequestService(
       appIdService,
-      accountService,
       masterPasswordService,
       keyService,
       encryptService,
       apiService,
       stateProvider,
+      authRequestApiService,
     );
 
     mockPrivateKey = new Uint8Array(64);

--- a/libs/common/src/auth/models/response/auth-request.response.ts
+++ b/libs/common/src/auth/models/response/auth-request.response.ts
@@ -18,6 +18,7 @@ export class AuthRequestResponse extends BaseResponse {
   responseDate?: string;
   isAnswered: boolean;
   isExpired: boolean;
+  deviceId?: string; // could be null or empty
 
   constructor(response: any) {
     super(response);
@@ -33,6 +34,7 @@ export class AuthRequestResponse extends BaseResponse {
     this.creationDate = this.getResponseProperty("CreationDate");
     this.requestApproved = this.getResponseProperty("RequestApproved");
     this.responseDate = this.getResponseProperty("ResponseDate");
+    this.deviceId = this.getResponseProperty("RequestDeviceId");
 
     const requestDate = new Date(this.creationDate);
     const requestDateUTC = Date.UTC(

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -19,6 +19,7 @@ export enum FeatureFlag {
   PM16117_SetInitialPasswordRefactor = "pm-16117-set-initial-password-refactor",
   PM16117_ChangeExistingPasswordRefactor = "pm-16117-change-existing-password-refactor",
   PM9115_TwoFactorExtensionDataPersistence = "pm-9115-two-factor-extension-data-persistence",
+  PM14938_BrowserExtensionLoginApproval = "pm-14938-browser-extension-login-approvals",
 
   /* Autofill */
   BlockBrowserInjectionsByDomain = "block-browser-injections-by-domain",
@@ -105,6 +106,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PM16117_SetInitialPasswordRefactor]: FALSE,
   [FeatureFlag.PM16117_ChangeExistingPasswordRefactor]: FALSE,
   [FeatureFlag.PM9115_TwoFactorExtensionDataPersistence]: FALSE,
+  [FeatureFlag.PM14938_BrowserExtensionLoginApproval]: FALSE,
 
   /* Billing */
   [FeatureFlag.TrialPaymentOptional]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -45,7 +45,6 @@ export enum FeatureFlag {
   EnrollAeadOnKeyRotation = "enroll-aead-on-key-rotation",
 
   /* Tools */
-  ItemShare = "item-share",
   DesktopSendUIRefresh = "desktop-send-ui-refresh",
 
   /* Vault */
@@ -91,7 +90,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.EnableRiskInsightsNotifications]: FALSE,
 
   /* Tools */
-  [FeatureFlag.ItemShare]: FALSE,
   [FeatureFlag.DesktopSendUIRefresh]: FALSE,
 
   /* Vault */

--- a/libs/common/src/platform/ipc/ipc.service.ts
+++ b/libs/common/src/platform/ipc/ipc.service.ts
@@ -4,7 +4,7 @@ import { IpcClient, IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-inte
 
 export abstract class IpcService {
   private _client?: IpcClient;
-  protected get client(): IpcClient {
+  get client(): IpcClient {
     if (!this._client) {
       throw new Error("IpcService not initialized");
     }

--- a/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.spec.ts
+++ b/libs/common/src/platform/notifications/internal/worker-webpush-connection.service.spec.ts
@@ -1,0 +1,387 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of } from "rxjs";
+
+import {
+  awaitAsync,
+  FakeGlobalState,
+  FakeStateProvider,
+  mockAccountServiceWith,
+} from "../../../../spec";
+import { PushTechnology } from "../../../enums/push-technology.enum";
+import { UserId } from "../../../types/guid";
+import { ConfigService } from "../../abstractions/config/config.service";
+import { ServerConfig } from "../../abstractions/config/server-config";
+import { Supported } from "../../misc/support-status";
+import { Utils } from "../../misc/utils";
+import { ServerConfigData } from "../../models/data/server-config.data";
+import { PushSettingsConfigResponse } from "../../models/response/server-config.response";
+import { KeyDefinition } from "../../state";
+
+import { WebPushNotificationsApiService } from "./web-push-notifications-api.service";
+import { WebPushConnector } from "./webpush-connection.service";
+import {
+  WEB_PUSH_SUBSCRIPTION_USERS,
+  WorkerWebPushConnectionService,
+} from "./worker-webpush-connection.service";
+
+const mockUser1 = "testUser1" as UserId;
+
+const createSub = (key: string) => {
+  return {
+    options: { applicationServerKey: Utils.fromUrlB64ToArray(key), userVisibleOnly: true },
+    endpoint: `web.push.endpoint/?${Utils.newGuid()}`,
+    expirationTime: 5,
+    getKey: () => null,
+    toJSON: () => ({ endpoint: "something", keys: {}, expirationTime: 5 }),
+    unsubscribe: () => Promise.resolve(true),
+  } satisfies PushSubscription;
+};
+
+describe("WorkerWebpushConnectionService", () => {
+  let configService: MockProxy<ConfigService>;
+  let webPushApiService: MockProxy<WebPushNotificationsApiService>;
+  let stateProvider: FakeStateProvider;
+  let pushManager: MockProxy<PushManager>;
+  const userId = "testUser1" as UserId;
+
+  let sut: WorkerWebPushConnectionService;
+
+  beforeEach(() => {
+    configService = mock();
+    webPushApiService = mock();
+    stateProvider = new FakeStateProvider(mockAccountServiceWith(userId));
+    pushManager = mock();
+
+    sut = new WorkerWebPushConnectionService(
+      configService,
+      webPushApiService,
+      mock<ServiceWorkerRegistration>({ pushManager: pushManager }),
+      stateProvider,
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  type ExtractKeyDefinitionType<T> = T extends KeyDefinition<infer U> ? U : never;
+  describe("supportStatus$", () => {
+    let fakeGlobalState: FakeGlobalState<
+      ExtractKeyDefinitionType<typeof WEB_PUSH_SUBSCRIPTION_USERS>
+    >;
+
+    beforeEach(() => {
+      fakeGlobalState = stateProvider.getGlobal(WEB_PUSH_SUBSCRIPTION_USERS) as FakeGlobalState<
+        ExtractKeyDefinitionType<typeof WEB_PUSH_SUBSCRIPTION_USERS>
+      >;
+    });
+
+    test("when web push is supported, have an existing subscription, and we've already registered the user, should not call API", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+      const existingSubscription = createSub("dGVzdA");
+      await fakeGlobalState.nextState({ [existingSubscription.endpoint]: [userId] });
+
+      pushManager.getSubscription.mockResolvedValue(existingSubscription);
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(0);
+
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledTimes(0);
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported, have an existing subscription, and we haven't registered the user, should call API", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+      const existingSubscription = createSub("dGVzdA");
+      await fakeGlobalState.nextState({
+        [existingSubscription.endpoint]: ["otherUserId" as UserId],
+      });
+
+      pushManager.getSubscription.mockResolvedValue(existingSubscription);
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledTimes(1);
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledWith({
+        [existingSubscription.endpoint]: ["otherUserId", mockUser1],
+      });
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported, have an existing subscription, but it isn't in state, should call API and add to state", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+      const existingSubscription = createSub("dGVzdA");
+      await fakeGlobalState.nextState({
+        [existingSubscription.endpoint]: null!,
+      });
+
+      pushManager.getSubscription.mockResolvedValue(existingSubscription);
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledTimes(1);
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledWith({
+        [existingSubscription.endpoint]: [mockUser1],
+      });
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported, have an existing subscription, but state array is null, should call API and add to state", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+      const existingSubscription = createSub("dGVzdA");
+      await fakeGlobalState.nextState({});
+
+      pushManager.getSubscription.mockResolvedValue(existingSubscription);
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledTimes(1);
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledWith({
+        [existingSubscription.endpoint]: [mockUser1],
+      });
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported, but we don't have an existing subscription, should call the api and wipe out existing state", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+      const existingState = createSub("dGVzdA");
+      await fakeGlobalState.nextState({ [existingState.endpoint]: [userId] });
+
+      pushManager.getSubscription.mockResolvedValue(null);
+      const newSubscription = createSub("dGVzdA");
+      pushManager.subscribe.mockResolvedValue(newSubscription);
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledTimes(1);
+      expect(fakeGlobalState.nextMock).toHaveBeenCalledWith({
+        [newSubscription.endpoint]: [mockUser1],
+      });
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported and no existing subscription, should call API", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+
+      pushManager.getSubscription.mockResolvedValue(null);
+      pushManager.subscribe.mockResolvedValue(createSub("dGVzdA"));
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(pushManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when web push is supported and existing subscription with different key, should call API", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+
+      pushManager.getSubscription.mockResolvedValue(createSub("dGVzdF9hbHQ"));
+
+      pushManager.subscribe.mockResolvedValue(createSub("dGVzdA"));
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(pushManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      notificationsSub.unsubscribe();
+    });
+
+    test("when server config emits multiple times quickly while api call takes a long time will only call API once", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: "dGVzdA",
+            }),
+          }),
+        ),
+      );
+
+      pushManager.getSubscription.mockResolvedValue(createSub("dGVzdF9hbHQ"));
+
+      pushManager.subscribe.mockResolvedValue(createSub("dGVzdA"));
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("supported");
+      const service = (supportStatus as Supported<WebPushConnector>).service;
+      expect(service).not.toBeFalsy();
+
+      const notificationsSub = service.notifications$.subscribe();
+
+      await awaitAsync(2);
+
+      expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+      expect(pushManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(webPushApiService.putSubscription).toHaveBeenCalledTimes(1);
+
+      notificationsSub.unsubscribe();
+    });
+
+    it("server config shows SignalR support should return not-supported", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.SignalR,
+            }),
+          }),
+        ),
+      );
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("not-supported");
+    });
+
+    it("server config shows web push but no public key support should return not-supported", async () => {
+      configService.serverConfig$ = of(
+        new ServerConfig(
+          new ServerConfigData({
+            push: new PushSettingsConfigResponse({
+              pushTechnology: PushTechnology.WebPush,
+              vapidPublicKey: null,
+            }),
+          }),
+        ),
+      );
+
+      const supportStatus = await firstValueFrom(sut.supportStatus$(mockUser1));
+      expect(supportStatus.type).toBe("not-supported");
+    });
+  });
+});

--- a/libs/common/src/platform/state/state-definitions.ts
+++ b/libs/common/src/platform/state/state-definitions.ts
@@ -128,6 +128,9 @@ export const EXTENSION_INITIAL_INSTALL_DISK = new StateDefinition(
   "extensionInitialInstall",
   "disk",
 );
+export const WEB_PUSH_SUBSCRIPTION = new StateDefinition("webPushSubscription", "disk", {
+  web: "disk-local",
+});
 
 // Design System
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1813,6 +1813,11 @@ export class ApiService implements ApiServiceAbstraction {
     if (authed) {
       const authHeader = await this.getActiveBearerToken();
       headers.set("Authorization", "Bearer " + authHeader);
+    } else {
+      // For unauthenticated requests, we need to tell the server what the device is for flag targeting,
+      // since it won't be able to get it from the access token.
+      const appId = await this.appIdService.getAppId();
+      headers.set("Device-Identifier", appId);
     }
 
     if (body != null) {

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -19,6 +19,7 @@
         bitIconButton
         bitPasswordInputToggle
         data-testid="toggle-privateKey"
+        [(toggled)]="revealSshKey"
       ></button>
       <button
         bitIconButton="bwi-clone"

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
@@ -27,6 +27,14 @@ import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-
     IconButtonModule,
   ],
 })
-export class SshKeyViewComponent {
+export class SshKeyViewComponent implements OnChanges {
   @Input() sshKey: SshKeyView;
+
+  revealSshKey = false;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["sshKey"]) {
+      this.revealSshKey = false;
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/platform-browser": "19.2.14",
         "@angular/platform-browser-dynamic": "19.2.14",
         "@angular/router": "19.2.14",
-        "@bitwarden/sdk-internal": "0.2.0-main.203",
+        "@bitwarden/sdk-internal": "0.2.0-main.213",
         "@electron/fuses": "1.8.0",
         "@emotion/css": "11.13.5",
         "@koa/multer": "3.1.0",
@@ -4589,9 +4589,9 @@
       "link": true
     },
     "node_modules/@bitwarden/sdk-internal": {
-      "version": "0.2.0-main.203",
-      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.203.tgz",
-      "integrity": "sha512-AcRX2odnabnx16VF+K7naEZ3R4Tv/o8mVsVhrvwOTG+TEBUxR1BzCoE2r+l0+iz1zV32UV2YHeLZvyCB2/KftA==",
+      "version": "0.2.0-main.213",
+      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.213.tgz",
+      "integrity": "sha512-/AUpdQQ++tLsH9dJDFQcIDihCpsI+ikdZuYwbztSXPp7piCnLk71f7r10yMPGQ8OEOF49mMEbLCG+dJKpBqeRg==",
       "license": "GPL-3.0",
       "dependencies": {
         "type-fest": "^4.41.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,7 +286,7 @@
     },
     "apps/desktop": {
       "name": "@bitwarden/desktop",
-      "version": "2025.6.1",
+      "version": "2025.6.2",
       "hasInstallScript": true,
       "license": "GPL-3.0"
     },

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "@angular/platform-browser": "19.2.14",
     "@angular/platform-browser-dynamic": "19.2.14",
     "@angular/router": "19.2.14",
-    "@bitwarden/sdk-internal": "0.2.0-main.203",
+    "@bitwarden/sdk-internal": "0.2.0-main.213",
     "@electron/fuses": "1.8.0",
     "@emotion/css": "11.13.5",
     "@koa/multer": "3.1.0",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20579

## 📔 Objective

To create an encryption/decryption service for risk insights
To Save and Fetch Risk insights data

## 📸 Screenshots

None at this time

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
