### PR TITLE
[PM 23856] Organization not found in dropdown for Free Bitwarden Families for Enterprise Subscriptions

### DIFF
--- a/apps/web/src/app/billing/settings/sponsored-families.component.html
+++ b/apps/web/src/app/billing/settings/sponsored-families.component.html
@@ -28,7 +28,7 @@
             >
               <bit-option
                 [disabled]="true"
-                [value]=""
+                [value]="null"
                 [label]="'--' + ('select' | i18n) + '--'"
               ></bit-option>
               <bit-option


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23856

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
🐛 **Problem**
The application encountered the following Angular runtime error:
`NG0950: Input is required but no value is available yet.`
This occurred because a <bit-option> used as a placeholder was passing an empty string ("") to the required [value] input, which Angular considered invalid during initial rendering, especially when using strict input validation or signals.

✅ **Solution**

- Replaced "" with null for the [value] input of the disabled placeholder <bit-option> to provide a safe and defined value.
- Ensured compatibility with Angular’s strict input validation by avoiding undefined or delayed values.

💡 **Notes**

- If necessary, consumers of this select can treat null as a sentinel value indicating no selection.
- This change prevents a runtime crash and aligns with Angular best practices for input initialization.

🧪 **Testing**

- Verified that the dropdown renders correctly without errors.
- Confirmed that form binding still works as expected.
- Placeholder option is correctly shown as disabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-07-21 at 14 24 49" src="https://github.com/user-attachments/assets/c2ee7b9f-481e-4861-9879-fd3dcb2f12b7" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
