### PR TITLE
[PM-23789] - [Web][Desktop][Browser] - Do not import cards if policy is enabled

### DIFF
--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -821,6 +821,7 @@ export class ServiceContainer {
       this.pinService,
       this.accountService,
       this.sdkService,
+      this.restrictedItemTypesService,
     );
 
     this.individualExportService = new IndividualVaultExportService(

--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -100,6 +100,7 @@ const safeProviders: SafeProvider[] = [
       PinServiceAbstraction,
       AccountService,
       SdkService,
+      RestrictedItemTypesService,
     ],
   }),
 ];

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -26,6 +26,7 @@ import { CipherRequest } from "@bitwarden/common/vault/models/request/cipher.req
 import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { KeyService } from "@bitwarden/key-management";
 
 import {
@@ -119,6 +120,7 @@ export class ImportService implements ImportServiceAbstraction {
     private pinService: PinServiceAbstraction,
     private accountService: AccountService,
     private sdkService: SdkService,
+    private restrictedItemTypesService: RestrictedItemTypesService,
   ) {}
 
   getImportOptions(): ImportOption[] {
@@ -165,6 +167,19 @@ export class ImportService implements ImportServiceAbstraction {
         throw new Error(this.i18nService.t("importFormatError"));
       }
     }
+
+    const restrictedItemTypes = await firstValueFrom(
+      this.restrictedItemTypesService.restricted$.pipe(
+        map((restrictedItemTypes) => restrictedItemTypes.map((r) => r.cipherType)),
+      ),
+    );
+
+    importResult.ciphers = importResult.ciphers.filter((cipher) => {
+      if (restrictedItemTypes.includes(cipher.type)) {
+        return false;
+      }
+      return true;
+    });
 
     if (organizationId && !selectedImportTarget && !canAccessImportExport) {
       const hasUnassignedCollections =

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -174,6 +174,7 @@ export class ImportService implements ImportServiceAbstraction {
       ),
     );
 
+    // Filter out restricted item types from the import result
     importResult.ciphers = importResult.ciphers.filter((cipher) => {
       if (restrictedItemTypes.includes(cipher.type)) {
         return false;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23789
https://bitwarden.atlassian.net/browse/PM-23790
https://bitwarden.atlassian.net/browse/PM-23791
https://bitwarden.atlassian.net/browse/PM-23792


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the import service to restrict any types that are restricted by any of the user's orgs. All clients use the same [import component](https://github.com/bitwarden/clients/blob/main/libs/importer/src/components/import.component.ts) and [import service](https://github.com/bitwarden/clients/blob/main/libs/importer/src/services/import.service.ts) so updating these (any the spec file) is all that's required. All clients were tested manually to ensure no regressions were introduced.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/8502e095-4000-4ff3-8180-d666ca056144


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
