### PR TITLE
[PM-22790] Adds SendInput() Functionality to the Autotype Crate

### DIFF
--- a/apps/desktop/desktop_native/autotype/src/lib.rs
+++ b/apps/desktop/desktop_native/autotype/src/lib.rs
@@ -16,8 +16,6 @@ pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
 /// `input` must be an array of utf-16 encoded characters to insert.
 ///
 /// TODO: The error handling will be improved in a future PR: PM-23615
-///
-/// https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 #[allow(clippy::result_unit_err)]
 pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
     windowing::type_input(input)

--- a/apps/desktop/desktop_native/autotype/src/lib.rs
+++ b/apps/desktop/desktop_native/autotype/src/lib.rs
@@ -10,3 +10,15 @@ mod windowing;
 pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     windowing::get_foreground_window_title()
 }
+
+/// Attempts to type the input text wherever the user's cursor is.
+///
+/// `input` must be an array of utf-16 encoded characters to insert.
+///
+/// TODO: The error handling will be improved in a future PR: PM-23615
+///
+/// https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+#[allow(clippy::result_unit_err)]
+pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
+    windowing::type_input(input)
+}

--- a/apps/desktop/desktop_native/autotype/src/linux.rs
+++ b/apps/desktop/desktop_native/autotype/src/linux.rs
@@ -2,6 +2,6 @@ pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     todo!("Bitwarden does not yet support Linux autotype");
 }
 
-pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
+pub fn type_input(_input: Vec<u16>) -> std::result::Result<(), ()> {
     todo!("Bitwarden does not yet support Linux autotype");
 }

--- a/apps/desktop/desktop_native/autotype/src/linux.rs
+++ b/apps/desktop/desktop_native/autotype/src/linux.rs
@@ -1,3 +1,7 @@
 pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     todo!("Bitwarden does not yet support Linux autotype");
 }
+
+pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
+    todo!("Bitwarden does not yet support Linux autotype");
+}

--- a/apps/desktop/desktop_native/autotype/src/macos.rs
+++ b/apps/desktop/desktop_native/autotype/src/macos.rs
@@ -1,3 +1,7 @@
 pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     todo!("Bitwarden does not yet support Mac OS autotype");
 }
+
+pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
+    todo!("Bitwarden does not yet support Mac OS autotype");
+}

--- a/apps/desktop/desktop_native/autotype/src/macos.rs
+++ b/apps/desktop/desktop_native/autotype/src/macos.rs
@@ -2,6 +2,6 @@ pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     todo!("Bitwarden does not yet support Mac OS autotype");
 }
 
-pub fn type_input(input: Vec<u16>) -> std::result::Result<(), ()> {
+pub fn type_input(_input: Vec<u16>) -> std::result::Result<(), ()> {
     todo!("Bitwarden does not yet support Mac OS autotype");
 }

--- a/apps/desktop/desktop_native/autotype/src/windows.rs
+++ b/apps/desktop/desktop_native/autotype/src/windows.rs
@@ -1,7 +1,11 @@
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 
-use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::{GetLastError, HWND};
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    BlockInput, SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+    KEYEVENTF_UNICODE,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
 };
@@ -16,6 +20,29 @@ pub fn get_foreground_window_title() -> std::result::Result<String, ()> {
     };
 
     Ok(window_title)
+}
+
+/// Attempts to type the input text wherever the user's cursor is.
+///
+/// `input` must be an array of utf-16 encoded characters to insert.
+///
+/// https://learn.microsoft.com/en-in/windows/win32/api/winuser/nf-winuser-sendinput
+pub fn type_input(input: Vec<u16>) -> Result<(), ()> {
+    let mut keyboard_inputs: Vec<INPUT> = Vec::new();
+
+    for i in input {
+        let next_down_input = build_input(InputKeyPress::Down, i);
+        let next_up_input = build_input(InputKeyPress::Up, i);
+
+        keyboard_inputs.push(next_down_input);
+        keyboard_inputs.push(next_up_input);
+    }
+
+    let _ = block_input(true);
+    let result = send_input(keyboard_inputs);
+    let _ = block_input(false);
+
+    result
 }
 
 /// Gets the foreground window handle.
@@ -33,8 +60,6 @@ fn get_foreground_window() -> Result<HWND, ()> {
 
 /// Gets the length of the window title bar text.
 ///
-/// TODO: Future improvement is to use GetLastError for better error handling
-///
 /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextlengthw
 fn get_window_title_length(window_handle: HWND) -> Result<usize, ()> {
     if window_handle.is_invalid() {
@@ -48,8 +73,6 @@ fn get_window_title_length(window_handle: HWND) -> Result<usize, ()> {
 }
 
 /// Gets the window title bar title.
-///
-/// TODO: Future improvement is to use GetLastError for better error handling
 ///
 /// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextw
 fn get_window_title(window_handle: HWND) -> Result<Option<String>, ()> {
@@ -72,4 +95,72 @@ fn get_window_title(window_handle: HWND) -> Result<Option<String>, ()> {
     let window_title = OsString::from_wide(&buffer);
 
     Ok(Some(window_title.to_string_lossy().into_owned()))
+}
+
+/// Used in build_input() to specify if an input key is being pressed (down) or released (up).
+enum InputKeyPress {
+    Down,
+    Up,
+}
+
+/// A function for easily building keyboard INPUT structs used in SendInput().
+///
+/// Before modifying this function, make sure you read the SendInput() documentation:
+/// https://learn.microsoft.com/en-in/windows/win32/api/winuser/nf-winuser-sendinput
+fn build_input(key_press: InputKeyPress, character: u16) -> INPUT {
+    match key_press {
+        InputKeyPress::Down => INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: Default::default(),
+                    wScan: character,
+                    dwFlags: KEYEVENTF_UNICODE,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        },
+        InputKeyPress::Up => INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: Default::default(),
+                    wScan: character,
+                    dwFlags: KEYEVENTF_KEYUP | KEYEVENTF_UNICODE,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        },
+    }
+}
+
+/// Block keyboard and mouse input events. This prevents the hotkey
+/// key presses from interfering with the input sent via SendInput().
+///
+/// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-blockinput
+fn block_input(block: bool) -> Result<(), ()> {
+    match unsafe { BlockInput(block) } {
+        Ok(()) => Ok(()),
+        Err(_) => Err(()),
+    }
+}
+
+/// Attempts to type the provided input wherever the user's cursor is.
+///
+/// https://learn.microsoft.com/en-in/windows/win32/api/winuser/nf-winuser-sendinput
+fn send_input(inputs: Vec<INPUT>) -> Result<(), ()> {
+    let insert_count = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
+
+    let e = unsafe { GetLastError().to_hresult().message() };
+    println!("type_input() called, GetLastError() is: {:?}", e);
+
+    if insert_count == 0 {
+        return Err(()); // input was blocked by another thread
+    } else if insert_count != inputs.len() as u32 {
+        return Err(()); // input insertion not completed
+    }
+
+    Ok(())
 }

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -210,4 +210,5 @@ export declare namespace logging {
 }
 export declare namespace autotype {
   export function getForegroundWindowTitle(): string
+  export function typeInput(input: Array<number>): void
 }

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -872,8 +872,15 @@ pub mod autotype {
     pub fn get_foreground_window_title() -> napi::Result<String, napi::Status> {
         autotype::get_foreground_window_title().map_err(|_| {
             napi::Error::from_reason(
-                "Autotype Error: faild to get foreground window title".to_string(),
+                "Autotype Error: failed to get foreground window title".to_string(),
             )
+        })
+    }
+
+    #[napi]
+    pub fn type_input(input: Vec<u16>) -> napi::Result<(), napi::Status> {
+        autotype::type_input(input).map_err(|_| {
+            napi::Error::from_reason("Autotype Error: failed to type input".to_string())
         })
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22790

## 📔 Objective

Adds the ability to send UTF-16 encoded characters as keyboard events to the focused location in Windows for the new autotype feature. This feature is behind a feature flag.

Please note, the `println` will be removed in a future PR, for now it provides logging during development after input insertion:

```rust
let e = unsafe { GetLastError().to_hresult().message() };
println!("type_input() called, GetLastError() is: {:?}", e);
```

(We can eventually use the `GetLastError()` function for more precise error handling.)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
