### PR TITLE
Auth/PM-23913 - ChangePassword - extension popout now closes on success

### DIFF
--- a/apps/browser/src/auth/popup/change-password/extension-change-password.service.spec.ts
+++ b/apps/browser/src/auth/popup/change-password/extension-change-password.service.spec.ts
@@ -1,0 +1,50 @@
+import { MockProxy, mock } from "jest-mock-extended";
+
+import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
+import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
+import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
+import { KeyService } from "@bitwarden/key-management";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+
+import { ExtensionChangePasswordService } from "./extension-change-password.service";
+
+describe("ExtensionChangePasswordService", () => {
+  let keyService: MockProxy<KeyService>;
+  let masterPasswordApiService: MockProxy<MasterPasswordApiService>;
+  let masterPasswordService: MockProxy<InternalMasterPasswordServiceAbstraction>;
+  let window: MockProxy<Window>;
+
+  let changePasswordService: ChangePasswordService;
+
+  beforeEach(() => {
+    keyService = mock<KeyService>();
+    masterPasswordApiService = mock<MasterPasswordApiService>();
+    masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
+    window = mock<Window>();
+
+    changePasswordService = new ExtensionChangePasswordService(
+      keyService,
+      masterPasswordApiService,
+      masterPasswordService,
+      window,
+    );
+  });
+
+  it("should instantiate the service", () => {
+    expect(changePasswordService).toBeDefined();
+  });
+
+  it("should close the browser extension popout", () => {
+    const closePopupSpy = jest.spyOn(BrowserApi, "closePopup");
+    const browserPopupUtilsInPopupSpy = jest
+      .spyOn(BrowserPopupUtils, "inPopout")
+      .mockReturnValue(true);
+
+    changePasswordService.closeBrowserExtensionPopout?.();
+
+    expect(closePopupSpy).toHaveBeenCalledWith(window);
+    expect(browserPopupUtilsInPopupSpy).toHaveBeenCalledWith(window);
+  });
+});

--- a/apps/browser/src/auth/popup/change-password/extension-change-password.service.ts
+++ b/apps/browser/src/auth/popup/change-password/extension-change-password.service.ts
@@ -1,0 +1,29 @@
+import {
+  DefaultChangePasswordService,
+  ChangePasswordService,
+} from "@bitwarden/angular/auth/password-management/change-password";
+import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
+import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
+import { KeyService } from "@bitwarden/key-management";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+
+export class ExtensionChangePasswordService
+  extends DefaultChangePasswordService
+  implements ChangePasswordService
+{
+  constructor(
+    protected keyService: KeyService,
+    protected masterPasswordApiService: MasterPasswordApiService,
+    protected masterPasswordService: InternalMasterPasswordServiceAbstraction,
+    private win: Window,
+  ) {
+    super(keyService, masterPasswordApiService, masterPasswordService);
+  }
+  closeBrowserExtensionPopout(): void {
+    if (BrowserPopupUtils.inPopout(this.win)) {
+      BrowserApi.closePopup(this.win);
+    }
+  }
+}

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -4,6 +4,7 @@ import { APP_INITIALIZER, NgModule, NgZone } from "@angular/core";
 import { merge, of, Subject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
+import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { AngularThemingService } from "@bitwarden/angular/platform/services/theming/angular-theming.service";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
 import { ViewCacheService } from "@bitwarden/angular/platform/view-cache";
@@ -44,6 +45,7 @@ import {
   AccountService as AccountServiceAbstraction,
 } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import {
@@ -142,6 +144,7 @@ import {
 
 import { AccountSwitcherService } from "../../auth/popup/account-switching/services/account-switcher.service";
 import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock.service";
+import { ExtensionChangePasswordService } from "../../auth/popup/change-password/extension-change-password.service";
 import { ExtensionLoginComponentService } from "../../auth/popup/login/extension-login-component.service";
 import { ExtensionSsoComponentService } from "../../auth/popup/login/extension-sso-component.service";
 import { ExtensionLogoutService } from "../../auth/popup/logout/extension-logout.service";
@@ -661,6 +664,11 @@ const safeProviders: SafeProvider[] = [
     provide: SshImportPromptService,
     useClass: DefaultSshImportPromptService,
     deps: [DialogService, ToastService, PlatformUtilsService, I18nServiceAbstraction],
+  }),
+  safeProvider({
+    provide: ChangePasswordService,
+    useClass: ExtensionChangePasswordService,
+    deps: [KeyService, MasterPasswordApiService, InternalMasterPasswordServiceAbstraction, WINDOW],
   }),
   safeProvider({
     provide: NotificationsService,

--- a/libs/angular/src/auth/password-management/change-password/change-password.component.ts
+++ b/libs/angular/src/auth/password-management/change-password/change-password.component.ts
@@ -177,6 +177,9 @@ export class ChangePasswordComponent implements OnInit {
 
         // TODO: PM-23515 eventually use the logout service instead of messaging service once it is available without circular dependencies
         this.messagingService.send("logout");
+
+        // Close the popout if we are in a browser extension popout.
+        this.changePasswordService.closeBrowserExtensionPopout?.();
       }
     } catch (error) {
       this.logService.error(error);

--- a/libs/angular/src/auth/password-management/change-password/change-password.service.abstraction.ts
+++ b/libs/angular/src/auth/password-management/change-password/change-password.service.abstraction.ts
@@ -59,4 +59,10 @@ export abstract class ChangePasswordService {
    * - Currently only used on the web change password service.
    */
   clearDeeplinkState?: () => Promise<void>;
+
+  /**
+   * Optional method that closes the browser extension popout if in a popout
+   * If not in a popout, does nothing.
+   */
+  abstract closeBrowserExtensionPopout?(): void;
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23913

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To make the extension popout close upon successful password change

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before

https://github.com/user-attachments/assets/aa91d6bf-f6c1-4902-a181-778f17735393


After
https://github.com/user-attachments/assets/72f767cf-02ee-4ce3-9fd6-304ffc920848



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
