### PR TITLE
[PM-24012] Empty Favorites section

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.ts
@@ -146,14 +146,16 @@ export class VaultListItemsContainerComponent implements AfterViewInit {
       ciphers: PopupCipherViewLike[];
     }[]
   >(() => {
+    const ciphers = this.ciphers();
+
     // Not grouping by type, return a single group with all ciphers
-    if (!this.groupByType()) {
-      return [{ ciphers: this.ciphers() }];
+    if (!this.groupByType() && ciphers.length > 0) {
+      return [{ ciphers }];
     }
 
     const groups: Record<string, PopupCipherViewLike[]> = {};
 
-    this.ciphers().forEach((cipher) => {
+    ciphers.forEach((cipher) => {
       let groupKey = "all";
       switch (CipherViewLikeUtils.getType(cipher)) {
         case CipherType.Card:


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24012](https://bitwarden.atlassian.net/browse/PM-24012)

## 📔 Objective

When there are no ciphers `[{ciphers: []}]` was being passed into the template for `cipherGroups()`. The conditionals within the template are checking for an empty array rather than an empty `ciphers` within the array. 

Fix: Only return ciphers directly when they are not sorted by groups _and_ there is at least one. 

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="390" height="607" alt="image" src="https://github.com/user-attachments/assets/de770d47-3877-4700-97ef-e8338185054c" />|<img width="390" height="607" alt="Screenshot 2025-07-21 at 11 25 50 PM" src="https://github.com/user-attachments/assets/959e88af-7099-4182-b958-b7ffd28b9088" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24012]: https://bitwarden.atlassian.net/browse/PM-24012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ