### PR TITLE
[PM-23974] Deprecate encstring's decrypt function

### DIFF
--- a/libs/common/src/key-management/crypto/models/enc-string.ts
+++ b/libs/common/src/key-management/crypto/models/enc-string.ts
@@ -153,6 +153,10 @@ export class EncString implements Encrypted {
     return EXPECTED_NUM_PARTS_BY_ENCRYPTION_TYPE[encType] === encPieces.length;
   }
 
+  /**
+   * @deprecated - This function is deprecated. Use EncryptService.decryptString instead.
+   * @returns - The decrypted string, or `[error: cannot decrypt]` if decryption fails.
+   */
   async decrypt(
     orgId: string | null,
     key: SymmetricCryptoKey | null = null,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23974

## 📔 Objective

EncString's decrypt function should no longer be consumed by teams. It exposes errors improperly, mapping them to valid placeholder values and easily leads to re-encrypting encryption errors as proper data, since these were previously validly mapped into the decrypted views as `[error: cannot decrypt]`.

Instead, teams should use encryptService, or the SDK. In case a team needs to handle decryption errors in the UI, teams should detect a decryption failure, and either re-implement the existing `[error: cannot decrypt]`, or custom handling (i18n'd errors) if they choose to do so.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
