### PR TITLE
[CL-801] Fix chromatic.yml externals formatting

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,7 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
+      - "uif/chromatic-externals"
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,6 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-      - "uif/chromatic-externals"
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -102,6 +102,9 @@ jobs:
           storybookBuildDir: ./storybook-static
           exitOnceUploaded: true
           onlyChanged: true
-          externals: "[\"libs/components/**/*.scss\", \"libs/components/**/*.css\", \"libs/components/tailwind.config*.js\"]"
+          externals: |
+            libs/components/**/*.scss
+            libs/components/**/*.css
+            libs/components/tailwind.config*.js
           # Rather than use an `if` check on the whole publish step, we need to tell Chromatic to skip so that any Chromatic-spawned actions are properly skipped
           skip: ${{ steps.get-changed-files-for-chromatic.outputs.storyFiles == 'false' }}

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -155,6 +155,7 @@ module.exports = {
         "90vw": "90vw",
       }),
       fontSize: {
+        xs: [".8125rem", "1rem"],
         "3xl": ["1.75rem", "2rem"],
       },
     },

--- a/libs/components/tailwind.config.base.js
+++ b/libs/components/tailwind.config.base.js
@@ -155,7 +155,6 @@ module.exports = {
         "90vw": "90vw",
       }),
       fontSize: {
-        xs: [".8125rem", "1rem"],
         "3xl": ["1.75rem", "2rem"],
       },
     },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-801](https://bitwarden.atlassian.net/browse/CL-801)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We noticed that a component library PR did not trigger the expected Chromatic UI Test diffs. The PR modified a file that is included in our chromatic workflow’s `externals` configuration, which tells Chromatic to rerun snapshots when anything in “externals” is changed because these files are processed outside of Webpack, where Chromatic sources its dependency graph from. ([Docs here](https://www.chromatic.com/docs/turbosnap/setup/#specify-external-files-to-trigger-a-full-re-test-when-they-change)) The formatting for our externals didn't match what’s in the docs, so I am updating it to match.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

This first screenshot is from the PR that had the issue. It is the workflow run from the original commit that changed the file specified in `externals`. Notice that it sees the file changed, but does not run any story files. Turbosnap is enabled, which means all unaffected stories are skipped. Since it doesn't think anything relevant has changed, it skips them all.

<img width="989" height="805" alt="Screenshot 2025-07-22 at 3 54 48 PM" src="https://github.com/user-attachments/assets/77c00ff1-8d60-456b-98ce-f908eb476be7" />


The following screenshot is from the current PR, from a commit (9f5ddd7) where I made a change to that same file to test the workflow's changes. Notice that it sees the changed file and then disables Turbosnap due to finding a match in the `externals` config. This is the expected behavior! If you check that commit's checks in this PR, you'll see a lot of UI Tests that are now picking up diffs.

<img width="899" height="624" alt="Screenshot 2025-07-22 at 3 55 57 PM" src="https://github.com/user-attachments/assets/4db5cb2e-8f2c-47ee-adb0-0cf2f12e4d7d" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-801]: https://bitwarden.atlassian.net/browse/CL-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ