### PR TITLE
[PM-23796] When Account Switching and unlocking a second account, the new/edit item screen is blank

### DIFF
--- a/libs/common/src/vault/services/folder/folder.service.ts
+++ b/libs/common/src/vault/services/folder/folder.service.ts
@@ -1,6 +1,16 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Observable, Subject, firstValueFrom, map, shareReplay, switchMap, merge } from "rxjs";
+import {
+  Observable,
+  Subject,
+  firstValueFrom,
+  map,
+  shareReplay,
+  switchMap,
+  merge,
+  filter,
+  combineLatest,
+} from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -69,8 +79,12 @@ export class FolderService implements InternalFolderServiceAbstraction {
 
       const observable = merge(
         this.forceFolderViews[userId],
-        this.encryptedFoldersState(userId).state$.pipe(
-          switchMap((folderData) => {
+        combineLatest([
+          this.encryptedFoldersState(userId).state$,
+          this.keyService.userKey$(userId),
+        ]).pipe(
+          filter(([folderData, userKey]) => folderData != null && userKey != null),
+          switchMap(([folderData, _]) => {
             return this.decryptFolders(userId, folderData);
           }),
         ),


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-23796
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
After unlocking multiple accounts and switching between them, attempting to create a new item or edit an existing item results in a blank screen instead of displaying the cipher form.

Root cause:
During account switching, the `folderViews$` observable in the `folder service` was hanging indefinitely due to a race condition. 

- Account switch triggers logout/lock for the previous user, clearing the user key from memory
- Folder data loads immediately from disk storage for the new account
- User key derivation takes time and isn't available yet, so we return an empty array [here](https://github.com/bitwarden/clients/blob/main/libs/common/src/vault/services/folder/folder.service.ts#L271-L273) even when folder data exists in cache

Fix:
Added a filter to the `folderViews$` to wait for the user key before attempting decryption

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Before  | After   |
|---|---|
| <video src="https://github.com/user-attachments/assets/d856c85e-b164-4881-813e-d8f94fbdff19" controls width="400"></video> |<video src="https://github.com/user-attachments/assets/91b53393-f471-449b-8700-64ee9a52cf50" controls width="400"></video>|
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
