### PR TITLE
[PM-22782] Missing SSH Key title/label

### DIFF
--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
@@ -21,6 +21,7 @@
         bitSuffix
         data-testid="import-privateKey"
         *ngIf="showImport"
+        appA11yTitle="{{ 'importSshKeyFromClipboard' | i18n }}"
         (click)="importSshKeyFromClipboard()"
       ></button>
     </bit-form-field>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22782](https://bitwarden.atlassian.net/browse/PM-22782)

## 📔 Objective

Add missing aria label / title to the Import SSH Key button. This feature is only available on browser and desktop. 

## 📸 Screenshots

|Browser|Desktop
|-|-|
|<img width="525" alt="Screenshot 2025-07-07 at 12 45 15 PM" src="https://github.com/user-attachments/assets/210f85d3-7d99-408a-9864-40cb73e6d24a" />|<img width="728" alt="Screenshot 2025-07-07 at 12 42 10 PM" src="https://github.com/user-attachments/assets/3ac328aa-c058-40af-80ec-e62242d6297a" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22782]: https://bitwarden.atlassian.net/browse/PM-22782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ