### PR TITLE
[PM-23748] -  Item selection count not cleared after actions in Vault

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -217,6 +217,10 @@ export class VaultItemsComponent<C extends CipherViewLike> {
     return this.showBulkAddToCollections && this.ciphers.length > 0;
   }
 
+  clearSelection() {
+    this.selection.clear();
+  }
+
   protected canEditCollection(collection: CollectionView): boolean {
     // Only allow allow deletion if collection editing is enabled and not deleting "Unassigned"
     if (collection.id === Unassigned) {

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -108,6 +108,7 @@ import {
 } from "../components/vault-item-dialog/vault-item-dialog.component";
 import { VaultItem } from "../components/vault-items/vault-item";
 import { VaultItemEvent } from "../components/vault-items/vault-item-event";
+import { VaultItemsComponent } from "../components/vault-items/vault-items.component";
 import { VaultItemsModule } from "../components/vault-items/vault-items.module";
 
 import {
@@ -156,6 +157,7 @@ const SearchTextDebounceInterval = 200;
 })
 export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestroy {
   @ViewChild("vaultFilter", { static: true }) filterComponent: VaultFilterComponent;
+  @ViewChild(VaultItemsComponent) vaultItemsComponent: VaultItemsComponent<C>;
 
   trashCleanupWarning: string = null;
   kdfIterations: number;
@@ -1070,6 +1072,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       message: this.i18nService.t("restoredItems"),
     });
     this.refresh();
+    this.vaultItemsComponent?.clearSelection();
   }
 
   private async handleDeleteEvent(items: VaultItem<C>[]) {
@@ -1162,6 +1165,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
 
     const result = await lastValueFrom(dialog.closed);
     if (result === BulkDeleteDialogResult.Deleted) {
+      this.vaultItemsComponent?.clearSelection();
       this.refresh();
     }
   }
@@ -1187,6 +1191,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
 
     const result = await lastValueFrom(dialog.closed);
     if (result === BulkMoveDialogResult.Moved) {
+      this.vaultItemsComponent?.clearSelection();
       this.refresh();
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23748


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where after completing a bulk action (delete, move, restore) the selected items weren't being reset, causing the count displayed to the user to be off as well as the actions being repeated for the previously selected items if an action was taken again.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/83bfa477-77b8-4ff1-b566-2ea1bb0fbb00


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
