### PR TITLE
[PM-23264] Show cipher name instead of short id in event logs

### DIFF
--- a/apps/web/src/app/admin-console/common/base.events.component.ts
+++ b/apps/web/src/app/admin-console/common/base.events.component.ts
@@ -10,6 +10,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { ToastService } from "@bitwarden/components";
 
 import { EventService } from "../../core";
@@ -24,6 +25,8 @@ export abstract class BaseEventsComponent {
   continuationToken: string;
 
   abstract readonly exportFileName: string;
+  abstract organizationId: OrganizationId;
+  abstract userId: UserId;
 
   protected eventsForm = new FormGroup({
     start: new FormControl(null),
@@ -134,6 +137,7 @@ export abstract class BaseEventsComponent {
     endDate: string,
     continuationToken: string,
   ) {
+    await this.eventService.loadAllOrganizationCiphers(this.organizationId, this.userId);
     const response = await this.requestEvents(startDate, endDate, continuationToken);
 
     const events = await Promise.all(
@@ -157,6 +161,8 @@ export abstract class BaseEventsComponent {
           installationId: r.installationId,
           systemUser: r.systemUser,
           serviceAccountId: r.serviceAccountId,
+          eventName: eventInfo.eventName,
+          eventLink: eventInfo.eventLink,
         });
       }),
     );

--- a/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/entity-events.component.ts
@@ -195,6 +195,8 @@ export class EntityEventsComponent implements OnInit, OnDestroy {
           installationId: r.installationId,
           systemUser: r.systemUser,
           serviceAccountId: r.serviceAccountId,
+          eventName: eventInfo.eventName,
+          eventLink: eventInfo.eventLink,
         });
       }),
     );

--- a/apps/web/src/app/admin-console/organizations/manage/events.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/events.component.html
@@ -100,7 +100,11 @@
         <td bitCell>
           <span title="{{ e.userEmail }}">{{ e.userName }}</span>
         </td>
-        <td bitCell [innerHTML]="e.message"></td>
+        <td bitCell *ngIf="e.eventName && e.eventLink">
+          <span>{{ e.eventName }}</span
+          ><br /><span [innerHtml]="e.eventLink"></span>
+        </td>
+        <td bitCell *ngIf="!(e.eventName && e.eventLink)" [innerHTML]="e.message"></td>
       </tr>
     </ng-template>
   </bit-table>

--- a/apps/web/src/app/admin-console/organizations/manage/events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/events.component.ts
@@ -27,6 +27,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import {
@@ -52,9 +53,10 @@ const EVENT_SYSTEM_USER_TO_TRANSLATION: Record<EventSystemUser, string> = {
 })
 export class EventsComponent extends BaseEventsComponent implements OnInit, OnDestroy {
   exportFileName = "org-events";
-  organizationId: string;
+  organizationId: OrganizationId;
   organization: Organization;
   organizationSubscription: OrganizationSubscriptionResponse;
+  userId: UserId;
 
   placeholderEvents = placeholderEvents as EventView[];
 
@@ -99,14 +101,14 @@ export class EventsComponent extends BaseEventsComponent implements OnInit, OnDe
   }
 
   async ngOnInit() {
-    const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+    this.userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
     this.route.params
       .pipe(
         concatMap(async (params) => {
           this.organizationId = params.organizationId;
           this.organization = await firstValueFrom(
             this.organizationService
-              .organizations$(userId)
+              .organizations$(this.userId)
               .pipe(getOrganizationById(this.organizationId)),
           );
 

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/events.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/events.component.ts
@@ -11,6 +11,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { ToastService } from "@bitwarden/components";
 import { BaseEventsComponent } from "@bitwarden/web-vault/app/admin-console/common/base.events.component";
 import { EventService } from "@bitwarden/web-vault/app/core";
@@ -22,6 +23,8 @@ import { EventExportService } from "@bitwarden/web-vault/app/tools/event-export"
   standalone: false,
 })
 export class EventsComponent extends BaseEventsComponent implements OnInit {
+  organizationId: OrganizationId;
+  userId: UserId;
   exportFileName = "provider-events";
   providerId: string;
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/event-logs/service-accounts-events.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/event-logs/service-accounts-events.component.ts
@@ -8,6 +8,7 @@ import { FileDownloadService } from "@bitwarden/common/platform/abstractions/fil
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { ToastService } from "@bitwarden/components";
 import { BaseEventsComponent } from "@bitwarden/web-vault/app/admin-console/common/base.events.component";
 import { EventService } from "@bitwarden/web-vault/app/core";
@@ -24,6 +25,8 @@ export class ServiceAccountEventsComponent
   extends BaseEventsComponent
   implements OnInit, OnDestroy
 {
+  organizationId: OrganizationId;
+  userId: UserId;
   exportFileName = "machine-account-events";
   private destroy$ = new Subject<void>();
   private serviceAccountId: string;

--- a/libs/common/src/models/view/event.view.ts
+++ b/libs/common/src/models/view/event.view.ts
@@ -14,6 +14,8 @@ export class EventView {
   installationId: string;
   systemUser: EventSystemUser;
   serviceAccountId: string;
+  eventName: string;
+  eventLink: string;
 
   constructor(data: Required<EventView>) {
     this.message = data.message;
@@ -29,5 +31,7 @@ export class EventView {
     this.installationId = data.installationId;
     this.systemUser = data.systemUser;
     this.serviceAccountId = data.serviceAccountId;
+    this.eventName = data.eventName;
+    this.eventLink = data.eventLink;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23264

## 📔 Objective

In the event logs, show the cipher name instead of the cipher short id.
However, only name of ciphers to which the user has access will be show, otherwise it will still render the short id

## 📸 Screenshots

View of the cipher name
![image](https://github.com/user-attachments/assets/ef0b258f-0722-44d7-8d6b-bcf98cd30065)

View of the cipher name, after it is clicked
![image](https://github.com/user-attachments/assets/7ab8e8f4-744a-4a46-9fd2-0f5f1ff370cc)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
