### PR TITLE
[PM-13444] Vault timeout policy won't let you change timeout time if vault timeout action set

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -449,7 +449,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     await this.vaultTimeoutSettingsService.setVaultTimeoutOptions(
       activeAccount.id,
       newValue,
-      this.form.value.vaultTimeoutAction,
+      this.form.getRawValue().vaultTimeoutAction,
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13444

## 📔 Objective

The vault timeout action form property is disabled, when the policy explicitly sets the vault timeout action.
As a result, when changing the vault timeout, nothing is set due to error throws, when changing vault timeout using `VaultTimeoutSettingsService.setVaultTimeoutOptions`, since the `vaultTimeoutAction: VaultTimeoutAction` argument is not expected to be null.
This happens, because we use Angular's `FormGroup.value` to access currently set form values, but it does not return disabled fields by default, hence why the vault timeout action is null.
Need to use `getRawValue()` function instead, for the disabled form property to be included.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
