### PR TITLE
[PM-14939] (follow-up-2) Feature flag Extension route

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -268,7 +268,7 @@ const routes: Routes = [
   {
     path: "device-management",
     component: ExtensionDeviceManagementComponent,
-    canActivate: [authGuard],
+    canActivate: [canAccessFeature(FeatureFlag.PM14938_BrowserExtensionLoginApproval), authGuard],
     data: { elevation: 1 } satisfies RouteDataProperties,
   },
   {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14939](https://bitwarden.atlassian.net/browse/PM-14939) (follow-up-2)

## 📔 Objective

Adds the feature flag to the Extension route. If the flag is off and a user uses an Extension tab an attempts to route to `/device-management`, they will be denied access.

## 📸 Screenshots

### Flag Off

Attempting to access `/device-management` in an Extension tab.

<img width="820" height="421" alt="Screenshot 2025-07-17 at 3 48 28 PM" src="https://github.com/user-attachments/assets/cccc3fc1-becc-47a6-9ca7-a58bd8ae204d" />

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14939]: https://bitwarden.atlassian.net/browse/PM-14939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ