### PR TITLE
add data-testids to address and tax inputs

### DIFF
--- a/apps/web/src/app/billing/payment/components/enter-billing-address.component.ts
+++ b/apps/web/src/app/billing/payment/components/enter-billing-address.component.ts
@@ -38,7 +38,7 @@ type Scenario =
         <div class="tw-col-span-6">
           <bit-form-field [disableMargin]="true">
             <bit-label>{{ "country" | i18n }}</bit-label>
-            <bit-select [formControl]="group.controls.country">
+            <bit-select [formControl]="group.controls.country" data-testid="country">
               @for (selectableCountry of selectableCountries; track selectableCountry.value) {
                 <bit-option
                   [value]="selectableCountry.value"
@@ -57,6 +57,7 @@ type Scenario =
               type="text"
               [formControl]="group.controls.postalCode"
               autocomplete="postal-code"
+              data-testid="postal-code"
             />
           </bit-form-field>
         </div>
@@ -68,6 +69,7 @@ type Scenario =
               type="text"
               [formControl]="group.controls.line1"
               autocomplete="address-line1"
+              data-testid="address-line1"
             />
           </bit-form-field>
         </div>
@@ -79,6 +81,7 @@ type Scenario =
               type="text"
               [formControl]="group.controls.line2"
               autocomplete="address-line2"
+              data-testid="address-line2"
             />
           </bit-form-field>
         </div>
@@ -90,6 +93,7 @@ type Scenario =
               type="text"
               [formControl]="group.controls.city"
               autocomplete="address-level2"
+              data-testid="city"
             />
           </bit-form-field>
         </div>
@@ -101,6 +105,7 @@ type Scenario =
               type="text"
               [formControl]="group.controls.state"
               autocomplete="address-level1"
+              data-testid="state"
             />
           </bit-form-field>
         </div>
@@ -108,7 +113,12 @@ type Scenario =
           <div class="tw-col-span-6">
             <bit-form-field [disableMargin]="true">
               <bit-label>{{ "taxIdNumber" | i18n }}</bit-label>
-              <input bitInput type="text" [formControl]="group.controls.taxId" />
+              <input
+                bitInput
+                type="text"
+                [formControl]="group.controls.taxId"
+                data-testid="tax-id"
+              />
             </bit-form-field>
           </div>
         }

--- a/apps/web/src/app/billing/shared/tax-info.component.html
+++ b/apps/web/src/app/billing/shared/tax-info.component.html
@@ -3,7 +3,7 @@
     <div class="tw-col-span-6">
       <bit-form-field>
         <bit-label>{{ "country" | i18n }}</bit-label>
-        <bit-select formControlName="country" autocomplete="country">
+        <bit-select formControlName="country" autocomplete="country" data-testid="country">
           <bit-option
             *ngFor="let country of countryList"
             [value]="country.value"
@@ -16,37 +16,67 @@
     <div class="tw-col-span-6">
       <bit-form-field>
         <bit-label>{{ "zipPostalCode" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="postalCode" autocomplete="postal-code" />
+        <input
+          bitInput
+          type="text"
+          formControlName="postalCode"
+          autocomplete="postal-code"
+          data-testid="postal-code"
+        />
       </bit-form-field>
     </div>
     <div class="tw-col-span-6" *ngIf="isTaxSupported">
       <bit-form-field>
         <bit-label>{{ "address1" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="line1" autocomplete="address-line1" />
+        <input
+          bitInput
+          type="text"
+          formControlName="line1"
+          autocomplete="address-line1"
+          data-testid="address-line1"
+        />
       </bit-form-field>
     </div>
     <div class="tw-col-span-6" *ngIf="isTaxSupported">
       <bit-form-field>
         <bit-label>{{ "address2" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="line2" autocomplete="address-line2" />
+        <input
+          bitInput
+          type="text"
+          formControlName="line2"
+          autocomplete="address-line2"
+          data-testid="address-line2"
+        />
       </bit-form-field>
     </div>
     <div class="tw-col-span-6" *ngIf="isTaxSupported">
       <bit-form-field>
         <bit-label for="addressCity">{{ "cityTown" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="city" autocomplete="address-level2" />
+        <input
+          bitInput
+          type="text"
+          formControlName="city"
+          autocomplete="address-level2"
+          data-testid="city"
+        />
       </bit-form-field>
     </div>
     <div class="tw-col-span-6" *ngIf="isTaxSupported">
       <bit-form-field>
         <bit-label>{{ "stateProvince" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="state" autocomplete="address-level1" />
+        <input
+          bitInput
+          type="text"
+          formControlName="state"
+          autocomplete="address-level1"
+          data-testid="state"
+        />
       </bit-form-field>
     </div>
     <div class="tw-col-span-6" *ngIf="isTaxSupported && showTaxIdField">
       <bit-form-field>
         <bit-label>{{ "taxIdNumber" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="taxId" />
+        <input bitInput type="text" formControlName="taxId" data-testid="tax-id" />
       </bit-form-field>
     </div>
   </div>

--- a/libs/angular/src/billing/components/manage-tax-information/manage-tax-information.component.html
+++ b/libs/angular/src/billing/components/manage-tax-information/manage-tax-information.component.html
@@ -3,7 +3,7 @@
     <div class="tw-col-span-6">
       <bit-form-field disableMargin>
         <bit-label>{{ "country" | i18n }}</bit-label>
-        <bit-select formControlName="country">
+        <bit-select formControlName="country" data-testid="country">
           <bit-option
             *ngFor="let country of countries"
             [value]="country.value"
@@ -16,38 +16,68 @@
     <div class="tw-col-span-6">
       <bit-form-field disableMargin>
         <bit-label>{{ "zipPostalCode" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="postalCode" autocomplete="postal-code" />
+        <input
+          bitInput
+          type="text"
+          formControlName="postalCode"
+          autocomplete="postal-code"
+          data-testid="postal-code"
+        />
       </bit-form-field>
     </div>
     <ng-container *ngIf="isTaxSupported">
       <div class="tw-col-span-6">
         <bit-form-field disableMargin>
           <bit-label>{{ "address1" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="line1" autocomplete="address-line1" />
+          <input
+            bitInput
+            type="text"
+            formControlName="line1"
+            autocomplete="address-line1"
+            data-testid="address-line1"
+          />
         </bit-form-field>
       </div>
       <div class="tw-col-span-6">
         <bit-form-field disableMargin>
           <bit-label>{{ "address2" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="line2" autocomplete="address-line2" />
+          <input
+            bitInput
+            type="text"
+            formControlName="line2"
+            autocomplete="address-line2"
+            data-testid="address-line2"
+          />
         </bit-form-field>
       </div>
       <div class="tw-col-span-6">
         <bit-form-field disableMargin>
           <bit-label>{{ "cityTown" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="city" autocomplete="address-level2" />
+          <input
+            bitInput
+            type="text"
+            formControlName="city"
+            autocomplete="address-level2"
+            data-testid="city"
+          />
         </bit-form-field>
       </div>
       <div class="tw-col-span-6">
         <bit-form-field disableMargin>
           <bit-label>{{ "stateProvince" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="state" autocomplete="address-level1" />
+          <input
+            bitInput
+            type="text"
+            formControlName="state"
+            autocomplete="address-level1"
+            data-testid="state"
+          />
         </bit-form-field>
       </div>
       <div class="tw-col-span-6" *ngIf="showTaxIdField">
         <bit-form-field disableMargin>
           <bit-label>{{ "taxIdNumber" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="taxId" />
+          <input bitInput type="text" formControlName="taxId" data-testid="tax-id" />
         </bit-form-field>
       </div>
     </ng-container>


### PR DESCRIPTION
## 📔 Objective
Adds data-testids to address/tax fields in:
enter-billing-address.component.ts
tax-info.component.html
manage-tax-information.component.html


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
