### PR TITLE
[PM-23697] Copy unmodified login uri instead of launchUri

### DIFF
--- a/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
+++ b/libs/vault/src/cipher-view/autofill-options/autofill-options-view.component.html
@@ -32,7 +32,7 @@
           bitIconButton="bwi-clone"
           bitSuffix
           type="button"
-          [appCopyClick]="login.launchUri"
+          [appCopyClick]="login.uri"
           [valueLabel]="'website' | i18n"
           showToast
           [appA11yTitle]="'copyWebsite' | i18n"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23697](https://bitwarden.atlassian.net/browse/PM-23697)

## 📔 Objective

Copy the unmodified login URI without prepending any protocol when the copy value button is clicked.

## 📸 Screenshots

https://github.com/user-attachments/assets/fa34435d-89c5-4e68-b64a-ec17e5ef635c

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23697]: https://bitwarden.atlassian.net/browse/PM-23697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ