### PR TITLE
[PM-14939] (follow-up) add missing translations for when user is using Browser extension as an extension tab"

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3476,6 +3476,12 @@
   "youDeniedLoginAttemptFromAnotherDevice": {
     "message": "You denied a login attempt from another device. If this was you, try to log in with the device again."
   },
+  "device": {
+    "message": "Device"
+  },
+  "loginStatus": {
+    "message": "Login status"
+  },
   "masterPasswordChanged": {
     "message": "Master password saved"
   },
@@ -3641,6 +3647,31 @@
   },
   "loginRequest": {
     "message": "Login request"
+  },
+  "thisRequestIsNoLongerValid": {
+    "message": "This request is no longer valid."
+  },
+  "areYouTryingToAccessYourAccount": {
+    "message": "Are you trying to access your account?"
+  },
+  "logInConfirmedForEmailOnDevice": {
+    "message": "Login confirmed for $EMAIL$ on $DEVICE$",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "name@example.com"
+      },
+      "device": {
+        "content": "$2",
+        "example": "iOS"
+      }
+    }
+  },
+  "youDeniedALogInAttemptFromAnotherDevice": {
+    "message": "You denied a login attempt from another device. If this really was you, try to log in with the device again."
+  },
+  "loginRequestHasAlreadyExpired": {
+    "message": "Login request has already expired."
   },
   "justNow": {
     "message": "Just now"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14939](https://bitwarden.atlassian.net/browse/PM-14939) (follow-up)

## 📔 Objective

This PR adds some translations to Browser. These translations are necessary when the user is using the browser extension, but using it as an extension tab (which means the device management will use the table, not the item-list view)

## 📸 Screenshots

These screenshots show the Table view when using an _Extension tab_ (they are not showing the Web client).

### Extension Tab - Device Management Table translations
<img width="1275" height="1173" alt="Screenshot 2025-07-17 at 1 27 02 PM" src="https://github.com/user-attachments/assets/d9acfb9a-a9d9-4e18-8d59-38c3a2905441" />

### Extension Tab - Login Approval Component translations

<img width="1273" height="1178" alt="Screenshot 2025-07-17 at 1 27 12 PM" src="https://github.com/user-attachments/assets/841ce3a5-dfe6-4f65-88a3-92f91063a44e" />

### Extension Tab - Login Approval Component success toast

<img width="1274" height="750" alt="Screenshot 2025-07-17 at 1 37 50 PM" src="https://github.com/user-attachments/assets/1223aeef-d795-48b0-9c0f-71435c5f71ce" />

### Extension Tab - Login Approval Component denied toast

<img width="1258" height="905" alt="Screenshot 2025-07-17 at 1 37 25 PM" src="https://github.com/user-attachments/assets/554efe63-773d-460a-81a5-972d62d53b20" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14939]: https://bitwarden.atlassian.net/browse/PM-14939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ