### PR TITLE
[PM-23542] After moving an item to an org, I cannot download attachment immediately

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -637,7 +637,15 @@ export class VaultV2Component implements OnInit, OnDestroy, CopyClickListener {
 
     const result = await lastValueFrom(dialog.closed);
     if (result === CollectionAssignmentResult.Saved) {
-      await this.savedCipher(cipher);
+      const updatedCipher = await firstValueFrom(
+        // Fetch the updated cipher from the service
+        this.cipherService.cipherViews$(this.activeUserId as UserId).pipe(
+          filter((ciphers) => ciphers != null),
+          map((ciphers) => ciphers!.find((c) => c.id === cipher.id)),
+          filter((foundCipher) => foundCipher != null),
+        ),
+      );
+      await this.savedCipher(updatedCipher);
     }
   }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-23542
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fix attachment download failures after assigning ciphers to collections on desktop. When users assign a cipher with attachments to a collection, the cipher moves to an organization and the server re-encrypts attachment keys with the organization's encryption key. However, the UI continues to display stale attachment data with old encryption keys, causing downloads to fail.
Root cause: The `shareCipher` method was passing stale cipher data to `savedCipher` after collection assignment.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/60a64006-da89-4930-8c86-6397bc8df38a


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
