### PR TITLE
[PM-23353] Fix second drawer padding

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
@@ -1,140 +1,138 @@
 <ng-container>
-  <bit-layout>
-    <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
-    <div class="tw-text-main tw-max-w-4xl tw-mb-2">
-      {{ "reviewAtRiskPasswords" | i18n }}
-    </div>
-    <div
-      *ngIf="dataLastUpdated$ | async"
-      class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
-    >
-      <i
-        class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] tw-text-muted"
-        aria-hidden="true"
-      ></i>
-      <span class="tw-mx-4">{{
-        "dataLastUpdated" | i18n: (dataLastUpdated$ | async | date: "MMMM d, y 'at' h:mm a")
-      }}</span>
-      <span class="tw-flex tw-justify-center tw-w-16">
-        <a
-          *ngIf="!(isRefreshing$ | async)"
-          bitButton
-          buttonType="unstyled"
-          class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
-          [bitAction]="refreshData.bind(this)"
-        >
-          {{ "refresh" | i18n }}
-        </a>
-        <span>
-          <i
-            *ngIf="isRefreshing$ | async"
-            class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
-            aria-hidden="true"
-          ></i>
-        </span>
+  <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
+  <div class="tw-text-main tw-max-w-4xl tw-mb-2">
+    {{ "reviewAtRiskPasswords" | i18n }}
+  </div>
+  <div
+    *ngIf="dataLastUpdated$ | async"
+    class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
+  >
+    <i
+      class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] tw-text-muted"
+      aria-hidden="true"
+    ></i>
+    <span class="tw-mx-4">{{
+      "dataLastUpdated" | i18n: (dataLastUpdated$ | async | date: "MMMM d, y 'at' h:mm a")
+    }}</span>
+    <span class="tw-flex tw-justify-center tw-w-16">
+      <a
+        *ngIf="!(isRefreshing$ | async)"
+        bitButton
+        buttonType="unstyled"
+        class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
+        [bitAction]="refreshData.bind(this)"
+      >
+        {{ "refresh" | i18n }}
+      </a>
+      <span>
+        <i
+          *ngIf="isRefreshing$ | async"
+          class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
+          aria-hidden="true"
+        ></i>
       </span>
-    </div>
-    <bit-tab-group [(selectedIndex)]="tabIndex" (selectedIndexChange)="onTabChange($event)">
-      <bit-tab label="{{ 'allApplicationsWithCount' | i18n: appsCount }}">
-        <tools-all-applications></tools-all-applications>
-      </bit-tab>
-      <bit-tab>
-        <ng-template bitTabLabel>
-          <i class="bwi bwi-star"></i>
-          {{ "criticalApplicationsWithCount" | i18n: (criticalApps$ | async)?.length ?? 0 }}
-        </ng-template>
-        <tools-critical-applications></tools-critical-applications>
-      </bit-tab>
-    </bit-tab-group>
+    </span>
+  </div>
+  <bit-tab-group [(selectedIndex)]="tabIndex" (selectedIndexChange)="onTabChange($event)">
+    <bit-tab label="{{ 'allApplicationsWithCount' | i18n: appsCount }}">
+      <tools-all-applications></tools-all-applications>
+    </bit-tab>
+    <bit-tab>
+      <ng-template bitTabLabel>
+        <i class="bwi bwi-star"></i>
+        {{ "criticalApplicationsWithCount" | i18n: (criticalApps$ | async)?.length ?? 0 }}
+      </ng-template>
+      <tools-critical-applications></tools-critical-applications>
+    </bit-tab>
+  </bit-tab-group>
 
-    <bit-drawer
-      style="width: 30%"
-      [(open)]="dataService.openDrawer"
-      (openChange)="dataService.closeDrawer()"
-    >
-      <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.OrgAtRiskMembers)">
-        <bit-drawer-header
-          title="{{ 'atRiskMembersWithCount' | i18n: dataService.atRiskMemberDetails.length }}"
-        >
-        </bit-drawer-header>
-        <bit-drawer-body>
-          <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
-            (dataService.atRiskMemberDetails.length > 0
-              ? "atRiskMembersDescription"
-              : "atRiskMembersDescriptionNone"
-            ) | i18n
-          }}</span>
-          <ng-container *ngIf="dataService.atRiskMemberDetails.length > 0">
-            <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-              <div bitTypography="body2" class="tw-text-sm tw-font-bold">{{ "email" | i18n }}</div>
-              <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-                {{ "atRiskPasswords" | i18n }}
-              </div>
+  <bit-drawer
+    style="width: 30%"
+    [(open)]="dataService.openDrawer"
+    (openChange)="dataService.closeDrawer()"
+  >
+    <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.OrgAtRiskMembers)">
+      <bit-drawer-header
+        title="{{ 'atRiskMembersWithCount' | i18n: dataService.atRiskMemberDetails.length }}"
+      >
+      </bit-drawer-header>
+      <bit-drawer-body>
+        <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
+          (dataService.atRiskMemberDetails.length > 0
+            ? "atRiskMembersDescription"
+            : "atRiskMembersDescriptionNone"
+          ) | i18n
+        }}</span>
+        <ng-container *ngIf="dataService.atRiskMemberDetails.length > 0">
+          <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
+            <div bitTypography="body2" class="tw-text-sm tw-font-bold">{{ "email" | i18n }}</div>
+            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+              {{ "atRiskPasswords" | i18n }}
             </div>
-            <ng-container *ngFor="let member of dataService.atRiskMemberDetails">
-              <div class="tw-flex tw-justify-between tw-mt-2">
-                <div>{{ member.email }}</div>
-                <div>{{ member.atRiskPasswordCount }}</div>
-              </div>
-            </ng-container>
-          </ng-container>
-        </bit-drawer-body>
-      </ng-container>
-
-      <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.AppAtRiskMembers)">
-        <bit-drawer-header title="{{ dataService.appAtRiskMembers.applicationName }}">
-        </bit-drawer-header>
-        <bit-drawer-body>
-          <div bitTypography="body1" class="tw-mb-2">
-            {{ "atRiskMembersWithCount" | i18n: dataService.appAtRiskMembers.members.length }}
           </div>
-          <div bitTypography="body1" class="tw-text-muted tw-text-sm tw-mb-2">
-            {{
-              (dataService.appAtRiskMembers.members.length > 0
-                ? "atRiskMembersDescriptionWithApp"
-                : "atRiskMembersDescriptionWithAppNone"
-              ) | i18n: dataService.appAtRiskMembers.applicationName
-            }}
-          </div>
-          <div class="tw-mt-1">
-            <ng-container *ngFor="let member of dataService.appAtRiskMembers.members">
+          <ng-container *ngFor="let member of dataService.atRiskMemberDetails">
+            <div class="tw-flex tw-justify-between tw-mt-2">
               <div>{{ member.email }}</div>
-            </ng-container>
-          </div>
-        </bit-drawer-body>
-      </ng-container>
-
-      <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.OrgAtRiskApps)">
-        <bit-drawer-header
-          title="{{ 'atRiskApplicationsWithCount' | i18n: dataService.atRiskAppDetails.length }}"
-        >
-        </bit-drawer-header>
-
-        <bit-drawer-body>
-          <span bitTypography="body2" class="tw-text-muted tw-text-sm">{{
-            (dataService.atRiskAppDetails.length > 0
-              ? "atRiskApplicationsDescription"
-              : "atRiskApplicationsDescriptionNone"
-            ) | i18n
-          }}</span>
-          <ng-container *ngIf="dataService.atRiskAppDetails.length > 0">
-            <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-              <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-                {{ "application" | i18n }}
-              </div>
-              <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-                {{ "atRiskPasswords" | i18n }}
-              </div>
+              <div>{{ member.atRiskPasswordCount }}</div>
             </div>
-            <ng-container *ngFor="let app of dataService.atRiskAppDetails">
-              <div class="tw-flex tw-justify-between tw-mt-2">
-                <div>{{ app.applicationName }}</div>
-                <div>{{ app.atRiskPasswordCount }}</div>
-              </div>
-            </ng-container>
           </ng-container>
-        </bit-drawer-body>
-      </ng-container>
-    </bit-drawer>
-  </bit-layout>
+        </ng-container>
+      </bit-drawer-body>
+    </ng-container>
+
+    <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.AppAtRiskMembers)">
+      <bit-drawer-header title="{{ dataService.appAtRiskMembers.applicationName }}">
+      </bit-drawer-header>
+      <bit-drawer-body>
+        <div bitTypography="body1" class="tw-mb-2">
+          {{ "atRiskMembersWithCount" | i18n: dataService.appAtRiskMembers.members.length }}
+        </div>
+        <div bitTypography="body1" class="tw-text-muted tw-text-sm tw-mb-2">
+          {{
+            (dataService.appAtRiskMembers.members.length > 0
+              ? "atRiskMembersDescriptionWithApp"
+              : "atRiskMembersDescriptionWithAppNone"
+            ) | i18n: dataService.appAtRiskMembers.applicationName
+          }}
+        </div>
+        <div class="tw-mt-1">
+          <ng-container *ngFor="let member of dataService.appAtRiskMembers.members">
+            <div>{{ member.email }}</div>
+          </ng-container>
+        </div>
+      </bit-drawer-body>
+    </ng-container>
+
+    <ng-container *ngIf="dataService.isActiveDrawerType(drawerTypes.OrgAtRiskApps)">
+      <bit-drawer-header
+        title="{{ 'atRiskApplicationsWithCount' | i18n: dataService.atRiskAppDetails.length }}"
+      >
+      </bit-drawer-header>
+
+      <bit-drawer-body>
+        <span bitTypography="body2" class="tw-text-muted tw-text-sm">{{
+          (dataService.atRiskAppDetails.length > 0
+            ? "atRiskApplicationsDescription"
+            : "atRiskApplicationsDescriptionNone"
+          ) | i18n
+        }}</span>
+        <ng-container *ngIf="dataService.atRiskAppDetails.length > 0">
+          <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
+            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+              {{ "application" | i18n }}
+            </div>
+            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+              {{ "atRiskPasswords" | i18n }}
+            </div>
+          </div>
+          <ng-container *ngFor="let app of dataService.atRiskAppDetails">
+            <div class="tw-flex tw-justify-between tw-mt-2">
+              <div>{{ app.applicationName }}</div>
+              <div>{{ app.atRiskPasswordCount }}</div>
+            </div>
+          </ng-container>
+        </ng-container>
+      </bit-drawer-body>
+    </ng-container>
+  </bit-drawer>
 </ng-container>

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
@@ -23,7 +23,6 @@ import {
   DrawerBodyComponent,
   DrawerComponent,
   DrawerHeaderComponent,
-  LayoutComponent,
   TabsModule,
 } from "@bitwarden/components";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
@@ -53,7 +52,6 @@ export enum RiskInsightsTabType {
     DrawerComponent,
     DrawerBodyComponent,
     DrawerHeaderComponent,
-    LayoutComponent,
   ],
 })
 export class RiskInsightsComponent implements OnInit {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23353](https://bitwarden.atlassian.net/browse/PM-23353)

## 📔 Objective

This pull request fixes extra padding that was introduced after changes to the `bit-layout` component. The changes fixed the need for a nested `bit-layout` which is unsupported. The nested component was needed due to the page throwing an error when the drawer couldn't access the higher level `bit-layout`

Note: Hide white space changes when reviewing to more easily see the changes made.

## 📸 Screenshots

<details>
<summary>Before</summary>

<img width="1466" height="1251" alt="image" src="https://github.com/user-attachments/assets/9225f1c9-6b02-4096-b924-294d409e593a" />

</details>

<details>
<summary> After </summary>

<img width="1465" height="1260" alt="image" src="https://github.com/user-attachments/assets/8fb07a8a-ac94-4d02-963c-cc016c75dae2" />

</details>

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23353]: https://bitwarden.atlassian.net/browse/PM-23353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ