### PR TITLE
Display the blue header on the locked vault passkey flow

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -263,13 +263,13 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   private async showUi(
     route: string,
     position?: { x: number; y: number },
-    showTrafficButtons?: boolean,
+    showTrafficButtons: boolean = false,
     disableRedirect?: boolean,
   ): Promise<void> {
     // Load the UI:
     await this.desktopSettingsService.setModalMode(true, showTrafficButtons, position);
     await this.centerOffscreenPopup();
-    await this.accountService.setShowHeader(false);
+    await this.accountService.setShowHeader(showTrafficButtons);
     await this.router.navigate([
       route,
       {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23873](https://bitwarden.atlassian.net/browse/PM-23873)

## 📔 Objective

When registering or authenticating a passkey when the vault is locked the blue header is missing.  Now the header will be displayed if the traffic light OS buttons are displayed since they are displayed together.

## 📸 Screenshots

Old:
<img width="607" height="600" alt="CleanShot 2025-07-17 at 14 05 47" src="https://github.com/user-attachments/assets/8e65058b-9b51-4260-8c6f-5387475afdf3" />

New:
<img width="599" height="601" alt="Screenshot 2025-07-17 at 11 08 42 AM" src="https://github.com/user-attachments/assets/fe79b48f-c957-4fa2-bb30-69c0d33412e1" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23873]: https://bitwarden.atlassian.net/browse/PM-23873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ