### PR TITLE
BRE-883 build(firefox): check file size

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -275,11 +275,7 @@ jobs:
           declare -a FILES
 
           # Search for source files that are greater than 4M
-          # TEST: failure condition
           TARGET_DIR='./browser-source/apps/browser'
-          TARGET='TEST.file'
-          dd if=/dev/zero of=$TARGET_DIR/$TARGET bs=1024 count=4099
-
           while IFS=' ' read -r RESULT; do
               FILES+=("$RESULT")
           done < <(find $TARGET_DIR -size +4M)


### PR DESCRIPTION
if building `firefox` or `firefox-mv3`

* check if any file(s) exceeds 4M (megabytes)
   - If true, fail and provide basic message.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-883

## 📔 Objective

Firefox enforces a size limit on files contained within an artifact. Add step when building for firefox which causes job to fail if a file is greater than 4M (megabytes) in size. Additionally, write the name and size of the file to stdout for logging.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
