### PR TITLE
Remove Transition Key

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -495,7 +495,7 @@
                       formControlName="enableAutotype"
                       (change)="saveEnableAutotype()"
                     />
-                    {{ "enableAutotypeTransitionKey" | i18n }}
+                    {{ "enableAutotype" | i18n }}
                   </label>
                 </div>
                 <small class="help-block"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -4006,7 +4006,7 @@
       }
     }
   },
-  "enableAutotypeTransitionKey": {
+  "enableAutotype": {
     "message": "Enable Autotype"
   },
   "enableAutotypeDescription": {


### PR DESCRIPTION
## 📔 Objective

From the original PR - changes the name of the autotype checkbox from `Enable autotype shortcut` to `Enable Autotype`.

This has been approved by design, and it is still hidden behind a feature flag.

---

This PR deletes the transition key and adds back the fixed original.

Original: https://github.com/bitwarden/clients/pull/15753

## 📸 Screenshots

New Look:

<img width="790" height="628" alt="image" src="https://github.com/user-attachments/assets/1ccf4626-d54e-456d-91e4-288820a60782" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
