### PR TITLE
[PM 22968] Enforce UI Restrictions When MSP/BUP Is Disabled

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/clients.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/clients.component.html
@@ -4,13 +4,32 @@
     [formControl]="searchControl"
     [placeholder]="'search' | i18n"
   ></bit-search>
-  <a bitButton routerLink="create" *ngIf="manageOrganizations" buttonType="primary">
+  <a
+    bitButton
+    routerLink="create"
+    *ngIf="canAddClients"
+    buttonType="primary"
+    [title]="addClientTooltip"
+  >
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "newClient" | i18n }}
   </a>
   <button
+    *ngIf="manageOrganizations && !canAddClients"
     type="button"
     bitButton
+    buttonType="primary"
+    [disabled]="true"
+    [title]="addClientTooltip"
+  >
+    <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+    {{ "newClient" | i18n }}
+  </button>
+  <button
+    type="button"
+    bitButton
+    [disabled]="!canAddClients"
+    [title]="addClientTooltip"
     (click)="addExistingOrganization()"
     *ngIf="manageOrganizations && showAddExisting"
   >

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/clients.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/clients.component.html
@@ -7,20 +7,20 @@
   <a
     bitButton
     routerLink="create"
-    *ngIf="canAddClients"
+    *ngIf="manageOrganizations && isSuspensionActive"
     buttonType="primary"
-    [title]="addClientTooltip"
+    [title]="addSuspensionTooltip"
   >
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "newClient" | i18n }}
   </a>
   <button
-    *ngIf="manageOrganizations && !canAddClients"
+    *ngIf="manageOrganizations && isSuspensionActive"
     type="button"
     bitButton
     buttonType="primary"
     [disabled]="true"
-    [title]="addClientTooltip"
+    [title]="addSuspensionTooltip"
   >
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "newClient" | i18n }}
@@ -28,8 +28,8 @@
   <button
     type="button"
     bitButton
-    [disabled]="!canAddClients"
-    [title]="addClientTooltip"
+    [disabled]="isSuspensionActive"
+    [title]="addSuspensionTooltip"
     (click)="addExistingOrganization()"
     *ngIf="manageOrganizations && showAddExisting"
   >

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
@@ -6,6 +6,16 @@
       [label]="'providerPortal' | i18n"
     ></bit-nav-logo>
 
+    <!-- Warning icon for suspended provider -->
+    <div *ngIf="!provider.enabled" class="tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-danger">
+      <i
+        class="bwi bwi-exclamation-triangle tw-mr-2"
+        title="{{ 'providerIsDisabled' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-text-sm tw-font-medium">{{ "providerIsDisabled" | i18n }}</span>
+    </div>
+
     <bit-nav-item
       icon="bwi-provider"
       [text]="clientsTranslationKey$ | async | i18n"

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
@@ -6,21 +6,19 @@
       [label]="'providerPortal' | i18n"
     ></bit-nav-logo>
 
-    <!-- Warning icon for suspended provider -->
-    <div *ngIf="!provider.enabled" class="tw-px-4 tw-py-2 tw-flex tw-items-center tw-text-danger">
-      <i
-        class="bwi bwi-exclamation-triangle tw-mr-2"
-        title="{{ 'providerIsDisabled' | i18n }}"
-        aria-hidden="true"
-      ></i>
-      <span class="tw-text-sm tw-font-medium">{{ "providerIsDisabled" | i18n }}</span>
-    </div>
-
     <bit-nav-item
       icon="bwi-provider"
       [text]="clientsTranslationKey$ | async | i18n"
       [route]="(isBillable | async) ? 'manage-client-organizations' : 'clients'"
-    ></bit-nav-item>
+    >
+      <i
+        *ngIf="!provider.enabled"
+        slot="end"
+        class="bwi bwi-exclamation-triangle tw-text-danger"
+        title="{{ 'providerIsDisabled' | i18n }}"
+        aria-hidden="true"
+      ></i>
+    </bit-nav-item>
     <bit-nav-group
       icon="bwi-sliders"
       [text]="'manage' | i18n"

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.html
@@ -12,7 +12,7 @@
       [route]="(isBillable | async) ? 'manage-client-organizations' : 'clients'"
     >
       <i
-        *ngIf="!provider.enabled"
+        *ngIf="!provider.enabled && (providerPortalTakeover$ | async)"
         slot="end"
         class="bwi bwi-exclamation-triangle tw-text-danger"
         title="{{ 'providerIsDisabled' | i18n }}"

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.ts
@@ -35,6 +35,7 @@ export class ProvidersLayoutComponent implements OnInit, OnDestroy {
 
   protected clientsTranslationKey$: Observable<string>;
   protected managePaymentDetailsOutsideCheckout$: Observable<boolean>;
+  protected providerPortalTakeover$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
@@ -76,6 +77,10 @@ export class ProvidersLayoutComponent implements OnInit, OnDestroy {
 
     this.managePaymentDetailsOutsideCheckout$ = this.configService.getFeatureFlag$(
       FeatureFlag.PM21881_ManagePaymentDetailsOutsideCheckout,
+    );
+
+    this.providerPortalTakeover$ = this.configService.getFeatureFlag$(
+      FeatureFlag.PM21821_ProviderPortalTakeover,
     );
   }
 

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.html
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.html
@@ -5,9 +5,9 @@
     buttonType="primary"
     type="button"
     [bitMenuTriggerFor]="clientMenu"
-    [disabled]="!canAddClients"
-    [title]="addClientTooltip"
-    appA11yTitle="{{ canAddClients ? ('add' | i18n) : addClientTooltip }}"
+    [disabled]="isSuspensionActive"
+    [title]="suspendedTooltip"
+    appA11yTitle="{{ isSuspensionActive ? ('add' | i18n) : suspendedTooltip }}"
   >
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "add" | i18n }}
@@ -16,8 +16,8 @@
     <button
       type="button"
       bitMenuItem
-      [disabled]="!canAddClients"
-      [title]="addClientTooltip"
+      [disabled]="isSuspensionActive"
+      [title]="suspendedTooltip"
       (click)="createClient()"
     >
       <i aria-hidden="true" class="bwi bwi-business"></i>
@@ -26,8 +26,8 @@
     <button
       type="button"
       bitMenuItem
-      [disabled]="!canAddClients"
-      [title]="addClientTooltip"
+      [disabled]="isSuspensionActive"
+      [title]="suspendedTooltip"
       (click)="addExistingOrganization()"
     >
       <i aria-hidden="true" class="bwi bwi-filter"></i>
@@ -90,8 +90,8 @@
           <button
             type="button"
             bitMenuItem
-            [disabled]="!canManageClientNames"
-            [title]="manageClientNameTooltip"
+            [disabled]="isSuspensionActive"
+            [title]="suspendedTooltip"
             (click)="manageClientName(row)"
           >
             <i aria-hidden="true" class="bwi bwi-pencil-square"></i>
@@ -100,14 +100,13 @@
           <button
             type="button"
             bitMenuItem
-            [disabled]="!canManageClientSubscriptions"
-            [title]="manageSubscriptionTooltip"
+            [disabled]="isSuspensionActive"
+            [title]="suspendedTooltip"
             (click)="manageClientSubscription(row)"
           >
             <i aria-hidden="true" class="bwi bwi-family"></i>
             {{ "manageSubscription" | i18n }}
           </button>
-          <!-- Keep unlink enabled even when provider is suspended -->
           <button *ngIf="isProviderAdmin" type="button" bitMenuItem (click)="remove(row)">
             <span class="tw-text-danger">
               <i aria-hidden="true" class="bwi bwi-close"></i> {{ "unlinkOrganization" | i18n }}
@@ -119,7 +118,7 @@
   </bit-table-scroll>
   <div *ngIf="dataSource.data.length === 0" class="tw-mt-10">
     <app-no-clients
-      [showAddOrganizationButton]="canAddClients"
+      [showAddOrganizationButton]="isSuspensionActive"
       (addNewOrganizationClicked)="createClient()"
     />
   </div>

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.html
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.html
@@ -5,17 +5,31 @@
     buttonType="primary"
     type="button"
     [bitMenuTriggerFor]="clientMenu"
-    appA11yTitle="{{ 'add' | i18n }}"
+    [disabled]="!canAddClients"
+    [title]="addClientTooltip"
+    appA11yTitle="{{ canAddClients ? ('add' | i18n) : addClientTooltip }}"
   >
     <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
     {{ "add" | i18n }}
   </button>
   <bit-menu #clientMenu>
-    <button type="button" bitMenuItem (click)="createClient()">
+    <button
+      type="button"
+      bitMenuItem
+      [disabled]="!canAddClients"
+      [title]="addClientTooltip"
+      (click)="createClient()"
+    >
       <i aria-hidden="true" class="bwi bwi-business"></i>
       {{ newClientButtonLabel }}
     </button>
-    <button type="button" bitMenuItem (click)="addExistingOrganization()">
+    <button
+      type="button"
+      bitMenuItem
+      [disabled]="!canAddClients"
+      [title]="addClientTooltip"
+      (click)="addExistingOrganization()"
+    >
       <i aria-hidden="true" class="bwi bwi-filter"></i>
       {{ "existingOrganization" | i18n }}
     </button>
@@ -73,14 +87,27 @@
           appA11yTitle="{{ 'options' | i18n }}"
         ></button>
         <bit-menu #rowMenu>
-          <button type="button" bitMenuItem (click)="manageClientName(row)">
+          <button
+            type="button"
+            bitMenuItem
+            [disabled]="!canManageClientNames"
+            [title]="manageClientNameTooltip"
+            (click)="manageClientName(row)"
+          >
             <i aria-hidden="true" class="bwi bwi-pencil-square"></i>
             {{ "updateName" | i18n }}
           </button>
-          <button type="button" bitMenuItem (click)="manageClientSubscription(row)">
+          <button
+            type="button"
+            bitMenuItem
+            [disabled]="!canManageClientSubscriptions"
+            [title]="manageSubscriptionTooltip"
+            (click)="manageClientSubscription(row)"
+          >
             <i aria-hidden="true" class="bwi bwi-family"></i>
             {{ "manageSubscription" | i18n }}
           </button>
+          <!-- Keep unlink enabled even when provider is suspended -->
           <button *ngIf="isProviderAdmin" type="button" bitMenuItem (click)="remove(row)">
             <span class="tw-text-danger">
               <i aria-hidden="true" class="bwi bwi-close"></i> {{ "unlinkOrganization" | i18n }}
@@ -92,7 +119,7 @@
   </bit-table-scroll>
   <div *ngIf="dataSource.data.length === 0" class="tw-mt-10">
     <app-no-clients
-      [showAddOrganizationButton]="isProviderAdmin"
+      [showAddOrganizationButton]="canAddClients"
       (addNewOrganizationClicked)="createClient()"
     />
   </div>

--- a/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/clients/manage-clients.component.ts
@@ -75,6 +75,44 @@ export class ManageClientsComponent {
   clientColumnHeader = this.i18nService.t("client");
   newClientButtonLabel = this.i18nService.t("newClient");
 
+  // Computed properties for provider suspension state
+  get isProviderDisabled(): boolean {
+    return !this.provider?.enabled;
+  }
+
+  get canAddClients(): boolean {
+    return this.isProviderAdmin && !this.isProviderDisabled;
+  }
+
+  get canManageClientNames(): boolean {
+    return this.isProviderAdmin && !this.isProviderDisabled;
+  }
+
+  get canManageClientSubscriptions(): boolean {
+    return this.isProviderAdmin && !this.isProviderDisabled;
+  }
+
+  get addClientTooltip(): string {
+    if (this.isProviderDisabled) {
+      return this.i18nService.t("providerIsDisabled");
+    }
+    return "";
+  }
+
+  get manageClientNameTooltip(): string {
+    if (this.isProviderDisabled) {
+      return this.i18nService.t("providerIsDisabled");
+    }
+    return "";
+  }
+
+  get manageSubscriptionTooltip(): string {
+    if (this.isProviderDisabled) {
+      return this.i18nService.t("providerIsDisabled");
+    }
+    return "";
+  }
+
   constructor(
     private billingApiService: BillingApiServiceAbstraction,
     private providerService: ProviderService,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -34,6 +34,7 @@ export enum FeatureFlag {
   UseOrganizationWarningsService = "use-organization-warnings-service",
   AllowTrialLengthZero = "pm-20322-allow-trial-length-0",
   PM21881_ManagePaymentDetailsOutsideCheckout = "pm-21881-manage-payment-details-outside-checkout",
+  PM21821_ProviderPortalTakeover = "pm-21821-provider-portal-takeover",
 
   /* Data Insights and Reporting */
   EnableRiskInsightsNotifications = "enable-risk-insights-notifications",
@@ -117,6 +118,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.UseOrganizationWarningsService]: FALSE,
   [FeatureFlag.AllowTrialLengthZero]: FALSE,
   [FeatureFlag.PM21881_ManagePaymentDetailsOutsideCheckout]: FALSE,
+  [FeatureFlag.PM21821_ProviderPortalTakeover]: FALSE,
 
   /* Key Management */
   [FeatureFlag.PrivateKeyRegeneration]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-22968

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR introduces logic to automatically suspend a provider when their subscription becomes unpaid, and restricts client management capabilities when MSP/BUP is disabled.

🔁 **Changes Introduced**
1. **Automatic Provider Suspension**
When a provider’s subscription status changes to unpaid, the provider is automatically suspended, preventing further usage until payment is resolved.

2. **MSP/BUP Disabled Behavior**
When the MSP/BUP feature is disabled, the following UI and permission changes are applied for provider admins and service users:

A warning icon is displayed next to the provider name.

The following actions are disabled, with a tooltip explaining why:
  - Add new client
  - Edit client names
  - Manage client subscriptions

**Unlinking clients** is still allowed for **provider admins.**
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-07-23 at 17 54 32" src="https://github.com/user-attachments/assets/5a2786ed-0d6d-4d55-a0a8-6afc9cf1c565" />
<img width="1728" height="1117" alt="Screenshot 2025-07-23 at 17 54 38" src="https://github.com/user-attachments/assets/5eda55ff-2b6f-4472-975d-7622c2aac6aa" />
<img width="1728" height="1117" alt="Screenshot 2025-07-23 at 17 54 50" src="https://github.com/user-attachments/assets/c11f5dc9-83fb-43cb-8c33-272447d87231" />
<img width="1728" height="1117" alt="Screenshot 2025-07-23 at 17 54 53" src="https://github.com/user-attachments/assets/4a41ab72-0416-4677-b6fa-d478d20b2dc3" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
