### PR TITLE
[PM-23689] Setup Extension Video tweaks

### DIFF
--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -610,7 +610,7 @@ const routes: Routes = [
         data: {
           hideCardWrapper: true,
           hideIcon: true,
-          maxWidth: "3xl",
+          maxWidth: "4xl",
         } satisfies AnonLayoutWrapperData,
         children: [
           {

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
@@ -49,9 +49,7 @@
   class="tw-mx-auto tw-w-[15rem] tw-mb-8 tw-relative md:tw-grid md:tw-gap-10 md:tw-w-auto md:tw-grid-rows-1 md:tw-grid-cols-3 md:tw-justify-center md:tw-justify-items-center"
   [attr.aria-label]="'setupExtensionContentAlt' | i18n"
 >
-  <div
-    class="tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] after:tw-absolute [--overlay-opacity:0.7] [--border-opacity:0] after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
-  >
+  <div [ngClass]="videoContainerClass">
     <div
       *ngIf="!allVideosLoaded"
       class="tw-animate-pulse tw-bg-secondary-300 tw-size-full tw-absolute tw-left-0 tw-top-0 tw-rounded-lg"
@@ -60,9 +58,7 @@
     <ng-container *ngTemplateOutlet="newLoginItem"></ng-container>
   </div>
 
-  <div
-    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] [--overlay-opacity:0.7] [--border-opacity:0] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
-  >
+  <div [ngClass]="videoContainerClass">
     <div
       *ngIf="!allVideosLoaded"
       class="tw-animate-pulse tw-bg-secondary-300 tw-size-full tw-absolute tw-left-0 tw-top-0 tw-rounded-lg"
@@ -71,9 +67,7 @@
     <ng-container *ngTemplateOutlet="browserExtensionEasyAccess"></ng-container>
   </div>
 
-  <div
-    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] [--overlay-opacity:0.7] [--border-opacity:0] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
-  >
+  <div [ngClass]="videoContainerClass">
     <div
       *ngIf="!allVideosLoaded"
       class="tw-animate-pulse tw-bg-secondary-300 tw-size-full tw-absolute tw-left-0 tw-top-0 tw-rounded-lg"

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
@@ -46,7 +46,7 @@
   The first video is relatively positioned to force the layout and spacing of the videos.
 -->
 <div
-  class="tw-mx-auto tw-w-[15rem] tw-mb-8 tw-relative md:tw-grid md:tw-gap-10 md:tw-w-auto md:tw-grid-rows-1 md:tw-grid-cols-3 md:tw-justify-center md:tw-justify-items-center"
+  class="tw-mx-auto tw-w-[15rem] tw-mb-8 tw-relative md:tw-grid md:tw-gap-10 md:tw-w-auto md:tw-grid-rows-1 md:tw-grid-cols-3 md:tw-justify-center md:tw-justify-items-center xl:tw-gap-12"
   [attr.aria-label]="'setupExtensionContentAlt' | i18n"
 >
   <div [ngClass]="videoContainerClass">
@@ -58,7 +58,8 @@
     <ng-container *ngTemplateOutlet="newLoginItem"></ng-container>
   </div>
 
-  <div [ngClass]="videoContainerClass">
+  <!-- Use `tw-relative` on the first video container to maintain the proper spacing -->
+  <div [ngClass]="videoContainerClass" class="tw-relative">
     <div
       *ngIf="!allVideosLoaded"
       class="tw-animate-pulse tw-bg-secondary-300 tw-size-full tw-absolute tw-left-0 tw-top-0 tw-rounded-lg"

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.html
@@ -49,7 +49,9 @@
   class="tw-mx-auto tw-w-[15rem] tw-mb-8 tw-relative md:tw-grid md:tw-gap-10 md:tw-w-auto md:tw-grid-rows-1 md:tw-grid-cols-3 md:tw-justify-center md:tw-justify-items-center"
   [attr.aria-label]="'setupExtensionContentAlt' | i18n"
 >
-  <div class="tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807]">
+  <div
+    class="tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] after:tw-absolute [--overlay-opacity:0.7] [--border-opacity:0] after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
+  >
     <div
       *ngIf="!allVideosLoaded"
       class="tw-animate-pulse tw-bg-secondary-300 tw-size-full tw-absolute tw-left-0 tw-top-0 tw-rounded-lg"
@@ -59,7 +61,7 @@
   </div>
 
   <div
-    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807]"
+    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] [--overlay-opacity:0.7] [--border-opacity:0] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
   >
     <div
       *ngIf="!allVideosLoaded"
@@ -70,7 +72,7 @@
   </div>
 
   <div
-    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807]"
+    class="tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807] [--overlay-opacity:0.7] [--border-opacity:0] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-opacity-[--overlay-opacity] after:tw-content-[''] after:tw-rounded-lg before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2 before:tw-rounded-t-lg before:tw-bg-primary-600 before:tw-content-[''] before:tw-opacity-[--border-opacity]"
   >
     <div
       *ngIf="!allVideosLoaded"

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
@@ -17,6 +17,11 @@ export class AddExtensionVideosComponent {
 
   private document = inject(DOCUMENT);
 
+  /** CSS variable name tied to the video overlay */
+  private cssOverlayVariable = "--overlay-opacity";
+  /** CSS variable name tied to the video border */
+  private cssBorderVariable = "--border-opacity";
+
   /** Current viewport size */
   protected variant: "mobile" | "desktop" = "desktop";
 
@@ -25,6 +30,13 @@ export class AddExtensionVideosComponent {
 
   /** True when the user prefers reduced motion */
   protected prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /** CSS classes for the video container, pulled into the class only for readability. */
+  protected videoContainerClass = [
+    "tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807]",
+    `[${this.cssOverlayVariable}:0.7] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-content-[''] after:tw-rounded-lg after:tw-opacity-[${this.cssOverlayVariable}]`,
+    `[${this.cssBorderVariable}:0] before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2  before:tw-bg-primary-600 before:tw-content-[''] before:tw-rounded-t-lg before:tw-opacity-[${this.cssBorderVariable}]`,
+  ].join(" ");
 
   /** Returns true when all videos are loaded */
   get allVideosLoaded(): boolean {
@@ -161,8 +173,8 @@ export class AddExtensionVideosComponent {
       const overlayOpacity = 0.7 * (percentComplete / 100);
       // The border opacity transitions from 1 to 0 based on the percent complete.
       const borderOpacity = (100 - percentComplete) / 100;
-      parentElement.style.setProperty("--border-opacity", borderOpacity.toString());
-      parentElement.style.setProperty("--overlay-opacity", overlayOpacity.toString());
+      parentElement.style.setProperty(this.cssBorderVariable, borderOpacity.toString());
+      parentElement.style.setProperty(this.cssOverlayVariable, overlayOpacity.toString());
     });
   }
 
@@ -181,8 +193,8 @@ export class AddExtensionVideosComponent {
       const overlayOpacity = 0.7 * (1 - percentComplete / 100);
       // The border opacity transitions from 0 to 1 based on the percent complete.
       const borderOpacity = percentComplete / 100;
-      parentElement.style.setProperty("--overlay-opacity", overlayOpacity.toString());
-      parentElement.style.setProperty("--border-opacity", borderOpacity.toString());
+      parentElement.style.setProperty(this.cssOverlayVariable, overlayOpacity.toString());
+      parentElement.style.setProperty(this.cssBorderVariable, borderOpacity.toString());
     });
   }
 

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
@@ -33,7 +33,7 @@ export class AddExtensionVideosComponent {
 
   /** CSS classes for the video container, pulled into the class only for readability. */
   protected videoContainerClass = [
-    "tw-absolute tw-left-0 tw-top-0 tw-opacity-0 md:tw-opacity-100 md:tw-relative tw-w-[15rem] tw-max-w-full tw-aspect-[0.807]",
+    "tw-absolute tw-left-0 tw-top-0 tw-w-[15rem] tw-opacity-0 md:tw-opacity-100 md:tw-relative lg:tw-w-[17rem] tw-max-w-full tw-aspect-[0.807]",
     `[${this.cssOverlayVariable}:0.7] after:tw-absolute after:tw-top-0 after:tw-left-0 after:tw-size-full after:tw-bg-primary-100 after:tw-content-[''] after:tw-rounded-lg after:tw-opacity-[${this.cssOverlayVariable}]`,
     `[${this.cssBorderVariable}:0] before:tw-absolute before:tw-top-0 before:tw-left-0 before:tw-w-full before:tw-h-2  before:tw-bg-primary-600 before:tw-content-[''] before:tw-rounded-t-lg before:tw-opacity-[${this.cssBorderVariable}]`,
   ].join(" ");

--- a/libs/components/src/anon-layout/anon-layout.component.ts
+++ b/libs/components/src/anon-layout/anon-layout.component.ts
@@ -15,7 +15,7 @@ import { AnonLayoutBitwardenShield } from "../icon/logos";
 import { SharedModule } from "../shared";
 import { TypographyModule } from "../typography";
 
-export type AnonLayoutMaxWidth = "md" | "lg" | "xl" | "2xl" | "3xl";
+export type AnonLayoutMaxWidth = "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
 
 @Component({
   selector: "auth-anon-layout",
@@ -65,6 +65,8 @@ export class AnonLayoutComponent implements OnInit, OnChanges {
         return "tw-max-w-2xl";
       case "3xl":
         return "tw-max-w-3xl";
+      case "4xl":
+        return "tw-max-w-4xl";
     }
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23689](https://bitwarden.atlassian.net/browse/PM-23689)

## 📔 Objective

- Update max width of the `/setup-extensions` page to be `896px` allowing for the videos to be larger on larger viewports
- Add overlays for paused and play videos
  - The playing video has a top border while paused videos have a full translucent overlay.
  - Both of these UI features use pseudo elements that transition via css variables assigned to each video container. 
    - The overlay transitions from `0` to `0.7` opacity
    - The border transitions from `0` to `1` opacity

## 📸 Screenshots

|Desktop|Mobile|
|-|-|
|<video src="https://github.com/user-attachments/assets/9d1d051a-64ee-49bc-be18-99259e6b32ab" />|<video src="https://github.com/user-attachments/assets/707296bf-a14a-41ab-8f24-35e5126ad306" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
