### PR TITLE
[PM-21719] update desktop to address personal items who cant assign to collections

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -482,7 +482,9 @@ export class VaultV2Component implements OnInit, OnDestroy, CopyClickListener {
         });
       }
 
-      if (cipher.canAssignToCollections) {
+      const hasEditableCollections = this.allCollections.some((collection) => !collection.readOnly);
+
+      if (cipher.canAssignToCollections && hasEditableCollections) {
         menu.push({
           label: this.i18nService.t("assignToCollections"),
           click: () =>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21719](https://bitwarden.atlassian.net/browse/PM-21719)

## 📔 Objective

Add a check to the desktop assign to collections menu option so if a user who right clicks on a personal item, should only see the assign to collections option when they have Edit Access to Collections.

## 📸 Screenshots

![Screenshot 2025-06-27 at 11 35 11 AM](https://github.com/user-attachments/assets/97ef087f-4efc-40d0-a37c-ec18a26ae362)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21719]: https://bitwarden.atlassian.net/browse/PM-21719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ