### PR TITLE
[PM-23226] ToTp updating on Desktop

### DIFF
--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.spec.ts
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.spec.ts
@@ -1,0 +1,95 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { BitTotpCountdownComponent } from "./totp-countdown.component";
+
+describe("BitTotpCountdownComponent", () => {
+  let component: BitTotpCountdownComponent;
+  let fixture: ComponentFixture<BitTotpCountdownComponent>;
+  let totpService: jest.Mocked<TotpService>;
+
+  const mockCipher1 = {
+    id: "cipher-id",
+    name: "Test Cipher",
+    login: { totp: "totp-secret" },
+  } as CipherView;
+
+  const mockCipher2 = {
+    id: "cipher-id-2",
+    name: "Test Cipher 2",
+    login: { totp: "totp-secret-2" },
+  } as CipherView;
+
+  const mockTotpResponse1 = {
+    code: "123456",
+    period: 30,
+  };
+
+  const mockTotpResponse2 = {
+    code: "987654",
+    period: 10,
+  };
+
+  beforeEach(async () => {
+    totpService = mock<TotpService>({
+      getCode$: jest.fn().mockImplementation((totp) => {
+        if (totp === mockCipher1.login.totp) {
+          return of(mockTotpResponse1);
+        }
+
+        return of(mockTotpResponse2);
+      }),
+    });
+
+    await TestBed.configureTestingModule({
+      providers: [{ provide: TotpService, useValue: totpService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BitTotpCountdownComponent);
+    component = fixture.componentInstance;
+    component.cipher = mockCipher1;
+    fixture.detectChanges();
+  });
+
+  it("initializes totpInfo$ observable", (done) => {
+    component.totpInfo$?.subscribe((info) => {
+      expect(info.totpCode).toBe(mockTotpResponse1.code);
+      expect(info.totpCodeFormatted).toBe("123 456");
+      done();
+    });
+  });
+
+  it("emits sendCopyCode when TOTP code is available", (done) => {
+    const emitter = jest.spyOn(component.sendCopyCode, "emit");
+
+    component.totpInfo$?.subscribe((info) => {
+      expect(emitter).toHaveBeenCalledWith({
+        totpCode: info.totpCode,
+        totpCodeFormatted: info.totpCodeFormatted,
+      });
+      done();
+    });
+  });
+
+  it("updates totpInfo$ when cipher changes", (done) => {
+    component.cipher = mockCipher2;
+    component.ngOnChanges({
+      cipher: {
+        currentValue: mockCipher2,
+        previousValue: mockCipher1,
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    });
+
+    component.totpInfo$?.subscribe((info) => {
+      expect(info.totpCode).toBe(mockTotpResponse2.code);
+      expect(info.totpCodeFormatted).toBe("987 654");
+      done();
+    });
+  });
+});

--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import {
   Component,
@@ -23,7 +21,7 @@ import { TypographyModule } from "@bitwarden/components";
   imports: [CommonModule, TypographyModule],
 })
 export class BitTotpCountdownComponent implements OnInit, OnChanges {
-  @Input() cipher: CipherView;
+  @Input({ required: true }) cipher!: CipherView;
   @Output() sendCopyCode = new EventEmitter();
 
   /**

--- a/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
+++ b/libs/vault/src/components/totp-countdown/totp-countdown.component.ts
@@ -1,7 +1,15 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  OnChanges,
+  SimpleChanges,
+} from "@angular/core";
 import { Observable, map, tap } from "rxjs";
 
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
@@ -14,7 +22,7 @@ import { TypographyModule } from "@bitwarden/components";
   templateUrl: "totp-countdown.component.html",
   imports: [CommonModule, TypographyModule],
 })
-export class BitTotpCountdownComponent implements OnInit {
+export class BitTotpCountdownComponent implements OnInit, OnChanges {
   @Input() cipher: CipherView;
   @Output() sendCopyCode = new EventEmitter();
 
@@ -26,6 +34,16 @@ export class BitTotpCountdownComponent implements OnInit {
   constructor(protected totpService: TotpService) {}
 
   async ngOnInit() {
+    this.setTotpInfo();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["cipher"]) {
+      this.setTotpInfo();
+    }
+  }
+
+  private setTotpInfo(): void {
     this.totpInfo$ = this.cipher?.login?.totp
       ? this.totpService.getCode$(this.cipher.login.totp).pipe(
           map((response) => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23226](https://bitwarden.atlassian.net/browse/PM-23226)

## 📔 Objective

The ToTp component was setting an observable in `ngOnInit`, with the nature of switching views on desktop the `LoginCredentialsViewComponent` is re-rendered by not re-initialized. This causes the old observable to stay intact with old cipher data when jumping between two ciphers.
- Using `ngOnChanges` the totp observable can be reset when the cipher is updated.

## 📸 Screenshots
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/d2bf14ac-01d9-456c-b4f2-760f2d51db4f" /> |<video src="https://github.com/user-attachments/assets/2e59c38e-d06c-48cc-94db-e9448f35683d"/>|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23226]: https://bitwarden.atlassian.net/browse/PM-23226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ