### PR TITLE
[PM-21943] Editing Unassigned Cipher

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1135,10 +1135,11 @@ export class VaultComponent implements OnInit, OnDestroy {
         message: this.i18nService.t("deletedCollectionId", collection.name),
       });
 
+      // Clear the cipher cache to clear the deleted collection from the cipher state
+      await this.cipherService.clear();
+
       // Navigate away if we deleted the collection we were viewing
       if (this.selectedCollection?.node.id === collection.id) {
-        // Clear the cipher cache to clear the deleted collection from the cipher state
-        await this.cipherService.clear();
         void this.router.navigate([], {
           queryParams: { collectionId: this.selectedCollection.parent?.node.id ?? null },
           queryParamsHandling: "merge",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21943](https://bitwarden.atlassian.net/browse/PM-21943)

## 📔 Objective

#### Issue

Users cannot edit a cipher that has recently been moved to unassigned (before another full sync).  

#### Root Cause 

When deleting a collection from the action menu the ciphers are not refreshed. The unassigned cipher still has a defined `collectionId` stored in local state. 

#### Fix

This works when a user deletes a collection when viewing it, the ciphers are cleared for this logic path. To solve all other means of deleting a collection I moved the clear logic outside of the redirection logic.

## 📸 Screenshots

|Deleting while viewing|Bug Before| Fixed|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/4ea043dd-77bf-4e80-9531-fe41774511d1" /> |<video src="https://github.com/user-attachments/assets/6014ed7b-14f3-4ee4-b0df-fb4f312df06f" /> |<video src="https://github.com/user-attachments/assets/427db822-cdda-470f-b6d0-04e6cd3087e9" /> |


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21943]: https://bitwarden.atlassian.net/browse/PM-21943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ