### PR TITLE
[PM-23978] Hide bank account for premium and non-premium non-US payer

### DIFF
--- a/apps/web/src/app/billing/payment/components/change-payment-method-dialog.component.ts
+++ b/apps/web/src/app/billing/payment/components/change-payment-method-dialog.component.ts
@@ -28,7 +28,11 @@ type DialogResult =
           {{ "changePaymentMethod" | i18n }}
         </span>
         <div bitDialogContent>
-          <app-enter-payment-method [group]="formGroup" [includeBillingAddress]="true">
+          <app-enter-payment-method
+            [group]="formGroup"
+            [showBankAccount]="dialogParams.owner.type !== 'account'"
+            [includeBillingAddress]="true"
+          >
           </app-enter-payment-method>
         </div>
         <ng-container bitDialogFooter>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-23978

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The bank account option in the new payment method component was incorrectly showing for both premium users and non-premium users that selected a non-US billing address their payment method. This PR resolves that.  

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/f1043468-80c2-4595-9e01-cea8551e5e75


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
