### PR TITLE
Fix action text and close vault modal

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -137,7 +137,7 @@ describe("Fido2CreateComponent", () => {
         title: { key: "unableToSavePasskey" },
         content: { key: "closeThisBitwardenWindow" },
         type: "danger",
-        acceptButtonText: { key: "closeBitwarden" },
+        acceptButtonText: { key: "closeThisWindow" },
         cancelButtonText: null,
       });
     });
@@ -217,7 +217,7 @@ describe("Fido2CreateComponent", () => {
         title: { key: "unableToSavePasskey" },
         content: { key: "closeThisBitwardenWindow" },
         type: "danger",
-        acceptButtonText: { key: "closeBitwarden" },
+        acceptButtonText: { key: "closeThisWindow" },
         cancelButtonText: null,
       });
     });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -35,28 +35,6 @@ import {
 import { BitwardenShield } from "./bitwarden-shield.icon";
 import { Fido2PasskeyExistsIcon } from "./fido2-passkey-exists-icon";
 
-const DIALOG_MESSAGES = {
-  unexpectedErrorShort: {
-    title: { key: "unexpectedErrorShort" },
-    content: { key: "closeThisBitwardenWindow" },
-    type: "danger",
-    acceptButtonText: { key: "closeBitwarden" },
-    cancelButtonText: null as null,
-  },
-  unableToSavePasskey: {
-    title: { key: "unableToSavePasskey" },
-    content: { key: "closeThisBitwardenWindow" },
-    type: "danger",
-    acceptButtonText: { key: "closeBitwarden" },
-    cancelButtonText: null as null,
-  },
-  overwritePasskey: {
-    title: { key: "overwritePasskey" },
-    content: { key: "alreadyContainsPasskey" },
-    type: "warning",
-  },
-} as const satisfies Record<string, SimpleDialogOptions>;
-
 @Component({
   standalone: true,
   imports: [
@@ -81,6 +59,32 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   readonly Icons = { BitwardenShield };
   protected fido2PasskeyExistsIcon = Fido2PasskeyExistsIcon;
 
+  private get DIALOG_MESSAGES() {
+    return {
+      unexpectedErrorShort: {
+        title: { key: "unexpectedErrorShort" },
+        content: { key: "closeThisBitwardenWindow" },
+        type: "danger",
+        acceptButtonText: { key: "closeThisWindow" },
+        cancelButtonText: null as null,
+        acceptAction: async () => this.dialogService.closeAll(),
+      },
+      unableToSavePasskey: {
+        title: { key: "unableToSavePasskey" },
+        content: { key: "closeThisBitwardenWindow" },
+        type: "danger",
+        acceptButtonText: { key: "closeThisWindow" },
+        cancelButtonText: null as null,
+        acceptAction: async () => this.dialogService.closeAll(),
+      },
+      overwritePasskey: {
+        title: { key: "overwritePasskey" },
+        content: { key: "alreadyContainsPasskey" },
+        type: "warning",
+      },
+    } as const satisfies Record<string, SimpleDialogOptions>;
+  }
+
   constructor(
     private readonly desktopSettingsService: DesktopSettingsService,
     private readonly fido2UserInterfaceService: DesktopFido2UserInterfaceService,
@@ -98,7 +102,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     const rpid = await this.session?.getRpId();
 
     if (!this.session) {
-      await this.showErrorDialog(DIALOG_MESSAGES.unableToSavePasskey);
+      await this.showErrorDialog(this.DIALOG_MESSAGES.unableToSavePasskey);
       return;
     }
 
@@ -119,7 +123,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
 
       this.session.notifyConfirmCreateCredential(isConfirmed, cipher);
     } catch {
-      await this.showErrorDialog(DIALOG_MESSAGES.unableToSavePasskey);
+      await this.showErrorDialog(this.DIALOG_MESSAGES.unableToSavePasskey);
       return;
     }
 
@@ -134,7 +138,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
 
       this.session.notifyConfirmCreateCredential(true);
     } catch {
-      await this.showErrorDialog(DIALOG_MESSAGES.unableToSavePasskey);
+      await this.showErrorDialog(this.DIALOG_MESSAGES.unableToSavePasskey);
     }
 
     await this.closeModal();
@@ -179,7 +183,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
               !cipher.deletedDate,
           );
         } catch {
-          await this.showErrorDialog(DIALOG_MESSAGES.unexpectedErrorShort);
+          await this.showErrorDialog(this.DIALOG_MESSAGES.unexpectedErrorShort);
           return [];
         }
       }),
@@ -189,7 +193,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   private async validateCipherAccess(cipher: CipherView): Promise<boolean> {
     if (cipher.login.hasFido2Credentials) {
       const overwriteConfirmed = await this.dialogService.openSimpleDialog(
-        DIALOG_MESSAGES.overwritePasskey,
+        this.DIALOG_MESSAGES.overwritePasskey,
       );
 
       if (!overwriteConfirmed) {

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -85,7 +85,7 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
         title: { key: "unexpectedErrorShort" },
         content: { key: "closeThisBitwardenWindow" },
         type: "danger",
-        acceptButtonText: { key: "closeBitwarden" },
+        acceptButtonText: { key: "closeThisWindow" },
         cancelButtonText: null,
       });
       await this.closeModal();

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3211,7 +3211,7 @@
   "orgTrustWarning1": {
     "message": "This organization has an Enterprise policy that will enroll you in account recovery. Enrollment will allow organization administrators to change your password. Only proceed if you recognize this organization and the fingerprint phrase displayed below matches the organization's fingerprint."
   },
-  "trustUser":{
+  "trustUser": {
     "message": "Trust user"
   },
   "inputRequired": {
@@ -3781,8 +3781,8 @@
   "applicationDoesNotSupportDuplicates": {
     "message": "This application does not support duplicates."
   },
-  "closeBitwarden": {
-    "message": "Close Bitwarden"
+  "closeThisWindow": {
+    "message": "Close this window"
   },
   "allowScreenshots": {
     "message": "Allow screen capture"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23814](https://bitwarden.atlassian.net/browse/PM-23814)
## 📔 Objective

Two changes were made to the error messages.  First, the action button on the error message said `Close Bitwarden` but we weren't actually closing Bitwarden.  This was changed to `Close this window`.

The second issue, and more problematic was that the error modal would remain on the vault until it was dismissed there.  Now all dialogs are properly closed when dismissed.

## 📸 Screenshots

Old:

https://github.com/user-attachments/assets/dff28814-665e-4755-ab3f-3bce7e0474bd


New:

https://github.com/user-attachments/assets/7ffffa73-622d-4746-8d23-924733aa7817


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
