### PR TITLE
PM-23848: Use the MacOS UI-friendly API instead

### DIFF
--- a/apps/desktop/macos/autofill-extension/Base.lproj/CredentialProviderViewController.xib
+++ b/apps/desktop/macos/autofill-extension/Base.lproj/CredentialProviderViewController.xib
@@ -29,7 +29,7 @@
                             </constraints>
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="bitwarden-icon" id="logoImageCell"/>
                         </imageView>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="statusLabel">
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="statusLabel">
                             <rect key="frame" x="68" y="16" width="157" height="19"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Enabling Bitwarden..." id="statusLabelCell">
                                 <font key="font" metaFont="system" size="16"/>

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -233,7 +233,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     UserVerification.discouraged
                 }
                 
-                let req = Passkey(
+                let req = PasskeyAssertionWithoutUserInterfaceRequest(
                     rpId: passkeyIdentity.relyingPartyIdentifier,
                     credentialId: passkeyIdentity.credentialID,
                     userName: passkeyIdentity.userName,
@@ -245,7 +245,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     windowXy: self.getWindowPosition()
                 )
                 
-                self.client.preparePasskeyAssertion(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer))
+                self.client.preparePasskeyAssertionWithoutUserInterface(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer))
                 return
             }
         }

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -181,8 +181,6 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
        let error = ASExtensionError(.userInteractionRequired)
        self.extensionContext.cancelRequest(withError: error)
        return
-        
-        
     }
     
     /*

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -171,11 +171,18 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             self?.extensionContext.completeExtensionConfigurationRequest()
         }
     }
-       
+    
+    /*
+     In order to implement this method, we need to query the state of the vault to be unlocked and have one and only one matching credential so that it doesn't need to show ui.
+     If we do show UI, it's going to fail and disconnect after the platform timeout which is 3s.
+     For now we just claim to always need UI displayed.
+     */
     override func provideCredentialWithoutUserInteraction(for credentialRequest: any ASCredentialRequest) {
        let error = ASExtensionError(.userInteractionRequired)
        self.extensionContext.cancelRequest(withError: error)
        return
+        
+        
     }
     
     /*

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -234,6 +234,9 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     UserVerification.discouraged
                 }
                 
+                /*
+                    We're still using the old request type here, because we're sending the same data, we're expecting a single credential to be used
+                */
                 let req = PasskeyAssertionWithoutUserInterfaceRequest(
                     rpId: passkeyIdentity.relyingPartyIdentifier,
                     credentialId: passkeyIdentity.credentialID,

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -195,8 +195,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         let timeoutTimer = createTimer()
         if let request = credentialRequest as? ASPasskeyCredentialRequest {
             if let passkeyIdentity = request.credentialIdentity as? ASPasskeyCredentialIdentity {
-                    
-                
+
                 logger.log("[autofill-extension] prepareInterfaceToProvideCredential (passkey) called \(request)")
                 
                 class CallbackImpl: PreparePasskeyAssertionCallback {
@@ -245,7 +244,6 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     recordIdentifier: passkeyIdentity.recordIdentifier,
                     clientDataHash: request.clientDataHash,
                     userVerification: userVerification,
-                
                     windowXy: self.getWindowPosition()
                 )
                 

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -13,6 +13,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     let logger: Logger
     
     @IBOutlet weak var statusLabel: NSTextField!
+    @IBOutlet weak var logoImageView: NSImageView!
     
     // There is something a bit strange about the initialization/deinitialization in this class.
     // Sometimes deinit won't be called after a request has successfully finished,
@@ -172,13 +173,9 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     }
        
     override func provideCredentialWithoutUserInteraction(for credentialRequest: any ASCredentialRequest) {
-       
-        
-        let error = ASExtensionError(.userInteractionRequired)
-        self.extensionContext.cancelRequest(withError: error)
-        return
-        
-        
+       let error = ASExtensionError(.userInteractionRequired)
+       self.extensionContext.cancelRequest(withError: error)
+       return
     }
     
     /*


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23848

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR changes adds an approproraite error response to the the `provideCredentialWithoutUserInteraction`-interface and uses the `prepareInterface`-method instead.

The Pull request also fixes a fatal-warning about a missing outlet.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
