### PR TITLE
Fix extra signalr connection web

### DIFF
--- a/libs/common/src/platform/abstractions/config/config-api.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/config/config-api.service.abstraction.ts
@@ -5,5 +5,5 @@ export abstract class ConfigApiServiceAbstraction {
   /**
    * Fetches the server configuration for the given user. If no user is provided, the configuration will not contain user-specific context.
    */
-  abstract get(userId: UserId | undefined): Promise<ServerConfigResponse>;
+  abstract get(userId: UserId | null): Promise<ServerConfigResponse>;
 }

--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -95,6 +95,13 @@ export interface Environment {
  */
 export abstract class EnvironmentService {
   abstract environment$: Observable<Environment>;
+
+  /**
+   * The environment stored in global state, when a user signs in the state stored here will become
+   * their user environment.
+   */
+  abstract globalEnvironment$: Observable<Environment>;
+
   abstract cloudWebVaultUrl$: Observable<string>;
 
   /**
@@ -125,12 +132,12 @@ export abstract class EnvironmentService {
    * @param userId - The user id to set the cloud web vault app URL for. If null or undefined the global environment is set.
    * @param region - The region of the cloud web vault app.
    */
-  abstract setCloudRegion(userId: UserId, region: Region): Promise<void>;
+  abstract setCloudRegion(userId: UserId | null, region: Region): Promise<void>;
 
   /**
    * Get the environment from state. Useful if you need to get the environment for another user.
    */
-  abstract getEnvironment$(userId: UserId): Observable<Environment | undefined>;
+  abstract getEnvironment$(userId: UserId): Observable<Environment>;
 
   /**
    * @deprecated Use {@link getEnvironment$} instead.

--- a/libs/common/src/platform/services/config/config-api.service.ts
+++ b/libs/common/src/platform/services/config/config-api.service.ts
@@ -10,7 +10,7 @@ export class ConfigApiService implements ConfigApiServiceAbstraction {
     private tokenService: TokenService,
   ) {}
 
-  async get(userId: UserId | undefined): Promise<ServerConfigResponse> {
+  async get(userId: UserId | null): Promise<ServerConfigResponse> {
     // Authentication adds extra context to config responses, if the user has an access token, we want to use it
     // We don't particularly care about ensuring the token is valid and not expired, just that it exists
     const authed: boolean =

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -1,17 +1,18 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import {
   combineLatest,
+  distinctUntilChanged,
   firstValueFrom,
   map,
   mergeWith,
   NEVER,
   Observable,
   of,
-  shareReplay,
+  ReplaySubject,
+  share,
   Subject,
   switchMap,
   tap,
+  timer,
 } from "rxjs";
 import { SemVer } from "semver";
 
@@ -50,11 +51,15 @@ export const GLOBAL_SERVER_CONFIGURATIONS = KeyDefinition.record<ServerConfig, A
   },
 );
 
+const environmentComparer = (previous: Environment, current: Environment) => {
+  return previous.getApiUrl() === current.getApiUrl();
+};
+
 // FIXME: currently we are limited to api requests for active users. Update to accept a UserId and APIUrl once ApiService supports it.
 export class DefaultConfigService implements ConfigService {
-  private failedFetchFallbackSubject = new Subject<ServerConfig>();
+  private failedFetchFallbackSubject = new Subject<ServerConfig | null>();
 
-  serverConfig$: Observable<ServerConfig>;
+  serverConfig$: Observable<ServerConfig | null>;
 
   serverSettings$: Observable<ServerSettings>;
 
@@ -67,25 +72,51 @@ export class DefaultConfigService implements ConfigService {
     private stateProvider: StateProvider,
     private authService: AuthService,
   ) {
-    const userId$ = this.stateProvider.activeUserId$;
-    const authStatus$ = userId$.pipe(
-      switchMap((userId) => (userId == null ? of(null) : this.authService.authStatusFor$(userId))),
+    const globalConfig$ = this.environmentService.globalEnvironment$.pipe(
+      distinctUntilChanged(environmentComparer),
+      switchMap((environment) =>
+        this.globalConfigFor$(environment.getApiUrl()).pipe(
+          map((config) => {
+            return [config, null as UserId | null, environment] as const;
+          }),
+        ),
+      ),
     );
 
-    this.serverConfig$ = combineLatest([
-      userId$,
-      this.environmentService.environment$,
-      authStatus$,
-    ]).pipe(
-      switchMap(([userId, environment, authStatus]) => {
-        if (userId == null || authStatus !== AuthenticationStatus.Unlocked) {
-          return this.globalConfigFor$(environment.getApiUrl()).pipe(
-            map((config) => [config, null, environment] as const),
-          );
+    this.serverConfig$ = this.stateProvider.activeUserId$.pipe(
+      distinctUntilChanged(),
+      switchMap((userId) => {
+        if (userId == null) {
+          // Global
+          return globalConfig$;
         }
 
-        return this.userConfigFor$(userId).pipe(
-          map((config) => [config, userId, environment] as const),
+        return this.authService.authStatusFor$(userId).pipe(
+          map((authStatus) => authStatus === AuthenticationStatus.Unlocked),
+          distinctUntilChanged(),
+          switchMap((isUnlocked) => {
+            if (!isUnlocked) {
+              return globalConfig$;
+            }
+
+            return combineLatest([
+              this.environmentService
+                .getEnvironment$(userId)
+                .pipe(distinctUntilChanged(environmentComparer)),
+              this.userConfigFor$(userId),
+            ]).pipe(
+              switchMap(([environment, config]) => {
+                if (config == null) {
+                  // If the user doesn't have any config yet, use the global config for that url as the fallback
+                  return this.globalConfigFor$(environment.getApiUrl()).pipe(
+                    map((globalConfig) => [globalConfig, userId, environment] as const),
+                  );
+                }
+
+                return of([config, userId, environment] as const);
+              }),
+            );
+          }),
         );
       }),
       tap(async (rec) => {
@@ -106,7 +137,7 @@ export class DefaultConfigService implements ConfigService {
       }),
       // If fetch fails, we'll emit on this subject to fallback to the existing config
       mergeWith(this.failedFetchFallbackSubject),
-      shareReplay({ refCount: true, bufferSize: 1 }),
+      share({ connector: () => new ReplaySubject(1), resetOnRefCountZero: () => timer(1000) }),
     );
 
     this.cloudRegion$ = this.serverConfig$.pipe(
@@ -155,8 +186,8 @@ export class DefaultConfigService implements ConfigService {
 
   // Updates the on-disk configuration with a newly retrieved configuration
   private async renewConfig(
-    existingConfig: ServerConfig,
-    userId: UserId,
+    existingConfig: ServerConfig | null,
+    userId: UserId | null,
     environment: Environment,
   ): Promise<void> {
     try {
@@ -164,9 +195,7 @@ export class DefaultConfigService implements ConfigService {
       // somewhat quickly even though it may not be accurate, we won't cancel the HTTP request
       // though so that hopefully it can have finished and hydrated a more accurate value.
       const handle = setTimeout(() => {
-        this.logService.info(
-          "Self-host environment did not respond in time, emitting previous config.",
-        );
+        this.logService.info("Environment did not respond in time, emitting previous config.");
         this.failedFetchFallbackSubject.next(existingConfig);
       }, SLOW_EMISSION_GUARD);
       const response = await this.configApiService.get(userId);
@@ -199,13 +228,13 @@ export class DefaultConfigService implements ConfigService {
     }
   }
 
-  private globalConfigFor$(apiUrl: string): Observable<ServerConfig> {
+  private globalConfigFor$(apiUrl: string): Observable<ServerConfig | null> {
     return this.stateProvider
       .getGlobal(GLOBAL_SERVER_CONFIGURATIONS)
-      .state$.pipe(map((configs) => configs?.[apiUrl]));
+      .state$.pipe(map((configs) => configs?.[apiUrl] ?? null));
   }
 
-  private userConfigFor$(userId: UserId): Observable<ServerConfig> {
+  private userConfigFor$(userId: UserId): Observable<ServerConfig | null> {
     return this.stateProvider.getUser(userId, USER_SERVER_CONFIG).state$;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-23062
https://bitwarden.atlassian.net/browse/PM-23800

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Unrevert of https://github.com/bitwarden/clients/pull/15432 and then a fix for web not calling `/config` when it has empty state. The problem was that we were now supplying global config, meant to be used as a backup, for when user config fails to be retrieved. The problem is we were also checking it for if it was up to date and to skip retrieving altogether. The fix is to add another argument one for the actual existing server config and one that should be used as the fallback.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
