### PR TITLE
[PM-23531] rename `SendCreatedIcon` to `ActiveSendIcon`

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.ts
@@ -13,7 +13,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { ButtonModule, IconModule, ToastService } from "@bitwarden/components";
-import { SendCreatedIcon } from "@bitwarden/send-ui";
+import { ActiveSendIcon } from "@bitwarden/send-ui";
 
 import { PopOutComponent } from "../../../../platform/popup/components/pop-out.component";
 import { PopupFooterComponent } from "../../../../platform/popup/layout/popup-footer.component";
@@ -36,7 +36,7 @@ import { PopupPageComponent } from "../../../../platform/popup/layout/popup-page
   ],
 })
 export class SendCreatedComponent {
-  protected sendCreatedIcon = SendCreatedIcon;
+  protected sendCreatedIcon = ActiveSendIcon;
   protected send: SendView;
   protected daysAvailable = 0;
   protected hoursAvailable = 0;

--- a/libs/tools/send/send-ui/src/icons/active-send.icon.ts
+++ b/libs/tools/send/send-ui/src/icons/active-send.icon.ts
@@ -1,6 +1,6 @@
 import { svgIcon } from "@bitwarden/components";
 
-export const SendCreatedIcon = svgIcon`
+export const ActiveSendIcon = svgIcon`
 <svg width="96" height="95" viewBox="0 0 96 95" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path class="tw-stroke-art-primary" d="M89.4998 48.3919C89.4998 70.5749 70.9198 88.5573 47.9998 88.5573C46.0374 88.5573 44.1068 88.4257 42.217 88.1707M6.49976 48.3919C6.49976 26.2092 25.08 8.22656 47.9998 8.22656C51.8283 8.22656 55.5353 8.72824 59.0553 9.66744" stroke-linecap="round" stroke-linejoin="round"/>
   <path class="tw-stroke-art-primary" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M5.47085 67.8617C2.60335 61.9801 1 55.4075 1 48.4729C1 23.3503 22.0426 2.98438 48 2.98438C52.3355 2.98438 56.534 3.55257 60.5205 4.61618M92.211 32.9993C94.016 37.8295 95 43.0399 95 48.4729C95 73.5956 73.9575 93.9614 48 93.9614C45.7775 93.9614 43.5911 93.8119 41.4508 93.5235" />

--- a/libs/tools/send/send-ui/src/icons/index.ts
+++ b/libs/tools/send/send-ui/src/icons/index.ts
@@ -1,3 +1,3 @@
 export { ExpiredSendIcon } from "./expired-send.icon";
 export { NoSendsIcon } from "./no-send.icon";
-export { SendCreatedIcon } from "./send-created.icon";
+export { ActiveSendIcon } from "./active-send.icon";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23531

## 📔 Objective

The “send created icon” is displayed by the send creation screen and the send access screens. Renaming the icon to ActiveSendIcon communicates its in-app usage more clearly, and distinguishes it from the other icons (“no send” and “expired send”).

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
