### PR TITLE
[PM-23687] Fix reload on organization-payment-details page

### DIFF
--- a/apps/web/src/app/billing/organizations/payment-details/organization-payment-details.component.ts
+++ b/apps/web/src/app/billing/organizations/payment-details/organization-payment-details.component.ts
@@ -156,13 +156,7 @@ export class OrganizationPaymentDetailsComponent implements OnInit {
     });
     const result = await lastValueFrom(dialogRef.closed);
     if (result?.type === "success") {
-      this.setPaymentMethod(result.paymentMethod);
-      if (!view.billingAddress && result.paymentMethod.type !== "payPal") {
-        const billingAddress = await this.billingClient.getBillingAddress(view.organization);
-        if (billingAddress) {
-          this.setBillingAddress(billingAddress);
-        }
-      }
+      await this.setPaymentMethod(result.paymentMethod);
       this.organizationFreeTrialWarningComponent.refresh();
     }
   };
@@ -176,11 +170,16 @@ export class OrganizationPaymentDetailsComponent implements OnInit {
     }
   };
 
-  setPaymentMethod = (paymentMethod: MaskedPaymentMethod) => {
+  setPaymentMethod = async (paymentMethod: MaskedPaymentMethod) => {
     if (this.viewState$.value) {
+      const billingAddress =
+        this.viewState$.value.billingAddress ??
+        (await this.billingClient.getBillingAddress(this.viewState$.value.organization));
+
       this.viewState$.next({
         ...this.viewState$.value,
         paymentMethod,
+        billingAddress,
       });
     }
   };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-23687

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR resolves an issue where the billing address section of the payment details page would not reload with new information when the user adds a payment method (with a billing address) when they currently have no billing address on file. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/510fd771-abb4-4187-8020-cd14e69c9402


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
