### PR TITLE
[PM-22822] Fix redirect loop bug

### DIFF
--- a/libs/angular/src/auth/guards/auth.guard.ts
+++ b/libs/angular/src/auth/guards/auth.guard.ts
@@ -100,10 +100,10 @@ export const authGuard: CanActivateFn = async (
 
   // Post- Account Recovery or Weak Password on login
   if (
-    forceSetPasswordReason === ForceSetPasswordReason.AdminForcePasswordReset ||
-    (forceSetPasswordReason === ForceSetPasswordReason.WeakMasterPassword &&
-      !routerState.url.includes("update-temp-password") &&
-      !routerState.url.includes("change-password"))
+    (forceSetPasswordReason === ForceSetPasswordReason.AdminForcePasswordReset ||
+      forceSetPasswordReason === ForceSetPasswordReason.WeakMasterPassword) &&
+    !routerState.url.includes("update-temp-password") &&
+    !routerState.url.includes("change-password")
   ) {
     const route = isChangePasswordFlagOn ? "/change-password" : "/update-temp-password";
     return router.createUrlTree([route]);


### PR DESCRIPTION
## 🎟️ Tracking

Follow up to [PM-22822](https://bitwarden.atlassian.net/browse/PM-22822)

## 📔 Objective

The conditional checks on the `AdminForcePasswordReset` case were slightly off, allowing for an infinite redirect loop such that when `ForceSetPasswordReason` is `AdminForcePasswordReset`, then we redirect to `/update-temp-password`. But `/update-temp-password` itself has the `authGuard` applied, which would re-run this code in an infinite loop, continually redirecting to `/update-temp-password`.

My fix makes sure that the `authGuard` will not attempt to redirect if the destination url is `"update-temp-password"` (that is, `routerState.url.includes("update-temp-password")`). This allows the user to actually continue to `/update-temp-password` to change their password.

## 📸 Screenshots

### Bugged Code 🐞 (infinite redirect loop)

https://github.com/user-attachments/assets/0deb5325-24a4-4c9c-b310-f195f5935aee

### Fix ✅

https://github.com/user-attachments/assets/6c4e9b86-527f-435c-9a82-768bcd8dbc5e

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22822]: https://bitwarden.atlassian.net/browse/PM-22822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ