### PR TITLE
[PM-23813] nudge service causing lag in firefox extension footer

### DIFF
--- a/libs/angular/src/vault/services/custom-nudges-services/account-security-nudge.service.ts
+++ b/libs/angular/src/vault/services/custom-nudges-services/account-security-nudge.service.ts
@@ -74,7 +74,10 @@ export class AccountSecurityNudgeService extends DefaultSingleNudgeService {
             hasSpotlightDismissed: status.hasSpotlightDismissed || hideNudge,
           };
 
-          if (isPinSet || biometricUnlockEnabled || hasOrgWithRemovePinPolicyOn) {
+          if (
+            (isPinSet || biometricUnlockEnabled || hasOrgWithRemovePinPolicyOn) &&
+            !status.hasSpotlightDismissed
+          ) {
             await this.setNudgeStatus(nudgeType, acctSecurityNudgeStatus, userId);
           }
           return acctSecurityNudgeStatus;

--- a/libs/angular/src/vault/services/custom-nudges-services/has-items-nudge.service.ts
+++ b/libs/angular/src/vault/services/custom-nudges-services/has-items-nudge.service.ts
@@ -44,7 +44,11 @@ export class HasItemsNudgeService extends DefaultSingleNudgeService {
           return cipher.deletedDate == null;
         });
 
-        if (profileOlderThanCutoff && filteredCiphers.length > 0) {
+        if (
+          profileOlderThanCutoff &&
+          filteredCiphers.length > 0 &&
+          !nudgeStatus.hasSpotlightDismissed
+        ) {
           const dismissedStatus = {
             hasSpotlightDismissed: true,
             hasBadgeDismissed: true,

--- a/libs/angular/src/vault/services/custom-nudges-services/new-item-nudge.service.ts
+++ b/libs/angular/src/vault/services/custom-nudges-services/new-item-nudge.service.ts
@@ -49,7 +49,7 @@ export class NewItemNudgeService extends DefaultSingleNudgeService {
 
         const ciphersBoolean = ciphers.some((cipher) => cipher.type === currentType);
 
-        if (ciphersBoolean) {
+        if (ciphersBoolean && !nudgeStatus.hasSpotlightDismissed) {
           const dismissedStatus = {
             hasSpotlightDismissed: true,
             hasBadgeDismissed: true,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23813](https://bitwarden.atlassian.net/browse/PM-23813)

## 📔 Objective

* Calling the `setNudgeStatus` inside the custom nudge services was causing an infinite loop and locking up the browser extension in Firefox whenever a user tried to navigate using the footer. 
* Applied a dismiss check inside those services to stop the repeated calls.
* All tests pass. Chrome and Firefox look good for both new account users and old users. Screen Recording of Firefox below

## 📸 Screen Recording

https://github.com/user-attachments/assets/cc0acb93-2f37-4bad-993f-667c7ebee4c9


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
