### PR TITLE
refactor(state): point storage imports to @bitwarden/storage-core

### DIFF
--- a/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
+++ b/libs/common/src/platform/state/implementations/default-active-user-state.spec.ts
@@ -6,12 +6,13 @@ import { any, mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, map, of, timeout } from "rxjs";
 import { Jsonify } from "type-fest";
 
+import { StorageServiceProvider } from "@bitwarden/storage-core";
+
 import { awaitAsync, trackEmissions } from "../../../../spec";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { Account } from "../../../auth/abstractions/account.service";
 import { UserId } from "../../../types/guid";
 import { LogService } from "../../abstractions/log.service";
-import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { StateDefinition } from "../state-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
 import { UserKeyDefinition } from "../user-key-definition";

--- a/libs/common/src/platform/state/implementations/default-global-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.provider.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { StorageServiceProvider } from "@bitwarden/storage-core";
+
 import { LogService } from "../../abstractions/log.service";
-import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { GlobalState } from "../global-state";
 import { GlobalStateProvider } from "../global-state.provider";
 import { KeyDefinition } from "../key-definition";

--- a/libs/common/src/platform/state/implementations/default-global-state.ts
+++ b/libs/common/src/platform/state/implementations/default-global-state.ts
@@ -1,8 +1,6 @@
+import { AbstractStorageService, ObservableStorageService } from "@bitwarden/storage-core";
+
 import { LogService } from "../../abstractions/log.service";
-import {
-  AbstractStorageService,
-  ObservableStorageService,
-} from "../../abstractions/storage.service";
 import { GlobalState } from "../global-state";
 import { KeyDefinition, globalKeyBuilder } from "../key-definition";
 

--- a/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.provider.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { StorageServiceProvider } from "@bitwarden/storage-core";
+
 import { UserId } from "../../../types/guid";
 import { LogService } from "../../abstractions/log.service";
-import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
 import { UserKeyDefinition } from "../user-key-definition";
 import { SingleUserState } from "../user-state";

--- a/libs/common/src/platform/state/implementations/default-single-user-state.ts
+++ b/libs/common/src/platform/state/implementations/default-single-user-state.ts
@@ -1,11 +1,9 @@
 import { Observable, combineLatest, of } from "rxjs";
 
+import { AbstractStorageService, ObservableStorageService } from "@bitwarden/storage-core";
+
 import { UserId } from "../../../types/guid";
 import { LogService } from "../../abstractions/log.service";
-import {
-  AbstractStorageService,
-  ObservableStorageService,
-} from "../../abstractions/storage.service";
 import { StateEventRegistrarService } from "../state-event-registrar.service";
 import { UserKeyDefinition } from "../user-key-definition";
 import { CombinedState, SingleUserState } from "../user-state";

--- a/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
+++ b/libs/common/src/platform/state/implementations/specific-state.provider.spec.ts
@@ -1,10 +1,11 @@
 import { mock } from "jest-mock-extended";
 
+import { StorageServiceProvider } from "@bitwarden/storage-core";
+
 import { mockAccountServiceWith } from "../../../../spec/fake-account-service";
 import { FakeStorageService } from "../../../../spec/fake-storage.service";
 import { UserId } from "../../../types/guid";
 import { LogService } from "../../abstractions/log.service";
-import { StorageServiceProvider } from "../../services/storage-service.provider";
 import { KeyDefinition } from "../key-definition";
 import { StateDefinition } from "../state-definition";
 import { StateEventRegistrarService } from "../state-event-registrar.service";

--- a/libs/common/src/platform/state/implementations/state-base.ts
+++ b/libs/common/src/platform/state/implementations/state-base.ts
@@ -15,12 +15,10 @@ import {
 } from "rxjs";
 import { Jsonify } from "type-fest";
 
+import { AbstractStorageService, ObservableStorageService } from "@bitwarden/storage-core";
+
 import { StorageKey } from "../../../types/state";
 import { LogService } from "../../abstractions/log.service";
-import {
-  AbstractStorageService,
-  ObservableStorageService,
-} from "../../abstractions/storage.service";
 import { DebugOptions } from "../key-definition";
 import { populateOptionsWithDefault, StateUpdateOptions } from "../state-update-options";
 

--- a/libs/common/src/platform/state/implementations/util.ts
+++ b/libs/common/src/platform/state/implementations/util.ts
@@ -1,6 +1,6 @@
 import { Jsonify } from "type-fest";
 
-import { AbstractStorageService } from "../../abstractions/storage.service";
+import { AbstractStorageService } from "@bitwarden/storage-core";
 
 export async function getStoredValue<T>(
   key: string,

--- a/libs/common/src/platform/state/state-event-registrar.service.spec.ts
+++ b/libs/common/src/platform/state/state-event-registrar.service.spec.ts
@@ -1,8 +1,12 @@
 import { mock } from "jest-mock-extended";
 
+import {
+  AbstractStorageService,
+  ObservableStorageService,
+  StorageServiceProvider,
+} from "@bitwarden/storage-core";
+
 import { FakeGlobalStateProvider } from "../../../spec";
-import { AbstractStorageService, ObservableStorageService } from "../abstractions/storage.service";
-import { StorageServiceProvider } from "../services/storage-service.provider";
 
 import { StateDefinition } from "./state-definition";
 import { STATE_LOCK_EVENT, StateEventRegistrarService } from "./state-event-registrar.service";

--- a/libs/common/src/platform/state/state-event-runner.service.spec.ts
+++ b/libs/common/src/platform/state/state-event-runner.service.spec.ts
@@ -1,9 +1,13 @@
 import { mock } from "jest-mock-extended";
 
+import {
+  AbstractStorageService,
+  ObservableStorageService,
+  StorageServiceProvider,
+} from "@bitwarden/storage-core";
+
 import { FakeGlobalStateProvider } from "../../../spec";
 import { UserId } from "../../types/guid";
-import { AbstractStorageService, ObservableStorageService } from "../abstractions/storage.service";
-import { StorageServiceProvider } from "../services/storage-service.provider";
 
 import { STATE_LOCK_EVENT } from "./state-event-registrar.service";
 import { StateEventRunnerService } from "./state-event-runner.service";

--- a/libs/common/src/platform/state/state-event-runner.service.ts
+++ b/libs/common/src/platform/state/state-event-runner.service.ts
@@ -2,8 +2,9 @@
 // @ts-strict-ignore
 import { firstValueFrom } from "rxjs";
 
+import { StorageServiceProvider } from "@bitwarden/storage-core";
+
 import { UserId } from "../../types/guid";
-import { StorageServiceProvider } from "../services/storage-service.provider";
 
 import { GlobalState } from "./global-state";
 import { GlobalStateProvider } from "./global-state.provider";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23205

## 📔 Objective

This change updates every import of StorageServiceProvider, AbstractStorageService, and ObservableStorageService throughout the common state code to pull from the new @bitwarden/storage-core package instead of their old relative paths. The cuts out one of the issues that needs to be resolved before state can hold its own as a library without importing common.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
