### PR TITLE
[PM-23722] remove previous change for the account security badge

### DIFF
--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -10,16 +10,7 @@
     <bit-item>
       <a bit-item-content routerLink="/account-security">
         <i slot="start" class="bwi bwi-lock" aria-hidden="true"></i>
-        <div class="tw-flex tw-items-center tw-justify-center">
-          <p class="tw-pr-2">{{ "accountSecurity" | i18n }}</p>
-          <span
-            *ngIf="showAcctSecurityNudge$ | async"
-            bitBadge
-            variant="notification"
-            [attr.aria-label]="'nudgeBadgeAria' | i18n"
-            >1</span
-          >
-        </div>
+        {{ "accountSecurity" | i18n }}
         <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </a>
     </bit-item>

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.ts
@@ -50,12 +50,6 @@ export class SettingsV2Component implements OnInit {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  protected showAcctSecurityNudge$: Observable<boolean> = this.authenticatedAccount$.pipe(
-    switchMap((account) =>
-      this.nudgesService.showNudgeBadge$(NudgeType.AccountSecurity, account.id),
-    ),
-  );
-
   showDownloadBitwardenNudge$: Observable<boolean> = this.authenticatedAccount$.pipe(
     switchMap((account) =>
       this.nudgesService.showNudgeBadge$(NudgeType.DownloadBitwarden, account.id),

--- a/libs/angular/src/vault/services/nudges.service.ts
+++ b/libs/angular/src/vault/services/nudges.service.ts
@@ -160,7 +160,6 @@ export class NudgesService {
   hasActiveBadges$(userId: UserId): Observable<boolean> {
     // Add more nudge types here if they have the settings badge feature
     const nudgeTypes = [
-      NudgeType.AccountSecurity,
       NudgeType.EmptyVaultNudge,
       NudgeType.DownloadBitwarden,
       NudgeType.AutofillNudge,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23722](https://bitwarden.atlassian.net/browse/PM-23722)

## 📔 Objective

Remove previously added badge that was thought to be missing. Recent design changes we will not be having a badge for Account Security. The nudge in account security is more educational for the user and no badge is required. 

## 📸 Screenshots

<img width="384" height="599" alt="Screenshot 2025-07-22 at 3 56 19 PM" src="https://github.com/user-attachments/assets/1bb929e6-1156-451d-9cd2-ea959bda048c" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
