### PR TITLE
[PM-24000]  Fix json import with SDK cipher encryption

### DIFF
--- a/libs/common/src/models/export/cipher.export.ts
+++ b/libs/common/src/models/export/cipher.export.ts
@@ -53,6 +53,7 @@ export class CipherExport {
     view.notes = req.notes;
     view.favorite = req.favorite;
     view.reprompt = req.reprompt ?? CipherRepromptType.None;
+    view.key = req.key != null ? new EncString(req.key) : null;
 
     if (req.fields != null) {
       view.fields = req.fields.map((f) => FieldExport.toView(f));
@@ -80,9 +81,9 @@ export class CipherExport {
       view.passwordHistory = req.passwordHistory.map((ph) => PasswordHistoryExport.toView(ph));
     }
 
-    view.creationDate = req.creationDate;
-    view.revisionDate = req.revisionDate;
-    view.deletedDate = req.deletedDate;
+    view.creationDate = req.creationDate ? new Date(req.creationDate) : null;
+    view.revisionDate = req.revisionDate ? new Date(req.revisionDate) : null;
+    view.deletedDate = req.deletedDate ? new Date(req.deletedDate) : null;
     return view;
   }
 

--- a/libs/common/src/models/export/password-history.export.ts
+++ b/libs/common/src/models/export/password-history.export.ts
@@ -16,7 +16,7 @@ export class PasswordHistoryExport {
 
   static toView(req: PasswordHistoryExport, view = new PasswordHistoryView()) {
     view.password = req.password;
-    view.lastUsedDate = req.lastUsedDate;
+    view.lastUsedDate = req.lastUsedDate ? new Date(req.lastUsedDate) : null;
     return view;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24000](https://bitwarden.atlassian.net/browse/PM-24000)

## 📔 Objective

Similar to https://github.com/bitwarden/clients/pull/15398, but now for importing decrypted ciphers. `CipherExport.toView()` was copying the string date value and not creating a Date object causing the `toSdkView()` method to throw.

Relates to #15337 but was separated to avoid re-requesting reviews for something independent.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
