### PR TITLE
[PM-23349] Use `LoginUriView` for uri logic

### DIFF
--- a/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
@@ -307,6 +307,16 @@ describe("CipherViewLikeUtils", () => {
         expect(CipherViewLikeUtils.canLaunch(cipherView)).toBe(true);
       });
 
+      it("returns true when the uri does not have a protocol", () => {
+        const cipherView = createCipherView(CipherType.Login);
+        cipherView.login = new LoginView();
+        const uriView = new LoginUriView();
+        uriView.uri = "bitwarden.com";
+        cipherView.login.uris = [uriView];
+
+        expect(CipherViewLikeUtils.canLaunch(cipherView)).toBe(true);
+      });
+
       it("returns false when the login has no URIs", () => {
         const cipherView = createCipherView(CipherType.Login);
         cipherView.login = new LoginView();
@@ -319,6 +329,14 @@ describe("CipherViewLikeUtils", () => {
       it("returns true when the login has URIs that can be launched", () => {
         const cipherListView = {
           type: { login: { uris: [{ uri: "https://example.com" }] } },
+        } as CipherListView;
+
+        expect(CipherViewLikeUtils.canLaunch(cipherListView)).toBe(true);
+      });
+
+      it("returns true when the uri does not have a protocol", () => {
+        const cipherListView = {
+          type: { login: { uris: [{ uri: "bitwarden.com" }] } },
         } as CipherListView;
 
         expect(CipherViewLikeUtils.canLaunch(cipherListView)).toBe(true);

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -2,12 +2,12 @@ import {
   UriMatchStrategy,
   UriMatchStrategySetting,
 } from "@bitwarden/common/models/domain/domain-service";
-import { SafeUrls } from "@bitwarden/common/platform/misc/safe-urls";
 import {
   CardListView,
   CipherListView,
   CopyableCipherFields,
   LoginListView,
+  LoginUriView as LoginListUriView,
 } from "@bitwarden/sdk-internal";
 
 import { CipherType } from "../enums";
@@ -148,7 +148,7 @@ export class CipherViewLikeUtils {
       return false;
     }
 
-    return !!login.uris?.map((u) => u.uri).some((uri) => uri && SafeUrls.canLaunch(uri));
+    return !!login.uris?.map((u) => toLoginUriView(u)).some((uri) => uri.canLaunch);
   };
 
   /**
@@ -162,7 +162,7 @@ export class CipherViewLikeUtils {
       return undefined;
     }
 
-    return login.uris?.map((u) => u.uri).find((uri) => uri && SafeUrls.canLaunch(uri));
+    return login.uris?.map((u) => toLoginUriView(u)).find((uri) => uri.canLaunch)?.uri;
   };
 
   /**
@@ -282,4 +282,20 @@ const copyActionToCopyableFieldMap: Record<string, CopyableCipherFields> = {
   privateKey: "SshKey",
   publicKey: "SshKey",
   keyFingerprint: "SshKey",
+};
+
+/** Converts a `LoginListUriView` to a `LoginUriView`. */
+const toLoginUriView = (uri: LoginListUriView | LoginUriView): LoginUriView => {
+  if (uri instanceof LoginUriView) {
+    return uri;
+  }
+
+  const loginUriView = new LoginUriView();
+  if (uri.match) {
+    loginUriView.match = uri.match;
+  }
+  if (uri.uri) {
+    loginUriView.uri = uri.uri;
+  }
+  return loginUriView;
 };


### PR DESCRIPTION
Stacked on top of https://github.com/bitwarden/clients/pull/15174

## 🎟️ Tracking

[PM-23349](https://bitwarden.atlassian.net/browse/PM-23349)

## 📔 Objective

Originally I didn't want to create any instances of classes and use only logic directly for `CipherListView`. I was proven wrong by that decision here, `LoginUriView` provides too much logic. In this case determining if a URI can be launched when it doesn't include a protocol. 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
