### PR TITLE
[PM-23350] Filter out null ciphers in browser

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -108,7 +108,9 @@ export class VaultPopupItemsService {
           waitUntilSync(this.syncService),
           switchMap(() =>
             combineLatest([
-              this.cipherService.cipherListViews$(userId),
+              this.cipherService
+                .cipherListViews$(userId)
+                .pipe(filter((ciphers) => ciphers != null)),
               this.cipherService.failedToDecryptCiphers$(userId),
             ]),
           ),


### PR DESCRIPTION
Stacked on top of https://github.com/bitwarden/clients/pull/15174

## 🎟️ Tracking

[PM-23350](https://bitwarden.atlassian.net/browse/PM-23350)

## 📔 Objective

The `cipherViews$` observable can [emit null when the cache is cleared](https://github.com/bitwarden/clients/blob/6a48db8dac2cd9beab2a7affb4212fc95b61747e/libs/common/src/vault/services/cipher.service.ts#L230-L231). This occurs when a cipher is moved to a collection in the browser. Adding a filter to the observable does the trick.

## 📸 Screenshots

|Before|After
|-|-|
|<video src="https://github.com/user-attachments/assets/6273dec9-d4b2-4c3c-b007-da62a8946488" /> |<video src="https://github.com/user-attachments/assets/e43c3659-34ac-4fca-999d-444181fa7bc2" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes





[PM-23350]: https://bitwarden.atlassian.net/browse/PM-23350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ