### PR TITLE
[CL-793] Exclude checkbox component from desktop global css

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -66,7 +66,7 @@ a {
   }
 }
 
-input:not(bit-form-field input),
+input:not(bit-form-field input, input[bitcheckbox]),
 select,
 textarea:not(bit-form-field textarea) {
   @include themify($themes) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-793](https://bitwarden.atlassian.net/browse/CL-793)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR excludes the checkbox component from the global desktop css, which applies a background color to input components. It caused 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="775" height="435" alt="Screenshot 2025-07-18 at 10 27 41 AM" src="https://github.com/user-attachments/assets/ee262bea-f833-49bb-b231-27bf49246910" /> | <img width="775" height="435" alt="Screenshot 2025-07-18 at 10 27 15 AM" src="https://github.com/user-attachments/assets/32726919-b01d-4b10-9cbe-7eb548d14a76" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
