### PR TITLE
[CL-759] Remove browser style overrides for checkbox

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -100,7 +100,7 @@ a:not(popup-page a, popup-tab-navigation a) {
   }
 }
 
-input:not(bit-form-field input, bit-search input),
+input:not(bit-form-field input, bit-search input, input[bitcheckbox]),
 select:not(bit-form-field select),
 textarea:not(bit-form-field textarea) {
   @include themify($themes) {
@@ -109,7 +109,7 @@ textarea:not(bit-form-field textarea) {
   }
 }
 
-input,
+input:not(input[bitcheckbox]),
 select,
 textarea,
 button:not(bit-chip-select button) {

--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -15,6 +15,7 @@ export class CheckboxComponent implements BitFormControlAbstraction {
   protected inputClasses = [
     "tw-appearance-none",
     "tw-outline-none",
+    "tw-box-border",
     "tw-relative",
     "tw-transition",
     "tw-cursor-pointer",
@@ -37,6 +38,7 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "before:tw-border",
     "before:tw-border-solid",
     "before:tw-border-secondary-500",
+    "before:tw-box-border",
 
     "after:tw-content-['']",
     "after:tw-block",
@@ -44,6 +46,7 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "after:tw-inset-0",
     "after:tw-h-[1.12rem]",
     "after:tw-w-[1.12rem]",
+    "after:tw-box-border",
 
     "hover:before:tw-border-2",
     "[&>label]:before:tw-border-2",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-759](https://bitwarden.atlassian.net/browse/CL-759)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The browser extension had some style overrides that were causing the checkbox component to display with a background color. The checkbox component was also relying on some web global styles that needed to be added to the component css to work in the browser extension.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/23a5fbba-3526-47f8-90fd-c1db84df9882


After:

https://github.com/user-attachments/assets/8ea535ef-6ff0-45be-8f91-952b2a86e111



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
